### PR TITLE
fix(server): preserve omitted model limits

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
@@ -108,12 +108,14 @@ pub async fn set_bamboo_config(
         )
         .await?;
 
-    // Persist model_limits.json under the config write lock so two concurrent
-    // set_bamboo_config calls can't race / clobber each other's writes (the
-    // write itself is now atomic too — see common::write_model_limits_file). #42.
-    {
+    // Omission means "leave this independently owned section unchanged"; only
+    // an explicit model_limits field may replace or clear it. Persist under the
+    // config write lock so concurrent compatibility writes cannot clobber each
+    // other (the file commit is atomic too — see common::write_model_limits_file).
+    // #42, #775.
+    if let Some(model_limits_patch) = model_limits_patch.as_ref() {
         let _config_guard = app_state.config.write().await;
-        write_model_limits_file(&app_state.app_data_dir, model_limits_patch.as_ref()).await?;
+        write_model_limits_file(&app_state.app_data_dir, Some(model_limits_patch)).await?;
     }
 
     if effects.reload_provider == config_manager::ReloadMode::BestEffort {

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -623,6 +623,139 @@ async fn set_then_get_bamboo_config_round_trips_all_overrides() {
     assert_eq!(limits[0]["max_context_tokens"], 128000);
 }
 
+#[actix_web::test]
+async fn omitted_model_limits_preserves_modular_section_data_and_revision() {
+    use crate::app_state::AppState;
+    use actix_web::{test, web, App};
+
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state should initialize");
+    assert!(
+        state.config_facade.is_some(),
+        "AppState must use the modular section layout for this regression"
+    );
+    let data_dir = state.app_data_dir.clone();
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .route("/bamboo/config", web::post().to(super::set_bamboo_config)),
+    )
+    .await;
+
+    let seed = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/bamboo/config")
+            .set_json(serde_json::json!({
+                "model_limits": [{
+                    "model_pattern": "preserved-model",
+                    "max_context_tokens": 128000,
+                    "max_output_tokens": 16000,
+                    "safety_margin": 1000
+                }]
+            }))
+            .to_request(),
+    )
+    .await;
+    assert!(
+        seed.status().is_success(),
+        "seeding model limits should succeed"
+    );
+
+    let path = model_limits_file_path(&data_dir);
+    let before: serde_json::Value = serde_json::from_slice(
+        &tokio::fs::read(&path)
+            .await
+            .expect("model-limits section should exist"),
+    )
+    .expect("model-limits section should be valid JSON");
+    assert_eq!(before["data"][0]["model_pattern"], "preserved-model");
+    let before_revision = before["revision"]
+        .as_u64()
+        .expect("model-limits section should have a revision");
+
+    let unrelated = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/bamboo/config")
+            .set_json(serde_json::json!({"headless_auth": true}))
+            .to_request(),
+    )
+    .await;
+    assert!(
+        unrelated.status().is_success(),
+        "unrelated config patch should succeed"
+    );
+
+    let after: serde_json::Value = serde_json::from_slice(
+        &tokio::fs::read(&path)
+            .await
+            .expect("model-limits section should remain present"),
+    )
+    .expect("model-limits section should remain valid JSON");
+    assert_eq!(
+        after["data"], before["data"],
+        "omitting model_limits must preserve its data"
+    );
+    assert_eq!(
+        after["revision"].as_u64(),
+        Some(before_revision),
+        "omitting model_limits must not create a new section revision"
+    );
+}
+
+#[actix_web::test]
+async fn explicit_empty_model_limits_clears_modular_section() {
+    use crate::app_state::AppState;
+    use actix_web::{test, web, App};
+
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state should initialize");
+    let data_dir = state.app_data_dir.clone();
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .route("/bamboo/config", web::post().to(super::set_bamboo_config)),
+    )
+    .await;
+
+    for model_limits in [
+        serde_json::json!([{
+            "model_pattern": "cleared-model",
+            "max_context_tokens": 64000,
+            "max_output_tokens": 8000
+        }]),
+        serde_json::json!([]),
+    ] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/bamboo/config")
+                .set_json(serde_json::json!({"model_limits": model_limits}))
+                .to_request(),
+        )
+        .await;
+        assert!(response.status().is_success());
+    }
+
+    let section: serde_json::Value = serde_json::from_slice(
+        &tokio::fs::read(model_limits_file_path(&data_dir))
+            .await
+            .expect("empty modular section should remain present"),
+    )
+    .expect("model-limits section should remain valid JSON");
+    assert_eq!(section["data"], serde_json::json!([]));
+    assert_eq!(
+        section["revision"].as_u64(),
+        Some(2),
+        "seed and explicit clear must each commit exactly one revision"
+    );
+}
+
 fn transaction_file_snapshot(data_dir: &std::path::Path) -> BTreeMap<String, Option<Vec<u8>>> {
     [
         "credentials.json",


### PR DESCRIPTION
## Summary

- preserve the independently persisted `model_limits.json` section when a compatibility config PATCH/POST omits `model_limits`
- keep explicit `"model_limits": []` as the intentional reset operation
- add modular-layout HTTP regressions for both omission and explicit clearing, including revision assertions

## Root cause

`set_bamboo_config` always called `write_model_limits_file`, including when `take_model_limits_patch` returned `None`. Under the modular section layout, `None` was converted to an empty row set and committed, so unrelated settings writes cleared model-limit overrides.

## Verification

- reproduced before the fix: `omitted_model_limits_preserves_modular_section_data_and_revision` failed because the saved row array became empty
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p bamboo-server --lib handlers::settings::bamboo_config::config_endpoints::tests -- --nocapture` — 35 passed
- `cargo test -p bamboo-server` — 1769 passed, 4 ignored
- `cargo clippy -p bamboo-server --all-targets --all-features -- -D warnings -A clippy::too_many_arguments` — passed

The unmodified strict Clippy command currently fails on clean `origin/dev@e3a6ad1e` at `crates/app/bamboo-server/src/connect/bridge.rs:195` (`clippy::too_many_arguments`). The same failure was reproduced in a detached clean-baseline worktree; this PR does not touch that code. With only that existing baseline lint exempted, all targets and features pass with warnings denied.

Closes #775
