### PR TITLE
fix: retry safe stream bootstrap timeouts

### DIFF
--- a/crates/core/bamboo-agent-core/src/agent/error.rs
+++ b/crates/core/bamboo-agent-core/src/agent/error.rs
@@ -2,7 +2,120 @@
 //!
 //! This module defines the error types used throughout the agent system.
 
+use std::fmt;
+use std::time::Duration;
+
 use thiserror::Error;
+
+/// Watchdog phase that expired while establishing or consuming an LLM stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamTimeoutPhase {
+    /// The provider call did not establish a response stream before the
+    /// transport-idle deadline.
+    Bootstrap,
+    /// No valid provider transport frame arrived before the transport-idle
+    /// deadline.
+    TransportIdle,
+    /// The stream was transport-live but produced no semantic output before
+    /// the first-semantic deadline.
+    FirstSemantic,
+    /// Semantic output had started, then stopped before the semantic-idle
+    /// deadline.
+    SemanticIdle,
+}
+
+impl fmt::Display for StreamTimeoutPhase {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Bootstrap => "bootstrap",
+            Self::TransportIdle => "transport_idle",
+            Self::FirstSemantic => "first_semantic",
+            Self::SemanticIdle => "semantic_idle",
+        })
+    }
+}
+
+/// Structured, secret-free diagnostics for one LLM stream watchdog expiry.
+///
+/// Retry safety is derived from structured request provenance and observed
+/// semantic output instead of parsed from the formatted diagnostic string. A
+/// primary response timeout before any text, reasoning, or tool-call delta can
+/// be replayed by the turn-level retry policy; auxiliary calls and timeouts
+/// after semantic output starts are terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamTimeoutError {
+    phase: StreamTimeoutPhase,
+    deadline: Duration,
+    provider: Option<String>,
+    model: Option<String>,
+    last_transport: Duration,
+    last_semantic: Option<Duration>,
+    turn_retry_eligible: bool,
+}
+
+impl StreamTimeoutError {
+    /// Build a timeout diagnostic from already-sanitized provider/model
+    /// identifiers, monotonic elapsed durations, and whether the caller is the
+    /// primary turn response eligible for replay.
+    pub fn new(
+        phase: StreamTimeoutPhase,
+        deadline: Duration,
+        provider: Option<String>,
+        model: Option<String>,
+        last_transport: Duration,
+        last_semantic: Option<Duration>,
+        turn_retry_eligible: bool,
+    ) -> Self {
+        Self {
+            phase,
+            deadline,
+            provider,
+            model,
+            last_transport,
+            last_semantic,
+            turn_retry_eligible,
+        }
+    }
+
+    /// Watchdog phase that expired.
+    pub fn phase(&self) -> StreamTimeoutPhase {
+        self.phase
+    }
+
+    /// Whether replaying the turn cannot duplicate already-visible semantic
+    /// output or a partially emitted tool call.
+    pub fn retry_safe(&self) -> bool {
+        self.turn_retry_eligible && self.last_semantic.is_none()
+    }
+
+    /// Whether any text, reasoning, or tool-call delta was observed before the
+    /// timeout.
+    pub fn semantic_output_started(&self) -> bool {
+        self.last_semantic.is_some()
+    }
+}
+
+impl fmt::Display for StreamTimeoutError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let last_semantic = self
+            .last_semantic
+            .map(|duration| format!("{}ms", duration.as_millis()))
+            .unwrap_or_else(|| "never".to_string());
+        write!(
+            formatter,
+            "phase={}, deadline_ms={}, provider={}, model={}, last_transport_ms_ago={}, \
+             last_semantic_ms_ago={}, semantic_output_started={}, retry_safe={}",
+            self.phase,
+            self.deadline.as_millis(),
+            self.provider.as_deref().unwrap_or("unknown"),
+            self.model.as_deref().unwrap_or("unknown"),
+            self.last_transport.as_millis(),
+            last_semantic,
+            self.semantic_output_started(),
+            self.retry_safe(),
+        )
+    }
+}
 
 /// Errors that can occur during agent operations
 #[derive(Error, Debug)]
@@ -33,10 +146,11 @@ pub enum AgentError {
 
     /// An LLM stream watchdog expired. The attached diagnostic identifies
     /// whether transport liveness, first semantic output, or midstream semantic
-    /// progress stalled. Kept distinct from `LLM` so generic retry logic cannot
-    /// replay partial output or tool-call state (#618).
+    /// progress stalled. Kept distinct from `LLM` so the turn retry policy can
+    /// replay only timeouts that occurred before semantic output, never partial
+    /// text or tool-call state (#618).
     #[error("Stream timed out: {0}")]
-    StreamTimeout(String),
+    StreamTimeout(StreamTimeoutError),
 
     /// Error during tool execution
     #[error("Tool error: {0}")]
@@ -86,7 +200,8 @@ impl AgentError {
 
 #[cfg(test)]
 mod tests {
-    use super::AgentError;
+    use super::{AgentError, StreamTimeoutError, StreamTimeoutPhase};
+    use std::time::Duration;
 
     #[test]
     fn empty_assistant_response_is_typed_and_has_secret_free_diagnostics() {
@@ -108,6 +223,29 @@ mod tests {
         assert_eq!(
             without_id.to_string(),
             "Empty assistant response from LLM (response_id=None)"
+        );
+    }
+
+    #[test]
+    fn stream_timeout_retry_safety_is_structured_not_message_parsed() {
+        let timeout = StreamTimeoutError::new(
+            StreamTimeoutPhase::Bootstrap,
+            Duration::from_secs(120),
+            Some("provider-id".to_string()),
+            Some("model-id".to_string()),
+            Duration::from_secs(120),
+            None,
+            true,
+        );
+
+        assert_eq!(timeout.phase(), StreamTimeoutPhase::Bootstrap);
+        assert!(timeout.retry_safe());
+        assert!(!timeout.semantic_output_started());
+        assert_eq!(
+            AgentError::StreamTimeout(timeout).to_string(),
+            "Stream timed out: phase=bootstrap, deadline_ms=120000, provider=provider-id, \
+             model=model-id, last_transport_ms_ago=120000, last_semantic_ms_ago=never, \
+             semantic_output_started=false, retry_safe=true"
         );
     }
 }

--- a/crates/core/bamboo-agent-core/src/agent/mod.rs
+++ b/crates/core/bamboo-agent-core/src/agent/mod.rs
@@ -18,7 +18,7 @@ pub mod types;
 pub use bamboo_domain::{
     ContextBlock, ContextBlockPriority, ContextBlockStability, ContextBlockType,
 };
-pub use error::AgentError;
+pub use error::{AgentError, StreamTimeoutError, StreamTimeoutPhase};
 pub use events::{AgentEvent, TokenUsage};
 pub use hooks::AgentHook;
 pub use types::{

--- a/crates/core/bamboo-agent-core/src/lib.rs
+++ b/crates/core/bamboo-agent-core/src/lib.rs
@@ -17,7 +17,7 @@ pub use agent::types::{
     ImageUrlRef, Message, MessageContent, MessagePart, MessagePhase, PendingQuestion,
     PendingQuestionSource, PromptMemoryObservability, PromptSnapshot, Role, Session, SessionKind,
 };
-pub use agent::AgentError;
+pub use agent::{AgentError, StreamTimeoutError, StreamTimeoutPhase};
 pub use bamboo_domain::TokenBudgetUsage;
 pub use bamboo_domain::{
     ContextBlock, ContextBlockPriority, ContextBlockStability, ContextBlockType,

--- a/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
+++ b/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
@@ -93,25 +93,32 @@ pub(crate) async fn evaluate_gold_auto_answer_question(
         cache: None,
     };
 
-    let stream = provider
-        .chat_stream_with_options(
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
+        stream_timeout,
+        Some(&provider_name),
+        Some(&model),
+    )
+    .begin_request();
+    let cancel_token = CancellationToken::new();
+    let stream = crate::runtime::stream::handler::await_stream_bootstrap(
+        provider.chat_stream_with_options(
             &messages,
             &tools,
             Some(gold_config.max_output_tokens),
             &model,
             Some(&request_options),
-        )
-        .await
-        .map_err(|error| format!("provider call failed: {error}"))?;
-
-    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
-        stream_timeout,
-        Some(&provider_name),
-        Some(&model),
+        ),
+        &cancel_token,
+        session_id,
+        &timeout_context,
     );
+    let stream = stream
+        .await
+        .map_err(|error| format!("provider bootstrap failed: {error}"))?
+        .map_err(|error| format!("provider call failed: {error}"))?;
     let stream_output = crate::runtime::stream::handler::consume_llm_stream_silent_with_context(
         stream,
-        &CancellationToken::new(),
+        &cancel_token,
         session_id,
         &timeout_context,
     )

--- a/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::runtime::config::GoldConfig;
 use crate::runtime::stream::handler::{
-    consume_llm_stream_silent_with_context, StreamTimeoutContext,
+    await_stream_bootstrap, consume_llm_stream_silent_with_context, StreamTimeoutContext,
 };
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_metrics::TokenUsage as MetricsTokenUsage;
@@ -213,48 +213,46 @@ pub async fn evaluate_gold(
         cache: None,
     };
 
-    match llm
-        .chat_stream_with_options(
+    let timeout_context = frame.timeout_context.clone().begin_request();
+    let cancel_token = CancellationToken::new();
+    let stream = await_stream_bootstrap(
+        llm.chat_stream_with_options(
             &messages,
             &tools,
             Some(config.max_output_tokens),
             model,
             Some(&request_options),
-        )
-        .await
-    {
-        Ok(stream) => {
-            let stream_output = consume_llm_stream_silent_with_context(
-                stream,
-                &CancellationToken::new(),
-                session_id,
-                &frame.timeout_context,
-            )
+        ),
+        &cancel_token,
+        session_id,
+        &timeout_context,
+    )
+    .await?
+    .map_err(|error| AgentError::LLM(error.to_string()))?;
+    let stream_output =
+        consume_llm_stream_silent_with_context(stream, &cancel_token, session_id, &timeout_context)
             .await?;
 
-            let result = parse_gold_evaluation(
-                &stream_output.content,
-                &stream_output.tool_calls,
-                checkpoint,
-                iteration,
-                prompt_tokens,
-            );
+    let result = parse_gold_evaluation(
+        &stream_output.content,
+        &stream_output.tool_calls,
+        checkpoint,
+        iteration,
+        prompt_tokens,
+    );
 
-            let _ = event_tx
-                .send(AgentEvent::GoldEvaluationCompleted {
-                    session_id: session_id.to_string(),
-                    checkpoint: result.checkpoint,
-                    iteration: result.iteration,
-                    decision: result.decision,
-                    confidence: result.confidence,
-                    reasoning: result.reasoning.clone(),
-                })
-                .await;
+    let _ = event_tx
+        .send(AgentEvent::GoldEvaluationCompleted {
+            session_id: session_id.to_string(),
+            checkpoint: result.checkpoint,
+            iteration: result.iteration,
+            decision: result.decision,
+            confidence: result.confidence,
+            reasoning: result.reasoning.clone(),
+        })
+        .await;
 
-            Ok(result)
-        }
-        Err(error) => Err(AgentError::LLM(error.to_string())),
-    }
+    Ok(result)
 }
 
 pub fn build_gold_messages(

--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm_mini_loop.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm_mini_loop.rs
@@ -109,17 +109,28 @@ impl MiniLoopExecutor for LLMMiniLoopExecutor {
             request_purpose: Some("mini_loop".to_string()),
             cache: None,
         };
-        let stream = self
-            .provider
-            .chat_stream_with_options(&messages, &[], Some(256), &self.model, Some(&options))
-            .await
-            .map_err(|e| AgentError::LLM(e.to_string()))?;
+        let timeout_context = self.timeout_context.clone().begin_request();
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let stream = crate::runtime::stream::handler::await_stream_bootstrap(
+            self.provider.chat_stream_with_options(
+                &messages,
+                &[],
+                Some(256),
+                &self.model,
+                Some(&options),
+            ),
+            &cancel_token,
+            "mini-loop",
+            &timeout_context,
+        )
+        .await?
+        .map_err(|e| AgentError::LLM(e.to_string()))?;
 
         let output = crate::runtime::stream::handler::consume_llm_stream_silent_with_context(
             stream,
-            &tokio_util::sync::CancellationToken::new(),
+            &cancel_token,
             "mini-loop",
-            &self.timeout_context,
+            &timeout_context,
         )
         .await?;
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -50,8 +50,10 @@ const LLM_RETRY_BASE_DELAY_MS: u64 = 400;
 // ---- Error classification (from rounds.rs) ----
 
 fn should_retry_turn_error(error: &AgentError) -> bool {
-    let AgentError::LLM(message) = error else {
-        return false;
+    let message = match error {
+        AgentError::StreamTimeout(timeout) => return timeout.retry_safe(),
+        AgentError::LLM(message) => message,
+        _ => return false,
     };
     let message = message.trim().to_ascii_lowercase();
     if message.is_empty() {
@@ -2560,7 +2562,9 @@ mod tests {
     };
     use crate::runtime::runner::state_bridge;
     use bamboo_agent_core::storage::Storage;
-    use bamboo_agent_core::{AgentError, AgentEvent, AgentHook, Message, Session};
+    use bamboo_agent_core::{
+        AgentError, AgentEvent, AgentHook, Message, Session, StreamTimeoutError, StreamTimeoutPhase,
+    };
     use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookPayload, HookResult};
     use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
     use bamboo_metrics::{
@@ -4679,9 +4683,42 @@ mod tests {
         assert!(!should_retry_turn_error(&AgentError::Budget(
             "budget exceeded".to_string(),
         )));
-        assert!(!should_retry_turn_error(&AgentError::StreamTimeout(
-            "semantic_output_started=true, retry_safe=false".to_string(),
-        )));
+    }
+
+    #[test]
+    fn retries_only_structurally_safe_stream_timeouts() {
+        let retry_safe = AgentError::StreamTimeout(StreamTimeoutError::new(
+            StreamTimeoutPhase::Bootstrap,
+            Duration::from_secs(120),
+            Some("provider".to_string()),
+            Some("model".to_string()),
+            Duration::from_secs(120),
+            None,
+            true,
+        ));
+        assert!(should_retry_turn_error(&retry_safe));
+
+        let partial_output = AgentError::StreamTimeout(StreamTimeoutError::new(
+            StreamTimeoutPhase::TransportIdle,
+            Duration::from_secs(120),
+            Some("provider".to_string()),
+            Some("model".to_string()),
+            Duration::from_secs(120),
+            Some(Duration::from_secs(120)),
+            true,
+        ));
+        assert!(!should_retry_turn_error(&partial_output));
+
+        let auxiliary_timeout = AgentError::StreamTimeout(StreamTimeoutError::new(
+            StreamTimeoutPhase::Bootstrap,
+            Duration::from_secs(120),
+            Some("provider".to_string()),
+            Some("model".to_string()),
+            Duration::from_secs(120),
+            None,
+            false,
+        ));
+        assert!(!should_retry_turn_error(&auxiliary_timeout));
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -869,26 +869,41 @@ pub(super) async fn execute_llm_stream(
     planned.render.log(session_id);
     persist_request_render_metadata(session, &planned.render);
 
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
+        config.stream_timeout,
+        provider_name,
+        Some(model),
+    )
+    .allow_turn_retry_before_semantic_output()
+    .begin_request();
+
     // ONE canonical dispatch: every provider renders the IR. The default lowering
     // (chat / continuation-delta) and the provider overrides (Anthropic block-native
     // system, OpenAI/Copilot Responses view) all derive their wire from this IR.
-    let stream = llm
-        .chat_stream_ir(
+    // The provider future itself is covered by the same transport-idle policy as
+    // the returned stream. This bounds proxies that accept the request but never
+    // return response headers, a phase the per-frame watchdog cannot observe.
+    let stream = crate::runtime::stream::handler::await_stream_bootstrap(
+        llm.chat_stream_ir(
             &prepared_envelope.ir,
             tool_schemas,
             Some(max_output_tokens),
             model,
             Some(&planned.request_options),
-        )
-        .await
-        .map_err(|error| {
-            let message = format_provider_error(error);
-            if is_llm_overflow_error(&message) {
-                AgentError::LLMOverflow(message)
-            } else {
-                AgentError::LLM(message)
-            }
-        })?;
+        ),
+        cancel_token,
+        session_id,
+        &timeout_context,
+    )
+    .await?
+    .map_err(|error| {
+        let message = format_provider_error(error);
+        if is_llm_overflow_error(&message) {
+            AgentError::LLMOverflow(message)
+        } else {
+            AgentError::LLM(message)
+        }
+    })?;
 
     // Send token budget update AFTER LLM call succeeds.
     // This timing gives frontend time to subscribe to /events endpoint.
@@ -918,11 +933,6 @@ pub(super) async fn execute_llm_stream(
         );
     }
 
-    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
-        config.stream_timeout,
-        provider_name,
-        Some(model),
-    );
     // A single structured explicit workflow has a fail-closed first step: the
     // model must call load_skill before any answer tokens become user-visible.
     // Keep that first stream silent; the pipeline verifies and executes the

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -1,8 +1,12 @@
+use std::future::Future;
+use std::time::Duration;
+
 use tokio::sync::mpsc;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::tools::ToolCall;
-use bamboo_agent_core::{AgentError, AgentEvent};
+use bamboo_agent_core::{AgentError, AgentEvent, StreamTimeoutError, StreamTimeoutPhase};
 use bamboo_config::StreamTimeoutConfig;
 use bamboo_llm::LLMStream;
 
@@ -18,6 +22,8 @@ pub struct StreamTimeoutContext {
     pub(crate) policy: StreamTimeoutConfig,
     pub(crate) provider: Option<String>,
     pub(crate) model: Option<String>,
+    request_started_at: Option<Instant>,
+    turn_retry_eligible: bool,
 }
 
 impl StreamTimeoutContext {
@@ -35,13 +41,90 @@ impl StreamTimeoutContext {
             policy,
             provider: provider.and_then(sanitize_identifier),
             model: model.and_then(sanitize_identifier),
+            request_started_at: None,
+            turn_retry_eligible: false,
         }
+    }
+
+    /// Mark this as the primary turn response. Only that stream can safely ask
+    /// the outer agent loop to replay a timeout that occurs before semantic
+    /// output; auxiliary streams may run after durable turn side effects.
+    pub(crate) fn allow_turn_retry_before_semantic_output(mut self) -> Self {
+        self.turn_retry_eligible = true;
+        self
+    }
+
+    /// Bind a fresh request-dispatch timestamp so the first-semantic deadline
+    /// includes provider bootstrap time as documented.
+    pub(crate) fn begin_request(mut self) -> Self {
+        self.request_started_at = Some(Instant::now());
+        self
+    }
+
+    fn timeout_error(
+        &self,
+        session_id: &str,
+        phase: StreamTimeoutPhase,
+        deadline: Duration,
+        last_transport: Duration,
+        last_semantic: Option<Duration>,
+    ) -> AgentError {
+        let timeout = StreamTimeoutError::new(
+            phase,
+            deadline,
+            self.provider.clone(),
+            self.model.clone(),
+            last_transport,
+            last_semantic,
+            self.turn_retry_eligible,
+        );
+        tracing::warn!("[{}] LLM stream watchdog expired: {}", session_id, timeout,);
+        AgentError::StreamTimeout(timeout)
     }
 }
 
 impl Default for StreamTimeoutContext {
     fn default() -> Self {
         Self::new(StreamTimeoutConfig::default(), None, None)
+    }
+}
+
+/// Wait for a provider call to establish its response stream while preserving
+/// cancellation and the existing transport-idle policy.
+///
+/// Provider implementations return [`LLMStream`] only after the initial HTTP
+/// response has been established. Without this outer watchdog, a proxy that
+/// accepts the request but never returns response headers can hold the agent
+/// forever before the normal per-frame stream watchdog starts.
+pub(crate) async fn await_stream_bootstrap<F, T>(
+    future: F,
+    cancel_token: &CancellationToken,
+    session_id: &str,
+    timeout_context: &StreamTimeoutContext,
+) -> Result<T, AgentError>
+where
+    F: Future<Output = T>,
+{
+    let started_at = timeout_context
+        .request_started_at
+        .unwrap_or_else(Instant::now);
+    let deadline = Duration::from_secs(timeout_context.policy.transport_idle_timeout_secs);
+    let expires_at = started_at + deadline;
+
+    tokio::select! {
+        biased;
+        _ = cancel_token.cancelled() => Err(AgentError::Cancelled),
+        result = future => Ok(result),
+        _ = tokio::time::sleep_until(expires_at) => {
+            let now = Instant::now();
+            Err(timeout_context.timeout_error(
+                session_id,
+                StreamTimeoutPhase::Bootstrap,
+                deadline,
+                now.saturating_duration_since(started_at),
+                None,
+            ))
+        }
     }
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
@@ -1,65 +1,15 @@
-use std::fmt;
 use std::time::Duration;
 
 use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use bamboo_agent_core::{AgentError, AgentEvent};
+use bamboo_agent_core::{AgentError, AgentEvent, StreamTimeoutPhase};
 use bamboo_llm::{LLMChunk, LLMStream};
 
 use super::chunk_handling::handle_chunk_result;
 use super::stream_state::StreamAccumulationState;
 use super::{StreamHandlingFailure, StreamHandlingOutput, StreamTimeoutContext};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StreamTimeoutPhase {
-    TransportIdle,
-    FirstSemantic,
-    SemanticIdle,
-}
-
-impl fmt::Display for StreamTimeoutPhase {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(match self {
-            Self::TransportIdle => "transport_idle",
-            Self::FirstSemantic => "first_semantic",
-            Self::SemanticIdle => "semantic_idle",
-        })
-    }
-}
-
-struct StreamTimeoutDiagnostic<'a> {
-    phase: StreamTimeoutPhase,
-    deadline: Duration,
-    provider: Option<&'a str>,
-    model: Option<&'a str>,
-    transport_idle: Duration,
-    semantic_idle: Option<Duration>,
-    semantic_output_started: bool,
-}
-
-impl fmt::Display for StreamTimeoutDiagnostic<'_> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let semantic_idle = self
-            .semantic_idle
-            .map(|duration| format!("{}ms", duration.as_millis()))
-            .unwrap_or_else(|| "never".to_string());
-        write!(
-            formatter,
-            "phase={}, deadline_ms={}, provider={}, model={}, last_transport_ms_ago={}, \
-             last_semantic_ms_ago={}, semantic_output_started={}, retry_safe={}",
-            self.phase,
-            self.deadline.as_millis(),
-            self.provider.unwrap_or("unknown"),
-            self.model.unwrap_or("unknown"),
-            self.transport_idle.as_millis(),
-            semantic_idle,
-            self.semantic_output_started,
-            !self.semantic_output_started,
-        )
-    }
-}
 
 fn timeout_duration(seconds: u64) -> Duration {
     Duration::from_secs(seconds)
@@ -78,22 +28,13 @@ fn timeout_error(
     last_transport_at: tokio::time::Instant,
     last_semantic_at: Option<tokio::time::Instant>,
 ) -> AgentError {
-    let diagnostic = StreamTimeoutDiagnostic {
+    timeout_context.timeout_error(
+        session_id,
         phase,
         deadline,
-        provider: timeout_context.provider.as_deref(),
-        model: timeout_context.model.as_deref(),
-        transport_idle: now.saturating_duration_since(last_transport_at),
-        semantic_idle: last_semantic_at
-            .map(|last_semantic| now.saturating_duration_since(last_semantic)),
-        semantic_output_started: last_semantic_at.is_some(),
-    };
-    tracing::warn!(
-        "[{}] LLM stream watchdog expired: {}",
-        session_id,
-        diagnostic,
-    );
-    AgentError::StreamTimeout(diagnostic.to_string())
+        now.saturating_duration_since(last_transport_at),
+        last_semantic_at.map(|last_semantic| now.saturating_duration_since(last_semantic)),
+    )
 }
 
 fn preview_for_log(value: &str, max_chars: usize) -> String {
@@ -138,8 +79,11 @@ pub(super) async fn consume_llm_stream_internal_with_partial(
 ) -> Result<StreamHandlingOutput, StreamHandlingFailure> {
     let mut state = StreamAccumulationState::new();
     let policy = timeout_context.policy;
-    let started_at = tokio::time::Instant::now();
-    let mut last_transport_at = started_at;
+    let stream_started_at = tokio::time::Instant::now();
+    let started_at = timeout_context
+        .request_started_at
+        .unwrap_or(stream_started_at);
+    let mut last_transport_at = stream_started_at;
     let mut last_semantic_at = None;
 
     loop {

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc::error::TryRecvError;
 use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::tools::{FunctionCall, ToolCall};
-use bamboo_agent_core::{AgentError, AgentEvent};
+use bamboo_agent_core::{AgentError, AgentEvent, StreamTimeoutPhase};
 use bamboo_config::StreamTimeoutConfig;
 use bamboo_llm::provider::LLMError;
 use bamboo_llm::providers::common::openai_compat::parse_openai_compat_sse_data_strict;
@@ -16,7 +16,8 @@ use bamboo_llm::{LLMChunk, LLMStream};
 
 use super::consume::consume_llm_stream_internal;
 use super::{
-    consume_llm_stream, consume_llm_stream_silent, ProviderUsageSnapshot, StreamTimeoutContext,
+    await_stream_bootstrap, consume_llm_stream, consume_llm_stream_silent, ProviderUsageSnapshot,
+    StreamTimeoutContext,
 };
 
 fn build_stream(items: Vec<bamboo_llm::provider::Result<LLMChunk>>) -> LLMStream {
@@ -37,6 +38,7 @@ fn timeout_context(
         Some("test-provider"),
         Some("test-model"),
     )
+    .allow_turn_retry_before_semantic_output()
 }
 
 #[tokio::test]
@@ -643,6 +645,98 @@ async fn consume_llm_stream_interrupts_blocked_next_on_mid_stream_cancel() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn stalled_stream_bootstrap_times_out_before_response_headers() {
+    let context = timeout_context(2, 20, 20);
+    let result = await_stream_bootstrap(
+        std::future::pending::<()>(),
+        &CancellationToken::new(),
+        "session-bootstrap-timeout",
+        &context,
+    )
+    .await;
+
+    let timeout = match result {
+        Err(AgentError::StreamTimeout(timeout)) => timeout,
+        Err(other) => panic!("expected bootstrap StreamTimeout, got {other:?}"),
+        Ok(_) => panic!("expected bootstrap StreamTimeout, got success"),
+    };
+    assert_eq!(timeout.phase(), StreamTimeoutPhase::Bootstrap);
+    assert!(timeout.retry_safe());
+    assert!(!timeout.semantic_output_started());
+    let message = timeout.to_string();
+    assert!(message.contains("phase=bootstrap"));
+    assert!(message.contains("deadline_ms=2000"));
+    assert!(message.contains("provider=test-provider"));
+    assert!(message.contains("model=test-model"));
+    assert!(message.contains("last_transport_ms_ago=2000"));
+    assert!(message.contains("last_semantic_ms_ago=never"));
+    assert!(message.contains("retry_safe=true"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn auxiliary_stream_timeout_does_not_authorize_turn_replay() {
+    let context = StreamTimeoutContext::new(
+        StreamTimeoutConfig {
+            transport_idle_timeout_secs: 2,
+            first_semantic_timeout_secs: 20,
+            semantic_idle_timeout_secs: 20,
+        },
+        Some("aux-provider"),
+        Some("aux-model"),
+    )
+    .begin_request();
+    let result = await_stream_bootstrap(
+        std::future::pending::<()>(),
+        &CancellationToken::new(),
+        "session-aux-bootstrap-timeout",
+        &context,
+    )
+    .await;
+
+    let timeout = match result {
+        Err(AgentError::StreamTimeout(timeout)) => timeout,
+        Err(other) => panic!("expected bootstrap StreamTimeout, got {other:?}"),
+        Ok(_) => panic!("expected bootstrap StreamTimeout, got success"),
+    };
+    assert_eq!(timeout.phase(), StreamTimeoutPhase::Bootstrap);
+    assert!(!timeout.retry_safe());
+    assert!(!timeout.semantic_output_started());
+    assert!(timeout.to_string().contains("retry_safe=false"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn bootstrap_time_counts_toward_first_semantic_deadline() {
+    let started_at = tokio::time::Instant::now();
+    let context = timeout_context(10, 2, 20).begin_request();
+    await_stream_bootstrap(
+        async { tokio::time::sleep(Duration::from_secs(1)).await },
+        &CancellationToken::new(),
+        "session-bootstrap-semantic-budget",
+        &context,
+    )
+    .await
+    .expect("bootstrap should complete inside the transport deadline");
+
+    let result = consume_llm_stream_internal(
+        Box::pin(stream::pending()),
+        None,
+        &CancellationToken::new(),
+        "session-bootstrap-semantic-budget",
+        &context,
+    )
+    .await;
+
+    let timeout = match result {
+        Err(AgentError::StreamTimeout(timeout)) => timeout,
+        Err(other) => panic!("expected first-semantic StreamTimeout, got {other:?}"),
+        Ok(_) => panic!("expected first-semantic StreamTimeout, got success"),
+    };
+    assert_eq!(timeout.phase(), StreamTimeoutPhase::FirstSemantic);
+    assert!(timeout.retry_safe());
+    assert_eq!(started_at.elapsed(), Duration::from_secs(2));
+}
+
+#[tokio::test(start_paused = true)]
 async fn truly_silent_transport_times_out_with_actionable_diagnostic() {
     let stream: LLMStream = Box::pin(stream::pending());
     let context = timeout_context(2, 20, 20);
@@ -656,11 +750,14 @@ async fn truly_silent_transport_times_out_with_actionable_diagnostic() {
     )
     .await;
 
-    let message = match result {
-        Err(AgentError::StreamTimeout(message)) => message,
+    let timeout = match result {
+        Err(AgentError::StreamTimeout(timeout)) => timeout,
         Err(other) => panic!("expected transport StreamTimeout, got {other:?}"),
         Ok(_) => panic!("expected transport StreamTimeout, got success"),
     };
+    assert_eq!(timeout.phase(), StreamTimeoutPhase::TransportIdle);
+    assert!(timeout.retry_safe());
+    let message = timeout.to_string();
     assert!(message.contains("phase=transport_idle"));
     assert!(message.contains("deadline_ms=2000"));
     assert!(message.contains("provider=test-provider"));
@@ -689,11 +786,14 @@ async fn stream_stall_after_semantic_output_is_not_retry_safe() {
     )
     .await;
 
-    let message = match result {
-        Err(AgentError::StreamTimeout(message)) => message,
+    let timeout = match result {
+        Err(AgentError::StreamTimeout(timeout)) => timeout,
         Err(other) => panic!("expected transport StreamTimeout, got {other:?}"),
         Ok(_) => panic!("expected transport StreamTimeout, got success"),
     };
+    assert_eq!(timeout.phase(), StreamTimeoutPhase::TransportIdle);
+    assert!(!timeout.retry_safe());
+    let message = timeout.to_string();
     assert!(message.contains("phase=transport_idle"));
     assert!(message.contains("semantic_output_started=true"));
     assert!(message.contains("retry_safe=false"));
@@ -854,11 +954,14 @@ async fn keepalives_do_not_make_first_semantic_deadline_unbounded() {
     )
     .await;
 
-    let message = match result {
-        Err(AgentError::StreamTimeout(message)) => message,
+    let timeout = match result {
+        Err(AgentError::StreamTimeout(timeout)) => timeout,
         Err(other) => panic!("expected first-semantic StreamTimeout, got {other:?}"),
         Ok(_) => panic!("expected first-semantic StreamTimeout, got success"),
     };
+    assert_eq!(timeout.phase(), StreamTimeoutPhase::FirstSemantic);
+    assert!(timeout.retry_safe());
+    let message = timeout.to_string();
     assert!(message.contains("phase=first_semantic"));
     assert!(message.contains("semantic_output_started=false"));
 }
@@ -884,11 +987,14 @@ async fn keepalives_do_not_hide_midstream_semantic_stall() {
     )
     .await;
 
-    let message = match result {
-        Err(AgentError::StreamTimeout(message)) => message,
+    let timeout = match result {
+        Err(AgentError::StreamTimeout(timeout)) => timeout,
         Err(other) => panic!("expected semantic-idle StreamTimeout, got {other:?}"),
         Ok(_) => panic!("expected semantic-idle StreamTimeout, got success"),
     };
+    assert_eq!(timeout.phase(), StreamTimeoutPhase::SemanticIdle);
+    assert!(!timeout.retry_safe());
+    let message = timeout.to_string();
     assert!(message.contains("phase=semantic_idle"));
     assert!(message.contains("semantic_output_started=true"));
     assert!(message.contains("retry_safe=false"));

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
@@ -49,13 +49,15 @@ pub async fn evaluate_task_progress(
     llm: Arc<dyn LLMProvider>,
     frame: &TaskEvaluationFrame<'_>,
 ) -> Result<TaskEvaluationResult, AgentError> {
-    use crate::runtime::stream::handler::consume_llm_stream_silent_with_context;
+    use crate::runtime::stream::handler::{
+        await_stream_bootstrap, consume_llm_stream_silent_with_context,
+    };
 
     let event_tx = frame.event_tx;
     let session_id = frame.session_id;
     let model = frame.model;
     let reasoning_effort = frame.reasoning_effort;
-    let timeout_context = frame.timeout_context;
+    let timeout_context = frame.timeout_context.clone().begin_request();
 
     let in_progress_count = ctx
         .items
@@ -110,31 +112,31 @@ pub async fn evaluate_task_progress(
         request_purpose: Some("task_evaluation".to_string()),
         cache: None,
     };
-    match llm
-        .chat_stream_with_options(&messages, &tools, Some(8192), model, Some(&request_options))
-        .await
+    let cancel_token = tokio_util::sync::CancellationToken::new();
+    let stream = match await_stream_bootstrap(
+        llm.chat_stream_with_options(&messages, &tools, Some(8192), model, Some(&request_options)),
+        &cancel_token,
+        session_id,
+        &timeout_context,
+    )
+    .await?
     {
-        Ok(stream) => {
-            let stream_output = consume_llm_stream_silent_with_context(
-                stream,
-                &tokio_util::sync::CancellationToken::new(),
-                session_id,
-                timeout_context,
-            )
-            .await?;
-
-            Ok(outcomes::build_success_result(
-                stream_output,
-                event_tx,
-                session_id,
-                prompt_tokens,
-                ctx.version,
-            )
-            .await)
-        }
+        Ok(stream) => stream,
         Err(error) => {
             tracing::warn!("[{}] Task evaluation failed: {}", session_id, error);
-            Ok(skipped_evaluation(&format!("Evaluation failed: {}", error)))
+            return Ok(skipped_evaluation(&format!("Evaluation failed: {}", error)));
         }
-    }
+    };
+    let stream_output =
+        consume_llm_stream_silent_with_context(stream, &cancel_token, session_id, &timeout_context)
+            .await?;
+
+    Ok(outcomes::build_success_result(
+        stream_output,
+        event_tx,
+        session_id,
+        prompt_tokens,
+        ctx.version,
+    )
+    .await)
 }

--- a/crates/engine/bamboo-engine/src/runtime/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/tests.rs
@@ -374,6 +374,14 @@ struct AlwaysTransientProvider {
     calls: AtomicUsize,
 }
 
+struct BootstrapStallThenSuccessProvider {
+    calls: AtomicUsize,
+}
+
+struct TransportStallThenSuccessProvider {
+    calls: AtomicUsize,
+}
+
 #[async_trait]
 impl LLMProvider for AlwaysTransientProvider {
     async fn chat_stream(
@@ -387,6 +395,46 @@ impl LLMProvider for AlwaysTransientProvider {
         Err(LLMError::Api(
             "temporary provider dispatch failure".to_string(),
         ))
+    }
+}
+
+#[async_trait]
+impl LLMProvider for BootstrapStallThenSuccessProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        match self.calls.fetch_add(1, Ordering::SeqCst) {
+            0 => std::future::pending::<Result<LLMStream, LLMError>>().await,
+            1 => Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::Token("bootstrap retry recovered".to_string())),
+                Ok(LLMChunk::Done),
+            ]))),
+            call => panic!("unexpected LLM call {call}"),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for TransportStallThenSuccessProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        match self.calls.fetch_add(1, Ordering::SeqCst) {
+            0 => Ok(Box::pin(stream::pending())),
+            1 => Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::Token("transport retry recovered".to_string())),
+                Ok(LLMChunk::Done),
+            ]))),
+            call => panic!("unexpected LLM call {call}"),
+        }
     }
 }
 
@@ -499,6 +547,21 @@ async fn build_direct_execute_agent(
     persistence_override: Option<Arc<dyn RuntimeSessionPersistence>>,
     tools_override: Option<Arc<dyn ToolExecutor>>,
 ) -> (tempfile::TempDir, crate::runtime::Agent, Arc<dyn Storage>) {
+    build_direct_execute_agent_with_config(
+        provider,
+        persistence_override,
+        tools_override,
+        bamboo_llm::Config::default(),
+    )
+    .await
+}
+
+async fn build_direct_execute_agent_with_config(
+    provider: Arc<dyn LLMProvider>,
+    persistence_override: Option<Arc<dyn RuntimeSessionPersistence>>,
+    tools_override: Option<Arc<dyn ToolExecutor>>,
+    config: bamboo_llm::Config,
+) -> (tempfile::TempDir, crate::runtime::Agent, Arc<dyn Storage>) {
     let temp = tempfile::tempdir().expect("tempdir");
     let session_store = Arc::new(
         bamboo_storage::SessionStoreV2::new(temp.path().join("sessions"))
@@ -522,7 +585,7 @@ async fn build_direct_execute_agent(
         .attachment_reader(session_store)
         .skill_manager(Arc::new(bamboo_skills::SkillManager::new()))
         .metrics_collector(metrics)
-        .config(Arc::new(RwLock::new(bamboo_llm::Config::default())))
+        .config(Arc::new(RwLock::new(config)))
         .provider(provider)
         .default_tools(tools_override.unwrap_or_else(|| Arc::new(BuiltinToolExecutor::new())))
         .build()
@@ -703,6 +766,70 @@ async fn direct_execute_retries_transient_llm_errors_to_existing_limit() {
         3,
         "genuine transient LLM failures keep the existing three-attempt limit"
     );
+}
+
+#[tokio::test]
+async fn direct_execute_retries_a_stalled_stream_bootstrap() {
+    let provider = Arc::new(BootstrapStallThenSuccessProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let mut config = bamboo_llm::Config::default();
+    config.stream_timeout.transport_idle_timeout_secs = 1;
+    let (_temp, agent, _storage) =
+        build_direct_execute_agent_with_config(provider.clone(), None, None, config).await;
+    let mut session = Session::new("direct-bootstrap-timeout-retry", "test-model");
+    session.add_message(Message::user("retry a request that never returns headers"));
+    let (event_tx, _event_rx) = mpsc::channel(64);
+
+    agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect("retry-safe bootstrap timeout should recover");
+
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        2,
+        "the stalled bootstrap should be cancelled and replayed once"
+    );
+    assert!(session
+        .messages
+        .iter()
+        .any(|message| message.content == "bootstrap retry recovered"));
+}
+
+#[tokio::test]
+async fn direct_execute_retries_transport_idle_before_semantic_output() {
+    let provider = Arc::new(TransportStallThenSuccessProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let mut config = bamboo_llm::Config::default();
+    config.stream_timeout.transport_idle_timeout_secs = 1;
+    let (_temp, agent, _storage) =
+        build_direct_execute_agent_with_config(provider.clone(), None, None, config).await;
+    let mut session = Session::new("direct-transport-idle-retry", "test-model");
+    session.add_message(Message::user("retry a stream with no transport frames"));
+    let (event_tx, _event_rx) = mpsc::channel(64);
+
+    agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect("retry-safe transport idle timeout should recover");
+
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        2,
+        "the silent stream should be discarded and replayed once"
+    );
+    assert!(session
+        .messages
+        .iter()
+        .any(|message| message.content == "transport retry recovered"));
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/title_gen/mod.rs
+++ b/crates/engine/bamboo-engine/src/title_gen/mod.rs
@@ -255,20 +255,33 @@ async fn try_llm_title(
         config_snapshot.stream_timeout,
         Some(&provider_name),
         Some(&model_name),
-    );
+    )
+    .begin_request();
 
     let fut = async move {
         let options = bamboo_llm::provider::LLMRequestOptions {
             request_purpose: Some("title_generation".to_string()),
             ..Default::default()
         };
-        let stream = provider
-            .chat_stream_with_options(&messages, &[], Some(64), &model_name, Some(&options))
-            .await
-            .map_err(|e| format!("chat_stream: {e}"))?;
+        let cancel_token = CancellationToken::new();
+        let stream = crate::runtime::stream::handler::await_stream_bootstrap(
+            provider.chat_stream_with_options(
+                &messages,
+                &[],
+                Some(64),
+                &model_name,
+                Some(&options),
+            ),
+            &cancel_token,
+            "title-gen",
+            &timeout_context,
+        )
+        .await
+        .map_err(|e| format!("chat_stream bootstrap: {e}"))?
+        .map_err(|e| format!("chat_stream: {e}"))?;
         let output = crate::runtime::stream::handler::consume_llm_stream_silent_with_context(
             stream,
-            &CancellationToken::new(),
+            &cancel_token,
             "title-gen",
             &timeout_context,
         )

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -191,7 +191,7 @@ main response stream and auxiliary silent model calls:
 
 | Field | Default | Meaning |
 |---|---:|---|
-| `transport_idle_timeout_secs` | `120` | Maximum gap between successfully received, non-empty provider response-body chunks. SSE ping/lifecycle events, comment heartbeats, and partial event fragments count even when they contain no token. |
+| `transport_idle_timeout_secs` | `120` | Maximum time for the provider call to establish its response stream, and the maximum subsequent gap between successfully received, non-empty response-body chunks. SSE ping/lifecycle events, comment heartbeats, and partial event fragments count even when they contain no token. |
 | `first_semantic_timeout_secs` | `600` | Maximum time from request dispatch to the first text, reasoning, or tool-call delta. Transport keepalives do not extend it. |
 | `semantic_idle_timeout_secs` | `600` | Maximum semantic-progress gap after output starts. Transport keepalives do not extend it. |
 
@@ -200,17 +200,21 @@ are rejected by config loading; invalid values constructed by an embedding are
 replaced with the safe defaults. Timeout errors report the expired phase,
 deadline, provider/model identifiers, and last transport/semantic activity,
 but never include prompts or raw provider payloads. A stream timeout is not
-automatically retried, because replay after partial output or tool-call deltas
-could duplicate externally visible state.
+retried after text, reasoning, or tool-call output has started, because replay
+could duplicate externally visible state. A timeout before any semantic output
+on the primary response stream is marked retry-safe and may use the agent
+loop's existing bounded turn retry policy. Auxiliary model calls are bounded by
+the same watchdogs but never replay the containing agent turn.
 
 ### OpenAI-compatible proxy heartbeats
 
-An OpenAI-compatible proxy should either forward upstream response bytes or
-emit an SSE heartbeat more frequently than `transport_idle_timeout_secs`.
-Bamboo treats any successfully received, non-empty body chunk as transport
-activity before parsing SSE, including the standard comment form
-`: keep-alive\n\n`. These internal activity markers do not become model output
-and do not extend either semantic deadline.
+An OpenAI-compatible proxy should establish the response stream within
+`transport_idle_timeout_secs`, then either forward upstream response bytes or
+emit an SSE heartbeat more frequently than that deadline. Bamboo treats any
+successfully received, non-empty body chunk as transport activity before
+parsing SSE, including the standard comment form `: keep-alive\n\n`. These
+internal activity markers do not become model output and do not extend either
+semantic deadline.
 
 For example, CLIProxyAPI supports periodic streaming heartbeats with:
 


### PR DESCRIPTION
## Summary

- Bound the provider response-stream bootstrap wait with the existing transport-idle watchdog, including proxies that accept a request but never return response headers.
- Replace string-only stream timeout diagnostics with structured timeout phase and retry-safety data.
- Route only primary-response timeouts before any text, reasoning, or tool-call delta through the existing bounded turn retry policy.
- Keep auxiliary model timeouts and any timeout after semantic output terminal for turn replay, preventing duplicate visible output or tool side effects.
- Apply the bootstrap watchdog to task evaluation, gold evaluation, mini-loop, gold auto-answer, and title generation calls, and document the behavior.

## Root Cause

Bamboo started its stream watchdog only after `chat_stream_ir(...).await` returned an `LLMStream`. If an OpenAI-compatible proxy accepted the request but never returned response headers, Bamboo remained blocked before the watchdog existed. The central retry classifier also rejected every `StreamTimeout`, even when no semantic output had started.

## Impact

A response-header stall now reports `phase=bootstrap` after `transport_idle_timeout_secs`. The primary turn may use the existing maximum of three attempts only when replay is structurally safe. Partial text, reasoning, tool-call deltas, and auxiliary calls never authorize whole-turn replay.

## Test Plan

- `cargo test --workspace -q`
- `cargo test -q -p bamboo-agent-core -p bamboo-engine` (148 core tests and 1279 engine tests)
- `cargo test --workspace --no-run -q`
- `cargo clippy -p bamboo-agent-core -p bamboo-engine --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Screenshots

Not applicable; backend-only behavior change.