### PR TITLE
fix: gate explicit prompt caching per provider instance (#781)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -142,6 +142,10 @@ pub struct ProviderInstanceSettingsData {
     pub responses_only_models: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_overrides: Option<RequestOverridesConfig>,
+    /// OpenAI-only compatibility switch for Bamboo-generated GPT-5.6+
+    /// `prompt_cache_options` and `prompt_cache_breakpoint` fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub explicit_prompt_cache: Option<bool>,
     #[serde(default = "provider_instance_enabled_default")]
     pub enabled: bool,
     /// Bodhi-only upstream routing target.
@@ -168,6 +172,14 @@ impl ProviderInstanceSettingsData {
             reasoning_effort: instance.reasoning_effort,
             responses_only_models: instance.responses_only_models.clone(),
             request_overrides: instance.request_overrides.clone(),
+            explicit_prompt_cache: (instance.provider_type == "openai")
+                .then(|| {
+                    instance
+                        .extra
+                        .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY)
+                        .and_then(Value::as_bool)
+                })
+                .flatten(),
             enabled: instance.enabled,
             target_provider: (instance.provider_type == "bodhi")
                 .then(|| {
@@ -199,6 +211,12 @@ impl ProviderInstanceSettingsData {
             extra.insert(
                 "thinking_replay_always".to_string(),
                 json!(thinking_replay_always),
+            );
+        }
+        if let Some(explicit_prompt_cache) = self.explicit_prompt_cache {
+            extra.insert(
+                bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY.to_string(),
+                json!(explicit_prompt_cache),
             );
         }
         ProviderInstanceConfig {
@@ -871,7 +889,12 @@ fn retain_provider_settings_server_owned_fields(
                 .extra
                 .iter()
                 .filter(|(key, _)| {
-                    !matches!(key.as_str(), "target_provider" | "thinking_replay_always")
+                    !matches!(
+                        key.as_str(),
+                        "target_provider"
+                            | "thinking_replay_always"
+                            | bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY
+                    )
                 })
                 .map(|(key, value)| (key.clone(), value.clone()))
                 .collect();
@@ -1019,6 +1042,12 @@ fn validate_provider_instance_shape(
         if instance.thinking_replay_always.is_some() && instance.provider_type != "anthropic" {
             return Err(format!(
                 "thinking_replay_always is only accepted for anthropic provider instance '{id}'"
+            ));
+        }
+        if instance.explicit_prompt_cache.is_some() && instance.provider_type != "openai" {
+            return Err(format!(
+                "{} is only accepted for OpenAI provider instance '{id}'",
+                bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY
             ));
         }
     }
@@ -1364,6 +1393,7 @@ fn provider_diagnostics(config: &bamboo_llm::Config) -> Value {
                 "vision_model": provider.vision_model,
                 "reasoning_effort": provider.reasoning_effort,
                 "responses_only_models": provider.responses_only_models,
+                "explicit_prompt_cache": provider.explicit_prompt_cache_enabled(),
             }),
         );
     }
@@ -2778,6 +2808,12 @@ mod tests {
                     "label": "GLM compatible",
                     "thinking_replay_always": true,
                     "enabled": false
+                },
+                "openai-proxy": {
+                    "provider_type": "openai",
+                    "label": "OpenAI-compatible proxy",
+                    "explicit_prompt_cache": false,
+                    "enabled": false
                 }
             },
             "default_provider_instance_id": null
@@ -2818,6 +2854,10 @@ mod tests {
             created["data"]["provider_instances"]["glm-compat"]["thinking_replay_always"],
             true
         );
+        assert_eq!(
+            created["data"]["provider_instances"]["openai-proxy"]["explicit_prompt_cache"],
+            false
+        );
 
         let hidden_value = "server-owned-provider-instance-metadata";
         state
@@ -2833,6 +2873,7 @@ mod tests {
         let mut updated = created["data"].clone();
         updated["provider_instances"]["bodhi-proxy"]["target_provider"] = json!("anthropic");
         updated["provider_instances"]["glm-compat"]["thinking_replay_always"] = json!(false);
+        updated["provider_instances"]["openai-proxy"]["explicit_prompt_cache"] = json!(true);
         let updated = test::call_service(
             &app,
             test::TestRequest::put()
@@ -2854,6 +2895,10 @@ mod tests {
             updated["data"]["provider_instances"]["glm-compat"]["thinking_replay_always"],
             false
         );
+        assert_eq!(
+            updated["data"]["provider_instances"]["openai-proxy"]["explicit_prompt_cache"],
+            true
+        );
         {
             let config = state.config.read().await;
             assert_eq!(
@@ -2868,6 +2913,11 @@ mod tests {
                 config.provider_instances["glm-compat"].extra["thinking_replay_always"],
                 false
             );
+            assert_eq!(
+                config.provider_instances["openai-proxy"].extra
+                    [bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY],
+                true
+            );
         }
 
         let mut removed = updated["data"].clone();
@@ -2879,6 +2929,10 @@ mod tests {
             .as_object_mut()
             .unwrap()
             .remove("thinking_replay_always");
+        removed["provider_instances"]["openai-proxy"]
+            .as_object_mut()
+            .unwrap()
+            .remove("explicit_prompt_cache");
         let removed = test::call_service(
             &app,
             test::TestRequest::put()
@@ -2894,6 +2948,10 @@ mod tests {
         assert!(
             removed["data"]["provider_instances"]["glm-compat"]["thinking_replay_always"].is_null()
         );
+        assert!(
+            removed["data"]["provider_instances"]["openai-proxy"]["explicit_prompt_cache"]
+                .is_null()
+        );
         {
             let config = state.config.read().await;
             assert_eq!(
@@ -2906,6 +2964,9 @@ mod tests {
             assert!(!config.provider_instances["glm-compat"]
                 .extra
                 .contains_key("thinking_replay_always"));
+            assert!(!config.provider_instances["openai-proxy"]
+                .extra
+                .contains_key(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY));
         }
 
         for (id, field, value) in [
@@ -2913,6 +2974,7 @@ mod tests {
             ("bodhi-proxy", "thinking_replay_always", json!(true)),
             ("bodhi-proxy", "target_provider", json!("copilot")),
             ("glm-compat", "target_provider", json!("openai")),
+            ("glm-compat", "explicit_prompt_cache", json!(false)),
         ] {
             let mut invalid = removed["data"].clone();
             invalid["provider_instances"][id][field] = value;

--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -185,6 +185,24 @@ fn validate_provider_type(provider_type: &str) -> Result<(), AppError> {
 fn validate_instance_config(instance: &ProviderInstanceConfig) -> Result<(), AppError> {
     validate_provider_type(&instance.provider_type)?;
 
+    if let Some(value) = instance
+        .extra
+        .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY)
+    {
+        if instance.provider_type != "openai" {
+            return Err(AppError::BadRequest(format!(
+                "{} is only accepted for OpenAI provider instances",
+                bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY
+            )));
+        }
+        if !value.is_boolean() {
+            return Err(AppError::BadRequest(format!(
+                "{} must be a boolean",
+                bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY
+            )));
+        }
+    }
+
     if instance.provider_type != "copilot" && instance.api_key.trim().is_empty() {
         return Err(AppError::BadRequest(
             "api_key is required for non-copilot providers".to_string(),
@@ -562,6 +580,43 @@ mod tests {
         let instance = build_instance_from_create(&create_request("****...****sk-new"))
             .expect("mixed value is not a placeholder");
         assert_eq!(instance.api_key, "****...****sk-new");
+    }
+
+    #[test]
+    fn openai_instance_accepts_explicit_prompt_cache_switch() {
+        let mut request = create_request("sk-real");
+        request.config["explicit_prompt_cache"] = Value::Bool(false);
+
+        let instance = build_instance_from_create(&request).expect("valid OpenAI switch");
+        assert_eq!(
+            instance
+                .extra
+                .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY),
+            Some(&Value::Bool(false))
+        );
+        assert_eq!(
+            instance_config_to_api(&instance)
+                .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY),
+            Some(&Value::Bool(false))
+        );
+    }
+
+    #[test]
+    fn explicit_prompt_cache_switch_rejects_wrong_type_or_provider() {
+        let mut wrong_type = create_request("sk-real");
+        wrong_type.config["explicit_prompt_cache"] = Value::String("false".to_string());
+        assert!(matches!(
+            build_instance_from_create(&wrong_type),
+            Err(AppError::BadRequest(_))
+        ));
+
+        let mut wrong_provider = create_request("sk-real");
+        wrong_provider.provider_type = "anthropic".to_string();
+        wrong_provider.config["explicit_prompt_cache"] = Value::Bool(false);
+        assert!(matches!(
+            build_instance_from_create(&wrong_provider),
+            Err(AppError::BadRequest(_))
+        ));
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -2623,6 +2623,8 @@ fn default_true_hooks() -> bool {
 ///   "model": "gpt-4"
 /// }
 /// ```
+pub const OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY: &str = "explicit_prompt_cache";
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct OpenAIConfig {
     /// OpenAI API key (plaintext, in-memory only).
@@ -2675,6 +2677,21 @@ pub struct OpenAIConfig {
     /// Preserve unknown keys under `providers.openai`.
     #[serde(default, flatten)]
     pub extra: BTreeMap<String, Value>,
+}
+
+impl OpenAIConfig {
+    /// Whether Bamboo may lower its provider-neutral cache plan into GPT-5.6+
+    /// `prompt_cache_options` and `prompt_cache_breakpoint` fields.
+    ///
+    /// This defaults to enabled. OpenAI-compatible upstreams that have not yet
+    /// implemented the explicit-cache request fields can opt out without
+    /// disabling `prompt_cache_key` or the upstream's implicit prompt cache.
+    pub fn explicit_prompt_cache_enabled(&self) -> bool {
+        self.extra
+            .get(OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY)
+            .and_then(Value::as_bool)
+            .unwrap_or(true)
+    }
 }
 
 /// Anthropic provider configuration

--- a/crates/infra/bamboo-config/src/provider_instance.rs
+++ b/crates/infra/bamboo-config/src/provider_instance.rs
@@ -31,7 +31,7 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     responses_only_models: openai.responses_only_models.clone(),
                     request_overrides: openai.request_overrides.clone(),
                     enabled: true,
-                    extra: Default::default(),
+                    extra: openai.extra.clone(),
                 },
             ));
         }
@@ -193,6 +193,11 @@ mod tests {
     #[test]
     fn synthesize_produces_openai_from_legacy() {
         let mut config = clean_test_config();
+        let mut extra = std::collections::BTreeMap::new();
+        extra.insert(
+            crate::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY.to_string(),
+            serde_json::json!(false),
+        );
         config.providers.openai = Some(crate::config::OpenAIConfig {
             api_key: "sk-test".to_string(),
             api_key_encrypted: None,
@@ -204,7 +209,7 @@ mod tests {
             reasoning_effort: None,
             responses_only_models: vec![],
             request_overrides: None,
-            extra: Default::default(),
+            extra,
             api_key_from_env: false,
         });
         // Clear any other legacy providers to isolate this test.
@@ -221,6 +226,11 @@ mod tests {
         assert_eq!(inst.provider_type, "openai");
         assert_eq!(inst.api_key, "sk-test");
         assert_eq!(inst.model.as_deref(), Some("gpt-4o"));
+        assert_eq!(
+            inst.extra
+                .get(crate::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY),
+            Some(&serde_json::json!(false))
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -111,6 +111,8 @@ pub async fn create_provider_by_name(
             }
 
             provider = provider.with_reasoning_effort(openai_config.reasoning_effort);
+            provider =
+                provider.with_explicit_prompt_cache(openai_config.explicit_prompt_cache_enabled());
             provider = provider.with_request_overrides(openai_config.request_overrides.clone());
 
             Ok(Arc::new(provider.with_masking(masking_config.clone())))

--- a/crates/infra/bamboo-llm/src/provider_registry.rs
+++ b/crates/infra/bamboo-llm/src/provider_registry.rs
@@ -369,6 +369,17 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
     let providers = config.providers_mut();
     match instance.provider_type.as_str() {
         "openai" => {
+            let extra = instance
+                .extra
+                .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY)
+                .map(|value| {
+                    std::iter::once((
+                        bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY.to_string(),
+                        value.clone(),
+                    ))
+                    .collect()
+                })
+                .unwrap_or_default();
             providers.openai = Some(bamboo_config::OpenAIConfig {
                 api_key: instance.api_key.clone(),
                 // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
@@ -383,7 +394,7 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
                 reasoning_effort: instance.reasoning_effort,
                 responses_only_models: instance.responses_only_models.clone(),
                 request_overrides: instance.request_overrides.clone(),
-                extra: Default::default(),
+                extra,
             });
         }
         "anthropic" => {
@@ -606,6 +617,11 @@ mod tests {
     #[test]
     fn test_apply_instance_to_config_openai() {
         let mut config = Config::default();
+        let mut extra = std::collections::BTreeMap::new();
+        extra.insert(
+            bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY.to_string(),
+            serde_json::json!(false),
+        );
         let instance = ProviderInstanceConfig {
             provider_type: "openai".to_string(),
             label: Some("Test OpenAI".to_string()),
@@ -620,7 +636,7 @@ mod tests {
             responses_only_models: vec![],
             request_overrides: None,
             enabled: true,
-            extra: Default::default(),
+            extra,
         };
 
         apply_instance_to_config(&mut config, &instance);
@@ -636,6 +652,7 @@ mod tests {
             Some("https://custom.api.com/v1")
         );
         assert_eq!(openai.model.as_deref(), Some("gpt-4o"));
+        assert!(!openai.explicit_prompt_cache_enabled());
         assert_eq!(config.provider, "openai");
     }
 

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -39,6 +39,7 @@ pub struct OpenAIProvider {
     base_url: String,
     responses_only_models: Vec<String>,
     default_reasoning_effort: Option<ReasoningEffort>,
+    explicit_prompt_cache: bool,
     request_overrides: Option<RequestOverridesConfig>,
     masking_config: KeywordMaskingConfig,
 }
@@ -52,6 +53,7 @@ impl OpenAIProvider {
             base_url: "https://api.openai.com/v1".to_string(),
             responses_only_models: vec![],
             default_reasoning_effort: None,
+            explicit_prompt_cache: true,
             request_overrides: None,
             masking_config: KeywordMaskingConfig::default(),
         }
@@ -85,6 +87,16 @@ impl OpenAIProvider {
     /// Configure default reasoning effort for requests sent through this provider.
     pub fn with_reasoning_effort(mut self, effort: Option<ReasoningEffort>) -> Self {
         self.default_reasoning_effort = effort;
+        self
+    }
+
+    /// Enable or disable Bamboo-generated GPT-5.6+ explicit prompt-cache
+    /// controls for this provider instance.
+    ///
+    /// Disabling this does not remove a caller-supplied `prompt_cache_key`, so
+    /// compatible upstreams can continue using their implicit prompt cache.
+    pub fn with_explicit_prompt_cache(mut self, enabled: bool) -> Self {
+        self.explicit_prompt_cache = enabled;
         self
     }
 
@@ -175,6 +187,7 @@ impl OpenAIProvider {
             ResponsesInputSource::Explicit => "explicit",
             ResponsesInputSource::Generic => "generic",
         };
+        let generated_cache_plan = self.explicit_prompt_cache.then_some(cache_plan).flatten();
         let mut body = build_responses_body(
             model,
             messages,
@@ -183,7 +196,7 @@ impl OpenAIProvider {
             reasoning_effort,
             responses_options,
             parallel_tool_calls,
-            cache_plan,
+            generated_cache_plan,
         );
         request_overrides::apply_overrides_to_body(
             &mut body,
@@ -197,7 +210,7 @@ impl OpenAIProvider {
         // Last-moment scan: mask every text value in the fully-assembled body.
         crate::masking::mask_outbound_body(&mut body, &self.masking_config);
         tracing::info!(
-            "[{}] OpenAI request protocol=responses model='{}' reasoning_effort={} reasoning_source={} request_reasoning_enabled={} max_output_tokens={} input_source={} input_messages_before={} input_messages_after={} duplicate_system_fallback={} [{}]",
+            "[{}] OpenAI request protocol=responses model='{}' reasoning_effort={} reasoning_source={} request_reasoning_enabled={} max_output_tokens={} input_source={} input_messages_before={} input_messages_after={} duplicate_system_fallback={} explicit_prompt_cache={} [{}]",
             session_log_id,
             model,
             reasoning_effort
@@ -212,6 +225,7 @@ impl OpenAIProvider {
             input_selection.original_len,
             input_selection.effective_len,
             input_selection.fallback_removed_duplicate_system,
+            self.explicit_prompt_cache,
             request_purpose
         );
 
@@ -261,7 +275,7 @@ impl OpenAIProvider {
                     reasoning_effort,
                     Some(&fallback_options),
                     parallel_tool_calls,
-                    cache_plan,
+                    generated_cache_plan,
                 );
                 request_overrides::apply_overrides_to_body(
                     &mut fallback_body,
@@ -333,7 +347,7 @@ impl OpenAIProvider {
                     None,
                     Some(&fallback_options),
                     parallel_tool_calls,
-                    cache_plan,
+                    generated_cache_plan,
                 );
                 request_overrides::apply_overrides_to_body(
                     &mut fallback_body,
@@ -696,6 +710,7 @@ mod tests {
         let provider = OpenAIProvider::new("test_key");
         assert_eq!(provider.api_key, "test_key");
         assert_eq!(provider.base_url, "https://api.openai.com/v1");
+        assert!(provider.explicit_prompt_cache);
     }
 
     #[test]
@@ -713,11 +728,13 @@ mod tests {
 
     #[test]
     fn test_chained_builders() {
-        let provider =
-            OpenAIProvider::new("test_key").with_base_url("https://custom.openai.com/v1");
+        let provider = OpenAIProvider::new("test_key")
+            .with_base_url("https://custom.openai.com/v1")
+            .with_explicit_prompt_cache(false);
 
         assert_eq!(provider.api_key, "test_key");
         assert_eq!(provider.base_url, "https://custom.openai.com/v1");
+        assert!(!provider.explicit_prompt_cache);
     }
 
     #[test]
@@ -1054,6 +1071,47 @@ mod tests {
         OpenAIProvider::new("test-key")
             .with_base_url(server.uri())
             .with_responses_only_models(vec!["gpt-5*".to_string()])
+    }
+
+    #[tokio::test]
+    async fn responses_can_disable_generated_explicit_cache_without_dropping_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(RESPONSES_SSE_OK),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = responses_provider(&server).with_explicit_prompt_cache(false);
+        let mut stable = Message::user("stable prefix");
+        stable.id = "stable-message".to_string();
+        let options = LLMRequestOptions {
+            responses: Some(ResponsesRequestOptions {
+                prompt_cache_key: Some("session-cache-key".to_string()),
+                ..Default::default()
+            }),
+            cache: Some(crate::cache::PromptCachePlan {
+                breakpoint_message_ids: vec!["stable-message".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let _stream = provider
+            .chat_stream_with_options(&[stable], &[], None, "gpt-5.6-sol", Some(&options))
+            .await
+            .expect("Responses request without generated explicit cache fields");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(body["prompt_cache_key"], "session-cache-key");
+        assert!(body.get("prompt_cache_options").is_none());
+        assert!(!body.to_string().contains("prompt_cache_breakpoint"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add an OpenAI provider-instance `explicit_prompt_cache` capability switch, defaulting to `true`.
- When disabled, omit only Bamboo-generated GPT-5.6 `prompt_cache_options` and nested `prompt_cache_breakpoint`.
- Preserve `prompt_cache_key`, implicit prefix caching, caller-supplied Responses options, and operator request overrides.
- Round-trip and validate the capability through legacy synthesis, provider registry projection, provider CRUD, and canonical provider-settings persistence.

## Root Cause

Bamboo inferred explicit prompt-cache support from the GPT-5.6 model family alone. The same Responses model can run behind an OpenAI-compatible endpoint that supports implicit caching but rejects the explicit cache fields, so this must be a provider-instance capability rather than a model-name or custom-`base_url` heuristic.

## User Impact

CLIProxy-compatible instances can disable unsupported explicit cache controls without disabling implicit upstream caching or losing stable cache keys. Existing provider instances retain current behavior because the setting defaults to enabled.

Fixes #781

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p bamboo-config -p bamboo-llm` (628 + 554 tests)
- [x] `cargo test -p bamboo-server` (1,738 unit tests plus integrations and docs)
- [x] Full workspace `cargo test`
- [x] Strict Clippy for affected config/LLM crates
- [x] Server Clippy with the existing unrelated `bridge.rs` `too_many_arguments` lint allowed
- [x] Live registered-workspace smoke against CLIProxy using `gpt-5.6-sol` and a real cache-breakpoint plan; completed with `OK` and no unsupported-parameter 400
- [x] Rebased onto current `dev`, then reran format and affected-crate tests

## Screenshots

Not applicable (backend/configuration change only).