### PR TITLE
fix(broker): close dropped client connections

### DIFF
--- a/crates/app/bamboo-broker/src/client.rs
+++ b/crates/app/bamboo-broker/src/client.rs
@@ -32,6 +32,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{
     connect_async_tls_with_config, Connector, MaybeTlsStream, WebSocketStream,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::error::{BrokerError, BrokerResult};
 use crate::proto::{BrokerFrame, ClientFrame};
@@ -55,6 +56,108 @@ pub(crate) type WsSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, M
 /// never hang indefinitely if the broker dies after receiving `Deliver`.
 const DELIVER_RECEIPT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Each phase of explicit client shutdown is bounded independently. Sending a
+/// Close frame can stall behind a wedged transport, and a reader can fail to
+/// observe cooperative cancellation, so neither phase may keep a caller alive
+/// indefinitely.
+pub(crate) const CLIENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Send and flush a WebSocket Close frame without trusting the transport to
+/// make progress forever. Shared by the ordinary and multiplexed client
+/// ownership shapes.
+pub(crate) async fn send_close(sink: &mut WsSink) -> BrokerResult<()> {
+    match tokio::time::timeout(CLIENT_SHUTDOWN_TIMEOUT, sink.send(Message::Close(None))).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(BrokerError::Transport(format!("send websocket close: {e}"))),
+        Err(_) => Err(BrokerError::Transport(
+            "timed out sending websocket close".into(),
+        )),
+    }
+}
+
+/// Why the WebSocket reader stopped. Keep this deliberately low-cardinality:
+/// the supervisor logs the category, never frame contents, credentials, actor
+/// ids, or endpoint details.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReaderExit {
+    IntentionalShutdown,
+    PeerClose,
+    PeerEof,
+    TransportError,
+}
+
+impl ReaderExit {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::IntentionalShutdown => "intentional_shutdown",
+            Self::PeerClose => "peer_close",
+            Self::PeerEof => "peer_eof",
+            Self::TransportError => "transport_error",
+        }
+    }
+}
+
+/// Authoritative ownership of the background reader. This value moves with
+/// the connection when a [`BrokerClient`] becomes a multiplexed client, so no
+/// public client shape can detach the read half from its owner.
+///
+/// The async shutdown path cooperatively cancels and awaits the reader. `Drop`
+/// is the non-async safety net: it marks the stop intentional, signals
+/// cancellation, and directly aborts the reader task (not merely the
+/// supervisor that owns its `JoinHandle`). Aborting the reader drops the split
+/// WebSocket source and therefore releases the underlying transport.
+pub(crate) struct ReaderLifecycle {
+    cancellation: CancellationToken,
+    reader_abort: tokio::task::AbortHandle,
+    supervisor: Option<tokio::task::JoinHandle<()>>,
+    intentional_shutdown: Arc<AtomicBool>,
+}
+
+impl ReaderLifecycle {
+    pub(crate) fn mark_intentional_shutdown(&self) {
+        self.intentional_shutdown.store(true, Ordering::SeqCst);
+    }
+
+    fn begin_intentional_shutdown(&self) {
+        self.mark_intentional_shutdown();
+        self.cancellation.cancel();
+    }
+
+    /// Cooperatively stop the reader and await its supervisor. If cooperative
+    /// cleanup misses its bound, directly abort the reader and give the
+    /// supervisor one final bounded chance to observe that outcome.
+    pub(crate) async fn shutdown(&mut self) {
+        self.begin_intentional_shutdown();
+        let Some(mut supervisor) = self.supervisor.take() else {
+            return;
+        };
+
+        if tokio::time::timeout(CLIENT_SHUTDOWN_TIMEOUT, &mut supervisor)
+            .await
+            .is_ok()
+        {
+            return;
+        }
+
+        self.reader_abort.abort();
+        if tokio::time::timeout(CLIENT_SHUTDOWN_TIMEOUT, &mut supervisor)
+            .await
+            .is_err()
+        {
+            // The reader has already been aborted. This only prevents a
+            // pathological supervisor from becoming another detached task.
+            supervisor.abort();
+        }
+    }
+}
+
+impl Drop for ReaderLifecycle {
+    fn drop(&mut self) {
+        self.begin_intentional_shutdown();
+        self.reader_abort.abort();
+    }
+}
+
 /// One demuxed serve event from [`BrokerClient::next_message_or_cancel`]: either
 /// the next inbound message or the next out-of-band cancel. The inner `Option` is
 /// `None` once that lane's channel closes (the reader exited). #45.
@@ -67,6 +170,9 @@ pub enum ServeEvent {
 
 /// A connected broker client bound to one session mailbox.
 pub struct BrokerClient {
+    /// Declared first so Drop cancels the reader before the transport sink and
+    /// response receivers are released.
+    reader: ReaderLifecycle,
     sink: WsSink,
     messages: mpsc::UnboundedReceiver<InboxMessage>,
     delivered: mpsc::UnboundedReceiver<MsgId>,
@@ -88,10 +194,6 @@ pub struct BrokerClient {
     /// right now" (`next_message() -> None` but still alive) apart from "the
     /// connection died". See [`BrokerClient::reader_alive`].
     reader_alive: Arc<AtomicBool>,
-    /// Supervisor that awaits the reader's `JoinHandle` and logs its outcome;
-    /// ends on its own the moment the reader resolves (clean disconnect → no
-    /// leaked task). Replaces the old ignored `_reader` handle.
-    _supervisor: tokio::task::JoinHandle<()>,
 }
 
 impl BrokerClient {
@@ -160,13 +262,23 @@ impl BrokerClient {
         let (err_tx, errors) = mpsc::unbounded_channel();
         let (cancel_tx, cancels) = mpsc::unbounded_channel();
         let (conn_tx, connected) = mpsc::unbounded_channel();
+        let cancellation = CancellationToken::new();
+        let reader_cancellation = cancellation.clone();
         // The demux loop pushes `Message`/`Delivered`/`Cancel`/`Error` frames
-        // into their respective channels and ends when the stream closes or
-        // errors.
+        // into their respective channels. Cancellation is owned by the public
+        // client lifecycle, so dropping that owner always reaches this source
+        // half directly instead of detaching it behind a supervisor.
         let reader = tokio::spawn(async move {
-            while let Some(frame) = source.next().await {
+            loop {
+                let frame = tokio::select! {
+                    biased;
+                    _ = reader_cancellation.cancelled() => {
+                        break ReaderExit::IntentionalShutdown;
+                    }
+                    frame = source.next() => frame,
+                };
                 match frame {
-                    Ok(Message::Text(t)) => match BrokerFrame::from_text(&t) {
+                    Some(Ok(Message::Text(t))) => match BrokerFrame::from_text(&t) {
                         Ok(BrokerFrame::Message { message }) => {
                             let _ = msg_tx.send(message);
                         }
@@ -199,7 +311,9 @@ impl BrokerClient {
                         }
                         _ => {}
                     },
-                    Ok(Message::Close(_)) | Err(_) => break,
+                    Some(Ok(Message::Close(_))) => break ReaderExit::PeerClose,
+                    Some(Err(_)) => break ReaderExit::TransportError,
+                    None => break ReaderExit::PeerEof,
                     _ => {}
                 }
             }
@@ -207,14 +321,26 @@ impl BrokerClient {
 
         // Supervise the reader so its termination is *observable* instead of
         // silently dropped (issue #52): log every exit kind and flip a shared
-        // flag callers can poll. The supervisor owns the reader handle and ends
-        // the instant the reader resolves — a clean disconnect leaves no leaked
-        // task. Holding this must not change the reader's behavior, so the
-        // reader body above is left exactly as it was.
+        // flag callers can poll. The movable lifecycle below owns cancellation,
+        // the reader's AbortHandle, and this supervisor, so neither ordinary
+        // clients nor multiplexed clients can detach the source half.
         let reader_alive = Arc::new(AtomicBool::new(true));
-        let supervisor = tokio::spawn(reader_supervisor(reader, reader_alive.clone()));
+        let intentional_shutdown = Arc::new(AtomicBool::new(false));
+        let reader_abort = reader.abort_handle();
+        let supervisor = tokio::spawn(reader_supervisor(
+            reader,
+            reader_alive.clone(),
+            intentional_shutdown.clone(),
+        ));
+        let reader = ReaderLifecycle {
+            cancellation,
+            reader_abort,
+            supervisor: Some(supervisor),
+            intentional_shutdown,
+        };
 
         Ok(Self {
+            reader,
             sink,
             messages,
             delivered,
@@ -222,8 +348,28 @@ impl BrokerClient {
             cancels,
             connected,
             reader_alive,
-            _supervisor: supervisor,
         })
+    }
+
+    /// Gracefully close this client without allowing cleanup to hang.
+    ///
+    /// The shutdown is intentionally two-stage: first send and flush a
+    /// WebSocket Close frame within a small bound, then cooperatively cancel
+    /// and await the reader/supervisor within their own bound. If the reader
+    /// does not cooperate, its lifecycle directly aborts it. Dropping the
+    /// future or the client at any point still runs the same direct-abort Drop
+    /// fallback.
+    pub async fn close(mut self) -> BrokerResult<()> {
+        // Mark intent before sending Close: a fast peer can echo Close and end
+        // the reader before `send` returns, and that is still our shutdown,
+        // not an unexpected reader death.
+        self.reader.mark_intentional_shutdown();
+        let close_result = send_close(&mut self.sink).await;
+
+        // Always clean up the source half, even when sending Close failed or
+        // timed out. Cleanup itself is bounded and escalates to direct abort.
+        self.reader.shutdown().await;
+        close_result
     }
 
     /// Durably enqueue `message` into session `to`'s mailbox; returns the stored
@@ -390,13 +536,15 @@ impl BrokerClient {
 
     /// Consume this (already connected + subscribed) client into a multiplexed
     /// request/reply driver so concurrent correlated requests on ONE connection
-    /// no longer serialize behind a single exclusive lock. The background reader
-    /// and supervisor keep running (detached) and feed `messages`, which the mux's
-    /// router drains and routes to per-request waiters by `correlation_id`. For a
-    /// replies-only connection (e.g. the MCP proxy) where every inbound message
-    /// is a correlated reply. #56.
+    /// no longer serialize behind a single exclusive lock. Ownership of the
+    /// background reader moves into the mux alongside the sink and channels, so
+    /// dropping either client shape terminates the same transport. The mux's
+    /// router drains `messages` and routes by `correlation_id`. For a replies-only
+    /// connection (e.g. the MCP proxy) where every inbound message is a
+    /// correlated reply. #56/#788.
     pub fn into_multiplexed(self, me: AgentRef) -> crate::mux::MultiplexedClient {
         crate::mux::MultiplexedClient::spawn(
+            self.reader,
             self.sink,
             self.messages,
             self.delivered,
@@ -427,15 +575,20 @@ impl BrokerClient {
 
 /// Await the reader task and make its exit observable (issue #52).
 ///
-/// - clean end (the demux loop returned / stream closed): `warn!`
+/// - intentional client shutdown: `debug!`
+/// - peer Close / EOF / transport error: categorized `warn!`
 /// - panic (`JoinError::is_panic`): `error!` with the panic message
-/// - other `JoinError` (cancelled / aborted): `error!`
+/// - unexpected cancellation / abort: `error!`
 ///
 /// In every case the shared `reader_alive` flag is cleared so callers can tell
 /// "the connection died" from "no messages right now". This owns the reader
 /// handle, so it resolves — and the supervisor task ends — exactly when the
 /// reader does: a clean disconnect leaves no leaked task.
-async fn reader_supervisor(reader: tokio::task::JoinHandle<()>, reader_alive: Arc<AtomicBool>) {
+async fn reader_supervisor(
+    reader: tokio::task::JoinHandle<ReaderExit>,
+    reader_alive: Arc<AtomicBool>,
+    intentional_shutdown: Arc<AtomicBool>,
+) {
     let outcome = reader.await;
     // Best-effort, eventually-consistent death signal: this store races the
     // reader dropping `msg_tx` (which is what makes `next_message()` return
@@ -445,13 +598,49 @@ async fn reader_supervisor(reader: tokio::task::JoinHandle<()>, reader_alive: Ar
     // `reader_alive` being false the instant `next_message()` returns `None`.
     reader_alive.store(false, Ordering::SeqCst);
     match outcome {
-        Ok(()) => {
-            tracing::warn!("broker reader task ended; connection closed");
-        }
         Err(err) if err.is_panic() => {
             tracing::error!(
                 "broker reader task panicked: {}",
                 panic_payload_message(err.into_panic())
+            );
+        }
+        Ok(exit) if intentional_shutdown.load(Ordering::SeqCst) => {
+            tracing::debug!(
+                reader_exit = exit.as_str(),
+                "broker reader stopped during intentional client shutdown"
+            );
+        }
+        Err(_) if intentional_shutdown.load(Ordering::SeqCst) => {
+            tracing::debug!(
+                reader_exit = "aborted",
+                "broker reader stopped during intentional client shutdown"
+            );
+        }
+        Ok(ReaderExit::IntentionalShutdown) => {
+            // Cancellation is only issued by ReaderLifecycle after it records
+            // intent. Keep this defensive arm low-noise if those operations
+            // are ever reordered in the future.
+            tracing::debug!(
+                reader_exit = ReaderExit::IntentionalShutdown.as_str(),
+                "broker reader stopped during intentional client shutdown"
+            );
+        }
+        Ok(ReaderExit::PeerClose) => {
+            tracing::warn!(
+                reader_exit = ReaderExit::PeerClose.as_str(),
+                "broker reader stopped after peer Close frame"
+            );
+        }
+        Ok(ReaderExit::PeerEof) => {
+            tracing::warn!(
+                reader_exit = ReaderExit::PeerEof.as_str(),
+                "broker reader stopped after peer EOF"
+            );
+        }
+        Ok(ReaderExit::TransportError) => {
+            tracing::warn!(
+                reader_exit = ReaderExit::TransportError.as_str(),
+                "broker reader stopped after transport error"
             );
         }
         Err(err) => {

--- a/crates/app/bamboo-broker/src/core.rs
+++ b/crates/app/bamboo-broker/src/core.rs
@@ -54,6 +54,13 @@ struct Subscriber {
     role: Option<String>,
 }
 
+/// Opaque proof that one server connection installed the current subscriber.
+/// Cleanup compares the underlying channel identity so an older connection
+/// cannot unregister a newer replacement for the same session. #788.
+pub(crate) struct SubscriptionLease {
+    sink: mpsc::UnboundedSender<PushItem>,
+}
+
 /// In-process routing engine: owns the mailbox root and the live subscriber table.
 pub struct BrokerCore {
     root: PathBuf,
@@ -156,7 +163,21 @@ impl BrokerCore {
         session_id: &str,
         role: Option<&str>,
     ) -> BrokerResult<mpsc::UnboundedReceiver<PushItem>> {
+        self.subscribe_with_lease(session_id, role)
+            .await
+            .map(|(rx, _lease)| rx)
+    }
+
+    /// Server-facing subscription API that returns connection-scoped
+    /// ownership. The lease must be presented to [`unsubscribe_if_owner`] so a
+    /// stale/replaced connection cannot delete the current subscriber.
+    pub(crate) async fn subscribe_with_lease(
+        &self,
+        session_id: &str,
+        role: Option<&str>,
+    ) -> BrokerResult<(mpsc::UnboundedReceiver<PushItem>, SubscriptionLease)> {
         let (tx, rx) = mpsc::unbounded_channel();
+        let lease = SubscriptionLease { sink: tx.clone() };
         self.subscribers.lock().await.insert(
             session_id.to_string(),
             Subscriber {
@@ -168,13 +189,21 @@ impl BrokerCore {
         let mb = self.mailbox(session_id);
         // Crash leftovers first (claimed-but-unacked from a previous connection),
         // then newly delivered, all in time order.
-        for d in mb.recover().await? {
-            let _ = tx.send(PushItem::Message(d.msg));
+        let preload: BrokerResult<()> = async {
+            for d in mb.recover().await? {
+                let _ = tx.send(PushItem::Message(d.msg));
+            }
+            for d in mb.drain().await? {
+                let _ = tx.send(PushItem::Message(d.msg));
+            }
+            Ok(())
         }
-        for d in mb.drain().await? {
-            let _ = tx.send(PushItem::Message(d.msg));
+        .await;
+        if let Err(error) = preload {
+            self.unsubscribe_if_owner(session_id, &lease).await;
+            return Err(error);
         }
-        Ok(rx)
+        Ok((rx, lease))
     }
 
     /// Out-of-band cancel: if `to` is currently subscribed, push an ephemeral
@@ -198,6 +227,24 @@ impl BrokerCore {
     /// remain in `cur/` for redelivery on the next subscribe.
     pub async fn unsubscribe(&self, session_id: &str) {
         self.subscribers.lock().await.remove(session_id);
+    }
+
+    /// Remove `session_id` only if `lease` still owns its subscriber entry.
+    /// Returns whether this call removed the entry. This is the connection-safe
+    /// counterpart to unconditional [`unsubscribe`](Self::unsubscribe).
+    pub(crate) async fn unsubscribe_if_owner(
+        &self,
+        session_id: &str,
+        lease: &SubscriptionLease,
+    ) -> bool {
+        let mut subscribers = self.subscribers.lock().await;
+        let owns_current = subscribers
+            .get(session_id)
+            .is_some_and(|subscriber| subscriber.sink.same_channel(&lease.sink));
+        if owns_current {
+            subscribers.remove(session_id);
+        }
+        owns_current
     }
 
     /// Acknowledge a processed message: delete it from `session_id`'s mailbox,

--- a/crates/app/bamboo-broker/src/mux.rs
+++ b/crates/app/bamboo-broker/src/mux.rs
@@ -22,7 +22,7 @@ use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
 use tokio_tungstenite::tungstenite::Message;
 
-use crate::client::WsSink;
+use crate::client::{send_close, ReaderLifecycle, WsSink, CLIENT_SHUTDOWN_TIMEOUT};
 use crate::error::{BrokerError, BrokerResult};
 use crate::proto::ClientFrame;
 
@@ -35,6 +35,10 @@ type Pending = Arc<Mutex<HashMap<MsgId, oneshot::Sender<InboxMessage>>>>;
 /// connected + subscribed [`crate::client::BrokerClient`] via
 /// `BrokerClient::into_multiplexed`.
 pub struct MultiplexedClient {
+    /// Authoritative ownership of the WebSocket reader. Dropping the mux
+    /// directly aborts that reader via `ReaderLifecycle::drop` instead of
+    /// detaching it behind its supervisor. #788.
+    reader: ReaderLifecycle,
     /// Locked only for the duration of one frame write — never across a reply wait.
     sink: Mutex<WsSink>,
     /// correlation_id (== the request msg.id) -> reply waiter.
@@ -46,7 +50,7 @@ pub struct MultiplexedClient {
     reader_alive: Arc<AtomicBool>,
     /// The correlation router; ends when `messages` closes (reader death) or when
     /// this client is dropped.
-    _router: JoinHandle<()>,
+    router: JoinHandle<()>,
     me: AgentRef,
 }
 
@@ -55,6 +59,7 @@ impl MultiplexedClient {
     /// that feeds `messages` keeps running independently; this router drains it
     /// and routes by `correlation_id`.
     pub(crate) fn spawn(
+        reader: ReaderLifecycle,
         sink: WsSink,
         mut messages: mpsc::UnboundedReceiver<InboxMessage>,
         delivered: mpsc::UnboundedReceiver<MsgId>,
@@ -82,13 +87,31 @@ impl MultiplexedClient {
         });
 
         Self {
+            reader,
             sink: Mutex::new(sink),
             pending,
             delivered: Mutex::new(delivered),
             reader_alive,
-            _router: router,
+            router,
             me,
         }
+    }
+
+    /// Gracefully close the underlying WebSocket and await bounded cleanup of
+    /// both the reader supervisor and correlation router. Drop remains a
+    /// direct-abort fallback if this future is cancelled or cleanup stalls.
+    pub async fn close(mut self) -> BrokerResult<()> {
+        self.reader.mark_intentional_shutdown();
+        let close_result = send_close(self.sink.get_mut()).await;
+        self.reader.shutdown().await;
+
+        if tokio::time::timeout(CLIENT_SHUTDOWN_TIMEOUT, &mut self.router)
+            .await
+            .is_err()
+        {
+            self.router.abort();
+        }
+        close_result
     }
 
     /// True while the underlying reader is still running. False once the
@@ -195,6 +218,16 @@ impl MultiplexedClient {
         sink.send(Message::text(frame.to_text()))
             .await
             .map_err(|e| BrokerError::Transport(format!("ws send: {e}")))
+    }
+}
+
+impl Drop for MultiplexedClient {
+    fn drop(&mut self) {
+        // ReaderLifecycle directly aborts the WebSocket reader when its field
+        // drops. Abort the router here as well so the mux leaves no detached
+        // per-connection task even if the runtime has not yet delivered the
+        // reader channel closure.
+        self.router.abort();
     }
 }
 

--- a/crates/app/bamboo-broker/src/server.rs
+++ b/crates/app/bamboo-broker/src/server.rs
@@ -15,6 +15,7 @@
 
 use std::num::NonZeroU32;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use futures_util::stream::{SplitSink, SplitStream};
@@ -94,6 +95,10 @@ pub struct BrokerServer {
     /// `limits.max_connections`. Held for the lifetime of each connection's
     /// task (#53).
     connection_slots: Arc<Semaphore>,
+    /// Monotonic, process-local count of connections rejected by the
+    /// semaphore limit. It has no labels or peer/session data, so exporting or
+    /// polling it cannot create high-cardinality or sensitive telemetry.
+    rejected_connections: AtomicU64,
     /// TLS acceptor for terminating `wss://` before the WS upgrade — `None`
     /// (the default) keeps the historical bare-`TcpStream` `ws://` behavior.
     /// Set via [`with_tls`](Self::with_tls). #48.
@@ -116,6 +121,7 @@ impl BrokerServer {
             core,
             token: token.into(),
             connection_slots: Arc::new(Semaphore::new(limits.max_connections)),
+            rejected_connections: AtomicU64::new(0),
             limits,
             tls: None,
         }
@@ -142,6 +148,21 @@ impl BrokerServer {
     /// — i.e. this server terminates `wss://`, not bare `ws://`.
     pub fn is_tls(&self) -> bool {
         self.tls.is_some()
+    }
+
+    /// Number of connections currently holding a server semaphore permit.
+    /// This includes accepted sockets still completing TLS/WS/Hello handshakes
+    /// because those sockets consume the same bounded resource.
+    pub fn active_connections(&self) -> usize {
+        self.limits
+            .max_connections
+            .saturating_sub(self.connection_slots.available_permits())
+    }
+
+    /// Total number of connections rejected because all permits were in use.
+    /// Monotonic for this server instance and intentionally unlabelled.
+    pub fn rejected_connections(&self) -> u64 {
+        self.rejected_connections.load(Ordering::Relaxed)
     }
 
     /// Accept connections forever, one task each. Returns only on a listener
@@ -183,9 +204,12 @@ impl BrokerServer {
                     });
                 }
                 Err(_) => {
+                    let rejected_connections =
+                        server.rejected_connections.fetch_add(1, Ordering::Relaxed) + 1;
                     tracing::warn!(
                         max_connections = server.limits.max_connections,
-                        %peer,
+                        active_connections = server.active_connections(),
+                        rejected_connections,
                         "broker: max_connections reached — rejecting connection"
                     );
                     drop(stream);
@@ -250,6 +274,11 @@ impl BrokerServer {
 
         // 2. Serve: client frames in, subscription stream out.
         let mut sub_rx: Option<mpsc::UnboundedReceiver<PushItem>> = None;
+        // Multiple connections may authenticate as the same agent: the
+        // long-lived worker subscribes while short-lived per-run connections
+        // only deliver. Disconnecting a delivery-only connection must never
+        // remove the worker's subscriber entry. #788.
+        let mut subscription = None;
         let outcome = loop {
             tokio::select! {
                 biased;
@@ -298,10 +327,15 @@ impl BrokerServer {
                                 }
                             }
                         }
-                        Ok(Some(ClientFrame::Subscribe)) => match self.core.subscribe(&session_id, role.as_deref()).await {
-                            Ok(rx) => sub_rx = Some(rx),
-                            Err(e) => {
-                                let _ = send(&mut sink, BrokerFrame::Error { reason: e.to_string(), id: None }).await;
+                        Ok(Some(ClientFrame::Subscribe)) => {
+                            match self.core.subscribe_with_lease(&session_id, role.as_deref()).await {
+                                Ok((rx, lease)) => {
+                                    sub_rx = Some(rx);
+                                    subscription = Some(lease);
+                                }
+                                Err(e) => {
+                                    let _ = send(&mut sink, BrokerFrame::Error { reason: e.to_string(), id: None }).await;
+                                }
                             }
                         },
                         Ok(Some(ClientFrame::Ack { id })) => {
@@ -347,7 +381,9 @@ impl BrokerServer {
             }
         };
 
-        self.core.unsubscribe(&session_id).await;
+        if let Some(lease) = subscription {
+            self.core.unsubscribe_if_owner(&session_id, &lease).await;
+        }
         outcome
     }
 }

--- a/crates/app/bamboo-broker/tests/ws_roundtrip.rs
+++ b/crates/app/bamboo-broker/tests/ws_roundtrip.rs
@@ -24,15 +24,43 @@ async fn start_broker() -> (String, TempDir) {
 /// the generous defaults — lets tests exercise `max_connections` /
 /// `messages_per_second` without waiting out production-sized quotas.
 async fn start_broker_with_limits(limits: BrokerLimits) -> (String, TempDir) {
+    let (endpoint, dir, _server) = start_observable_broker_with_limits(limits).await;
+    (endpoint, dir)
+}
+
+/// Lifecycle/limit tests retain the server handle so they can deterministically
+/// observe the semaphore rather than infer cleanup from sleeps or socket tools.
+async fn start_observable_broker_with_limits(
+    limits: BrokerLimits,
+) -> (String, TempDir, Arc<BrokerServer>) {
     let dir = tempfile::tempdir().expect("tempdir");
     let core = Arc::new(BrokerCore::new(dir.path()));
     let server = Arc::new(BrokerServer::with_limits(core, TOKEN, limits));
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("local_addr");
+    let serving = Arc::clone(&server);
     tokio::spawn(async move {
-        let _ = server.serve(listener).await;
+        let _ = serving.serve(listener).await;
     });
-    (format!("ws://{addr}"), dir)
+    (format!("ws://{addr}"), dir, server)
+}
+
+async fn wait_for_active_connections(server: &BrokerServer, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if server.active_connections() == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "active connections did not reach {expected}; current={}",
+            server.active_connections()
+        )
+    });
 }
 
 fn agent(id: &str) -> AgentRef {
@@ -288,13 +316,185 @@ async fn unacked_messages_redelivered_after_broker_crash_and_restart() {
     server2.abort();
 }
 
+/// Issue #788: a short-lived presence-query client must not leave its reader,
+/// socket, or server connection permit alive after ordinary Drop.
+#[tokio::test]
+async fn short_lived_clients_release_connection_slot_on_drop() {
+    let (endpoint, _dir, server) = start_observable_broker_with_limits(BrokerLimits {
+        max_connections: 1,
+        ..BrokerLimits::default()
+    })
+    .await;
+
+    // This is the Fabric presence-probe shape: connect, query, then let the
+    // short-lived client fall out of scope. Alternate subscription state to
+    // prove both server branches release their registry/permit resources.
+    for cycle in 0..8 {
+        let mut client = BrokerClient::connect(&endpoint, agent("probe"), TOKEN)
+            .await
+            .unwrap_or_else(|e| panic!("cycle {cycle} failed to connect: {e}"));
+        if cycle % 2 == 0 {
+            client.subscribe().await.expect("subscribe");
+        }
+        assert!(client
+            .list_connected("absent-role")
+            .await
+            .expect("presence query")
+            .is_empty());
+        assert_eq!(server.active_connections(), 1);
+        drop(client);
+        wait_for_active_connections(&server, 0).await;
+    }
+
+    assert_eq!(server.rejected_connections(), 0);
+}
+
+#[tokio::test]
+async fn explicit_close_releases_connection_slot_after_bounded_cleanup() {
+    let (endpoint, _dir, server) = start_observable_broker_with_limits(BrokerLimits {
+        max_connections: 1,
+        ..BrokerLimits::default()
+    })
+    .await;
+
+    for cycle in 0..4 {
+        let mut client = BrokerClient::connect(&endpoint, agent("graceful"), TOKEN)
+            .await
+            .unwrap_or_else(|e| panic!("cycle {cycle} failed to connect: {e}"));
+        client
+            .list_connected("absent-role")
+            .await
+            .expect("presence query");
+        client.close().await.expect("graceful close");
+        wait_for_active_connections(&server, 0).await;
+    }
+
+    assert_eq!(server.rejected_connections(), 0);
+}
+
+#[tokio::test]
+async fn multiplexed_client_drop_releases_reader_and_connection_slot() {
+    let (endpoint, _dir, server) = start_observable_broker_with_limits(BrokerLimits {
+        max_connections: 1,
+        ..BrokerLimits::default()
+    })
+    .await;
+
+    let mut client = BrokerClient::connect(&endpoint, agent("mux"), TOKEN)
+        .await
+        .expect("connect");
+    client.subscribe().await.expect("subscribe");
+    let mux = client.into_multiplexed(agent("mux"));
+    assert!(mux.reader_alive());
+    assert_eq!(server.active_connections(), 1);
+
+    drop(mux);
+    wait_for_active_connections(&server, 0).await;
+
+    // If the mux had detached the reader, the only permit would still be held
+    // and this reconnect would be rejected.
+    let next = BrokerClient::connect(&endpoint, agent("after-mux"), TOKEN)
+        .await
+        .expect("slot released after mux drop");
+    next.close().await.expect("close reconnect");
+    wait_for_active_connections(&server, 0).await;
+
+    let mut graceful = BrokerClient::connect(&endpoint, agent("mux-close"), TOKEN)
+        .await
+        .expect("graceful mux connects");
+    graceful.subscribe().await.expect("subscribe graceful mux");
+    graceful
+        .into_multiplexed(agent("mux-close"))
+        .close()
+        .await
+        .expect("graceful mux close");
+    wait_for_active_connections(&server, 0).await;
+}
+
+/// A worker's long-lived subscribed connection and its short-lived per-run
+/// delivery connections intentionally authenticate with the same AgentRef.
+/// Closing a delivery-only connection must not unregister the worker.
+#[tokio::test]
+async fn delivery_only_disconnect_does_not_remove_same_identity_subscriber() {
+    let (endpoint, _dir, server) =
+        start_observable_broker_with_limits(BrokerLimits::default()).await;
+
+    let mut worker = BrokerClient::connect(&endpoint, agent("shared-worker"), TOKEN)
+        .await
+        .expect("worker connects");
+    worker.subscribe().await.expect("worker subscribes");
+
+    let mut delivery_only = BrokerClient::connect(&endpoint, agent("shared-worker"), TOKEN)
+        .await
+        .expect("delivery-only connection with same identity connects");
+    delivery_only
+        .list_connected("unused-role")
+        .await
+        .expect("delivery-only connection remains healthy");
+    drop(delivery_only);
+    wait_for_active_connections(&server, 1).await;
+
+    let mut sender = BrokerClient::connect(&endpoint, agent("sender"), TOKEN)
+        .await
+        .expect("sender connects");
+    let message = ask("sender");
+    sender
+        .deliver("shared-worker", message.clone())
+        .await
+        .expect("deliver after sibling disconnect");
+    let received = tokio::time::timeout(Duration::from_secs(2), worker.next_message())
+        .await
+        .expect("subscriber still receives live push")
+        .expect("worker connection remains open");
+    assert_eq!(received.id, message.id);
+}
+
+/// Reconnect ownership regression: once a new subscribed connection replaces
+/// an older connection for the same session, late cleanup from the old socket
+/// must not unregister the replacement.
+#[tokio::test]
+async fn replaced_subscriber_survives_old_connection_disconnect() {
+    let (endpoint, _dir, server) =
+        start_observable_broker_with_limits(BrokerLimits::default()).await;
+
+    let mut old = BrokerClient::connect(&endpoint, agent("reconnecting-worker"), TOKEN)
+        .await
+        .expect("old subscriber connects");
+    old.subscribe().await.expect("old subscriber subscribes");
+
+    let mut replacement = BrokerClient::connect(&endpoint, agent("reconnecting-worker"), TOKEN)
+        .await
+        .expect("replacement connects");
+    replacement
+        .subscribe()
+        .await
+        .expect("replacement subscribes");
+
+    drop(old);
+    wait_for_active_connections(&server, 1).await;
+
+    let mut sender = BrokerClient::connect(&endpoint, agent("reconnect-sender"), TOKEN)
+        .await
+        .expect("sender connects");
+    let message = ask("reconnect-sender");
+    sender
+        .deliver("reconnecting-worker", message.clone())
+        .await
+        .expect("deliver to replacement");
+    let received = tokio::time::timeout(Duration::from_secs(2), replacement.next_message())
+        .await
+        .expect("replacement receives live push")
+        .expect("replacement connection remains open");
+    assert_eq!(received.id, message.id);
+}
+
 /// Connection-flood DoS defense (#53): once `max_connections` accepted slots
 /// are all held, a new connection attempt must be rejected rather than
 /// accepted (which would let an attacker keep opening connections without
 /// bound).
 #[tokio::test]
 async fn max_connections_rejects_beyond_cap() {
-    let (endpoint, _dir) = start_broker_with_limits(BrokerLimits {
+    let (endpoint, _dir, server) = start_observable_broker_with_limits(BrokerLimits {
         max_connections: 1,
         ..BrokerLimits::default()
     })
@@ -318,6 +518,8 @@ async fn max_connections_rejects_beyond_cap() {
         second.is_err(),
         "a connection beyond max_connections must be rejected"
     );
+    assert_eq!(server.active_connections(), 1);
+    assert_eq!(server.rejected_connections(), 1);
 }
 
 /// The connection cap is a live pool, not a one-shot budget (#53): once a
@@ -336,10 +538,9 @@ async fn max_connections_slot_frees_on_disconnect() {
         // Take the one slot with a raw TCP connection — the semaphore permit
         // is acquired and held for the connection task's whole lifetime
         // regardless of whether the WS/Hello handshake ever completes, so
-        // this alone is enough to occupy the slot. (`BrokerClient` isn't used
-        // here because its background reader task outlives a mere `drop`,
-        // which would make this test about the client's lifecycle rather
-        // than the server's slot accounting.)
+        // this alone is enough to occupy the slot. Use raw TCP here to isolate
+        // the server's slot accounting from `BrokerClient` lifecycle behavior,
+        // which has dedicated Drop and explicit-close coverage above.
         let _raw = tokio::net::TcpStream::connect(addr)
             .await
             .expect("raw tcp connects");

--- a/crates/app/bamboo-broker/tests/wss_roundtrip.rs
+++ b/crates/app/bamboo-broker/tests/wss_roundtrip.rs
@@ -63,6 +63,7 @@ async fn recv(client: &mut BrokerClient) -> InboxMessage {
 ///   as a CA (`CaUsedAsEndEntity`) — being a trust anchor doesn't need
 ///   `CA:TRUE` (anchors aren't constraint-checked the way intermediate/leaf
 ///   certs are), so `CA:FALSE` satisfies both roles at once.
+///
 /// Returns `None` (skip) if `openssl` is unavailable or too old to support
 /// `-addext`.
 fn gen_self_signed(dir: &Path) -> Option<(PathBuf, PathBuf)> {
@@ -95,9 +96,9 @@ fn gen_self_signed(dir: &Path) -> Option<(PathBuf, PathBuf)> {
     }
 }
 
-/// Start a TLS-terminated broker; returns the `wss://` endpoint, the cert
-/// path (for the client to trust), and the mailbox-root guard.
-async fn start_tls_broker(cert: &Path, key: &Path) -> (String, TempDir) {
+/// Start a TLS-terminated broker; returns the `wss://` endpoint, mailbox-root
+/// guard, and an observability handle for deterministic lifecycle assertions.
+async fn start_tls_broker(cert: &Path, key: &Path) -> (String, TempDir, Arc<BrokerServer>) {
     let dir = tempfile::tempdir().expect("tempdir");
     let core = Arc::new(BrokerCore::new(dir.path()));
     let server = Arc::new(
@@ -108,10 +109,26 @@ async fn start_tls_broker(cert: &Path, key: &Path) -> (String, TempDir) {
     assert!(server.is_tls(), "with_tls must flip is_tls() on");
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("local_addr");
+    let serving = Arc::clone(&server);
     tokio::spawn(async move {
-        let _ = server.serve(listener).await;
+        let _ = serving.serve(listener).await;
     });
-    (format!("wss://{addr}"), dir)
+    (format!("wss://{addr}"), dir, server)
+}
+
+async fn wait_for_no_connections(server: &BrokerServer) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while server.active_connections() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "TLS broker retained {} active connections",
+            server.active_connections()
+        )
+    });
 }
 
 #[tokio::test]
@@ -121,7 +138,7 @@ async fn ask_reply_round_trip_over_wss_with_trusted_self_signed_cert() {
         eprintln!("skipping wss round-trip test: openssl unavailable");
         return;
     };
-    let (endpoint, _mailbox_dir) = start_tls_broker(&cert, &key).await;
+    let (endpoint, _mailbox_dir, _server) = start_tls_broker(&cert, &key).await;
 
     // Trust EXACTLY this self-signed cert (the homelab/cross-network
     // quick-start path, #48) — no OS trust-store changes.
@@ -175,6 +192,48 @@ async fn ask_reply_round_trip_over_wss_with_trusted_self_signed_cert() {
     assert_eq!(body.answer, "all systems nominal, encrypted");
 }
 
+/// The reader/source ownership fix must release TLS transports too: retaining
+/// the `SplitStream` would otherwise keep the rustls session, TCP socket, and
+/// server semaphore permit alive exactly like plaintext WebSockets.
+#[tokio::test]
+async fn short_lived_wss_clients_release_on_drop_and_explicit_close() {
+    let cert_dir = tempfile::tempdir().expect("tempdir");
+    let Some((cert, key)) = gen_self_signed(cert_dir.path()) else {
+        eprintln!("skipping wss lifecycle test: openssl unavailable");
+        return;
+    };
+    let (endpoint, _mailbox_dir, server) = start_tls_broker(&cert, &key).await;
+    let tls_config = bamboo_broker::client_config_trusting_cert(&cert)
+        .expect("client config trusts generated certificate");
+
+    let mut dropped = BrokerClient::connect_with_tls(
+        &endpoint,
+        agent("tls-drop"),
+        TOKEN,
+        Some(tls_config.clone()),
+    )
+    .await
+    .expect("drop client connects over wss");
+    dropped
+        .list_connected("absent-role")
+        .await
+        .expect("presence query over wss");
+    assert_eq!(server.active_connections(), 1);
+    drop(dropped);
+    wait_for_no_connections(&server).await;
+
+    let mut graceful =
+        BrokerClient::connect_with_tls(&endpoint, agent("tls-close"), TOKEN, Some(tls_config))
+            .await
+            .expect("close client connects over wss");
+    graceful
+        .list_connected("absent-role")
+        .await
+        .expect("presence query over wss");
+    graceful.close().await.expect("bounded graceful close");
+    wait_for_no_connections(&server).await;
+}
+
 /// Security regression: a client that does NOT explicitly trust the
 /// self-signed cert (i.e. plain [`BrokerClient::connect`], the OS native root
 /// store) must be REJECTED — a self-signed cert must never be silently
@@ -189,7 +248,7 @@ async fn wss_with_untrusted_self_signed_cert_is_rejected() {
         eprintln!("skipping untrusted-cert rejection test: openssl unavailable");
         return;
     };
-    let (endpoint, _mailbox_dir) = start_tls_broker(&cert, &key).await;
+    let (endpoint, _mailbox_dir, _server) = start_tls_broker(&cert, &key).await;
 
     let result = tokio::time::timeout(
         Duration::from_secs(5),

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -1841,21 +1841,40 @@ async fn verify_worker_connected(
         .await
         .map_err(|e| e.to_string())?;
     let deadline = Instant::now() + timeout;
-    loop {
-        match client.list_connected(role).await {
-            Ok(ids) if ids.iter().any(|id| id == worker_id) => return Ok(()),
-            Ok(_) => {}
-            Err(e) => return Err(e.to_string()),
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "worker '{worker_id}' never registered on the bus under role \
+    let timeout_error = || {
+        format!(
+            "worker '{worker_id}' never registered on the bus under role \
                  '{role}' within {}s",
-                timeout.as_secs()
-            ));
+            timeout.as_secs()
+        )
+    };
+    let result = loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break Err(timeout_error());
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        match tokio::time::timeout(remaining, client.list_connected(role)).await {
+            Ok(Ok(ids)) if ids.iter().any(|id| id == worker_id) => break Ok(()),
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => break Err(e.to_string()),
+            Err(_) => break Err(timeout_error()),
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break Err(timeout_error());
+        }
+        tokio::time::sleep(remaining.min(Duration::from_millis(500))).await;
+    };
+
+    // Presence clients are deliberately short-lived. Prefer a Close frame and
+    // bounded reader/supervisor cleanup; BrokerClient's direct-abort Drop path
+    // still guarantees release if the peer stopped making progress.
+    if client.close().await.is_err() {
+        tracing::debug!("fabric presence probe could not complete graceful broker close");
     }
+    result
 }
 
 /// Build the deployer for a node. `bamboo_bin` is the local `bamboo` path used
@@ -3771,16 +3790,32 @@ mod presence_verify_tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    async fn start_broker() -> (String, tempfile::TempDir) {
+    async fn start_broker() -> (String, tempfile::TempDir, Arc<bamboo_broker::BrokerServer>) {
         let dir = tempfile::tempdir().unwrap();
         let core = Arc::new(bamboo_broker::BrokerCore::new(dir.path()));
         let server = Arc::new(bamboo_broker::BrokerServer::new(core, "t"));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let serving = Arc::clone(&server);
         tokio::spawn(async move {
-            let _ = server.serve(listener).await;
+            let _ = serving.serve(listener).await;
         });
-        (format!("ws://{addr}"), dir)
+        (format!("ws://{addr}"), dir, server)
+    }
+
+    async fn wait_for_active_connections(server: &bamboo_broker::BrokerServer, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while server.active_connections() != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "active broker connections did not reach {expected}; current={}",
+                server.active_connections()
+            )
+        });
     }
 
     /// Connect + subscribe a worker so the broker's live-actor registry lists it
@@ -3812,7 +3847,7 @@ mod presence_verify_tests {
 
     #[tokio::test]
     async fn ok_when_worker_registered_under_role() {
-        let (endpoint, _dir) = start_broker().await;
+        let (endpoint, _dir, _server) = start_broker().await;
         let _worker = join(&endpoint, "w-mon", "monitor").await;
         let out =
             verify_worker_connected(&cfg(&endpoint), "w-mon", "monitor", Duration::from_secs(3))
@@ -3822,7 +3857,7 @@ mod presence_verify_tests {
 
     #[tokio::test]
     async fn times_out_when_worker_absent() {
-        let (endpoint, _dir) = start_broker().await;
+        let (endpoint, _dir, _server) = start_broker().await;
         // Nobody joined "monitor" — the probe must fail fast, never hang.
         let out = verify_worker_connected(
             &cfg(&endpoint),
@@ -3837,7 +3872,7 @@ mod presence_verify_tests {
 
     #[tokio::test]
     async fn role_scoped_ignores_worker_under_other_role() {
-        let (endpoint, _dir) = start_broker().await;
+        let (endpoint, _dir, _server) = start_broker().await;
         // Right id, wrong role bucket → must not satisfy a "monitor" probe.
         let _other = join(&endpoint, "w-mon", "builder").await;
         let out = verify_worker_connected(
@@ -3851,6 +3886,48 @@ mod presence_verify_tests {
             out.is_err(),
             "a worker under a different role must not count"
         );
+    }
+
+    /// Issue #788 regression at the Fabric call site: every absent-worker
+    /// health sweep creates a fresh presence client. With one server permit,
+    /// any leaked reader would make the very next sweep fail at connect and
+    /// active connections would climb/stick instead of returning to baseline.
+    #[tokio::test]
+    async fn repeated_absent_worker_probes_release_broker_connections() {
+        let dir = tempfile::tempdir().unwrap();
+        let core = Arc::new(bamboo_broker::BrokerCore::new(dir.path()));
+        let server = Arc::new(bamboo_broker::BrokerServer::with_limits(
+            core,
+            "t",
+            bamboo_broker::BrokerLimits {
+                max_connections: 1,
+                ..bamboo_broker::BrokerLimits::default()
+            },
+        ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let serving = Arc::clone(&server);
+        tokio::spawn(async move {
+            let _ = serving.serve(listener).await;
+        });
+        let endpoint = format!("ws://{addr}");
+
+        for sweep in 0..6 {
+            let out = verify_worker_connected(
+                &cfg(&endpoint),
+                "absent-worker",
+                "monitor",
+                Duration::from_millis(50),
+            )
+            .await;
+            assert!(
+                matches!(out, Err(ref error) if error.contains("never registered")),
+                "sweep {sweep} must reach the expected absence timeout: {out:?}"
+            );
+            wait_for_active_connections(&server, 0).await;
+        }
+
+        assert_eq!(server.rejected_connections(), 0);
     }
 }
 


### PR DESCRIPTION
## Summary

- Make `BrokerClient` and `MultiplexedClient` own the background WebSocket reader lifecycle so ordinary Drop always terminates the source half and releases the transport.
- Add bounded explicit `close(self)` paths that send a WebSocket Close frame before cooperative cancellation and direct-abort fallback.
- Close short-lived Cluster Fabric presence clients explicitly and keep the entire presence polling loop bounded by its deadline.
- Add connection-safe subscription leases plus low-cardinality active/rejected connection observability.

## Root Cause

`BrokerClient::connect` split the WebSocket and moved the source half into a reader task. A supervisor task owned the reader `JoinHandle`, while the public client owned only the supervisor `JoinHandle`, sink, and response receivers.

Dropping a Tokio `JoinHandle` detaches its task. Therefore dropping `BrokerClient` detached the supervisor; the supervisor kept awaiting the reader; and the reader kept awaiting `source.next()`. The read half retained the WebSocket/TCP transport, so the broker connection task never observed Close or EOF and continued holding its semaphore permit.

`verify_worker_connected` creates a fresh presence client for each Fabric health probe. An absent worker therefore amplified the generic lifecycle defect into one retained WebSocket per health sweep until `max_connections` was exhausted.

Fixing Drop exposed a second ownership bug: every server connection previously called unconditional `unsubscribe(session_id)` during teardown. A short-lived delivery-only connection can share the worker session identity, so its newly-correct disconnect could remove the long-lived worker subscriber. An older subscribed connection could likewise remove a newer reconnect replacement.

## Fix

- Introduce movable `ReaderLifecycle` ownership containing a cancellation token, the reader `AbortHandle`, supervisor handle, and intentional-shutdown marker.
- On Drop, mark shutdown intentional, cancel, and directly abort the reader/source. This does not rely on dropping or aborting only the supervisor.
- On explicit close, bound Close send/flush, cooperative reader completion, direct-abort escalation, and final supervisor/router cleanup.
- Preserve the same lifecycle when converting into `MultiplexedClient`; mux Drop also aborts its correlation router.
- Categorize reader exits as intentional shutdown, peer Close, peer EOF, transport error, or panic without logging endpoint, token, actor, or payload data.
- Add `SubscriptionLease` channel-identity ownership and `unsubscribe_if_owner` so only the connection that installed the current subscriber can remove it.
- Make Fabric presence polling use its remaining deadline and explicitly close its short-lived client on every completed result path; cancellation remains protected by Drop.
- Expose unlabeled active and monotonic rejected connection counters and remove the high-cardinality peer value from rejection warnings.

## Test Plan

- `cargo test -p bamboo-broker`
- `cargo test -p bamboo-server-tools`
- `cargo test`
- `cargo clippy -p bamboo-broker -p bamboo-server-tools --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Regression coverage includes repeated WS and WSS Drop/close cycles, mux Drop/close, semaphore release, rejection counters, delivery-only same-identity teardown, subscriber replacement/reconnect ownership, repeated absent-worker Fabric probes, and sequential warm-worker runs.

Independent exact-head review approved `b571eae47af2f632d26981e1f78a8fabc786b34c` with no findings.

Closes #788