### PR TITLE
feat: upgrade MCP protocol to 2026-07-28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -1183,6 +1184,7 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "hex",
+ "jsonschema",
  "mockall",
  "reqwest",
  "serde",
@@ -1736,6 +1738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1786,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -2619,6 +2633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +2797,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,6 +2886,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,6 +2936,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -3785,6 +3840,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.18.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4113,6 +4220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4334,6 +4447,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4342,6 +4469,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -4375,6 +4508,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4546,6 +4700,12 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -5305,6 +5465,43 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -7038,6 +7235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7172,6 +7375,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "v_htmlescape"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7194,6 +7407,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,7 @@ dependencies = [
  "bamboo-domain",
  "bamboo-infrastructure",
  "bamboo-llm",
+ "base64 0.23.0",
  "chrono",
  "dashmap",
  "eventsource-stream",

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -6384,6 +6384,13 @@ for line in sys.stdin:
     request_id = request.get("id")
     if request_id is None:
         continue
+    if request.get("method") == "server/discover":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "Method not found"},
+        }), flush=True)
+        continue
     if request.get("method") == "initialize":
         result = {
             "protocolVersion": "2024-11-05",

--- a/crates/infra/bamboo-mcp/Cargo.toml
+++ b/crates/infra/bamboo-mcp/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.23"
 sha2 = "0.11"
 hex = "0.4"
 thiserror = "2"
+jsonschema = { version = "0.49.2", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/infra/bamboo-mcp/Cargo.toml
+++ b/crates/infra/bamboo-mcp/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "form", "query", "native-tls", "charset", "http2", "system-proxy"] }
 eventsource-stream = "0.2"
 dashmap = "6"
+base64 = "0.23"
 sha2 = "0.11"
 hex = "0.4"
 thiserror = "2"

--- a/crates/infra/bamboo-mcp/src/error.rs
+++ b/crates/infra/bamboo-mcp/src/error.rs
@@ -8,6 +8,13 @@ pub enum McpError {
     #[error("Protocol error: {0}")]
     Protocol(String),
 
+    #[error("Remote protocol error {code}: {message}")]
+    RemoteProtocol {
+        code: i32,
+        message: String,
+        data: Option<serde_json::Value>,
+    },
+
     #[error("Connection error: {0}")]
     Connection(String),
 
@@ -73,6 +80,19 @@ mod tests {
     fn test_error_display_protocol() {
         let error = McpError::Protocol("invalid message".to_string());
         assert_eq!(format!("{}", error), "Protocol error: invalid message");
+    }
+
+    #[test]
+    fn test_error_display_remote_protocol() {
+        let error = McpError::RemoteProtocol {
+            code: -32022,
+            message: "Unsupported protocol version".to_string(),
+            data: None,
+        };
+        assert_eq!(
+            format!("{}", error),
+            "Remote protocol error -32022: Unsupported protocol version"
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-mcp/src/error.rs
+++ b/crates/infra/bamboo-mcp/src/error.rs
@@ -5,6 +5,17 @@ pub enum McpError {
     #[error("Transport error: {0}")]
     Transport(String),
 
+    #[error("HTTP request failed with status {status}: {body}")]
+    HttpStatus { status: u16, body: String },
+
+    #[error("HTTP {status} returned protocol error {code}: {message}")]
+    HttpProtocol {
+        status: u16,
+        code: i32,
+        message: String,
+        data: Option<serde_json::Value>,
+    },
+
     #[error("Protocol error: {0}")]
     Protocol(String),
 

--- a/crates/infra/bamboo-mcp/src/executor.rs
+++ b/crates/infra/bamboo-mcp/src/executor.rs
@@ -9,7 +9,7 @@ use tracing::{debug, error, warn};
 use crate::error::McpError;
 use crate::manager::McpServerManager;
 use crate::tool_index::ToolIndex;
-use crate::types::{McpContentItem, McpStructuredContent};
+use crate::types::{McpContentItem, McpContentMetadata, McpStructuredContent};
 
 /// MCP tool executor that delegates to the MCP server manager
 pub struct McpToolExecutor {
@@ -48,39 +48,70 @@ impl McpToolExecutor {
         let mut images = Vec::new();
         for item in content {
             match item {
-                McpContentItem::Text { text } => parts.push(text.clone()),
-                McpContentItem::Image { data, mime_type } => {
+                McpContentItem::Text { text, metadata } => {
+                    parts.push(Self::append_content_metadata(text.clone(), metadata));
+                }
+                McpContentItem::Image {
+                    data,
+                    mime_type,
+                    metadata,
+                } => {
                     images.push(ToolResultImage {
                         mime_type: mime_type.clone(),
                         data: data.clone(),
                     });
-                    parts.push(format!("[image returned: {mime_type}]"));
+                    parts.push(Self::append_content_metadata(
+                        format!("[image returned: {mime_type}]"),
+                        metadata,
+                    ));
                 }
-                McpContentItem::Audio { mime_type, .. } => {
-                    parts.push(format!("[audio returned: {mime_type}]"));
+                McpContentItem::Audio { .. } => {
+                    parts.push(Self::serialized_content_block("audio content", item));
                 }
-                McpContentItem::ResourceLink {
-                    uri,
-                    name,
-                    description,
-                    ..
-                } => {
-                    if let Some(description) = description {
-                        parts.push(format!("[Resource link {name} ({uri})]: {description}"));
-                    } else {
-                        parts.push(format!("[Resource link {name} ({uri})]"));
-                    }
+                McpContentItem::ResourceLink { .. } => {
+                    parts.push(Self::serialized_content_block("resource link", item));
                 }
-                McpContentItem::Resource { resource } => {
+                McpContentItem::Resource { resource, metadata } => {
                     if let Some(text) = &resource.text {
-                        parts.push(format!("[Resource {}]: {}", resource.uri, text));
+                        let rendered = format!("[Resource {}]: {}", resource.uri, text);
+                        if resource.meta.is_some()
+                            || metadata.annotations.is_some()
+                            || metadata.meta.is_some()
+                        {
+                            parts.push(format!(
+                                "{rendered}\n{}",
+                                Self::serialized_content_block("embedded resource metadata", item)
+                            ));
+                        } else {
+                            parts.push(rendered);
+                        }
                     } else {
-                        parts.push(format!("[Resource {}]", resource.uri));
+                        // Binary embedded resources have no native ToolResult
+                        // carrier. Preserve the base64 payload and all metadata
+                        // in an explicit JSON content block for the model.
+                        parts.push(Self::serialized_content_block("embedded resource", item));
                     }
                 }
             }
         }
         (parts.join("\n"), images)
+    }
+
+    fn append_content_metadata(mut rendered: String, metadata: &McpContentMetadata) -> String {
+        if metadata.annotations.is_none() && metadata.meta.is_none() {
+            return rendered;
+        }
+        let encoded = serde_json::to_string(metadata)
+            .unwrap_or_else(|error| format!("{{\"serializationError\":\"{error}\"}}"));
+        rendered.push_str("\n[MCP content metadata]: ");
+        rendered.push_str(&encoded);
+        rendered
+    }
+
+    fn serialized_content_block(label: &str, item: &McpContentItem) -> String {
+        let encoded = serde_json::to_string(item)
+            .unwrap_or_else(|error| format!("{{\"serializationError\":\"{error}\"}}"));
+        format!("[MCP {label}]: {encoded}")
     }
 
     fn append_structured_content(
@@ -490,10 +521,12 @@ mod tests {
         let content = vec![
             McpContentItem::Text {
                 text: "screenshot 1280x536".to_string(),
+                metadata: McpContentMetadata::default(),
             },
             McpContentItem::Image {
                 data: "abc123".to_string(),
                 mime_type: "image/jpeg".to_string(),
+                metadata: McpContentMetadata::default(),
             },
         ];
         let (text, images) = McpToolExecutor::format_result_content(&content);
@@ -519,9 +552,11 @@ mod tests {
         let content = vec![
             McpContentItem::Text {
                 text: "Hello".to_string(),
+                metadata: McpContentMetadata::default(),
             },
             McpContentItem::Text {
                 text: "World".to_string(),
+                metadata: McpContentMetadata::default(),
             },
         ];
         let (text, images) = McpToolExecutor::format_result_content(&content);
@@ -534,6 +569,7 @@ mod tests {
         let content = vec![McpContentItem::Image {
             data: "base64imagedata".to_string(),
             mime_type: "image/png".to_string(),
+            metadata: McpContentMetadata::default(),
         }];
         // The image is no longer flattened to a placeholder; it is collected
         // separately, with a short marker left in the text.
@@ -552,7 +588,9 @@ mod tests {
                 mime_type: Some("text/plain".to_string()),
                 text: Some("File content".to_string()),
                 blob: None,
+                meta: None,
             },
+            metadata: McpContentMetadata::default(),
         }];
         let (text, _images) = McpToolExecutor::format_result_content(&content);
         assert_eq!(text, "[Resource file:///test.txt]: File content");
@@ -566,10 +604,61 @@ mod tests {
                 mime_type: None,
                 text: None,
                 blob: Some("base64data".to_string()),
+                meta: None,
             },
+            metadata: McpContentMetadata::default(),
         }];
         let (text, _images) = McpToolExecutor::format_result_content(&content);
-        assert_eq!(text, "[Resource file:///test.bin]");
+        assert!(text.starts_with("[MCP embedded resource]: "));
+        assert!(text.contains("\"blob\":\"base64data\""));
+    }
+
+    #[test]
+    fn non_native_content_and_metadata_reach_the_model_without_data_loss() {
+        let audio: McpContentItem = serde_json::from_value(serde_json::json!({
+            "type": "audio",
+            "data": "UklGRg==",
+            "mimeType": "audio/wav",
+            "annotations": {"audience": ["assistant"]},
+            "_meta": {"example.com/trace": "trace-1"}
+        }))
+        .expect("audio block");
+        let link: McpContentItem = serde_json::from_value(serde_json::json!({
+            "type": "resource_link",
+            "uri": "file:///report.json",
+            "name": "report",
+            "icons": [{"src": "data:image/png;base64,AA=="}],
+            "_meta": {"example.com/link": true}
+        }))
+        .expect("resource link block");
+        let blob: McpContentItem = serde_json::from_value(serde_json::json!({
+            "type": "resource",
+            "resource": {
+                "uri": "file:///payload.bin",
+                "blob": "AAEC",
+                "_meta": {"example.com/checksum": "abc"}
+            },
+            "annotations": {"priority": 1.0}
+        }))
+        .expect("embedded blob block");
+
+        let (text, images) = McpToolExecutor::format_result_content(&[audio, link, blob]);
+        assert!(images.is_empty());
+        for preserved in [
+            "UklGRg==",
+            "audio/wav",
+            "example.com/trace",
+            "data:image/png;base64,AA==",
+            "example.com/link",
+            "AAEC",
+            "example.com/checksum",
+            "\"priority\":1.0",
+        ] {
+            assert!(
+                text.contains(preserved),
+                "formatted content omitted {preserved}: {text}"
+            );
+        }
     }
 
     #[test]
@@ -577,10 +666,12 @@ mod tests {
         let content = vec![
             McpContentItem::Text {
                 text: "Result:".to_string(),
+                metadata: McpContentMetadata::default(),
             },
             McpContentItem::Image {
                 data: "img".to_string(),
                 mime_type: "image/png".to_string(),
+                metadata: McpContentMetadata::default(),
             },
         ];
         let (text, images) = McpToolExecutor::format_result_content(&content);

--- a/crates/infra/bamboo-mcp/src/executor.rs
+++ b/crates/infra/bamboo-mcp/src/executor.rs
@@ -9,7 +9,7 @@ use tracing::{debug, error, warn};
 use crate::error::McpError;
 use crate::manager::McpServerManager;
 use crate::tool_index::ToolIndex;
-use crate::types::McpContentItem;
+use crate::types::{McpContentItem, McpStructuredContent};
 
 /// MCP tool executor that delegates to the MCP server manager
 pub struct McpToolExecutor {
@@ -56,6 +56,21 @@ impl McpToolExecutor {
                     });
                     parts.push(format!("[image returned: {mime_type}]"));
                 }
+                McpContentItem::Audio { mime_type, .. } => {
+                    parts.push(format!("[audio returned: {mime_type}]"));
+                }
+                McpContentItem::ResourceLink {
+                    uri,
+                    name,
+                    description,
+                    ..
+                } => {
+                    if let Some(description) = description {
+                        parts.push(format!("[Resource link {name} ({uri})]: {description}"));
+                    } else {
+                        parts.push(format!("[Resource link {name} ({uri})]"));
+                    }
+                }
                 McpContentItem::Resource { resource } => {
                     if let Some(text) = &resource.text {
                         parts.push(format!("[Resource {}]: {}", resource.uri, text));
@@ -66,6 +81,26 @@ impl McpToolExecutor {
             }
         }
         (parts.join("\n"), images)
+    }
+
+    fn append_structured_content(
+        mut text: String,
+        structured_content: &McpStructuredContent,
+    ) -> String {
+        let Some(value) = structured_content.to_json_value() else {
+            return text;
+        };
+        let encoded = serde_json::to_string(&value)
+            .unwrap_or_else(|error| format!("[unserializable structured content: {error}]"));
+        if text.trim() == encoded {
+            return text;
+        }
+        if !text.is_empty() {
+            text.push('\n');
+            text.push_str("[structured content]: ");
+        }
+        text.push_str(&encoded);
+        text
     }
 }
 
@@ -113,6 +148,7 @@ impl ToolExecutor for McpToolExecutor {
         {
             Ok(result) => {
                 let (text, images) = Self::format_result_content(&result.content);
+                let text = Self::append_structured_content(text, &result.structured_content);
                 if result.is_error {
                     // Errors are textual; don't forward images.
                     Ok(ToolResult {
@@ -551,6 +587,30 @@ mod tests {
         assert!(text.contains("Result:"));
         assert!(text.contains("[image returned:"));
         assert_eq!(images.len(), 1);
+    }
+
+    #[test]
+    fn structured_content_is_preserved_without_duplicating_text_fallback() {
+        let structured = McpStructuredContent::Value(serde_json::json!({
+            "temperature": 22.5,
+            "condition": "clear"
+        }));
+        let encoded = r#"{"condition":"clear","temperature":22.5}"#;
+        assert_eq!(
+            McpToolExecutor::append_structured_content(String::new(), &structured),
+            encoded
+        );
+        assert_eq!(
+            McpToolExecutor::append_structured_content(encoded.to_string(), &structured),
+            encoded
+        );
+        assert_eq!(
+            McpToolExecutor::append_structured_content(
+                "Weather result".to_string(),
+                &McpStructuredContent::Null,
+            ),
+            "Weather result\n[structured content]: null"
+        );
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-mcp/src/manager/tests.rs
+++ b/crates/infra/bamboo-mcp/src/manager/tests.rs
@@ -545,6 +545,7 @@ fn marker_tool(name: &str) -> McpTool {
         name: name.to_string(),
         description: format!("{name} marker"),
         parameters: serde_json::json!({"type": "object"}),
+        output_schema: None,
     }
 }
 
@@ -559,6 +560,7 @@ async fn transactional_reconcile_bootstrap_failure_keeps_old_runtime_and_tool_in
         name: "still_available".to_string(),
         description: "old runtime marker".to_string(),
         parameters: serde_json::json!({"type": "object"}),
+        output_schema: None,
     };
     manager
         .index

--- a/crates/infra/bamboo-mcp/src/protocol/client.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/client.rs
@@ -31,6 +31,7 @@ const MODERN_DISCOVERY_PROBE_TIMEOUT_MS: u64 = 5_000;
 /// Cancellation is best-effort and must never turn an already-expired request
 /// into another unbounded wait (for example, on a stalled stdio writer).
 const CANCELLATION_ATTEMPT_TIMEOUT_MS: u64 = 250;
+const JSON_RPC_METHOD_NOT_FOUND_ERROR: i32 = -32601;
 const SUBSCRIPTION_ACK_METHOD: &str = "notifications/subscriptions/acknowledged";
 const SUBSCRIPTION_ID_META_KEY: &str = "io.modelcontextprotocol/subscriptionId";
 
@@ -1099,6 +1100,9 @@ impl McpProtocolClient {
     }
 
     fn is_recognized_modern_error(error: &McpError) -> bool {
+        // HTTP uses a structured Method not found response as evidence that
+        // the endpoint understood the modern request envelope. On stdio the
+        // same code is the legacy `server/discover` fallback signal.
         matches!(
             error,
             McpError::RemoteProtocol {
@@ -1107,7 +1111,8 @@ impl McpProtocolClient {
                     | UNSUPPORTED_PROTOCOL_VERSION_ERROR,
                 ..
             } | McpError::HttpProtocol {
-                code: HEADER_MISMATCH_ERROR
+                code: JSON_RPC_METHOD_NOT_FOUND_ERROR
+                    | HEADER_MISMATCH_ERROR
                     | MISSING_REQUIRED_CLIENT_CAPABILITY_ERROR
                     | UNSUPPORTED_PROTOCOL_VERSION_ERROR,
                 ..
@@ -2178,11 +2183,9 @@ mod tests {
             }))]);
         let transport = transport
             .with_http_fallback_rules()
-            .with_send_failures(vec![McpError::HttpProtocol {
+            .with_send_failures(vec![McpError::HttpStatus {
                 status: 400,
-                code: -32601,
-                message: "Method not found".to_string(),
-                data: None,
+                body: "legacy endpoint rejection".to_string(),
             }]);
         let mut client = McpProtocolClient::new(Box::new(transport));
         client.connect().await.expect("connect");
@@ -2194,6 +2197,41 @@ mod tests {
         assert_eq!(captured[0].0["method"], "server/discover");
         assert_eq!(captured[1].0["method"], "initialize");
         assert_eq!(captured[2].0["method"], "notifications/initialized");
+    }
+
+    #[tokio::test]
+    async fn http_method_not_found_error_pins_modern_instead_of_initializing() {
+        let (transport, captured) = ScriptedTransport::new(Vec::new());
+        let transport = transport
+            .with_http_fallback_rules()
+            .with_send_failures(vec![McpError::HttpProtocol {
+                status: 404,
+                code: JSON_RPC_METHOD_NOT_FOUND_ERROR,
+                message: "Method not found".to_string(),
+                data: None,
+            }]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let error = client
+            .initialize(1000)
+            .await
+            .expect_err("HTTP method-not-found body identifies a modern endpoint");
+        assert!(matches!(
+            error,
+            McpError::HttpProtocol {
+                status: 404,
+                code: JSON_RPC_METHOD_NOT_FOUND_ERROR,
+                ..
+            }
+        ));
+        let captured = captured.lock().await;
+        assert_eq!(
+            captured.len(),
+            1,
+            "recognized modern HTTP error must not send initialize"
+        );
+        assert_eq!(captured[0].0["method"], "server/discover");
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-mcp/src/protocol/client.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/client.rs
@@ -28,6 +28,8 @@ const NOTIFICATION_CHANNEL_CAPACITY: usize = 100;
 /// ignores pre-initialize requests does not consume the full operation timeout
 /// (60 seconds by default) before Bamboo falls back to `initialize`.
 const MODERN_DISCOVERY_PROBE_TIMEOUT_MS: u64 = 5_000;
+const SUBSCRIPTION_ACK_METHOD: &str = "notifications/subscriptions/acknowledged";
+const SUBSCRIPTION_ID_META_KEY: &str = "io.modelcontextprotocol/subscriptionId";
 
 /// HTTP-envelope metadata derived from an MCP request.
 ///
@@ -35,6 +37,9 @@ const MODERN_DISCOVERY_PROBE_TIMEOUT_MS: u64 = 5_000;
 /// the modern protocol's body metadata into mandatory request headers.
 #[derive(Debug, Clone, Default)]
 pub struct McpTransportMetadata {
+    /// JSON-RPC request ID, used to associate a Streamable HTTP response stream
+    /// with the operation that owns it.
+    pub request_id: Option<u64>,
     pub protocol_version: Option<String>,
     pub modern: bool,
     pub method: String,
@@ -61,6 +66,22 @@ pub trait McpTransport: Send + Sync {
         _metadata: McpTransportMetadata,
     ) -> Result<()> {
         self.send(message).await
+    }
+
+    /// Cancel an in-flight request after Bamboo stops waiting for its result.
+    ///
+    /// stdio cancellation is a JSON-RPC notification. Streamable HTTP
+    /// overrides this hook and closes the request's response stream instead.
+    async fn cancel_request(&self, request_id: u64, reason: &str) -> Result<()> {
+        let notification = JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: "notifications/cancelled".to_string(),
+            params: Some(serde_json::json!({
+                "requestId": request_id,
+                "reason": reason,
+            })),
+        };
+        self.send(serde_json::to_string(&notification)?).await
     }
 
     /// Whether this transport can speak the stateless MCP 2026-07-28 protocol.
@@ -120,6 +141,20 @@ enum RequestProtocol {
     Legacy { version: Option<String> },
 }
 
+enum ModernDiscoveryError {
+    /// No successful modern response was received, so a legacy probe is safe.
+    Fallback(McpError),
+    /// A modern response or a normative modern error pinned the protocol era.
+    Pinned(McpError),
+}
+
+#[derive(Default)]
+struct ToolSubscriptionState {
+    id: Option<u64>,
+    acknowledged: bool,
+    ack_sender: Option<oneshot::Sender<Result<()>>>,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ToolHeaderValueType {
     String,
@@ -156,7 +191,10 @@ pub struct McpProtocolClient {
     tool_header_specs: RwLock<HashMap<String, Vec<ToolHeaderSpec>>>,
     /// Long-lived `subscriptions/listen` request used by modern servers to
     /// deliver `notifications/tools/list_changed`.
-    tool_subscription_id: Mutex<Option<u64>>,
+    tool_subscription: Arc<Mutex<ToolSubscriptionState>>,
+    /// Whether the current modern discovery result requires a tool-change
+    /// subscription. Shared with the inbound handler for stdio correlation.
+    modern_tool_list_changes: Arc<AtomicBool>,
 }
 
 impl McpProtocolClient {
@@ -172,7 +210,8 @@ impl McpProtocolClient {
             notification_queue_full: Arc::new(AtomicBool::new(false)),
             protocol_mode: RwLock::new(ProtocolMode::Unnegotiated),
             tool_header_specs: RwLock::new(HashMap::new()),
-            tool_subscription_id: Mutex::new(None),
+            tool_subscription: Arc::new(Mutex::new(ToolSubscriptionState::default())),
+            modern_tool_list_changes: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -205,7 +244,13 @@ impl McpProtocolClient {
         }
 
         self.pending_requests.write().await.clear();
-        *self.tool_subscription_id.lock().await = None;
+        let mut subscription = self.tool_subscription.lock().await;
+        if let Some(sender) = subscription.ack_sender.take() {
+            let _ = sender.send(Err(McpError::Disconnected));
+        }
+        *subscription = ToolSubscriptionState::default();
+        self.modern_tool_list_changes.store(false, Ordering::SeqCst);
+        drop(subscription);
 
         let mut transport = self.transport.write().await;
         transport.disconnect().await
@@ -222,6 +267,8 @@ impl McpProtocolClient {
         let pending_requests = self.pending_requests.clone();
         let notification_tx = self.notification_tx.clone();
         let notification_queue_full = self.notification_queue_full.clone();
+        let tool_subscription = self.tool_subscription.clone();
+        let modern_tool_list_changes = self.modern_tool_list_changes.clone();
 
         let handler = tokio::spawn(async move {
             // Await the next message from the channel. When the channel closes
@@ -235,12 +282,24 @@ impl McpProtocolClient {
                     &pending_requests,
                     &notification_tx,
                     &notification_queue_full,
+                    &tool_subscription,
+                    &modern_tool_list_changes,
                 )
                 .await
                 {
                     warn!("Failed to handle message: {}", e);
                 }
             }
+            let mut pending = pending_requests.write().await;
+            for (_, request) in pending.drain() {
+                let _ = request.sender.send(Err(McpError::Disconnected));
+            }
+            drop(pending);
+            let mut subscription = tool_subscription.lock().await;
+            if let Some(sender) = subscription.ack_sender.take() {
+                let _ = sender.send(Err(McpError::Disconnected));
+            }
+            *subscription = ToolSubscriptionState::default();
             trace!("MCP message handler exited (channel closed)");
         });
 
@@ -252,6 +311,8 @@ impl McpProtocolClient {
         pending_requests: &RwLock<std::collections::HashMap<u64, PendingRequest>>,
         notification_tx: &mpsc::Sender<JsonRpcNotification>,
         notification_queue_full: &AtomicBool,
+        tool_subscription: &Mutex<ToolSubscriptionState>,
+        modern_tool_list_changes: &AtomicBool,
     ) -> Result<()> {
         // Try to parse as response
         if let Ok(response) = serde_json::from_str::<JsonRpcResponse>(message) {
@@ -276,6 +337,16 @@ impl McpProtocolClient {
                 "MCP JSON-RPC notification received (method={})",
                 notification.method
             );
+            if Self::handle_subscription_notification(
+                &notification,
+                pending_requests,
+                tool_subscription,
+                modern_tool_list_changes,
+            )
+            .await?
+            {
+                return Ok(());
+            }
             // Non-blocking: this handler loop ALSO matches JSON-RPC responses to
             // their pending requests, so a blocking `send().await` would wedge
             // response delivery once the (undrained) queue fills — timing out
@@ -306,6 +377,100 @@ impl McpProtocolClient {
         }
 
         Err(McpError::Protocol("Unknown message type".to_string()))
+    }
+
+    async fn handle_subscription_notification(
+        notification: &JsonRpcNotification,
+        pending_requests: &RwLock<std::collections::HashMap<u64, PendingRequest>>,
+        tool_subscription: &Mutex<ToolSubscriptionState>,
+        modern_tool_list_changes: &AtomicBool,
+    ) -> Result<bool> {
+        if notification.method == SUBSCRIPTION_ACK_METHOD {
+            let received_id = Self::notification_subscription_id(notification);
+            let accepts_tool_changes = notification
+                .params
+                .as_ref()
+                .and_then(|params| params.get("notifications"))
+                .and_then(|notifications| notifications.get("toolsListChanged"))
+                .and_then(Value::as_bool)
+                == Some(true);
+            let mut subscription = tool_subscription.lock().await;
+            let Some(expected_id) = subscription.id else {
+                warn!("Ignoring MCP subscription acknowledgment with no active subscription");
+                return Ok(true);
+            };
+            if received_id != Some(expected_id) {
+                warn!(
+                    "Ignoring MCP subscription acknowledgment with mismatched id (expected={:?}, received={:?})",
+                    subscription.id, received_id
+                );
+                return Ok(true);
+            }
+            if !accepts_tool_changes {
+                let error = McpError::Protocol(
+                    "MCP subscription acknowledgment omitted requested toolsListChanged"
+                        .to_string(),
+                );
+                if let Some(sender) = subscription.ack_sender.take() {
+                    let _ = sender.send(Err(error));
+                }
+                return Ok(true);
+            }
+            subscription.acknowledged = true;
+            if let Some(sender) = subscription.ack_sender.take() {
+                let _ = sender.send(Ok(()));
+            }
+            return Ok(true);
+        }
+
+        if notification.method == "notifications/cancelled" {
+            let request_id = notification
+                .params
+                .as_ref()
+                .and_then(|params| params.get("requestId"))
+                .and_then(Value::as_u64);
+            let mut subscription = tool_subscription.lock().await;
+            if let Some(id) = request_id.filter(|id| Some(*id) == subscription.id) {
+                if let Some(sender) = subscription.ack_sender.take() {
+                    let _ = sender.send(Err(McpError::Protocol(
+                        "MCP server cancelled subscriptions/listen".to_string(),
+                    )));
+                }
+                *subscription = ToolSubscriptionState::default();
+                drop(subscription);
+                if let Some(request) = pending_requests.write().await.remove(&id) {
+                    let _ = request.sender.send(Err(McpError::Protocol(
+                        "MCP server cancelled subscriptions/listen".to_string(),
+                    )));
+                }
+                return Ok(true);
+            }
+        }
+
+        if notification.method == "notifications/tools/list_changed"
+            && modern_tool_list_changes.load(Ordering::SeqCst)
+        {
+            let received_id = Self::notification_subscription_id(notification);
+            let subscription = tool_subscription.lock().await;
+            if !subscription.acknowledged || received_id != subscription.id {
+                warn!(
+                    "Ignoring uncorrelated MCP tools/list_changed notification (active={:?}, acknowledged={}, received={:?})",
+                    subscription.id, subscription.acknowledged, received_id
+                );
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn notification_subscription_id(notification: &JsonRpcNotification) -> Option<u64> {
+        notification
+            .params
+            .as_ref()
+            .and_then(|params| params.get("_meta"))
+            .and_then(|meta| meta.get(SUBSCRIPTION_ID_META_KEY))
+            .and_then(Value::as_u64)
     }
 
     /// Records that a notification was dropped because the queue was full, and
@@ -386,6 +551,7 @@ impl McpProtocolClient {
 
         let metadata = match protocol {
             RequestProtocol::Modern { version } => McpTransportMetadata {
+                request_id: Some(id),
                 protocol_version: Some(version),
                 modern: true,
                 method: method.to_string(),
@@ -393,6 +559,7 @@ impl McpProtocolClient {
                 tool_parameter_headers,
             },
             RequestProtocol::Legacy { version } => McpTransportMetadata {
+                request_id: Some(id),
                 protocol_version: version,
                 modern: false,
                 method: method.to_string(),
@@ -401,19 +568,35 @@ impl McpProtocolClient {
             },
         };
 
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
         let transport = self.transport.read().await;
-        if let Err(e) = transport.send_with_metadata(request_json, metadata).await {
-            // Avoid leaking pending requests on send failure.
-            self.pending_requests.write().await.remove(&id);
-            warn!(
-                "MCP JSON-RPC request send failed (id={}, method={}): {}",
-                id, method, e
-            );
-            return Err(e);
+        match tokio::time::timeout_at(
+            deadline,
+            transport.send_with_metadata(request_json, metadata),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                // Avoid leaking pending requests on send failure.
+                self.pending_requests.write().await.remove(&id);
+                warn!(
+                    "MCP JSON-RPC request send failed (id={}, method={}): {}",
+                    id, method, error
+                );
+                return Err(error);
+            }
+            Err(_) => {
+                drop(transport);
+                self.cancel_timed_out_request(id, method, timeout_ms).await;
+                return Err(McpError::Timeout(format!(
+                    "Request {id} timed out after {timeout_ms}ms"
+                )));
+            }
         }
         drop(transport);
 
-        match tokio::time::timeout(tokio::time::Duration::from_millis(timeout_ms), rx).await {
+        match tokio::time::timeout_at(deadline, rx).await {
             Ok(Ok(Ok(response))) => {
                 if let Some(error) = response.error {
                     Err(McpError::RemoteProtocol {
@@ -428,17 +611,29 @@ impl McpProtocolClient {
             Ok(Ok(Err(e))) => Err(e),
             Ok(Err(_)) => Err(McpError::Disconnected),
             Err(_) => {
-                self.pending_requests.write().await.remove(&id);
-                warn!(
-                    "MCP JSON-RPC request timed out (id={}, method={}, timeout_ms={})",
-                    id, method, timeout_ms
-                );
+                self.cancel_timed_out_request(id, method, timeout_ms).await;
                 Err(McpError::Timeout(format!(
-                    "Request {} timed out after {}ms",
-                    id, timeout_ms
+                    "Request {id} timed out after {timeout_ms}ms"
                 )))
             }
         }
+    }
+
+    async fn cancel_timed_out_request(&self, id: u64, method: &str, timeout_ms: u64) {
+        self.pending_requests.write().await.remove(&id);
+        let reason = format!("Request timed out after {timeout_ms}ms");
+        let transport = self.transport.read().await;
+        if let Err(error) = transport.cancel_request(id, &reason).await {
+            warn!(
+                "MCP request cancellation failed after timeout (id={}, method={}): {}",
+                id, method, error
+            );
+        }
+        drop(transport);
+        warn!(
+            "MCP JSON-RPC request timed out (id={}, method={}, timeout_ms={})",
+            id, method, timeout_ms
+        );
     }
 
     fn with_modern_request_metadata(params: Option<Value>, version: &str) -> Result<Value> {
@@ -486,8 +681,8 @@ impl McpProtocolClient {
             let probe_timeout_ms = timeout_ms.min(MODERN_DISCOVERY_PROBE_TIMEOUT_MS);
             match self.discover_modern(probe_timeout_ms).await {
                 Ok(result) => return Ok(result),
-                Err(error) if Self::is_recognized_modern_error(&error) => return Err(error),
-                Err(error) => {
+                Err(ModernDiscoveryError::Pinned(error)) => return Err(error),
+                Err(ModernDiscoveryError::Fallback(error)) => {
                     debug!(
                         "MCP server did not complete modern discovery; falling back to legacy initialization: {}",
                         error
@@ -499,7 +694,10 @@ impl McpProtocolClient {
         self.initialize_legacy(timeout_ms).await
     }
 
-    async fn discover_modern(&self, timeout_ms: u64) -> Result<McpInitializeResult> {
+    async fn discover_modern(
+        &self,
+        timeout_ms: u64,
+    ) -> std::result::Result<McpInitializeResult, ModernDiscoveryError> {
         let response = self
             .send_request_using(
                 "server/discover",
@@ -510,15 +708,32 @@ impl McpProtocolClient {
                 },
                 Vec::new(),
             )
-            .await?;
+            .await
+            .map_err(|error| {
+                if Self::is_recognized_modern_error(&error) {
+                    ModernDiscoveryError::Pinned(error)
+                } else {
+                    ModernDiscoveryError::Fallback(error)
+                }
+            })?;
+
+        // A successful `server/discover` response pins the server to the
+        // modern era. Any malformed or incompatible result must surface as a
+        // protocol error rather than being retried as legacy initialization.
+        *self.protocol_mode.write().await = ProtocolMode::Modern {
+            version: LATEST_PROTOCOL_VERSION.to_string(),
+        };
 
         let result: McpDiscoverResult = serde_json::from_value(
             response
                 .result
-                .ok_or_else(|| McpError::Protocol("Missing discovery result".to_string()))?,
-        )?;
+                .ok_or_else(|| McpError::Protocol("Missing discovery result".to_string()))
+                .map_err(ModernDiscoveryError::Pinned)?,
+        )
+        .map_err(McpError::from)
+        .map_err(ModernDiscoveryError::Pinned)?;
 
-        Self::validate_modern_discovery(&result)?;
+        Self::validate_modern_discovery(&result).map_err(ModernDiscoveryError::Pinned)?;
 
         let server_info = result.server_info().unwrap_or_else(|| Implementation {
             name: "unnamed-mcp-server".to_string(),
@@ -535,16 +750,12 @@ impl McpProtocolClient {
             server_info,
             instructions: result.instructions,
         };
-        *self.protocol_mode.write().await = ProtocolMode::Modern {
-            version: LATEST_PROTOCOL_VERSION.to_string(),
-        };
+        self.modern_tool_list_changes
+            .store(supports_tool_list_changes, Ordering::SeqCst);
         if supports_tool_list_changes {
-            if let Err(error) = self.start_tool_change_subscription().await {
-                warn!(
-                    "MCP server advertised tool-list changes but Bamboo could not open subscriptions/listen: {}",
-                    error
-                );
-            }
+            self.start_tool_change_subscription(timeout_ms)
+                .await
+                .map_err(ModernDiscoveryError::Pinned)?;
         }
         Ok(normalized)
     }
@@ -566,10 +777,18 @@ impl McpProtocolClient {
         Ok(())
     }
 
-    async fn start_tool_change_subscription(&self) -> Result<()> {
-        let mut subscription_id = self.tool_subscription_id.lock().await;
-        if subscription_id.is_some() {
-            return Ok(());
+    async fn start_tool_change_subscription(&self, timeout_ms: u64) -> Result<()> {
+        {
+            let subscription = self.tool_subscription.lock().await;
+            if subscription.id.is_some() {
+                return if subscription.acknowledged {
+                    Ok(())
+                } else {
+                    Err(McpError::Protocol(
+                        "MCP tool-change subscription acknowledgment is still pending".to_string(),
+                    ))
+                };
+            }
         }
 
         let version = match self.protocol_mode.read().await.clone() {
@@ -581,6 +800,13 @@ impl McpProtocolClient {
             }
         };
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let (ack_tx, ack_rx) = oneshot::channel();
+        {
+            let mut subscription = self.tool_subscription.lock().await;
+            subscription.id = Some(id);
+            subscription.acknowledged = false;
+            subscription.ack_sender = Some(ack_tx);
+        }
         let params = Self::with_modern_request_metadata(
             Some(serde_json::json!({
                 "notifications": {
@@ -601,29 +827,60 @@ impl McpProtocolClient {
             .await
             .insert(id, PendingRequest { sender: tx });
 
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
         let transport = self.transport.read().await;
-        let send_result = transport
-            .send_with_metadata(
+        let send_result = tokio::time::timeout_at(
+            deadline,
+            transport.send_with_metadata(
                 request_json,
                 McpTransportMetadata {
+                    request_id: Some(id),
                     protocol_version: Some(version),
                     modern: true,
                     method: "subscriptions/listen".to_string(),
                     name: None,
                     tool_parameter_headers: Vec::new(),
                 },
-            )
-            .await;
+            ),
+        )
+        .await;
         drop(transport);
-        if let Err(error) = send_result {
-            self.pending_requests.write().await.remove(&id);
-            return Err(error);
+        match send_result {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                self.pending_requests.write().await.remove(&id);
+                let mut subscription = self.tool_subscription.lock().await;
+                if subscription.id == Some(id) {
+                    *subscription = ToolSubscriptionState::default();
+                }
+                return Err(error);
+            }
+            Err(_) => {
+                let error = McpError::Timeout(format!(
+                    "MCP subscriptions/listen send timed out after {timeout_ms}ms"
+                ));
+                self.cancel_tool_subscription(id, "Subscription send timed out")
+                    .await;
+                return Err(error);
+            }
         }
 
-        // A graceful server-side close eventually resolves this request. It is
-        // not an operation result the manager needs to await.
+        // A graceful server-side close eventually resolves this request.
+        // Clear the active state so the next health probe can reopen it.
+        let subscription = self.tool_subscription.clone();
         tokio::spawn(async move {
-            match rx.await {
+            let result = rx.await;
+            let mut state = subscription.lock().await;
+            if state.id == Some(id) {
+                if let Some(sender) = state.ack_sender.take() {
+                    let _ = sender.send(Err(McpError::Protocol(
+                        "MCP subscriptions/listen ended before acknowledgment".to_string(),
+                    )));
+                }
+                *state = ToolSubscriptionState::default();
+            }
+            drop(state);
+            match result {
                 Ok(Ok(response)) if response.error.is_some() => {
                     warn!(
                         "MCP subscriptions/listen closed with an error: {:?}",
@@ -636,8 +893,47 @@ impl McpProtocolClient {
                 _ => {}
             }
         });
-        *subscription_id = Some(id);
-        Ok(())
+
+        let acknowledgment = tokio::time::timeout_at(deadline, ack_rx).await;
+        let error = match acknowledgment {
+            Ok(Ok(Ok(()))) => {
+                let subscription = self.tool_subscription.lock().await;
+                if subscription.id == Some(id) && subscription.acknowledged {
+                    return Ok(());
+                }
+                McpError::Protocol(
+                    "MCP subscriptions/listen closed during acknowledgment".to_string(),
+                )
+            }
+            Ok(Ok(Err(error))) => error,
+            Ok(Err(_)) => McpError::Disconnected,
+            Err(_) => McpError::Timeout(format!(
+                "MCP subscriptions/listen acknowledgment timed out after {timeout_ms}ms"
+            )),
+        };
+        self.cancel_tool_subscription(id, "Subscription acknowledgment failed")
+            .await;
+        Err(error)
+    }
+
+    async fn cancel_tool_subscription(&self, id: u64, reason: &str) {
+        self.pending_requests.write().await.remove(&id);
+        let mut subscription = self.tool_subscription.lock().await;
+        if subscription.id == Some(id) {
+            if let Some(sender) = subscription.ack_sender.take() {
+                let _ = sender.send(Err(McpError::Protocol(reason.to_string())));
+            }
+            *subscription = ToolSubscriptionState::default();
+        }
+        drop(subscription);
+
+        let transport = self.transport.read().await;
+        if let Err(error) = transport.cancel_request(id, reason).await {
+            warn!(
+                "Failed to cancel MCP subscriptions/listen (id={}): {}",
+                id, error
+            );
+        }
     }
 
     async fn initialize_legacy(&self, timeout_ms: u64) -> Result<McpInitializeResult> {
@@ -682,6 +978,7 @@ impl McpProtocolClient {
             .send_with_metadata(
                 serde_json::to_string(&initialized)?,
                 McpTransportMetadata {
+                    request_id: None,
                     protocol_version: Some(result.protocol_version.clone()),
                     modern: false,
                     method: initialized.method.clone(),
@@ -695,6 +992,7 @@ impl McpProtocolClient {
         *self.protocol_mode.write().await = ProtocolMode::Legacy {
             version: result.protocol_version.clone(),
         };
+        self.modern_tool_list_changes.store(false, Ordering::SeqCst);
 
         Ok(result)
     }
@@ -767,6 +1065,16 @@ impl McpProtocolClient {
         let mut tools = Vec::with_capacity(tool_infos.len());
 
         for tool in tool_infos {
+            let output_schema = match tool.output_schema {
+                Some(schema) if modern && !schema.is_object() => {
+                    warn!(
+                        "Ignoring modern MCP tool '{}' because outputSchema must be a JSON Schema object",
+                        tool.name
+                    );
+                    continue;
+                }
+                schema => schema,
+            };
             let parameters = match tool.input_schema {
                 Some(parameters)
                     if !modern
@@ -804,6 +1112,7 @@ impl McpProtocolClient {
                 name: tool.name,
                 description: tool.description,
                 parameters,
+                output_schema,
             });
         }
         *self.tool_header_specs.write().await = header_specs;
@@ -859,6 +1168,7 @@ impl McpProtocolClient {
         Ok(McpCallResult {
             content: result.content,
             is_error: result.is_error,
+            structured_content: result.structured_content,
         })
     }
 
@@ -1079,6 +1389,16 @@ impl McpProtocolClient {
                     .ok_or_else(|| McpError::Protocol("Missing discovery result".to_string()))?,
             )?;
             Self::validate_modern_discovery(&result)?;
+            let supports_tool_list_changes = result
+                .capabilities
+                .tools
+                .as_ref()
+                .is_some_and(|tools| tools.list_changed);
+            self.modern_tool_list_changes
+                .store(supports_tool_list_changes, Ordering::SeqCst);
+            if supports_tool_list_changes {
+                self.start_tool_change_subscription(timeout_ms).await?;
+            }
         } else {
             self.send_request("ping", None, timeout_ms).await?;
         }
@@ -1285,6 +1605,21 @@ mod tests {
                 "cacheScope": "private"
             })
         }
+
+        fn subscription_ack(id: u64, tools_list_changed: bool) -> Option<Value> {
+            Some(serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": SUBSCRIPTION_ACK_METHOD,
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/subscriptionId": id
+                    },
+                    "notifications": {
+                        "toolsListChanged": tools_list_changed
+                    }
+                }
+            }))
+        }
     }
 
     #[async_trait]
@@ -1318,7 +1653,9 @@ mod tests {
                     McpError::Transport("script has no response for request".to_string())
                 })?;
                 if let Some(mut response) = response {
-                    response["id"] = id;
+                    if response.get("method").is_none() {
+                        response["id"] = id;
+                    }
                     self.response_tx
                         .send(response.to_string())
                         .await
@@ -1644,7 +1981,7 @@ mod tests {
     async fn modern_tool_change_capability_opens_subscription_stream() {
         let (transport, captured) = ScriptedTransport::new(vec![
             ScriptedTransport::success(ScriptedTransport::discover_result(true)),
-            None,
+            ScriptedTransport::subscription_ack(2, true),
         ]);
         let mut client = McpProtocolClient::new(Box::new(transport));
         client.connect().await.expect("connect");
@@ -1661,12 +1998,158 @@ mod tests {
             captured[1].0["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"],
             LATEST_PROTOCOL_VERSION
         );
-        assert_eq!(*client.tool_subscription_id.lock().await, Some(2));
+        let subscription = client.tool_subscription.lock().await;
+        assert_eq!(subscription.id, Some(2));
+        assert!(subscription.acknowledged);
+        drop(subscription);
         assert!(client.pending_requests.read().await.contains_key(&2));
         drop(captured);
 
         client.disconnect().await.expect("disconnect");
         assert!(client.pending_requests.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn subscription_is_not_active_until_requested_filter_is_acknowledged() {
+        let (transport, captured) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(true)),
+            ScriptedTransport::subscription_ack(2, false),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let error = client
+            .initialize(1000)
+            .await
+            .expect_err("rejected subscription filter must fail initialization");
+        assert!(error.to_string().contains("toolsListChanged"));
+        assert!(client.tool_subscription.lock().await.id.is_none());
+        assert!(client.pending_requests.read().await.is_empty());
+
+        let captured = captured.lock().await;
+        assert_eq!(captured[0].0["method"], "server/discover");
+        assert_eq!(captured[1].0["method"], "subscriptions/listen");
+        assert_eq!(captured[2].0["method"], "notifications/cancelled");
+        assert_eq!(captured[2].0["params"]["requestId"], 2);
+    }
+
+    #[tokio::test]
+    async fn malformed_modern_discovery_never_downgrades_to_legacy() {
+        let (transport, captured) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "supportedVersions": [LATEST_PROTOCOL_VERSION],
+                "capabilities": {},
+                "ttlMs": 1000
+            })),
+            ScriptedTransport::success(serde_json::json!({
+                "protocolVersion": LATEST_LEGACY_PROTOCOL_VERSION,
+                "capabilities": {},
+                "serverInfo": {"name": "must-not-run", "version": "1"}
+            })),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let error = client
+            .initialize(1000)
+            .await
+            .expect_err("malformed modern result must surface");
+        assert!(error.to_string().contains("cacheScope"));
+        assert_eq!(
+            captured.lock().await.len(),
+            1,
+            "successful server/discover response must pin the modern era"
+        );
+        assert!(matches!(
+            &*client.protocol_mode.read().await,
+            ProtocolMode::Modern { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn modern_tool_change_notifications_require_acknowledged_matching_subscription() {
+        use std::collections::HashMap;
+
+        let pending: RwLock<HashMap<u64, PendingRequest>> = RwLock::new(HashMap::new());
+        let (notification_tx, mut notification_rx) = mpsc::channel(4);
+        let queue_full = AtomicBool::new(false);
+        let subscription = Mutex::new(ToolSubscriptionState {
+            id: Some(7),
+            acknowledged: true,
+            ack_sender: None,
+        });
+        let modern_tool_list_changes = AtomicBool::new(true);
+
+        let mismatched = r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed","params":{"_meta":{"io.modelcontextprotocol/subscriptionId":8}}}"#;
+        McpProtocolClient::handle_message(
+            mismatched,
+            &pending,
+            &notification_tx,
+            &queue_full,
+            &subscription,
+            &modern_tool_list_changes,
+        )
+        .await
+        .expect("ignore mismatched notification");
+        assert!(notification_rx.try_recv().is_err());
+
+        let matched = r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed","params":{"_meta":{"io.modelcontextprotocol/subscriptionId":7}}}"#;
+        McpProtocolClient::handle_message(
+            matched,
+            &pending,
+            &notification_tx,
+            &queue_full,
+            &subscription,
+            &modern_tool_list_changes,
+        )
+        .await
+        .expect("accept correlated notification");
+        assert_eq!(
+            notification_rx
+                .try_recv()
+                .expect("correlated notification")
+                .method,
+            "notifications/tools/list_changed"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_probe_reopens_a_closed_tool_change_subscription() {
+        let (transport, captured) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(true)),
+            ScriptedTransport::subscription_ack(2, true),
+            ScriptedTransport::success(ScriptedTransport::discover_result(true)),
+            ScriptedTransport::subscription_ack(4, true),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+        client.initialize(1000).await.expect("initial subscription");
+
+        let close = r#"{"jsonrpc":"2.0","id":2,"result":{"resultType":"complete","_meta":{"io.modelcontextprotocol/subscriptionId":2}}}"#;
+        McpProtocolClient::handle_message(
+            close,
+            &client.pending_requests,
+            &client.notification_tx,
+            &client.notification_queue_full,
+            &client.tool_subscription,
+            &client.modern_tool_list_changes,
+        )
+        .await
+        .expect("route graceful close");
+        tokio::task::yield_now().await;
+        assert!(client.tool_subscription.lock().await.id.is_none());
+
+        client.ping(1000).await.expect("health probe resubscribes");
+        let subscription = client.tool_subscription.lock().await;
+        assert_eq!(subscription.id, Some(4));
+        assert!(subscription.acknowledged);
+        drop(subscription);
+
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), 4);
+        assert_eq!(captured[2].0["method"], "server/discover");
+        assert_eq!(captured[3].0["method"], "subscriptions/listen");
     }
 
     #[tokio::test]
@@ -1797,6 +2280,74 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn modern_tool_output_schema_and_all_content_blocks_are_preserved() {
+        let (transport, _) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(false)),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "tools": [{
+                    "name": "report",
+                    "description": "Return a report",
+                    "inputSchema": {"type": "object"},
+                    "outputSchema": {
+                        "type": "object",
+                        "properties": {"count": {"type": "integer"}}
+                    }
+                }],
+                "ttlMs": 1000,
+                "cacheScope": "private"
+            })),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "content": [
+                    {
+                        "type": "audio",
+                        "data": "UklGRg==",
+                        "mimeType": "audio/wav"
+                    },
+                    {
+                        "type": "resource_link",
+                        "uri": "file:///report.json",
+                        "name": "report",
+                        "mimeType": "application/json",
+                        "size": 42
+                    }
+                ],
+                "structuredContent": null
+            })),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+        client.initialize(1000).await.expect("modern discovery");
+
+        let tools = client.list_tools(1000).await.expect("tools/list");
+        assert_eq!(
+            tools[0].output_schema,
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {"count": {"type": "integer"}}
+            }))
+        );
+
+        let result = client
+            .call_tool("report", serde_json::json!({}), 1000)
+            .await
+            .expect("tools/call");
+        assert!(matches!(
+            result.content[0],
+            crate::types::McpContentItem::Audio { .. }
+        ));
+        assert!(matches!(
+            result.content[1],
+            crate::types::McpContentItem::ResourceLink { .. }
+        ));
+        assert_eq!(
+            result.structured_content,
+            crate::types::McpStructuredContent::Null
+        );
+    }
+
     #[test]
     fn invalid_tool_header_annotations_are_rejected() {
         let duplicate = serde_json::json!({
@@ -1849,8 +2400,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_request_timeout() {
-        let transport = Box::new(MockTransport::new()); // Won't respond
-        let client = McpProtocolClient::new(transport);
+        let transport = MockTransport::new(); // Won't respond
+        let messages = transport.messages_sent.clone();
+        let client = McpProtocolClient::new(Box::new(transport));
 
         let result = client.send_request("test", None, 100).await;
         assert!(result.is_err());
@@ -1858,6 +2410,11 @@ mod tests {
             McpError::Timeout(_) => {}
             _ => panic!("Expected Timeout error"),
         }
+        let sent = messages.read().await;
+        assert_eq!(sent.len(), 2, "request plus cancellation notification");
+        let cancellation: Value = serde_json::from_str(&sent[1]).expect("cancellation JSON");
+        assert_eq!(cancellation["method"], "notifications/cancelled");
+        assert_eq!(cancellation["params"]["requestId"], 1);
     }
 
     #[tokio::test]
@@ -1921,6 +2478,8 @@ mod tests {
             .expect("first notification fills the cap-1 queue");
 
         let queue_full = AtomicBool::new(false);
+        let subscription = Mutex::new(ToolSubscriptionState::default());
+        let modern_tool_list_changes = AtomicBool::new(false);
 
         // A pending request awaiting its JSON-RPC response.
         let pending: RwLock<HashMap<u64, PendingRequest>> = RwLock::new(HashMap::new());
@@ -1936,7 +2495,14 @@ mod tests {
         let notif_json = r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{}}"#;
         tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            McpProtocolClient::handle_message(notif_json, &pending, &notif_tx, &queue_full),
+            McpProtocolClient::handle_message(
+                notif_json,
+                &pending,
+                &notif_tx,
+                &queue_full,
+                &subscription,
+                &modern_tool_list_changes,
+            ),
         )
         .await
         .expect("handle_message must not block on a full notification queue")
@@ -1952,9 +2518,16 @@ mod tests {
         // 2) A JSON-RPC response must still be dispatched to its pending request,
         //    even though the notification queue is saturated.
         let resp_json = r#"{"jsonrpc":"2.0","id":7,"result":{"ok":true}}"#;
-        McpProtocolClient::handle_message(resp_json, &pending, &notif_tx, &queue_full)
-            .await
-            .expect("handle_message returns Ok");
+        McpProtocolClient::handle_message(
+            resp_json,
+            &pending,
+            &notif_tx,
+            &queue_full,
+            &subscription,
+            &modern_tool_list_changes,
+        )
+        .await
+        .expect("handle_message returns Ok");
         let delivered = tokio::time::timeout(std::time::Duration::from_secs(2), resp_rx)
             .await
             .expect("response must be delivered despite a full notification queue");
@@ -2021,13 +2594,22 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<JsonRpcNotification>(NOTIFICATION_CHANNEL_CAPACITY);
         let pending: RwLock<HashMap<u64, PendingRequest>> = RwLock::new(HashMap::new());
         let queue_full = AtomicBool::new(false);
+        let subscription = Mutex::new(ToolSubscriptionState::default());
+        let modern_tool_list_changes = AtomicBool::new(false);
 
         // Fill exactly to capacity via the production send path — all accepted.
         for i in 0..NOTIFICATION_CHANNEL_CAPACITY {
             let json = format!(r#"{{"jsonrpc":"2.0","method":"notifications/message/{i}"}}"#);
-            McpProtocolClient::handle_message(&json, &pending, &tx, &queue_full)
-                .await
-                .expect("handle_message returns Ok");
+            McpProtocolClient::handle_message(
+                &json,
+                &pending,
+                &tx,
+                &queue_full,
+                &subscription,
+                &modern_tool_list_changes,
+            )
+            .await
+            .expect("handle_message returns Ok");
         }
         assert!(
             !queue_full.load(Ordering::Relaxed),
@@ -2040,7 +2622,14 @@ mod tests {
             let json = format!(r#"{{"jsonrpc":"2.0","method":"notifications/overflow/{i}"}}"#);
             tokio::time::timeout(
                 std::time::Duration::from_millis(500),
-                McpProtocolClient::handle_message(&json, &pending, &tx, &queue_full),
+                McpProtocolClient::handle_message(
+                    &json,
+                    &pending,
+                    &tx,
+                    &queue_full,
+                    &subscription,
+                    &modern_tool_list_changes,
+                ),
             )
             .await
             .expect("over-capacity send must not block")

--- a/crates/infra/bamboo-mcp/src/protocol/client.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/client.rs
@@ -28,6 +28,9 @@ const NOTIFICATION_CHANNEL_CAPACITY: usize = 100;
 /// ignores pre-initialize requests does not consume the full operation timeout
 /// (60 seconds by default) before Bamboo falls back to `initialize`.
 const MODERN_DISCOVERY_PROBE_TIMEOUT_MS: u64 = 5_000;
+/// Cancellation is best-effort and must never turn an already-expired request
+/// into another unbounded wait (for example, on a stalled stdio writer).
+const CANCELLATION_ATTEMPT_TIMEOUT_MS: u64 = 250;
 const SUBSCRIPTION_ACK_METHOD: &str = "notifications/subscriptions/acknowledged";
 const SUBSCRIPTION_ID_META_KEY: &str = "io.modelcontextprotocol/subscriptionId";
 
@@ -47,6 +50,14 @@ pub struct McpTransportMetadata {
     /// Raw `x-mcp-header` name/value pairs. The HTTP transport performs the
     /// required safe header-value encoding.
     pub tool_parameter_headers: Vec<(String, String)>,
+}
+
+/// Protocol-era context needed to choose the transport-specific cancellation
+/// mechanism without consulting mutable post-negotiation client state.
+#[derive(Debug, Clone, Default)]
+pub struct McpCancellationMetadata {
+    pub protocol_version: Option<String>,
+    pub modern: bool,
 }
 
 /// Transport trait for MCP communication
@@ -72,7 +83,12 @@ pub trait McpTransport: Send + Sync {
     ///
     /// stdio cancellation is a JSON-RPC notification. Streamable HTTP
     /// overrides this hook and closes the request's response stream instead.
-    async fn cancel_request(&self, request_id: u64, reason: &str) -> Result<()> {
+    async fn cancel_request(
+        &self,
+        request_id: u64,
+        reason: &str,
+        _metadata: McpCancellationMetadata,
+    ) -> Result<()> {
         let notification = JsonRpcNotification {
             jsonrpc: "2.0".to_string(),
             method: "notifications/cancelled".to_string(),
@@ -86,6 +102,13 @@ pub trait McpTransport: Send + Sync {
 
     /// Whether this transport can speak the stateless MCP 2026-07-28 protocol.
     fn supports_modern_protocol(&self) -> bool {
+        true
+    }
+
+    /// Whether an unrecognized modern discovery error proves that this server
+    /// is legacy. stdio falls back on any unrecognized error. Streamable HTTP
+    /// overrides this and permits fallback only for an explicit 4xx response.
+    fn is_legacy_fallback_error(&self, _error: &McpError) -> bool {
         true
     }
 
@@ -189,6 +212,7 @@ pub struct McpProtocolClient {
     notification_queue_full: Arc<AtomicBool>,
     protocol_mode: RwLock<ProtocolMode>,
     tool_header_specs: RwLock<HashMap<String, Vec<ToolHeaderSpec>>>,
+    tool_output_validators: RwLock<HashMap<String, Arc<jsonschema::Validator>>>,
     /// Long-lived `subscriptions/listen` request used by modern servers to
     /// deliver `notifications/tools/list_changed`.
     tool_subscription: Arc<Mutex<ToolSubscriptionState>>,
@@ -210,6 +234,7 @@ impl McpProtocolClient {
             notification_queue_full: Arc::new(AtomicBool::new(false)),
             protocol_mode: RwLock::new(ProtocolMode::Unnegotiated),
             tool_header_specs: RwLock::new(HashMap::new()),
+            tool_output_validators: RwLock::new(HashMap::new()),
             tool_subscription: Arc::new(Mutex::new(ToolSubscriptionState::default())),
             modern_tool_list_changes: Arc::new(AtomicBool::new(false)),
         }
@@ -526,6 +551,16 @@ impl McpProtocolClient {
         tool_parameter_headers: Vec<(String, String)>,
     ) -> Result<JsonRpcResponse> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let cancellation_metadata = match &protocol {
+            RequestProtocol::Modern { version } => McpCancellationMetadata {
+                protocol_version: Some(version.clone()),
+                modern: true,
+            },
+            RequestProtocol::Legacy { version } => McpCancellationMetadata {
+                protocol_version: version.clone(),
+                modern: false,
+            },
+        };
 
         let params = match &protocol {
             RequestProtocol::Modern { version } => {
@@ -549,10 +584,10 @@ impl McpProtocolClient {
             pending.insert(id, PendingRequest { sender: tx });
         }
 
-        let metadata = match protocol {
+        let metadata = match &protocol {
             RequestProtocol::Modern { version } => McpTransportMetadata {
                 request_id: Some(id),
-                protocol_version: Some(version),
+                protocol_version: Some(version.clone()),
                 modern: true,
                 method: method.to_string(),
                 name,
@@ -560,7 +595,7 @@ impl McpProtocolClient {
             },
             RequestProtocol::Legacy { version } => McpTransportMetadata {
                 request_id: Some(id),
-                protocol_version: version,
+                protocol_version: version.clone(),
                 modern: false,
                 method: method.to_string(),
                 name,
@@ -588,7 +623,13 @@ impl McpProtocolClient {
             }
             Err(_) => {
                 drop(transport);
-                self.cancel_timed_out_request(id, method, timeout_ms).await;
+                self.cancel_timed_out_request(
+                    id,
+                    method,
+                    timeout_ms,
+                    cancellation_metadata.clone(),
+                )
+                .await;
                 return Err(McpError::Timeout(format!(
                     "Request {id} timed out after {timeout_ms}ms"
                 )));
@@ -611,7 +652,8 @@ impl McpProtocolClient {
             Ok(Ok(Err(e))) => Err(e),
             Ok(Err(_)) => Err(McpError::Disconnected),
             Err(_) => {
-                self.cancel_timed_out_request(id, method, timeout_ms).await;
+                self.cancel_timed_out_request(id, method, timeout_ms, cancellation_metadata)
+                    .await;
                 Err(McpError::Timeout(format!(
                     "Request {id} timed out after {timeout_ms}ms"
                 )))
@@ -619,17 +661,43 @@ impl McpProtocolClient {
         }
     }
 
-    async fn cancel_timed_out_request(&self, id: u64, method: &str, timeout_ms: u64) {
+    async fn cancel_timed_out_request(
+        &self,
+        id: u64,
+        method: &str,
+        timeout_ms: u64,
+        metadata: McpCancellationMetadata,
+    ) {
         self.pending_requests.write().await.remove(&id);
         let reason = format!("Request timed out after {timeout_ms}ms");
-        let transport = self.transport.read().await;
-        if let Err(error) = transport.cancel_request(id, &reason).await {
-            warn!(
-                "MCP request cancellation failed after timeout (id={}, method={}): {}",
-                id, method, error
-            );
+        // Initialization-based protocol revisions explicitly forbid cancelling
+        // `initialize`. A timeout still removes the local pending request.
+        if method != "initialize" {
+            let attempt = async {
+                let transport = self.transport.read().await;
+                transport.cancel_request(id, &reason, metadata).await
+            };
+            match tokio::time::timeout(
+                tokio::time::Duration::from_millis(CANCELLATION_ATTEMPT_TIMEOUT_MS),
+                attempt,
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    warn!(
+                        "MCP request cancellation failed after timeout (id={}, method={}): {}",
+                        id, method, error
+                    );
+                }
+                Err(_) => {
+                    warn!(
+                        "MCP request cancellation attempt timed out (id={}, method={}, cancellation_timeout_ms={})",
+                        id, method, CANCELLATION_ATTEMPT_TIMEOUT_MS
+                    );
+                }
+            }
         }
-        drop(transport);
         warn!(
             "MCP JSON-RPC request timed out (id={}, method={}, timeout_ms={})",
             id, method, timeout_ms
@@ -698,7 +766,7 @@ impl McpProtocolClient {
         &self,
         timeout_ms: u64,
     ) -> std::result::Result<McpInitializeResult, ModernDiscoveryError> {
-        let response = self
+        let response = match self
             .send_request_using(
                 "server/discover",
                 Some(serde_json::json!({})),
@@ -709,13 +777,20 @@ impl McpProtocolClient {
                 Vec::new(),
             )
             .await
-            .map_err(|error| {
+        {
+            Ok(response) => response,
+            Err(error) => {
                 if Self::is_recognized_modern_error(&error) {
-                    ModernDiscoveryError::Pinned(error)
-                } else {
-                    ModernDiscoveryError::Fallback(error)
+                    return Err(ModernDiscoveryError::Pinned(error));
                 }
-            })?;
+                let may_fallback = self.transport.read().await.is_legacy_fallback_error(&error);
+                return Err(if may_fallback {
+                    ModernDiscoveryError::Fallback(error)
+                } else {
+                    ModernDiscoveryError::Pinned(error)
+                });
+            }
+        };
 
         // A successful `server/discover` response pins the server to the
         // modern era. Any malformed or incompatible result must surface as a
@@ -927,12 +1002,38 @@ impl McpProtocolClient {
         }
         drop(subscription);
 
-        let transport = self.transport.read().await;
-        if let Err(error) = transport.cancel_request(id, reason).await {
-            warn!(
-                "Failed to cancel MCP subscriptions/listen (id={}): {}",
-                id, error
-            );
+        let attempt = async {
+            let transport = self.transport.read().await;
+            transport
+                .cancel_request(
+                    id,
+                    reason,
+                    McpCancellationMetadata {
+                        protocol_version: Some(LATEST_PROTOCOL_VERSION.to_string()),
+                        modern: true,
+                    },
+                )
+                .await
+        };
+        match tokio::time::timeout(
+            tokio::time::Duration::from_millis(CANCELLATION_ATTEMPT_TIMEOUT_MS),
+            attempt,
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                warn!(
+                    "Failed to cancel MCP subscriptions/listen (id={}): {}",
+                    id, error
+                );
+            }
+            Err(_) => {
+                warn!(
+                    "MCP subscriptions/listen cancellation timed out (id={}, cancellation_timeout_ms={})",
+                    id, CANCELLATION_ATTEMPT_TIMEOUT_MS
+                );
+            }
         }
     }
 
@@ -1005,6 +1106,11 @@ impl McpProtocolClient {
                     | MISSING_REQUIRED_CLIENT_CAPABILITY_ERROR
                     | UNSUPPORTED_PROTOCOL_VERSION_ERROR,
                 ..
+            } | McpError::HttpProtocol {
+                code: HEADER_MISMATCH_ERROR
+                    | MISSING_REQUIRED_CLIENT_CAPABILITY_ERROR
+                    | UNSUPPORTED_PROTOCOL_VERSION_ERROR,
+                ..
             }
         )
     }
@@ -1062,6 +1168,7 @@ impl McpProtocolClient {
         }
 
         let mut header_specs = HashMap::new();
+        let mut output_validators = HashMap::new();
         let mut tools = Vec::with_capacity(tool_infos.len());
 
         for tool in tool_infos {
@@ -1074,6 +1181,19 @@ impl McpProtocolClient {
                     continue;
                 }
                 schema => schema,
+            };
+            let output_validator = match output_schema.as_ref() {
+                Some(schema) => match jsonschema::validator_for(schema) {
+                    Ok(validator) => Some(Arc::new(validator)),
+                    Err(error) => {
+                        warn!(
+                            "Ignoring MCP tool '{}' because outputSchema is invalid: {}",
+                            tool.name, error
+                        );
+                        continue;
+                    }
+                },
+                None => None,
             };
             let parameters = match tool.input_schema {
                 Some(parameters)
@@ -1108,6 +1228,9 @@ impl McpProtocolClient {
                     }
                 }
             }
+            if let Some(validator) = output_validator {
+                output_validators.insert(tool.name.clone(), validator);
+            }
             tools.push(McpTool {
                 name: tool.name,
                 description: tool.description,
@@ -1116,6 +1239,7 @@ impl McpProtocolClient {
             });
         }
         *self.tool_header_specs.write().await = header_specs;
+        *self.tool_output_validators.write().await = output_validators;
         Ok(tools)
     }
 
@@ -1164,6 +1288,21 @@ impl McpProtocolClient {
                 .ok_or_else(|| McpError::Protocol("Missing result".to_string()))?,
         )?;
         Self::ensure_complete_result(result.result_type.as_deref(), self.is_modern().await)?;
+        if let Some(validator) = self.tool_output_validators.read().await.get(name).cloned() {
+            match result.structured_content.to_json_value() {
+                Some(value) => validator.validate(&value).map_err(|error| {
+                    McpError::Protocol(format!(
+                        "MCP tool '{name}' structuredContent does not conform to outputSchema: {error}"
+                    ))
+                })?,
+                None if !result.is_error => {
+                    return Err(McpError::Protocol(format!(
+                        "MCP tool '{name}' declared outputSchema but omitted structuredContent"
+                    )));
+                }
+                None => {}
+            }
+        }
 
         Ok(McpCallResult {
             content: result.content,
@@ -1536,8 +1675,10 @@ mod tests {
         message_rx: TokioMutex<Option<mpsc::Receiver<String>>>,
         response_tx: mpsc::Sender<String>,
         responses: TokioMutex<VecDeque<Option<Value>>>,
+        send_failures: TokioMutex<VecDeque<McpError>>,
         captured: CapturedMessages,
         supports_modern: bool,
+        http_fallback_rules: bool,
         requires_tool_parameter_headers: bool,
         legacy_version: &'static str,
     }
@@ -1552,8 +1693,10 @@ mod tests {
                     message_rx: TokioMutex::new(Some(message_rx)),
                     response_tx,
                     responses: TokioMutex::new(responses.into()),
+                    send_failures: TokioMutex::new(VecDeque::new()),
                     captured: captured.clone(),
                     supports_modern: true,
+                    http_fallback_rules: false,
                     requires_tool_parameter_headers: false,
                     legacy_version: LATEST_LEGACY_PROTOCOL_VERSION,
                 },
@@ -1563,6 +1706,16 @@ mod tests {
 
         fn with_tool_parameter_headers(mut self) -> Self {
             self.requires_tool_parameter_headers = true;
+            self
+        }
+
+        fn with_send_failures(self, failures: Vec<McpError>) -> Self {
+            *self.send_failures.try_lock().expect("uncontended failures") = failures.into();
+            self
+        }
+
+        fn with_http_fallback_rules(mut self) -> Self {
+            self.http_fallback_rules = true;
             self
         }
 
@@ -1649,6 +1802,9 @@ mod tests {
             self.captured.lock().await.push((request, metadata));
 
             if let Some(id) = id {
+                if let Some(error) = self.send_failures.lock().await.pop_front() {
+                    return Err(error);
+                }
                 let response = self.responses.lock().await.pop_front().ok_or_else(|| {
                     McpError::Transport("script has no response for request".to_string())
                 })?;
@@ -1669,6 +1825,20 @@ mod tests {
             self.supports_modern
         }
 
+        fn is_legacy_fallback_error(&self, error: &McpError) -> bool {
+            !self.http_fallback_rules
+                || matches!(
+                    error,
+                    McpError::HttpStatus {
+                        status: 400..=499,
+                        ..
+                    } | McpError::HttpProtocol {
+                        status: 400..=499,
+                        ..
+                    }
+                )
+        }
+
         fn latest_legacy_protocol_version(&self) -> &'static str {
             self.legacy_version
         }
@@ -1683,6 +1853,50 @@ mod tests {
 
         async fn receive(&self) -> Result<Option<String>> {
             Err(McpError::Disconnected)
+        }
+
+        fn is_connected(&self) -> bool {
+            self.connected
+        }
+    }
+
+    struct HangingCancellationTransport {
+        connected: bool,
+        cancellation_started: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl McpTransport for HangingCancellationTransport {
+        async fn connect(&mut self) -> Result<()> {
+            self.connected = true;
+            Ok(())
+        }
+
+        async fn disconnect(&mut self) -> Result<()> {
+            self.connected = false;
+            Ok(())
+        }
+
+        async fn send(&self, _message: String) -> Result<()> {
+            Ok(())
+        }
+
+        async fn cancel_request(
+            &self,
+            _request_id: u64,
+            _reason: &str,
+            _metadata: McpCancellationMetadata,
+        ) -> Result<()> {
+            self.cancellation_started.store(true, Ordering::SeqCst);
+            std::future::pending::<Result<()>>().await
+        }
+
+        async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
+            None
+        }
+
+        async fn receive(&self) -> Result<Option<String>> {
+            Ok(None)
         }
 
         fn is_connected(&self) -> bool {
@@ -1952,6 +2166,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn http_4xx_without_modern_error_falls_back_to_legacy_initialization() {
+        let (transport, captured) =
+            ScriptedTransport::new(vec![ScriptedTransport::success(serde_json::json!({
+                "protocolVersion": LATEST_LEGACY_PROTOCOL_VERSION,
+                "capabilities": {},
+                "serverInfo": {
+                    "name": "legacy-http-server",
+                    "version": "1.0.0"
+                }
+            }))]);
+        let transport = transport
+            .with_http_fallback_rules()
+            .with_send_failures(vec![McpError::HttpProtocol {
+                status: 400,
+                code: -32601,
+                message: "Method not found".to_string(),
+                data: None,
+            }]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let initialized = client.initialize(1000).await.expect("legacy fallback");
+        assert_eq!(initialized.protocol_version, LATEST_LEGACY_PROTOCOL_VERSION);
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), 3);
+        assert_eq!(captured[0].0["method"], "server/discover");
+        assert_eq!(captured[1].0["method"], "initialize");
+        assert_eq!(captured[2].0["method"], "notifications/initialized");
+    }
+
+    #[tokio::test]
+    async fn http_timeout_network_and_5xx_never_fall_back_to_initialize() {
+        let failures = [
+            McpError::Timeout("probe timeout".to_string()),
+            McpError::Transport("connection reset".to_string()),
+            McpError::HttpProtocol {
+                status: 503,
+                code: -32603,
+                message: "temporary outage".to_string(),
+                data: None,
+            },
+        ];
+
+        for failure in failures {
+            let (transport, captured) =
+                ScriptedTransport::new(vec![ScriptedTransport::success(serde_json::json!({
+                    "protocolVersion": LATEST_LEGACY_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "serverInfo": {"name": "must-not-run", "version": "1"}
+                }))]);
+            let transport = transport
+                .with_http_fallback_rules()
+                .with_send_failures(vec![failure]);
+            let mut client = McpProtocolClient::new(Box::new(transport));
+            client.connect().await.expect("connect");
+
+            client
+                .initialize(1000)
+                .await
+                .expect_err("HTTP transport failure must pin the probe error");
+            let captured = captured.lock().await;
+            assert_eq!(
+                captured.len(),
+                1,
+                "HTTP failure must not send legacy initialize"
+            );
+            assert_eq!(captured[0].0["method"], "server/discover");
+        }
+    }
+
+    #[tokio::test]
+    async fn stdio_style_timeout_remains_a_legacy_fallback_signal() {
+        let (transport, captured) =
+            ScriptedTransport::new(vec![ScriptedTransport::success(serde_json::json!({
+                "protocolVersion": LATEST_LEGACY_PROTOCOL_VERSION,
+                "capabilities": {},
+                "serverInfo": {"name": "legacy-stdio", "version": "1"}
+            }))]);
+        let transport =
+            transport.with_send_failures(vec![McpError::Timeout("silent probe".to_string())]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        client.initialize(1000).await.expect("stdio fallback");
+        let captured = captured.lock().await;
+        assert_eq!(captured[0].0["method"], "server/discover");
+        assert_eq!(captured[1].0["method"], "initialize");
+    }
+
+    #[tokio::test]
     async fn recognized_modern_error_never_falls_back_to_initialize() {
         let (transport, captured) = ScriptedTransport::new(vec![ScriptedTransport::error(
             UNSUPPORTED_PROTOCOL_VERSION_ERROR,
@@ -1970,6 +2274,34 @@ mod tests {
         assert!(matches!(
             error,
             McpError::RemoteProtocol {
+                code: UNSUPPORTED_PROTOCOL_VERSION_ERROR,
+                ..
+            }
+        ));
+        assert_eq!(captured.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn recognized_modern_http_error_never_falls_back_to_initialize() {
+        let (transport, captured) = ScriptedTransport::new(Vec::new());
+        let transport = transport
+            .with_http_fallback_rules()
+            .with_send_failures(vec![McpError::HttpProtocol {
+                status: 400,
+                code: UNSUPPORTED_PROTOCOL_VERSION_ERROR,
+                message: "Unsupported protocol version".to_string(),
+                data: Some(serde_json::json!({"supported": ["2099-01-01"]})),
+            }]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let error = client
+            .initialize(1000)
+            .await
+            .expect_err("recognized modern HTTP error must surface");
+        assert!(matches!(
+            error,
+            McpError::HttpProtocol {
                 code: UNSUPPORTED_PROTOCOL_VERSION_ERROR,
                 ..
             }
@@ -2291,8 +2623,11 @@ mod tests {
                     "description": "Return a report",
                     "inputSchema": {"type": "object"},
                     "outputSchema": {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
                         "type": "object",
-                        "properties": {"count": {"type": "integer"}}
+                        "properties": {"count": {"type": "integer"}},
+                        "required": ["count"],
+                        "additionalProperties": false
                     }
                 }],
                 "ttlMs": 1000,
@@ -2304,17 +2639,30 @@ mod tests {
                     {
                         "type": "audio",
                         "data": "UklGRg==",
-                        "mimeType": "audio/wav"
+                        "mimeType": "audio/wav",
+                        "annotations": {"audience": ["assistant"], "priority": 0.8},
+                        "_meta": {"example.com/trace": "trace-1"}
                     },
                     {
                         "type": "resource_link",
                         "uri": "file:///report.json",
                         "name": "report",
                         "mimeType": "application/json",
-                        "size": 42
+                        "size": 42,
+                        "icons": [{"src": "data:image/png;base64,AA=="}],
+                        "_meta": {"example.com/link": true}
+                    },
+                    {
+                        "type": "resource",
+                        "resource": {
+                            "uri": "file:///report.bin",
+                            "blob": "AAEC",
+                            "_meta": {"example.com/checksum": "abc"}
+                        },
+                        "annotations": {"audience": ["user"]}
                     }
                 ],
-                "structuredContent": null
+                "structuredContent": {"count": 42}
             })),
         ]);
         let mut client = McpProtocolClient::new(Box::new(transport));
@@ -2325,8 +2673,11 @@ mod tests {
         assert_eq!(
             tools[0].output_schema,
             Some(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
-                "properties": {"count": {"type": "integer"}}
+                "properties": {"count": {"type": "integer"}},
+                "required": ["count"],
+                "additionalProperties": false
             }))
         );
 
@@ -2342,10 +2693,99 @@ mod tests {
             result.content[1],
             crate::types::McpContentItem::ResourceLink { .. }
         ));
+        assert!(matches!(
+            result.content[2],
+            crate::types::McpContentItem::Resource { .. }
+        ));
+        let serialized_content =
+            serde_json::to_value(&result.content).expect("serialize preserved content");
+        assert_eq!(
+            serialized_content[0]["_meta"]["example.com/trace"],
+            "trace-1"
+        );
+        assert_eq!(
+            serialized_content[1]["icons"][0]["src"],
+            "data:image/png;base64,AA=="
+        );
+        assert_eq!(
+            serialized_content[2]["resource"]["_meta"]["example.com/checksum"],
+            "abc"
+        );
         assert_eq!(
             result.structured_content,
-            crate::types::McpStructuredContent::Null
+            crate::types::McpStructuredContent::Value(serde_json::json!({"count": 42}))
         );
+    }
+
+    #[tokio::test]
+    async fn tool_structured_content_is_validated_before_returning_to_executor() {
+        let (transport, _) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(false)),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "tools": [{
+                    "name": "numbers",
+                    "description": "Return integers",
+                    "inputSchema": {"type": "object"},
+                    "outputSchema": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "type": "array",
+                        "items": {"type": "integer"}
+                    }
+                }],
+                "ttlMs": 1000,
+                "cacheScope": "private"
+            })),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "content": [{"type": "text", "text": "[1, \"invalid\"]"}],
+                "structuredContent": [1, "invalid"]
+            })),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+        client.initialize(1000).await.expect("modern discovery");
+        client.list_tools(1000).await.expect("tools/list");
+
+        let error = client
+            .call_tool("numbers", serde_json::json!({}), 1000)
+            .await
+            .expect_err("invalid structured content must not reach the executor");
+        let message = error.to_string();
+        assert!(message.contains("structuredContent"));
+        assert!(message.contains("outputSchema"));
+    }
+
+    #[tokio::test]
+    async fn successful_tool_with_output_schema_must_return_structured_content() {
+        let (transport, _) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(false)),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "tools": [{
+                    "name": "report",
+                    "description": "Return a report",
+                    "inputSchema": {"type": "object"},
+                    "outputSchema": {"type": "object"}
+                }],
+                "ttlMs": 1000,
+                "cacheScope": "private"
+            })),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "content": [{"type": "text", "text": "missing structured result"}]
+            })),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+        client.initialize(1000).await.expect("modern discovery");
+        client.list_tools(1000).await.expect("tools/list");
+
+        let error = client
+            .call_tool("report", serde_json::json!({}), 1000)
+            .await
+            .expect_err("missing structured content must fail");
+        assert!(error.to_string().contains("omitted structuredContent"));
     }
 
     #[test]
@@ -2415,6 +2855,42 @@ mod tests {
         let cancellation: Value = serde_json::from_str(&sent[1]).expect("cancellation JSON");
         assert_eq!(cancellation["method"], "notifications/cancelled");
         assert_eq!(cancellation["params"]["requestId"], 1);
+    }
+
+    #[tokio::test]
+    async fn legacy_initialize_timeout_is_never_cancelled() {
+        let (mut transport, captured) = ScriptedTransport::new(vec![None]);
+        transport.supports_modern = false;
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let error = client
+            .initialize(20)
+            .await
+            .expect_err("silent initialize must time out");
+        assert!(matches!(error, McpError::Timeout(_)));
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), 1, "initialize must not be cancelled");
+        assert_eq!(captured[0].0["method"], "initialize");
+    }
+
+    #[tokio::test]
+    async fn timed_out_request_does_not_wait_forever_for_cancellation() {
+        let cancellation_started = Arc::new(AtomicBool::new(false));
+        let transport = HangingCancellationTransport {
+            connected: true,
+            cancellation_started: cancellation_started.clone(),
+        };
+        let client = McpProtocolClient::new(Box::new(transport));
+
+        let result = tokio::time::timeout(
+            tokio::time::Duration::from_secs(1),
+            client.send_request("tools/call", None, 10),
+        )
+        .await
+        .expect("bounded cancellation must return");
+        assert!(matches!(result, Err(McpError::Timeout(_))));
+        assert!(cancellation_started.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-mcp/src/protocol/client.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/client.rs
@@ -1,9 +1,10 @@
 use async_trait::async_trait;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 use crate::error::{McpError, Result};
 use crate::protocol::models::*;
@@ -23,12 +24,59 @@ use crate::types::{McpCallResult, McpTool};
 /// the normal path. #366.
 const NOTIFICATION_CHANNEL_CAPACITY: usize = 100;
 
+/// Bound the dual-era discovery probe so a legacy stdio server that silently
+/// ignores pre-initialize requests does not consume the full operation timeout
+/// (60 seconds by default) before Bamboo falls back to `initialize`.
+const MODERN_DISCOVERY_PROBE_TIMEOUT_MS: u64 = 5_000;
+
+/// HTTP-envelope metadata derived from an MCP request.
+///
+/// Non-HTTP transports ignore this value. Streamable HTTP uses it to mirror
+/// the modern protocol's body metadata into mandatory request headers.
+#[derive(Debug, Clone, Default)]
+pub struct McpTransportMetadata {
+    pub protocol_version: Option<String>,
+    pub modern: bool,
+    pub method: String,
+    pub name: Option<String>,
+    /// Raw `x-mcp-header` name/value pairs. The HTTP transport performs the
+    /// required safe header-value encoding.
+    pub tool_parameter_headers: Vec<(String, String)>,
+}
+
 /// Transport trait for MCP communication
 #[async_trait]
 pub trait McpTransport: Send + Sync {
     async fn connect(&mut self) -> Result<()>;
     async fn disconnect(&mut self) -> Result<()>;
     async fn send(&self, message: String) -> Result<()>;
+
+    /// Send a message with protocol-derived envelope metadata.
+    ///
+    /// stdio and deprecated HTTP+SSE do not need the modern HTTP envelope, so
+    /// their default implementation delegates to [`send`](Self::send).
+    async fn send_with_metadata(
+        &self,
+        message: String,
+        _metadata: McpTransportMetadata,
+    ) -> Result<()> {
+        self.send(message).await
+    }
+
+    /// Whether this transport can speak the stateless MCP 2026-07-28 protocol.
+    fn supports_modern_protocol(&self) -> bool {
+        true
+    }
+
+    /// Latest initialization-based protocol revision appropriate for fallback.
+    fn latest_legacy_protocol_version(&self) -> &'static str {
+        LATEST_LEGACY_PROTOCOL_VERSION
+    }
+
+    /// Whether tool `x-mcp-header` annotations must be validated and mirrored.
+    fn requires_tool_parameter_headers(&self) -> bool {
+        false
+    }
 
     /// Returns the inbound message channel receiver for efficient, non-polling
     /// consumption.
@@ -59,6 +107,33 @@ struct PendingRequest {
     sender: oneshot::Sender<Result<JsonRpcResponse>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ProtocolMode {
+    Unnegotiated,
+    Modern { version: String },
+    Legacy { version: String },
+}
+
+#[derive(Debug, Clone)]
+enum RequestProtocol {
+    Modern { version: String },
+    Legacy { version: Option<String> },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ToolHeaderValueType {
+    String,
+    Integer,
+    Boolean,
+}
+
+#[derive(Debug, Clone)]
+struct ToolHeaderSpec {
+    name: String,
+    path: Vec<String>,
+    value_type: ToolHeaderValueType,
+}
+
 /// MCP protocol client
 pub struct McpProtocolClient {
     transport: Arc<RwLock<Box<dyn McpTransport>>>,
@@ -77,6 +152,11 @@ pub struct McpProtocolClient {
     /// Gates the drop `warn!` to once per episode instead of once per dropped
     /// notification, so a chatty server can't produce continuous warn spam. #366.
     notification_queue_full: Arc<AtomicBool>,
+    protocol_mode: RwLock<ProtocolMode>,
+    tool_header_specs: RwLock<HashMap<String, Vec<ToolHeaderSpec>>>,
+    /// Long-lived `subscriptions/listen` request used by modern servers to
+    /// deliver `notifications/tools/list_changed`.
+    tool_subscription_id: Mutex<Option<u64>>,
 }
 
 impl McpProtocolClient {
@@ -90,6 +170,9 @@ impl McpProtocolClient {
             notification_tx,
             notification_rx: Mutex::new(Some(notification_rx)),
             notification_queue_full: Arc::new(AtomicBool::new(false)),
+            protocol_mode: RwLock::new(ProtocolMode::Unnegotiated),
+            tool_header_specs: RwLock::new(HashMap::new()),
+            tool_subscription_id: Mutex::new(None),
         }
     }
 
@@ -120,6 +203,9 @@ impl McpProtocolClient {
         if let Some(handler) = self.message_handler.take() {
             handler.abort();
         }
+
+        self.pending_requests.write().await.clear();
+        *self.tool_subscription_id.lock().await = None;
 
         let mut transport = self.transport.write().await;
         transport.disconnect().await
@@ -242,8 +328,47 @@ impl McpProtocolClient {
         params: Option<Value>,
         timeout_ms: u64,
     ) -> Result<JsonRpcResponse> {
+        self.send_request_with_tool_headers(method, params, timeout_ms, Vec::new())
+            .await
+    }
+
+    async fn send_request_with_tool_headers(
+        &self,
+        method: &str,
+        params: Option<Value>,
+        timeout_ms: u64,
+        tool_parameter_headers: Vec<(String, String)>,
+    ) -> Result<JsonRpcResponse> {
+        let protocol = match self.protocol_mode.read().await.clone() {
+            ProtocolMode::Modern { version } => RequestProtocol::Modern { version },
+            ProtocolMode::Legacy { version } => RequestProtocol::Legacy {
+                version: Some(version),
+            },
+            // Kept for low-level tests and diagnostics. Production requests
+            // negotiate before entering the operation phase.
+            ProtocolMode::Unnegotiated => RequestProtocol::Legacy { version: None },
+        };
+        self.send_request_using(method, params, timeout_ms, protocol, tool_parameter_headers)
+            .await
+    }
+
+    async fn send_request_using(
+        &self,
+        method: &str,
+        params: Option<Value>,
+        timeout_ms: u64,
+        protocol: RequestProtocol,
+        tool_parameter_headers: Vec<(String, String)>,
+    ) -> Result<JsonRpcResponse> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
 
+        let params = match &protocol {
+            RequestProtocol::Modern { version } => {
+                Some(Self::with_modern_request_metadata(params, version)?)
+            }
+            RequestProtocol::Legacy { .. } => params,
+        };
+        let name = Self::request_name(method, params.as_ref());
         let request = JsonRpcRequest::new(id, method, params);
         let request_json = serde_json::to_string(&request)?;
         trace!(
@@ -259,8 +384,25 @@ impl McpProtocolClient {
             pending.insert(id, PendingRequest { sender: tx });
         }
 
+        let metadata = match protocol {
+            RequestProtocol::Modern { version } => McpTransportMetadata {
+                protocol_version: Some(version),
+                modern: true,
+                method: method.to_string(),
+                name,
+                tool_parameter_headers,
+            },
+            RequestProtocol::Legacy { version } => McpTransportMetadata {
+                protocol_version: version,
+                modern: false,
+                method: method.to_string(),
+                name,
+                tool_parameter_headers: Vec::new(),
+            },
+        };
+
         let transport = self.transport.read().await;
-        if let Err(e) = transport.send(request_json).await {
+        if let Err(e) = transport.send_with_metadata(request_json, metadata).await {
             // Avoid leaking pending requests on send failure.
             self.pending_requests.write().await.remove(&id);
             warn!(
@@ -274,10 +416,11 @@ impl McpProtocolClient {
         match tokio::time::timeout(tokio::time::Duration::from_millis(timeout_ms), rx).await {
             Ok(Ok(Ok(response))) => {
                 if let Some(error) = response.error {
-                    Err(McpError::Protocol(format!(
-                        "{}: {}",
-                        error.code, error.message
-                    )))
+                    Err(McpError::RemoteProtocol {
+                        code: error.code,
+                        message: error.message,
+                        data: error.data,
+                    })
                 } else {
                     Ok(response)
                 }
@@ -298,12 +441,221 @@ impl McpProtocolClient {
         }
     }
 
+    fn with_modern_request_metadata(params: Option<Value>, version: &str) -> Result<Value> {
+        let mut params = params.unwrap_or_else(|| serde_json::json!({}));
+        let object = params.as_object_mut().ok_or_else(|| {
+            McpError::Protocol("MCP request params must be a JSON object".to_string())
+        })?;
+
+        let meta = object
+            .entry("_meta")
+            .or_insert_with(|| serde_json::json!({}));
+        let meta = meta.as_object_mut().ok_or_else(|| {
+            McpError::Protocol("MCP request _meta must be a JSON object".to_string())
+        })?;
+        meta.insert(
+            "io.modelcontextprotocol/protocolVersion".to_string(),
+            Value::String(version.to_string()),
+        );
+        meta.insert(
+            "io.modelcontextprotocol/clientInfo".to_string(),
+            serde_json::json!({
+                "name": "bamboo-agent",
+                "version": env!("CARGO_PKG_VERSION"),
+            }),
+        );
+        meta.insert(
+            "io.modelcontextprotocol/clientCapabilities".to_string(),
+            serde_json::to_value(ClientCapabilities::default())?,
+        );
+        Ok(params)
+    }
+
+    fn request_name(method: &str, params: Option<&Value>) -> Option<String> {
+        let key = match method {
+            "tools/call" | "prompts/get" => "name",
+            "resources/read" => "uri",
+            _ => return None,
+        };
+        params?.get(key)?.as_str().map(ToString::to_string)
+    }
+
     pub async fn initialize(&self, timeout_ms: u64) -> Result<McpInitializeResult> {
-        let request = McpInitializeRequest::default();
+        let supports_modern = self.transport.read().await.supports_modern_protocol();
+        if supports_modern {
+            let probe_timeout_ms = timeout_ms.min(MODERN_DISCOVERY_PROBE_TIMEOUT_MS);
+            match self.discover_modern(probe_timeout_ms).await {
+                Ok(result) => return Ok(result),
+                Err(error) if Self::is_recognized_modern_error(&error) => return Err(error),
+                Err(error) => {
+                    debug!(
+                        "MCP server did not complete modern discovery; falling back to legacy initialization: {}",
+                        error
+                    );
+                }
+            }
+        }
+
+        self.initialize_legacy(timeout_ms).await
+    }
+
+    async fn discover_modern(&self, timeout_ms: u64) -> Result<McpInitializeResult> {
+        let response = self
+            .send_request_using(
+                "server/discover",
+                Some(serde_json::json!({})),
+                timeout_ms,
+                RequestProtocol::Modern {
+                    version: LATEST_PROTOCOL_VERSION.to_string(),
+                },
+                Vec::new(),
+            )
+            .await?;
+
+        let result: McpDiscoverResult = serde_json::from_value(
+            response
+                .result
+                .ok_or_else(|| McpError::Protocol("Missing discovery result".to_string()))?,
+        )?;
+
+        Self::validate_modern_discovery(&result)?;
+
+        let server_info = result.server_info().unwrap_or_else(|| Implementation {
+            name: "unnamed-mcp-server".to_string(),
+            version: "unknown".to_string(),
+        });
+        let supports_tool_list_changes = result
+            .capabilities
+            .tools
+            .as_ref()
+            .is_some_and(|tools| tools.list_changed);
+        let normalized = McpInitializeResult {
+            protocol_version: LATEST_PROTOCOL_VERSION.to_string(),
+            capabilities: result.capabilities,
+            server_info,
+            instructions: result.instructions,
+        };
+        *self.protocol_mode.write().await = ProtocolMode::Modern {
+            version: LATEST_PROTOCOL_VERSION.to_string(),
+        };
+        if supports_tool_list_changes {
+            if let Err(error) = self.start_tool_change_subscription().await {
+                warn!(
+                    "MCP server advertised tool-list changes but Bamboo could not open subscriptions/listen: {}",
+                    error
+                );
+            }
+        }
+        Ok(normalized)
+    }
+
+    fn validate_modern_discovery(result: &McpDiscoverResult) -> Result<()> {
+        Self::ensure_complete_result(Some(&result.result_type), true)?;
+        Self::ensure_cacheable_result(Some(result.ttl_ms), Some(&result.cache_scope), true)?;
+        if !result
+            .supported_versions
+            .iter()
+            .any(|version| version == LATEST_PROTOCOL_VERSION)
+        {
+            return Err(McpError::Protocol(format!(
+                "MCP server does not advertise Bamboo's supported modern version {}; server supports [{}]",
+                LATEST_PROTOCOL_VERSION,
+                result.supported_versions.join(", ")
+            )));
+        }
+        Ok(())
+    }
+
+    async fn start_tool_change_subscription(&self) -> Result<()> {
+        let mut subscription_id = self.tool_subscription_id.lock().await;
+        if subscription_id.is_some() {
+            return Ok(());
+        }
+
+        let version = match self.protocol_mode.read().await.clone() {
+            ProtocolMode::Modern { version } => version,
+            _ => {
+                return Err(McpError::Protocol(
+                    "Tool-change subscriptions require modern MCP".to_string(),
+                ))
+            }
+        };
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let params = Self::with_modern_request_metadata(
+            Some(serde_json::json!({
+                "notifications": {
+                    "toolsListChanged": true
+                }
+            })),
+            &version,
+        )?;
+        let request = JsonRpcRequest::new(id, "subscriptions/listen", Some(params));
+        let request_json = serde_json::to_string(&request)?;
+
+        // The request intentionally remains in flight for the lifetime of the
+        // connection. Retain a pending entry so a graceful close is correlated
+        // instead of logged as an unmatched response.
+        let (tx, rx) = oneshot::channel();
+        self.pending_requests
+            .write()
+            .await
+            .insert(id, PendingRequest { sender: tx });
+
+        let transport = self.transport.read().await;
+        let send_result = transport
+            .send_with_metadata(
+                request_json,
+                McpTransportMetadata {
+                    protocol_version: Some(version),
+                    modern: true,
+                    method: "subscriptions/listen".to_string(),
+                    name: None,
+                    tool_parameter_headers: Vec::new(),
+                },
+            )
+            .await;
+        drop(transport);
+        if let Err(error) = send_result {
+            self.pending_requests.write().await.remove(&id);
+            return Err(error);
+        }
+
+        // A graceful server-side close eventually resolves this request. It is
+        // not an operation result the manager needs to await.
+        tokio::spawn(async move {
+            match rx.await {
+                Ok(Ok(response)) if response.error.is_some() => {
+                    warn!(
+                        "MCP subscriptions/listen closed with an error: {:?}",
+                        response.error
+                    );
+                }
+                Ok(Err(error)) => {
+                    debug!("MCP subscriptions/listen ended: {}", error);
+                }
+                _ => {}
+            }
+        });
+        *subscription_id = Some(id);
+        Ok(())
+    }
+
+    async fn initialize_legacy(&self, timeout_ms: u64) -> Result<McpInitializeResult> {
+        let preferred_version = self.transport.read().await.latest_legacy_protocol_version();
+        let request = McpInitializeRequest {
+            protocol_version: preferred_version.to_string(),
+            ..McpInitializeRequest::default()
+        };
         let params = serde_json::to_value(request)?;
 
         let response = self
-            .send_request("initialize", Some(params), timeout_ms)
+            .send_request_using(
+                "initialize",
+                Some(params),
+                timeout_ms,
+                RequestProtocol::Legacy { version: None },
+                Vec::new(),
+            )
             .await?;
 
         let result: McpInitializeResult = serde_json::from_value(
@@ -312,6 +664,13 @@ impl McpProtocolClient {
                 .ok_or_else(|| McpError::Protocol("Missing result".to_string()))?,
         )?;
 
+        if !Self::supports_legacy_version(&result.protocol_version) {
+            return Err(McpError::Protocol(format!(
+                "MCP server selected unsupported legacy protocol version '{}'",
+                result.protocol_version
+            )));
+        }
+
         // Send initialized notification
         let initialized = JsonRpcNotification {
             jsonrpc: "2.0".to_string(),
@@ -319,29 +678,136 @@ impl McpProtocolClient {
             params: None,
         };
         let transport = self.transport.read().await;
-        transport.send(serde_json::to_string(&initialized)?).await?;
+        transport
+            .send_with_metadata(
+                serde_json::to_string(&initialized)?,
+                McpTransportMetadata {
+                    protocol_version: Some(result.protocol_version.clone()),
+                    modern: false,
+                    method: initialized.method.clone(),
+                    name: None,
+                    tool_parameter_headers: Vec::new(),
+                },
+            )
+            .await?;
+        drop(transport);
+
+        *self.protocol_mode.write().await = ProtocolMode::Legacy {
+            version: result.protocol_version.clone(),
+        };
 
         Ok(result)
     }
 
+    fn is_recognized_modern_error(error: &McpError) -> bool {
+        matches!(
+            error,
+            McpError::RemoteProtocol {
+                code: HEADER_MISMATCH_ERROR
+                    | MISSING_REQUIRED_CLIENT_CAPABILITY_ERROR
+                    | UNSUPPORTED_PROTOCOL_VERSION_ERROR,
+                ..
+            }
+        )
+    }
+
+    fn supports_legacy_version(version: &str) -> bool {
+        matches!(
+            version,
+            "2025-11-25" | "2025-06-18" | "2025-03-26" | "2024-11-05"
+        )
+    }
+
+    async fn is_modern(&self) -> bool {
+        matches!(
+            &*self.protocol_mode.read().await,
+            ProtocolMode::Modern { .. }
+        )
+    }
+
     pub async fn list_tools(&self, timeout_ms: u64) -> Result<Vec<McpTool>> {
-        let response = self.send_request("tools/list", None, timeout_ms).await?;
+        let modern = self.is_modern().await;
+        let requires_parameter_headers = self
+            .transport
+            .read()
+            .await
+            .requires_tool_parameter_headers()
+            && modern;
+        let mut cursor = None;
+        let mut seen_cursors = std::collections::HashSet::new();
+        let mut tool_infos = Vec::new();
 
-        let result: McpToolListResult = serde_json::from_value(
-            response
-                .result
-                .ok_or_else(|| McpError::Protocol("Missing result".to_string()))?,
-        )?;
+        loop {
+            let params = cursor
+                .as_ref()
+                .map(|cursor| serde_json::json!({ "cursor": cursor }));
+            let response = self.send_request("tools/list", params, timeout_ms).await?;
+            let result: McpToolListResult = serde_json::from_value(
+                response
+                    .result
+                    .ok_or_else(|| McpError::Protocol("Missing result".to_string()))?,
+            )?;
 
-        Ok(result
-            .tools
-            .into_iter()
-            .map(|t| McpTool {
-                name: t.name,
-                description: t.description,
-                parameters: t.input_schema.unwrap_or_else(|| serde_json::json!({})),
-            })
-            .collect())
+            Self::ensure_complete_result(result.result_type.as_deref(), modern)?;
+            Self::ensure_cacheable_result(result.ttl_ms, result.cache_scope.as_deref(), modern)?;
+            tool_infos.extend(result.tools);
+
+            let Some(next_cursor) = result.next_cursor else {
+                break;
+            };
+            if !seen_cursors.insert(next_cursor.clone()) {
+                return Err(McpError::Protocol(format!(
+                    "MCP tools/list repeated pagination cursor '{next_cursor}'"
+                )));
+            }
+            cursor = Some(next_cursor);
+        }
+
+        let mut header_specs = HashMap::new();
+        let mut tools = Vec::with_capacity(tool_infos.len());
+
+        for tool in tool_infos {
+            let parameters = match tool.input_schema {
+                Some(parameters)
+                    if !modern
+                        || (parameters.is_object()
+                            && parameters.get("type").and_then(Value::as_str)
+                                == Some("object")) =>
+                {
+                    parameters
+                }
+                Some(_) | None if modern => {
+                    warn!(
+                        "Ignoring modern MCP tool '{}' because inputSchema must be an object schema with type 'object'",
+                        tool.name
+                    );
+                    continue;
+                }
+                None => serde_json::json!({}),
+                Some(parameters) => parameters,
+            };
+            if requires_parameter_headers {
+                match Self::tool_header_specs(&parameters) {
+                    Ok(specs) => {
+                        header_specs.insert(tool.name.clone(), specs);
+                    }
+                    Err(reason) => {
+                        warn!(
+                            "Ignoring MCP tool '{}' because its x-mcp-header schema is invalid: {}",
+                            tool.name, reason
+                        );
+                        continue;
+                    }
+                }
+            }
+            tools.push(McpTool {
+                name: tool.name,
+                description: tool.description,
+                parameters,
+            });
+        }
+        *self.tool_header_specs.write().await = header_specs;
+        Ok(tools)
     }
 
     pub async fn call_tool(
@@ -350,6 +816,24 @@ impl McpProtocolClient {
         arguments: Value,
         timeout_ms: u64,
     ) -> Result<McpCallResult> {
+        let modern = self.is_modern().await;
+        if modern && !arguments.is_object() {
+            return Err(McpError::Protocol(
+                "Modern MCP tool arguments must be a JSON object".to_string(),
+            ));
+        }
+        let tool_parameter_headers = if modern {
+            let specs = self
+                .tool_header_specs
+                .read()
+                .await
+                .get(name)
+                .cloned()
+                .unwrap_or_default();
+            Self::extract_tool_parameter_headers(&specs, &arguments)?
+        } else {
+            Vec::new()
+        };
         let request = McpToolCallRequest {
             name: name.to_string(),
             arguments: Some(arguments),
@@ -357,7 +841,12 @@ impl McpProtocolClient {
         let params = serde_json::to_value(request)?;
 
         let response = self
-            .send_request("tools/call", Some(params), timeout_ms)
+            .send_request_with_tool_headers(
+                "tools/call",
+                Some(params),
+                timeout_ms,
+                tool_parameter_headers,
+            )
             .await?;
 
         let result: McpToolCallResult = serde_json::from_value(
@@ -365,6 +854,7 @@ impl McpProtocolClient {
                 .result
                 .ok_or_else(|| McpError::Protocol("Missing result".to_string()))?,
         )?;
+        Self::ensure_complete_result(result.result_type.as_deref(), self.is_modern().await)?;
 
         Ok(McpCallResult {
             content: result.content,
@@ -372,8 +862,226 @@ impl McpProtocolClient {
         })
     }
 
+    fn ensure_complete_result(result_type: Option<&str>, modern: bool) -> Result<()> {
+        match result_type {
+            Some("complete") => Ok(()),
+            None if !modern => Ok(()),
+            None => Err(McpError::Protocol(
+                "Modern MCP result is missing required resultType".to_string(),
+            )),
+            Some("input_required") => Err(McpError::Protocol(
+                "MCP request requires client input that Bamboo did not advertise".to_string(),
+            )),
+            Some(other) => Err(McpError::Protocol(format!(
+                "Unsupported MCP resultType '{other}'"
+            ))),
+        }
+    }
+
+    fn ensure_cacheable_result(
+        ttl_ms: Option<u64>,
+        cache_scope: Option<&str>,
+        modern: bool,
+    ) -> Result<()> {
+        if !modern {
+            return Ok(());
+        }
+        if ttl_ms.is_none() {
+            return Err(McpError::Protocol(
+                "Modern MCP cacheable result is missing required ttlMs".to_string(),
+            ));
+        }
+        match cache_scope {
+            Some("public" | "private") => Ok(()),
+            None => Err(McpError::Protocol(
+                "Modern MCP cacheable result is missing required cacheScope".to_string(),
+            )),
+            Some(other) => Err(McpError::Protocol(format!(
+                "Modern MCP cacheable result has invalid cacheScope '{other}'"
+            ))),
+        }
+    }
+
+    fn tool_header_specs(schema: &Value) -> std::result::Result<Vec<ToolHeaderSpec>, String> {
+        let mut specs = Vec::new();
+        let mut names = std::collections::HashSet::new();
+        Self::collect_tool_header_specs(schema, &mut Vec::new(), &mut names, &mut specs)?;
+        Ok(specs)
+    }
+
+    fn collect_tool_header_specs(
+        schema: &Value,
+        path: &mut Vec<String>,
+        names: &mut std::collections::HashSet<String>,
+        specs: &mut Vec<ToolHeaderSpec>,
+    ) -> std::result::Result<(), String> {
+        let Some(object) = schema.as_object() else {
+            return Ok(());
+        };
+
+        if let Some(annotation) = object.get("x-mcp-header") {
+            if path.is_empty() {
+                return Err("x-mcp-header cannot annotate the schema root".to_string());
+            }
+            let name = annotation
+                .as_str()
+                .ok_or_else(|| "x-mcp-header must be a string".to_string())?;
+            if !Self::is_http_token(name) {
+                return Err(format!("'{name}' is not a valid HTTP field-name token"));
+            }
+            if !names.insert(name.to_ascii_lowercase()) {
+                return Err(format!("duplicate x-mcp-header name '{name}'"));
+            }
+            let value_type = match object.get("type").and_then(Value::as_str) {
+                Some("string") => ToolHeaderValueType::String,
+                Some("integer") => ToolHeaderValueType::Integer,
+                Some("boolean") => ToolHeaderValueType::Boolean,
+                _ => {
+                    return Err(format!(
+                        "x-mcp-header '{name}' must annotate a string, integer, or boolean property"
+                    ))
+                }
+            };
+            specs.push(ToolHeaderSpec {
+                name: name.to_string(),
+                path: path.clone(),
+                value_type,
+            });
+        }
+
+        if let Some(properties) = object.get("properties") {
+            let properties = properties
+                .as_object()
+                .ok_or_else(|| "JSON Schema properties must be an object".to_string())?;
+            for (property, child_schema) in properties {
+                path.push(property.clone());
+                Self::collect_tool_header_specs(child_schema, path, names, specs)?;
+                path.pop();
+            }
+        }
+
+        for (keyword, value) in object {
+            if keyword != "properties"
+                && keyword != "x-mcp-header"
+                && Self::contains_tool_header_annotation(value)
+            {
+                return Err(format!(
+                    "x-mcp-header is not statically reachable through properties (found under {keyword})"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn contains_tool_header_annotation(value: &Value) -> bool {
+        match value {
+            Value::Object(object) => {
+                object.contains_key("x-mcp-header")
+                    || object.values().any(Self::contains_tool_header_annotation)
+            }
+            Value::Array(values) => values.iter().any(Self::contains_tool_header_annotation),
+            _ => false,
+        }
+    }
+
+    fn is_http_token(value: &str) -> bool {
+        !value.is_empty()
+            && value.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric()
+                    || matches!(
+                        byte,
+                        b'!' | b'#'
+                            | b'$'
+                            | b'%'
+                            | b'&'
+                            | b'\''
+                            | b'*'
+                            | b'+'
+                            | b'-'
+                            | b'.'
+                            | b'^'
+                            | b'_'
+                            | b'`'
+                            | b'|'
+                            | b'~'
+                    )
+            })
+    }
+
+    fn extract_tool_parameter_headers(
+        specs: &[ToolHeaderSpec],
+        arguments: &Value,
+    ) -> Result<Vec<(String, String)>> {
+        const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+        const MIN_SAFE_INTEGER: i64 = -9_007_199_254_740_991;
+
+        let mut headers = Vec::with_capacity(specs.len());
+        for spec in specs {
+            let value = spec
+                .path
+                .iter()
+                .try_fold(arguments, |current, segment| current.get(segment));
+            let Some(value) = value.filter(|value| !value.is_null()) else {
+                continue;
+            };
+
+            let encoded = match spec.value_type {
+                ToolHeaderValueType::String => value.as_str().map(ToString::to_string),
+                ToolHeaderValueType::Boolean => value.as_bool().map(|value| value.to_string()),
+                ToolHeaderValueType::Integer => {
+                    if let Some(value) = value.as_i64() {
+                        (value >= MIN_SAFE_INTEGER && value <= MAX_SAFE_INTEGER as i64)
+                            .then(|| value.to_string())
+                    } else if let Some(value) = value.as_u64() {
+                        (value <= MAX_SAFE_INTEGER).then(|| value.to_string())
+                    } else if let Some(value) = value.as_f64() {
+                        (value.is_finite()
+                            && value.fract() == 0.0
+                            && value >= MIN_SAFE_INTEGER as f64
+                            && value <= MAX_SAFE_INTEGER as f64)
+                            .then(|| {
+                                if value == 0.0 {
+                                    "0".to_string()
+                                } else {
+                                    format!("{value:.0}")
+                                }
+                            })
+                    } else {
+                        None
+                    }
+                }
+            }
+            .ok_or_else(|| {
+                McpError::Protocol(format!(
+                    "Tool argument '{}' cannot be mirrored into Mcp-Param-{} with its declared primitive type",
+                    spec.path.join("."),
+                    spec.name
+                ))
+            })?;
+            headers.push((spec.name.clone(), encoded));
+        }
+        Ok(headers)
+    }
+
+    /// Health probe compatible with both protocol eras.
+    ///
+    /// MCP 2026-07-28 removed `ping`, so modern connections use the mandatory
+    /// `server/discover` RPC. Legacy connections retain `ping`.
     pub async fn ping(&self, timeout_ms: u64) -> Result<()> {
-        self.send_request("ping", None, timeout_ms).await?;
+        if self.is_modern().await {
+            let response = self
+                .send_request("server/discover", Some(serde_json::json!({})), timeout_ms)
+                .await?;
+            let result: McpDiscoverResult = serde_json::from_value(
+                response
+                    .result
+                    .ok_or_else(|| McpError::Protocol("Missing discovery result".to_string()))?,
+            )?;
+            Self::validate_modern_discovery(&result)?;
+        } else {
+            self.send_request("ping", None, timeout_ms).await?;
+        }
         Ok(())
     }
 
@@ -411,6 +1119,7 @@ impl McpProtocolClient {
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use std::collections::VecDeque;
     use tokio::sync::Mutex as TokioMutex;
 
     // Mock transport for testing — backed by an mpsc channel so that
@@ -491,6 +1200,152 @@ mod tests {
                     }
                 }
             }
+        }
+
+        fn is_connected(&self) -> bool {
+            self.connected
+        }
+    }
+
+    type CapturedMessages = Arc<TokioMutex<Vec<(Value, McpTransportMetadata)>>>;
+
+    /// Deterministic request/response transport used to verify protocol-era
+    /// negotiation and the exact modern wire envelope.
+    struct ScriptedTransport {
+        connected: bool,
+        message_rx: TokioMutex<Option<mpsc::Receiver<String>>>,
+        response_tx: mpsc::Sender<String>,
+        responses: TokioMutex<VecDeque<Option<Value>>>,
+        captured: CapturedMessages,
+        supports_modern: bool,
+        requires_tool_parameter_headers: bool,
+        legacy_version: &'static str,
+    }
+
+    impl ScriptedTransport {
+        fn new(responses: Vec<Option<Value>>) -> (Self, CapturedMessages) {
+            let (response_tx, message_rx) = mpsc::channel(100);
+            let captured = Arc::new(TokioMutex::new(Vec::new()));
+            (
+                Self {
+                    connected: false,
+                    message_rx: TokioMutex::new(Some(message_rx)),
+                    response_tx,
+                    responses: TokioMutex::new(responses.into()),
+                    captured: captured.clone(),
+                    supports_modern: true,
+                    requires_tool_parameter_headers: false,
+                    legacy_version: LATEST_LEGACY_PROTOCOL_VERSION,
+                },
+                captured,
+            )
+        }
+
+        fn with_tool_parameter_headers(mut self) -> Self {
+            self.requires_tool_parameter_headers = true;
+            self
+        }
+
+        fn success(result: Value) -> Option<Value> {
+            Some(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "result": result
+            }))
+        }
+
+        fn error(code: i32, message: &str, data: Option<Value>) -> Option<Value> {
+            Some(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "error": {
+                    "code": code,
+                    "message": message,
+                    "data": data
+                }
+            }))
+        }
+
+        fn discover_result(tools_list_changed: bool) -> Value {
+            serde_json::json!({
+                "resultType": "complete",
+                "supportedVersions": [LATEST_PROTOCOL_VERSION],
+                "capabilities": {
+                    "tools": {
+                        "listChanged": tools_list_changed
+                    }
+                },
+                "_meta": {
+                    "io.modelcontextprotocol/serverInfo": {
+                        "name": "modern-test-server",
+                        "version": "1.0.0"
+                    }
+                },
+                "ttlMs": 1000,
+                "cacheScope": "private"
+            })
+        }
+    }
+
+    #[async_trait]
+    impl McpTransport for ScriptedTransport {
+        async fn connect(&mut self) -> Result<()> {
+            self.connected = true;
+            Ok(())
+        }
+
+        async fn disconnect(&mut self) -> Result<()> {
+            self.connected = false;
+            Ok(())
+        }
+
+        async fn send(&self, message: String) -> Result<()> {
+            self.send_with_metadata(message, McpTransportMetadata::default())
+                .await
+        }
+
+        async fn send_with_metadata(
+            &self,
+            message: String,
+            metadata: McpTransportMetadata,
+        ) -> Result<()> {
+            let request: Value = serde_json::from_str(&message)?;
+            let id = request.get("id").cloned();
+            self.captured.lock().await.push((request, metadata));
+
+            if let Some(id) = id {
+                let response = self.responses.lock().await.pop_front().ok_or_else(|| {
+                    McpError::Transport("script has no response for request".to_string())
+                })?;
+                if let Some(mut response) = response {
+                    response["id"] = id;
+                    self.response_tx
+                        .send(response.to_string())
+                        .await
+                        .map_err(|_| McpError::Disconnected)?;
+                }
+            }
+            Ok(())
+        }
+
+        fn supports_modern_protocol(&self) -> bool {
+            self.supports_modern
+        }
+
+        fn latest_legacy_protocol_version(&self) -> &'static str {
+            self.legacy_version
+        }
+
+        fn requires_tool_parameter_headers(&self) -> bool {
+            self.requires_tool_parameter_headers
+        }
+
+        async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
+            self.message_rx.lock().await.take()
+        }
+
+        async fn receive(&self) -> Result<Option<String>> {
+            Err(McpError::Disconnected)
         }
 
         fn is_connected(&self) -> bool {
@@ -644,6 +1499,342 @@ mod tests {
         assert!(!client.is_connected().await);
         client.connect().await.unwrap();
         assert!(client.is_connected().await);
+    }
+
+    #[tokio::test]
+    async fn modern_negotiation_uses_discovery_and_per_request_metadata() {
+        let (transport, captured) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(false)),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "tools": [{
+                    "name": "weather",
+                    "description": "Get weather",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }],
+                "ttlMs": 1000,
+                "cacheScope": "private"
+            })),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let initialized = client.initialize(1000).await.expect("modern discovery");
+        assert_eq!(initialized.protocol_version, LATEST_PROTOCOL_VERSION);
+        assert_eq!(initialized.server_info.name, "modern-test-server");
+        assert!(matches!(
+            &*client.protocol_mode.read().await,
+            ProtocolMode::Modern { version } if version == LATEST_PROTOCOL_VERSION
+        ));
+
+        let tools = client.list_tools(1000).await.expect("modern tools/list");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "weather");
+
+        let captured = captured.lock().await;
+        assert_eq!(
+            captured.len(),
+            2,
+            "modern negotiation must not send initialize/initialized"
+        );
+        assert_eq!(captured[0].0["method"], "server/discover");
+        assert_eq!(captured[1].0["method"], "tools/list");
+        for (request, metadata) in captured.iter() {
+            assert!(metadata.modern);
+            assert_eq!(
+                metadata.protocol_version.as_deref(),
+                Some(LATEST_PROTOCOL_VERSION)
+            );
+            assert_eq!(
+                request["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"],
+                LATEST_PROTOCOL_VERSION
+            );
+            assert_eq!(
+                request["params"]["_meta"]["io.modelcontextprotocol/clientInfo"]["name"],
+                "bamboo-agent"
+            );
+            assert_eq!(
+                request["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"],
+                serde_json::json!({})
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn legacy_server_falls_back_to_latest_initialization_revision() {
+        let (transport, captured) = ScriptedTransport::new(vec![
+            ScriptedTransport::error(-32601, "Method not found", None),
+            ScriptedTransport::success(serde_json::json!({
+                "protocolVersion": LATEST_LEGACY_PROTOCOL_VERSION,
+                "capabilities": {},
+                "serverInfo": {
+                    "name": "legacy-test-server",
+                    "version": "1.0.0"
+                }
+            })),
+            ScriptedTransport::success(serde_json::json!({})),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let initialized = client.initialize(1000).await.expect("legacy fallback");
+        assert_eq!(initialized.protocol_version, LATEST_LEGACY_PROTOCOL_VERSION);
+        assert!(matches!(
+            &*client.protocol_mode.read().await,
+            ProtocolMode::Legacy { version } if version == LATEST_LEGACY_PROTOCOL_VERSION
+        ));
+        client.ping(1000).await.expect("legacy ping");
+
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), 4);
+        assert_eq!(captured[0].0["method"], "server/discover");
+        assert!(captured[0].1.modern);
+
+        assert_eq!(captured[1].0["method"], "initialize");
+        assert_eq!(
+            captured[1].0["params"]["protocolVersion"],
+            LATEST_LEGACY_PROTOCOL_VERSION
+        );
+        assert!(!captured[1].1.modern);
+        assert!(captured[1].1.protocol_version.is_none());
+
+        assert_eq!(captured[2].0["method"], "notifications/initialized");
+        assert_eq!(
+            captured[2].1.protocol_version.as_deref(),
+            Some(LATEST_LEGACY_PROTOCOL_VERSION)
+        );
+
+        assert_eq!(captured[3].0["method"], "ping");
+        assert_eq!(
+            captured[3].1.protocol_version.as_deref(),
+            Some(LATEST_LEGACY_PROTOCOL_VERSION)
+        );
+    }
+
+    #[tokio::test]
+    async fn recognized_modern_error_never_falls_back_to_initialize() {
+        let (transport, captured) = ScriptedTransport::new(vec![ScriptedTransport::error(
+            UNSUPPORTED_PROTOCOL_VERSION_ERROR,
+            "Unsupported protocol version",
+            Some(serde_json::json!({
+                "supported": ["2099-01-01"]
+            })),
+        )]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+
+        let error = client
+            .initialize(1000)
+            .await
+            .expect_err("recognized modern error must surface");
+        assert!(matches!(
+            error,
+            McpError::RemoteProtocol {
+                code: UNSUPPORTED_PROTOCOL_VERSION_ERROR,
+                ..
+            }
+        ));
+        assert_eq!(captured.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn modern_tool_change_capability_opens_subscription_stream() {
+        let (transport, captured) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(true)),
+            None,
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+        client.initialize(1000).await.expect("modern discovery");
+
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[1].0["method"], "subscriptions/listen");
+        assert_eq!(
+            captured[1].0["params"]["notifications"]["toolsListChanged"],
+            true
+        );
+        assert_eq!(
+            captured[1].0["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"],
+            LATEST_PROTOCOL_VERSION
+        );
+        assert_eq!(*client.tool_subscription_id.lock().await, Some(2));
+        assert!(client.pending_requests.read().await.contains_key(&2));
+        drop(captured);
+
+        client.disconnect().await.expect("disconnect");
+        assert!(client.pending_requests.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn modern_tools_list_follows_all_pages_and_rejects_bad_cache_fields() {
+        let (transport, captured) = ScriptedTransport::new(vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(false)),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "tools": [{
+                    "name": "first",
+                    "description": "First page",
+                    "inputSchema": {"type": "object"}
+                }],
+                "nextCursor": "page-2",
+                "ttlMs": 1000,
+                "cacheScope": "public"
+            })),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "tools": [{
+                    "name": "second",
+                    "description": "Second page",
+                    "inputSchema": {"type": "object"}
+                }],
+                "ttlMs": 1000,
+                "cacheScope": "private"
+            })),
+        ]);
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+        client.initialize(1000).await.expect("modern discovery");
+
+        let tools = client.list_tools(1000).await.expect("paginated tools/list");
+        assert_eq!(
+            tools
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), 3);
+        assert!(captured[1].0["params"].get("cursor").is_none());
+        assert_eq!(captured[2].0["params"]["cursor"], "page-2");
+        drop(captured);
+
+        assert!(McpProtocolClient::ensure_cacheable_result(None, Some("private"), true).is_err());
+        assert!(McpProtocolClient::ensure_cacheable_result(Some(1), None, true).is_err());
+        assert!(McpProtocolClient::ensure_cacheable_result(Some(1), Some("shared"), true).is_err());
+        assert!(
+            McpProtocolClient::ensure_cacheable_result(None, None, false).is_ok(),
+            "legacy results do not have cache fields"
+        );
+    }
+
+    #[tokio::test]
+    async fn modern_http_tool_headers_are_derived_from_valid_nested_properties() {
+        let responses = vec![
+            ScriptedTransport::success(ScriptedTransport::discover_result(false)),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "tools": [{
+                    "name": "route",
+                    "description": "Route a request",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "routing": {
+                                "type": "object",
+                                "properties": {
+                                    "region": {
+                                        "type": "string",
+                                        "x-mcp-header": "Region"
+                                    },
+                                    "shard": {
+                                        "type": "integer",
+                                        "x-mcp-header": "Shard"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }],
+                "ttlMs": 1000,
+                "cacheScope": "private"
+            })),
+            ScriptedTransport::success(serde_json::json!({
+                "resultType": "complete",
+                "content": [{
+                    "type": "text",
+                    "text": "ok"
+                }]
+            })),
+        ];
+        let (transport, captured) = ScriptedTransport::new(responses);
+        let transport = transport.with_tool_parameter_headers();
+        let mut client = McpProtocolClient::new(Box::new(transport));
+        client.connect().await.expect("connect");
+        client.initialize(1000).await.expect("modern discovery");
+        client.list_tools(1000).await.expect("tools/list");
+        client
+            .call_tool(
+                "route",
+                serde_json::json!({
+                    "routing": {
+                        "region": "华东",
+                        "shard": 42.0
+                    }
+                }),
+                1000,
+            )
+            .await
+            .expect("tools/call");
+
+        let captured = captured.lock().await;
+        let (_, metadata) = &captured[2];
+        assert_eq!(metadata.method, "tools/call");
+        assert_eq!(metadata.name.as_deref(), Some("route"));
+        let mut headers = metadata.tool_parameter_headers.clone();
+        headers.sort();
+        assert_eq!(
+            headers,
+            vec![
+                ("Region".to_string(), "华东".to_string()),
+                ("Shard".to_string(), "42".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_tool_header_annotations_are_rejected() {
+        let duplicate = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string", "x-mcp-header": "Tenant"},
+                "b": {"type": "string", "x-mcp-header": "tenant"}
+            }
+        });
+        assert!(McpProtocolClient::tool_header_specs(&duplicate)
+            .expect_err("header names are case-insensitively unique")
+            .contains("duplicate"));
+
+        let unreachable = serde_json::json!({
+            "type": "object",
+            "allOf": [{
+                "properties": {
+                    "region": {"type": "string", "x-mcp-header": "Region"}
+                }
+            }]
+        });
+        assert!(McpProtocolClient::tool_header_specs(&unreachable)
+            .expect_err("composition branch is not statically reachable")
+            .contains("allOf"));
+
+        let unsafe_integer_schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "shard": {"type": "integer", "x-mcp-header": "Shard"}
+            }
+        });
+        let specs =
+            McpProtocolClient::tool_header_specs(&unsafe_integer_schema).expect("valid schema");
+        assert!(McpProtocolClient::extract_tool_parameter_headers(
+            &specs,
+            &serde_json::json!({"shard": 9_007_199_254_740_992_u64})
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/infra/bamboo-mcp/src/protocol/models.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/models.rs
@@ -10,10 +10,14 @@
 //!
 //! # Protocol Flow
 //!
-//! 1. Client sends `McpInitializeRequest` to establish connection
-//! 2. Server responds with `McpInitializeResult` and capabilities
-//! 3. Client discovers available tools via `McpToolListRequest`
-//! 4. Client invokes tools using `McpToolCallRequest`
+//! Modern servers use the stateless MCP `2026-07-28` flow:
+//! 1. Client probes with `server/discover`
+//! 2. Every request carries the protocol version, capabilities, and identity
+//! 3. Client discovers available tools via `tools/list`
+//! 4. Client invokes tools using `tools/call`
+//!
+//! Legacy servers (`2025-11-25` and earlier) continue to use the
+//! `initialize` / `notifications/initialized` handshake.
 //!
 //! # Example
 //!
@@ -32,6 +36,22 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+/// Current stable MCP protocol revision implemented by Bamboo.
+pub const LATEST_PROTOCOL_VERSION: &str = "2026-07-28";
+
+/// Latest initialization-based MCP revision used for legacy fallback.
+pub const LATEST_LEGACY_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Protocol revision used by the deprecated HTTP+SSE transport.
+pub const LEGACY_SSE_PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// MCP error returned by a modern server when a request version is unsupported.
+pub const UNSUPPORTED_PROTOCOL_VERSION_ERROR: i32 = -32022;
+
+/// Modern MCP protocol errors that unambiguously identify a modern server.
+pub const HEADER_MISMATCH_ERROR: i32 = -32020;
+pub const MISSING_REQUIRED_CLIENT_CAPABILITY_ERROR: i32 = -32021;
 
 // JSON-RPC 2.0 base types
 
@@ -195,10 +215,11 @@ pub struct McpInitializeRequest {
 impl Default for McpInitializeRequest {
     /// Creates a default initialization request for the bamboo agent.
     ///
-    /// Uses protocol version "2024-11-05" and the current package version.
+    /// Uses the latest initialization-based revision and the current package
+    /// version. Modern `2026-07-28` servers use `server/discover` instead.
     fn default() -> Self {
         Self {
-            protocol_version: "2024-11-05".to_string(),
+            protocol_version: LATEST_LEGACY_PROTOCOL_VERSION.to_string(),
             capabilities: ClientCapabilities::default(),
             client_info: Implementation {
                 name: "bamboo-agent".to_string(),
@@ -231,6 +252,38 @@ pub struct McpInitializeResult {
     /// Optional instructions for using this server
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+}
+
+/// Result returned by the modern `server/discover` request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpDiscoverResult {
+    /// Modern results must carry `resultType = "complete"`.
+    pub result_type: String,
+    /// Protocol revisions supported by the server.
+    pub supported_versions: Vec<String>,
+    /// Capabilities advertised by the server.
+    pub capabilities: ServerCapabilities,
+    /// Optional usage guidance for the client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    /// Result metadata, including the optional server implementation identity.
+    #[serde(rename = "_meta", default)]
+    pub meta: Value,
+    /// Server-provided freshness hint for this discovery result.
+    pub ttl_ms: u64,
+    /// Cache isolation requested by the server.
+    pub cache_scope: String,
+}
+
+impl McpDiscoverResult {
+    /// Extract the optional server identity carried in modern result metadata.
+    pub fn server_info(&self) -> Option<Implementation> {
+        self.meta
+            .get("io.modelcontextprotocol/serverInfo")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok())
+    }
 }
 
 /// Client capabilities declaration.
@@ -381,6 +434,18 @@ pub struct McpToolListRequest {}
 pub struct McpToolListResult {
     /// List of available tools
     pub tools: Vec<McpToolInfo>,
+    /// Modern results include a result discriminator. Legacy results omit it.
+    #[serde(rename = "resultType", default)]
+    pub result_type: Option<String>,
+    /// Opaque pagination cursor, when more tools are available.
+    #[serde(rename = "nextCursor", default)]
+    pub next_cursor: Option<String>,
+    /// Modern cache freshness hint.
+    #[serde(rename = "ttlMs", default)]
+    pub ttl_ms: Option<u64>,
+    /// Modern cache isolation scope.
+    #[serde(rename = "cacheScope", default)]
+    pub cache_scope: Option<String>,
 }
 
 /// Tool metadata and schema information.
@@ -414,6 +479,7 @@ pub struct McpToolInfo {
     /// Unique tool identifier
     pub name: String,
     /// Human-readable tool description
+    #[serde(default)]
     pub description: String,
     /// JSON Schema for tool input parameters
     #[serde(
@@ -472,6 +538,12 @@ pub struct McpToolCallResult {
     /// Whether the tool execution encountered an error
     #[serde(default)]
     pub is_error: bool,
+    /// Modern results include a result discriminator. Legacy results omit it.
+    #[serde(rename = "resultType", default)]
+    pub result_type: Option<String>,
+    /// Optional structured result defined by the tool's output schema.
+    #[serde(rename = "structuredContent", default)]
+    pub structured_content: Option<Value>,
 }
 
 #[cfg(test)]
@@ -532,7 +604,7 @@ mod tests {
     #[test]
     fn test_mcp_initialize_request_default() {
         let request = McpInitializeRequest::default();
-        assert_eq!(request.protocol_version, "2024-11-05");
+        assert_eq!(request.protocol_version, LATEST_LEGACY_PROTOCOL_VERSION);
         assert_eq!(request.client_info.name, "bamboo-agent");
     }
 
@@ -558,6 +630,29 @@ mod tests {
         assert_eq!(result.protocol_version, "2024-11-05");
         assert_eq!(result.server_info.name, "test-server");
         assert_eq!(result.server_info.version, "1.0.0");
+    }
+
+    #[test]
+    fn test_mcp_discover_result_extracts_server_info() {
+        let json = r#"{
+            "resultType": "complete",
+            "supportedVersions": ["2026-07-28"],
+            "capabilities": {"tools": {}},
+            "_meta": {
+                "io.modelcontextprotocol/serverInfo": {
+                    "name": "test-server",
+                    "version": "2.0.0"
+                }
+            },
+            "ttlMs": 1000,
+            "cacheScope": "private"
+        }"#;
+        let result: McpDiscoverResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.result_type, "complete");
+        assert_eq!(
+            result.server_info().map(|info| info.name),
+            Some("test-server".to_string())
+        );
     }
 
     #[test]
@@ -714,6 +809,8 @@ mod tests {
         let result = McpToolCallResult {
             content: vec![],
             is_error: false,
+            result_type: None,
+            structured_content: None,
         };
         assert!(!result.is_error);
         assert!(result.content.is_empty());

--- a/crates/infra/bamboo-mcp/src/protocol/models.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/models.rs
@@ -488,6 +488,14 @@ pub struct McpToolInfo {
         skip_serializing_if = "Option::is_none"
     )]
     pub input_schema: Option<Value>,
+    /// Optional JSON Schema for `structuredContent` returned by this tool.
+    #[serde(
+        rename = "outputSchema",
+        alias = "output_schema",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub output_schema: Option<Value>,
 }
 
 /// Tool call request to invoke a tool.
@@ -542,8 +550,12 @@ pub struct McpToolCallResult {
     #[serde(rename = "resultType", default)]
     pub result_type: Option<String>,
     /// Optional structured result defined by the tool's output schema.
-    #[serde(rename = "structuredContent", default)]
-    pub structured_content: Option<Value>,
+    #[serde(
+        rename = "structuredContent",
+        default,
+        skip_serializing_if = "crate::types::McpStructuredContent::is_missing"
+    )]
+    pub structured_content: crate::types::McpStructuredContent,
 }
 
 #[cfg(test)]
@@ -777,6 +789,7 @@ mod tests {
             name: "read_file".to_string(),
             description: "Read a file".to_string(),
             input_schema: Some(serde_json::json!({"type": "object"})),
+            output_schema: None,
         };
         assert_eq!(tool.name, "read_file");
         assert_eq!(tool.description, "Read a file");
@@ -810,7 +823,7 @@ mod tests {
             content: vec![],
             is_error: false,
             result_type: None,
-            structured_content: None,
+            structured_content: crate::types::McpStructuredContent::Missing,
         };
         assert!(!result.is_error);
         assert!(result.content.is_empty());

--- a/crates/infra/bamboo-mcp/src/tool_index.rs
+++ b/crates/infra/bamboo-mcp/src/tool_index.rs
@@ -150,11 +150,13 @@ mod tests {
                 name: "read_file".to_string(),
                 description: "Read a file".to_string(),
                 parameters: serde_json::json!({}),
+                output_schema: None,
             },
             McpTool {
                 name: "write_file".to_string(),
                 description: "Write a file".to_string(),
                 parameters: serde_json::json!({}),
+                output_schema: None,
             },
         ];
 
@@ -176,11 +178,13 @@ mod tests {
                 name: "read_file".to_string(),
                 description: "Read".to_string(),
                 parameters: serde_json::json!({}),
+                output_schema: None,
             },
             McpTool {
                 name: "delete_file".to_string(),
                 description: "Delete".to_string(),
                 parameters: serde_json::json!({}),
+                output_schema: None,
             },
         ];
 
@@ -197,11 +201,13 @@ mod tests {
                 name: "read_file".to_string(),
                 description: "Read".to_string(),
                 parameters: serde_json::json!({}),
+                output_schema: None,
             },
             McpTool {
                 name: "delete_file".to_string(),
                 description: "Delete".to_string(),
                 parameters: serde_json::json!({}),
+                output_schema: None,
             },
         ];
 
@@ -217,6 +223,7 @@ mod tests {
             name: "read_file".to_string(),
             description: "Read".to_string(),
             parameters: serde_json::json!({}),
+            output_schema: None,
         }];
 
         index.register_server_tools("fs", &tools, &[], &[]);

--- a/crates/infra/bamboo-mcp/src/transports/sse.rs
+++ b/crates/infra/bamboo-mcp/src/transports/sse.rs
@@ -10,6 +10,7 @@ use tracing::{debug, info, trace, warn};
 use crate::config::{HeaderConfig, SseConfig};
 use crate::error::{McpError, Result};
 use crate::protocol::client::McpTransport;
+use crate::protocol::models::LEGACY_SSE_PROTOCOL_VERSION;
 
 #[derive(Debug, Clone)]
 struct PostResponse {
@@ -411,6 +412,14 @@ impl McpTransport for SseTransport {
 
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::SeqCst)
+    }
+
+    fn supports_modern_protocol(&self) -> bool {
+        false
+    }
+
+    fn latest_legacy_protocol_version(&self) -> &'static str {
+        LEGACY_SSE_PROTOCOL_VERSION
     }
 }
 

--- a/crates/infra/bamboo-mcp/src/transports/streamable_http.rs
+++ b/crates/infra/bamboo-mcp/src/transports/streamable_http.rs
@@ -19,12 +19,19 @@ use tracing::{debug, trace, warn};
 use crate::config::{HeaderConfig, StreamableHttpConfig};
 use crate::error::{McpError, Result};
 use crate::protocol::client::{McpTransport, McpTransportMetadata};
+use crate::protocol::models::JsonRpcError;
 
 const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
 const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
 const MCP_METHOD_HEADER: &str = "mcp-method";
 const MCP_NAME_HEADER: &str = "mcp-name";
 const ACCEPT_HEADER: &str = "application/json, text/event-stream";
+const RESPONSE_STREAM_CLOSED_ERROR: i32 = -32000;
+
+struct PostSseHandle {
+    request_id: Option<u64>,
+    handle: tokio::task::JoinHandle<()>,
+}
 
 pub struct StreamableHttpTransport {
     config: StreamableHttpConfig,
@@ -40,7 +47,7 @@ pub struct StreamableHttpTransport {
     // Per-POST SSE forwarder tasks. Stored so they can be aborted
     // deterministically in disconnect() (they otherwise exit only on the next
     // send-Err once the receiver is dropped).
-    post_sse_handles: Mutex<Vec<tokio::task::JoinHandle<()>>>,
+    post_sse_handles: Mutex<Vec<PostSseHandle>>,
 }
 
 impl StreamableHttpTransport {
@@ -241,13 +248,15 @@ impl StreamableHttpTransport {
 
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            // Modern negotiation errors use HTTP 400 with a JSON-RPC error body.
-            // Route a well-formed error through the normal response channel so
-            // the protocol client can distinguish modern errors from legacy
-            // fallback signals.
-            if Self::is_json_rpc_error_response(&body) {
-                self.route_message(body).await?;
-                return Ok(());
+            // Modern negotiation errors may omit the JSON-RPC id. Return the
+            // error directly instead of routing it through `JsonRpcResponse`,
+            // whose response correlation necessarily requires an id.
+            if let Some(error) = Self::parse_json_rpc_error_response(&body) {
+                return Err(McpError::RemoteProtocol {
+                    code: error.code,
+                    message: error.message,
+                    data: error.data,
+                });
             }
             return Err(McpError::Transport(format!(
                 "POST failed: {} - {}",
@@ -267,24 +276,34 @@ impl StreamableHttpTransport {
             let Some(tx) = self.message_tx.clone() else {
                 return Ok(()); // disconnected
             };
-            let url = self.config.url.clone();
             let connected = self.connected.clone();
+            let request_id = metadata.request_id;
 
             // We need to consume the response body in a spawned task to avoid
             // blocking the caller. Events from this POST's SSE response are
             // forwarded to the channel so receive() can pick them up.
             let handle = tokio::spawn(async move {
                 let mut stream = response.bytes_stream().eventsource();
+                let mut saw_terminal_response = false;
                 while let Some(event) = stream.next().await {
                     match event {
                         Ok(evt) => {
                             if !evt.data.trim().is_empty() {
+                                let is_terminal = request_id.is_some_and(|id| {
+                                    StreamableHttpTransport::is_terminal_response_for(&evt.data, id)
+                                });
+                                if is_terminal {
+                                    saw_terminal_response = true;
+                                }
                                 trace!(
                                     "MCP StreamableHTTP POST SSE event (event='{}', data_len={})",
                                     evt.event,
                                     evt.data.len()
                                 );
                                 if tx.send(evt.data).await.is_err() {
+                                    break;
+                                }
+                                if is_terminal {
                                     break;
                                 }
                             }
@@ -295,15 +314,27 @@ impl StreamableHttpTransport {
                         }
                     }
                 }
-                let _ = (url, connected); // suppress unused warnings
+                if !saw_terminal_response && connected.load(Ordering::SeqCst) {
+                    if let Some(id) = request_id {
+                        let synthetic = serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "error": {
+                                "code": RESPONSE_STREAM_CLOSED_ERROR,
+                                "message": "Streamable HTTP response stream closed before a terminal response"
+                            }
+                        });
+                        let _ = tx.send(synthetic.to_string()).await;
+                    }
+                }
             });
 
             // Track the forwarder so disconnect() can abort it deterministically.
             // Also prune any already-finished handles so the Vec doesn't grow
             // unbounded across many POSTs.
             let mut handles = self.post_sse_handles.lock().await;
-            handles.retain(|h| !h.is_finished());
-            handles.push(handle);
+            handles.retain(|entry| !entry.handle.is_finished());
+            handles.push(PostSseHandle { request_id, handle });
         } else {
             // JSON response — forward the body directly.
             let body = response.text().await?;
@@ -326,12 +357,27 @@ impl StreamableHttpTransport {
         tx.send(body).await.map_err(|_| McpError::Disconnected)
     }
 
-    fn is_json_rpc_error_response(body: &str) -> bool {
+    fn parse_json_rpc_error_response(body: &str) -> Option<JsonRpcError> {
+        let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
+        if value.get("jsonrpc").and_then(serde_json::Value::as_str) != Some("2.0") {
+            return None;
+        }
+        serde_json::from_value(value.get("error")?.clone()).ok()
+    }
+
+    fn is_terminal_response_for(body: &str, request_id: u64) -> bool {
         serde_json::from_str::<serde_json::Value>(body)
             .ok()
             .is_some_and(|value| {
-                value.get("jsonrpc").and_then(serde_json::Value::as_str) == Some("2.0")
-                    && value.get("error").is_some_and(serde_json::Value::is_object)
+                (value.get("id").and_then(serde_json::Value::as_u64) == Some(request_id)
+                    && (value.get("result").is_some() || value.get("error").is_some()))
+                    || (value.get("method").and_then(serde_json::Value::as_str)
+                        == Some("notifications/cancelled")
+                        && value
+                            .get("params")
+                            .and_then(|params| params.get("requestId"))
+                            .and_then(serde_json::Value::as_u64)
+                            == Some(request_id))
             })
     }
 
@@ -470,8 +516,8 @@ impl McpTransport for StreamableHttpTransport {
         }
         {
             let mut handles = self.post_sse_handles.lock().await;
-            for handle in handles.drain(..) {
-                handle.abort();
+            for entry in handles.drain(..) {
+                entry.handle.abort();
             }
         }
 
@@ -503,8 +549,8 @@ impl McpTransport for StreamableHttpTransport {
         // next send-Err, but aborting is immediate and leaves no leaked tasks.
         {
             let mut handles = self.post_sse_handles.lock().await;
-            for handle in handles.drain(..) {
-                handle.abort();
+            for entry in handles.drain(..) {
+                entry.handle.abort();
             }
         }
 
@@ -587,6 +633,22 @@ impl McpTransport for StreamableHttpTransport {
         Ok(())
     }
 
+    async fn cancel_request(&self, request_id: u64, _reason: &str) -> Result<()> {
+        let mut handles = self.post_sse_handles.lock().await;
+        if let Some(index) = handles
+            .iter()
+            .position(|entry| entry.request_id == Some(request_id))
+        {
+            let entry = handles.remove(index);
+            entry.handle.abort();
+            trace!(
+                "Cancelled MCP StreamableHTTP request by closing response stream (id={})",
+                request_id
+            );
+        }
+        Ok(())
+    }
+
     fn requires_tool_parameter_headers(&self) -> bool {
         true
     }
@@ -641,8 +703,8 @@ impl Drop for StreamableHttpTransport {
             }
         }
         if let Ok(mut handles) = self.post_sse_handles.try_lock() {
-            for handle in handles.drain(..) {
-                handle.abort();
+            for entry in handles.drain(..) {
+                entry.handle.abort();
             }
         }
     }
@@ -651,6 +713,7 @@ impl Drop for StreamableHttpTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     fn create_test_config() -> StreamableHttpConfig {
         StreamableHttpConfig {
@@ -658,6 +721,30 @@ mod tests {
             headers: vec![],
             connect_timeout_ms: 5000,
         }
+    }
+
+    async fn serve_http_once(status: &str, content_type: &str, body: &str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let status = status.to_string();
+        let content_type = content_type.to_string();
+        let body = body.to_string();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept test request");
+            let mut request = vec![0_u8; 4096];
+            let _ = socket.read(&mut request).await.expect("read test request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write test response");
+        });
+        format!("http://{address}/mcp")
     }
 
     #[test]
@@ -757,6 +844,7 @@ mod tests {
         StreamableHttpTransport::apply_request_metadata(
             &mut headers,
             &McpTransportMetadata {
+                request_id: Some(7),
                 protocol_version: Some("2026-07-28".to_string()),
                 modern: true,
                 method: "tools/call".to_string(),
@@ -794,6 +882,7 @@ mod tests {
         StreamableHttpTransport::apply_request_metadata(
             &mut headers,
             &McpTransportMetadata {
+                request_id: Some(7),
                 protocol_version: Some("2025-11-25".to_string()),
                 modern: false,
                 method: "tools/call".to_string(),
@@ -830,15 +919,119 @@ mod tests {
     }
 
     #[test]
-    fn recognizes_json_rpc_error_bodies_for_http_negotiation() {
-        assert!(StreamableHttpTransport::is_json_rpc_error_response(
-            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32022,"message":"unsupported"}}"#
-        ));
-        assert!(!StreamableHttpTransport::is_json_rpc_error_response(
+    fn parses_json_rpc_error_bodies_with_or_without_id() {
+        let with_id = StreamableHttpTransport::parse_json_rpc_error_response(
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32022,"message":"unsupported"}}"#,
+        )
+        .expect("error with id");
+        assert_eq!(with_id.code, -32022);
+        let without_id = StreamableHttpTransport::parse_json_rpc_error_response(
+            r#"{"jsonrpc":"2.0","error":{"code":-32023,"message":"missing capability"}}"#,
+        )
+        .expect("error without id");
+        assert_eq!(without_id.code, -32023);
+        assert!(StreamableHttpTransport::parse_json_rpc_error_response(
             r#"{"jsonrpc":"2.0","id":1,"result":{}}"#
+        )
+        .is_none());
+        assert!(
+            StreamableHttpTransport::parse_json_rpc_error_response("legacy error page").is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn non_success_json_rpc_error_without_id_surfaces_directly() {
+        let url = serve_http_once(
+            "400 Bad Request",
+            "application/json",
+            r#"{"jsonrpc":"2.0","error":{"code":-32022,"message":"unsupported"}}"#,
+        )
+        .await;
+        let transport = StreamableHttpTransport::new(StreamableHttpConfig {
+            url,
+            headers: Vec::new(),
+            connect_timeout_ms: 1000,
+        });
+        let error = transport
+            .post_and_route_response(
+                r#"{"jsonrpc":"2.0","id":7,"method":"server/discover","params":{}}"#.to_string(),
+                &McpTransportMetadata {
+                    request_id: Some(7),
+                    protocol_version: Some("2026-07-28".to_string()),
+                    modern: true,
+                    method: "server/discover".to_string(),
+                    name: None,
+                    tool_parameter_headers: Vec::new(),
+                },
+            )
+            .await
+            .expect_err("HTTP JSON-RPC error must surface");
+        assert!(matches!(
+            error,
+            McpError::RemoteProtocol { code: -32022, .. }
         ));
-        assert!(!StreamableHttpTransport::is_json_rpc_error_response(
-            "legacy error page"
+    }
+
+    #[tokio::test]
+    async fn abrupt_post_sse_eof_resolves_the_owning_request() {
+        let url = serve_http_once("200 OK", "text/event-stream", "").await;
+        let mut transport = StreamableHttpTransport::new(StreamableHttpConfig {
+            url,
+            headers: Vec::new(),
+            connect_timeout_ms: 1000,
+        });
+        transport.connect().await.expect("connect");
+        let mut receiver = transport
+            .take_message_receiver()
+            .await
+            .expect("message receiver");
+        transport
+            .post_and_route_response(
+                r#"{"jsonrpc":"2.0","id":7,"method":"subscriptions/listen","params":{}}"#
+                    .to_string(),
+                &McpTransportMetadata {
+                    request_id: Some(7),
+                    protocol_version: Some("2026-07-28".to_string()),
+                    modern: true,
+                    method: "subscriptions/listen".to_string(),
+                    name: None,
+                    tool_parameter_headers: Vec::new(),
+                },
+            )
+            .await
+            .expect("accepted SSE response");
+
+        let routed = tokio::time::timeout(tokio::time::Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("synthetic response timeout")
+            .expect("synthetic response");
+        let response: serde_json::Value =
+            serde_json::from_str(&routed).expect("synthetic response JSON");
+        assert_eq!(response["id"], 7);
+        assert_eq!(response["error"]["code"], RESPONSE_STREAM_CLOSED_ERROR);
+    }
+
+    #[test]
+    fn terminal_response_detection_requires_matching_request_id() {
+        assert!(StreamableHttpTransport::is_terminal_response_for(
+            r#"{"jsonrpc":"2.0","id":7,"result":{}}"#,
+            7
+        ));
+        assert!(StreamableHttpTransport::is_terminal_response_for(
+            r#"{"jsonrpc":"2.0","id":7,"error":{"code":-32000,"message":"failed"}}"#,
+            7
+        ));
+        assert!(StreamableHttpTransport::is_terminal_response_for(
+            r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7}}"#,
+            7
+        ));
+        assert!(!StreamableHttpTransport::is_terminal_response_for(
+            r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{}}"#,
+            7
+        ));
+        assert!(!StreamableHttpTransport::is_terminal_response_for(
+            r#"{"jsonrpc":"2.0","id":8,"result":{}}"#,
+            7
         ));
     }
 
@@ -974,7 +1167,10 @@ mod tests {
                 tokio::time::sleep(tokio::time::Duration::from_secs(3600)).await;
             }
         });
-        transport.post_sse_handles.lock().await.push(handle);
+        transport.post_sse_handles.lock().await.push(PostSseHandle {
+            request_id: Some(1),
+            handle,
+        });
 
         // Let the task begin.
         tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
@@ -1004,7 +1200,10 @@ mod tests {
             }
         });
         let abort_handle = forever.abort_handle();
-        transport.post_sse_handles.lock().await.push(forever);
+        transport.post_sse_handles.lock().await.push(PostSseHandle {
+            request_id: Some(1),
+            handle: forever,
+        });
 
         assert!(!abort_handle.is_finished(), "task should be running");
 
@@ -1016,6 +1215,42 @@ mod tests {
             abort_handle.is_finished(),
             "disconnect should have aborted the forwarder task"
         );
+    }
+
+    #[tokio::test]
+    async fn cancelling_request_aborts_only_its_response_stream() {
+        let config = create_test_config();
+        let transport = StreamableHttpTransport::new(config);
+        let first = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+        let first_abort = first.abort_handle();
+        let second = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+        let second_abort = second.abort_handle();
+        {
+            let mut handles = transport.post_sse_handles.lock().await;
+            handles.push(PostSseHandle {
+                request_id: Some(7),
+                handle: first,
+            });
+            handles.push(PostSseHandle {
+                request_id: Some(8),
+                handle: second,
+            });
+        }
+
+        transport
+            .cancel_request(7, "test timeout")
+            .await
+            .expect("cancel stream");
+        tokio::task::yield_now().await;
+        assert!(first_abort.is_finished());
+        assert!(!second_abort.is_finished());
+        assert_eq!(transport.post_sse_handles.lock().await.len(), 1);
+
+        second_abort.abort();
     }
 
     #[tokio::test]
@@ -1031,7 +1266,10 @@ mod tests {
             }
         });
         let abort_handle = forever.abort_handle();
-        transport.post_sse_handles.lock().await.push(forever);
+        transport.post_sse_handles.lock().await.push(PostSseHandle {
+            request_id: Some(1),
+            handle: forever,
+        });
 
         assert!(!abort_handle.is_finished());
 

--- a/crates/infra/bamboo-mcp/src/transports/streamable_http.rs
+++ b/crates/infra/bamboo-mcp/src/transports/streamable_http.rs
@@ -1,13 +1,15 @@
-//! MCP Streamable HTTP transport (MCP protocol version 2025-03-26).
+//! MCP Streamable HTTP transport.
 //!
-//! Implements the "Streamable HTTP" transport where a single HTTP endpoint
-//! handles POST (send), GET (server-initiated SSE), and DELETE (session termination).
-//! See <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
+//! Implements the stateless MCP `2026-07-28` POST transport while retaining
+//! the session / GET / DELETE behavior needed by initialization-based servers
+//! through `2025-11-25`.
+//! See <https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http>
 
 use async_trait::async_trait;
+use base64::prelude::{Engine as _, BASE64_STANDARD};
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -16,15 +18,19 @@ use tracing::{debug, trace, warn};
 
 use crate::config::{HeaderConfig, StreamableHttpConfig};
 use crate::error::{McpError, Result};
-use crate::protocol::client::McpTransport;
+use crate::protocol::client::{McpTransport, McpTransportMetadata};
 
 const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
+const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+const MCP_METHOD_HEADER: &str = "mcp-method";
+const MCP_NAME_HEADER: &str = "mcp-name";
 const ACCEPT_HEADER: &str = "application/json, text/event-stream";
 
 pub struct StreamableHttpTransport {
     config: StreamableHttpConfig,
     client: Client,
     session_id: Arc<Mutex<Option<String>>>,
+    legacy_protocol_version: Arc<Mutex<Option<String>>>,
     connected: Arc<AtomicBool>,
     // Dropped in disconnect() so the channel closes and the client handler
     // wakes without polling.
@@ -48,6 +54,7 @@ impl StreamableHttpTransport {
             config,
             client,
             session_id: Arc::new(Mutex::new(None)),
+            legacy_protocol_version: Arc::new(Mutex::new(None)),
             connected: Arc::new(AtomicBool::new(false)),
             message_tx: Some(message_tx),
             message_rx: Mutex::new(Some(message_rx)),
@@ -56,7 +63,7 @@ impl StreamableHttpTransport {
         }
     }
 
-    fn build_headers(&self, include_session_id: bool) -> Result<HeaderMap> {
+    fn build_headers(&self) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         headers.insert(
             reqwest::header::ACCEPT,
@@ -76,11 +83,93 @@ impl StreamableHttpTransport {
             headers.insert(header_name, header_value);
         }
 
-        if include_session_id {
-            // Session id is added per-request in send() after reading the lock.
+        Ok(headers)
+    }
+
+    fn apply_request_metadata(
+        headers: &mut HeaderMap,
+        metadata: &McpTransportMetadata,
+    ) -> Result<()> {
+        // Protocol-derived headers must reflect the JSON-RPC body exactly.
+        // Remove configured values first so a stale Mcp-Param-* value cannot
+        // survive when the corresponding tool argument is absent.
+        let configured_protocol_headers: Vec<HeaderName> = headers
+            .keys()
+            .filter(|name| {
+                let name = name.as_str();
+                matches!(
+                    name,
+                    MCP_SESSION_ID_HEADER
+                        | MCP_PROTOCOL_VERSION_HEADER
+                        | MCP_METHOD_HEADER
+                        | MCP_NAME_HEADER
+                ) || name.starts_with("mcp-param-")
+            })
+            .cloned()
+            .collect();
+        for name in configured_protocol_headers {
+            headers.remove(name);
         }
 
-        Ok(headers)
+        if let Some(version) = metadata.protocol_version.as_deref() {
+            headers.insert(
+                MCP_PROTOCOL_VERSION_HEADER,
+                HeaderValue::from_str(version).map_err(|error| {
+                    McpError::Transport(format!("Invalid MCP protocol version header: {error}"))
+                })?,
+            );
+        } else if metadata.modern {
+            return Err(McpError::Protocol(
+                "Modern Streamable HTTP request is missing a protocol version".to_string(),
+            ));
+        }
+
+        if !metadata.modern {
+            return Ok(());
+        }
+
+        headers.insert(
+            MCP_METHOD_HEADER,
+            HeaderValue::from_str(&metadata.method).map_err(|error| {
+                McpError::Transport(format!("Invalid MCP method header: {error}"))
+            })?,
+        );
+        if let Some(name) = metadata.name.as_deref() {
+            headers.insert(
+                MCP_NAME_HEADER,
+                Self::encoded_header_value(name, "Mcp-Name")?,
+            );
+        }
+        for (name, value) in &metadata.tool_parameter_headers {
+            let header_name = HeaderName::from_bytes(format!("mcp-param-{name}").as_bytes())
+                .map_err(|error| {
+                    McpError::Protocol(format!("Invalid x-mcp-header name '{name}': {error}"))
+                })?;
+            headers.insert(
+                header_name,
+                Self::encoded_header_value(value, &format!("Mcp-Param-{name}"))?,
+            );
+        }
+        Ok(())
+    }
+
+    fn encoded_header_value(value: &str, label: &str) -> Result<HeaderValue> {
+        let bytes = value.as_bytes();
+        let has_edge_whitespace = bytes
+            .first()
+            .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+            || bytes
+                .last()
+                .is_some_and(|byte| matches!(byte, b' ' | b'\t'));
+        let visible_ascii_or_tab = bytes.iter().all(|byte| matches!(byte, b'\t' | b' '..=b'~'));
+        let matches_sentinel = value.starts_with("=?base64?") && value.ends_with("?=");
+        let encoded = if visible_ascii_or_tab && !has_edge_whitespace && !matches_sentinel {
+            value.to_string()
+        } else {
+            format!("=?base64?{}?=", BASE64_STANDARD.encode(bytes))
+        };
+        HeaderValue::from_str(&encoded)
+            .map_err(|error| McpError::Transport(format!("Invalid {label} value: {error}")))
     }
 
     fn redact_url_for_log(url: &str) -> String {
@@ -100,14 +189,17 @@ impl StreamableHttpTransport {
     async fn post_and_route_response(
         &self,
         message: String,
-        session_id: Option<String>,
+        metadata: &McpTransportMetadata,
     ) -> Result<()> {
-        let mut headers = self.build_headers(true)?;
+        let mut headers = self.build_headers()?;
+        Self::apply_request_metadata(&mut headers, metadata)?;
 
-        if let Some(sid) = session_id {
-            let value = HeaderValue::from_str(&sid)
-                .map_err(|e| McpError::Transport(format!("Invalid session id: {}", e)))?;
-            headers.insert(MCP_SESSION_ID_HEADER, value);
+        if !metadata.modern {
+            if let Some(sid) = self.session_id.lock().await.clone() {
+                let value = HeaderValue::from_str(&sid)
+                    .map_err(|e| McpError::Transport(format!("Invalid session id: {}", e)))?;
+                headers.insert(MCP_SESSION_ID_HEADER, value);
+            }
         }
 
         trace!(
@@ -129,13 +221,16 @@ impl StreamableHttpTransport {
 
         let status = response.status();
 
-        // Extract session id from response if present.
-        if let Some(sid) = response.headers().get(MCP_SESSION_ID_HEADER) {
-            let sid_str = sid
-                .to_str()
-                .map_err(|e| McpError::Transport(format!("Invalid session id header: {}", e)))?;
-            let mut guard = self.session_id.lock().await;
-            guard.get_or_insert_with(|| sid_str.to_string());
+        // Modern MCP is sessionless. Only legacy exchanges may establish a
+        // protocol-level session.
+        if !metadata.modern {
+            if let Some(sid) = response.headers().get(MCP_SESSION_ID_HEADER) {
+                let sid_str = sid.to_str().map_err(|e| {
+                    McpError::Transport(format!("Invalid session id header: {}", e))
+                })?;
+                let mut guard = self.session_id.lock().await;
+                guard.get_or_insert_with(|| sid_str.to_string());
+            }
         }
 
         if status == reqwest::StatusCode::ACCEPTED {
@@ -146,6 +241,14 @@ impl StreamableHttpTransport {
 
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
+            // Modern negotiation errors use HTTP 400 with a JSON-RPC error body.
+            // Route a well-formed error through the normal response channel so
+            // the protocol client can distinguish modern errors from legacy
+            // fallback signals.
+            if Self::is_json_rpc_error_response(&body) {
+                self.route_message(body).await?;
+                return Ok(());
+            }
             return Err(McpError::Transport(format!(
                 "POST failed: {} - {}",
                 status, body
@@ -209,25 +312,43 @@ impl StreamableHttpTransport {
                     "MCP StreamableHTTP POST response is JSON (bytes={})",
                     body.len()
                 );
-                if let Some(tx) = self.message_tx.as_ref() {
-                    if tx.send(body).await.is_err() {
-                        warn!("MCP StreamableHTTP: message channel closed");
-                    }
-                }
+                self.route_message(body).await?;
             }
         }
 
         Ok(())
     }
 
+    async fn route_message(&self, body: String) -> Result<()> {
+        let Some(tx) = self.message_tx.as_ref() else {
+            return Err(McpError::Disconnected);
+        };
+        tx.send(body).await.map_err(|_| McpError::Disconnected)
+    }
+
+    fn is_json_rpc_error_response(body: &str) -> bool {
+        serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .is_some_and(|value| {
+                value.get("jsonrpc").and_then(serde_json::Value::as_str) == Some("2.0")
+                    && value.get("error").is_some_and(serde_json::Value::is_object)
+            })
+    }
+
     /// Attempt to open a GET SSE stream for server-initiated messages.
     /// Per spec, the server MAY return 405 if it doesn't support this.
     async fn start_get_sse_stream(&self) {
-        let mut headers = self.build_headers(true).unwrap_or_default();
+        let mut headers = self.build_headers().unwrap_or_default();
         headers.insert(
             reqwest::header::ACCEPT,
             HeaderValue::from_static("text/event-stream"),
         );
+
+        if let Some(version) = self.legacy_protocol_version.lock().await.as_deref() {
+            if let Ok(value) = HeaderValue::from_str(version) {
+                headers.insert(MCP_PROTOCOL_VERSION_HEADER, value);
+            }
+        }
 
         // Add session id if available.
         {
@@ -325,9 +446,9 @@ impl McpTransport for StreamableHttpTransport {
             self.config.connect_timeout_ms
         );
 
-        // Streamable HTTP doesn't have a separate "connect" step in the traditional
-        // sense. The first request (initialize) will be sent via send(). Here we
-        // just mark the transport as ready and optionally open a GET SSE stream.
+        // Streamable HTTP has no separate wire-level connect step. The protocol
+        // client first probes with `server/discover`, or falls back to legacy
+        // `initialize`.
         //
         // Recreate the message channel so a connect()-after-disconnect() works.
         // disconnect() drops `message_tx` and the receiver is take-once, so
@@ -391,9 +512,14 @@ impl McpTransport for StreamableHttpTransport {
         {
             let sid = self.session_id.lock().await;
             if let Some(session_id) = sid.as_ref() {
-                let mut headers = self.build_headers(false)?;
+                let mut headers = self.build_headers()?;
                 if let Ok(value) = HeaderValue::from_str(session_id) {
                     headers.insert(MCP_SESSION_ID_HEADER, value);
+                }
+                if let Some(version) = self.legacy_protocol_version.lock().await.as_deref() {
+                    if let Ok(value) = HeaderValue::from_str(version) {
+                        headers.insert(MCP_PROTOCOL_VERSION_HEADER, value);
+                    }
                 }
 
                 trace!(
@@ -414,32 +540,55 @@ impl McpTransport for StreamableHttpTransport {
             let mut guard = self.session_id.lock().await;
             *guard = None;
         }
+        {
+            let mut guard = self.legacy_protocol_version.lock().await;
+            *guard = None;
+        }
 
         debug!("MCP StreamableHTTP transport disconnected");
         Ok(())
     }
 
     async fn send(&self, message: String) -> Result<()> {
+        self.send_with_metadata(message, McpTransportMetadata::default())
+            .await
+    }
+
+    async fn send_with_metadata(
+        &self,
+        message: String,
+        metadata: McpTransportMetadata,
+    ) -> Result<()> {
         if !self.is_connected() {
             return Err(McpError::Disconnected);
         }
 
-        let session_id = self.session_id.lock().await.clone();
-
-        self.post_and_route_response(message, session_id).await?;
-
-        // After the first successful exchange, try to open the GET SSE stream
-        // for server-initiated messages (if not already opened).
+        let starts_legacy_operation_phase = !metadata.modern && metadata.protocol_version.is_some();
+        if let Some(version) = (!metadata.modern)
+            .then_some(metadata.protocol_version.as_ref())
+            .flatten()
         {
+            *self.legacy_protocol_version.lock().await = Some(version.clone());
+        }
+
+        self.post_and_route_response(message, &metadata).await?;
+
+        // GET streams and protocol sessions were removed in 2026-07-28. Open
+        // the standalone stream only after legacy initialization has completed
+        // and the negotiated protocol version is available.
+        if starts_legacy_operation_phase {
             let guard = self.get_sse_handle.lock().await;
             if guard.is_none() {
-                // Don't hold the lock while starting the stream.
                 drop(guard);
                 self.start_get_sse_stream().await;
             }
         }
 
         Ok(())
+    }
+
+    fn requires_tool_parameter_headers(&self) -> bool {
+        true
     }
 
     async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
@@ -522,7 +671,7 @@ mod tests {
     fn test_build_headers_basic() {
         let config = create_test_config();
         let transport = StreamableHttpTransport::new(config);
-        let headers = transport.build_headers(false).unwrap();
+        let headers = transport.build_headers().unwrap();
 
         assert_eq!(headers.get(reqwest::header::ACCEPT).unwrap(), ACCEPT_HEADER);
         assert_eq!(
@@ -544,7 +693,7 @@ mod tests {
             connect_timeout_ms: 5000,
         };
         let transport = StreamableHttpTransport::new(config);
-        let headers = transport.build_headers(false).unwrap();
+        let headers = transport.build_headers().unwrap();
 
         assert!(headers.contains_key("authorization"));
     }
@@ -562,7 +711,135 @@ mod tests {
             connect_timeout_ms: 5000,
         };
         let transport = StreamableHttpTransport::new(config);
-        assert!(transport.build_headers(false).is_err());
+        assert!(transport.build_headers().is_err());
+    }
+
+    #[test]
+    fn modern_request_headers_are_body_derived_and_safely_encoded() {
+        let config = StreamableHttpConfig {
+            url: "http://localhost:3000/mcp".to_string(),
+            headers: vec![
+                HeaderConfig {
+                    name: "MCP-Protocol-Version".to_string(),
+                    value: "stale".to_string(),
+                    value_encrypted: None,
+                    credential_ref: None,
+                },
+                HeaderConfig {
+                    name: "Mcp-Method".to_string(),
+                    value: "wrong/method".to_string(),
+                    value_encrypted: None,
+                    credential_ref: None,
+                },
+                HeaderConfig {
+                    name: "Mcp-Name".to_string(),
+                    value: "wrong-name".to_string(),
+                    value_encrypted: None,
+                    credential_ref: None,
+                },
+                HeaderConfig {
+                    name: "Mcp-Param-Unused".to_string(),
+                    value: "must-be-removed".to_string(),
+                    value_encrypted: None,
+                    credential_ref: None,
+                },
+                HeaderConfig {
+                    name: "Authorization".to_string(),
+                    value: "Bearer retained".to_string(),
+                    value_encrypted: None,
+                    credential_ref: None,
+                },
+            ],
+            connect_timeout_ms: 5000,
+        };
+        let transport = StreamableHttpTransport::new(config);
+        let mut headers = transport.build_headers().expect("configured headers");
+        StreamableHttpTransport::apply_request_metadata(
+            &mut headers,
+            &McpTransportMetadata {
+                protocol_version: Some("2026-07-28".to_string()),
+                modern: true,
+                method: "tools/call".to_string(),
+                name: Some("天气".to_string()),
+                tool_parameter_headers: vec![
+                    ("Region".to_string(), " 华东 ".to_string()),
+                    ("Shard".to_string(), "42".to_string()),
+                ],
+            },
+        )
+        .expect("modern headers");
+
+        assert_eq!(headers[MCP_PROTOCOL_VERSION_HEADER], "2026-07-28");
+        assert_eq!(headers[MCP_METHOD_HEADER], "tools/call");
+        assert_eq!(
+            headers[MCP_NAME_HEADER],
+            format!("=?base64?{}?=", BASE64_STANDARD.encode("天气"))
+        );
+        assert_eq!(
+            headers["mcp-param-region"],
+            format!("=?base64?{}?=", BASE64_STANDARD.encode(" 华东 "))
+        );
+        assert_eq!(headers["mcp-param-shard"], "42");
+        assert!(!headers.contains_key("mcp-param-unused"));
+        assert_eq!(headers["authorization"], "Bearer retained");
+    }
+
+    #[test]
+    fn legacy_request_omits_modern_standard_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(MCP_METHOD_HEADER, HeaderValue::from_static("stale"));
+        headers.insert(MCP_NAME_HEADER, HeaderValue::from_static("stale"));
+        headers.insert("mcp-param-region", HeaderValue::from_static("stale"));
+
+        StreamableHttpTransport::apply_request_metadata(
+            &mut headers,
+            &McpTransportMetadata {
+                protocol_version: Some("2025-11-25".to_string()),
+                modern: false,
+                method: "tools/call".to_string(),
+                name: Some("weather".to_string()),
+                tool_parameter_headers: vec![("Region".to_string(), "west".to_string())],
+            },
+        )
+        .expect("legacy headers");
+
+        assert_eq!(headers[MCP_PROTOCOL_VERSION_HEADER], "2025-11-25");
+        assert!(!headers.contains_key(MCP_METHOD_HEADER));
+        assert!(!headers.contains_key(MCP_NAME_HEADER));
+        assert!(!headers.contains_key("mcp-param-region"));
+    }
+
+    #[test]
+    fn modern_header_encoding_escapes_sentinel_and_control_characters() {
+        let sentinel = StreamableHttpTransport::encoded_header_value("=?base64?literal?=", "test")
+            .expect("sentinel encoding");
+        assert_eq!(
+            sentinel,
+            format!(
+                "=?base64?{}?=",
+                BASE64_STANDARD.encode("=?base64?literal?=")
+            )
+        );
+
+        let newline = StreamableHttpTransport::encoded_header_value("line1\nline2", "test")
+            .expect("control encoding");
+        assert_eq!(
+            newline,
+            format!("=?base64?{}?=", BASE64_STANDARD.encode("line1\nline2"))
+        );
+    }
+
+    #[test]
+    fn recognizes_json_rpc_error_bodies_for_http_negotiation() {
+        assert!(StreamableHttpTransport::is_json_rpc_error_response(
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32022,"message":"unsupported"}}"#
+        ));
+        assert!(!StreamableHttpTransport::is_json_rpc_error_response(
+            r#"{"jsonrpc":"2.0","id":1,"result":{}}"#
+        ));
+        assert!(!StreamableHttpTransport::is_json_rpc_error_response(
+            "legacy error page"
+        ));
     }
 
     #[test]

--- a/crates/infra/bamboo-mcp/src/transports/streamable_http.rs
+++ b/crates/infra/bamboo-mcp/src/transports/streamable_http.rs
@@ -18,8 +18,8 @@ use tracing::{debug, trace, warn};
 
 use crate::config::{HeaderConfig, StreamableHttpConfig};
 use crate::error::{McpError, Result};
-use crate::protocol::client::{McpTransport, McpTransportMetadata};
-use crate::protocol::models::JsonRpcError;
+use crate::protocol::client::{McpCancellationMetadata, McpTransport, McpTransportMetadata};
+use crate::protocol::models::{JsonRpcError, JsonRpcNotification};
 
 const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
 const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
@@ -252,16 +252,17 @@ impl StreamableHttpTransport {
             // error directly instead of routing it through `JsonRpcResponse`,
             // whose response correlation necessarily requires an id.
             if let Some(error) = Self::parse_json_rpc_error_response(&body) {
-                return Err(McpError::RemoteProtocol {
+                return Err(McpError::HttpProtocol {
+                    status: status.as_u16(),
                     code: error.code,
                     message: error.message,
                     data: error.data,
                 });
             }
-            return Err(McpError::Transport(format!(
-                "POST failed: {} - {}",
-                status, body
-            )));
+            return Err(McpError::HttpStatus {
+                status: status.as_u16(),
+                body,
+            });
         }
 
         let content_type = response
@@ -633,20 +634,64 @@ impl McpTransport for StreamableHttpTransport {
         Ok(())
     }
 
-    async fn cancel_request(&self, request_id: u64, _reason: &str) -> Result<()> {
-        let mut handles = self.post_sse_handles.lock().await;
-        if let Some(index) = handles
-            .iter()
-            .position(|entry| entry.request_id == Some(request_id))
-        {
-            let entry = handles.remove(index);
-            entry.handle.abort();
-            trace!(
-                "Cancelled MCP StreamableHTTP request by closing response stream (id={})",
-                request_id
-            );
+    async fn cancel_request(
+        &self,
+        request_id: u64,
+        reason: &str,
+        metadata: McpCancellationMetadata,
+    ) -> Result<()> {
+        if metadata.modern {
+            let mut handles = self.post_sse_handles.lock().await;
+            if let Some(index) = handles
+                .iter()
+                .position(|entry| entry.request_id == Some(request_id))
+            {
+                let entry = handles.remove(index);
+                entry.handle.abort();
+                trace!(
+                    "Cancelled modern MCP StreamableHTTP request by closing response stream (id={})",
+                    request_id
+                );
+            }
+            return Ok(());
         }
-        Ok(())
+
+        // Initialization-based Streamable HTTP revisions use the JSON-RPC
+        // cancellation notification, just like stdio. They do not assign an
+        // SSE response stream as the cancellation primitive.
+        let notification = JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: "notifications/cancelled".to_string(),
+            params: Some(serde_json::json!({
+                "requestId": request_id,
+                "reason": reason,
+            })),
+        };
+        self.send_with_metadata(
+            serde_json::to_string(&notification)?,
+            McpTransportMetadata {
+                request_id: None,
+                protocol_version: metadata.protocol_version,
+                modern: false,
+                method: notification.method,
+                name: None,
+                tool_parameter_headers: Vec::new(),
+            },
+        )
+        .await
+    }
+
+    fn is_legacy_fallback_error(&self, error: &McpError) -> bool {
+        matches!(
+            error,
+            McpError::HttpStatus {
+                status: 400..=499,
+                ..
+            } | McpError::HttpProtocol {
+                status: 400..=499,
+                ..
+            }
+        )
     }
 
     fn requires_tool_parameter_headers(&self) -> bool {
@@ -745,6 +790,62 @@ mod tests {
                 .expect("write test response");
         });
         format!("http://{address}/mcp")
+    }
+
+    async fn serve_http_once_and_capture(
+        status: &str,
+        content_type: &str,
+        body: &str,
+    ) -> (String, tokio::sync::oneshot::Receiver<String>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let status = status.to_string();
+        let content_type = content_type.to_string();
+        let body = body.to_string();
+        let (request_tx, request_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept test request");
+            let mut request = Vec::new();
+            let expected_len = loop {
+                let mut chunk = [0_u8; 2048];
+                let read = socket.read(&mut chunk).await.expect("read test request");
+                assert!(read > 0, "request closed before headers completed");
+                request.extend_from_slice(&chunk[..read]);
+                let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_len = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                break header_end + 4 + content_len;
+            };
+            while request.len() < expected_len {
+                let mut chunk = [0_u8; 2048];
+                let read = socket.read(&mut chunk).await.expect("read test body");
+                assert!(read > 0, "request closed before body completed");
+                request.extend_from_slice(&chunk[..read]);
+            }
+            let _ = request_tx.send(String::from_utf8_lossy(&request).into_owned());
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write test response");
+        });
+        (format!("http://{address}/mcp"), request_rx)
     }
 
     #[test]
@@ -968,8 +1069,77 @@ mod tests {
             .expect_err("HTTP JSON-RPC error must surface");
         assert!(matches!(
             error,
-            McpError::RemoteProtocol { code: -32022, .. }
+            McpError::HttpProtocol {
+                status: 400,
+                code: -32022,
+                ..
+            }
         ));
+    }
+
+    #[tokio::test]
+    async fn non_json_http_errors_preserve_status_for_era_detection() {
+        for (status_line, expected_status) in [
+            ("400 Bad Request", 400_u16),
+            ("404 Not Found", 404_u16),
+            ("503 Service Unavailable", 503_u16),
+        ] {
+            let url = serve_http_once(status_line, "text/plain", "not JSON-RPC").await;
+            let transport = StreamableHttpTransport::new(StreamableHttpConfig {
+                url,
+                headers: Vec::new(),
+                connect_timeout_ms: 1000,
+            });
+            let error = transport
+                .post_and_route_response(
+                    r#"{"jsonrpc":"2.0","id":7,"method":"server/discover","params":{}}"#
+                        .to_string(),
+                    &McpTransportMetadata {
+                        request_id: Some(7),
+                        protocol_version: Some("2026-07-28".to_string()),
+                        modern: true,
+                        method: "server/discover".to_string(),
+                        name: None,
+                        tool_parameter_headers: Vec::new(),
+                    },
+                )
+                .await
+                .expect_err("HTTP status must surface");
+            assert!(matches!(
+                error,
+                McpError::HttpStatus {
+                    status,
+                    ref body
+                } if status == expected_status && body == "not JSON-RPC"
+            ));
+        }
+    }
+
+    #[test]
+    fn only_http_4xx_is_a_legacy_fallback_signal() {
+        let transport = StreamableHttpTransport::new(create_test_config());
+        assert!(transport.is_legacy_fallback_error(&McpError::HttpStatus {
+            status: 400,
+            body: "legacy".to_string(),
+        }));
+        assert!(transport.is_legacy_fallback_error(&McpError::HttpStatus {
+            status: 404,
+            body: "legacy".to_string(),
+        }));
+        assert!(transport.is_legacy_fallback_error(&McpError::HttpProtocol {
+            status: 400,
+            code: -32601,
+            message: "Method not found".to_string(),
+            data: None,
+        }));
+        assert!(!transport.is_legacy_fallback_error(&McpError::HttpStatus {
+            status: 503,
+            body: "temporary failure".to_string(),
+        }));
+        assert!(!transport
+            .is_legacy_fallback_error(&McpError::Timeout("modern probe timed out".to_string(),)));
+        assert!(!transport
+            .is_legacy_fallback_error(&McpError::Transport("connection refused".to_string(),)));
     }
 
     #[tokio::test]
@@ -1242,7 +1412,14 @@ mod tests {
         }
 
         transport
-            .cancel_request(7, "test timeout")
+            .cancel_request(
+                7,
+                "test timeout",
+                McpCancellationMetadata {
+                    protocol_version: Some("2026-07-28".to_string()),
+                    modern: true,
+                },
+            )
             .await
             .expect("cancel stream");
         tokio::task::yield_now().await;
@@ -1251,6 +1428,43 @@ mod tests {
         assert_eq!(transport.post_sse_handles.lock().await.len(), 1);
 
         second_abort.abort();
+    }
+
+    #[tokio::test]
+    async fn legacy_http_cancellation_sends_notification_instead_of_closing_stream() {
+        let (url, request_rx) =
+            serve_http_once_and_capture("202 Accepted", "application/json", "").await;
+        let mut transport = StreamableHttpTransport::new(StreamableHttpConfig {
+            url,
+            headers: Vec::new(),
+            connect_timeout_ms: 1000,
+        });
+        transport.connect().await.expect("connect");
+
+        transport
+            .cancel_request(
+                19,
+                "legacy timeout",
+                McpCancellationMetadata {
+                    protocol_version: Some("2025-11-25".to_string()),
+                    modern: false,
+                },
+            )
+            .await
+            .expect("send legacy cancellation");
+
+        let request = request_rx.await.expect("captured cancellation");
+        let request_lower = request.to_ascii_lowercase();
+        assert!(request_lower.contains("mcp-protocol-version: 2025-11-25"));
+        let body = request
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body)
+            .expect("HTTP body");
+        let notification: serde_json::Value =
+            serde_json::from_str(body).expect("cancellation notification JSON");
+        assert_eq!(notification["method"], "notifications/cancelled");
+        assert_eq!(notification["params"]["requestId"], 19);
+        assert_eq!(notification["params"]["reason"], "legacy timeout");
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-mcp/src/types.rs
+++ b/crates/infra/bamboo-mcp/src/types.rs
@@ -83,8 +83,10 @@ pub struct McpTool {
 /// let result = McpCallResult {
 ///     content: vec![McpContentItem::Text {
 ///         text: "File contents here".to_string(),
+///         metadata: McpContentMetadata::default(),
 ///     }],
 ///     is_error: false,
+///     structured_content: McpStructuredContent::Missing,
 /// };
 ///
 /// if !result.is_error {
@@ -154,12 +156,14 @@ impl McpStructuredContent {
 /// // Text content
 /// let text = McpContentItem::Text {
 ///     text: "Hello, world!".to_string(),
+///     metadata: McpContentMetadata::default(),
 /// };
 ///
 /// // Image content
 /// let image = McpContentItem::Image {
 ///     data: base64_encoded_data,
 ///     mime_type: "image/png".to_string(),
+///     metadata: McpContentMetadata::default(),
 /// };
 ///
 /// // Resource reference
@@ -169,9 +173,58 @@ impl McpStructuredContent {
 ///         mime_type: Some("text/plain".to_string()),
 ///         text: Some("file contents".to_string()),
 ///         blob: None,
+///         meta: None,
 ///     },
+///     metadata: McpContentMetadata::default(),
 /// };
 /// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct McpContentMetadata {
+    /// Optional hints about intended audience, priority, and freshness.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<McpAnnotations>,
+    /// Protocol/application metadata whose prefixed keys must round-trip.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct McpAnnotations {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audience: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<f64>,
+    #[serde(
+        rename = "lastModified",
+        alias = "last_modified",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub last_modified: Option<String>,
+    /// Preserve future annotation fields instead of silently discarding them.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpIcon {
+    pub src: String,
+    #[serde(
+        rename = "mimeType",
+        alias = "mime_type",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sizes: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
+    /// Preserve future icon fields instead of silently discarding them.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum McpContentItem {
@@ -180,6 +233,8 @@ pub enum McpContentItem {
     Text {
         /// The text content
         text: String,
+        #[serde(flatten)]
+        metadata: McpContentMetadata,
     },
     /// Image content (base64-encoded)
     #[serde(rename = "image")]
@@ -190,6 +245,8 @@ pub enum McpContentItem {
         /// MCP sends this as `mimeType`; accept legacy `mime_type` too.
         #[serde(rename = "mimeType", alias = "mime_type")]
         mime_type: String,
+        #[serde(flatten)]
+        metadata: McpContentMetadata,
     },
     /// Audio content (base64-encoded).
     #[serde(rename = "audio")]
@@ -199,6 +256,8 @@ pub enum McpContentItem {
         /// MIME type of the audio.
         #[serde(rename = "mimeType", alias = "mime_type")]
         mime_type: String,
+        #[serde(flatten)]
+        metadata: McpContentMetadata,
     },
     /// Link to a resource that the server can read.
     #[serde(rename = "resource_link")]
@@ -224,12 +283,19 @@ pub enum McpContentItem {
         /// Optional raw resource size in bytes.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         size: Option<u64>,
+        /// Optional display icons.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        icons: Option<Vec<McpIcon>>,
+        #[serde(flatten)]
+        metadata: McpContentMetadata,
     },
     /// Resource reference
     #[serde(rename = "resource")]
     Resource {
         /// The resource being referenced
         resource: McpResource,
+        #[serde(flatten)]
+        metadata: McpContentMetadata,
     },
 }
 
@@ -258,6 +324,7 @@ pub enum McpContentItem {
 ///     mime_type: Some("text/plain".to_string()),
 ///     text: Some("File contents here".to_string()),
 ///     blob: None,
+///     meta: None,
 /// };
 ///
 /// // Binary file resource
@@ -266,6 +333,7 @@ pub enum McpContentItem {
 ///     mime_type: Some("image/png".to_string()),
 ///     text: None,
 ///     blob: Some(base64_encoded_data),
+///     meta: None,
 /// };
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -286,6 +354,9 @@ pub struct McpResource {
     /// Binary content as base64 (for binary resources)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob: Option<String>,
+    /// Metadata attached directly to the embedded resource contents.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 /// Server runtime status indicator.
@@ -536,6 +607,7 @@ mod tests {
         let result = McpCallResult {
             content: vec![McpContentItem::Text {
                 text: "success".to_string(),
+                metadata: McpContentMetadata::default(),
             }],
             is_error: false,
             structured_content: McpStructuredContent::Missing,
@@ -549,6 +621,7 @@ mod tests {
         let result = McpCallResult {
             content: vec![McpContentItem::Text {
                 text: "error occurred".to_string(),
+                metadata: McpContentMetadata::default(),
             }],
             is_error: true,
             structured_content: McpStructuredContent::Missing,
@@ -560,9 +633,10 @@ mod tests {
     fn test_mcp_content_item_text() {
         let item = McpContentItem::Text {
             text: "hello".to_string(),
+            metadata: McpContentMetadata::default(),
         };
         match item {
-            McpContentItem::Text { text } => assert_eq!(text, "hello"),
+            McpContentItem::Text { text, .. } => assert_eq!(text, "hello"),
             _ => panic!("Expected Text variant"),
         }
     }
@@ -572,9 +646,12 @@ mod tests {
         let item = McpContentItem::Image {
             data: "base64data".to_string(),
             mime_type: "image/png".to_string(),
+            metadata: McpContentMetadata::default(),
         };
         match item {
-            McpContentItem::Image { data, mime_type } => {
+            McpContentItem::Image {
+                data, mime_type, ..
+            } => {
                 assert_eq!(data, "base64data");
                 assert_eq!(mime_type, "image/png");
             }
@@ -590,7 +667,9 @@ mod tests {
         let json = r#"{"type":"image","data":"abc","mimeType":"image/jpeg"}"#;
         let item: McpContentItem = serde_json::from_str(json).expect("parse mimeType image");
         match item {
-            McpContentItem::Image { data, mime_type } => {
+            McpContentItem::Image {
+                data, mime_type, ..
+            } => {
                 assert_eq!(data, "abc");
                 assert_eq!(mime_type, "image/jpeg");
             }
@@ -603,29 +682,91 @@ mod tests {
     }
 
     #[test]
-    fn modern_audio_and_resource_link_content_deserialize() {
+    fn modern_content_metadata_and_resource_icons_round_trip() {
+        let audio_json = serde_json::json!({
+            "type": "audio",
+            "data": "UklGRg==",
+            "mimeType": "audio/wav",
+            "annotations": {
+                "audience": ["assistant"],
+                "priority": 0.8,
+                "futureHint": true
+            },
+            "_meta": {"example.com/trace": "trace-1"}
+        });
         let audio: McpContentItem =
-            serde_json::from_str(r#"{"type":"audio","data":"UklGRg==","mimeType":"audio/wav"}"#)
-                .expect("parse modern audio");
+            serde_json::from_value(audio_json.clone()).expect("parse modern audio");
         assert!(matches!(
-            audio,
-            McpContentItem::Audio { ref data, ref mime_type }
-                if data == "UklGRg==" && mime_type == "audio/wav"
+            &audio,
+            McpContentItem::Audio {
+                data,
+                mime_type,
+                metadata
+            } if data == "UklGRg=="
+                && mime_type == "audio/wav"
+                && metadata.annotations.as_ref().is_some_and(|annotations| {
+                    annotations.extra.get("futureHint") == Some(&serde_json::Value::Bool(true))
+                })
         ));
+        assert_eq!(
+            serde_json::to_value(&audio).expect("serialize audio"),
+            audio_json
+        );
 
-        let link: McpContentItem = serde_json::from_str(
-            r#"{"type":"resource_link","uri":"file:///report.json","name":"report","title":"Report","mimeType":"application/json","size":42}"#,
-        )
-        .expect("parse modern resource link");
+        let link_json = serde_json::json!({
+            "type": "resource_link",
+            "uri": "file:///report.json",
+            "name": "report",
+            "title": "Report",
+            "mimeType": "application/json",
+            "size": 42,
+            "icons": [{
+                "src": "data:image/png;base64,AA==",
+                "mimeType": "image/png",
+                "sizes": ["16x16"],
+                "theme": "dark",
+                "futureIconField": "kept"
+            }],
+            "annotations": {"lastModified": "2026-07-30T00:00:00Z"},
+            "_meta": {"example.com/source": "fixture"}
+        });
+        let link: McpContentItem =
+            serde_json::from_value(link_json.clone()).expect("parse modern resource link");
         assert!(matches!(
-            link,
+            &link,
             McpContentItem::ResourceLink {
-                ref uri,
-                ref name,
+                uri,
+                name,
                 size: Some(42),
+                icons: Some(icons),
                 ..
-            } if uri == "file:///report.json" && name == "report"
+            } if uri == "file:///report.json"
+                && name == "report"
+                && icons[0].extra.get("futureIconField")
+                    == Some(&serde_json::Value::String("kept".to_string()))
         ));
+        assert_eq!(
+            serde_json::to_value(&link).expect("serialize link"),
+            link_json
+        );
+
+        let embedded_json = serde_json::json!({
+            "type": "resource",
+            "resource": {
+                "uri": "file:///payload.bin",
+                "mimeType": "application/octet-stream",
+                "blob": "AAEC",
+                "_meta": {"example.com/checksum": "abc"}
+            },
+            "annotations": {"audience": ["user"]},
+            "_meta": {"example.com/container": true}
+        });
+        let embedded: McpContentItem =
+            serde_json::from_value(embedded_json.clone()).expect("parse embedded resource");
+        assert_eq!(
+            serde_json::to_value(&embedded).expect("serialize embedded resource"),
+            embedded_json
+        );
     }
 
     #[test]
@@ -656,10 +797,12 @@ mod tests {
                 mime_type: Some("text/plain".to_string()),
                 text: Some("content".to_string()),
                 blob: None,
+                meta: None,
             },
+            metadata: McpContentMetadata::default(),
         };
         match item {
-            McpContentItem::Resource { resource } => {
+            McpContentItem::Resource { resource, .. } => {
                 assert_eq!(resource.uri, "file:///test.txt");
             }
             _ => panic!("Expected Resource variant"),
@@ -673,6 +816,7 @@ mod tests {
             mime_type: Some("text/plain".to_string()),
             text: Some("file content".to_string()),
             blob: None,
+            meta: None,
         };
         assert_eq!(resource.uri, "file:///test.txt");
         assert_eq!(resource.mime_type, Some("text/plain".to_string()));

--- a/crates/infra/bamboo-mcp/src/types.rs
+++ b/crates/infra/bamboo-mcp/src/types.rs
@@ -56,6 +56,9 @@ pub struct McpTool {
     pub description: String,
     /// JSON Schema describing the tool's input parameters
     pub parameters: serde_json::Value,
+    /// Optional JSON Schema describing the tool's structured output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
 }
 
 /// Result of calling an MCP tool.
@@ -97,6 +100,41 @@ pub struct McpCallResult {
     /// Whether the tool execution encountered an error
     #[serde(default)]
     pub is_error: bool,
+    /// Optional structured result. `Missing` and an explicit JSON `null` stay
+    /// distinct so the 2026-07-28 wire value is preserved exactly.
+    #[serde(default, skip_serializing_if = "McpStructuredContent::is_missing")]
+    pub structured_content: McpStructuredContent,
+}
+
+/// Presence-aware structured tool output.
+///
+/// MCP permits any JSON value, including `null`, in `structuredContent`.
+/// A plain `Option<Value>` would collapse an explicit `null` into a missing
+/// field during deserialization.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum McpStructuredContent {
+    /// An explicitly returned JSON `null`.
+    Null,
+    /// Any non-null JSON value.
+    Value(serde_json::Value),
+    /// The server omitted `structuredContent`.
+    #[default]
+    Missing,
+}
+
+impl McpStructuredContent {
+    pub fn is_missing(&self) -> bool {
+        matches!(self, Self::Missing)
+    }
+
+    pub fn to_json_value(&self) -> Option<serde_json::Value> {
+        match self {
+            Self::Missing => None,
+            Self::Null => Some(serde_json::Value::Null),
+            Self::Value(value) => Some(value.clone()),
+        }
+    }
 }
 
 /// Content item returned by MCP tools.
@@ -152,6 +190,40 @@ pub enum McpContentItem {
         /// MCP sends this as `mimeType`; accept legacy `mime_type` too.
         #[serde(rename = "mimeType", alias = "mime_type")]
         mime_type: String,
+    },
+    /// Audio content (base64-encoded).
+    #[serde(rename = "audio")]
+    Audio {
+        /// Base64-encoded audio data.
+        data: String,
+        /// MIME type of the audio.
+        #[serde(rename = "mimeType", alias = "mime_type")]
+        mime_type: String,
+    },
+    /// Link to a resource that the server can read.
+    #[serde(rename = "resource_link")]
+    ResourceLink {
+        /// Resource URI.
+        uri: String,
+        /// Programmatic resource name.
+        name: String,
+        /// Optional display title.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        /// Optional human-readable description.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        /// Optional resource MIME type.
+        #[serde(
+            rename = "mimeType",
+            alias = "mime_type",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        mime_type: Option<String>,
+        /// Optional raw resource size in bytes.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        size: Option<u64>,
     },
     /// Resource reference
     #[serde(rename = "resource")]
@@ -453,6 +525,7 @@ mod tests {
             name: "read_file".to_string(),
             description: "Read a file".to_string(),
             parameters: serde_json::json!({"type": "object"}),
+            output_schema: None,
         };
         assert_eq!(tool.name, "read_file");
         assert_eq!(tool.description, "Read a file");
@@ -465,6 +538,7 @@ mod tests {
                 text: "success".to_string(),
             }],
             is_error: false,
+            structured_content: McpStructuredContent::Missing,
         };
         assert!(!result.is_error);
         assert_eq!(result.content.len(), 1);
@@ -477,6 +551,7 @@ mod tests {
                 text: "error occurred".to_string(),
             }],
             is_error: true,
+            structured_content: McpStructuredContent::Missing,
         };
         assert!(result.is_error);
     }
@@ -525,6 +600,52 @@ mod tests {
         // Legacy snake_case still accepted via alias.
         let legacy = r#"{"type":"image","data":"abc","mime_type":"image/png"}"#;
         assert!(serde_json::from_str::<McpContentItem>(legacy).is_ok());
+    }
+
+    #[test]
+    fn modern_audio_and_resource_link_content_deserialize() {
+        let audio: McpContentItem =
+            serde_json::from_str(r#"{"type":"audio","data":"UklGRg==","mimeType":"audio/wav"}"#)
+                .expect("parse modern audio");
+        assert!(matches!(
+            audio,
+            McpContentItem::Audio { ref data, ref mime_type }
+                if data == "UklGRg==" && mime_type == "audio/wav"
+        ));
+
+        let link: McpContentItem = serde_json::from_str(
+            r#"{"type":"resource_link","uri":"file:///report.json","name":"report","title":"Report","mimeType":"application/json","size":42}"#,
+        )
+        .expect("parse modern resource link");
+        assert!(matches!(
+            link,
+            McpContentItem::ResourceLink {
+                ref uri,
+                ref name,
+                size: Some(42),
+                ..
+            } if uri == "file:///report.json" && name == "report"
+        ));
+    }
+
+    #[test]
+    fn structured_content_distinguishes_missing_null_and_value() {
+        let missing: McpCallResult =
+            serde_json::from_str(r#"{"content":[],"is_error":false}"#).expect("missing");
+        assert_eq!(missing.structured_content, McpStructuredContent::Missing);
+
+        let explicit_null: McpCallResult =
+            serde_json::from_str(r#"{"content":[],"is_error":false,"structured_content":null}"#)
+                .expect("explicit null");
+        assert_eq!(explicit_null.structured_content, McpStructuredContent::Null);
+
+        let value: McpCallResult =
+            serde_json::from_str(r#"{"content":[],"structured_content":{"answer":42}}"#)
+                .expect("object value");
+        assert_eq!(
+            value.structured_content,
+            McpStructuredContent::Value(serde_json::json!({"answer": 42}))
+        );
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -113,9 +113,11 @@ confidence-threshold = 0.8
 #
 # Keep exceptions pinned to an exact package version instead of widening the
 # workspace-wide allow list. `notify` uses CC0-1.0 for a small portion of its
-# cross-platform filesystem-watcher implementation.
+# cross-platform filesystem-watcher implementation. `borrow-or-share` is a
+# transitive dependency of the MCP JSON Schema validator and uses MIT-0.
 exceptions = [
     { crate = "notify@8.2.0", allow = ["CC0-1.0"] },
+    { crate = "borrow-or-share@0.2.4", allow = ["MIT-0"] },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,


### PR DESCRIPTION
## Summary

- upgrade Bamboo MCP to the stable `2026-07-28` protocol revision with stateless per-request metadata and `server/discover`
- retain dual-era compatibility through `2025-11-25` initialization fallback and deprecated `2024-11-05` HTTP+SSE support
- implement sessionless Streamable HTTP, mandatory routing headers, safe parameter-header encoding, result discrimination, pagination, and cache fields
- open `subscriptions/listen` only after a correlated acknowledgment, enforce subscription IDs, detect broken streams, and reopen via health discovery
- apply protocol-aware cancellation: modern HTTP closes the owned SSE stream, legacy HTTP/stdio sends `notifications/cancelled`, and `initialize` is never cancelled
- preserve modern content blocks and metadata, including audio/base64 payloads, resource icons, annotations, and `_meta`
- compile each advertised `outputSchema` and validate successful `structuredContent` before it reaches the executor
- preserve HTTP status/protocol errors so only an unrecognized 4xx response body can fall back; timeouts, network failures, 5xx responses, and recognized modern errors stay pinned
- treat HTTP `4xx + -32601 Method not found` as modern evidence while retaining stdio `-32601` legacy fallback
- update the Bamboo server legacy MCP fixture to reject `server/discover` with JSON-RPC Method not found before initialization fallback

## Why

MCP `2026-07-28` removes protocol-level sessions and the initialization handshake for modern servers. It requires per-request version/capability metadata, modern HTTP routing headers, and acknowledged subscription streams for server-to-client list-change notifications. Bamboo needs these semantics while continuing to interoperate with installed legacy MCP servers.

## Review follow-up

The latest head addresses the independent review findings around HTTP downgrade safety (including transport-specific `-32601` handling), protocol-aware bounded cancellation, lossless content-block handling, and `outputSchema` validation.

## Test Plan

- `cargo metadata --locked --all-features --format-version 1`
- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-mcp --all-targets --all-features -- -D warnings`
- `cargo test --locked -p bamboo-mcp` — 209 passed
- `cargo test --all-features --lib --tests` — passed across the full workspace test graph on the preceding review-fix head; CI reruns the complete graph on this exact head
- `cargo test -p bamboo-server --all-features generic_runtime_effects_finish_before_later_config_writer` — 1 passed
- `cargo deny check --hide-inclusion-graph`
- `git diff --check`

## Screenshots

Not applicable — backend protocol and transport change only.