### PR TITLE
fix: run scheduled sessions in auto permission mode

### DIFF
--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -413,15 +413,6 @@ async fn run_schedule_job(
             .map_err(|error| error.to_string())?;
     }
 
-    // #73: a scheduled run has no interactive human approver — mark the root so
-    // its sub-agents (which inherit the flag) decide gated actions with the
-    // off-loop model-reviewer locally instead of escalating to an absent human,
-    // which would 300s-deny.
-    session
-        .agent_runtime_state
-        .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
-        .no_human_approver = true;
-
     let mut prompt_hook_block = None;
     if let Some(user_index) = session
         .messages
@@ -449,7 +440,7 @@ async fn run_schedule_job(
 
     // Persist session and index entry.
     ctx.persistence
-        .merge_save_runtime(&mut session)
+        .save_runtime_authoritative_flags(&mut session)
         .await
         .map_err(|e| format!("failed to save scheduled session: {e}"))?;
     if let Err(error) = ctx

--- a/crates/app/bamboo-server/src/schedule_app/scheduler_tool.rs
+++ b/crates/app/bamboo-server/src/schedule_app/scheduler_tool.rs
@@ -623,8 +623,44 @@ impl Tool for ScheduleTasksTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bamboo_agent_core::tools::ToolExecutionContext;
+    use bamboo_agent_core::tools::{
+        FunctionCall, ToolCall, ToolExecutionContext, ToolExecutionSessionFlags,
+    };
+    use bamboo_domain::{PermissionAuditSnapshot, PermissionMode, SessionPermissionMode};
+    use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
+    use futures::stream;
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
+    use tokio::sync::{Mutex, Notify};
+
+    struct ScriptedScheduleProvider {
+        responses: Mutex<VecDeque<Vec<bamboo_llm::provider::Result<LLMChunk>>>>,
+        calls: AtomicUsize,
+        first_call_started: Arc<Notify>,
+        release_first_call: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl LLMProvider for ScriptedScheduleProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[bamboo_agent_core::Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.first_call_started.notify_one();
+                self.release_first_call.notified().await;
+            }
+            let chunks =
+                self.responses.lock().await.pop_front().ok_or_else(|| {
+                    LLMError::Api("scripted schedule provider exhausted".to_string())
+                })?;
+            Ok(Box::pin(stream::iter(chunks)))
+        }
+    }
 
     fn context(session_id: &str) -> ToolCtx {
         ToolExecutionContext {
@@ -640,6 +676,221 @@ mod tests {
             pre_parsed_args: None,
         }
         .to_tool_ctx()
+    }
+
+    #[tokio::test]
+    async fn auto_execute_schedule_runs_forced_ask_tool_without_approval_while_interactive_asks() {
+        let dir = tempfile::tempdir().unwrap();
+        bamboo_config::paths::init_bamboo_dir(dir.path().to_path_buf());
+        let workspace = dir.path().join("scheduled-project");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let scheduled_output = workspace.join("scheduled-auto.txt");
+        let interactive_output = workspace.join("interactive-must-not-run.txt");
+        let scheduled_command = format!("printf scheduled-auto > {}", scheduled_output.display());
+        let scheduled_call = ToolCall {
+            id: "scheduled-forced-ask".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "Bash".to_string(),
+                arguments: serde_json::json!({"command": scheduled_command}).to_string(),
+            },
+        };
+        let first_call_started = Arc::new(Notify::new());
+        let release_first_call = Arc::new(Notify::new());
+        let provider = Arc::new(ScriptedScheduleProvider {
+            responses: Mutex::new(VecDeque::from([
+                vec![
+                    Ok(LLMChunk::ToolCalls(vec![scheduled_call])),
+                    Ok(LLMChunk::Done),
+                ],
+                vec![
+                    Ok(LLMChunk::Token("scheduled complete".to_string())),
+                    Ok(LLMChunk::Done),
+                ],
+            ])),
+            calls: AtomicUsize::new(0),
+            first_call_started: first_call_started.clone(),
+            release_first_call: release_first_call.clone(),
+        });
+        let state = crate::AppState::new_with_provider(
+            dir.path().to_path_buf(),
+            Config::default(),
+            provider,
+        )
+        .await
+        .expect("AppState with scripted provider");
+        let permission_config = state
+            .permission_checker
+            .permission_config()
+            .expect("config-backed permission checker");
+        permission_config.set_ask_rules(["Bash(printf *)".to_string()]);
+        assert_eq!(permission_config.mode(), PermissionMode::Default);
+
+        let project = state
+            .project_store
+            .create_with_project_path(
+                "Scheduled Auto",
+                None,
+                workspace.to_string_lossy(),
+                Vec::new(),
+            )
+            .unwrap();
+        let mut caller = Session::new("scheduled-auto-caller", "model");
+        caller.kind = SessionKind::Root;
+        caller.set_project_id_meta(project.id.to_string());
+        state.storage.save_session(&caller).await.unwrap();
+        let tool = ScheduleTasksTool::new(
+            state.schedule_store.clone(),
+            state.schedule_manager.clone(),
+            state.session_store.clone(),
+            state.storage.clone(),
+            state.config.clone(),
+            state.project_store.clone(),
+            state.workspace_resolver.clone(),
+        );
+        tool.invoke(
+            json!({
+                "action": "create",
+                "name": "forced ask scheduled auto",
+                "trigger": {"type": "interval", "every_seconds": 3600},
+                "enabled": false,
+                "run_config": {
+                    "auto_execute": true,
+                    "model": "test-model",
+                    "task_message": "run the scripted forced-ask command"
+                }
+            }),
+            context(&caller.id),
+        )
+        .await
+        .expect("create auto schedule");
+        let schedule = state.schedule_store.list_schedules().await.remove(0);
+        let mut account_feed = state.account_sink.subscribe();
+        tool.invoke(
+            json!({"action": "run_now", "schedule_id": schedule.id}),
+            context(&caller.id),
+        )
+        .await
+        .expect("enqueue scheduled auto run");
+        tokio::time::timeout(Duration::from_secs(5), first_call_started.notified())
+            .await
+            .expect("scheduled agent reaches scripted provider");
+
+        // The interactive request runs while the scheduled loop is active and
+        // uses the exact same process-global Default permission config.
+        let interactive = Session::new("concurrent-interactive", "model");
+        permission_config.register_session_workspace(
+            interactive.id.clone(),
+            workspace.to_string_lossy().to_string(),
+        );
+        let interactive_command = format!("printf interactive > {}", interactive_output.display());
+        let interactive_call = ToolCall {
+            id: "interactive-forced-ask".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "Bash".to_string(),
+                arguments: serde_json::json!({"command": interactive_command}).to_string(),
+            },
+        };
+        let (interactive_event_tx, mut interactive_event_rx) = tokio::sync::mpsc::channel(8);
+        let interactive_result = state
+            .tools_for(crate::tools::ToolSurface::Root)
+            .execute_with_context(
+                &interactive_call,
+                ToolExecutionContext {
+                    session_id: Some(&interactive.id),
+                    tool_call_id: &interactive_call.id,
+                    event_tx: Some(&interactive_event_tx),
+                    available_tool_schemas: None,
+                    bypass_permissions: false,
+                    auto_approve_permissions: false,
+                    plan_read_only: false,
+                    can_async_resume: false,
+                    bash_completion_sink: None,
+                    pre_parsed_args: None,
+                },
+            )
+            .await
+            .expect("interactive forced ask returns an approval pause");
+        assert_eq!(
+            interactive_result.display_preference.as_deref(),
+            Some("request_permissions")
+        );
+        let interactive_event =
+            tokio::time::timeout(Duration::from_secs(2), interactive_event_rx.recv())
+                .await
+                .expect("interactive approval event arrives before timeout");
+        assert!(matches!(
+            interactive_event,
+            Some(bamboo_agent_core::AgentEvent::ToolApprovalRequested { .. })
+        ));
+        assert!(!interactive_output.exists());
+        assert_eq!(permission_config.mode(), PermissionMode::Default);
+
+        release_first_call.notify_one();
+        let terminal = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let Some(record) = state
+                    .schedule_store
+                    .list_run_records_for_schedule(&schedule.id)
+                    .await
+                    .into_iter()
+                    .find(|record| record.status.is_terminal())
+                {
+                    break record;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("scheduled auto run reaches terminal state");
+        assert_eq!(terminal.status, bamboo_domain::ScheduleRunStatus::Success);
+        assert_eq!(
+            std::fs::read_to_string(&scheduled_output).unwrap(),
+            "scheduled-auto"
+        );
+        let scheduled_session_id = terminal.session_id.expect("scheduled session id");
+
+        let mut scheduled_approval_seen = false;
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let change = account_feed.recv().await.expect("account event");
+                if change.session_id.as_deref() != Some(scheduled_session_id.as_str()) {
+                    continue;
+                }
+                if matches!(
+                    &change.event,
+                    bamboo_agent_core::AgentEvent::ToolApprovalRequested { .. }
+                ) {
+                    scheduled_approval_seen = true;
+                }
+                if matches!(
+                    &change.event,
+                    bamboo_agent_core::AgentEvent::Complete { .. }
+                        | bamboo_agent_core::AgentEvent::Cancelled { .. }
+                        | bamboo_agent_core::AgentEvent::Error { .. }
+                ) {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("scheduled terminal event reaches account feed");
+        assert!(
+            !scheduled_approval_seen,
+            "scheduled Auto must never emit a human approval request"
+        );
+        let saved = state
+            .storage
+            .load_session(&scheduled_session_id)
+            .await
+            .unwrap()
+            .expect("saved scheduled session");
+        assert!(saved.pending_question.is_none());
+        let runtime = saved.agent_runtime_state.as_ref().unwrap();
+        assert_eq!(runtime.permission_mode, SessionPermissionMode::Auto);
+        assert!(runtime.bypass_permissions);
+        assert!(runtime.no_human_approver);
     }
 
     #[tokio::test]
@@ -829,6 +1080,59 @@ mod tests {
             .await
             .expect("load fired session")
             .expect("fired session");
+        let runtime = fired_session
+            .agent_runtime_state
+            .as_ref()
+            .expect("scheduled session permission posture");
+        assert_eq!(runtime.permission_mode, SessionPermissionMode::Auto);
+        assert!(
+            runtime.bypass_permissions,
+            "legacy Auto compatibility mirror"
+        );
+        assert!(runtime.no_human_approver);
+        let initial_audit =
+            PermissionAuditSnapshot::from_metadata(&fired_session.metadata).unwrap();
+        assert_eq!(
+            initial_audit.resolution.requested,
+            SessionPermissionMode::Auto
+        );
+        assert_eq!(initial_audit.resolution.effective, PermissionMode::Auto);
+
+        let permission_config = state
+            .permission_checker
+            .permission_config()
+            .expect("config-backed permission checker");
+        assert_eq!(permission_config.mode(), PermissionMode::Default);
+        let interactive = Session::new("concurrent-interactive", "model");
+        assert_eq!(
+            ToolExecutionSessionFlags::from_session_and_configured_mode(
+                &interactive,
+                permission_config.mode(),
+            ),
+            ToolExecutionSessionFlags::default()
+        );
+
+        let mut first_runtime_carry_forward = fired_session.clone();
+        first_runtime_carry_forward.set_last_run_status("carried-forward");
+        state
+            .persistence
+            .merge_save_runtime(&mut first_runtime_carry_forward)
+            .await
+            .expect("ordinary runtime carry-forward");
+        let carried = state
+            .storage
+            .load_session(&fired.id)
+            .await
+            .expect("load carried scheduled session")
+            .expect("carried scheduled session");
+        let carried_runtime = carried.agent_runtime_state.as_ref().unwrap();
+        assert_eq!(carried_runtime.permission_mode, SessionPermissionMode::Auto);
+        assert!(carried_runtime.bypass_permissions);
+        assert!(carried_runtime.no_human_approver);
+        assert_eq!(
+            PermissionAuditSnapshot::from_metadata(&carried.metadata).unwrap(),
+            initial_audit
+        );
         assert_eq!(
             bamboo_engine::project_context::ProjectContextResolver::project_id_from_session(
                 &fired_session

--- a/crates/app/bamboo-server/src/schedule_app/session_factory.rs
+++ b/crates/app/bamboo-server/src/schedule_app/session_factory.rs
@@ -1,14 +1,26 @@
 //! Helper for creating sessions from schedule run jobs.
 
 use bamboo_domain::reasoning::ReasoningEffort;
-use bamboo_domain::{Message, Session};
+use bamboo_domain::{Message, Session, SessionPermissionMode};
 use bamboo_engine::runner;
 
 use super::manager::ScheduleRunJob;
 
+/// Apply the per-session permission posture required by an unattended root.
+///
+/// This must happen in the factory, before the manager records permission
+/// audit metadata, so every schedule entrypoint starts from the same explicit
+/// Auto request without widening the process-global permission mode.
+fn apply_unattended_permission_posture(session: &mut Session) {
+    let runtime = session.agent_runtime_state.get_or_insert_default();
+    runtime.set_permission_mode(SessionPermissionMode::Auto);
+    runtime.no_human_approver = true;
+}
+
 /// Create and configure a new session for a scheduled run.
 ///
-/// Sets up session metadata, workspace, system prompt, and optional initial user message.
+/// Sets up the unattended permission posture, metadata, workspace, system
+/// prompt, and optional initial user message.
 pub fn create_schedule_session(
     job: &ScheduleRunJob,
     model: &str,
@@ -26,6 +38,7 @@ pub fn create_schedule_session(
     );
 
     let mut session = Session::new(session_id.clone(), model.to_string());
+    apply_unattended_permission_posture(&mut session);
     session.metadata.insert(
         bamboo_engine::session_app::chat::SESSION_START_SOURCE_METADATA_KEY.to_string(),
         "startup".to_string(),
@@ -93,8 +106,129 @@ pub fn create_schedule_session(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bamboo_agent_core::tools::ToolExecutionSessionFlags;
     use bamboo_agent_core::workspace_state::{WorkspaceResolver, WorkspaceRootConfig};
-    use bamboo_domain::ScheduleRunConfig;
+    use bamboo_domain::{PermissionAuditSnapshot, PermissionMode, ScheduleRunConfig};
+    use bamboo_tools::permission::{
+        EffectivePermissionPolicy, PermissionConfig, PermissionDecisionKind,
+        PermissionDecisionSource, PermissionEvaluation, PermissionOutcome, PermissionReasonCode,
+        PermissionRequest, PermissionType, RiskLevel,
+    };
+
+    fn test_job() -> ScheduleRunJob {
+        ScheduleRunJob {
+            run_id: "run-scheduled-auto".to_string(),
+            schedule_id: "schedule-scheduled-auto".to_string(),
+            schedule_name: "scheduled auto".to_string(),
+            run_config: ScheduleRunConfig::default(),
+            scheduled_for: chrono::Utc::now(),
+            claimed_at: chrono::Utc::now(),
+            was_catch_up: false,
+        }
+    }
+
+    fn permission_evaluation(session: &Session, config: &PermissionConfig) -> PermissionEvaluation {
+        let flags =
+            ToolExecutionSessionFlags::from_session_and_configured_mode(session, config.mode());
+        PermissionEvaluation {
+            request_id: format!("request-{}", session.id),
+            session_id: session.id.clone(),
+            workspace_path: None,
+            tool_name: "Bash".to_string(),
+            tool_args: serde_json::json!({"command": "eval 'printf gated'"}),
+            permission_type: PermissionType::ExecuteCommand,
+            resource: "eval 'printf gated'".to_string(),
+            operation_summary: "execute a forced-ask high-risk command".to_string(),
+            risk_level: RiskLevel::High,
+            bypass_requested: flags.bypass_permissions,
+            auto_approve_requested: flags.auto_approve_permissions,
+            platform_hard_deny: None,
+            consume_once: true,
+            supported_decisions: PermissionDecisionKind::all_supported(),
+        }
+    }
+
+    #[test]
+    fn scheduled_factory_sets_typed_auto_mirror_and_no_human_without_widening_global_mode() {
+        let config = PermissionConfig::new();
+        let interactive_before = Session::new("interactive-before", "model");
+        let resolver = WorkspaceResolver::from_process_globals();
+
+        let mut scheduled = create_schedule_session(
+            &test_job(),
+            "model",
+            "system",
+            "base",
+            None,
+            None,
+            &resolver,
+        );
+        crate::permission_audit::record_bamboo_runtime_permission_metadata(&mut scheduled, &config)
+            .unwrap();
+
+        let runtime = scheduled
+            .agent_runtime_state
+            .as_ref()
+            .expect("scheduled root runtime posture");
+        assert_eq!(runtime.permission_mode, SessionPermissionMode::Auto);
+        assert!(runtime.bypass_permissions, "legacy compatibility mirror");
+        assert!(runtime.no_human_approver);
+        let audit = PermissionAuditSnapshot::from_metadata(&scheduled.metadata).unwrap();
+        assert_eq!(audit.resolution.requested, SessionPermissionMode::Auto);
+        assert_eq!(audit.resolution.effective, PermissionMode::Auto);
+
+        assert_eq!(config.mode(), PermissionMode::Default);
+        for interactive in [
+            interactive_before,
+            Session::new("interactive-concurrent", "model"),
+        ] {
+            assert!(interactive.agent_runtime_state.is_none());
+            assert_eq!(
+                ToolExecutionSessionFlags::from_session_and_configured_mode(
+                    &interactive,
+                    config.mode(),
+                ),
+                ToolExecutionSessionFlags::default()
+            );
+        }
+    }
+
+    #[test]
+    fn scheduled_auto_allows_forced_ask_high_risk_while_interactive_still_asks() {
+        let config = PermissionConfig::new();
+        let resolver = WorkspaceResolver::from_process_globals();
+        let scheduled = create_schedule_session(
+            &test_job(),
+            "model",
+            "system",
+            "base",
+            None,
+            None,
+            &resolver,
+        );
+        let interactive = Session::new("interactive-gated", "model");
+
+        assert!(matches!(
+            config.evaluate(permission_evaluation(&scheduled, &config)),
+            PermissionOutcome::Allow {
+                source: PermissionDecisionSource::Auto,
+                effective_policy: EffectivePermissionPolicy {
+                    mode: PermissionMode::Auto,
+                    auto_approve_requested: true,
+                    ..
+                }
+            }
+        ));
+        assert!(matches!(
+            config.evaluate(permission_evaluation(&interactive, &config)),
+            PermissionOutcome::Ask(PermissionRequest {
+                reason_code: PermissionReasonCode::HardDangerous,
+                effective_mode: PermissionMode::Default,
+                auto_approve_requested: false,
+                ..
+            })
+        ));
+    }
 
     #[test]
     fn schedule_publication_uses_the_validating_instance_workspace_root() {
@@ -111,10 +245,7 @@ mod tests {
             run_id: "run-instance-root".to_string(),
             schedule_id: "schedule-instance-root".to_string(),
             schedule_name: "instance root".to_string(),
-            run_config: ScheduleRunConfig::default(),
-            scheduled_for: chrono::Utc::now(),
-            claimed_at: chrono::Utc::now(),
-            was_catch_up: false,
+            ..test_job()
         };
 
         let session = create_schedule_session(

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
@@ -212,10 +212,13 @@ mod tests {
     use crate::runtime::config::{AgentLoopConfig, AuxiliaryModelConfig};
     use async_trait::async_trait;
     use bamboo_agent_core::tools::{
-        FunctionSchema, ToolCall, ToolExecutor, ToolResult, ToolSchema,
+        FunctionSchema, ToolCall, ToolExecutionSessionFlags, ToolExecutor, ToolResult, ToolSchema,
     };
     use bamboo_agent_core::Session;
-    use bamboo_domain::{AgentRuntimeState, AgentStatusState};
+    use bamboo_domain::{
+        record_permission_audit, resolve_permission_mode, AgentRuntimeState, AgentStatusState,
+        PermissionAuditSeed, PermissionAuditSnapshot, PermissionMode, SessionPermissionMode,
+    };
     use bamboo_skills::runtime_metadata::{
         LOADED_SKILL_IDS_METADATA_KEY, SKILL_RUNTIME_ACTIVATION_GENERATION_KEY,
         SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY, SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY,
@@ -329,6 +332,59 @@ mod tests {
 
         assert_eq!(first.summarization_model_name.as_deref(), Some("sum-1"));
         assert_eq!(second.summarization_model_name.as_deref(), Some("sum-2"));
+    }
+
+    #[tokio::test]
+    async fn startup_carries_scheduled_auto_no_human_and_audit_into_fresh_loop_state() {
+        let mut session = Session::new("scheduled-startup", "model");
+        let runtime = session.agent_runtime_state.get_or_insert_default();
+        runtime.set_permission_mode(SessionPermissionMode::Auto);
+        runtime.no_human_approver = true;
+        record_permission_audit(
+            &mut session.metadata,
+            &PermissionAuditSeed::bamboo_runtime(
+                17,
+                resolve_permission_mode(SessionPermissionMode::Auto, PermissionMode::Default),
+            ),
+            Some("2026-08-04T00:00:00Z"),
+        )
+        .unwrap();
+        let audit_before = PermissionAuditSnapshot::from_metadata(&session.metadata).unwrap();
+        let tools = SuccessfulLoadSkill::default();
+        let config = AgentLoopConfig::default();
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(8);
+
+        let loop_state =
+            initialize_loop_state(&mut session, "scheduled task", &config, &tools, &event_tx)
+                .await
+                .expect("scheduled startup");
+
+        for runtime in [
+            &loop_state.runtime_state,
+            session
+                .agent_runtime_state
+                .as_ref()
+                .expect("startup writes runtime state"),
+        ] {
+            assert_eq!(runtime.permission_mode, SessionPermissionMode::Auto);
+            assert!(
+                runtime.bypass_permissions,
+                "legacy Auto compatibility mirror"
+            );
+            assert!(runtime.no_human_approver);
+        }
+        assert_eq!(
+            ToolExecutionSessionFlags::from_session(&session),
+            ToolExecutionSessionFlags {
+                bypass_permissions: false,
+                auto_approve_permissions: true,
+                plan_read_only: false,
+            }
+        );
+        assert_eq!(
+            PermissionAuditSnapshot::from_metadata(&session.metadata).unwrap(),
+            audit_before
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- set every scheduled root session to the typed Auto permission mode before permission audit metadata is recorded
- mark scheduled roots as having no human approver without widening the process-global permission mode
- persist the initial scheduled runtime posture authoritatively and preserve it across loop startup and later runtime saves
- add unit, startup, persistence, and real tool-execution coverage proving a concurrent interactive session still pauses for approval

## Root Cause

Scheduled sessions only set the no-human-approver flag after session creation. They never requested the typed Auto permission mode, so ordinary permission rules could pause unattended runs waiting for an approval that would never arrive.

## User Impact

Unattended scheduled jobs can now execute Auto-eligible gated tools without stalling, while hard denies and plan/read-only overlays remain enforced and interactive sessions retain their existing approval behavior.

## Test Plan

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features
- cargo test
- cargo test -p bamboo-server schedule_app:: -- --nocapture
- cargo test -p bamboo-engine startup_carries_scheduled_auto_no_human_and_audit_into_fresh_loop_state -- --nocapture

## Screenshots

Not applicable; backend behavior only.

Closes #744