### PR TITLE
fix: default server logging to info

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Arguments supported by `bamboo serve` (all override the config file):
 
 The admin commands (`health` / `status` / `sessions` / `stop` / `history` / `respond` / `session` / `schedules`) are thin HTTP clients over a running `bamboo serve`; point them at a non-default server with `--server-url` / `--port` / `--data-dir`. The read commands (`skills list` / `mcp list`) work offline against `--data-dir` (default `~/.bamboo`); the other `mcp` verbs are server-backed and take the same connection flags. (`bamboo subagent-worker` also exists but is an internal worker process spawned by the server — not for interactive use.)
 
-A global `--log-level <error|warn|info|debug|trace>` sets the default log level for any command when `RUST_LOG` is unset (`RUST_LOG` still wins when present).
+A global `--log-level <error|warn|info|debug|trace>` sets the default log level for any command when `RUST_LOG` is unset (`RUST_LOG` still wins when present). `bamboo serve` defaults to `info` in every build profile; use `--log-level debug`, `-v`, or `RUST_LOG` to opt into more verbose server logs.
 
 **Defaults** (verified against code):
 

--- a/crates/app/bamboo-server/src/logging.rs
+++ b/crates/app/bamboo-server/src/logging.rs
@@ -1,11 +1,12 @@
 //! Logging initialization.
 //!
 //! The implementation lives in `bamboo-infrastructure` so the server binary, the
-//! CLI/TUI, and embedded hosts (e.g. the Bodhi Tauri app) share one policy:
-//! daily-rotating log files with date-based retention and build-profile levels.
+//! CLI/TUI, and embedded hosts share daily-rotating log files with date-based
+//! retention. The standalone server has a stable `info` default while embedding
+//! APIs can opt into build-profile-derived levels.
 //! These re-exports preserve the historical `bamboo_agent::server::logging::*`
 //! call paths.
 pub use bamboo_infrastructure::logging::{
-    init_logging, init_logging_with_home, init_logging_with_options, LogOptions,
-    DEFAULT_MAX_LOG_FILES,
+    init_logging, init_logging_with_home, init_logging_with_options, init_server_logging_with_home,
+    LogOptions, DEFAULT_MAX_LOG_FILES,
 };

--- a/crates/infra/bamboo-infrastructure/src/logging.rs
+++ b/crates/infra/bamboo-infrastructure/src/logging.rs
@@ -12,8 +12,9 @@
 //!   so a single run's logs are never split mid-stream on a byte threshold.
 //! - **Old files are purged.** At most [`DEFAULT_MAX_LOG_FILES`] dated files are
 //!   kept; the appender deletes the oldest beyond that on rollover.
-//! - **Level matches the build profile.** Debug builds default to `debug`, release
-//!   builds to `info`, and `RUST_LOG` always overrides both.
+//! - **Server logs are quiet by default.** `bamboo serve` defaults to `info` in
+//!   every build profile. Explicit `RUST_LOG` directives still override that
+//!   policy, while embedding APIs may opt into a build-profile-derived level.
 //!
 //! All initializers are best-effort and idempotent: they use `try_init`, so a
 //! second call (or a call after some other subscriber is installed) is a no-op
@@ -69,6 +70,22 @@ pub fn init_logging_with_home(home: &Path, debug: bool) {
     init_logging_with_options(options_for_home(home, debug));
 }
 
+/// Initialize file + stdout logging for the standalone `bamboo serve` process.
+///
+/// Server operation defaults to `info` in every build profile. A debug binary is
+/// an implementation detail of the development toolchain, not an operator
+/// request for dependency-wide debug logs. Callers can still opt in explicitly
+/// through `RUST_LOG`, `--log-level`, or `-v` before this initializer runs.
+pub fn init_server_logging_with_home(home: &Path) {
+    init_logging_with_options(options_for_server_home(home, cfg!(debug_assertions)));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogContext {
+    Server,
+    BuildProfile,
+}
+
 /// Build the [`LogOptions`] used by [`init_logging_with_home`]: logs under
 /// `{home}/logs`, level by build profile, shared defaults otherwise.
 ///
@@ -76,7 +93,16 @@ pub fn init_logging_with_home(home: &Path, debug: bool) {
 /// tested without installing a process-global subscriber.
 fn options_for_home(home: &Path, debug: bool) -> LogOptions {
     let mut opts = LogOptions::new(home.join("logs"));
-    opts.default_level = level_for(debug).to_string();
+    opts.default_level = level_for(LogContext::BuildProfile, debug).to_string();
+    opts
+}
+
+/// Build server options without installing a process-global subscriber.
+/// Keeping the build-profile input explicit makes the invariant directly
+/// testable: both debug and release servers must resolve to `info`.
+fn options_for_server_home(home: &Path, debug_build: bool) -> LogOptions {
+    let mut opts = LogOptions::new(home.join("logs"));
+    opts.default_level = level_for(LogContext::Server, debug_build).to_string();
     opts
 }
 
@@ -146,17 +172,17 @@ pub fn init_logging(debug: bool) {
     let _ = fmt()
         .with_target(true)
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level_for(debug))),
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new(level_for(LogContext::BuildProfile, debug))),
         )
         .try_init();
 }
 
-/// Default level string for a build profile when `RUST_LOG` is unset.
-fn level_for(debug: bool) -> &'static str {
-    if debug {
-        "debug"
-    } else {
-        "info"
+/// Default level string for a logging context when `RUST_LOG` is unset.
+fn level_for(context: LogContext, debug_build: bool) -> &'static str {
+    match (context, debug_build) {
+        (LogContext::Server, _) | (LogContext::BuildProfile, false) => "info",
+        (LogContext::BuildProfile, true) => "debug",
     }
 }
 
@@ -168,9 +194,15 @@ mod tests {
     use tracing_subscriber::fmt::MakeWriter;
 
     #[test]
-    fn level_for_maps_build_profile() {
-        assert_eq!(level_for(true), "debug");
-        assert_eq!(level_for(false), "info");
+    fn level_for_maps_build_profile_for_embedding_apis() {
+        assert_eq!(level_for(LogContext::BuildProfile, true), "debug");
+        assert_eq!(level_for(LogContext::BuildProfile, false), "info");
+    }
+
+    #[test]
+    fn server_level_is_info_in_debug_and_release_builds() {
+        assert_eq!(level_for(LogContext::Server, true), "info");
+        assert_eq!(level_for(LogContext::Server, false), "info");
     }
 
     #[test]
@@ -190,6 +222,15 @@ mod tests {
 
         let release = options_for_home(Path::new("/srv/data"), false);
         assert_eq!(release.default_level, "info");
+    }
+
+    #[test]
+    fn server_options_are_info_in_debug_and_release_builds() {
+        for debug_build in [true, false] {
+            let opts = options_for_server_home(Path::new("/srv/data"), debug_build);
+            assert_eq!(opts.dir, PathBuf::from("/srv/data/logs"));
+            assert_eq!(opts.default_level, "info");
+        }
     }
 
     #[test]

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -1227,6 +1227,22 @@ enum ActorCommands {
     },
 }
 
+fn requested_log_level(log_level: Option<&str>, verbose: u8) -> Option<&str> {
+    log_level.or(match verbose {
+        0 => None,
+        1 => Some("debug"),
+        _ => Some("trace"),
+    })
+}
+
+fn log_level_to_seed(rust_log_is_set: bool, requested_level: Option<&str>) -> Option<&str> {
+    if rust_log_is_set {
+        None
+    } else {
+        requested_level
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
@@ -1262,12 +1278,8 @@ async fn main() {
     // `serve`'s file logging — honors it uniformly. An explicit `RUST_LOG` still
     // wins. Validated to a plain level here (use `RUST_LOG` directly for
     // target-scoped directives).
-    let verbose_level = match cli.verbose {
-        0 => None,
-        1 => Some("debug"),
-        _ => Some("trace"),
-    };
-    if let Some(level) = cli.log_level.as_deref().or(verbose_level) {
+    let requested_log_level = requested_log_level(cli.log_level.as_deref(), cli.verbose);
+    if let Some(level) = requested_log_level {
         const LEVELS: [&str; 5] = ["error", "warn", "info", "debug", "trace"];
         if !LEVELS.contains(&level.to_ascii_lowercase().as_str()) {
             eprintln!(
@@ -1276,26 +1288,28 @@ async fn main() {
             );
             std::process::exit(2);
         }
-        if std::env::var_os("RUST_LOG").is_none() {
-            // SAFETY: consistent with the other env seeding in this file. We run
-            // before any logging subscriber is installed and while the tokio
-            // worker threads (already spawned by `#[tokio::main]`) are parked and
-            // read no env, so this write races nothing in practice.
-            unsafe {
-                std::env::set_var("RUST_LOG", level);
-            }
+    }
+    if let Some(level) =
+        log_level_to_seed(std::env::var_os("RUST_LOG").is_some(), requested_log_level)
+    {
+        // SAFETY: consistent with the other env seeding in this file. We run
+        // before any logging subscriber is installed and while the tokio
+        // worker threads (already spawned by `#[tokio::main]`) are parked and
+        // read no env, so this write races nothing in practice.
+        unsafe {
+            std::env::set_var("RUST_LOG", level);
         }
     }
 
-    // Initialize logging (file + stdout, with rotation).
-    // Use debug level in debug builds, info in release.
-    let debug = cfg!(debug_assertions);
+    // Initialize logging (file + stdout, with rotation). The standalone server
+    // owns its quiet-by-default policy; embedding applications do not need to
+    // pass a log-level argument based on how the binary was built.
     match &cli.command {
         Some(Commands::Serve { data_dir, .. }) => {
             let home = data_dir
                 .clone()
                 .unwrap_or_else(bamboo_config::paths::resolve_bamboo_dir);
-            bamboo_agent::server::logging::init_logging_with_home(&home, debug);
+            bamboo_agent::server::logging::init_server_logging_with_home(&home);
         }
         Some(Commands::Config { .. }) => {
             // No file logging for config subcommand; stdout only.
@@ -2104,11 +2118,29 @@ fn serialize_config_for_cli(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_config_data_dir, serialize_config_for_cli};
+    use super::{
+        log_level_to_seed, requested_log_level, resolve_config_data_dir, serialize_config_for_cli,
+    };
     use bamboo_config::{Config, OpenAIConfig, ProviderConfigs, ProxyAuth};
     use bamboo_mcp::{McpServerConfig, StdioConfig, TransportConfig};
     use serde_json::json;
     use std::collections::{BTreeMap, HashMap};
+
+    #[test]
+    fn requested_log_level_prefers_explicit_level_then_verbose_count() {
+        assert_eq!(requested_log_level(Some("error"), 2), Some("error"));
+        assert_eq!(requested_log_level(None, 0), None);
+        assert_eq!(requested_log_level(None, 1), Some("debug"));
+        assert_eq!(requested_log_level(None, 2), Some("trace"));
+        assert_eq!(requested_log_level(None, u8::MAX), Some("trace"));
+    }
+
+    #[test]
+    fn rust_log_prevents_cli_level_from_being_seeded() {
+        assert_eq!(log_level_to_seed(true, Some("debug")), None);
+        assert_eq!(log_level_to_seed(false, Some("debug")), Some("debug"));
+        assert_eq!(log_level_to_seed(false, None), None);
+    }
 
     /// `--config <dir>` pointing at an existing directory is used as-is (same
     /// semantics as `--data-dir`).


### PR DESCRIPTION
## Summary
- make `bamboo serve` default to `info` in both debug and release builds inside Bamboo's logging initialization
- preserve explicit `RUST_LOG`, `--log-level`, and `-v/-vv` precedence without requiring Bodhi or another launcher to synthesize logging arguments
- keep the existing build-profile-derived logging API for embedded/library callers
- document the server default and add deterministic policy/precedence tests without mutating process-global environment state

Closes #778

## Test Plan
- `cargo fmt --check`
- `cargo test`
- `cargo clippy -p bamboo-infrastructure --all-targets --all-features -- -D warnings`
- `cargo clippy --bin bamboo --all-features -- -A clippy::too_many_arguments -D warnings`
- debug binary smoke test with fresh data dirs:
  - no `RUST_LOG` or CLI override: 0 DEBUG records
  - `--log-level debug`: DEBUG records emitted

The unmodified strict binary Clippy command is currently blocked on two pre-existing `too_many_arguments` warnings in `bamboo-sdk/src/agent/mod.rs` and `bamboo-server/src/connect/bridge.rs`; allowing only that existing lint leaves the changed binary clean under `-D warnings`.

## Screenshots
Not applicable (backend logging policy).