### PR TITLE
[bamboo-llm] fix: preserve SSE comment heartbeats for transport-idle liveness

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -11,6 +11,7 @@ use bamboo_config::StreamTimeoutConfig;
 use bamboo_llm::provider::LLMError;
 use bamboo_llm::providers::common::openai_compat::parse_openai_compat_sse_data_strict;
 use bamboo_llm::providers::common::openai_responses::ResponsesSseParser;
+use bamboo_llm::providers::common::sse::llm_stream_from_sse_multi_requiring_done;
 use bamboo_llm::{LLMChunk, LLMStream};
 
 use super::consume::consume_llm_stream_internal;
@@ -762,6 +763,78 @@ async fn transport_keepalives_allow_midstream_semantic_gap_after_120_seconds() {
     .expect("live stream should survive a 180-second semantic gap");
 
     assert_eq!(output.content, "firstsecond");
+}
+
+#[tokio::test(start_paused = true)]
+async fn sse_comment_heartbeats_survive_transport_timeout_until_responses_completion() {
+    let chunks = vec![
+        (
+            Duration::ZERO,
+            bytes::Bytes::from_static(
+                b"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"delta\":\"first\"}\n\n",
+            ),
+        ),
+        (
+            Duration::from_secs(30),
+            bytes::Bytes::from_static(b": keep-alive\n\n"),
+        ),
+        (
+            Duration::from_secs(30),
+            bytes::Bytes::from_static(b": keep-alive\n\n"),
+        ),
+        (
+            Duration::from_secs(30),
+            bytes::Bytes::from_static(b": keep-alive\n\n"),
+        ),
+        (
+            Duration::from_secs(30),
+            bytes::Bytes::from_static(b": keep-alive\n\n"),
+        ),
+        (
+            Duration::from_secs(30),
+            bytes::Bytes::from_static(
+                b"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"delta\":\"second\"}\n\n",
+            ),
+        ),
+        (
+            Duration::ZERO,
+            bytes::Bytes::from_static(
+                b"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_done\"}}\n\n",
+            ),
+        ),
+    ];
+    let body_stream = stream::unfold(chunks.into_iter(), |mut chunks| async move {
+        let (delay, chunk) = chunks.next()?;
+        tokio::time::sleep(delay).await;
+        Some((Ok::<_, std::io::Error>(chunk), chunks))
+    });
+    let response = reqwest::Response::from(
+        http::Response::builder()
+            .status(200)
+            .header("content-type", "text/event-stream")
+            .body(reqwest::Body::wrap_stream(body_stream))
+            .expect("http response"),
+    );
+    let mut parser = ResponsesSseParser::new();
+    let stream = llm_stream_from_sse_multi_requiring_done(
+        response,
+        move |event, data| parser.handle_event_multi(event, data),
+        "OpenAI Responses",
+    );
+    let context = timeout_context(45, 200, 200);
+
+    let output = consume_llm_stream_internal(
+        stream,
+        None,
+        &CancellationToken::new(),
+        "session-comment-heartbeat",
+        &context,
+    )
+    .await
+    .expect("comment heartbeats should preserve transport liveness");
+
+    assert_eq!(output.content, "firstsecond");
+    assert_eq!(output.response_id.as_deref(), Some("resp_done"));
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/infra/bamboo-llm/src/providers/common/sse.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/sse.rs
@@ -1,8 +1,14 @@
 //! Shared SSE -> [`LLMStream`] adapter.
 
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::task::Poll;
+
 use eventsource_stream::Eventsource;
 use futures::stream;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use reqwest::Response;
 use serde_json::Value;
 
@@ -58,7 +64,10 @@ where
 /// Like [`llm_stream_from_sse`], but the handler may emit **zero or more**
 /// chunks per SSE event; they are flattened into the stream in order. A valid
 /// event producing zero chunks becomes one [`LLMChunk::TransportActivity`]
-/// marker rather than disappearing from the transport watchdog.
+/// marker rather than disappearing from the transport watchdog. Successfully
+/// received, non-empty HTTP body chunks are observed before EventSource
+/// dispatch, so SSE comments and incomplete event fragments also retain
+/// transport liveness while remaining invisible to provider handlers.
 ///
 /// This is required for providers where a single SSE event must surface
 /// multiple logical chunks. The motivating case is Gemini: a final
@@ -72,20 +81,61 @@ pub fn llm_stream_from_sse_multi<H>(response: Response, mut handler: H) -> LLMSt
 where
     H: FnMut(&str, &str) -> Result<Vec<LLMChunk>> + Send + 'static,
 {
-    let stream = response
-        .bytes_stream()
-        .eventsource()
-        .map(move |event| {
-            let event = event.map_err(|e| LLMError::Stream(e.to_string()))?;
-            handler(event.event.as_str(), event.data.as_str()).map_err(to_stream_error)
-        })
-        .flat_map(|result| {
-            stream::iter(match result {
-                Ok(chunks) if chunks.is_empty() => vec![Ok(LLMChunk::TransportActivity)],
-                Ok(chunks) => chunks.into_iter().map(Ok).collect::<Vec<_>>(),
-                Err(err) => vec![Err(err)],
+    // `eventsource-stream` intentionally discards SSE comments and buffers
+    // incomplete event fragments. Observe the raw body first so those bytes
+    // can still refresh the independent transport watchdog (#787). A boolean
+    // coalesces any number of synchronously consumed fragments into at most
+    // one marker and cannot build an unbounded side queue.
+    let raw_body_activity = Arc::new(AtomicBool::new(false));
+    let observed_activity = Arc::clone(&raw_body_activity);
+    let observed_body = response.bytes_stream().map(move |result| {
+        if result.as_ref().is_ok_and(|bytes| !bytes.is_empty()) {
+            observed_activity.store(true, Ordering::Relaxed);
+        }
+        result
+    });
+
+    let mut parsed = Box::pin(
+        observed_body
+            .eventsource()
+            .map(move |event| {
+                let event = event.map_err(|e| LLMError::Stream(e.to_string()))?;
+                handler(event.event.as_str(), event.data.as_str()).map_err(to_stream_error)
             })
-        });
+            .flat_map(|result| {
+                stream::iter(match result {
+                    Ok(chunks) if chunks.is_empty() => vec![Ok(LLMChunk::TransportActivity)],
+                    Ok(chunks) => chunks.into_iter().map(Ok).collect::<Vec<_>>(),
+                    Err(err) => vec![Err(err)],
+                })
+            }),
+    );
+
+    // Poll the parser first. When it immediately produces an item, that item
+    // already counts as transport activity in the engine, so suppress the
+    // redundant raw marker. If comments/fragments made the parser return
+    // Pending (or EOF), surface exactly one internal marker first. The next
+    // poll then preserves the parser's original Pending/EOF/error contract.
+    let stream = stream::poll_fn(move |cx| match parsed.as_mut().poll_next(cx) {
+        Poll::Ready(Some(item)) => {
+            raw_body_activity.store(false, Ordering::Relaxed);
+            Poll::Ready(Some(item))
+        }
+        Poll::Ready(None) => {
+            if raw_body_activity.swap(false, Ordering::Relaxed) {
+                Poll::Ready(Some(Ok(LLMChunk::TransportActivity)))
+            } else {
+                Poll::Ready(None)
+            }
+        }
+        Poll::Pending => {
+            if raw_body_activity.swap(false, Ordering::Relaxed) {
+                Poll::Ready(Some(Ok(LLMChunk::TransportActivity)))
+            } else {
+                Poll::Pending
+            }
+        }
+    });
 
     Box::pin(stream)
 }
@@ -137,9 +187,30 @@ mod tests {
     use crate::providers::anthropic::{parse_anthropic_sse_event, AnthropicStreamState};
     use crate::providers::common::openai_compat::parse_openai_compat_sse_data_strict_multi;
     use crate::providers::common::openai_responses::ResponsesSseParser;
+    use bytes::Bytes;
     use futures::StreamExt;
     use serde_json::json;
-    // use http; // TODO: add http crate if needed
+
+    /// Build a body whose chunks are separated by an actual `Poll::Pending`.
+    /// This models network delivery and ensures the adapter has an opportunity
+    /// to surface liveness before an incomplete SSE event becomes dispatchable.
+    fn chunked_sse_response(chunks: Vec<Bytes>) -> Response {
+        let body_stream = stream::unfold(chunks.into_iter(), |mut chunks| async move {
+            tokio::task::yield_now().await;
+            chunks
+                .next()
+                .map(|chunk| (Ok::<_, std::io::Error>(chunk), chunks))
+        });
+        let body = reqwest::Body::wrap_stream(body_stream);
+
+        reqwest::Response::from(
+            http::Response::builder()
+                .status(200)
+                .header("content-type", "text/event-stream")
+                .body(body)
+                .expect("http response"),
+        )
+    }
 
     #[test]
     fn sse_error_is_present_distinguishes_real_errors_from_benign_markers() {
@@ -242,6 +313,105 @@ mod tests {
             .expect("keepalive should yield a liveness marker")
             .expect("keepalive should not fail the stream");
         assert!(matches!(chunk, LLMChunk::TransportActivity));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn sse_comment_only_body_is_preserved_as_transport_activity() {
+        let response = chunked_sse_response(vec![Bytes::from_static(b": keep-alive\n\n")]);
+        let mut stream = llm_stream_from_sse(response, |_event, _data| {
+            panic!("SSE comments must not be dispatched to the provider handler")
+        });
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(LLMChunk::TransportActivity))
+        ));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn partial_sse_fragments_refresh_transport_without_corrupting_utf8() {
+        let response = chunked_sse_response(vec![
+            Bytes::from_static(b"event: token\ndata: \xe4"),
+            Bytes::from_static(b"\xbd\xa0\xe5"),
+            Bytes::from_static(b"\xa5\xbd\n\n"),
+        ]);
+        let mut stream = llm_stream_from_sse(response, |event, data| {
+            Ok(Some(LLMChunk::Token(format!("{event}:{data}"))))
+        });
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(LLMChunk::TransportActivity))
+        ));
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(LLMChunk::TransportActivity))
+        ));
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(LLMChunk::Token(text))) if text == "token:你好"
+        ));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn responses_comment_then_completed_emits_one_done_without_trailing_activity() {
+        let response = chunked_sse_response(vec![
+            Bytes::from_static(b": keep-alive\n\n"),
+            Bytes::from_static(
+                b"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_done\"}}\n\n",
+            ),
+        ]);
+        let mut parser = ResponsesSseParser::new();
+        let mut stream = llm_stream_from_sse_multi_requiring_done(
+            response,
+            move |event, data| parser.handle_event_multi(event, data),
+            "OpenAI Responses",
+        );
+
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.expect("valid Responses stream"));
+        }
+
+        assert!(matches!(chunks.first(), Some(LLMChunk::TransportActivity)));
+        assert!(chunks
+            .iter()
+            .any(|chunk| matches!(chunk, LLMChunk::ResponseId(id) if id == "resp_done")));
+        assert_eq!(
+            chunks
+                .iter()
+                .filter(|chunk| matches!(chunk, LLMChunk::Done))
+                .count(),
+            1
+        );
+        assert!(matches!(chunks.last(), Some(LLMChunk::Done)));
+    }
+
+    #[tokio::test]
+    async fn responses_comment_then_eof_emits_activity_and_one_terminal_error() {
+        let response = chunked_sse_response(vec![Bytes::from_static(b": keep-alive\n\n")]);
+        let mut parser = ResponsesSseParser::new();
+        let mut stream = llm_stream_from_sse_multi_requiring_done(
+            response,
+            move |event, data| parser.handle_event_multi(event, data),
+            "OpenAI Responses",
+        );
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(LLMChunk::TransportActivity))
+        ));
+        let error = stream
+            .next()
+            .await
+            .expect("premature EOF error")
+            .expect_err("comment-only EOF cannot complete a Responses stream");
+        assert!(error
+            .to_string()
+            .contains("ended before a protocol terminal event"));
         assert!(stream.next().await.is_none());
     }
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -191,7 +191,7 @@ main response stream and auxiliary silent model calls:
 
 | Field | Default | Meaning |
 |---|---:|---|
-| `transport_idle_timeout_secs` | `120` | Maximum gap between valid provider transport frames. Parsed SSE ping/lifecycle frames count even when they contain no token. |
+| `transport_idle_timeout_secs` | `120` | Maximum gap between successfully received, non-empty provider response-body chunks. SSE ping/lifecycle events, comment heartbeats, and partial event fragments count even when they contain no token. |
 | `first_semantic_timeout_secs` | `600` | Maximum time from request dispatch to the first text, reasoning, or tool-call delta. Transport keepalives do not extend it. |
 | `semantic_idle_timeout_secs` | `600` | Maximum semantic-progress gap after output starts. Transport keepalives do not extend it. |
 
@@ -202,6 +202,29 @@ deadline, provider/model identifiers, and last transport/semantic activity,
 but never include prompts or raw provider payloads. A stream timeout is not
 automatically retried, because replay after partial output or tool-call deltas
 could duplicate externally visible state.
+
+### OpenAI-compatible proxy heartbeats
+
+An OpenAI-compatible proxy should either forward upstream response bytes or
+emit an SSE heartbeat more frequently than `transport_idle_timeout_secs`.
+Bamboo treats any successfully received, non-empty body chunk as transport
+activity before parsing SSE, including the standard comment form
+`: keep-alive\n\n`. These internal activity markers do not become model output
+and do not extend either semantic deadline.
+
+For example, CLIProxyAPI supports periodic streaming heartbeats with:
+
+```yaml
+streaming:
+  keepalive-seconds: 15
+```
+
+CLIProxyAPI documents `0` (disabled) as the default. Operators using that or
+another compatible proxy should choose a heartbeat interval safely below the
+transport timeout. If a proxy cannot emit heartbeats during long upstream
+reasoning gaps, configure `transport_idle_timeout_secs` at least as high as the
+intended semantic wait instead; disabling the bounded transport watchdog is
+not recommended.
 
 ## Memory / auto-dream / gardener
 


### PR DESCRIPTION
## Summary

- observe successful non-empty HTTP body chunks before `eventsource-stream` parsing so SSE comments and partial fragments refresh Bamboo's transport watchdog
- coalesce raw activity into bounded internal `LLMChunk::TransportActivity` markers without exposing heartbeat bytes as model output
- preserve parser errors, premature-EOF failure, and the exactly-once Responses `Done` contract
- document CLIProxyAPI heartbeat configuration and timeout guidance

## Root Cause

The shared SSE adapter previously derived transport liveness only from parsed EventSource events. Standard SSE comment heartbeats such as `: keep-alive\n\n` are valid received transport bytes, but `eventsource-stream` intentionally consumes them without dispatching an event. Partial SSE fragments are buffered for the same reason. Consequently, neither form reached `LLMStream`, so the engine's 120-second transport watchdog could expire even while a proxy connection was still receiving bytes.

The production incident also depends on an operational precondition: CLIProxyAPI defaults `streaming.keepalive-seconds` to `0` (disabled). Enabling heartbeats alone was insufficient before this patch because Bamboo discarded their comment form.

## Fix

A raw-body observer now records each successful non-empty response chunk before EventSource decoding. The adapter polls the existing parser first and emits a coalesced internal transport marker only when raw activity produced no parsed output. This preserves event ordering and avoids an unbounded side queue.

The engine still treats `TransportActivity` as non-semantic, so heartbeats cannot extend `first_semantic` or `semantic_idle` deadlines. Byte-silent connections remain bounded by `transport_idle_timeout_secs`.

## Test Plan

- `cargo test --quiet`
- `cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p bamboo-llm providers::common::sse::tests -- --nocapture`
- `cargo test -p bamboo-engine keepalive -- --nocapture`
- `cargo test -p bamboo-engine sse_comment_heartbeats_survive_transport_timeout_until_responses_completion -- --nocapture`

The paused-time cross-layer regression sends Responses semantic output, four pure comment heartbeats across a 150-second semantic gap, more semantic output, and a valid terminal event under a 45-second transport deadline.

## Screenshots

Not applicable (backend transport fix).

Closes #787