### PR TITLE
fix: make OpenAI Responses contracts spec-faithful

### DIFF
--- a/crates/app/bamboo-server/src/handlers/anthropic/complete/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/complete/non_stream.rs
@@ -92,6 +92,7 @@ pub(super) async fn handle_non_streaming_complete(
             }
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
             Ok(bamboo_llm::types::LLMChunk::TransportActivity)
+            | Ok(bamboo_llm::types::LLMChunk::ResponsesEvent { .. })
             | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::ProviderUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })

--- a/crates/app/bamboo-server/src/handlers/anthropic/conversion.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/conversion.rs
@@ -156,6 +156,7 @@ pub(super) fn convert_llm_chunk_to_openai(
             usage: None,
         }),
         bamboo_llm::types::LLMChunk::TransportActivity
+        | bamboo_llm::types::LLMChunk::ResponsesEvent { .. }
         | bamboo_llm::types::LLMChunk::CacheUsage { .. }
         | bamboo_llm::types::LLMChunk::ProviderUsage { .. }
         | bamboo_llm::types::LLMChunk::UsageSummary { .. }

--- a/crates/app/bamboo-server/src/handlers/anthropic/messages/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/messages/non_stream.rs
@@ -90,6 +90,7 @@ pub(super) async fn handle_non_streaming_messages(
             }
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
             Ok(bamboo_llm::types::LLMChunk::TransportActivity)
+            | Ok(bamboo_llm::types::LLMChunk::ResponsesEvent { .. })
             | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::ProviderUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })

--- a/crates/app/bamboo-server/src/handlers/gemini/generate/collect.rs
+++ b/crates/app/bamboo-server/src/handlers/gemini/generate/collect.rs
@@ -17,7 +17,7 @@ where
 
     while let Some(chunk) = stream.next().await {
         match chunk? {
-            LLMChunk::ResponseId(_) => {}
+            LLMChunk::ResponseId(_) | LLMChunk::ResponsesEvent { .. } => {}
             LLMChunk::Token(token) => collected.full_content.push_str(&token),
             LLMChunk::ReasoningToken(_) => {}
             LLMChunk::Done => break,

--- a/crates/app/bamboo-server/src/handlers/gemini/stream/runtime.rs
+++ b/crates/app/bamboo-server/src/handlers/gemini/stream/runtime.rs
@@ -65,6 +65,7 @@ pub(super) fn build_gemini_event_stream(
                     break;
                 }
                 Ok(LLMChunk::TransportActivity)
+                | Ok(LLMChunk::ResponsesEvent { .. })
                 | Ok(LLMChunk::CacheUsage { .. })
                 | Ok(LLMChunk::ProviderUsage { .. })
                 | Ok(LLMChunk::UsageSummary { .. })

--- a/crates/app/bamboo-server/src/handlers/openai/chat/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/non_stream.rs
@@ -87,6 +87,7 @@ pub(super) async fn handle_non_streaming_chat(
                 ));
             }
             Ok(bamboo_llm::types::LLMChunk::TransportActivity) => {}
+            Ok(bamboo_llm::types::LLMChunk::ResponsesEvent { .. }) => {}
             Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. }) => {}
             Ok(bamboo_llm::types::LLMChunk::ProviderUsage { .. }) => {}
             Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}

--- a/crates/app/bamboo-server/src/handlers/openai/chat/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/stream/worker.rs
@@ -67,6 +67,7 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
                 }
             }
             Ok(LLMChunk::TransportActivity)
+            | Ok(LLMChunk::ResponsesEvent { .. })
             | Ok(LLMChunk::CacheUsage { .. })
             | Ok(LLMChunk::ProviderUsage { .. })
             | Ok(LLMChunk::UsageSummary { .. })

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/mod.rs
@@ -30,6 +30,10 @@ pub(super) fn responses_input_to_chat_messages(
     responses_input::responses_input_to_chat_messages(input)
 }
 
+pub(super) fn has_responses_prompt_cache_breakpoint(input: &serde_json::Value) -> bool {
+    responses_options::has_responses_prompt_cache_breakpoint(input)
+}
+
 pub(super) fn now_unix_ts() -> u64 {
     stream_utils::now_unix_ts()
 }

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/responses_options.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/responses_options.rs
@@ -4,6 +4,21 @@ use serde_json::Value;
 
 use bamboo_llm::provider::ResponsesRequestOptions;
 
+pub(super) fn has_responses_prompt_cache_breakpoint(value: &Value) -> bool {
+    match value {
+        Value::Array(values) => values.iter().any(has_responses_prompt_cache_breakpoint),
+        Value::Object(object) => {
+            let supported_block = matches!(
+                object.get("type").and_then(Value::as_str),
+                Some("input_text" | "input_image" | "input_file")
+            );
+            supported_block && object.contains_key("prompt_cache_breakpoint")
+                || object.values().any(has_responses_prompt_cache_breakpoint)
+        }
+        _ => false,
+    }
+}
+
 fn parse_reasoning_summary(parameters: &HashMap<String, Value>) -> Option<String> {
     parameters
         .get("reasoning")
@@ -112,12 +127,24 @@ pub(super) fn parse_responses_request_options(
             .map(ToString::to_string),
         truncation: parse_truncation(parameters),
         text_verbosity,
+        prompt_cache_key: parameters
+            .get("prompt_cache_key")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string),
+        prompt_cache_options: parameters
+            .get("prompt_cache_options")
+            .filter(|value| value.is_object())
+            .cloned(),
+        raw_input_with_cache_breakpoints: None,
+        retain_protocol_events: true,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::parse_responses_request_options;
+    use super::{has_responses_prompt_cache_breakpoint, parse_responses_request_options};
     use serde_json::Value;
     use std::collections::HashMap;
 
@@ -129,7 +156,9 @@ mod tests {
             "store": true,
             "previous_response_id": "resp_123",
             "truncation": "auto",
-            "text": { "verbosity": "high" }
+            "text": { "verbosity": "high" },
+            "prompt_cache_key": "tenant:stable",
+            "prompt_cache_options": { "mode": "explicit", "ttl": "30m" }
         }))
         .expect("valid params");
 
@@ -145,6 +174,37 @@ mod tests {
         assert_eq!(parsed.previous_response_id.as_deref(), Some("resp_123"));
         assert_eq!(parsed.truncation.as_deref(), Some("auto"));
         assert_eq!(parsed.text_verbosity.as_deref(), Some("high"));
+        assert_eq!(parsed.prompt_cache_key.as_deref(), Some("tenant:stable"));
+        assert_eq!(
+            parsed.prompt_cache_options,
+            Some(serde_json::json!({"mode": "explicit", "ttl": "30m"}))
+        );
+        assert!(parsed.raw_input_with_cache_breakpoints.is_none());
+        assert!(parsed.retain_protocol_events);
+    }
+
+    #[test]
+    fn detects_supported_content_breakpoints_without_accepting_unrelated_fields() {
+        assert!(has_responses_prompt_cache_breakpoint(&serde_json::json!([{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_id": "file_123",
+                "prompt_cache_breakpoint": {"mode": "explicit"}
+            }]
+        }])));
+        assert!(!has_responses_prompt_cache_breakpoint(
+            &serde_json::json!([{
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "output_text",
+                    "text": "not a supported Responses input block",
+                    "prompt_cache_breakpoint": {"mode": "explicit"}
+                }]
+            }])
+        ));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/stream_utils.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/stream_utils.rs
@@ -110,6 +110,7 @@ pub(super) fn convert_chunk_to_openai(
             usage: None,
         }),
         bamboo_llm::types::LLMChunk::TransportActivity
+        | bamboo_llm::types::LLMChunk::ResponsesEvent { .. }
         | bamboo_llm::types::LLMChunk::CacheUsage { .. }
         | bamboo_llm::types::LLMChunk::ProviderUsage { .. }
         | bamboo_llm::types::LLMChunk::UsageSummary { .. }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/mod.rs
@@ -2,6 +2,7 @@ mod non_stream;
 mod output;
 mod prepare;
 mod stream;
+mod usage;
 
 use actix_web::{web, HttpMessage, HttpRequest, HttpResponse};
 

--- a/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
@@ -7,8 +7,9 @@ use bamboo_metrics::types::ForwardStatus;
 
 use super::super::helpers::now_unix_ts;
 use super::output::{build_completed_response, build_output_items};
+use super::usage::ResponsesUsageAccumulator;
 use super::PreparedResponsesRequest;
-use crate::handlers::llm_compat::usage::{build_estimated_usage, estimate_completion_tokens};
+use crate::handlers::llm_compat::usage::estimate_completion_tokens;
 
 pub(super) async fn handle_non_streaming_response(
     app_state: web::Data<AppState>,
@@ -57,28 +58,58 @@ pub(super) async fn handle_non_streaming_response(
         .map_err(map_provider_error)?;
 
     let mut content = String::new();
+    let mut reasoning_content = String::new();
     // Merge partial tool-call fragments by index/id — a raw Vec shatters one
     // call into N broken output items (#525). Same as the streaming worker.
     let mut tool_calls = bamboo_agent_core::tools::ToolCallAccumulator::new();
     let mut upstream_response_id: Option<String> = None;
+    let mut provider_usage = ResponsesUsageAccumulator::default();
+    let mut saw_done = false;
+    let mut raw_completed_response: Option<serde_json::Value> = None;
 
     while let Some(chunk_result) = stream.next().await {
         match chunk_result {
+            Ok(bamboo_llm::types::LLMChunk::ResponsesEvent { event_type, data }) => {
+                if event_type == "response.completed" {
+                    raw_completed_response = data.get("response").cloned();
+                }
+            }
             Ok(bamboo_llm::types::LLMChunk::ResponseId(response_id)) => {
                 upstream_response_id = Some(response_id);
             }
             Ok(bamboo_llm::types::LLMChunk::Token(text)) => content.push_str(&text),
-            // Keep parity with streaming behavior: expose reasoning narration as text.
-            Ok(bamboo_llm::types::LLMChunk::ReasoningToken(text)) => content.push_str(&text),
+            // Native Responses events retain reasoning items structurally.
+            // Never relabel provider-neutral reasoning as assistant output text.
+            Ok(bamboo_llm::types::LLMChunk::ReasoningToken(text)) => {
+                reasoning_content.push_str(&text)
+            }
             Ok(bamboo_llm::types::LLMChunk::ToolCalls(calls)) => tool_calls.extend(calls),
             // Indexed variant: route fragments by provider index (#236/#525).
             Ok(bamboo_llm::types::LLMChunk::ToolCallsIndexed(calls)) => {
                 tool_calls.extend_indexed(calls)
             }
-            Ok(bamboo_llm::types::LLMChunk::Done) => break,
+            Ok(bamboo_llm::types::LLMChunk::Done) => {
+                saw_done = true;
+                break;
+            }
+            Ok(bamboo_llm::types::LLMChunk::ProviderUsage {
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                reasoning_tokens,
+                cache_read_input_tokens,
+                cache_write_input_tokens,
+                ..
+            }) => provider_usage.record(
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                reasoning_tokens,
+                cache_read_input_tokens,
+                cache_write_input_tokens,
+            ),
             Ok(bamboo_llm::types::LLMChunk::TransportActivity)
             | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
-            | Ok(bamboo_llm::types::LLMChunk::ProviderUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })
             | Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {
@@ -98,7 +129,21 @@ pub(super) async fn handle_non_streaming_response(
         }
     }
 
-    let completion_tokens = estimate_completion_tokens(&content);
+    if !saw_done {
+        let message = "Stream ended before a protocol completion event";
+        app_state.metrics_service.collector().forward_completed(
+            forward_id,
+            chrono::Utc::now(),
+            None,
+            ForwardStatus::Error,
+            None,
+            Some(message.to_string()),
+        );
+        return Err(AppError::InternalError(anyhow::anyhow!(message)));
+    }
+
+    let completion_tokens = estimate_completion_tokens(&content)
+        .saturating_add(estimate_completion_tokens(&reasoning_content));
     let response_id =
         upstream_response_id.unwrap_or_else(|| format!("resp_{}", uuid::Uuid::new_v4()));
     let message_id = format!("msg_{}", uuid::Uuid::new_v4());
@@ -115,18 +160,40 @@ pub(super) async fn handle_non_streaming_response(
         );
     }
     let output = build_output_items(&message_id, content, finalized_calls);
-    let resp = build_completed_response(response_id, created_at, display_model, output);
+    let response_usage = provider_usage.response_usage();
+    let (metrics_usage, metrics_details) =
+        provider_usage.metrics_usage(prepared.estimated_prompt_tokens, completion_tokens);
+    app_state
+        .metrics_service
+        .collector()
+        .forward_completed_with_details(
+            forward_id,
+            chrono::Utc::now(),
+            Some(200),
+            ForwardStatus::Success,
+            Some(metrics_usage),
+            metrics_details,
+            None,
+        );
 
-    app_state.metrics_service.collector().forward_completed(
-        forward_id,
-        chrono::Utc::now(),
-        Some(200),
-        ForwardStatus::Success,
-        Some(build_estimated_usage(
-            prepared.estimated_prompt_tokens,
-            completion_tokens,
-        )),
-        None,
+    if let Some(mut raw_response) = raw_completed_response {
+        if raw_response
+            .get("usage")
+            .is_none_or(serde_json::Value::is_null)
+        {
+            if let Some(usage) = response_usage.as_ref() {
+                raw_response["usage"] = serde_json::to_value(usage).unwrap_or_default();
+            }
+        }
+        return Ok(HttpResponse::Ok().json(raw_response));
+    }
+
+    let resp = build_completed_response(
+        response_id,
+        created_at,
+        display_model,
+        output,
+        response_usage,
     );
 
     Ok(HttpResponse::Ok().json(resp))

--- a/crates/app/bamboo-server/src/handlers/openai/responses/output.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/output.rs
@@ -2,7 +2,7 @@ use bamboo_agent_core::tools::ToolCall;
 
 use super::super::types::{
     ResponsesCreateResponse, ResponsesFunctionCallOutputItem, ResponsesMessageOutputItem,
-    ResponsesOutputItem, ResponsesTextContent,
+    ResponsesOutputItem, ResponsesTextContent, ResponsesUsage,
 };
 
 pub(super) fn build_output_items(
@@ -11,16 +11,21 @@ pub(super) fn build_output_items(
     tool_calls: Vec<ToolCall>,
 ) -> Vec<ResponsesOutputItem> {
     let mut output: Vec<ResponsesOutputItem> = Vec::new();
-    output.push(ResponsesOutputItem::Message(ResponsesMessageOutputItem {
-        id: message_id.to_string(),
-        item_type: "message".to_string(),
-        role: "assistant".to_string(),
-        content: vec![ResponsesTextContent {
-            content_type: "output_text".to_string(),
-            text: content,
-        }],
-        status: Some("completed".to_string()),
-    }));
+    // A tool-only response must not grow a synthetic empty message item. Keep
+    // one empty assistant message only for a truly empty no-tool completion so
+    // legacy clients still receive a representable response.
+    if !content.is_empty() || tool_calls.is_empty() {
+        output.push(ResponsesOutputItem::Message(ResponsesMessageOutputItem {
+            id: message_id.to_string(),
+            item_type: "message".to_string(),
+            role: "assistant".to_string(),
+            content: vec![ResponsesTextContent {
+                content_type: "output_text".to_string(),
+                text: content,
+            }],
+            status: Some("completed".to_string()),
+        }));
+    }
 
     for (idx, tool_call) in tool_calls.into_iter().enumerate() {
         output.push(ResponsesOutputItem::FunctionCall(
@@ -43,6 +48,7 @@ pub(super) fn build_completed_response(
     created_at: u64,
     model: String,
     output: Vec<ResponsesOutputItem>,
+    usage: Option<ResponsesUsage>,
 ) -> ResponsesCreateResponse {
     ResponsesCreateResponse {
         id: response_id,
@@ -51,6 +57,6 @@ pub(super) fn build_completed_response(
         model,
         status: "completed".to_string(),
         output,
-        usage: None,
+        usage,
     }
 }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/output.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/output.rs
@@ -22,6 +22,7 @@ pub(super) fn build_output_items(
             content: vec![ResponsesTextContent {
                 content_type: "output_text".to_string(),
                 text: content,
+                annotations: Vec::new(),
             }],
             status: Some("completed".to_string()),
         }));

--- a/crates/app/bamboo-server/src/handlers/openai/responses/prepare.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/prepare.rs
@@ -3,8 +3,9 @@ use actix_web::web;
 use crate::{app_state::AppState, error::AppError};
 
 use super::super::helpers::{
-    convert_messages, convert_responses_tools, parse_parallel_tool_calls, parse_reasoning_effort,
-    parse_responses_request_options, responses_input_to_chat_messages,
+    convert_messages, convert_responses_tools, has_responses_prompt_cache_breakpoint,
+    parse_parallel_tool_calls, parse_reasoning_effort, parse_responses_request_options,
+    responses_input_to_chat_messages,
 };
 use super::super::types::ResponsesCreateRequest;
 use super::PreparedResponsesRequest;
@@ -33,6 +34,8 @@ pub(super) async fn prepare_request(
         .map(|value| value.trim())
         .filter(|value| !value.is_empty())
         .map(ToString::to_string);
+    let raw_input_with_cache_breakpoints =
+        has_responses_prompt_cache_breakpoint(&request.input).then(|| request.input.clone());
     let input_messages = responses_input_to_chat_messages(request.input)?;
 
     if input_messages.is_empty() && instructions.is_none() {
@@ -71,6 +74,7 @@ pub(super) async fn prepare_request(
     let parallel_tool_calls = parse_parallel_tool_calls(&request.parameters);
     let mut responses_options = parse_responses_request_options(&request.parameters);
     responses_options.instructions = instructions.clone();
+    responses_options.raw_input_with_cache_breakpoints = raw_input_with_cache_breakpoints;
 
     let estimated_prompt_tokens = estimate_prompt_tokens(&internal_messages).saturating_add(
         instructions

--- a/crates/app/bamboo-server/src/handlers/openai/responses/prepare.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/prepare.rs
@@ -46,6 +46,9 @@ pub(super) async fn prepare_request(
 
     // Convert to internal messages (preserving multimodal parts), then apply preflight hooks.
     let mut internal_messages = convert_messages(input_messages)?;
+    let internal_messages_before_preflight = raw_input_with_cache_breakpoints
+        .as_ref()
+        .map(|_| internal_messages.clone());
     let config_snapshot = app_state.config.read().await.clone();
     bamboo_engine::message_hooks::apply_message_preflight_hooks(
         Some(app_state.session_store.as_ref() as &dyn bamboo_agent_core::storage::AttachmentReader),
@@ -60,6 +63,15 @@ pub(super) async fn prepare_request(
             AppError::InternalError(anyhow::anyhow!(msg))
         }
     })?;
+    let raw_input_with_cache_breakpoints = match (
+        raw_input_with_cache_breakpoints,
+        internal_messages_before_preflight,
+    ) {
+        (Some(raw_input), Some(before)) => {
+            retain_raw_cache_input_after_preflight(raw_input, &before, &internal_messages)
+        }
+        _ => None,
+    };
 
     let internal_tools = convert_responses_tools(request.tools)?;
 
@@ -95,4 +107,109 @@ pub(super) async fn prepare_request(
         estimated_prompt_tokens,
         request_session_id: None,
     })
+}
+
+fn retain_raw_cache_input_after_preflight(
+    raw_input: serde_json::Value,
+    before: &[bamboo_agent_core::Message],
+    after: &[bamboo_agent_core::Message],
+) -> Option<serde_json::Value> {
+    let unchanged = match (serde_json::to_value(before), serde_json::to_value(after)) {
+        (Ok(before), Ok(after)) => before == after,
+        (before, after) => {
+            tracing::warn!(
+                before_error = ?before.err(),
+                after_error = ?after.err(),
+                "Could not compare Responses input before and after preflight hooks"
+            );
+            false
+        }
+    };
+
+    if unchanged {
+        Some(raw_input)
+    } else {
+        // Raw passthrough exists only to preserve caller-authored cache
+        // breakpoints. It must never undo a safety/configuration hook rewrite
+        // (for example, reintroducing a base64 image after placeholder mode
+        // removed it). Fall back to rendering the rewritten internal messages.
+        tracing::warn!(
+            "Responses preflight hooks rewrote input; disabling raw cache-breakpoint passthrough"
+        );
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retain_raw_cache_input_after_preflight;
+    use bamboo_agent_core::Message;
+    use bamboo_llm::{
+        models::{ContentPart, ImageUrl},
+        Config,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn unchanged_preflight_input_preserves_raw_cache_breakpoints() {
+        let raw_input = json!([{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_text",
+                "text": "stable context",
+                "prompt_cache_breakpoint": {"mode": "explicit"}
+            }]
+        }]);
+        let messages = vec![Message::user("stable context")];
+
+        assert_eq!(
+            retain_raw_cache_input_after_preflight(raw_input.clone(), &messages, &messages),
+            Some(raw_input)
+        );
+    }
+
+    #[tokio::test]
+    async fn image_fallback_rewrite_disables_raw_cache_breakpoint_passthrough() {
+        let raw_input = json!([{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_image",
+                "image_url": "data:image/png;base64,AAAABBBBCCCC",
+                "prompt_cache_breakpoint": {"mode": "explicit"}
+            }]
+        }]);
+        let mut messages = vec![Message::user_with_parts(
+            "",
+            vec![ContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: "data:image/png;base64,AAAABBBBCCCC".to_string(),
+                    detail: None,
+                },
+            }]
+            .into_iter()
+            .map(Into::into)
+            .collect(),
+        )];
+        let before = messages.clone();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let mut config = Config::from_data_dir(Some(temp_dir.path().to_path_buf()));
+        config.hooks.image_fallback.enabled = true;
+        config.hooks.image_fallback.mode = "placeholder".to_string();
+
+        bamboo_engine::message_hooks::apply_message_preflight_hooks(
+            None,
+            &config,
+            "gpt-5.6",
+            &mut messages,
+        )
+        .await
+        .expect("placeholder hook should succeed");
+
+        assert!(retain_raw_cache_input_after_preflight(raw_input, &before, &messages).is_none());
+        assert!(messages[0].content.contains("Image omitted: image/png"));
+        assert!(!messages[0].content.contains("AAAABBBBCCCC"));
+        assert!(messages[0].content_parts.is_none());
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
@@ -108,6 +108,7 @@ pub(super) fn message_content_part_added_event(
     event.part = Some(ResponsesTextContent {
         content_type: "output_text".to_string(),
         text: String::new(),
+        annotations: Vec::new(),
     });
     event
 }
@@ -124,6 +125,7 @@ pub(super) fn message_item_done_events(
         .unwrap_or(ResponsesTextContent {
             content_type: "output_text".to_string(),
             text: String::new(),
+            annotations: Vec::new(),
         });
 
     let mut text_done = item_event("response.output_text.done", response_id, &item.id, 0);
@@ -181,6 +183,7 @@ pub(super) fn function_call_item_events(
         output_index,
     );
     arguments_done.arguments = Some(item.arguments.clone());
+    arguments_done.name = Some(item.name.clone());
 
     let mut done = item_event(
         "response.output_item.done",

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
@@ -3,8 +3,20 @@ use serde::Serialize;
 
 use super::super::super::types::{
     ResponsesCreateResponse, ResponsesFunctionCallOutputItem, ResponsesMessageOutputItem,
-    ResponsesOutputItem, ResponsesStreamEvent,
+    ResponsesOutputItem, ResponsesStreamEvent, ResponsesTextContent,
 };
+
+/// Assign the next response-scoped sequence number immediately before an event
+/// is serialized. Keeping this at the final emission boundary makes every
+/// event family share one monotonic counter.
+pub(super) fn sequence_event<T>(
+    mut event: ResponsesStreamEvent<T>,
+    next_sequence_number: &mut u64,
+) -> ResponsesStreamEvent<T> {
+    event.sequence_number = *next_sequence_number;
+    *next_sequence_number = next_sequence_number.saturating_add(1);
+    event
+}
 
 pub(super) fn created_event(
     response_id: String,
@@ -87,15 +99,44 @@ pub(super) fn message_item_added_event(
     event
 }
 
-/// `response.output_item.done` for the completed assistant message item
-/// (full text), emitted before the function-call item events (#525).
-pub(super) fn message_item_done_event(
+pub(super) fn message_content_part_added_event(
+    response_id: &str,
+    message_id: &str,
+) -> ResponsesStreamEvent<ResponsesCreateResponse> {
+    let mut event = item_event("response.content_part.added", response_id, message_id, 0);
+    event.content_index = Some(0);
+    event.part = Some(ResponsesTextContent {
+        content_type: "output_text".to_string(),
+        text: String::new(),
+    });
+    event
+}
+
+/// Complete the assistant text content before marking its output item done.
+pub(super) fn message_item_done_events(
     response_id: &str,
     item: &ResponsesMessageOutputItem,
-) -> ResponsesStreamEvent<ResponsesCreateResponse> {
-    let mut event = item_event("response.output_item.done", response_id, &item.id, 0);
-    event.item = Some(ResponsesOutputItem::Message(item.clone()));
-    event
+) -> Vec<ResponsesStreamEvent<ResponsesCreateResponse>> {
+    let content = item
+        .content
+        .first()
+        .cloned()
+        .unwrap_or(ResponsesTextContent {
+            content_type: "output_text".to_string(),
+            text: String::new(),
+        });
+
+    let mut text_done = item_event("response.output_text.done", response_id, &item.id, 0);
+    text_done.content_index = Some(0);
+    text_done.text = Some(content.text.clone());
+
+    let mut part_done = item_event("response.content_part.done", response_id, &item.id, 0);
+    part_done.content_index = Some(0);
+    part_done.part = Some(content);
+
+    let mut item_done = item_event("response.output_item.done", response_id, &item.id, 0);
+    item_done.item = Some(ResponsesOutputItem::Message(item.clone()));
+    vec![text_done, part_done, item_done]
 }
 
 /// The standard Responses event sequence for ONE completed function call,
@@ -165,6 +206,24 @@ pub(super) fn event_to_sse_bytes<T: Serialize>(event: &ResponsesStreamEvent<T>) 
     ))
 }
 
+/// Serialize an upstream Responses event while assigning Bamboo's own
+/// response-scoped monotonic sequence number. All other provider fields and
+/// item structure remain untouched.
+pub(super) fn raw_event_to_sse_bytes(
+    event_type: &str,
+    data: &serde_json::Value,
+    next_sequence_number: &mut u64,
+) -> Bytes {
+    let mut payload = data.clone();
+    if !payload.is_object() {
+        payload = serde_json::json!({"data": payload});
+    }
+    payload["type"] = serde_json::json!(event_type);
+    payload["sequence_number"] = serde_json::json!(*next_sequence_number);
+    *next_sequence_number = next_sequence_number.saturating_add(1);
+    Bytes::from(format!("event: {event_type}\ndata: {payload}\n\n"))
+}
+
 /// A `response.failed` SSE event carrying the upstream error.
 ///
 /// Without this, a mid-stream upstream failure is reported to the client as a
@@ -173,9 +232,10 @@ pub(super) fn event_to_sse_bytes<T: Serialize>(event: &ResponsesStreamEvent<T>) 
 /// `response.failed` before `[DONE]` lets the client distinguish a cut-off stream
 /// from a complete one — mirroring the Anthropic handler's `error` event and the
 /// chat endpoint's error chunk (#383). #355.
-pub(super) fn failed_sse_bytes(message: &str) -> Bytes {
+pub(super) fn failed_sse_bytes(message: &str, sequence_number: u64) -> Bytes {
     let payload = serde_json::json!({
         "type": "response.failed",
+        "sequence_number": sequence_number,
         "response": {
             "status": "failed",
             "error": { "message": message, "type": "api_error" },

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
@@ -484,6 +484,7 @@ fn function_call_item_events_emit_standard_sequence() {
 
     let (_, args_done) = &decoded[2];
     assert_eq!(args_done["arguments"], "{\"location\":\"NYC\"}");
+    assert_eq!(args_done["name"], "get_weather");
 
     let (_, item_done) = &decoded[3];
     assert_eq!(item_done["item"]["status"], "completed");

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
@@ -32,12 +32,13 @@ fn decode_sse_event(bytes: bytes::Bytes) -> (String, Value) {
 fn failed_sse_bytes_signals_failure_with_error() {
     // #355: a mid-stream upstream error must surface as a `response.failed` event
     // (with the error), not a clean `[DONE]` the client reads as success.
-    let (event_name, payload) = decode_sse_event(failed_sse_bytes("upstream 503"));
+    let (event_name, payload) = decode_sse_event(failed_sse_bytes("upstream 503", 7));
     assert_eq!(event_name, "response.failed");
     assert_eq!(payload["type"], "response.failed");
     assert_eq!(payload["response"]["status"], "failed");
     assert_eq!(payload["response"]["error"]["message"], "upstream 503");
     assert_eq!(payload["response"]["error"]["type"], "api_error");
+    assert_eq!(payload["sequence_number"], 7);
 }
 
 #[test]
@@ -65,7 +66,8 @@ fn output_text_delta_event_carries_response_and_item_identity() {
 #[test]
 fn completed_event_serializes_completed_response() {
     let output = build_output_items("msg_1", "done".to_string(), vec![]);
-    let response = build_completed_response("resp_1".to_string(), 123, "gpt-5".to_string(), output);
+    let response =
+        build_completed_response("resp_1".to_string(), 123, "gpt-5".to_string(), output, None);
     let event = completed_event(response);
 
     let (event_name, payload) = decode_sse_event(event_to_sse_bytes(&event));
@@ -80,6 +82,299 @@ fn done_sse_bytes_emits_done_sentinel() {
     let done = done_sse_bytes();
     let payload = std::str::from_utf8(&done).expect("sse bytes should be utf8");
     assert_eq!(payload, "data: [DONE]\n\n");
+}
+
+#[test]
+fn raw_protocol_events_preserve_items_and_get_monotonic_sequences() {
+    use super::events::raw_event_to_sse_bytes;
+
+    let raw = serde_json::json!({
+        "type": "response.output_item.done",
+        "sequence_number": 99,
+        "output_index": 2,
+        "item": {
+            "id": "msg_2",
+            "type": "message",
+            "content": [{"type": "output_text", "text": "second"}]
+        }
+    });
+    let mut sequence = 4;
+    let (name, first) = decode_sse_event(raw_event_to_sse_bytes(
+        "response.output_item.done",
+        &raw,
+        &mut sequence,
+    ));
+    assert_eq!(name, "response.output_item.done");
+    assert_eq!(first["sequence_number"], 4);
+    assert_eq!(first["output_index"], 2);
+    assert_eq!(first["item"]["id"], "msg_2");
+
+    let (_, second) = decode_sse_event(raw_event_to_sse_bytes(
+        "response.completed",
+        &serde_json::json!({"response":{"status":"completed"}}),
+        &mut sequence,
+    ));
+    assert_eq!(second["sequence_number"], 5);
+}
+
+fn test_metrics() -> (bamboo_metrics::MetricsCollector, tempfile::TempDir) {
+    use bamboo_metrics::storage::SqliteMetricsStorage;
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().expect("temp metrics directory");
+    let storage = Arc::new(SqliteMetricsStorage::new(dir.path().join("metrics.db")));
+    (bamboo_metrics::MetricsCollector::spawn(storage, 7), dir)
+}
+
+fn drain_frames(
+    rx: &mut tokio::sync::mpsc::Receiver<Result<bytes::Bytes, anyhow::Error>>,
+) -> Vec<String> {
+    let mut frames = Vec::new();
+    while let Ok(item) = rx.try_recv() {
+        frames.push(
+            String::from_utf8(item.expect("worker frame").to_vec()).expect("utf8 worker frame"),
+        );
+    }
+    frames
+}
+
+#[tokio::test]
+async fn synthesized_worker_emits_usage_and_complete_message_lifecycle() {
+    use super::worker::{run_stream_worker, StreamWorkerArgs};
+    use bamboo_llm::provider::LLMStream;
+    use bamboo_llm::types::LLMChunk;
+    use futures::stream;
+
+    let (metrics, _dir) = test_metrics();
+    let chunks = vec![
+        Ok(LLMChunk::ResponseId("resp_usage".to_string())),
+        Ok(LLMChunk::ReasoningToken("private reasoning".to_string())),
+        Ok(LLMChunk::Token("hello".to_string())),
+        Ok(LLMChunk::ProviderUsage {
+            input_tokens: Some(80),
+            output_tokens: Some(20),
+            total_tokens: Some(100),
+            reasoning_tokens: Some(5),
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: Some(32),
+            cache_write_input_tokens: Some(48),
+        }),
+        Ok(LLMChunk::Done),
+    ];
+    let stream_result: LLMStream = Box::pin(stream::iter(chunks));
+    let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+
+    run_stream_worker(StreamWorkerArgs {
+        stream_result,
+        tx,
+        metrics,
+        forward_id: "forward-usage".to_string(),
+        fallback_response_id: "resp_fallback".to_string(),
+        message_id: "msg_usage".to_string(),
+        created_at: 123,
+        resolved_model: "gpt-5.6".to_string(),
+        estimated_prompt_tokens: 999,
+    })
+    .await;
+
+    let frames = drain_frames(&mut rx);
+    let decoded: Vec<_> = frames
+        .iter()
+        .filter(|frame| frame.starts_with("event: "))
+        .map(|frame| decode_sse_event(bytes::Bytes::copy_from_slice(frame.as_bytes())))
+        .collect();
+    assert_eq!(
+        decoded
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "response.created",
+            "response.output_item.added",
+            "response.content_part.added",
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.content_part.done",
+            "response.output_item.done",
+            "response.completed",
+        ]
+    );
+    assert_eq!(
+        decoded
+            .iter()
+            .map(|(_, payload)| payload["sequence_number"].as_u64().unwrap())
+            .collect::<Vec<_>>(),
+        (0..8).collect::<Vec<_>>()
+    );
+    let completed = &decoded.last().expect("completed event").1["response"];
+    assert_eq!(completed["usage"]["input_tokens"], 80);
+    assert_eq!(completed["usage"]["output_tokens"], 20);
+    assert_eq!(completed["usage"]["total_tokens"], 100);
+    assert_eq!(
+        completed["usage"]["input_tokens_details"]["cached_tokens"],
+        32
+    );
+    assert_eq!(
+        completed["usage"]["input_tokens_details"]["cache_write_tokens"],
+        48
+    );
+    assert_eq!(
+        completed["usage"]["output_tokens_details"]["reasoning_tokens"],
+        5
+    );
+    assert!(
+        frames
+            .iter()
+            .all(|frame| !frame.contains("private reasoning")),
+        "reasoning must not be relabeled as output_text"
+    );
+    assert_eq!(frames.last().map(String::as_str), Some("data: [DONE]\n\n"));
+}
+
+#[tokio::test]
+async fn raw_worker_preserves_mixed_item_identity_and_order() {
+    use super::worker::{run_stream_worker, StreamWorkerArgs};
+    use bamboo_llm::provider::LLMStream;
+    use bamboo_llm::types::LLMChunk;
+    use futures::stream;
+
+    let (metrics, _dir) = test_metrics();
+    let completed = serde_json::json!({
+        "type": "response.completed",
+        "response": {
+            "id": "resp_raw",
+            "status": "completed",
+            "output": [
+                {"id": "msg_a", "type": "message", "content": [{"type": "output_text", "text": "a"}]},
+                {"id": "rs_a", "type": "reasoning", "summary": [{"type": "summary_text", "text": "why"}]},
+                {"id": "fc_a", "type": "function_call", "call_id": "call_a", "name": "search", "arguments": "{}"},
+                {"id": "msg_b", "type": "message", "content": [{"type": "output_text", "text": "b"}]}
+            ],
+            "usage": {"input_tokens": 4, "output_tokens": 2, "total_tokens": 6}
+        }
+    });
+    let chunks = vec![
+        Ok(LLMChunk::ResponsesEvent {
+            event_type: "response.created".to_string(),
+            data: Box::new(serde_json::json!({
+                "type": "response.created",
+                "response": {"id": "resp_raw", "status": "in_progress"}
+            })),
+        }),
+        Ok(LLMChunk::ResponsesEvent {
+            event_type: "response.completed".to_string(),
+            data: Box::new(completed),
+        }),
+        Ok(LLMChunk::ProviderUsage {
+            input_tokens: Some(4),
+            output_tokens: Some(2),
+            total_tokens: Some(6),
+            reasoning_tokens: None,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: Some(0),
+            cache_write_input_tokens: Some(4),
+        }),
+        Ok(LLMChunk::Done),
+    ];
+    let stream_result: LLMStream = Box::pin(stream::iter(chunks));
+    let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+
+    run_stream_worker(StreamWorkerArgs {
+        stream_result,
+        tx,
+        metrics,
+        forward_id: "forward-raw".to_string(),
+        fallback_response_id: "resp_fallback".to_string(),
+        message_id: "msg_fallback".to_string(),
+        created_at: 123,
+        resolved_model: "gpt-5.6".to_string(),
+        estimated_prompt_tokens: 999,
+    })
+    .await;
+
+    let frames = drain_frames(&mut rx);
+    let decoded: Vec<_> = frames
+        .iter()
+        .filter(|frame| frame.starts_with("event: "))
+        .map(|frame| decode_sse_event(bytes::Bytes::copy_from_slice(frame.as_bytes())))
+        .collect();
+    assert_eq!(
+        decoded
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["response.created", "response.completed"]
+    );
+    assert_eq!(decoded[0].1["sequence_number"], 0);
+    assert_eq!(decoded[1].1["sequence_number"], 1);
+    assert_eq!(
+        decoded[1].1["response"]["output"]
+            .as_array()
+            .expect("output")
+            .iter()
+            .map(|item| item["id"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["msg_a", "rs_a", "fc_a", "msg_b"]
+    );
+    assert_eq!(frames.last().map(String::as_str), Some("data: [DONE]\n\n"));
+}
+
+#[tokio::test]
+async fn worker_reports_premature_eof_as_failure_not_completion() {
+    use super::worker::{run_stream_worker, StreamWorkerArgs};
+    use bamboo_llm::provider::LLMStream;
+    use bamboo_llm::types::LLMChunk;
+    use futures::stream;
+
+    let (metrics, _dir) = test_metrics();
+    let stream_result: LLMStream = Box::pin(stream::iter(vec![Ok(LLMChunk::Token(
+        "partial".to_string(),
+    ))]));
+    let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+
+    run_stream_worker(StreamWorkerArgs {
+        stream_result,
+        tx,
+        metrics,
+        forward_id: "forward-eof".to_string(),
+        fallback_response_id: "resp_eof".to_string(),
+        message_id: "msg_eof".to_string(),
+        created_at: 123,
+        resolved_model: "gpt-5.6".to_string(),
+        estimated_prompt_tokens: 1,
+    })
+    .await;
+
+    let frames = drain_frames(&mut rx);
+    assert!(frames.iter().any(|frame| {
+        frame.contains("response.failed")
+            && frame.contains("ended before a protocol completion event")
+    }));
+    assert!(!frames
+        .iter()
+        .any(|frame| frame.contains("response.completed")));
+    assert_eq!(frames.last().map(String::as_str), Some("data: [DONE]\n\n"));
+}
+
+#[test]
+fn tool_only_output_has_no_synthetic_empty_message() {
+    let output = build_output_items(
+        "msg_unused",
+        String::new(),
+        vec![bamboo_agent_core::tools::ToolCall {
+            id: "call_1".to_string(),
+            tool_type: "function".to_string(),
+            function: bamboo_domain::FunctionCall {
+                name: "search".to_string(),
+                arguments: "{}".to_string(),
+            },
+        }],
+    );
+    assert_eq!(output.len(), 1);
+    assert!(matches!(
+        output[0],
+        super::super::super::types::ResponsesOutputItem::FunctionCall(_)
+    ));
 }
 
 #[test]
@@ -153,11 +448,11 @@ fn function_call_item_events_emit_standard_sequence() {
         String::new(),
         vec![fragment("call_w1", "get_weather", "{\"location\":\"NYC\"}")],
     );
-    let super::super::super::types::ResponsesOutputItem::FunctionCall(fc) = &output[1] else {
-        panic!("expected function_call item at output_index 1");
+    let super::super::super::types::ResponsesOutputItem::FunctionCall(fc) = &output[0] else {
+        panic!("expected function_call item at output_index 0");
     };
 
-    let events = function_call_item_events("resp_1", fc, 1);
+    let events = function_call_item_events("resp_1", fc, 0);
     let decoded: Vec<_> = events
         .iter()
         .map(|event| decode_sse_event(event_to_sse_bytes(event)))
@@ -181,7 +476,7 @@ fn function_call_item_events_emit_standard_sequence() {
     assert_eq!(added["item"]["call_id"], "call_w1");
     assert_eq!(added["item"]["status"], "in_progress");
     assert_eq!(added["item"]["arguments"], "");
-    assert_eq!(added["output_index"], 1);
+    assert_eq!(added["output_index"], 0);
 
     let (_, delta) = &decoded[1];
     assert_eq!(delta["delta"], "{\"location\":\"NYC\"}");
@@ -203,7 +498,7 @@ fn completed_response_carries_aggregated_function_call() {
     acc.extend(vec![fragment("call_1", "", "\"hi\"}")]);
 
     let output = build_output_items("msg_1", "text".to_string(), acc.finalize());
-    let response = build_completed_response("resp_1".to_string(), 1, "m".to_string(), output);
+    let response = build_completed_response("resp_1".to_string(), 1, "m".to_string(), output, None);
     let event = completed_event(response);
     let (_, payload) = decode_sse_event(event_to_sse_bytes(&event));
 
@@ -221,7 +516,9 @@ fn completed_response_carries_aggregated_function_call() {
 // events would otherwise never finalize the assistant's text.
 #[test]
 fn message_item_events_announce_and_finalize_the_message_item() {
-    use super::events::{message_item_added_event, message_item_done_event};
+    use super::events::{
+        message_content_part_added_event, message_item_added_event, message_item_done_events,
+    };
 
     let (name, added) = decode_sse_event(event_to_sse_bytes(&message_item_added_event(
         "resp_1", "msg_1",
@@ -232,15 +529,28 @@ fn message_item_events_announce_and_finalize_the_message_item() {
     assert_eq!(added["item"]["id"], "msg_1");
     assert_eq!(added["item"]["status"], "in_progress");
 
+    let (name, content_added) = decode_sse_event(event_to_sse_bytes(
+        &message_content_part_added_event("resp_1", "msg_1"),
+    ));
+    assert_eq!(name, "response.content_part.added");
+    assert_eq!(content_added["part"]["type"], "output_text");
+    assert_eq!(content_added["part"]["text"], "");
+
     let output = build_output_items("msg_1", "final text".to_string(), vec![]);
     let super::super::super::types::ResponsesOutputItem::Message(message) = &output[0] else {
         panic!("expected message item at output_index 0");
     };
-    let (name, done) = decode_sse_event(event_to_sse_bytes(&message_item_done_event(
-        "resp_1", message,
-    )));
-    assert_eq!(name, "response.output_item.done");
-    assert_eq!(done["item"]["type"], "message");
-    assert_eq!(done["item"]["status"], "completed");
-    assert_eq!(done["item"]["content"][0]["text"], "final text");
+    let done_events = message_item_done_events("resp_1", message);
+    assert_eq!(done_events.len(), 3);
+    let (text_name, text_done) = decode_sse_event(event_to_sse_bytes(&done_events[0]));
+    assert_eq!(text_name, "response.output_text.done");
+    assert_eq!(text_done["text"], "final text");
+    let (part_name, part_done) = decode_sse_event(event_to_sse_bytes(&done_events[1]));
+    assert_eq!(part_name, "response.content_part.done");
+    assert_eq!(part_done["part"]["text"], "final text");
+    let (item_name, item_done) = decode_sse_event(event_to_sse_bytes(&done_events[2]));
+    assert_eq!(item_name, "response.output_item.done");
+    assert_eq!(item_done["item"]["type"], "message");
+    assert_eq!(item_done["item"]["status"], "completed");
+    assert_eq!(item_done["item"]["content"][0]["text"], "final text");
 }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
@@ -10,12 +10,13 @@ use bamboo_agent_core::tools::ToolCallAccumulator;
 
 use super::super::super::types::ResponsesOutputItem;
 use super::super::output::{build_completed_response, build_output_items};
+use super::super::usage::ResponsesUsageAccumulator;
 use super::events::{
     completed_event, created_event, done_sse_bytes, event_to_sse_bytes, failed_sse_bytes,
-    function_call_item_events, message_item_added_event, message_item_done_event,
-    output_text_delta_event,
+    function_call_item_events, message_content_part_added_event, message_item_added_event,
+    message_item_done_events, output_text_delta_event, raw_event_to_sse_bytes, sequence_event,
 };
-use crate::handlers::llm_compat::usage::{build_estimated_usage, estimate_completion_tokens};
+use crate::handlers::llm_compat::usage::estimate_completion_tokens;
 
 pub(super) struct StreamWorkerArgs {
     pub(super) stream_result: LLMStream,
@@ -35,10 +36,11 @@ pub(super) fn spawn_stream_worker(args: StreamWorkerArgs) {
     });
 }
 
-async fn run_stream_worker(mut args: StreamWorkerArgs) {
+pub(super) async fn run_stream_worker(mut args: StreamWorkerArgs) {
     let mut had_error = false;
     let mut error_message: Option<String> = None;
     let mut content = String::new();
+    let mut reasoning_content = String::new();
     // Providers stream PARTIAL tool-call fragments (argument-only continuation
     // chunks with empty id/name). Merge them by provider index / call id via
     // the engine's accumulator instead of collecting raw fragments — a raw Vec
@@ -46,39 +48,97 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
     let mut tool_calls = ToolCallAccumulator::new();
     let mut response_id: Option<String> = None;
     let mut created_sent = false;
+    let mut message_started = false;
+    let mut next_sequence_number = 0u64;
+    let mut saw_done = false;
+    let mut provider_usage = ResponsesUsageAccumulator::default();
+    let mut raw_responses_mode = false;
 
     async fn ensure_created_event(
         args: &mut StreamWorkerArgs,
         response_id: &str,
         created_sent: &mut bool,
+        next_sequence_number: &mut u64,
     ) -> bool {
         if *created_sent {
             return true;
         }
-        let event = created_event(
-            response_id.to_string(),
-            args.resolved_model.clone(),
-            args.created_at,
+        let event = sequence_event(
+            created_event(
+                response_id.to_string(),
+                args.resolved_model.clone(),
+                args.created_at,
+            ),
+            next_sequence_number,
         );
         if args.tx.send(Ok(event_to_sse_bytes(&event))).await.is_err() {
-            return false;
-        }
-        // The assistant message item (output_index 0) must be announced too —
-        // clients that assemble output from output_item events would
-        // otherwise never associate the text deltas with an item (#525).
-        let added = message_item_added_event(response_id, &args.message_id);
-        if args.tx.send(Ok(event_to_sse_bytes(&added))).await.is_err() {
             return false;
         }
         *created_sent = true;
         true
     }
 
+    async fn ensure_message_started(
+        args: &mut StreamWorkerArgs,
+        response_id: &str,
+        created_sent: &mut bool,
+        message_started: &mut bool,
+        next_sequence_number: &mut u64,
+    ) -> bool {
+        if *message_started {
+            return true;
+        }
+        if !ensure_created_event(args, response_id, created_sent, next_sequence_number).await {
+            return false;
+        }
+
+        let added = sequence_event(
+            message_item_added_event(response_id, &args.message_id),
+            next_sequence_number,
+        );
+        if args.tx.send(Ok(event_to_sse_bytes(&added))).await.is_err() {
+            return false;
+        }
+        let content_added = sequence_event(
+            message_content_part_added_event(response_id, &args.message_id),
+            next_sequence_number,
+        );
+        if args
+            .tx
+            .send(Ok(event_to_sse_bytes(&content_added)))
+            .await
+            .is_err()
+        {
+            return false;
+        }
+        *message_started = true;
+        true
+    }
+
     while let Some(chunk_result) = args.stream_result.next().await {
         match chunk_result {
+            Ok(LLMChunk::ResponsesEvent { event_type, data }) => {
+                raw_responses_mode = true;
+                let bytes = raw_event_to_sse_bytes(
+                    event_type.as_str(),
+                    data.as_ref(),
+                    &mut next_sequence_number,
+                );
+                if args.tx.send(Ok(bytes)).await.is_err() {
+                    break;
+                }
+            }
             Ok(LLMChunk::ResponseId(id)) => {
                 response_id = Some(id.clone());
-                if !ensure_created_event(&mut args, &id, &mut created_sent).await {
+                if !raw_responses_mode
+                    && !ensure_created_event(
+                        &mut args,
+                        &id,
+                        &mut created_sent,
+                        &mut next_sequence_number,
+                    )
+                    .await
+                {
                     break;
                 }
             }
@@ -87,34 +147,48 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
                 let active_response_id = response_id
                     .clone()
                     .unwrap_or_else(|| args.fallback_response_id.clone());
-                if !ensure_created_event(&mut args, &active_response_id, &mut created_sent).await {
+                if !raw_responses_mode
+                    && !ensure_message_started(
+                        &mut args,
+                        &active_response_id,
+                        &mut created_sent,
+                        &mut message_started,
+                        &mut next_sequence_number,
+                    )
+                    .await
+                {
                     break;
                 }
-                let event = output_text_delta_event(&active_response_id, &args.message_id, text);
-                if args.tx.send(Ok(event_to_sse_bytes(&event))).await.is_err() {
-                    break;
+                if !raw_responses_mode {
+                    let event = sequence_event(
+                        output_text_delta_event(&active_response_id, &args.message_id, text),
+                        &mut next_sequence_number,
+                    );
+                    if args.tx.send(Ok(event_to_sse_bytes(&event))).await.is_err() {
+                        break;
+                    }
                 }
             }
-            // Compatibility behavior: surface reasoning deltas in the same stream channel
-            // so clients that only render output_text can still show interim narration.
             Ok(LLMChunk::ReasoningToken(text)) => {
-                content.push_str(&text);
-                let active_response_id = response_id
-                    .clone()
-                    .unwrap_or_else(|| args.fallback_response_id.clone());
-                if !ensure_created_event(&mut args, &active_response_id, &mut created_sent).await {
-                    break;
-                }
-                let event = output_text_delta_event(&active_response_id, &args.message_id, text);
-                if args.tx.send(Ok(event_to_sse_bytes(&event))).await.is_err() {
-                    break;
-                }
+                // Never relabel reasoning as assistant output_text. Native
+                // Responses providers retain the real reasoning item through
+                // `ResponsesEvent`; provider-neutral fallbacks have no stable
+                // item identity, so retain it only for usage estimation.
+                reasoning_content.push_str(&text);
             }
             Ok(LLMChunk::ToolCalls(calls)) => {
                 let active_response_id = response_id
                     .clone()
                     .unwrap_or_else(|| args.fallback_response_id.clone());
-                if !ensure_created_event(&mut args, &active_response_id, &mut created_sent).await {
+                if !raw_responses_mode
+                    && !ensure_created_event(
+                        &mut args,
+                        &active_response_id,
+                        &mut created_sent,
+                        &mut next_sequence_number,
+                    )
+                    .await
+                {
                     break;
                 }
                 tool_calls.extend(calls)
@@ -124,15 +198,41 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
                 let active_response_id = response_id
                     .clone()
                     .unwrap_or_else(|| args.fallback_response_id.clone());
-                if !ensure_created_event(&mut args, &active_response_id, &mut created_sent).await {
+                if !raw_responses_mode
+                    && !ensure_created_event(
+                        &mut args,
+                        &active_response_id,
+                        &mut created_sent,
+                        &mut next_sequence_number,
+                    )
+                    .await
+                {
                     break;
                 }
                 tool_calls.extend_indexed(indexed)
             }
-            Ok(LLMChunk::Done) => break,
+            Ok(LLMChunk::Done) => {
+                saw_done = true;
+                break;
+            }
+            Ok(LLMChunk::ProviderUsage {
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                reasoning_tokens,
+                cache_read_input_tokens,
+                cache_write_input_tokens,
+                ..
+            }) => provider_usage.record(
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                reasoning_tokens,
+                cache_read_input_tokens,
+                cache_write_input_tokens,
+            ),
             Ok(LLMChunk::TransportActivity)
             | Ok(LLMChunk::CacheUsage { .. })
-            | Ok(LLMChunk::ProviderUsage { .. })
             | Ok(LLMChunk::UsageSummary { .. })
             | Ok(LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {
@@ -152,18 +252,59 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
         }
     }
 
+    if !had_error && !saw_done {
+        had_error = true;
+        error_message = Some("Stream ended before a protocol completion event".to_string());
+        args.metrics.forward_completed(
+            args.forward_id.clone(),
+            chrono::Utc::now(),
+            None,
+            ForwardStatus::Error,
+            None,
+            error_message.clone(),
+        );
+    }
+
     if had_error {
         // Signal the failure so the client can tell a truncated stream from a
         // completed one, instead of a clean `[DONE]` that looks like success. #355.
         let message = error_message.as_deref().unwrap_or("upstream stream error");
-        let _ = args.tx.send(Ok(failed_sse_bytes(message))).await;
+        let _ = args
+            .tx
+            .send(Ok(failed_sse_bytes(message, next_sequence_number)))
+            .await;
         let _ = args.tx.send(Ok(done_sse_bytes())).await;
         return;
     }
 
-    let completion_tokens = estimate_completion_tokens(&content);
+    let completion_tokens = estimate_completion_tokens(&content)
+        .saturating_add(estimate_completion_tokens(&reasoning_content));
+    let response_usage = provider_usage.response_usage();
+    let (metrics_usage, metrics_details) =
+        provider_usage.metrics_usage(args.estimated_prompt_tokens, completion_tokens);
     let final_response_id = response_id.unwrap_or_else(|| args.fallback_response_id.clone());
-    if !ensure_created_event(&mut args, &final_response_id, &mut created_sent).await {
+    if raw_responses_mode {
+        let _ = args.tx.send(Ok(done_sse_bytes())).await;
+        args.metrics.forward_completed_with_details(
+            args.forward_id,
+            chrono::Utc::now(),
+            Some(200),
+            ForwardStatus::Success,
+            Some(metrics_usage),
+            metrics_details,
+            None,
+        );
+        return;
+    }
+
+    if !ensure_created_event(
+        &mut args,
+        &final_response_id,
+        &mut created_sent,
+        &mut next_sequence_number,
+    )
+    .await
+    {
         return;
     }
 
@@ -192,13 +333,26 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
     'items: for (output_index, item) in output.iter().enumerate() {
         let events = match item {
             ResponsesOutputItem::Message(message) => {
-                vec![message_item_done_event(&final_response_id, message)]
+                if !ensure_message_started(
+                    &mut args,
+                    &final_response_id,
+                    &mut created_sent,
+                    &mut message_started,
+                    &mut next_sequence_number,
+                )
+                .await
+                {
+                    client_gone = true;
+                    break 'items;
+                }
+                message_item_done_events(&final_response_id, message)
             }
             ResponsesOutputItem::FunctionCall(fc) => {
                 function_call_item_events(&final_response_id, fc, output_index as u32)
             }
         };
         for event in events {
+            let event = sequence_event(event, &mut next_sequence_number);
             if args.tx.send(Ok(event_to_sse_bytes(&event))).await.is_err() {
                 client_gone = true;
                 break 'items;
@@ -212,22 +366,21 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
             args.created_at,
             args.resolved_model,
             output,
+            response_usage,
         );
-        let complete = completed_event(response);
+        let complete = sequence_event(completed_event(response), &mut next_sequence_number);
 
         let _ = args.tx.send(Ok(event_to_sse_bytes(&complete))).await;
         let _ = args.tx.send(Ok(done_sse_bytes())).await;
     }
 
-    args.metrics.forward_completed(
+    args.metrics.forward_completed_with_details(
         args.forward_id,
         chrono::Utc::now(),
         Some(200),
         ForwardStatus::Success,
-        Some(build_estimated_usage(
-            args.estimated_prompt_tokens,
-            completion_tokens,
-        )),
+        Some(metrics_usage),
+        metrics_details,
         None,
     );
 }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/usage.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/usage.rs
@@ -1,0 +1,177 @@
+use bamboo_metrics::types::{ForwardTokenDetails, TokenUsage as MetricsTokenUsage};
+
+use super::super::types::{
+    ResponsesInputTokensDetails, ResponsesOutputTokensDetails, ResponsesUsage,
+};
+use crate::handlers::llm_compat::usage::build_estimated_usage;
+
+/// Cumulative provider usage observed on the compatibility stream.
+///
+/// OpenAI terminal usage frames are snapshots, not deltas. Each present field
+/// replaces the previous value while omitted fields retain what was already
+/// observed. Explicit zeros therefore remain authoritative.
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct ResponsesUsageAccumulator {
+    saw_provider_usage: bool,
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+    reasoning_tokens: Option<u64>,
+    cached_tokens: Option<u64>,
+    cache_write_tokens: Option<u64>,
+}
+
+impl ResponsesUsageAccumulator {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn record(
+        &mut self,
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+        total_tokens: Option<u64>,
+        reasoning_tokens: Option<u64>,
+        cached_tokens: Option<u64>,
+        cache_write_tokens: Option<u64>,
+    ) {
+        self.saw_provider_usage = true;
+        if input_tokens.is_some() {
+            self.input_tokens = input_tokens;
+        }
+        if output_tokens.is_some() {
+            self.output_tokens = output_tokens;
+        }
+        if total_tokens.is_some() {
+            self.total_tokens = total_tokens;
+        }
+        if reasoning_tokens.is_some() {
+            self.reasoning_tokens = reasoning_tokens;
+        }
+        if cached_tokens.is_some() {
+            self.cached_tokens = cached_tokens;
+        }
+        if cache_write_tokens.is_some() {
+            self.cache_write_tokens = cache_write_tokens;
+        }
+    }
+
+    pub(super) fn response_usage(self) -> Option<ResponsesUsage> {
+        if !self.saw_provider_usage {
+            return None;
+        }
+
+        let input_tokens_details = (self.cached_tokens.is_some()
+            || self.cache_write_tokens.is_some())
+        .then_some(ResponsesInputTokensDetails {
+            cached_tokens: self.cached_tokens,
+            cache_write_tokens: self.cache_write_tokens,
+        });
+        let output_tokens_details =
+            self.reasoning_tokens
+                .is_some()
+                .then_some(ResponsesOutputTokensDetails {
+                    reasoning_tokens: self.reasoning_tokens,
+                });
+        Some(ResponsesUsage {
+            input_tokens: self.input_tokens,
+            input_tokens_details,
+            output_tokens: self.output_tokens,
+            output_tokens_details,
+            total_tokens: self.total_tokens,
+        })
+    }
+
+    /// Metrics use exact provider fields independently, falling back only for
+    /// the field the provider omitted.
+    pub(super) fn metrics_usage(
+        self,
+        estimated_prompt_tokens: u64,
+        estimated_completion_tokens: u64,
+    ) -> (MetricsTokenUsage, Option<ForwardTokenDetails>) {
+        if !self.saw_provider_usage {
+            return (
+                build_estimated_usage(estimated_prompt_tokens, estimated_completion_tokens),
+                None,
+            );
+        }
+
+        let prompt_tokens = self.input_tokens.unwrap_or(estimated_prompt_tokens);
+        let completion_tokens = self.output_tokens.unwrap_or(estimated_completion_tokens);
+        let token_details = ForwardTokenDetails {
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: self.cached_tokens,
+            cache_write_input_tokens: self.cache_write_tokens,
+            reasoning_output_tokens: self.reasoning_tokens,
+        };
+        (
+            MetricsTokenUsage {
+                prompt_tokens,
+                completion_tokens,
+                total_tokens: self
+                    .total_tokens
+                    .unwrap_or_else(|| prompt_tokens.saturating_add(completion_tokens)),
+            },
+            (!token_details.is_empty()).then_some(token_details),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_openai_details_and_explicit_zeroes() {
+        let mut usage = ResponsesUsageAccumulator::default();
+        usage.record(Some(80), Some(20), Some(100), Some(5), Some(0), Some(64));
+
+        let response = usage.response_usage().expect("provider usage");
+        assert_eq!(response.input_tokens, Some(80));
+        assert_eq!(response.output_tokens, Some(20));
+        assert_eq!(response.total_tokens, Some(100));
+        let input_details = response.input_tokens_details.expect("input details");
+        assert_eq!(input_details.cached_tokens, Some(0));
+        assert_eq!(input_details.cache_write_tokens, Some(64));
+        assert_eq!(
+            response
+                .output_tokens_details
+                .expect("output details")
+                .reasoning_tokens,
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn metrics_prefer_provider_values_field_by_field() {
+        let mut usage = ResponsesUsageAccumulator::default();
+        usage.record(Some(8), None, Some(13), None, None, None);
+
+        let (metrics, details) = usage.metrics_usage(99, 5);
+        assert_eq!(metrics.prompt_tokens, 8);
+        assert_eq!(metrics.completion_tokens, 5);
+        assert_eq!(metrics.total_tokens, 13);
+        assert!(details.is_none());
+    }
+
+    #[test]
+    fn metrics_keep_cache_write_distinct_from_cache_creation() {
+        let mut usage = ResponsesUsageAccumulator::default();
+        usage.record(Some(80), Some(20), Some(100), Some(5), Some(32), Some(48));
+
+        let (_, details) = usage.metrics_usage(999, 999);
+        let details = details.expect("provider token details");
+        assert_eq!(details.cache_creation_input_tokens, None);
+        assert_eq!(details.cache_read_input_tokens, Some(32));
+        assert_eq!(details.cache_write_input_tokens, Some(48));
+        assert_eq!(details.reasoning_output_tokens, Some(5));
+    }
+
+    #[test]
+    fn outward_usage_does_not_invent_an_omitted_total() {
+        let mut usage = ResponsesUsageAccumulator::default();
+        usage.record(Some(8), Some(5), None, None, None, None);
+
+        let response = usage.response_usage().expect("provider usage");
+        assert_eq!(response.input_tokens, Some(8));
+        assert_eq!(response.output_tokens, Some(5));
+        assert_eq!(response.total_tokens, None);
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/openai/types.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/types.rs
@@ -122,6 +122,9 @@ pub(super) struct ResponsesTextContent {
     #[serde(rename = "type")]
     pub(super) content_type: String, // "output_text"
     pub(super) text: String,
+    /// Synthetic output has no citations, but the Responses `output_text`
+    /// object still requires the annotations collection.
+    pub(super) annotations: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -198,6 +201,9 @@ pub(super) struct ResponsesStreamEvent<T> {
     /// Complete arguments for `response.function_call_arguments.done` (#525).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) arguments: Option<String>,
+    /// Function name for `response.function_call_arguments.done`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) name: Option<String>,
 }
 
 /// Manual impl (not derived) so it doesn't require `T: Default` — event
@@ -217,6 +223,7 @@ impl<T> Default for ResponsesStreamEvent<T> {
             text: None,
             item: None,
             arguments: None,
+            name: None,
         }
     }
 }
@@ -347,11 +354,13 @@ mod tests {
         let content = ResponsesTextContent {
             content_type: "output_text".to_string(),
             text: "Hello world".to_string(),
+            annotations: Vec::new(),
         };
 
         let json = serde_json::to_string(&content).unwrap();
         assert!(json.contains("\"type\":\"output_text\""));
         assert!(json.contains("\"text\":\"Hello world\""));
+        assert!(json.contains("\"annotations\":[]"));
     }
 
     #[test]
@@ -363,6 +372,7 @@ mod tests {
             content: vec![ResponsesTextContent {
                 content_type: "output_text".to_string(),
                 text: "Response text".to_string(),
+                annotations: Vec::new(),
             }],
             status: None,
         };

--- a/crates/app/bamboo-server/src/handlers/openai/types.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/types.rs
@@ -94,9 +94,27 @@ pub(super) struct ResponsesUsage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) input_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) input_tokens_details: Option<ResponsesInputTokensDetails>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) output_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) output_tokens_details: Option<ResponsesOutputTokensDetails>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) total_tokens: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub(super) struct ResponsesInputTokensDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) cached_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) cache_write_tokens: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub(super) struct ResponsesOutputTokensDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) reasoning_tokens: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -155,6 +173,7 @@ pub(super) struct ResponsesCreateResponse {
 pub(super) struct ResponsesStreamEvent<T> {
     #[serde(rename = "type")]
     pub(super) event_type: String,
+    pub(super) sequence_number: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) response: Option<T>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -167,6 +186,12 @@ pub(super) struct ResponsesStreamEvent<T> {
     pub(super) content_index: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) delta: Option<String>,
+    /// Content part for `response.content_part.added` / `.done`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) part: Option<ResponsesTextContent>,
+    /// Full text for `response.output_text.done`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) text: Option<String>,
     /// Full item object for `response.output_item.added` / `.done` (#525).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) item: Option<ResponsesOutputItem>,
@@ -181,12 +206,15 @@ impl<T> Default for ResponsesStreamEvent<T> {
     fn default() -> Self {
         Self {
             event_type: String::new(),
+            sequence_number: 0,
             response: None,
             response_id: None,
             item_id: None,
             output_index: None,
             content_index: None,
             delta: None,
+            part: None,
+            text: None,
             item: None,
             arguments: None,
         }
@@ -280,20 +308,32 @@ mod tests {
     fn test_responses_usage_serialization() {
         let usage = ResponsesUsage {
             input_tokens: Some(100),
+            input_tokens_details: Some(ResponsesInputTokensDetails {
+                cached_tokens: Some(25),
+                cache_write_tokens: Some(64),
+            }),
             output_tokens: Some(50),
+            output_tokens_details: Some(ResponsesOutputTokensDetails {
+                reasoning_tokens: Some(10),
+            }),
             total_tokens: Some(150),
         };
 
         let json = serde_json::to_string(&usage).unwrap();
         assert!(json.contains("\"input_tokens\":100"));
         assert!(json.contains("\"output_tokens\":50"));
+        assert!(json.contains("\"cached_tokens\":25"));
+        assert!(json.contains("\"cache_write_tokens\":64"));
+        assert!(json.contains("\"reasoning_tokens\":10"));
     }
 
     #[test]
     fn test_responses_usage_minimal() {
         let usage = ResponsesUsage {
             input_tokens: None,
+            input_tokens_details: None,
             output_tokens: None,
+            output_tokens_details: None,
             total_tokens: None,
         };
 
@@ -404,7 +444,9 @@ mod tests {
     fn test_responses_create_response_with_usage() {
         let usage = ResponsesUsage {
             input_tokens: Some(100),
+            input_tokens_details: None,
             output_tokens: Some(50),
+            output_tokens_details: None,
             total_tokens: Some(150),
         };
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -4308,9 +4308,11 @@ mod tests {
             provider_usage: Some(ProviderUsageSnapshot {
                 input_tokens: Some(1000),
                 output_tokens: Some(120),
+                total_tokens: Some(1120),
                 reasoning_tokens: Some(20),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(768),
+                cache_write_input_tokens: None,
             }),
             input_tokens: 232,
         };

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -984,12 +984,20 @@ pub(super) async fn execute_llm_stream(
         }
     }
 
-    if stream_output.cache_creation_input_tokens > 0 || stream_output.cache_read_input_tokens > 0 {
+    let cache_write_input_tokens = stream_output
+        .provider_usage
+        .and_then(|usage| usage.cache_write_input_tokens)
+        .unwrap_or(0);
+    if stream_output.cache_creation_input_tokens > 0
+        || stream_output.cache_read_input_tokens > 0
+        || cache_write_input_tokens > 0
+    {
         tracing::info!(
-            "[{}] Anthropic prompt cache: creation={}, read={}, output={}, thinking={}",
+            "[{}] Provider prompt cache: creation={}, read={}, write={}, output={}, thinking={}",
             session_id,
             stream_output.cache_creation_input_tokens,
             stream_output.cache_read_input_tokens,
+            cache_write_input_tokens,
             stream_output.output_tokens,
             stream_output.thinking_tokens,
         );
@@ -1017,6 +1025,7 @@ pub(super) async fn execute_llm_stream(
                 session.token_usage.as_ref(),
                 stream_output.cache_creation_input_tokens,
                 stream_output.cache_read_input_tokens,
+                cache_write_input_tokens,
                 stream_output.input_tokens,
                 stream_output.output_tokens,
                 stream_output.thinking_tokens,

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -459,9 +459,11 @@ async fn execute_llm_stream_emits_final_budget_event_with_provider_usage() {
         LLMChunk::ProviderUsage {
             input_tokens: Some(100),
             output_tokens: Some(80),
+            total_tokens: Some(180),
             reasoning_tokens: Some(24),
             cache_creation_input_tokens: None,
             cache_read_input_tokens: Some(34),
+            cache_write_input_tokens: None,
         },
         // Later legacy summaries/cache frames must not overwrite authoritative
         // provider fields or double the cache badge.

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -71,9 +71,13 @@ fn sanitize_identifier(value: &str) -> Option<String> {
 pub struct ProviderUsageSnapshot {
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
     pub reasoning_tokens: Option<u64>,
     pub cache_creation_input_tokens: Option<u64>,
     pub cache_read_input_tokens: Option<u64>,
+    /// OpenAI Responses cache-write volume. This is raw provider metadata and
+    /// is not folded into the disjoint legacy prompt-cache counters.
+    pub cache_write_input_tokens: Option<u64>,
 }
 
 pub struct StreamHandlingOutput {

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/chunk_handling.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/chunk_handling.rs
@@ -22,6 +22,7 @@ pub(super) async fn handle_chunk_result(
             state.set_response_id(response_id);
             Ok(())
         }
+        Ok(LLMChunk::ResponsesEvent { .. }) => Ok(()),
         Ok(LLMChunk::Token(token)) => {
             state.append_token(&token);
             if let Some(event_tx) = event_tx {
@@ -119,26 +120,32 @@ pub(super) async fn handle_chunk_result(
         Ok(LLMChunk::ProviderUsage {
             input_tokens,
             output_tokens,
+            total_tokens,
             reasoning_tokens,
             cache_creation_input_tokens,
             cache_read_input_tokens,
+            cache_write_input_tokens,
         }) => {
             tracing::debug!(
                 "[{}] Provider usage: input={:?}, output={:?}, reasoning={:?}, \
-                 cache_creation={:?}, cache_read={:?}",
+                 total={:?}, cache_creation={:?}, cache_read={:?}, cache_write={:?}",
                 session_id,
                 input_tokens,
                 output_tokens,
                 reasoning_tokens,
+                total_tokens,
                 cache_creation_input_tokens,
-                cache_read_input_tokens
+                cache_read_input_tokens,
+                cache_write_input_tokens
             );
             state.record_provider_usage(
                 input_tokens,
                 output_tokens,
+                total_tokens,
                 reasoning_tokens,
                 cache_creation_input_tokens,
                 cache_read_input_tokens,
+                cache_write_input_tokens,
             );
             Ok(())
         }

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
@@ -112,13 +112,16 @@ impl StreamAccumulationState {
     /// request, so addition would double-count if an upstream repeats a final
     /// frame. Omitted fields leave existing state untouched; an explicit zero
     /// remains authoritative.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn record_provider_usage(
         &mut self,
         input_tokens: Option<u64>,
         output_tokens: Option<u64>,
+        total_tokens: Option<u64>,
         reasoning_tokens: Option<u64>,
         cache_creation_input_tokens: Option<u64>,
         cache_read_input_tokens: Option<u64>,
+        cache_write_input_tokens: Option<u64>,
     ) {
         {
             let snapshot = self.provider_usage.get_or_insert_default();
@@ -128,6 +131,9 @@ impl StreamAccumulationState {
             if let Some(output_tokens) = output_tokens {
                 snapshot.output_tokens = Some(output_tokens);
             }
+            if let Some(total_tokens) = total_tokens {
+                snapshot.total_tokens = Some(total_tokens);
+            }
             if let Some(reasoning_tokens) = reasoning_tokens {
                 snapshot.reasoning_tokens = Some(reasoning_tokens);
             }
@@ -136,6 +142,9 @@ impl StreamAccumulationState {
             }
             if let Some(cache_read_input_tokens) = cache_read_input_tokens {
                 snapshot.cache_read_input_tokens = Some(cache_read_input_tokens);
+            }
+            if let Some(cache_write_input_tokens) = cache_write_input_tokens {
+                snapshot.cache_write_input_tokens = Some(cache_write_input_tokens);
             }
         }
 

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -153,9 +153,11 @@ async fn consume_llm_stream_records_provider_usage_snapshots_without_double_coun
     let usage = LLMChunk::ProviderUsage {
         input_tokens: Some(101),
         output_tokens: Some(37),
+        total_tokens: Some(138),
         reasoning_tokens: Some(11),
         cache_creation_input_tokens: Some(0),
         cache_read_input_tokens: Some(29),
+        cache_write_input_tokens: Some(64),
     };
     let stream = build_stream(vec![
         Ok(usage.clone()),
@@ -165,9 +167,11 @@ async fn consume_llm_stream_records_provider_usage_snapshots_without_double_coun
         Ok(LLMChunk::ProviderUsage {
             input_tokens: None,
             output_tokens: None,
+            total_tokens: None,
             reasoning_tokens: None,
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            cache_write_input_tokens: None,
         }),
         Ok(LLMChunk::Done),
     ]);
@@ -187,9 +191,11 @@ async fn consume_llm_stream_records_provider_usage_snapshots_without_double_coun
         Some(ProviderUsageSnapshot {
             input_tokens: Some(101),
             output_tokens: Some(37),
+            total_tokens: Some(138),
             reasoning_tokens: Some(11),
             cache_creation_input_tokens: Some(0),
             cache_read_input_tokens: Some(29),
+            cache_write_input_tokens: Some(64),
         })
     );
 }
@@ -201,9 +207,11 @@ async fn provider_usage_snapshot_distinguishes_omitted_from_zero_for_every_field
             Ok(LLMChunk::ProviderUsage {
                 input_tokens: None,
                 output_tokens: None,
+                total_tokens: None,
                 reasoning_tokens: None,
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: None,
+                cache_write_input_tokens: None,
             }),
             Ok(LLMChunk::Done),
         ]),
@@ -222,16 +230,20 @@ async fn provider_usage_snapshot_distinguishes_omitted_from_zero_for_every_field
             Ok(LLMChunk::ProviderUsage {
                 input_tokens: Some(9),
                 output_tokens: Some(9),
+                total_tokens: Some(18),
                 reasoning_tokens: Some(9),
                 cache_creation_input_tokens: Some(9),
                 cache_read_input_tokens: Some(9),
+                cache_write_input_tokens: Some(9),
             }),
             Ok(LLMChunk::ProviderUsage {
                 input_tokens: Some(0),
                 output_tokens: Some(0),
+                total_tokens: Some(0),
                 reasoning_tokens: Some(0),
                 cache_creation_input_tokens: Some(0),
                 cache_read_input_tokens: Some(0),
+                cache_write_input_tokens: Some(0),
             }),
             Ok(LLMChunk::Done),
         ]),
@@ -245,9 +257,11 @@ async fn provider_usage_snapshot_distinguishes_omitted_from_zero_for_every_field
         Some(ProviderUsageSnapshot {
             input_tokens: Some(0),
             output_tokens: Some(0),
+            total_tokens: Some(0),
             reasoning_tokens: Some(0),
             cache_creation_input_tokens: Some(0),
             cache_read_input_tokens: Some(0),
+            cache_write_input_tokens: Some(0),
         })
     );
 }
@@ -268,9 +282,11 @@ async fn provider_output_and_reasoning_reconcile_independently_in_both_orders() 
             let provider = LLMChunk::ProviderUsage {
                 input_tokens: None,
                 output_tokens: provider_output,
+                total_tokens: None,
                 reasoning_tokens: provider_reasoning,
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: None,
+                cache_write_input_tokens: None,
             };
             let legacy = LLMChunk::UsageSummary {
                 output_tokens: 56,
@@ -296,9 +312,11 @@ async fn provider_output_and_reasoning_reconcile_independently_in_both_orders() 
                 Some(ProviderUsageSnapshot {
                     input_tokens: None,
                     output_tokens: provider_output,
+                    total_tokens: None,
                     reasoning_tokens: provider_reasoning,
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
+                    cache_write_input_tokens: None,
                 })
             );
 
@@ -311,6 +329,10 @@ async fn provider_output_and_reasoning_reconcile_independently_in_both_orders() 
                 None,
                 output.cache_creation_input_tokens,
                 output.cache_read_input_tokens,
+                output
+                    .provider_usage
+                    .and_then(|usage| usage.cache_write_input_tokens)
+                    .unwrap_or(0),
                 output.input_tokens,
                 output.output_tokens,
                 output.thinking_tokens,
@@ -336,9 +358,11 @@ async fn provider_cache_reconciles_without_input_total_in_both_orders() {
             let provider = LLMChunk::ProviderUsage {
                 input_tokens: None,
                 output_tokens: None,
+                total_tokens: None,
                 reasoning_tokens: None,
                 cache_creation_input_tokens: provider_creation,
                 cache_read_input_tokens: provider_read,
+                cache_write_input_tokens: None,
             };
             let legacy = LLMChunk::CacheUsage {
                 cache_creation_input_tokens: 11,
@@ -372,9 +396,11 @@ async fn provider_cache_reconciles_without_input_total_in_both_orders() {
                 Some(ProviderUsageSnapshot {
                     input_tokens: None,
                     output_tokens: None,
+                    total_tokens: None,
                     reasoning_tokens: None,
                     cache_creation_input_tokens: provider_creation,
                     cache_read_input_tokens: provider_read,
+                    cache_write_input_tokens: None,
                 })
             );
 
@@ -387,6 +413,10 @@ async fn provider_cache_reconciles_without_input_total_in_both_orders() {
                 None,
                 output.cache_creation_input_tokens,
                 output.cache_read_input_tokens,
+                output
+                    .provider_usage
+                    .and_then(|usage| usage.cache_write_input_tokens)
+                    .unwrap_or(0),
                 output.input_tokens,
                 output.output_tokens,
                 output.thinking_tokens,
@@ -475,9 +505,11 @@ async fn provider_total_clamps_flat_cache_subset_without_mutating_raw_snapshot()
             Ok(LLMChunk::ProviderUsage {
                 input_tokens: Some(100),
                 output_tokens: None,
+                total_tokens: None,
                 reasoning_tokens: None,
                 cache_creation_input_tokens: Some(50),
                 cache_read_input_tokens: Some(80),
+                cache_write_input_tokens: None,
             }),
             Ok(LLMChunk::Done),
         ]),
@@ -501,9 +533,11 @@ async fn provider_total_clamps_flat_cache_subset_without_mutating_raw_snapshot()
         Some(ProviderUsageSnapshot {
             input_tokens: Some(100),
             output_tokens: None,
+            total_tokens: None,
             reasoning_tokens: None,
             cache_creation_input_tokens: Some(50),
             cache_read_input_tokens: Some(80),
+            cache_write_input_tokens: None,
         }),
         "raw anomalous provider values remain available for diagnostics"
     );
@@ -513,9 +547,11 @@ async fn provider_total_clamps_flat_cache_subset_without_mutating_raw_snapshot()
             Ok(LLMChunk::ProviderUsage {
                 input_tokens: Some(100),
                 output_tokens: None,
+                total_tokens: None,
                 reasoning_tokens: None,
                 cache_creation_input_tokens: Some(30),
                 cache_read_input_tokens: Some(120),
+                cache_write_input_tokens: None,
             }),
             Ok(LLMChunk::Done),
         ]),

--- a/crates/engine/bamboo-engine/src/token_usage_log.rs
+++ b/crates/engine/bamboo-engine/src/token_usage_log.rs
@@ -10,8 +10,8 @@
 //!
 //! The record bridges two sources: the prompt-side budget snapshot
 //! ([`TokenBudgetUsage`], already on the session) and the server-returned stream
-//! stats — notably `cache_creation_input_tokens`, which is NOT part of
-//! `TokenBudgetUsage` and would otherwise only exist in the logs.
+//! stats — notably cache-creation and OpenAI cache-write dimensions, which are
+//! NOT part of `TokenBudgetUsage` and would otherwise only exist transiently.
 
 use bamboo_domain::TokenBudgetUsage;
 use serde::Serialize;
@@ -32,6 +32,9 @@ pub struct TokenUsageRecord {
     // --- server-returned usage (this call) ---
     pub cache_creation_input_tokens: u64,
     pub cache_read_input_tokens: u64,
+    /// OpenAI cache-write volume. This can overlap the fresh-input count and
+    /// therefore must not be added to the disjoint prompt-total equation.
+    pub cache_write_input_tokens: u64,
     /// Non-cached "fresh" input tokens (server-reported), disjoint from the two
     /// cache counts. The precise prompt size is
     /// `input_tokens + cache_read + cache_creation`, and the exact cache-hit
@@ -58,9 +61,9 @@ pub struct TokenUsageRecord {
 
 impl TokenUsageRecord {
     /// Build a record from the prompt-side budget snapshot (`usage`) and the
-    /// server-side stream stats. The cache-creation count lives only on the
-    /// stream output — it is not part of [`TokenBudgetUsage`] — so it is passed
-    /// in explicitly.
+    /// server-side stream stats. Cache creation and cache writes live only on
+    /// the stream output — they are not part of [`TokenBudgetUsage`] — so they
+    /// are passed in explicitly.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         ts: String,
@@ -71,6 +74,7 @@ impl TokenUsageRecord {
         usage: Option<&TokenBudgetUsage>,
         cache_creation_input_tokens: u64,
         cache_read_input_tokens: u64,
+        cache_write_input_tokens: u64,
         input_tokens: u64,
         output_tokens: u64,
         thinking_tokens: u64,
@@ -83,6 +87,7 @@ impl TokenUsageRecord {
             message_count,
             cache_creation_input_tokens,
             cache_read_input_tokens,
+            cache_write_input_tokens,
             input_tokens,
             output_tokens,
             thinking_tokens,
@@ -137,6 +142,7 @@ mod tests {
             Some(&usage),
             1500, // cache_creation — only present on the stream output
             12_000,
+            0,
             800, // input_tokens (fresh, non-cached)
             300,
             7,
@@ -145,6 +151,7 @@ mod tests {
         assert!(!line.contains('\n'), "must be a single line");
         assert!(line.contains("\"cache_creation_input_tokens\":1500"));
         assert!(line.contains("\"cache_read_input_tokens\":12000"));
+        assert!(line.contains("\"cache_write_input_tokens\":0"));
         assert!(line.contains("\"input_tokens\":800"));
         assert!(line.contains("\"session_id\":\"sess-1\""));
     }
@@ -160,6 +167,7 @@ mod tests {
             None,
             0,
             768,
+            64,
             232,
             120,
             20,
@@ -173,6 +181,7 @@ mod tests {
 
         assert_eq!(record.input_tokens, 232);
         assert_eq!(prompt_total, 1000);
+        assert_eq!(record.cache_write_input_tokens, 64);
         assert!((cache_hit_ratio - 0.768).abs() < f64::EPSILON);
         assert_eq!(record.output_tokens, 120);
         assert_eq!(record.thinking_tokens, 20);

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
@@ -90,9 +90,9 @@ use thiserror::Error;
 
 use crate::metrics::types::{
     DailyMetrics, ForwardEndpointMetrics, ForwardMetricsFilter, ForwardMetricsSummary,
-    ForwardRequestMetrics, ForwardStatus, MetricsDateFilter, MetricsSummary, ModelMetrics,
-    RoundMetrics, RoundStatus, SessionDetail, SessionMetrics, SessionMetricsFilter, SessionStatus,
-    TokenUsage, ToolCallMetrics,
+    ForwardRequestMetrics, ForwardStatus, ForwardTokenDetails, MetricsDateFilter, MetricsSummary,
+    ModelMetrics, RoundMetrics, RoundStatus, SessionDetail, SessionMetrics, SessionMetricsFilter,
+    SessionStatus, TokenUsage, ToolCallMetrics,
 };
 
 /// Result type for metrics storage operations.
@@ -416,7 +416,9 @@ pub trait MetricsStorage: Send + Sync {
     /// * `status_code` - HTTP status code from the upstream API
     /// * `status` - Classified status (success, error, or timeout)
     /// * `usage` - Token usage if provided in the response
+    /// * `token_details` - Provider-specific cache/reasoning dimensions
     /// * `error` - Error message if the request failed
+    #[allow(clippy::too_many_arguments)]
     async fn complete_forward(
         &self,
         forward_id: &str,
@@ -424,6 +426,7 @@ pub trait MetricsStorage: Send + Sync {
         status_code: Option<u16>,
         status: ForwardStatus,
         usage: Option<TokenUsage>,
+        token_details: Option<ForwardTokenDetails>,
         error: Option<String>,
     ) -> MetricsResult<()>;
 
@@ -935,6 +938,10 @@ impl MetricsStorage for SqliteMetricsStorage {
                     prompt_tokens INTEGER,
                     completion_tokens INTEGER,
                     total_tokens INTEGER,
+                    cache_creation_input_tokens INTEGER,
+                    cache_read_input_tokens INTEGER,
+                    cache_write_input_tokens INTEGER,
+                    reasoning_output_tokens INTEGER,
                     error TEXT,
                     updated_at TEXT NOT NULL
                 );
@@ -967,6 +974,26 @@ impl MetricsStorage for SqliteMetricsStorage {
             ensure_integer_column(connection, "round_metrics", "prompt_cached_tool_tokens_saved", 0)?;
             ensure_integer_column(connection, "round_metrics", "compression_count", 0)?;
             ensure_integer_column(connection, "round_metrics", "tokens_saved", 0)?;
+            ensure_nullable_integer_column(
+                connection,
+                "forward_request_metrics",
+                "cache_creation_input_tokens",
+            )?;
+            ensure_nullable_integer_column(
+                connection,
+                "forward_request_metrics",
+                "cache_read_input_tokens",
+            )?;
+            ensure_nullable_integer_column(
+                connection,
+                "forward_request_metrics",
+                "cache_write_input_tokens",
+            )?;
+            ensure_nullable_integer_column(
+                connection,
+                "forward_request_metrics",
+                "reasoning_output_tokens",
+            )?;
             connection.execute(
                 "UPDATE forward_request_metrics SET status = 'pending' WHERE status IS NULL OR trim(status) = ''",
                 [],
@@ -1259,6 +1286,10 @@ impl MetricsStorage for SqliteMetricsStorage {
                     prompt_tokens = NULL,
                     completion_tokens = NULL,
                     total_tokens = NULL,
+                    cache_creation_input_tokens = NULL,
+                    cache_read_input_tokens = NULL,
+                    cache_write_input_tokens = NULL,
+                    reasoning_output_tokens = NULL,
                     error = NULL,
                     updated_at = excluded.updated_at
                 "#,
@@ -1276,6 +1307,7 @@ impl MetricsStorage for SqliteMetricsStorage {
         status_code: Option<u16>,
         status: ForwardStatus,
         usage: Option<TokenUsage>,
+        token_details: Option<ForwardTokenDetails>,
         error: Option<String>,
     ) -> MetricsResult<()> {
         let forward_id = forward_id.to_string();
@@ -1289,6 +1321,19 @@ impl MetricsStorage for SqliteMetricsStorage {
             ),
             None => (None, None, None),
         };
+        let token_details = token_details.unwrap_or_default();
+        let cache_creation = token_details
+            .cache_creation_input_tokens
+            .map(|value| value as i64);
+        let cache_read = token_details
+            .cache_read_input_tokens
+            .map(|value| value as i64);
+        let cache_write = token_details
+            .cache_write_input_tokens
+            .map(|value| value as i64);
+        let reasoning_output = token_details
+            .reasoning_output_tokens
+            .map(|value| value as i64);
 
         self.with_connection(move |connection| {
             connection.execute(
@@ -1300,9 +1345,13 @@ impl MetricsStorage for SqliteMetricsStorage {
                     prompt_tokens = ?4,
                     completion_tokens = ?5,
                     total_tokens = ?6,
-                    error = ?7,
+                    cache_creation_input_tokens = ?7,
+                    cache_read_input_tokens = ?8,
+                    cache_write_input_tokens = ?9,
+                    reasoning_output_tokens = ?10,
+                    error = ?11,
                     updated_at = ?1
-                WHERE forward_id = ?8
+                WHERE forward_id = ?12
                 "#,
                 params![
                     completed_at_str,
@@ -1311,6 +1360,10 @@ impl MetricsStorage for SqliteMetricsStorage {
                     prompt,
                     completion,
                     total,
+                    cache_creation,
+                    cache_read,
+                    cache_write,
+                    reasoning_output,
                     error,
                     forward_id,
                 ],
@@ -1341,6 +1394,10 @@ impl MetricsStorage for SqliteMetricsStorage {
                  COALESCE(SUM(prompt_tokens), 0), \
                  COALESCE(SUM(completion_tokens), 0), \
                  COALESCE(SUM(total_tokens), 0), \
+                 SUM(cache_creation_input_tokens), \
+                 SUM(cache_read_input_tokens), \
+                 SUM(cache_write_input_tokens), \
+                 SUM(reasoning_output_tokens), \
                  AVG(CASE WHEN completed_at IS NOT NULL THEN \
                      (julianday(completed_at) - julianday(started_at)) * 86400000 END) \
                  FROM forward_request_metrics {}",
@@ -1349,7 +1406,7 @@ impl MetricsStorage for SqliteMetricsStorage {
 
             let mut stmt = connection.prepare(&sql)?;
             let summary = stmt.query_row(params_from_iter(params_vec.iter()), |row| {
-                let avg_duration: Option<f64> = row.get(6)?;
+                let avg_duration: Option<f64> = row.get(10)?;
                 Ok(ForwardMetricsSummary {
                     total_requests: row.get::<_, i64>(0)? as u64,
                     successful_requests: row.get::<_, i64>(1)? as u64,
@@ -1358,6 +1415,20 @@ impl MetricsStorage for SqliteMetricsStorage {
                         prompt_tokens: row.get::<_, i64>(3)? as u64,
                         completion_tokens: row.get::<_, i64>(4)? as u64,
                         total_tokens: row.get::<_, i64>(5)? as u64,
+                    },
+                    token_details: ForwardTokenDetails {
+                        cache_creation_input_tokens: row
+                            .get::<_, Option<i64>>(6)?
+                            .map(|value| value as u64),
+                        cache_read_input_tokens: row
+                            .get::<_, Option<i64>>(7)?
+                            .map(|value| value as u64),
+                        cache_write_input_tokens: row
+                            .get::<_, Option<i64>>(8)?
+                            .map(|value| value as u64),
+                        reasoning_output_tokens: row
+                            .get::<_, Option<i64>>(9)?
+                            .map(|value| value as u64),
                     },
                     avg_duration_ms: avg_duration.map(|d| d as u64),
                 })
@@ -1389,6 +1460,10 @@ impl MetricsStorage for SqliteMetricsStorage {
                  COALESCE(SUM(prompt_tokens), 0), \
                  COALESCE(SUM(completion_tokens), 0), \
                  COALESCE(SUM(total_tokens), 0), \
+                 SUM(cache_creation_input_tokens), \
+                 SUM(cache_read_input_tokens), \
+                 SUM(cache_write_input_tokens), \
+                 SUM(reasoning_output_tokens), \
                  AVG(CASE WHEN completed_at IS NOT NULL THEN \
                      (julianday(completed_at) - julianday(started_at)) * 86400000 END) \
                  FROM forward_request_metrics {} \
@@ -1401,7 +1476,7 @@ impl MetricsStorage for SqliteMetricsStorage {
             let mut endpoints = Vec::new();
 
             while let Some(row) = rows.next()? {
-                let avg_duration: Option<f64> = row.get(7)?;
+                let avg_duration: Option<f64> = row.get(11)?;
                 endpoints.push(ForwardEndpointMetrics {
                     endpoint: row.get(0)?,
                     requests: row.get::<_, i64>(1)? as u64,
@@ -1411,6 +1486,20 @@ impl MetricsStorage for SqliteMetricsStorage {
                         prompt_tokens: row.get::<_, i64>(4)? as u64,
                         completion_tokens: row.get::<_, i64>(5)? as u64,
                         total_tokens: row.get::<_, i64>(6)? as u64,
+                    },
+                    token_details: ForwardTokenDetails {
+                        cache_creation_input_tokens: row
+                            .get::<_, Option<i64>>(7)?
+                            .map(|value| value as u64),
+                        cache_read_input_tokens: row
+                            .get::<_, Option<i64>>(8)?
+                            .map(|value| value as u64),
+                        cache_write_input_tokens: row
+                            .get::<_, Option<i64>>(9)?
+                            .map(|value| value as u64),
+                        reasoning_output_tokens: row
+                            .get::<_, Option<i64>>(10)?
+                            .map(|value| value as u64),
                     },
                     avg_duration_ms: avg_duration.map(|d| d as u64),
                 });
@@ -1438,7 +1527,9 @@ impl MetricsStorage for SqliteMetricsStorage {
             let limit = i64::from(filter.limit.unwrap_or(100).min(1_000));
             let sql = format!(
                 "SELECT forward_id, endpoint, model, is_stream, started_at, completed_at, \
-                 status_code, status, prompt_tokens, completion_tokens, total_tokens, error \
+                 status_code, status, prompt_tokens, completion_tokens, total_tokens, \
+                 cache_creation_input_tokens, cache_read_input_tokens, \
+                 cache_write_input_tokens, reasoning_output_tokens, error \
                  FROM forward_request_metrics {} \
                  ORDER BY started_at DESC LIMIT {}",
                 where_clause, limit
@@ -1476,7 +1567,21 @@ impl MetricsStorage for SqliteMetricsStorage {
                     status_code: row.get::<_, Option<i64>>(6)?.map(|s| s as u16),
                     status,
                     token_usage,
-                    error: row.get(11)?,
+                    token_details: ForwardTokenDetails {
+                        cache_creation_input_tokens: row
+                            .get::<_, Option<i64>>(11)?
+                            .map(|value| value as u64),
+                        cache_read_input_tokens: row
+                            .get::<_, Option<i64>>(12)?
+                            .map(|value| value as u64),
+                        cache_write_input_tokens: row
+                            .get::<_, Option<i64>>(13)?
+                            .map(|value| value as u64),
+                        reasoning_output_tokens: row
+                            .get::<_, Option<i64>>(14)?
+                            .map(|value| value as u64),
+                    },
+                    error: row.get(15)?,
                     duration_ms: compute_duration_ms(started_at, completed_at),
                 });
             }
@@ -2278,6 +2383,26 @@ fn ensure_integer_column(
     Ok(())
 }
 
+fn ensure_nullable_integer_column(
+    connection: &Connection,
+    table: &str,
+    column: &str,
+) -> MetricsResult<()> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let mut stmt = connection.prepare(&pragma)?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == column {
+            return Ok(());
+        }
+    }
+
+    let alter = format!("ALTER TABLE {table} ADD COLUMN {column} INTEGER");
+    connection.execute(&alter, [])?;
+    Ok(())
+}
+
 /// Refreshes aggregated metrics for a session by recalculating from child entities.
 ///
 /// This function updates the session's aggregate columns by summing values
@@ -2592,8 +2717,8 @@ mod tests {
 
     use super::{MetricsStorage, SqliteMetricsStorage, ToolCallCompletion};
     use crate::metrics::types::{
-        ForwardMetricsFilter, ForwardStatus, MetricsDateFilter, RoundStatus, SessionMetricsFilter,
-        SessionStatus, TokenUsage,
+        ForwardMetricsFilter, ForwardStatus, ForwardTokenDetails, MetricsDateFilter, RoundStatus,
+        SessionMetricsFilter, SessionStatus, TokenUsage,
     };
 
     #[test]
@@ -2939,6 +3064,97 @@ mod tests {
         assert_eq!(
             daily[0].total_sessions, 1,
             "the 23:59:59 session is in range; the next-day 00:00 session is not"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_metrics_preserve_provider_cache_dimensions_separately() {
+        let dir = tempdir().expect("temp dir");
+        let database_path = dir.path().join("metrics.db");
+        let legacy = rusqlite::Connection::open(&database_path).expect("legacy database");
+        legacy
+            .execute_batch(
+                r#"
+                CREATE TABLE forward_request_metrics (
+                    forward_id TEXT PRIMARY KEY,
+                    endpoint TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    is_stream INTEGER NOT NULL,
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT,
+                    status_code INTEGER,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    prompt_tokens INTEGER,
+                    completion_tokens INTEGER,
+                    total_tokens INTEGER,
+                    error TEXT,
+                    updated_at TEXT NOT NULL
+                );
+                "#,
+            )
+            .expect("legacy forward schema");
+        drop(legacy);
+
+        let storage = SqliteMetricsStorage::new(database_path);
+        storage.init().await.expect("init storage");
+        let now = Utc
+            .with_ymd_and_hms(2026, 2, 11, 9, 0, 0)
+            .single()
+            .expect("valid datetime");
+
+        storage
+            .insert_forward_start("forward-cache", "openai.responses", "gpt-5.6", true, now)
+            .await
+            .expect("forward start");
+        storage
+            .complete_forward(
+                "forward-cache",
+                now + chrono::Duration::milliseconds(25),
+                Some(200),
+                ForwardStatus::Success,
+                Some(TokenUsage {
+                    prompt_tokens: 80,
+                    completion_tokens: 20,
+                    total_tokens: 100,
+                }),
+                Some(ForwardTokenDetails {
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: Some(32),
+                    cache_write_input_tokens: Some(48),
+                    reasoning_output_tokens: Some(5),
+                }),
+                None,
+            )
+            .await
+            .expect("forward completion");
+
+        let requests = storage
+            .forward_requests(ForwardMetricsFilter::default())
+            .await
+            .expect("forward requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].token_details.cache_read_input_tokens, Some(32));
+        assert_eq!(requests[0].token_details.cache_write_input_tokens, Some(48));
+        assert_eq!(requests[0].token_details.cache_creation_input_tokens, None);
+        assert_eq!(requests[0].token_details.reasoning_output_tokens, Some(5));
+
+        let summary = storage
+            .forward_summary(ForwardMetricsFilter::default())
+            .await
+            .expect("forward summary");
+        assert_eq!(summary.token_details.cache_read_input_tokens, Some(32));
+        assert_eq!(summary.token_details.cache_write_input_tokens, Some(48));
+        assert_eq!(summary.token_details.cache_creation_input_tokens, None);
+        assert_eq!(summary.token_details.reasoning_output_tokens, Some(5));
+
+        let endpoints = storage
+            .forward_by_endpoint(ForwardMetricsFilter::default())
+            .await
+            .expect("forward endpoints");
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(
+            endpoints[0].token_details.cache_write_input_tokens,
+            Some(48)
         );
     }
 

--- a/crates/infra/bamboo-infrastructure/src/metrics/types.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/types.rs
@@ -330,6 +330,33 @@ impl ForwardStatus {
     }
 }
 
+/// Provider token details that are not safely interchangeable with the base
+/// prompt/completion totals.
+///
+/// The fields stay optional so a missing provider value is distinct from an
+/// authoritative zero. In particular, OpenAI cache writes are not Anthropic
+/// cache creations and must never be folded into that counter.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForwardTokenDetails {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write_input_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_output_tokens: Option<u64>,
+}
+
+impl ForwardTokenDetails {
+    pub fn is_empty(&self) -> bool {
+        self.cache_creation_input_tokens.is_none()
+            && self.cache_read_input_tokens.is_none()
+            && self.cache_write_input_tokens.is_none()
+            && self.reasoning_output_tokens.is_none()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ForwardRequestMetrics {
     pub forward_id: String,
@@ -341,6 +368,8 @@ pub struct ForwardRequestMetrics {
     pub status_code: Option<u16>,
     pub status: Option<ForwardStatus>,
     pub token_usage: Option<TokenUsage>,
+    #[serde(default, skip_serializing_if = "ForwardTokenDetails::is_empty")]
+    pub token_details: ForwardTokenDetails,
     pub error: Option<String>,
     pub duration_ms: Option<u64>,
 }
@@ -351,6 +380,8 @@ pub struct ForwardMetricsSummary {
     pub successful_requests: u64,
     pub failed_requests: u64,
     pub total_tokens: TokenUsage,
+    #[serde(default, skip_serializing_if = "ForwardTokenDetails::is_empty")]
+    pub token_details: ForwardTokenDetails,
     pub avg_duration_ms: Option<u64>,
 }
 
@@ -361,6 +392,8 @@ pub struct ForwardEndpointMetrics {
     pub successful: u64,
     pub failed: u64,
     pub tokens: TokenUsage,
+    #[serde(default, skip_serializing_if = "ForwardTokenDetails::is_empty")]
+    pub token_details: ForwardTokenDetails,
     pub avg_duration_ms: Option<u64>,
 }
 
@@ -649,6 +682,12 @@ mod tests {
             status_code: Some(200),
             status: Some(ForwardStatus::Success),
             token_usage: None,
+            token_details: ForwardTokenDetails {
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(32),
+                cache_write_input_tokens: Some(48),
+                reasoning_output_tokens: Some(5),
+            },
             error: None,
             duration_ms: Some(250),
         };
@@ -656,6 +695,8 @@ mod tests {
         let json = serde_json::to_string(&metrics).unwrap();
         assert!(json.contains("\"forward_id\":\"fwd-123\""));
         assert!(json.contains("\"endpoint\":\"/api/chat\""));
+        assert!(json.contains("\"cache_read_input_tokens\":32"));
+        assert!(json.contains("\"cache_write_input_tokens\":48"));
     }
 
     #[test]
@@ -665,6 +706,7 @@ mod tests {
             successful_requests: 950,
             failed_requests: 50,
             total_tokens: TokenUsage::default(),
+            token_details: ForwardTokenDetails::default(),
             avg_duration_ms: Some(200),
         };
 

--- a/crates/infra/bamboo-llm/src/cache.rs
+++ b/crates/infra/bamboo-llm/src/cache.rs
@@ -4,13 +4,15 @@
 //! policy, so the policy lives here and each provider only renders it:
 //!
 //! 1. **Where the cacheable prefix ends.** Anthropic needs explicit
-//!    `cache_control` breakpoints (at most [`MAX_ANTHROPIC_CACHE_BREAKPOINTS`]);
-//!    OpenAI / Gemini / Copilot cache an identical prefix automatically. In every
-//!    case a cache *hit* requires the bytes before the breakpoint to be identical
-//!    to a previous request. That means the engine must keep per-round volatile
-//!    content (task list, recalled memory, plan state) **out** of the cacheable
-//!    prefix and order it last — otherwise the breakpoint moves every round and
-//!    the cache read size swings or drops to zero.
+//!    `cache_control` breakpoints (at most [`MAX_ANTHROPIC_CACHE_BREAKPOINTS`]).
+//!    GPT-5.6+ Responses requests can lower the same plan into explicit OpenAI
+//!    content breakpoints; older OpenAI models, Gemini, and Copilot retain their
+//!    automatic prefix caching. In every case a cache *hit* requires the bytes
+//!    before the selected prefix boundary to be identical to a previous request.
+//!    That means the engine must keep per-round volatile content (task list,
+//!    recalled memory, plan state) **out** of the cacheable prefix and order it
+//!    last — otherwise the boundary moves every round and the cache read size
+//!    swings or drops to zero.
 //!
 //! 2. **How cached-token usage is reported.** Anthropic reports
 //!    `cache_read_input_tokens`; OpenAI-compatible APIs report
@@ -146,16 +148,21 @@ pub fn provider_usage_from_openai_usage(usage: &Value) -> Option<LLMChunk> {
         direct_u64(usage, "prompt_tokens").or_else(|| direct_u64(usage, "input_tokens"));
     let output_tokens =
         direct_u64(usage, "completion_tokens").or_else(|| direct_u64(usage, "output_tokens"));
+    let total_tokens = direct_u64(usage, "total_tokens");
     let reasoning_tokens = nested_u64(usage, "completion_tokens_details", "reasoning_tokens")
         .or_else(|| nested_u64(usage, "output_tokens_details", "reasoning_tokens"))
         .or_else(|| direct_u64(usage, "reasoning_tokens"));
     let cache_read_input_tokens = nested_u64(usage, "prompt_tokens_details", "cached_tokens")
         .or_else(|| nested_u64(usage, "input_tokens_details", "cached_tokens"));
+    let cache_write_input_tokens = nested_u64(usage, "prompt_tokens_details", "cache_write_tokens")
+        .or_else(|| nested_u64(usage, "input_tokens_details", "cache_write_tokens"));
 
     if input_tokens.is_none()
         && output_tokens.is_none()
+        && total_tokens.is_none()
         && reasoning_tokens.is_none()
         && cache_read_input_tokens.is_none()
+        && cache_write_input_tokens.is_none()
     {
         return None;
     }
@@ -163,9 +170,11 @@ pub fn provider_usage_from_openai_usage(usage: &Value) -> Option<LLMChunk> {
     Some(LLMChunk::ProviderUsage {
         input_tokens,
         output_tokens,
+        total_tokens,
         reasoning_tokens,
         cache_creation_input_tokens: None,
         cache_read_input_tokens,
+        cache_write_input_tokens,
     })
 }
 
@@ -260,7 +269,10 @@ mod tests {
         let chat = serde_json::json!({
             "prompt_tokens": 100,
             "completion_tokens": 30,
-            "prompt_tokens_details": {"cached_tokens": 0},
+            "prompt_tokens_details": {
+                "cached_tokens": 0,
+                "cache_write_tokens": 12
+            },
             "completion_tokens_details": {"reasoning_tokens": 7}
         });
         assert!(matches!(
@@ -268,16 +280,22 @@ mod tests {
             Some(LLMChunk::ProviderUsage {
                 input_tokens: Some(100),
                 output_tokens: Some(30),
+                total_tokens: None,
                 reasoning_tokens: Some(7),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(0),
+                cache_write_input_tokens: Some(12),
             })
         ));
 
         let responses = serde_json::json!({
             "input_tokens": 80,
             "output_tokens": 20,
-            "input_tokens_details": {"cached_tokens": 24},
+            "total_tokens": 100,
+            "input_tokens_details": {
+                "cached_tokens": 24,
+                "cache_write_tokens": 64
+            },
             "output_tokens_details": {"reasoning_tokens": 5}
         });
         assert!(matches!(
@@ -285,9 +303,11 @@ mod tests {
             Some(LLMChunk::ProviderUsage {
                 input_tokens: Some(80),
                 output_tokens: Some(20),
+                total_tokens: Some(100),
                 reasoning_tokens: Some(5),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(24),
+                cache_write_input_tokens: Some(64),
             })
         ));
     }
@@ -295,12 +315,22 @@ mod tests {
     #[test]
     fn openai_provider_usage_does_not_invent_missing_fields() {
         assert!(provider_usage_from_openai_usage(&serde_json::json!({})).is_none());
-        assert!(provider_usage_from_openai_usage(&serde_json::json!({
+        assert!(matches!(
+            provider_usage_from_openai_usage(&serde_json::json!({
             "total_tokens": 42,
             "prompt_tokens": null,
             "output_tokens_details": {}
-        }))
-        .is_none());
+            })),
+            Some(LLMChunk::ProviderUsage {
+                input_tokens: None,
+                output_tokens: None,
+                total_tokens: Some(42),
+                reasoning_tokens: None,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+                cache_write_input_tokens: None,
+            })
+        ));
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/provider.rs
+++ b/crates/infra/bamboo-llm/src/provider.rs
@@ -99,6 +99,27 @@ pub struct ResponsesRequestOptions {
     /// Optional text verbosity for Responses API requests
     /// (e.g. "low", "medium", "high").
     pub text_verbosity: Option<String>,
+    /// Stable affinity key for OpenAI prompt caching. Callers should provide a
+    /// privacy-preserving value; Bamboo never derives one from raw session
+    /// identity in this generic request DTO.
+    pub prompt_cache_key: Option<String>,
+    /// OpenAI request-wide cache policy (currently `mode` and optional `ttl`).
+    /// Kept as JSON so newly added official policy keys survive proxying.
+    pub prompt_cache_options: Option<serde_json::Value>,
+    /// Original Responses `input` retained by the compatibility endpoint when
+    /// it contains caller-authored explicit cache breakpoints.
+    ///
+    /// The OpenAI Responses adapter may use this instead of the provider-neutral
+    /// message rendering so supported `input_text`, `input_image`, and
+    /// `input_file` markers survive byte-for-byte. Agent/runtime calls leave it
+    /// unset.
+    pub raw_input_with_cache_breakpoints: Option<serde_json::Value>,
+    /// Retain raw Responses protocol events alongside provider-neutral chunks.
+    ///
+    /// This is an internal compatibility-endpoint control, not an upstream
+    /// request field. Agent/runtime calls leave it disabled to avoid cloning
+    /// every SSE payload when only normalized chunks are needed.
+    pub retain_protocol_events: bool,
 }
 
 /// Optional request-time controls for provider calls.
@@ -123,8 +144,9 @@ pub struct LLMRequestOptions {
     pub request_purpose: Option<String>,
     /// Provider-agnostic prompt-cache plan describing the stable, cacheable
     /// prefix of this request. Providers render it in their own dialect
-    /// (Anthropic `cache_control` breakpoints; OpenAI/Gemini rely on the stable
-    /// prefix automatically). `None` means "no explicit cache hints".
+    /// (Anthropic `cache_control`; GPT-5.6+ OpenAI Responses explicit content
+    /// breakpoints; automatic caching for providers without explicit support).
+    /// `None` means "no explicit cache hints".
     pub cache: Option<crate::cache::PromptCachePlan>,
 }
 

--- a/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
@@ -896,6 +896,7 @@ mod tests {
                 reasoning_tokens: Some(20),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(768),
+                ..
             }
         ));
     }
@@ -914,6 +915,7 @@ mod tests {
                 reasoning_tokens: None,
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(0),
+                ..
             }
         ));
     }
@@ -924,7 +926,15 @@ mod tests {
 
         let chunk = super::parse_openai_compat_sse_data_strict(data).unwrap();
 
-        assert!(matches!(chunk, LLMChunk::Token(token) if token.is_empty()));
+        assert!(matches!(
+            chunk,
+            LLMChunk::ProviderUsage {
+                input_tokens: None,
+                output_tokens: None,
+                total_tokens: Some(1120),
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -5,6 +5,7 @@
 //! events into [`LLMChunk`] so the rest of Bamboo can stay provider-agnostic.
 
 use super::tool_schema::sanitize_openai_function_parameters_schema;
+use crate::cache::PromptCachePlan;
 use crate::provider::{LLMError, ResponsesRequestOptions, Result};
 use crate::types::LLMChunk;
 use bamboo_domain::MessagePart;
@@ -31,6 +32,101 @@ use std::collections::{HashMap, HashSet};
 ///
 /// For tool-result messages (`Role::Tool`), we emit a `function_call_output` item.
 pub fn messages_to_responses_input_json(messages: &[Message]) -> Vec<Value> {
+    messages_to_responses_input_json_with_cache(messages, None).0
+}
+
+fn message_supports_explicit_breakpoint(message: &Message) -> bool {
+    matches!(message.role, Role::System | Role::User | Role::Tool)
+}
+
+fn explicit_breakpoint_message_ids(
+    messages: &[Message],
+    cache_plan: Option<&PromptCachePlan>,
+) -> HashSet<String> {
+    let Some(cache_plan) = cache_plan.filter(|plan| plan.is_enabled()) else {
+        return HashSet::new();
+    };
+
+    let mut selected = HashSet::new();
+    for requested_id in &cache_plan.breakpoint_message_ids {
+        let Some(requested_index) = messages
+            .iter()
+            .position(|message| message.id == *requested_id)
+        else {
+            continue;
+        };
+        // Responses only permits markers on input_text/input_image/input_file.
+        // When a provider-neutral plan ends on an assistant/function item,
+        // select the nearest preceding cacheable input block rather than
+        // emitting an invalid marker or expanding the prefix past the target.
+        if let Some(message) = messages[..=requested_index]
+            .iter()
+            .rev()
+            .find(|message| message_supports_explicit_breakpoint(message))
+        {
+            selected.insert(message.id.clone());
+        }
+    }
+    selected
+}
+
+fn add_explicit_breakpoint(content: &mut Value) -> bool {
+    let marker = json!({"mode": "explicit"});
+    match content {
+        Value::String(text) => {
+            let text = std::mem::take(text);
+            *content = json!([{
+                "type": "input_text",
+                "text": text,
+                "prompt_cache_breakpoint": marker,
+            }]);
+            true
+        }
+        Value::Array(parts) => {
+            let Some(part) = parts.iter_mut().rev().find(|part| {
+                matches!(
+                    part.get("type").and_then(Value::as_str),
+                    Some("input_text" | "input_image" | "input_file")
+                )
+            }) else {
+                return false;
+            };
+            part["prompt_cache_breakpoint"] = marker;
+            true
+        }
+        _ => false,
+    }
+}
+
+fn count_responses_explicit_breakpoints(value: &Value) -> usize {
+    match value {
+        Value::Array(values) => values
+            .iter()
+            .map(count_responses_explicit_breakpoints)
+            .sum(),
+        Value::Object(object) => {
+            let this_block = (matches!(
+                object.get("type").and_then(Value::as_str),
+                Some("input_text" | "input_image" | "input_file")
+            ) && object
+                .get("prompt_cache_breakpoint")
+                .and_then(|breakpoint| breakpoint.get("mode"))
+                .and_then(Value::as_str)
+                == Some("explicit")) as usize;
+            this_block
+                + object
+                    .values()
+                    .map(count_responses_explicit_breakpoints)
+                    .sum::<usize>()
+        }
+        _ => 0,
+    }
+}
+
+fn messages_to_responses_input_json_with_cache(
+    messages: &[Message],
+    cache_plan: Option<&PromptCachePlan>,
+) -> (Vec<Value>, usize) {
     // If any message contains image parts, emit a "typed" content array shape so
     // multimodal inputs have a chance to reach upstream Responses implementations.
     let has_images = messages.iter().any(|m| {
@@ -42,6 +138,8 @@ pub fn messages_to_responses_input_json(messages: &[Message]) -> Vec<Value> {
     });
 
     let mut out: Vec<Value> = Vec::with_capacity(messages.len());
+    let breakpoint_message_ids = explicit_breakpoint_message_ids(messages, cache_plan);
+    let mut rendered_breakpoints = 0usize;
 
     for m in messages {
         match m.role {
@@ -78,11 +176,17 @@ pub fn messages_to_responses_input_json(messages: &[Message]) -> Vec<Value> {
                 // Emit tool result as a structured function_call_output item.
                 let call_id = m.tool_call_id.as_deref().unwrap_or("");
                 if !call_id.is_empty() {
-                    out.push(json!({
+                    let mut item = json!({
                         "type": "function_call_output",
                         "call_id": call_id,
                         "output": tool_output_value(m),
-                    }));
+                    });
+                    if breakpoint_message_ids.contains(&m.id)
+                        && add_explicit_breakpoint(&mut item["output"])
+                    {
+                        rendered_breakpoints = rendered_breakpoints.saturating_add(1);
+                    }
+                    out.push(item);
                 } else {
                     // Fallback: no call_id available — degrade to user message with
                     // prefix. Preserve any image parts as a typed content array so
@@ -95,11 +199,17 @@ pub fn messages_to_responses_input_json(messages: &[Message]) -> Vec<Value> {
                     } else {
                         json!(prefixed)
                     };
-                    out.push(json!({
+                    let mut item = json!({
                         "type": "message",
                         "role": "user",
                         "content": content,
-                    }));
+                    });
+                    if breakpoint_message_ids.contains(&m.id)
+                        && add_explicit_breakpoint(&mut item["content"])
+                    {
+                        rendered_breakpoints = rendered_breakpoints.saturating_add(1);
+                    }
+                    out.push(item);
                 }
             }
 
@@ -110,16 +220,22 @@ pub fn messages_to_responses_input_json(messages: &[Message]) -> Vec<Value> {
                     "user"
                 };
                 let content = build_content_value(m, has_images, None, "input_text");
-                out.push(json!({
+                let mut item = json!({
                     "type": "message",
                     "role": role,
                     "content": content,
-                }));
+                });
+                if breakpoint_message_ids.contains(&m.id)
+                    && add_explicit_breakpoint(&mut item["content"])
+                {
+                    rendered_breakpoints = rendered_breakpoints.saturating_add(1);
+                }
+                out.push(item);
             }
         }
     }
 
-    out
+    (out, rendered_breakpoints)
 }
 
 fn assistant_phase_for_responses_input(message: &Message) -> Option<&'static str> {
@@ -314,6 +430,7 @@ pub fn select_responses_input_messages<'a>(
 }
 
 /// Build a standard Responses API streaming request body.
+#[allow(clippy::too_many_arguments)]
 pub fn build_responses_body(
     model: &str,
     messages: &[Message],
@@ -322,6 +439,7 @@ pub fn build_responses_body(
     reasoning_effort: Option<ReasoningEffort>,
     responses_options: Option<&ResponsesRequestOptions>,
     parallel_tool_calls: Option<bool>,
+    cache_plan: Option<&PromptCachePlan>,
 ) -> Value {
     let instructions = responses_options
         .and_then(|opts| opts.instructions.as_deref())
@@ -330,9 +448,29 @@ pub fn build_responses_body(
     let input_selection = select_responses_input_messages(messages, responses_options);
     let effective_messages = input_selection.input_messages;
 
+    let explicit_cache_supported = supports_openai_explicit_prompt_cache(model);
+    let caller_cache_input = explicit_cache_supported
+        .then(|| {
+            responses_options.and_then(|options| options.raw_input_with_cache_breakpoints.as_ref())
+        })
+        .flatten();
+    let (input, rendered_breakpoints, generated_breakpoints) =
+        if let Some(raw_input) = caller_cache_input {
+            (
+                raw_input.clone(),
+                count_responses_explicit_breakpoints(raw_input),
+                false,
+            )
+        } else {
+            let (input, rendered_breakpoints) = messages_to_responses_input_json_with_cache(
+                effective_messages,
+                explicit_cache_supported.then_some(cache_plan).flatten(),
+            );
+            (Value::Array(input), rendered_breakpoints, true)
+        };
     let mut body = json!({
         "model": model,
-        "input": messages_to_responses_input_json(effective_messages),
+        "input": input,
         "stream": true,
     });
 
@@ -407,7 +545,70 @@ pub fn build_responses_body(
         .unwrap_or(false);
     body["store"] = json!(store);
 
+    if explicit_cache_supported {
+        if let Some(prompt_cache_key) = responses_options
+            .and_then(|opts| opts.prompt_cache_key.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            body["prompt_cache_key"] = json!(prompt_cache_key);
+        }
+
+        if let Some(prompt_cache_options) =
+            responses_options.and_then(|opts| opts.prompt_cache_options.as_ref())
+        {
+            if generated_breakpoints && rendered_breakpoints > 0 {
+                let mut merged =
+                    serde_json::Map::from_iter([("mode".to_string(), json!("explicit"))]);
+                if let Some(caller_fields) = prompt_cache_options.as_object() {
+                    merged.extend(caller_fields.clone());
+                    body["prompt_cache_options"] = Value::Object(merged);
+                } else {
+                    // Direct internal callers can construct a non-object value;
+                    // preserve it so the upstream returns the authoritative
+                    // validation error instead of silently changing intent.
+                    body["prompt_cache_options"] = prompt_cache_options.clone();
+                }
+            } else {
+                body["prompt_cache_options"] = prompt_cache_options.clone();
+            }
+        } else if generated_breakpoints && rendered_breakpoints > 0 {
+            body["prompt_cache_options"] = json!({"mode": "explicit"});
+        }
+    }
+
     body
+}
+
+/// Explicit prompt-cache controls were introduced for GPT-5.6 and later GPT
+/// model families. Unknown aliases fail closed because older models reject the
+/// fields with HTTP 400.
+pub fn supports_openai_explicit_prompt_cache(model: &str) -> bool {
+    let normalized = model
+        .rsplit('/')
+        .next()
+        .unwrap_or(model)
+        .trim()
+        .to_ascii_lowercase();
+    let Some(version) = normalized.strip_prefix("gpt-") else {
+        return false;
+    };
+    let numeric = version
+        .split(|character: char| !(character.is_ascii_digit() || character == '.'))
+        .next()
+        .unwrap_or("");
+    let mut components = numeric.split('.');
+    let Some(major) = components
+        .next()
+        .and_then(|component| component.parse::<u64>().ok())
+    else {
+        return false;
+    };
+    let minor = components
+        .next()
+        .and_then(|component| component.parse::<u64>().ok())
+        .unwrap_or(0);
+    major > 5 || major == 5 && minor >= 6
 }
 
 #[derive(Debug, Default)]
@@ -487,6 +688,12 @@ pub struct ResponsesSseParser {
     reasoning_text_chars: usize,
     logged_summary: bool,
     emitted_response_id: Option<String>,
+    retain_protocol_events: bool,
+    /// Once a protocol terminal is observed, every later frame is ignored.
+    ///
+    /// Responses usage and `Done` are cumulative terminal data, so accepting a
+    /// duplicated `response.completed` frame would double-publish both.
+    terminal_seen: bool,
 }
 
 impl Default for ResponsesSseParser {
@@ -531,7 +738,14 @@ impl ResponsesSseParser {
             reasoning_text_chars: 0,
             logged_summary: false,
             emitted_response_id: None,
+            retain_protocol_events: false,
+            terminal_seen: false,
         }
+    }
+
+    pub fn with_protocol_events(mut self, retain_protocol_events: bool) -> Self {
+        self.retain_protocol_events = retain_protocol_events;
+        self
     }
 
     fn event_type<'a>(&self, event: &'a str, v: &'a Value) -> &'a str {
@@ -1178,6 +1392,34 @@ impl ResponsesSseParser {
         Some(LLMChunk::ResponseId(response_id.to_string()))
     }
 
+    fn terminal_error_message(event_type: &str, value: &Value) -> String {
+        let response = value.get("response").unwrap_or(value);
+        let error = response
+            .get("error")
+            .or_else(|| value.get("error"))
+            .unwrap_or(response);
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .or_else(|| error.as_str())
+            .or_else(|| value.get("message").and_then(Value::as_str));
+        let code = error
+            .get("code")
+            .and_then(Value::as_str)
+            .or_else(|| response.get("status").and_then(Value::as_str));
+        let incomplete_reason = response
+            .get("incomplete_details")
+            .or_else(|| value.get("incomplete_details"))
+            .and_then(|details| details.get("reason"))
+            .and_then(Value::as_str);
+
+        let detail = message
+            .or(incomplete_reason)
+            .or(code)
+            .unwrap_or("upstream returned no error details");
+        format!("OpenAI Responses {event_type}: {detail}")
+    }
+
     fn handle_event_value(&mut self, event_type: &str, v: Value) -> Result<Option<LLMChunk>> {
         match event_type {
             // `summary_part.added` is typically a shape/placeholder signal; text is usually empty.
@@ -1524,12 +1766,51 @@ impl ResponsesSseParser {
         };
 
         let event_type = self.event_type(event, &v).to_string();
+        if self.terminal_seen {
+            return Ok(Vec::new());
+        }
+
+        let response_status = v
+            .get("response")
+            .and_then(|response| response.get("status"))
+            .and_then(Value::as_str);
+        let top_level_error = v.get("error").is_some_and(super::sse::sse_error_is_present);
+        if top_level_error
+            || matches!(response_status, Some("failed" | "incomplete" | "cancelled"))
+            || matches!(
+                event_type.as_str(),
+                "response.failed"
+                    | "response.incomplete"
+                    | "response.cancelled"
+                    | "response.error"
+                    | "error"
+            )
+        {
+            self.terminal_seen = true;
+            let terminal_type = if event_type.is_empty() {
+                "error"
+            } else {
+                event_type.as_str()
+            };
+            return Err(LLMError::Stream(Self::terminal_error_message(
+                terminal_type,
+                &v,
+            )));
+        }
+
         let mut chunks = Vec::new();
+        if self.retain_protocol_events && event_type.starts_with("response.") {
+            chunks.push(LLMChunk::ResponsesEvent {
+                event_type: event_type.clone(),
+                data: Box::new(v.clone()),
+            });
+        }
         if let Some(chunk) = self.maybe_emit_response_id(event_type.as_str(), &v) {
             chunks.push(chunk);
         }
 
         if event_type == "response.completed" {
+            self.terminal_seen = true;
             chunks.extend(self.completed_output_chunks(&v));
             let usage = v
                 .get("response")
@@ -1579,7 +1860,8 @@ mod tests {
 
     #[test]
     fn build_responses_body_includes_input_and_stream() {
-        let body = build_responses_body("gpt-5.3-codex", &[], &[], Some(123), None, None, None);
+        let body =
+            build_responses_body("gpt-5.3-codex", &[], &[], Some(123), None, None, None, None);
         assert_eq!(body["model"], "gpt-5.3-codex");
         assert_eq!(body["stream"], true);
         assert_eq!(body["max_output_tokens"], 123);
@@ -1604,7 +1886,12 @@ mod tests {
                 previous_response_id: Some("resp_123".to_string()),
                 truncation: Some("auto".to_string()),
                 text_verbosity: Some("high".to_string()),
+                prompt_cache_key: None,
+                prompt_cache_options: None,
+                raw_input_with_cache_breakpoints: None,
+                retain_protocol_events: false,
             }),
+            None,
             None,
         );
         assert_eq!(body["reasoning"]["effort"], "high");
@@ -1622,7 +1909,7 @@ mod tests {
 
     #[test]
     fn build_responses_body_with_parallel_tool_calls() {
-        let body = build_responses_body("gpt-5.4", &[], &[], None, None, None, Some(false));
+        let body = build_responses_body("gpt-5.4", &[], &[], None, None, None, Some(false), None);
         assert_eq!(body["parallel_tool_calls"], false);
     }
 
@@ -1642,6 +1929,7 @@ mod tests {
                 instructions: Some("Stable instructions".to_string()),
                 ..Default::default()
             }),
+            None,
             None,
         );
 
@@ -1671,6 +1959,7 @@ mod tests {
                 input_messages: Some(explicit_input_messages),
                 ..Default::default()
             }),
+            None,
             None,
         );
 
@@ -1704,6 +1993,7 @@ mod tests {
                 previous_response_id: Some("resp_123".to_string()),
                 ..Default::default()
             }),
+            None,
             None,
         );
 
@@ -1753,6 +2043,7 @@ mod tests {
                 previous_response_id: Some("resp_tool".to_string()),
                 ..Default::default()
             }),
+            None,
             None,
         );
 
@@ -2458,6 +2749,7 @@ mod tests {
                 reasoning_tokens: Some(5),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(8),
+                ..
             }
         ));
         assert!(matches!(chunks[3], LLMChunk::Done));
@@ -2496,6 +2788,7 @@ mod tests {
                 reasoning_tokens: Some(3),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(0),
+                ..
             }
         ));
         assert!(matches!(chunks[1], LLMChunk::Done));
@@ -2511,8 +2804,20 @@ mod tests {
             )
             .expect("completed event");
 
-        assert_eq!(chunks.len(), 1);
-        assert!(matches!(chunks[0], LLMChunk::Done));
+        assert_eq!(chunks.len(), 2);
+        assert!(matches!(
+            chunks[0],
+            LLMChunk::ProviderUsage {
+                input_tokens: None,
+                output_tokens: None,
+                total_tokens: Some(46),
+                reasoning_tokens: None,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+                cache_write_input_tokens: None,
+            }
+        ));
+        assert!(matches!(chunks[1], LLMChunk::Done));
     }
 
     #[test]
@@ -3195,7 +3500,8 @@ mod tests {
                 }]),
             ),
         ];
-        let mut body = build_responses_body("gpt-5.4", &messages, &[], None, None, None, None);
+        let mut body =
+            build_responses_body("gpt-5.4", &messages, &[], None, None, None, None, None);
         let config = KeywordMaskingConfig {
             entries: vec![KeywordEntry {
                 pattern: "hunter2".to_string(),
@@ -3217,5 +3523,402 @@ mod tests {
         // ...but the correlation id and tool name are preserved.
         assert_eq!(function_call["call_id"], "call_1");
         assert_eq!(function_call["name"], "search");
+    }
+
+    #[test]
+    fn gpt_5_6_lowers_stable_plan_to_explicit_breakpoint() {
+        let mut stable_user = Message::user("stable prefix");
+        stable_user.id = "stable-user".to_string();
+        let mut assistant = Message::assistant("stable answer", None);
+        assistant.id = "stable-assistant".to_string();
+        let mut volatile_user = Message::user("changing suffix");
+        volatile_user.id = "volatile-user".to_string();
+        let messages = vec![stable_user, assistant, volatile_user];
+        let plan = PromptCachePlan {
+            cache_tools: true,
+            cache_system: true,
+            // Assistant output blocks cannot carry Responses breakpoints, so
+            // lowering must select the nearest preceding input block.
+            breakpoint_message_ids: vec!["stable-assistant".to_string()],
+            ..Default::default()
+        };
+        let options = ResponsesRequestOptions {
+            prompt_cache_key: Some("tenant:stable".to_string()),
+            ..Default::default()
+        };
+
+        let body = build_responses_body(
+            "gpt-5.6-sol",
+            &messages,
+            &[],
+            None,
+            None,
+            Some(&options),
+            None,
+            Some(&plan),
+        );
+
+        assert_eq!(body["prompt_cache_key"], "tenant:stable");
+        assert_eq!(body["prompt_cache_options"]["mode"], "explicit");
+        assert_eq!(
+            body["input"][0]["content"][0]["prompt_cache_breakpoint"]["mode"],
+            "explicit"
+        );
+        assert!(body["input"][1]["content"]
+            .get("prompt_cache_breakpoint")
+            .is_none());
+        assert!(body["input"][2]["content"]
+            .get("prompt_cache_breakpoint")
+            .is_none());
+    }
+
+    #[test]
+    fn caller_cache_policy_wins_and_legacy_models_are_gated() {
+        let mut stable = Message::user("stable");
+        stable.id = "stable".to_string();
+        let plan = PromptCachePlan {
+            breakpoint_message_ids: vec!["stable".to_string()],
+            ..Default::default()
+        };
+        let options = ResponsesRequestOptions {
+            prompt_cache_key: Some("cache-key".to_string()),
+            prompt_cache_options: Some(json!({"mode": "implicit", "ttl": "30m"})),
+            ..Default::default()
+        };
+
+        let supported = build_responses_body(
+            "gpt-5.6-terra",
+            std::slice::from_ref(&stable),
+            &[],
+            None,
+            None,
+            Some(&options),
+            None,
+            Some(&plan),
+        );
+        assert_eq!(
+            supported["prompt_cache_options"],
+            json!({"mode": "implicit", "ttl": "30m"})
+        );
+
+        let ttl_only_options = ResponsesRequestOptions {
+            prompt_cache_options: Some(json!({"ttl": "30m"})),
+            ..Default::default()
+        };
+        let ttl_only = build_responses_body(
+            "gpt-5.6-terra",
+            std::slice::from_ref(&stable),
+            &[],
+            None,
+            None,
+            Some(&ttl_only_options),
+            None,
+            Some(&plan),
+        );
+        assert_eq!(
+            ttl_only["prompt_cache_options"],
+            json!({"mode": "explicit", "ttl": "30m"})
+        );
+
+        let legacy = build_responses_body(
+            "gpt-5.5",
+            &[stable],
+            &[],
+            None,
+            None,
+            Some(&options),
+            None,
+            Some(&plan),
+        );
+        assert!(legacy.get("prompt_cache_key").is_none());
+        assert!(legacy.get("prompt_cache_options").is_none());
+        assert!(legacy["input"][0]["content"].is_string());
+    }
+
+    #[test]
+    fn caller_authored_responses_breakpoints_survive_without_policy_rewrite() {
+        let raw_input = json!([{
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_file",
+                    "file_id": "file_123",
+                    "prompt_cache_breakpoint": {"mode": "explicit"}
+                },
+                {
+                    "type": "input_text",
+                    "text": "volatile question"
+                }
+            ]
+        }]);
+        let options = ResponsesRequestOptions {
+            prompt_cache_key: Some("tenant:file-prefix".to_string()),
+            raw_input_with_cache_breakpoints: Some(raw_input.clone()),
+            ..Default::default()
+        };
+
+        let body =
+            build_responses_body("gpt-5.6", &[], &[], None, None, Some(&options), None, None);
+        assert_eq!(body["input"], raw_input);
+        assert_eq!(body["prompt_cache_key"], "tenant:file-prefix");
+        assert!(
+            body.get("prompt_cache_options").is_none(),
+            "the caller omitted policy, so OpenAI's implicit default must remain"
+        );
+
+        let explicit_options = ResponsesRequestOptions {
+            prompt_cache_options: Some(json!({"mode": "explicit", "ttl": "30m"})),
+            ..options.clone()
+        };
+        let explicit = build_responses_body(
+            "gpt-5.6",
+            &[],
+            &[],
+            None,
+            None,
+            Some(&explicit_options),
+            None,
+            None,
+        );
+        assert_eq!(
+            explicit["prompt_cache_options"],
+            json!({"mode": "explicit", "ttl": "30m"})
+        );
+
+        let legacy =
+            build_responses_body("gpt-5.5", &[], &[], None, None, Some(&options), None, None);
+        assert_eq!(legacy["input"], json!([]));
+        assert!(legacy.get("prompt_cache_key").is_none());
+    }
+
+    #[test]
+    fn explicit_breakpoint_keeps_same_stable_prefix_when_tail_changes() {
+        let mut stable = Message::user("same stable prefix");
+        stable.id = "stable".to_string();
+        let mut volatile_a = Message::user("volatile A");
+        volatile_a.id = "tail-a".to_string();
+        let mut volatile_b = Message::user("volatile B");
+        volatile_b.id = "tail-b".to_string();
+        let plan = PromptCachePlan {
+            breakpoint_message_ids: vec!["stable".to_string()],
+            ..Default::default()
+        };
+
+        let first = build_responses_body(
+            "gpt-5.6",
+            &[stable.clone(), volatile_a],
+            &[],
+            None,
+            None,
+            None,
+            None,
+            Some(&plan),
+        );
+        let second = build_responses_body(
+            "gpt-5.6",
+            &[stable, volatile_b],
+            &[],
+            None,
+            None,
+            None,
+            None,
+            Some(&plan),
+        );
+
+        assert_eq!(first["input"][0], second["input"][0]);
+        assert_eq!(
+            first["input"][0]["content"][0]["prompt_cache_breakpoint"]["mode"],
+            "explicit"
+        );
+        assert_ne!(first["input"][1], second["input"][1]);
+    }
+
+    #[test]
+    fn explicit_breakpoint_can_end_after_typed_tool_output() {
+        let mut tool_output = Message::tool_result("call_1", "stable tool output");
+        tool_output.id = "tool-output".to_string();
+        let plan = PromptCachePlan {
+            breakpoint_message_ids: vec!["tool-output".to_string()],
+            ..Default::default()
+        };
+
+        let body = build_responses_body(
+            "gpt-5.6",
+            &[tool_output],
+            &[],
+            None,
+            None,
+            None,
+            None,
+            Some(&plan),
+        );
+
+        assert_eq!(body["input"][0]["type"], "function_call_output");
+        assert_eq!(
+            body["input"][0]["output"][0]["prompt_cache_breakpoint"]["mode"],
+            "explicit"
+        );
+        assert_eq!(body["input"][0]["output"][0]["text"], "stable tool output");
+    }
+
+    #[test]
+    fn request_overrides_run_after_generated_cache_defaults() {
+        use bamboo_config::{
+            BodyPatch, BodyPatchOp, PatchValue, RequestOverridesConfig, RequestScopeOverride,
+        };
+
+        let mut stable = Message::user("stable");
+        stable.id = "stable".to_string();
+        let plan = PromptCachePlan {
+            breakpoint_message_ids: vec!["stable".to_string()],
+            ..Default::default()
+        };
+        let options = ResponsesRequestOptions {
+            prompt_cache_key: Some("generated".to_string()),
+            ..Default::default()
+        };
+        let mut body = build_responses_body(
+            "gpt-5.6",
+            &[stable],
+            &[],
+            None,
+            None,
+            Some(&options),
+            None,
+            Some(&plan),
+        );
+        let overrides = RequestOverridesConfig {
+            common: RequestScopeOverride {
+                headers: Default::default(),
+                body_patch: vec![
+                    BodyPatch {
+                        path: "prompt_cache_key".to_string(),
+                        op: BodyPatchOp::Set,
+                        value: Some(PatchValue::Json(json!("operator-key"))),
+                    },
+                    BodyPatch {
+                        path: "prompt_cache_options".to_string(),
+                        op: BodyPatchOp::Remove,
+                        value: None,
+                    },
+                ],
+            },
+            endpoints: Default::default(),
+            rules: Vec::new(),
+        };
+
+        crate::providers::common::request_overrides::apply_overrides_to_body_with_env(
+            &mut body,
+            Some(&overrides),
+            crate::providers::common::request_overrides::ENDPOINT_RESPONSES,
+            Some("gpt-5.6"),
+            &HashMap::new(),
+        );
+
+        assert_eq!(body["prompt_cache_key"], "operator-key");
+        assert!(body.get("prompt_cache_options").is_none());
+    }
+
+    #[test]
+    fn explicit_cache_model_gate_is_fail_closed() {
+        assert!(supports_openai_explicit_prompt_cache("gpt-5.6"));
+        assert!(supports_openai_explicit_prompt_cache("openai/gpt-5.6-luna"));
+        assert!(supports_openai_explicit_prompt_cache("gpt-6"));
+        assert!(!supports_openai_explicit_prompt_cache("gpt-5.5"));
+        assert!(!supports_openai_explicit_prompt_cache("chat-latest"));
+    }
+
+    #[test]
+    fn failure_and_incomplete_events_are_terminal_errors() {
+        for (event, payload, detail) in [
+            (
+                "response.failed",
+                r#"{"type":"response.failed","response":{"error":{"message":"quota exhausted"}}}"#,
+                "quota exhausted",
+            ),
+            (
+                "response.incomplete",
+                r#"{"type":"response.incomplete","response":{"incomplete_details":{"reason":"max_output_tokens"}}}"#,
+                "max_output_tokens",
+            ),
+            (
+                "error",
+                r#"{"type":"error","error":{"message":"bad gateway"}}"#,
+                "bad gateway",
+            ),
+            (
+                "response.cancelled",
+                r#"{"type":"response.cancelled","response":{"status":"cancelled","error":{"message":"request cancelled"}}}"#,
+                "request cancelled",
+            ),
+            (
+                "",
+                r#"{"error":{"message":"untyped upstream error"}}"#,
+                "untyped upstream error",
+            ),
+        ] {
+            let mut parser = ResponsesSseParser::new();
+            let error = parser
+                .handle_event_multi(event, payload)
+                .expect_err("terminal event must fail");
+            assert!(error.to_string().contains(detail));
+            assert!(parser
+                .handle_event_multi(
+                    "response.completed",
+                    r#"{"type":"response.completed","response":{}}"#,
+                )
+                .expect("post-terminal frame is ignored")
+                .is_empty());
+        }
+    }
+
+    #[test]
+    fn duplicate_completed_emits_usage_and_done_once() {
+        let mut parser = ResponsesSseParser::new();
+        let payload = r#"{"type":"response.completed","response":{"usage":{"input_tokens":8,"output_tokens":2,"total_tokens":10,"input_tokens_details":{"cached_tokens":3,"cache_write_tokens":5},"output_tokens_details":{"reasoning_tokens":1}}}}"#;
+        let first = parser
+            .handle_event_multi("response.completed", payload)
+            .expect("first terminal");
+        assert!(matches!(
+            first.as_slice(),
+            [
+                LLMChunk::ProviderUsage {
+                    input_tokens: Some(8),
+                    output_tokens: Some(2),
+                    total_tokens: Some(10),
+                    reasoning_tokens: Some(1),
+                    cache_read_input_tokens: Some(3),
+                    cache_write_input_tokens: Some(5),
+                    ..
+                },
+                LLMChunk::Done
+            ]
+        ));
+        assert!(parser
+            .handle_event_multi("response.completed", payload)
+            .expect("duplicate terminal is ignored")
+            .is_empty());
+    }
+
+    #[test]
+    fn provider_parser_retains_raw_protocol_event_before_normalized_chunks() {
+        let mut parser = ResponsesSseParser::new_with_context("OpenAI", "gpt-5.6", None)
+            .with_protocol_events(true);
+        let chunks = parser
+            .handle_event_multi(
+                "response.completed",
+                r#"{"type":"response.completed","sequence_number":42,"response":{"id":"resp_raw","output":[{"id":"msg_a","type":"message","content":[{"type":"output_text","text":"a"}]},{"id":"rs_a","type":"reasoning","summary":[{"type":"summary_text","text":"why"}]},{"id":"msg_b","type":"message","content":[{"type":"output_text","text":"b"}]}],"usage":{"input_tokens":4,"output_tokens":2,"total_tokens":6}}}"#,
+            )
+            .expect("completed event");
+
+        assert!(matches!(
+            &chunks[0],
+            LLMChunk::ResponsesEvent { event_type, data }
+                if event_type == "response.completed"
+                    && data["response"]["output"].as_array().is_some_and(|items| items.len() == 3)
+                    && data["sequence_number"] == 42
+        ));
+        assert!(matches!(chunks.last(), Some(LLMChunk::Done)));
     }
 }

--- a/crates/infra/bamboo-llm/src/providers/common/sse.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/sse.rs
@@ -90,6 +90,47 @@ where
     Box::pin(stream)
 }
 
+/// Like [`llm_stream_from_sse_multi`], but requires an explicit protocol
+/// completion chunk.
+///
+/// A clean HTTP/SSE EOF is transport completion, not proof that an OpenAI
+/// Responses request succeeded. This adapter stops after the first `Done` or
+/// error and turns a premature EOF into one stream error.
+pub fn llm_stream_from_sse_multi_requiring_done<H>(
+    response: Response,
+    handler: H,
+    protocol: &'static str,
+) -> LLMStream
+where
+    H: FnMut(&str, &str) -> Result<Vec<LLMChunk>> + Send + 'static,
+{
+    require_done_terminal(llm_stream_from_sse_multi(response, handler), protocol)
+}
+
+fn require_done_terminal(upstream: LLMStream, protocol: &'static str) -> LLMStream {
+    let stream = stream::unfold(
+        (upstream, false),
+        move |(mut upstream, terminal)| async move {
+            if terminal {
+                return None;
+            }
+
+            match upstream.next().await {
+                Some(Ok(LLMChunk::Done)) => Some((Ok(LLMChunk::Done), (upstream, true))),
+                Some(Err(error)) => Some((Err(error), (upstream, true))),
+                Some(other) => Some((other, (upstream, false))),
+                None => Some((
+                    Err(LLMError::Stream(format!(
+                        "{protocol} stream ended before a protocol terminal event"
+                    ))),
+                    (upstream, true),
+                )),
+            }
+        },
+    );
+    Box::pin(stream)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,6 +282,7 @@ mod tests {
                 reasoning_tokens: Some(5),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(8),
+                ..
             }
         ));
         assert!(matches!(chunks[3], LLMChunk::Done));
@@ -311,5 +353,39 @@ mod tests {
             Err(LLMError::Stream(msg)) => assert!(msg.contains("API error")),
             Err(other) => panic!("expected LLMError::Stream, got: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn required_done_turns_clean_eof_into_one_error() {
+        let upstream: LLMStream = Box::pin(stream::iter(vec![Ok(LLMChunk::Token(
+            "partial".to_string(),
+        ))]));
+        let mut stream = require_done_terminal(upstream, "Responses");
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(LLMChunk::Token(text))) if text == "partial"
+        ));
+        let error = stream
+            .next()
+            .await
+            .expect("premature EOF error")
+            .expect_err("EOF must not synthesize success");
+        assert!(error
+            .to_string()
+            .contains("ended before a protocol terminal"));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn required_done_stops_after_first_success_terminal() {
+        let upstream: LLMStream = Box::pin(stream::iter(vec![
+            Ok(LLMChunk::Done),
+            Ok(LLMChunk::Token("after".to_string())),
+        ]));
+        let mut stream = require_done_terminal(upstream, "Responses");
+
+        assert!(matches!(stream.next().await, Some(Ok(LLMChunk::Done))));
+        assert!(stream.next().await.is_none());
     }
 }

--- a/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
@@ -27,7 +27,7 @@ use super::common::openai_responses::{
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
-use super::common::sse::llm_stream_from_sse_multi;
+use super::common::sse::llm_stream_from_sse_multi_requiring_done;
 
 const COPILOT_TRANSPORT_MAX_ATTEMPTS: usize = 2;
 const COPILOT_TRANSPORT_RETRY_BASE_DELAY_MS: u64 = 250;
@@ -586,6 +586,13 @@ impl CopilotProvider {
             );
         }
         effective_responses_options.store = Some(false);
+        let retain_protocol_events = effective_responses_options.retain_protocol_events;
+        // OpenAI-specific cache controls are not part of Copilot's documented
+        // Responses request shape. Keep this unrelated provider byte-compatible
+        // with its pre-cache-control behavior.
+        effective_responses_options.prompt_cache_key = None;
+        effective_responses_options.prompt_cache_options = None;
+        effective_responses_options.raw_input_with_cache_breakpoints = None;
         let input_selection =
             select_responses_input_messages(messages, Some(&effective_responses_options));
         let input_source = match input_selection.source {
@@ -600,6 +607,7 @@ impl CopilotProvider {
             reasoning_effort,
             Some(&effective_responses_options),
             parallel_tool_calls,
+            None,
         );
         request_overrides::apply_overrides_to_body(
             &mut body,
@@ -732,6 +740,7 @@ impl CopilotProvider {
                         None,
                         Some(&fallback_options),
                         parallel_tool_calls,
+                        None,
                     );
                     request_overrides::apply_overrides_to_body(
                         &mut fallback_body,
@@ -798,19 +807,24 @@ impl CopilotProvider {
 
                     if fallback.status().is_success() {
                         let mut parser =
-                            ResponsesSseParser::new_with_context("Copilot", model, None);
+                            ResponsesSseParser::new_with_context("Copilot", model, None)
+                                .with_protocol_events(retain_protocol_events);
                         let model_for_debug = model.to_string();
-                        let stream = llm_stream_from_sse_multi(fallback, move |event, data| {
-                            let parsed = parser.handle_event_multi(event, data);
-                            append_responses_sse_record(
-                                "Copilot",
-                                &model_for_debug,
-                                event,
-                                data,
-                                &parsed,
-                            );
-                            parsed
-                        });
+                        let stream = llm_stream_from_sse_multi_requiring_done(
+                            fallback,
+                            move |event, data| {
+                                let parsed = parser.handle_event_multi(event, data);
+                                append_responses_sse_record(
+                                    "Copilot",
+                                    &model_for_debug,
+                                    event,
+                                    data,
+                                    &parsed,
+                                );
+                                parsed
+                            },
+                            "Copilot Responses",
+                        );
                         return Ok(stream);
                     }
                 }
@@ -860,13 +874,18 @@ impl CopilotProvider {
             }
         }
 
-        let mut parser = ResponsesSseParser::new_with_context("Copilot", model, reasoning_effort);
+        let mut parser = ResponsesSseParser::new_with_context("Copilot", model, reasoning_effort)
+            .with_protocol_events(retain_protocol_events);
         let model_for_debug = model.to_string();
-        let stream = llm_stream_from_sse_multi(response, move |event, data| {
-            let parsed = parser.handle_event_multi(event, data);
-            append_responses_sse_record("Copilot", &model_for_debug, event, data, &parsed);
-            parsed
-        });
+        let stream = llm_stream_from_sse_multi_requiring_done(
+            response,
+            move |event, data| {
+                let parsed = parser.handle_event_multi(event, data);
+                append_responses_sse_record("Copilot", &model_for_debug, event, data, &parsed);
+                parsed
+            },
+            "Copilot Responses",
+        );
         Ok(stream)
     }
 
@@ -1902,27 +1921,45 @@ mod tests {
     }
 
     #[test]
-    fn copilot_responses_forces_store_false_before_building_body() {
+    fn copilot_responses_forces_store_false_and_strips_openai_cache_controls() {
         let mut effective_responses_options = ResponsesRequestOptions {
             store: Some(true),
             instructions: Some("Stable instructions".to_string()),
+            prompt_cache_key: Some("openai-only".to_string()),
+            prompt_cache_options: Some(json!({"mode": "explicit"})),
+            raw_input_with_cache_breakpoints: Some(json!([{
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": "raw",
+                    "prompt_cache_breakpoint": {"mode": "explicit"}
+                }]
+            }])),
             ..Default::default()
         };
         if effective_responses_options.store == Some(true) {
             effective_responses_options.store = Some(false);
         }
+        effective_responses_options.prompt_cache_key = None;
+        effective_responses_options.prompt_cache_options = None;
+        effective_responses_options.raw_input_with_cache_breakpoints = None;
 
         let body = build_responses_body(
-            "gpt-4o",
+            "gpt-5.6",
             &[Message::user("hello")],
             &[],
             None,
             None,
             Some(&effective_responses_options),
             None,
+            None,
         );
 
         assert_eq!(body["store"], false);
+        assert!(body.get("prompt_cache_key").is_none());
+        assert!(body.get("prompt_cache_options").is_none());
+        assert_eq!(body["input"][0]["content"], "hello");
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -30,7 +30,7 @@ use super::common::openai_responses::{
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
-use super::common::sse::llm_stream_from_sse_multi;
+use super::common::sse::llm_stream_from_sse_multi_requiring_done;
 
 /// OpenAI API provider for chat completions.
 pub struct OpenAIProvider {
@@ -162,11 +162,14 @@ impl OpenAIProvider {
         reasoning_effort: Option<ReasoningEffort>,
         responses_options: Option<&ResponsesRequestOptions>,
         parallel_tool_calls: Option<bool>,
+        cache_plan: Option<&crate::cache::PromptCachePlan>,
         required_tool: Option<&str>,
         reasoning_source: &str,
         request_purpose: &str,
         session_log_id: &str,
     ) -> Result<LLMStream> {
+        let retain_protocol_events =
+            responses_options.is_some_and(|options| options.retain_protocol_events);
         let input_selection = select_responses_input_messages(messages, responses_options);
         let input_source = match input_selection.source {
             ResponsesInputSource::Explicit => "explicit",
@@ -180,6 +183,7 @@ impl OpenAIProvider {
             reasoning_effort,
             responses_options,
             parallel_tool_calls,
+            cache_plan,
         );
         request_overrides::apply_overrides_to_body(
             &mut body,
@@ -257,6 +261,7 @@ impl OpenAIProvider {
                     reasoning_effort,
                     Some(&fallback_options),
                     parallel_tool_calls,
+                    cache_plan,
                 );
                 request_overrides::apply_overrides_to_body(
                     &mut fallback_body,
@@ -289,13 +294,24 @@ impl OpenAIProvider {
                 }
 
                 let mut parser =
-                    ResponsesSseParser::new_with_context("OpenAI", model, reasoning_effort);
+                    ResponsesSseParser::new_with_context("OpenAI", model, reasoning_effort)
+                        .with_protocol_events(retain_protocol_events);
                 let model_for_debug = model.to_string();
-                let stream = llm_stream_from_sse_multi(fallback, move |event, data| {
-                    let parsed = parser.handle_event_multi(event, data);
-                    append_responses_sse_record("OpenAI", &model_for_debug, event, data, &parsed);
-                    parsed
-                });
+                let stream = llm_stream_from_sse_multi_requiring_done(
+                    fallback,
+                    move |event, data| {
+                        let parsed = parser.handle_event_multi(event, data);
+                        append_responses_sse_record(
+                            "OpenAI",
+                            &model_for_debug,
+                            event,
+                            data,
+                            &parsed,
+                        );
+                        parsed
+                    },
+                    "OpenAI Responses",
+                );
                 return Ok(stream);
             }
 
@@ -317,6 +333,7 @@ impl OpenAIProvider {
                     None,
                     Some(&fallback_options),
                     parallel_tool_calls,
+                    cache_plan,
                 );
                 request_overrides::apply_overrides_to_body(
                     &mut fallback_body,
@@ -348,26 +365,42 @@ impl OpenAIProvider {
                     )));
                 }
 
-                let mut parser = ResponsesSseParser::new_with_context("OpenAI", model, None);
+                let mut parser = ResponsesSseParser::new_with_context("OpenAI", model, None)
+                    .with_protocol_events(retain_protocol_events);
                 let model_for_debug = model.to_string();
-                let stream = llm_stream_from_sse_multi(fallback, move |event, data| {
-                    let parsed = parser.handle_event_multi(event, data);
-                    append_responses_sse_record("OpenAI", &model_for_debug, event, data, &parsed);
-                    parsed
-                });
+                let stream = llm_stream_from_sse_multi_requiring_done(
+                    fallback,
+                    move |event, data| {
+                        let parsed = parser.handle_event_multi(event, data);
+                        append_responses_sse_record(
+                            "OpenAI",
+                            &model_for_debug,
+                            event,
+                            data,
+                            &parsed,
+                        );
+                        parsed
+                    },
+                    "OpenAI Responses",
+                );
                 return Ok(stream);
             }
 
             return Err(LLMError::Api(format!("HTTP {}: {}", status, text)));
         }
 
-        let mut parser = ResponsesSseParser::new_with_context("OpenAI", model, reasoning_effort);
+        let mut parser = ResponsesSseParser::new_with_context("OpenAI", model, reasoning_effort)
+            .with_protocol_events(retain_protocol_events);
         let model_for_debug = model.to_string();
-        let stream = llm_stream_from_sse_multi(response, move |event, data| {
-            let parsed = parser.handle_event_multi(event, data);
-            append_responses_sse_record("OpenAI", &model_for_debug, event, data, &parsed);
-            parsed
-        });
+        let stream = llm_stream_from_sse_multi_requiring_done(
+            response,
+            move |event, data| {
+                let parsed = parser.handle_event_multi(event, data);
+                append_responses_sse_record("OpenAI", &model_for_debug, event, data, &parsed);
+                parsed
+            },
+            "OpenAI Responses",
+        );
         Ok(stream)
     }
 }
@@ -407,6 +440,7 @@ impl LLMProvider for OpenAIProvider {
         let parallel_tool_calls = options.and_then(|o| o.parallel_tool_calls);
         let required_tool = required_tool_from_options(options, tools)?;
         let responses_options = options.and_then(|o| o.responses.as_ref());
+        let cache_plan = options.and_then(|o| o.cache.as_ref());
         let request_purpose = options
             .and_then(|o| o.request_purpose.as_deref())
             .unwrap_or("unknown");
@@ -431,6 +465,7 @@ impl LLMProvider for OpenAIProvider {
                     reasoning_effort,
                     responses_options,
                     parallel_tool_calls,
+                    cache_plan,
                     required_tool,
                     reasoning_source,
                     request_purpose,
@@ -565,6 +600,7 @@ impl LLMProvider for OpenAIProvider {
                         reasoning_effort,
                         responses_options,
                         parallel_tool_calls,
+                        cache_plan,
                         required_tool,
                         reasoning_source,
                         request_purpose,

--- a/crates/infra/bamboo-llm/src/types.rs
+++ b/crates/infra/bamboo-llm/src/types.rs
@@ -10,6 +10,16 @@ pub enum LLMChunk {
     /// when provider parsers filter the frame's payload (#618).
     TransportActivity,
     ResponseId(String),
+    /// Original OpenAI Responses protocol event, retained alongside Bamboo's
+    /// provider-neutral chunks.
+    ///
+    /// Compatibility endpoints can forward this structure without collapsing
+    /// multiple message/reasoning/function items. Agent/runtime consumers ignore
+    /// it and continue using the normalized Token/ToolCalls/usage variants.
+    ResponsesEvent {
+        event_type: String,
+        data: Box<serde_json::Value>,
+    },
     Token(String),
     ReasoningToken(String),
     /// Provider-minted cryptographic signature covering the turn's accumulated
@@ -57,9 +67,19 @@ pub enum LLMChunk {
     ProviderUsage {
         input_tokens: Option<u64>,
         output_tokens: Option<u64>,
+        /// Provider-reported request total. This is preserved independently
+        /// instead of being reconstructed from input/output so compatibility
+        /// endpoints can forward the authoritative wire value.
+        total_tokens: Option<u64>,
         reasoning_tokens: Option<u64>,
         cache_creation_input_tokens: Option<u64>,
         cache_read_input_tokens: Option<u64>,
+        /// OpenAI Responses `input_tokens_details.cache_write_tokens`.
+        ///
+        /// This is deliberately distinct from Anthropic cache creation:
+        /// OpenAI does not define it as a disjoint prompt subset that can be
+        /// folded into Bamboo's historical fresh/read/creation counters.
+        cache_write_input_tokens: Option<u64>,
     },
     /// Token usage summary at the end of an Anthropic response.
     UsageSummary {
@@ -80,6 +100,7 @@ impl LLMChunk {
             Self::ToolCallsIndexed(calls) => !calls.is_empty(),
             Self::TransportActivity
             | Self::ResponseId(_)
+            | Self::ResponsesEvent { .. }
             | Self::ReasoningSignature(_)
             | Self::CacheUsage { .. }
             | Self::ProviderUsage { .. }

--- a/crates/infra/bamboo-metrics/src/collector.rs
+++ b/crates/infra/bamboo-metrics/src/collector.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Duration, Utc};
 use tokio::sync::mpsc;
 
 use crate::storage::{MetricsStorage, ToolCallCompletion};
-use crate::types::{RoundStatus, SessionStatus, TokenUsage};
+use crate::types::{ForwardTokenDetails, RoundStatus, SessionStatus, TokenUsage};
 
 #[derive(Debug)]
 enum CollectorCommand {
@@ -77,6 +77,7 @@ enum CollectorCommand {
         status_code: Option<u16>,
         status: crate::types::ForwardStatus,
         usage: Option<TokenUsage>,
+        token_details: Option<ForwardTokenDetails>,
         error: Option<String>,
     },
     Prune {
@@ -229,6 +230,7 @@ impl MetricsCollector {
                         status_code,
                         status,
                         usage,
+                        token_details,
                         error,
                     } => {
                         storage
@@ -238,6 +240,7 @@ impl MetricsCollector {
                                 status_code,
                                 status,
                                 usage,
+                                token_details,
                                 error,
                             )
                             .await
@@ -409,12 +412,35 @@ impl MetricsCollector {
         usage: Option<TokenUsage>,
         error: Option<String>,
     ) {
+        self.forward_completed_with_details(
+            forward_id,
+            completed_at,
+            status_code,
+            status,
+            usage,
+            None,
+            error,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_completed_with_details(
+        &self,
+        forward_id: impl Into<String>,
+        completed_at: DateTime<Utc>,
+        status_code: Option<u16>,
+        status: crate::types::ForwardStatus,
+        usage: Option<TokenUsage>,
+        token_details: Option<ForwardTokenDetails>,
+        error: Option<String>,
+    ) {
         let _ = self.tx.send(CollectorCommand::ForwardCompleted {
             forward_id: forward_id.into(),
             completed_at,
             status_code,
             status,
             usage,
+            token_details,
             error,
         });
     }

--- a/crates/infra/bamboo-metrics/src/lib.rs
+++ b/crates/infra/bamboo-metrics/src/lib.rs
@@ -23,8 +23,8 @@ pub use metrics_service::MetricsService;
 pub use storage::{MetricsError, MetricsResult, MetricsStorage, SqliteMetricsStorage};
 pub use types::{
     DailyMetrics, ForwardEndpointMetrics, ForwardMetricsFilter, ForwardMetricsSummary,
-    ForwardRequestMetrics, ForwardStatus, MetricsDateFilter, MetricsSummary, ModelMetrics,
-    RoundMetrics, RoundStatus, SessionDetail, SessionMetrics, SessionMetricsFilter, SessionStatus,
-    TokenUsage, ToolCallMetrics,
+    ForwardRequestMetrics, ForwardStatus, ForwardTokenDetails, MetricsDateFilter, MetricsSummary,
+    ModelMetrics, RoundMetrics, RoundStatus, SessionDetail, SessionMetrics, SessionMetricsFilter,
+    SessionStatus, TokenUsage, ToolCallMetrics,
 };
 pub use worker::MetricsWorker;

--- a/crates/infra/bamboo-metrics/src/worker.rs
+++ b/crates/infra/bamboo-metrics/src/worker.rs
@@ -250,6 +250,7 @@ impl MetricsWorker {
                         Some(*status_code),
                         *status,
                         *usage,
+                        None,
                         error.clone(),
                     )
                     .await?;


### PR DESCRIPTION
Closes #769

## Summary

- Preserve authoritative OpenAI Responses usage end-to-end, including `total_tokens`, cached reads, cache writes, and reasoning tokens.
- Lower Bamboo prompt-cache plans into GPT-5.6+ explicit Responses breakpoints while preserving caller cache controls and keeping older models/Copilot unchanged.
- Make Responses terminal handling fail closed and preserve native multi-item/multi-event output order, identity, lifecycle, and sequence numbers.

## Root Cause

The provider parser had partial knowledge of terminal usage and output events, but the contract became lossy at later boundaries:

- `ProviderUsage` was ignored by the public Responses workers, so outward usage and forward metrics fell back to estimates.
- cache-write tokens had no distinct representation and could not safely compose with Bamboo's Anthropic-oriented cache counters.
- `PromptCachePlan` stopped before the OpenAI Responses body builder, while inbound cache controls and explicit content markers were discarded.
- transport EOF and non-success terminal events were not authoritative, and the compatibility layer reconstructed output from normalized text/tool chunks, collapsing native reasoning and multiple message items.

## Changes

### Usage and metrics

- Carry optional provider `total_tokens` and `cache_write_input_tokens` through `bamboo-llm` and `bamboo-engine` without synthesizing missing values.
- Expose Responses input/output token details in streaming and non-streaming responses.
- Prefer exact provider usage field-by-field; estimate only omitted metrics fields.
- Add backward-compatible SQLite columns and API fields for cache creation/read/write and reasoning dimensions.

### Prefix caching

- Support official GPT-5.6+ explicit `prompt_cache_breakpoint` lowering on cacheable Responses input blocks.
- Preserve valid caller `prompt_cache_key`, `prompt_cache_options`, and raw marked `input` content.
- If a preflight hook rewrites input, prefer the rewritten provider-neutral rendering so raw breakpoint passthrough cannot undo safety/configuration transformations.
- Keep caller policy authoritative, apply operator request overrides last, and fail closed for unsupported/unknown models.
- Do not map Anthropic's one-hour TTL to OpenAI, and strip OpenAI-only controls from Copilot.

### Terminal and multi-item lifecycle

- Treat failed, incomplete, cancelled, and error events as terminal errors with upstream context.
- Require a protocol terminal; premature EOF is an error, duplicate terminals are ignored, and usage precedes the single `Done`.
- Retain raw native Responses events for the compatibility endpoint, preserving mixed message/reasoning/function-call order and identity.
- Add monotonic `sequence_number` values and complete synthesized message content-part/text/item lifecycle events.
- Include required empty `annotations` on synthesized output text and function `name` on argument-done events.
- Avoid synthetic empty message items for tool-only output and never relabel reasoning as assistant text.

## Test Plan

- `cargo fmt --check`
- `cargo check --workspace --all-targets`
- `cargo clippy -p bamboo-llm -p bamboo-engine -p bamboo-server -p bamboo-infrastructure -p bamboo-metrics --all-targets`
- `cargo test -p bamboo-llm openai_responses --quiet` (75 passed)
- `cargo test -p bamboo-llm cache::tests --quiet` (10 passed)
- `cargo test -p bamboo-engine runtime::stream::handler::tests --quiet` (21 passed)
- `cargo test -p bamboo-engine token_usage_log::tests --quiet` (2 passed)
- `cargo test -p bamboo-server handlers::openai::responses --quiet` (37 passed)
- `cargo test -p bamboo-infrastructure forward_metrics_preserve_provider_cache_dimensions_separately --quiet` (passed)
- `cargo test -p bamboo-metrics --quiet` (11 passed; 3 ignored)
- `cargo test --quiet -- --test-threads=1` (full workspace passed)

## Screenshots

Not applicable; backend protocol and metrics change.