### PR TITLE
fix: remove legacy provider dependency from instance settings

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -401,7 +401,7 @@ pub async fn put_provider_settings_section(
 
             let ProviderSettingsData {
                 provider,
-                providers,
+                mut providers,
                 defaults,
                 features,
                 provider_instances,
@@ -409,6 +409,10 @@ pub async fn put_provider_settings_section(
                 available_providers: _,
                 credential_status: _,
             } = data;
+
+            if default_provider_instance_id.is_some() {
+                providers.clear_legacy_builtin_aliases();
+            }
 
             for name in ["openai", "anthropic", "gemini", "bodhi"] {
                 if provider_exists(current.providers(), name) && !provider_exists(&providers, name)
@@ -2616,10 +2620,8 @@ mod tests {
         assert!(!updated_body.contains(hidden_forward_value));
         let updated: Value = serde_json::from_str(&updated_body).unwrap();
         assert_eq!(updated["revision"], 2);
-        assert_eq!(
-            updated["data"]["providers"]["openai"]["model"],
-            "gpt-edited"
-        );
+        assert_eq!(updated["data"]["providers"], json!({}));
+        assert_eq!(updated["data"]["credential_status"]["providers"], json!({}));
         assert_eq!(updated["data"]["defaults"]["fast"]["model"], "gpt-fast");
         assert_eq!(updated["data"]["features"]["provider_model_ref"], true);
         assert_eq!(updated["data"]["default_provider_instance_id"], "work");
@@ -2628,13 +2630,15 @@ mod tests {
             true
         );
 
+        let mut stale_data = updated["data"].clone();
+        stale_data["defaults"]["fast"]["model"] = json!("lost-update");
         let stale = test::call_service(
             &app,
             test::TestRequest::put()
                 .uri("/provider-settings")
                 .set_json(json!({
                     "expected_revision": 1,
-                    "data": editable_provider_settings()
+                    "data": stale_data
                 }))
                 .to_request(),
         )
@@ -2658,6 +2662,7 @@ mod tests {
         let mut cleared = updated["data"].clone();
         cleared["provider_instances"] = json!({});
         cleared["default_provider_instance_id"] = Value::Null;
+        cleared["providers"] = editable_provider_settings()["providers"].clone();
         let cleared = test::call_service(
             &app,
             test::TestRequest::put()
@@ -2666,6 +2671,10 @@ mod tests {
                     "expected_revision": 2,
                     "data": cleared,
                     "credential_changes": {
+                        "providers": {
+                            "openai": {"action": "replace", "value": openai_secret},
+                            "anthropic": {"action": "replace", "value": anthropic_secret}
+                        },
                         "provider_instances": {
                             "work": {"action": "clear"}
                         }
@@ -2684,6 +2693,19 @@ mod tests {
         assert_eq!(cleared["revision"], 3);
         assert!(cleared["data"]["provider_instances"]["work"].is_null());
         assert!(cleared["data"]["provider_instances"]["personal"].is_null());
+        state
+            .config
+            .write()
+            .await
+            .providers_mut()
+            .openai
+            .as_mut()
+            .unwrap()
+            .extra
+            .insert(
+                "future_provider_metadata".to_string(),
+                json!(hidden_forward_value),
+            );
 
         let mut metadata_only = cleared["data"].clone();
         metadata_only["providers"]["openai"]["model"] = json!("gpt-metadata-only");
@@ -2775,9 +2797,18 @@ mod tests {
 
     #[actix_web::test]
     async fn instance_native_provider_settings_save_without_legacy_provider_fields() {
-        let _key = bamboo_config::encryption::set_test_encryption_key([0x74; 32]);
         let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        {
+            let mut config = state.config.write().await;
+            config.provider = "anthropic".to_string();
+            *config.providers_mut() = serde_json::from_value(json!({
+                "openai": {"model": "stale-openai"},
+                "anthropic": {"model": "stale-anthropic"}
+            }))
+            .unwrap();
+        }
         let app = test::init_service(
             App::new().app_data(state.clone()).service(
                 web::resource("/provider-settings")
@@ -2786,6 +2817,8 @@ mod tests {
             ),
         )
         .await;
+        let work_secret = "instance-native-work-secret";
+        let personal_secret = "instance-native-personal-secret";
 
         let saved = test::call_service(
             &app,
@@ -2797,7 +2830,8 @@ mod tests {
                         "provider": "anthropic",
                         "providers": {},
                         "defaults": {
-                            "chat": {"provider": "work", "model": "gpt-instance"}
+                            "chat": {"provider": "work", "model": "gpt-instance"},
+                            "fast": {"provider": "personal", "model": "claude-instance"}
                         },
                         "features": {
                             "provider_model_ref": true,
@@ -2808,13 +2842,19 @@ mod tests {
                                 "provider_type": "openai",
                                 "model": "gpt-instance",
                                 "enabled": true
+                            },
+                            "personal": {
+                                "provider_type": "anthropic",
+                                "model": "claude-instance",
+                                "enabled": true
                             }
                         },
                         "default_provider_instance_id": "work"
                     },
                     "credential_changes": {
                         "provider_instances": {
-                            "work": {"action": "replace", "value": "sk-instance-only"}
+                            "work": {"action": "replace", "value": work_secret},
+                            "personal": {"action": "replace", "value": personal_secret}
                         }
                     }
                 }))
@@ -2827,13 +2867,42 @@ mod tests {
             status.is_success(),
             "unexpected instance-native provider response {status}: {body}"
         );
-        assert!(!body.contains("sk-instance-only"));
+        assert!(!body.contains(work_secret));
+        assert!(!body.contains(personal_secret));
         let saved: Value = serde_json::from_str(&body).unwrap();
         assert_eq!(saved["revision"], 1);
+        assert_eq!(saved["data"]["providers"], json!({}));
         assert_eq!(
             saved["data"]["credential_status"]["provider_instances"]["work"]["configured"],
             true
         );
+        assert_eq!(
+            saved["data"]["credential_status"]["provider_instances"]["personal"]["configured"],
+            true
+        );
+
+        let no_op = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": saved["data"].clone()
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = no_op.status();
+        let no_op_body = String::from_utf8(test::read_body(no_op).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "instance-native no-op save failed {status}: {no_op_body}"
+        );
+        assert!(!no_op_body.contains(work_secret));
+        assert!(!no_op_body.contains(personal_secret));
+        let no_op: Value = serde_json::from_str(&no_op_body).unwrap();
+        assert_eq!(no_op["revision"], 1);
+        assert_eq!(no_op["data"]["providers"], json!({}));
 
         let round_trip = test::call_service(
             &app,
@@ -2853,18 +2922,103 @@ mod tests {
             status.is_success(),
             "instance-native settings round trip failed {status}: {round_trip_body}"
         );
+        assert!(!round_trip_body.contains(work_secret));
+        assert!(!round_trip_body.contains(personal_secret));
+        let round_trip: Value = serde_json::from_str(&round_trip_body).unwrap();
+        assert_eq!(round_trip["revision"], 1);
+        assert_eq!(round_trip["data"]["providers"], json!({}));
+
+        let root_document: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("config.json")).unwrap())
+                .unwrap();
+        assert!(root_document.get("provider").is_none());
+        assert!(root_document.get("providers").is_none());
 
         let provider_document: Value =
             serde_json::from_slice(&std::fs::read(dir.path().join("providers.json")).unwrap())
                 .unwrap();
         let provider_data = &provider_document["data"];
         assert!(provider_data.get("provider").is_none());
-        assert!(provider_data.get("openai").is_none());
-        assert!(provider_data.get("anthropic").is_none());
+        for key in ["openai", "anthropic", "gemini", "copilot", "bodhi"] {
+            assert!(
+                provider_data.get(key).is_none(),
+                "persisted legacy alias {key}"
+            );
+        }
         assert_eq!(provider_data["default_provider_instance"], "work");
+        assert_eq!(provider_data["defaults"]["fast"]["provider"], "personal");
+        assert_eq!(provider_data["features"]["provider_model_ref"], true);
+        assert!(provider_data["provider_instances"]["work"].is_object());
+        assert!(provider_data["provider_instances"]["personal"].is_object());
+        let work_ref = CredentialRef::parse(
+            provider_data["provider_instances"]["work"]["credential_ref"]
+                .as_str()
+                .expect("work credential ref is durable")
+                .to_string(),
+        )
+        .unwrap();
+        let personal_ref = CredentialRef::parse(
+            provider_data["provider_instances"]["personal"]["credential_ref"]
+                .as_str()
+                .expect("personal credential ref is durable")
+                .to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            state
+                .credential_store
+                .resolve(&work_ref)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            work_secret
+        );
+        assert_eq!(
+            state
+                .credential_store
+                .resolve(&personal_ref)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            personal_secret
+        );
+        let durable = std::fs::read_to_string(dir.path().join("providers.json")).unwrap();
+        assert!(!durable.contains(work_secret));
+        assert!(!durable.contains(personal_secret));
 
         assert!(state.config.read().await.providers().openai.is_none());
         assert!(state.config.read().await.providers().anthropic.is_none());
+        assert_eq!(state.config.read().await.provider_instances.len(), 2);
+
+        drop(app);
+        drop(state);
+        let restarted = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let restarted_health = restarted
+            .config_live_health
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        assert_eq!(
+            restarted_health.status,
+            SectionStatus::Healthy,
+            "provider restart health: {restarted_health:?}"
+        );
+        let restarted_config = restarted.config.read().await;
+        assert_eq!(
+            restarted_config.default_provider_instance.as_deref(),
+            Some("work")
+        );
+        assert_eq!(restarted_config.provider_instances.len(), 2);
+        assert_eq!(
+            restarted_config.provider_instances["work"].api_key,
+            work_secret
+        );
+        assert_eq!(
+            restarted_config.provider_instances["personal"].api_key,
+            personal_secret
+        );
+        assert!(restarted_config.providers().openai.is_none());
+        assert!(restarted_config.providers().anthropic.is_none());
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -410,7 +410,10 @@ pub async fn put_provider_settings_section(
                 credential_status: _,
             } = data;
 
-            if default_provider_instance_id.is_some() {
+            let instance_native = default_provider_instance_id
+                .as_ref()
+                .is_some_and(|id| provider_instances.contains_key(id));
+            if instance_native {
                 providers.clear_legacy_builtin_aliases();
             }
 
@@ -3019,6 +3022,100 @@ mod tests {
         );
         assert!(restarted_config.providers().openai.is_none());
         assert!(restarted_config.providers().anthropic.is_none());
+    }
+
+    #[actix_web::test]
+    async fn hybrid_legacy_default_provider_settings_preserve_builtin_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new().app_data(state.clone()).service(
+                web::resource("/provider-settings")
+                    .route(web::get().to(get_provider_settings_section))
+                    .route(web::put().to(put_provider_settings_section)),
+            ),
+        )
+        .await;
+        let legacy_secret = "hybrid-legacy-openai-secret";
+
+        let saved = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 0,
+                    "data": {
+                        "provider": "openai",
+                        "providers": {
+                            "openai": {"model": "gpt-legacy"}
+                        },
+                        "defaults": {
+                            "chat": {"provider": "openai", "model": "gpt-legacy"}
+                        },
+                        "features": {},
+                        "provider_instances": {
+                            "work": {
+                                "provider_type": "copilot",
+                                "enabled": true
+                            }
+                        },
+                        "default_provider_instance_id": "openai"
+                    },
+                    "credential_changes": {
+                        "providers": {
+                            "openai": {"action": "replace", "value": legacy_secret}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = saved.status();
+        let body = String::from_utf8(test::read_body(saved).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "hybrid legacy-default save failed {status}: {body}"
+        );
+        assert!(!body.contains(legacy_secret));
+        let saved: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(saved["revision"], 1);
+        assert_eq!(saved["data"]["default_provider_instance_id"], "openai");
+        assert_eq!(saved["data"]["providers"]["openai"]["model"], "gpt-legacy");
+        assert!(saved["data"]["provider_instances"]["work"].is_object());
+
+        let root: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("config.json")).unwrap())
+                .unwrap();
+        assert!(root.get("provider").is_none());
+        assert!(root.get("default_provider_instance").is_none());
+        let providers: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("providers.json")).unwrap())
+                .unwrap();
+        assert_eq!(providers["data"]["provider"], "openai");
+        assert_eq!(providers["data"]["openai"]["model"], "gpt-legacy");
+        assert!(!std::fs::read_to_string(dir.path().join("providers.json"))
+            .unwrap()
+            .contains(legacy_secret));
+
+        drop(app);
+        drop(state);
+        let restarted = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let restarted_config = restarted.config.read().await;
+        assert_eq!(
+            restarted_config.default_provider_instance.as_deref(),
+            Some("openai")
+        );
+        assert!(restarted_config.provider_instances.contains_key("work"));
+        assert_eq!(
+            restarted_config
+                .providers()
+                .openai
+                .as_ref()
+                .unwrap()
+                .api_key,
+            legacy_secret
+        );
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -2744,6 +2744,100 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn instance_native_provider_settings_save_without_legacy_provider_fields() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x74; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new().app_data(state.clone()).service(
+                web::resource("/provider-settings")
+                    .route(web::get().to(get_provider_settings_section))
+                    .route(web::put().to(put_provider_settings_section)),
+            ),
+        )
+        .await;
+
+        let saved = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 0,
+                    "data": {
+                        "provider": "anthropic",
+                        "providers": {},
+                        "defaults": {
+                            "chat": {"provider": "work", "model": "gpt-instance"}
+                        },
+                        "features": {
+                            "provider_model_ref": true,
+                            "dynamic_model_routing": false
+                        },
+                        "provider_instances": {
+                            "work": {
+                                "provider_type": "openai",
+                                "model": "gpt-instance",
+                                "enabled": true
+                            }
+                        },
+                        "default_provider_instance_id": "work"
+                    },
+                    "credential_changes": {
+                        "provider_instances": {
+                            "work": {"action": "replace", "value": "sk-instance-only"}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = saved.status();
+        let body = String::from_utf8(test::read_body(saved).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "unexpected instance-native provider response {status}: {body}"
+        );
+        assert!(!body.contains("sk-instance-only"));
+        let saved: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(saved["revision"], 1);
+        assert_eq!(
+            saved["data"]["credential_status"]["provider_instances"]["work"]["configured"],
+            true
+        );
+
+        let round_trip = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": saved["data"].clone()
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = round_trip.status();
+        let round_trip_body =
+            String::from_utf8(test::read_body(round_trip).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "instance-native settings round trip failed {status}: {round_trip_body}"
+        );
+
+        let provider_document: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("providers.json")).unwrap())
+                .unwrap();
+        let provider_data = &provider_document["data"];
+        assert!(provider_data.get("provider").is_none());
+        assert!(provider_data.get("openai").is_none());
+        assert!(provider_data.get("anthropic").is_none());
+        assert_eq!(provider_data["default_provider_instance"], "work");
+
+        assert!(state.config.read().await.providers().openai.is_none());
+        assert!(state.config.read().await.providers().anthropic.is_none());
+    }
+
+    #[actix_web::test]
     async fn provider_instance_runtime_fields_are_explicit_editable_and_preserve_unknown_metadata()
     {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x71; 32]);

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -2006,7 +2006,10 @@ impl From<ConfigRoot> for ConfigValues {
 /// instance-native writes are narrower: the explicit instance default is the
 /// routing authority, so legacy routing fields must not be written back.
 fn durable_root_value(values: ConfigValues) -> serde_json::Result<Value> {
-    let instance_native = values.default_provider_instance.is_some();
+    let instance_native = values
+        .default_provider_instance
+        .as_ref()
+        .is_some_and(|id| values.provider_instances.contains_key(id));
     let mut value = serde_json::to_value(ConfigRoot::from(values))?;
     if instance_native {
         if let Some(object) = value.as_object_mut() {
@@ -3254,7 +3257,11 @@ impl Config {
     /// authoritative. Unknown provider entries remain available for forward
     /// compatibility.
     pub(crate) fn clear_legacy_provider_aliases_for_instance_mode(&mut self) {
-        if self.default_provider_instance.is_some() {
+        if self
+            .default_provider_instance
+            .as_ref()
+            .is_some_and(|id| self.provider_instances.contains_key(id))
+        {
             self.providers.0.clear_legacy_builtin_aliases();
         }
     }
@@ -5404,6 +5411,34 @@ mod tests {
         assert!(provider_only.get("gemini").is_none());
         assert!(provider_only.get("provider").is_none());
         assert_eq!(provider_only["future_provider"]["kept"], true);
+    }
+
+    #[test]
+    fn hybrid_legacy_default_preserves_its_builtin_alias_on_durable_writes() {
+        let mut config = Config::default();
+        config.values.provider = "openai".to_string();
+        config.providers_mut().openai = Some(OpenAIConfig {
+            model: Some("gpt-legacy".to_string()),
+            ..OpenAIConfig::default()
+        });
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "copilot",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("openai".to_string());
+
+        let (root_bytes, provider_bytes) =
+            config.prepare_provider_transaction_documents(&[]).unwrap();
+        let root: Value = serde_json::from_slice(&root_bytes).unwrap();
+        let providers: Value = serde_json::from_slice(&provider_bytes).unwrap();
+        assert_eq!(root["provider"], "openai");
+        assert_eq!(root["default_provider_instance"], "openai");
+        assert!(root["provider_instances"]["work"].is_object());
+        assert_eq!(providers["openai"]["model"], "gpt-legacy");
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1679,21 +1679,27 @@ struct NetworkConfigSection {
     server: ServerConfig,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ProviderRoutingConfigSection {
-    /// Legacy single-provider routing key.
-    ///
-    /// An explicit provider-instance default is authoritative, so persisting
-    /// this compatibility field in that mode only creates stale state that can
-    /// disagree with `default_provider_instance`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    provider: Option<String>,
+    #[serde(default = "default_provider")]
+    provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     defaults: Option<DefaultsConfig>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     provider_instances: HashMap<String, ProviderInstanceConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     default_provider_instance: Option<String>,
+}
+
+impl Default for ProviderRoutingConfigSection {
+    fn default() -> Self {
+        Self {
+            provider: default_provider(),
+            defaults: None,
+            provider_instances: HashMap::new(),
+            default_provider_instance: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1858,8 +1864,6 @@ impl From<ConfigValues> for ConfigRoot {
             extra,
         } = values;
 
-        let provider = default_provider_instance.is_none().then_some(provider);
-
         Self {
             network: NetworkConfigSection {
                 http_proxy,
@@ -1967,7 +1971,7 @@ impl From<ConfigRoot> for ConfigValues {
             proxy_auth_encrypted,
             proxy_auth_credential_ref,
             headless_auth,
-            provider: provider.unwrap_or_else(default_provider),
+            provider,
             defaults,
             provider_instances,
             default_provider_instance,
@@ -1993,6 +1997,24 @@ impl From<ConfigRoot> for ConfigValues {
             extra,
         }
     }
+}
+
+/// Serialize the root-only durable document.
+///
+/// Public `Config` serialization intentionally retains the historical
+/// compatibility shape, including the legacy `provider` selector. Durable
+/// instance-native writes are narrower: the explicit instance default is the
+/// routing authority, so legacy routing fields must not be written back.
+fn durable_root_value(values: ConfigValues) -> serde_json::Result<Value> {
+    let instance_native = values.default_provider_instance.is_some();
+    let mut value = serde_json::to_value(ConfigRoot::from(values))?;
+    if instance_native {
+        if let Some(object) = value.as_object_mut() {
+            object.remove("provider");
+            object.remove("providers");
+        }
+    }
+    Ok(value)
 }
 
 define_counted_struct! {
@@ -2140,6 +2162,19 @@ pub struct ProviderConfigs {
     /// Preserve unknown provider keys (forward compatibility).
     #[serde(default, flatten)]
     pub extra: BTreeMap<String, Value>,
+}
+
+impl ProviderConfigs {
+    /// Remove only the known legacy selector and built-in aliases while
+    /// preserving unknown forward-compatible provider entries in `extra`.
+    pub fn clear_legacy_builtin_aliases(&mut self) {
+        self.openai = None;
+        self.anthropic = None;
+        self.gemini = None;
+        self.copilot = None;
+        self.bodhi = None;
+        self.extra.remove("provider");
+    }
 }
 
 /// Feature flags for incremental rollout of new subsystems.
@@ -3213,6 +3248,15 @@ impl Config {
 
     pub fn providers_mut(&mut self) -> &mut ProviderConfigs {
         &mut self.providers.0
+    }
+
+    /// Canonicalize only the durable provider view when instance routing is
+    /// authoritative. Unknown provider entries remain available for forward
+    /// compatibility.
+    pub(crate) fn clear_legacy_provider_aliases_for_instance_mode(&mut self) {
+        if self.default_provider_instance.is_some() {
+            self.providers.0.clear_legacy_builtin_aliases();
+        }
     }
 
     /// Build the legacy full-config JSON view used by in-memory patching APIs.
@@ -4304,6 +4348,7 @@ impl Config {
     /// refreshed into their encrypted at-rest representation.
     pub fn save_providers_to_dir(&self, data_dir: &std::path::Path) -> Result<()> {
         let mut config = self.clone();
+        config.clear_legacy_provider_aliases_for_instance_mode();
         config.refresh_provider_api_keys_encrypted()?;
         config.providers.save_sync(data_dir)
     }
@@ -4323,6 +4368,7 @@ impl Config {
         }
 
         let mut to_save = self.clone();
+        to_save.clear_legacy_provider_aliases_for_instance_mode();
         to_save.extra.remove("data_dir");
         to_save.extra.remove("model");
         to_save.refresh_encrypted_secrets()?;
@@ -4335,7 +4381,7 @@ impl Config {
         to_save.normalize_tool_settings();
         to_save.normalize_skill_settings();
 
-        let mut root = serde_json::to_value(ConfigRoot::from(to_save.values.clone()))
+        let mut root = durable_root_value(to_save.values.clone())
             .context("Failed to serialize root config DTO to JSON")?;
         if let Some(object) = root.as_object_mut() {
             object.remove("connect");
@@ -4541,6 +4587,7 @@ impl Config {
         }
 
         let mut to_save = self.clone();
+        to_save.clear_legacy_provider_aliases_for_instance_mode();
         // Never persist `data_dir` into config.json (data dir is runtime-derived).
         to_save.extra.remove("data_dir");
         // Root-level `model` is deprecated; do not persist it.
@@ -4566,7 +4613,7 @@ impl Config {
         // in-memory struct) — only the serialized DOCUMENT that becomes
         // config.json's bytes has the key stripped, and that's done on the
         // `serde_json::Value` here, not via `#[serde(skip)]` on the field.
-        let mut config_value = serde_json::to_value(ConfigRoot::from(to_save.values.clone()))
+        let mut config_value = durable_root_value(to_save.values.clone())
             .context("Failed to serialize root config DTO to JSON")?;
         if let Some(obj) = config_value.as_object_mut() {
             obj.remove("connect");
@@ -5259,31 +5306,104 @@ mod tests {
     }
 
     #[test]
-    fn persistence_omits_legacy_provider_when_instance_default_is_explicit() {
+    fn compatibility_serialization_keeps_legacy_provider_in_instance_mode() {
         let instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
             "provider_type": "openai",
             "enabled": true
         }))
         .unwrap();
-        let values = ConfigValues {
-            provider: "gemini".to_string(),
-            provider_instances: std::collections::HashMap::from([("work".to_string(), instance)]),
-            default_provider_instance: Some("work".to_string()),
-            ..ConfigValues::default()
-        };
+        let mut config = Config::default();
+        config.values.provider = "gemini".to_string();
+        config
+            .provider_instances
+            .insert("work".to_string(), instance);
+        config.default_provider_instance = Some("work".to_string());
+        config.providers_mut().openai = Some(OpenAIConfig::default());
 
-        let json = serde_json::to_value(ConfigRoot::from(values)).unwrap();
-        assert!(json.get("provider").is_none());
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["provider"], "gemini");
+        assert!(json["providers"]["openai"].is_object());
         assert_eq!(json["default_provider_instance"], "work");
 
-        let root: ConfigRoot = serde_json::from_value(json).unwrap();
-        let round_trip = ConfigValues::from(root);
-        assert_eq!(round_trip.provider, default_provider());
+        let round_trip: Config = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip.provider, "gemini");
         assert_eq!(
             round_trip.default_provider_instance.as_deref(),
             Some("work")
         );
         assert!(round_trip.provider_instances.contains_key("work"));
+        assert!(round_trip.providers().openai.is_some());
+    }
+
+    #[test]
+    fn instance_native_durable_writes_remove_only_legacy_builtin_aliases() {
+        let _key = crate::encryption::set_test_encryption_key([0x73; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.values.provider = "anthropic".to_string();
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "model": "gpt-instance",
+                "enabled": true,
+                "future_instance_metadata": "preserved"
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("work".to_string());
+        config.features.provider_model_ref = true;
+        config.providers_mut().openai = Some(OpenAIConfig::default());
+        config.providers_mut().anthropic = Some(AnthropicConfig::default());
+        config
+            .providers_mut()
+            .extra
+            .insert("provider".to_string(), serde_json::json!("anthropic"));
+        config.providers_mut().extra.insert(
+            "future_provider".to_string(),
+            serde_json::json!({"kept": true}),
+        );
+
+        let (root_bytes, provider_bytes) =
+            config.prepare_provider_transaction_documents(&[]).unwrap();
+        let root: Value = serde_json::from_slice(&root_bytes).unwrap();
+        let providers: Value = serde_json::from_slice(&provider_bytes).unwrap();
+        assert!(root.get("provider").is_none());
+        assert!(root.get("providers").is_none());
+        assert_eq!(root["default_provider_instance"], "work");
+        assert_eq!(
+            root["provider_instances"]["work"]["future_instance_metadata"],
+            "preserved"
+        );
+        assert!(providers.get("provider").is_none());
+        for key in ["openai", "anthropic", "gemini", "copilot", "bodhi"] {
+            assert!(providers.get(key).is_none(), "persisted legacy alias {key}");
+        }
+        assert_eq!(providers["future_provider"]["kept"], true);
+
+        config.save_to_dir(dir.path().to_path_buf()).unwrap();
+        let saved_root: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("config.json")).unwrap())
+                .unwrap();
+        let saved_providers: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("providers.json")).unwrap())
+                .unwrap();
+        assert!(saved_root.get("provider").is_none());
+        assert!(saved_root.get("providers").is_none());
+        assert_eq!(saved_root["default_provider_instance"], "work");
+        assert!(saved_providers.get("openai").is_none());
+        assert!(saved_providers.get("anthropic").is_none());
+        assert!(saved_providers.get("provider").is_none());
+        assert_eq!(saved_providers["future_provider"]["kept"], true);
+
+        config.providers_mut().gemini = Some(GeminiConfig::default());
+        config.save_providers_to_dir(dir.path()).unwrap();
+        let provider_only: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("providers.json")).unwrap())
+                .unwrap();
+        assert!(provider_only.get("gemini").is_none());
+        assert!(provider_only.get("provider").is_none());
+        assert_eq!(provider_only["future_provider"]["kept"], true);
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1679,27 +1679,21 @@ struct NetworkConfigSection {
     server: ServerConfig,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct ProviderRoutingConfigSection {
-    #[serde(default = "default_provider")]
-    provider: String,
+    /// Legacy single-provider routing key.
+    ///
+    /// An explicit provider-instance default is authoritative, so persisting
+    /// this compatibility field in that mode only creates stale state that can
+    /// disagree with `default_provider_instance`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     defaults: Option<DefaultsConfig>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     provider_instances: HashMap<String, ProviderInstanceConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     default_provider_instance: Option<String>,
-}
-
-impl Default for ProviderRoutingConfigSection {
-    fn default() -> Self {
-        Self {
-            provider: default_provider(),
-            defaults: None,
-            provider_instances: HashMap::new(),
-            default_provider_instance: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1864,6 +1858,8 @@ impl From<ConfigValues> for ConfigRoot {
             extra,
         } = values;
 
+        let provider = default_provider_instance.is_none().then_some(provider);
+
         Self {
             network: NetworkConfigSection {
                 http_proxy,
@@ -1971,7 +1967,7 @@ impl From<ConfigRoot> for ConfigValues {
             proxy_auth_encrypted,
             proxy_auth_credential_ref,
             headless_auth,
-            provider,
+            provider: provider.unwrap_or_else(default_provider),
             defaults,
             provider_instances,
             default_provider_instance,
@@ -5243,6 +5239,45 @@ mod tests {
                 semantic_idle_timeout_secs: 300,
             }
         );
+    }
+
+    #[test]
+    fn persistence_omits_legacy_provider_when_instance_default_is_explicit() {
+        let instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "enabled": true
+        }))
+        .unwrap();
+        let values = ConfigValues {
+            provider: "gemini".to_string(),
+            provider_instances: std::collections::HashMap::from([("work".to_string(), instance)]),
+            default_provider_instance: Some("work".to_string()),
+            ..ConfigValues::default()
+        };
+
+        let json = serde_json::to_value(ConfigRoot::from(values)).unwrap();
+        assert!(json.get("provider").is_none());
+        assert_eq!(json["default_provider_instance"], "work");
+
+        let root: ConfigRoot = serde_json::from_value(json).unwrap();
+        let round_trip = ConfigValues::from(root);
+        assert_eq!(round_trip.provider, default_provider());
+        assert_eq!(
+            round_trip.default_provider_instance.as_deref(),
+            Some("work")
+        );
+        assert!(round_trip.provider_instances.contains_key("work"));
+    }
+
+    #[test]
+    fn persistence_keeps_legacy_provider_without_instance_default() {
+        let values = ConfigValues {
+            provider: "gemini".to_string(),
+            ..ConfigValues::default()
+        };
+
+        let json = serde_json::to_value(ConfigRoot::from(values)).unwrap();
+        assert_eq!(json["provider"], "gemini");
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -417,6 +417,10 @@ impl SectionProjection {
         model_limits: ModelLimitsSection,
     ) -> ConfigStoreResult<Self> {
         let mut disk = config.clone();
+        let instance_native = disk
+            .default_provider_instance
+            .as_ref()
+            .is_some_and(|id| disk.provider_instances.contains_key(id));
         disk.clear_legacy_provider_aliases_for_instance_mode();
         disk.ensure_provider_instance_credentials_isolated()
             .map_err(|error| crate::ConfigStoreError::Validation(error.to_string()))?;
@@ -494,7 +498,7 @@ impl SectionProjection {
             extra,
         } = disk.section_values();
 
-        let provider = default_provider_instance.is_none().then_some(provider);
+        let provider = (!instance_native).then_some(provider);
 
         Ok(Self {
             core: CoreSection {
@@ -783,10 +787,8 @@ where
         });
     let has_legacy_raw = legacy_raw.is_some();
     let typed_baseline = serde_json::to_value(value)?;
-    let instance_native_providers = name == "providers.json"
-        && typed_baseline
-            .get("default_provider_instance")
-            .is_some_and(|value| !value.is_null());
+    let instance_native_providers =
+        name == "providers.json" && has_explicit_default_provider_instance(&typed_baseline);
     let mut merged_data = match legacy_raw {
         Some(mut raw) => {
             if instance_native_providers {
@@ -909,6 +911,19 @@ fn remove_instance_native_legacy_provider_fields(value: &mut Value) {
     ] {
         object.remove(key);
     }
+}
+
+fn has_explicit_default_provider_instance(value: &Value) -> bool {
+    let Some(default_id) = value
+        .get("default_provider_instance")
+        .and_then(Value::as_str)
+    else {
+        return false;
+    };
+    value
+        .get("provider_instances")
+        .and_then(Value::as_object)
+        .is_some_and(|instances| instances.contains_key(default_id))
 }
 
 /// Merge a typed, precedence-resolved baseline over legacy raw JSON while
@@ -1111,6 +1126,13 @@ fn validate_core(value: &CoreSection) -> Result<(), String> {
     validate_json_serializable(value)
 }
 
+fn is_legacy_provider_type(value: &str) -> bool {
+    matches!(
+        value,
+        "openai" | "anthropic" | "gemini" | "copilot" | "bodhi"
+    )
+}
+
 fn validate_providers(value: &ProvidersSection) -> Result<(), String> {
     if value
         .provider
@@ -1124,12 +1146,10 @@ fn validate_providers(value: &ProvidersSection) -> Result<(), String> {
             return Err("provider instance id and type must not be empty".to_string());
         }
     }
-    if value
-        .default_provider_instance
-        .as_ref()
-        .is_some_and(|id| !value.provider_instances.contains_key(id))
-    {
-        return Err("default provider instance does not exist".to_string());
+    if value.default_provider_instance.as_ref().is_some_and(|id| {
+        !value.provider_instances.contains_key(id) && !is_legacy_provider_type(id)
+    }) {
+        return Err("default provider instance or legacy provider type does not exist".to_string());
     }
     macro_rules! validate_builtin_credential {
         ($field:ident) => {
@@ -2583,7 +2603,11 @@ fn preflight_legacy_root_sections(
     if let Some(providers) = load_strict_sidecar_value(data_dir, "providers.json")? {
         validate_preflight_provider_secret_consistency(&providers)?;
     }
-    let instance_native_providers = projection.providers.default_provider_instance.is_some();
+    let instance_native_providers = projection
+        .providers
+        .default_provider_instance
+        .as_ref()
+        .is_some_and(|id| projection.providers.provider_instances.contains_key(id));
     for descriptor in SECTION_DESCRIPTORS
         .iter()
         .filter(|descriptor| descriptor.id != SectionId::Credentials)
@@ -5870,6 +5894,35 @@ mod tests {
     }
 
     #[test]
+    fn hybrid_legacy_default_projection_preserves_legacy_routing() {
+        let mut config = Config::default();
+        config.provider = "openai".to_string();
+        config.providers_mut().openai = Some(crate::OpenAIConfig {
+            model: Some("gpt-legacy".to_string()),
+            ..crate::OpenAIConfig::default()
+        });
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(json!({
+                "provider_type": "copilot",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("openai".to_string());
+
+        let projection =
+            SectionProjection::from_config(&config, ModelLimitsSection::default()).unwrap();
+        let durable = serde_json::to_value(&projection.providers).unwrap();
+
+        assert_eq!(durable["provider"], "openai");
+        assert_eq!(durable["default_provider_instance"], "openai");
+        assert_eq!(durable["openai"]["model"], "gpt-legacy");
+        assert!(durable["provider_instances"]["work"].is_object());
+        assert!(validate_providers(&projection.providers).is_ok());
+    }
+
+    #[test]
     fn legacy_split_is_manifest_gated_idempotent_and_preserves_sidecar_precedence() {
         let _key = crate::encryption::set_test_encryption_key([61; 32]);
         let dir = TempDir::new().unwrap();
@@ -7779,6 +7832,71 @@ mod tests {
         assert_eq!(
             restarted.providers().extra["future_provider"]["from_sidecar"],
             true
+        );
+    }
+
+    #[test]
+    fn hybrid_legacy_default_migration_preserves_legacy_alias_and_restarts() {
+        let _key = crate::encryption::set_test_encryption_key([0x65; 32]);
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "provider": "openai",
+                "provider_instances": {
+                    "work": {
+                        "provider_type": "copilot",
+                        "enabled": true
+                    }
+                },
+                "default_provider_instance": "openai",
+                "providers": {
+                    "openai": {
+                        "model": "inline-model",
+                        "future_inline": true
+                    }
+                }
+            }),
+        );
+        write_json(
+            &dir.path().join("providers.json"),
+            &json!({
+                "provider": "openai",
+                "openai": {
+                    "model": "sidecar-model",
+                    "future_sidecar": true
+                }
+            }),
+        );
+
+        migrate_config_facade_layout(dir.path()).unwrap();
+
+        let providers: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("providers.json")).unwrap())
+                .unwrap();
+        let data = &providers["data"];
+        assert_eq!(data["provider"], "openai");
+        assert_eq!(data["default_provider_instance"], "openai");
+        assert_eq!(data["openai"]["model"], "sidecar-model");
+        assert_eq!(data["openai"]["future_inline"], true);
+        assert_eq!(data["openai"]["future_sidecar"], true);
+        assert!(data["provider_instances"]["work"].is_object());
+
+        let restarted = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+        assert_eq!(
+            restarted.default_provider_instance.as_deref(),
+            Some("openai")
+        );
+        assert!(restarted.provider_instances.contains_key("work"));
+        assert_eq!(
+            restarted
+                .providers()
+                .openai
+                .as_ref()
+                .unwrap()
+                .model
+                .as_deref(),
+            Some("sidecar-model")
         );
     }
 

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -246,10 +246,12 @@ pub struct CoreSection {
 /// shape. Routing/default/features fields are additive flattened keys, so the
 /// existing `AtomicJsonStore<ProviderConfigs>` and exact credential transaction
 /// can continue parsing them through `ProviderConfigs::extra`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProvidersSection {
-    #[serde(default = "default_provider_name")]
-    pub provider: String,
+    /// Legacy single-provider routing key. Instance-native configurations with
+    /// an explicit default omit it from durable storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub defaults: Option<DefaultsConfig>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -264,19 +266,6 @@ pub struct ProvidersSection {
 
 fn default_provider_name() -> String {
     "openai".to_string()
-}
-
-impl Default for ProvidersSection {
-    fn default() -> Self {
-        Self {
-            provider: default_provider_name(),
-            defaults: None,
-            provider_instances: HashMap::new(),
-            default_provider_instance: None,
-            features: FeatureFlags::default(),
-            providers: ProviderConfigs::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -504,6 +493,8 @@ impl SectionProjection {
             extra,
         } = disk.section_values();
 
+        let provider = default_provider_instance.is_none().then_some(provider);
+
         Ok(Self {
             core: CoreSection {
                 http_proxy,
@@ -614,7 +605,7 @@ impl SectionProjection {
                 proxy_auth_encrypted: None,
                 proxy_auth_credential_ref,
                 headless_auth,
-                provider,
+                provider: provider.unwrap_or_else(default_provider_name),
                 defaults,
                 provider_instances,
                 default_provider_instance,
@@ -1087,7 +1078,11 @@ fn validate_core(value: &CoreSection) -> Result<(), String> {
 }
 
 fn validate_providers(value: &ProvidersSection) -> Result<(), String> {
-    if value.provider.trim().is_empty() {
+    if value
+        .provider
+        .as_ref()
+        .is_some_and(|provider| provider.trim().is_empty())
+    {
         return Err("default provider must not be empty".to_string());
     }
     for (id, instance) in &value.provider_instances {
@@ -2725,7 +2720,7 @@ fn load_strict_planning_input_with_overrides(
             providers,
         } = providers;
         if owns_provider {
-            config.provider = provider;
+            config.provider = provider.unwrap_or_else(default_provider_name);
         }
         if owns_defaults {
             config.defaults = defaults;
@@ -5777,7 +5772,7 @@ mod tests {
     #[test]
     fn providers_section_remains_readable_by_existing_exact_transaction_wire_type() {
         let section = ProvidersSection {
-            provider: "openai".to_string(),
+            provider: Some("openai".to_string()),
             features: FeatureFlags {
                 dynamic_model_routing: true,
                 ..FeatureFlags::default()
@@ -5789,8 +5784,31 @@ mod tests {
         assert_eq!(legacy.extra["provider"], "openai");
         assert_eq!(legacy.extra["features"]["dynamic_model_routing"], true);
         let reparsed: ProvidersSection = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(reparsed.provider, "openai");
+        assert_eq!(reparsed.provider.as_deref(), Some("openai"));
         assert!(reparsed.features.dynamic_model_routing);
+    }
+
+    #[test]
+    fn instance_native_projection_omits_legacy_provider_routing() {
+        let mut config = Config::default();
+        config.provider = "anthropic".to_string();
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(json!({
+                "provider_type": "openai",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        let projection =
+            SectionProjection::from_config(&config, ModelLimitsSection::default()).unwrap();
+        let durable = serde_json::to_value(&projection.providers).unwrap();
+
+        assert!(durable.get("provider").is_none());
+        assert_eq!(durable["default_provider_instance"], "work");
+        assert!(durable["provider_instances"]["work"].is_object());
     }
 
     #[test]
@@ -6414,7 +6432,7 @@ mod tests {
 
         let providers = facade.registry().providers.snapshot();
         let mut provider_candidate = providers.data.as_ref().clone();
-        provider_candidate.provider = "anthropic".to_string();
+        provider_candidate.provider = Some("anthropic".to_string());
         facade
             .registry()
             .providers

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -417,6 +417,7 @@ impl SectionProjection {
         model_limits: ModelLimitsSection,
     ) -> ConfigStoreResult<Self> {
         let mut disk = config.clone();
+        disk.clear_legacy_provider_aliases_for_instance_mode();
         disk.ensure_provider_instance_credentials_isolated()
             .map_err(|error| crate::ConfigStoreError::Validation(error.to_string()))?;
         disk.sanitize_mcp_credential_refs_for_disk();
@@ -782,15 +783,29 @@ where
         });
     let has_legacy_raw = legacy_raw.is_some();
     let typed_baseline = serde_json::to_value(value)?;
+    let instance_native_providers = name == "providers.json"
+        && typed_baseline
+            .get("default_provider_instance")
+            .is_some_and(|value| !value.is_null());
     let mut merged_data = match legacy_raw {
         Some(mut raw) => {
+            if instance_native_providers {
+                remove_instance_native_legacy_provider_fields(&mut raw);
+            }
             deep_merge_typed_over_raw(&mut raw, typed_baseline);
             raw
         }
         None => typed_baseline,
     };
     if let Some(existing_data) = existing_data.as_ref() {
-        deep_merge_json(&mut merged_data, existing_data.clone());
+        let mut existing_data = existing_data.clone();
+        if instance_native_providers {
+            remove_instance_native_legacy_provider_fields(&mut existing_data);
+        }
+        deep_merge_json(&mut merged_data, existing_data);
+    }
+    if instance_native_providers {
+        remove_instance_native_legacy_provider_fields(&mut merged_data);
     }
     // A materialized default is still the revision-zero baseline. Preserve an
     // already-versioned sidecar when migration leaves its data byte-equivalent;
@@ -874,6 +889,25 @@ fn deep_merge_json(base: &mut Value, overlay: Value) {
             }
         }
         (base, overlay) => *base = overlay,
+    }
+}
+
+/// Remove only legacy routing and known built-in aliases from an
+/// instance-native providers document. Unknown keys remain untouched so a
+/// newer runtime's provider metadata survives migration by an older binary.
+fn remove_instance_native_legacy_provider_fields(value: &mut Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    for key in [
+        "provider",
+        "openai",
+        "anthropic",
+        "gemini",
+        "copilot",
+        "bodhi",
+    ] {
+        object.remove(key);
     }
 }
 
@@ -2549,6 +2583,7 @@ fn preflight_legacy_root_sections(
     if let Some(providers) = load_strict_sidecar_value(data_dir, "providers.json")? {
         validate_preflight_provider_secret_consistency(&providers)?;
     }
+    let instance_native_providers = projection.providers.default_provider_instance.is_some();
     for descriptor in SECTION_DESCRIPTORS
         .iter()
         .filter(|descriptor| descriptor.id != SectionId::Credentials)
@@ -2573,13 +2608,23 @@ fn preflight_legacy_root_sections(
         };
         let mut data = match sections.remove(&id) {
             Some(mut legacy) => {
+                if id == SectionId::Providers && instance_native_providers {
+                    remove_instance_native_legacy_provider_fields(&mut legacy);
+                }
                 deep_merge_typed_over_raw(&mut legacy, typed_baseline);
                 legacy
             }
             None => typed_baseline,
         };
-        if let Some(existing) = load_strict_sidecar_value(data_dir, id.descriptor().file_name)? {
+        if let Some(mut existing) = load_strict_sidecar_value(data_dir, id.descriptor().file_name)?
+        {
+            if id == SectionId::Providers && instance_native_providers {
+                remove_instance_native_legacy_provider_fields(&mut existing);
+            }
             deep_merge_json(&mut data, existing);
+        }
+        if id == SectionId::Providers && instance_native_providers {
+            remove_instance_native_legacy_provider_fields(&mut data);
         }
         match id {
             SectionId::Core => {
@@ -5792,6 +5837,15 @@ mod tests {
     fn instance_native_projection_omits_legacy_provider_routing() {
         let mut config = Config::default();
         config.provider = "anthropic".to_string();
+        config.providers_mut().openai = Some(crate::OpenAIConfig::default());
+        config.providers_mut().anthropic = Some(crate::AnthropicConfig::default());
+        config.providers_mut().gemini = Some(crate::GeminiConfig::default());
+        config.providers_mut().copilot = Some(crate::CopilotConfig::default());
+        config.providers_mut().bodhi = Some(serde_json::from_value(json!({})).unwrap());
+        config
+            .providers_mut()
+            .extra
+            .insert("future_provider".to_string(), json!({"kept": true}));
         config.provider_instances.insert(
             "work".to_string(),
             serde_json::from_value(json!({
@@ -5807,6 +5861,10 @@ mod tests {
         let durable = serde_json::to_value(&projection.providers).unwrap();
 
         assert!(durable.get("provider").is_none());
+        for key in ["openai", "anthropic", "gemini", "copilot", "bodhi"] {
+            assert!(durable.get(key).is_none(), "persisted legacy alias {key}");
+        }
+        assert_eq!(durable["future_provider"]["kept"], true);
         assert_eq!(durable["default_provider_instance"], "work");
         assert!(durable["provider_instances"]["work"].is_object());
     }
@@ -7621,6 +7679,107 @@ mod tests {
         );
         assert_eq!(data["openai"]["model"], "sidecar-model");
         assert_eq!(data["openai"]["future_provider"]["nested"], "kept");
+    }
+
+    #[test]
+    fn instance_native_dual_config_migration_drops_legacy_aliases_and_restarts() {
+        let _key = crate::encryption::set_test_encryption_key([0x64; 32]);
+        let dir = TempDir::new().unwrap();
+        let instance_secret = "instance-native-migration-secret";
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "provider": "anthropic",
+                "defaults": {
+                    "chat": {"provider": "work", "model": "gpt-instance"}
+                },
+                "features": {
+                    "provider_model_ref": true,
+                    "dynamic_model_routing": false
+                },
+                "provider_instances": {
+                    "work": {
+                        "provider_type": "openai",
+                        "api_key": instance_secret,
+                        "model": "gpt-instance",
+                        "explicit_prompt_cache": false,
+                        "enabled": true,
+                        "future_instance": {"nested": "kept"}
+                    }
+                },
+                "default_provider_instance": "work",
+                "providers": {
+                    "openai": {"model": "inline-stale"},
+                    "anthropic": {"model": "inline-stale"},
+                    "future_provider": {"from_root": true}
+                }
+            }),
+        );
+        write_json(
+            &dir.path().join("providers.json"),
+            &json!({
+                "provider": "gemini",
+                "openai": {"model": "sidecar-stale"},
+                "gemini": {"model": "sidecar-stale"},
+                "future_provider": {"from_sidecar": true}
+            }),
+        );
+
+        migrate_config_facade_layout(dir.path()).unwrap();
+
+        let providers: Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("providers.json")).unwrap())
+                .unwrap();
+        let data = &providers["data"];
+        for key in [
+            "provider",
+            "openai",
+            "anthropic",
+            "gemini",
+            "copilot",
+            "bodhi",
+        ] {
+            assert!(data.get(key).is_none(), "migrated legacy field {key}");
+        }
+        assert_eq!(data["default_provider_instance"], "work");
+        assert_eq!(data["defaults"]["chat"]["provider"], "work");
+        assert_eq!(data["features"]["provider_model_ref"], true);
+        assert_eq!(
+            data["provider_instances"]["work"]["future_instance"]["nested"],
+            "kept"
+        );
+        assert_eq!(
+            data["provider_instances"]["work"][crate::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY],
+            false
+        );
+        assert_eq!(data["future_provider"]["from_root"], true);
+        assert_eq!(data["future_provider"]["from_sidecar"], true);
+        assert!(!std::fs::read_to_string(dir.path().join("providers.json"))
+            .unwrap()
+            .contains(instance_secret));
+
+        let restarted = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+        assert_eq!(restarted.default_provider_instance.as_deref(), Some("work"));
+        assert_eq!(
+            restarted.provider_instances["work"].api_key,
+            instance_secret
+        );
+        assert_eq!(
+            restarted.provider_instances["work"].extra["future_instance"]["nested"],
+            "kept"
+        );
+        assert_eq!(
+            restarted.provider_instances["work"].extra
+                [crate::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY],
+            false
+        );
+        assert!(restarted.providers().openai.is_none());
+        assert!(restarted.providers().anthropic.is_none());
+        assert!(restarted.providers().gemini.is_none());
+        assert_eq!(
+            restarted.providers().extra["future_provider"]["from_sidecar"],
+            true
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -213,6 +213,35 @@ pub async fn create_provider_by_name(
 
 /// Validate provider configuration without creating the provider
 pub fn validate_provider_config(config: &Config) -> Result<(), LLMError> {
+    if let Some(instance_id) = config.default_provider_instance.as_deref() {
+        let instance = config.provider_instances.get(instance_id).ok_or_else(|| {
+            LLMError::Auth(format!(
+                "Default provider instance '{instance_id}' configuration required"
+            ))
+        })?;
+        if !instance.enabled {
+            return Err(LLMError::Auth(format!(
+                "Default provider instance '{instance_id}' is disabled"
+            )));
+        }
+        return match instance.provider_type.as_str() {
+            "copilot" => Ok(()),
+            "openai" | "anthropic" | "gemini" | "bodhi" => {
+                if instance.api_key.is_empty() {
+                    Err(LLMError::Auth(format!(
+                        "{} API key is required for provider instance '{instance_id}'",
+                        provider_display_name(&instance.provider_type)
+                    )))
+                } else {
+                    Ok(())
+                }
+            }
+            other => Err(LLMError::Auth(format!(
+                "Unknown provider type '{other}' for provider instance '{instance_id}'"
+            ))),
+        };
+    }
+
     match config.provider.as_str() {
         "copilot" => Ok(()),
 
@@ -275,6 +304,16 @@ pub fn validate_provider_config(config: &Config) -> Result<(), LLMError> {
             "Unknown provider: {}",
             config.provider
         ))),
+    }
+}
+
+fn provider_display_name(provider_type: &str) -> &str {
+    match provider_type {
+        "openai" => "OpenAI",
+        "anthropic" => "Anthropic",
+        "gemini" => "Gemini",
+        "bodhi" => "Bodhi",
+        other => other,
     }
 }
 
@@ -453,5 +492,43 @@ mod tests {
 
         let result = validate_provider_config(&config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_instance_default_without_legacy_provider_config() {
+        let mut config = config_with_provider("anthropic", ProviderConfigs::default());
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "api_key": "sk-instance",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        assert!(validate_provider_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_instance_default_requires_existing_enabled_instance() {
+        let mut missing = config_with_provider("copilot", ProviderConfigs::default());
+        missing.default_provider_instance = Some("missing".to_string());
+        let error = validate_provider_config(&missing).unwrap_err().to_string();
+        assert!(error.contains("Default provider instance 'missing' configuration required"));
+
+        let mut disabled = config_with_provider("copilot", ProviderConfigs::default());
+        disabled.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "copilot",
+                "enabled": false
+            }))
+            .unwrap(),
+        );
+        disabled.default_provider_instance = Some("work".to_string());
+        let error = validate_provider_config(&disabled).unwrap_err().to_string();
+        assert!(error.contains("Default provider instance 'work' is disabled"));
     }
 }

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -216,35 +216,41 @@ pub async fn create_provider_by_name(
 /// Validate provider configuration without creating the provider
 pub fn validate_provider_config(config: &Config) -> Result<(), LLMError> {
     if let Some(instance_id) = config.default_provider_instance.as_deref() {
-        let instance = config.provider_instances.get(instance_id).ok_or_else(|| {
-            LLMError::Auth(format!(
-                "Default provider instance '{instance_id}' configuration required"
-            ))
-        })?;
-        if !instance.enabled {
+        if let Some(instance) = config.provider_instances.get(instance_id) {
+            if !instance.enabled {
+                return Err(LLMError::Auth(format!(
+                    "Default provider instance '{instance_id}' is disabled"
+                )));
+            }
+            return match instance.provider_type.as_str() {
+                "copilot" => Ok(()),
+                "openai" | "anthropic" | "gemini" | "bodhi" => {
+                    if instance.api_key.is_empty() {
+                        Err(LLMError::Auth(format!(
+                            "{} API key is required for provider instance '{instance_id}'",
+                            provider_display_name(&instance.provider_type)
+                        )))
+                    } else {
+                        Ok(())
+                    }
+                }
+                other => Err(LLMError::Auth(format!(
+                    "Unknown provider type '{other}' for provider instance '{instance_id}'"
+                ))),
+            };
+        }
+        if !AVAILABLE_PROVIDERS.contains(&instance_id) {
             return Err(LLMError::Auth(format!(
-                "Default provider instance '{instance_id}' is disabled"
+                "Default provider instance '{instance_id}' configuration required"
             )));
         }
-        return match instance.provider_type.as_str() {
-            "copilot" => Ok(()),
-            "openai" | "anthropic" | "gemini" | "bodhi" => {
-                if instance.api_key.is_empty() {
-                    Err(LLMError::Auth(format!(
-                        "{} API key is required for provider instance '{instance_id}'",
-                        provider_display_name(&instance.provider_type)
-                    )))
-                } else {
-                    Ok(())
-                }
-            }
-            other => Err(LLMError::Auth(format!(
-                "Unknown provider type '{other}' for provider instance '{instance_id}'"
-            ))),
-        };
     }
 
-    match config.provider.as_str() {
+    let provider_name = config
+        .default_provider_instance
+        .as_deref()
+        .unwrap_or(&config.provider);
+    match provider_name {
         "copilot" => Ok(()),
 
         "openai" => {
@@ -302,10 +308,7 @@ pub fn validate_provider_config(config: &Config) -> Result<(), LLMError> {
             Ok(())
         }
 
-        _ => Err(LLMError::Auth(format!(
-            "Unknown provider: {}",
-            config.provider
-        ))),
+        _ => Err(LLMError::Auth(format!("Unknown provider: {provider_name}"))),
     }
 }
 
@@ -509,6 +512,31 @@ mod tests {
             .unwrap(),
         );
         config.default_provider_instance = Some("work".to_string());
+
+        assert!(validate_provider_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_legacy_default_alongside_explicit_instances() {
+        let mut config = config_with_provider(
+            "anthropic",
+            ProviderConfigs {
+                openai: Some(OpenAIConfig {
+                    api_key: "sk-legacy".to_string(),
+                    ..OpenAIConfig::default()
+                }),
+                ..ProviderConfigs::default()
+            },
+        );
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "copilot",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("openai".to_string());
 
         assert!(validate_provider_config(&config).is_ok());
     }


### PR DESCRIPTION
## Summary

- treat an explicit default provider instance as authoritative only when its ID exists in `provider_instances`
- validate that selected instance directly instead of requiring the legacy `Config.provider` / `Config.providers` pair
- canonicalize instance-native runtime state and durable writes by removing the legacy selector and five built-in aliases
- prevent raw/existing migration deep-merges from resurrecting removed aliases while preserving unknown forward-compatible metadata
- preserve the supported hybrid compatibility path where the default key is a legacy provider type alongside explicit instances
- keep public compatibility serialization and genuinely legacy-only configurations readable until the broader retirement tracked by #730

Closes #780.

## Root cause

The canonical provider-settings PUT copied instance data into a candidate and then called `validate_provider_config`, which always followed the legacy selector. A valid selected instance could therefore fail with `Anthropic configuration required` unless callers created an unrelated legacy alias.

Persistence and migration also retained—or could reintroduce through deep merge—the stale selector and built-in aliases. Review additionally found that treating every non-null `default_provider_instance` as instance-native would break the existing hybrid legacy-default API. The final implementation distinguishes an actual explicit instance ID from a known legacy provider type.

## User impact

Instance-native model/default updates now work without synthetic legacy provider entries. Canonical saves, restart, no-op round trips, and dual-file migration keep only the explicit instances and isolated credential references. Existing hybrid and legacy-only routing remains compatible.

## Test Plan

- `cargo test -p bamboo-config --lib -- --test-threads=1` — 636 passed
- `cargo test -p bamboo-llm --lib` — 561 passed
- `cargo test -p bamboo-server --lib provider_settings -- --test-threads=1` — 5 passed
- `cargo test -p bamboo-server --lib provider_instance_runtime_fields_are_explicit_editable_and_preserve_unknown_metadata -- --test-threads=1` — passed
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p bamboo-config -p bamboo-llm --all-targets -- -D warnings`
- `cargo clippy -p bamboo-server --all-targets -- -D warnings -A clippy::too_many_arguments`
- independent exact-head review and Issue #780 acceptance audit — no blocking findings

The server regression covers `providers: {}`, two configured instances, an explicit default, a semantic no-op PUT, credential redaction and durable refs, disk normalization, and restart. Hybrid regressions cover durable DTOs, facade projection/migration, LLM validation, canonical PUT, credential recovery, and restart.

## Screenshots

Not applicable; backend/configuration-only change.
