### PR TITLE
fix: reclaim orphaned workers and narrow skill watchers

### DIFF
--- a/crates/app/bamboo-broker/src/lib.rs
+++ b/crates/app/bamboo-broker/src/lib.rs
@@ -54,8 +54,9 @@ pub use crate::mcp::{
 pub use crate::mux::MultiplexedClient;
 pub use crate::proto::{BrokerFrame, ClientFrame};
 pub use crate::serve::{
-    serve_executor, serve_executor_full, serve_executor_with_shutdown, serve_loop, serve_mailbox,
-    serve_mailbox_full, serve_mailbox_with_shutdown, serve_with, Handled,
+    serve_executor, serve_executor_full, serve_executor_with_lifecycle,
+    serve_executor_with_shutdown, serve_loop, serve_loop_with_idle_timeout, serve_mailbox,
+    serve_mailbox_full, serve_mailbox_with_shutdown, serve_with, Handled, ServeExitReason,
 };
 pub use crate::server::{BrokerLimits, BrokerServer};
 pub use bamboo_subagent::AgentRef;

--- a/crates/app/bamboo-broker/src/serve.rs
+++ b/crates/app/bamboo-broker/src/serve.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bamboo_subagent::{AgentRef, InboxKind, InboxMessage, MsgId, ReplyBody};
 use chrono::Utc;
@@ -27,6 +28,18 @@ pub enum Handled {
     Ack,
     /// Leave the message unacked (it will be redelivered on the next subscribe).
     Leave,
+}
+
+/// Why a mailbox worker stopped serving normally.
+///
+/// Transport errors still return [`crate::BrokerError`]. These reasons cover
+/// clean lifecycle exits and are intentionally separate from durable child
+/// business state (#592): callers use them for process/pool observability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServeExitReason {
+    ShutdownRequested,
+    ConnectionClosed,
+    IdleTimeout,
 }
 
 /// Connect as `me`, subscribe, and serve inbound messages with `handler` until
@@ -85,11 +98,29 @@ where
     H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Handled> + Send + 'static,
 {
+    serve_mailbox_full_with_lifecycle(endpoint, me, token, handler, shutdown, tls_config, None)
+        .await
+        .map(|_| ())
+}
+
+async fn serve_mailbox_full_with_lifecycle<H, Fut>(
+    endpoint: &str,
+    me: AgentRef,
+    token: &str,
+    handler: H,
+    shutdown: CancellationToken,
+    tls_config: Option<Arc<rustls::ClientConfig>>,
+    idle_timeout: Option<Duration>,
+) -> BrokerResult<ServeExitReason>
+where
+    H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Handled> + Send + 'static,
+{
     let mut client =
         BrokerClient::connect_with_tls(endpoint, me.clone(), token, clone_tls_config(&tls_config))
             .await?;
     client.subscribe().await?;
-    serve_loop(&mut client, &me, handler, shutdown).await
+    serve_loop_with_idle_timeout(&mut client, &me, handler, shutdown, idle_timeout).await
 }
 
 /// [`BrokerClient::connect_with_tls`] takes an owned `ClientConfig` (it hands
@@ -144,6 +175,25 @@ where
     H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Handled> + Send + 'static,
 {
+    serve_loop_with_idle_timeout(client, me, handler, shutdown, None)
+        .await
+        .map(|_| ())
+}
+
+/// Serve with an optional true-idle deadline and report the clean exit reason.
+/// The deadline is disabled while any handler is in flight and restarts only
+/// after the final completion is delivered and acked.
+pub async fn serve_loop_with_idle_timeout<H, Fut>(
+    client: &mut BrokerClient,
+    me: &AgentRef,
+    handler: H,
+    shutdown: CancellationToken,
+    idle_timeout: Option<Duration>,
+) -> BrokerResult<ServeExitReason>
+where
+    H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Handled> + Send + 'static,
+{
     let handler = Arc::new(handler);
 
     // Live cancel tokens for runs still in flight, keyed by the run (message) id.
@@ -160,6 +210,10 @@ where
     let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel::<Completion>();
 
     let mut messages_open = true;
+    let mut exit_reason = ServeExitReason::ConnectionClosed;
+    let idle_sleep =
+        tokio::time::sleep(idle_timeout.unwrap_or_else(|| Duration::from_secs(365 * 24 * 60 * 60)));
+    tokio::pin!(idle_sleep);
     loop {
         tokio::select! {
             // `biased`: drain finished handlers (arm A) ahead of a graceful-stop
@@ -196,6 +250,11 @@ where
                     Handled::Ack => client.ack(id).await?,
                     Handled::Leave => {}
                 }
+                if let Some(timeout) = idle_timeout {
+                    idle_sleep
+                        .as_mut()
+                        .reset(tokio::time::Instant::now() + timeout);
+                }
             }
             // B. Graceful stop requested (#49): stop pulling new work — mirrors
             //    the `Message(None)` connection-closed case below — but leave
@@ -206,6 +265,7 @@ where
             _ = shutdown.cancelled(), if messages_open => {
                 tracing::info!("broker worker: graceful shutdown requested — draining in-flight work");
                 messages_open = false;
+                exit_reason = ServeExitReason::ShutdownRequested;
             }
             // C. The next inbound message OR out-of-band cancel (demuxed over one
             //    `&mut client` borrow). A cancel trips the matching in-flight run's
@@ -214,6 +274,11 @@ where
             //    only the (cheap) wire I/O stays serialized through this owner. #45.
             event = client.next_message_or_cancel(), if messages_open => match event {
                 crate::client::ServeEvent::Cancel(Some(cid)) => {
+                    if let Some(timeout) = idle_timeout {
+                        idle_sleep
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + timeout);
+                    }
                     if let Some(tok) = inflight.get(&cid) {
                         tok.cancel();
                     }
@@ -221,8 +286,16 @@ where
                 // Cancel lane closed (reader gone). The message lane is fed by the
                 // same reader, so treat it as connection teardown: stop pulling and
                 // drain the in-flight handlers through arm A.
-                crate::client::ServeEvent::Cancel(None) => messages_open = false,
+                crate::client::ServeEvent::Cancel(None) => {
+                    messages_open = false;
+                    exit_reason = ServeExitReason::ConnectionClosed;
+                }
                 crate::client::ServeEvent::Message(Some(msg)) => {
+                    if let Some(timeout) = idle_timeout {
+                        idle_sleep
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + timeout);
+                    }
                     let id = msg.id.clone();
                     let reply_to = msg.from.session_id.clone();
                     let token = CancellationToken::new();
@@ -238,8 +311,22 @@ where
                 }
                 // Connection closed: stop pulling new messages and let the remaining
                 // in-flight handlers drain through arm A before we exit.
-                crate::client::ServeEvent::Message(None) => messages_open = false,
+                crate::client::ServeEvent::Message(None) => {
+                    messages_open = false;
+                    exit_reason = ServeExitReason::ConnectionClosed;
+                }
             },
+            _ = &mut idle_sleep,
+                if messages_open && inflight.is_empty() && idle_timeout.is_some() =>
+            {
+                tracing::info!(
+                    idle_timeout_ms = idle_timeout.expect("guarded").as_millis() as u64,
+                    shutdown_reason = "idle_timeout",
+                    "broker worker reached its true-idle deadline"
+                );
+                messages_open = false;
+                exit_reason = ServeExitReason::IdleTimeout;
+            }
         }
 
         // Once the message stream is closed, exit as soon as every in-flight run
@@ -248,7 +335,7 @@ where
             break;
         }
     }
-    Ok(())
+    Ok(exit_reason)
 }
 
 /// Convenience wrapper for `serve_mailbox` whose `Arc`-shared handler answers
@@ -343,6 +430,42 @@ pub async fn serve_executor_full<E>(
 where
     E: bamboo_subagent::ChildExecutor + ?Sized,
 {
+    serve_executor_full_with_lifecycle(endpoint, me, token, executor, shutdown, tls_config, None)
+        .await
+        .map(|_| ())
+}
+
+/// Serve an executor with bounded true-idle lifetime and return a structured
+/// clean shutdown reason. In-flight work disables the idle deadline; explicit
+/// shutdown keeps the existing graceful-drain behavior.
+pub async fn serve_executor_with_lifecycle<E>(
+    endpoint: &str,
+    me: AgentRef,
+    token: &str,
+    executor: Arc<E>,
+    shutdown: CancellationToken,
+    idle_timeout: Option<Duration>,
+) -> BrokerResult<ServeExitReason>
+where
+    E: bamboo_subagent::ChildExecutor + ?Sized,
+{
+    serve_executor_full_with_lifecycle(endpoint, me, token, executor, shutdown, None, idle_timeout)
+        .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn serve_executor_full_with_lifecycle<E>(
+    endpoint: &str,
+    me: AgentRef,
+    token: &str,
+    executor: Arc<E>,
+    shutdown: CancellationToken,
+    tls_config: Option<Arc<rustls::ClientConfig>>,
+    idle_timeout: Option<Duration>,
+) -> BrokerResult<ServeExitReason>
+where
+    E: bamboo_subagent::ChildExecutor + ?Sized,
+{
     let context: Arc<tokio::sync::Mutex<Vec<serde_json::Value>>> =
         Arc::new(tokio::sync::Mutex::new(Vec::new()));
     // Per-run coordination so a SEPARATE Steer / ApprovalReply mailbox message can
@@ -354,7 +477,7 @@ where
     let token_owned = token.to_string();
     let me_owned = me.clone();
     let tls_owned = tls_config.clone();
-    serve_mailbox_full(
+    serve_mailbox_full_with_lifecycle(
         endpoint,
         me,
         token,
@@ -424,6 +547,7 @@ where
         },
         shutdown,
         tls_config,
+        idle_timeout,
     )
     .await
 }
@@ -766,6 +890,24 @@ mod tests {
             let _ = server.serve(listener).await;
         });
         (format!("ws://{addr}"), dir)
+    }
+
+    async fn start_single_connection() -> (
+        String,
+        tempfile::TempDir,
+        Arc<BrokerCore>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let core = Arc::new(BrokerCore::new(dir.path()));
+        let server = Arc::new(BrokerServer::new(core.clone(), TOKEN));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connection = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("worker connection");
+            let _ = server.handle_conn(stream).await;
+        });
+        (format!("ws://{addr}"), dir, core, connection)
     }
 
     fn ask(from: &str, q: &str) -> InboxMessage {
@@ -1382,6 +1524,156 @@ mod tests {
         assert!(events >= 1, "expected streamed events, got {events}");
         let oc: bamboo_subagent::ChildOutcome = serde_json::from_value(outcome.body).unwrap();
         assert_eq!(oc.result.as_deref(), Some("echo: ping pong"));
+    }
+
+    #[tokio::test]
+    async fn lifecycle_reports_idle_timeout_for_unused_worker() {
+        let (endpoint, _dir) = start().await;
+        let reason = tokio::time::timeout(
+            Duration::from_secs(2),
+            serve_executor_with_lifecycle(
+                &endpoint,
+                AgentRef {
+                    session_id: "idle-timeout-worker".into(),
+                    role: None,
+                },
+                TOKEN,
+                Arc::new(bamboo_subagent::EchoExecutor),
+                CancellationToken::new(),
+                Some(Duration::from_millis(100)),
+            ),
+        )
+        .await
+        .expect("idle worker exits within the bound")
+        .expect("clean lifecycle exit");
+        assert_eq!(reason, ServeExitReason::IdleTimeout);
+    }
+
+    #[tokio::test]
+    async fn true_idle_timeout_never_fires_while_a_run_is_in_flight() {
+        use bamboo_subagent::{ChildExecutor, ChildOutcome, EventSink, RunSpec, SteerInbox};
+
+        struct BlockingEcho {
+            started: Arc<tokio::sync::Notify>,
+            release: Arc<tokio::sync::Notify>,
+        }
+
+        #[async_trait::async_trait]
+        impl ChildExecutor for BlockingEcho {
+            async fn run(
+                &self,
+                spec: RunSpec,
+                _events: EventSink,
+                _steer: SteerInbox,
+                _cancel: CancellationToken,
+            ) -> ChildOutcome {
+                self.started.notify_one();
+                self.release.notified().await;
+                ChildOutcome::completed(format!("echo: {}", spec.assignment))
+            }
+        }
+
+        let (endpoint, _dir) = start().await;
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let worker_endpoint = endpoint.clone();
+        let worker = tokio::spawn({
+            let started = started.clone();
+            let release = release.clone();
+            async move {
+                serve_executor_with_lifecycle(
+                    &worker_endpoint,
+                    AgentRef {
+                        session_id: "busy-worker".into(),
+                        role: None,
+                    },
+                    TOKEN,
+                    Arc::new(BlockingEcho { started, release }),
+                    CancellationToken::new(),
+                    Some(Duration::from_millis(100)),
+                )
+                .await
+            }
+        });
+        let mut parent = BrokerClient::connect(
+            &endpoint,
+            AgentRef {
+                session_id: "busy-parent".into(),
+                role: None,
+            },
+            TOKEN,
+        )
+        .await
+        .unwrap();
+        parent.subscribe().await.unwrap();
+        let request = ask("busy-parent", "held open");
+        let request_id = request.id.clone();
+        parent.deliver("busy-worker", request).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .expect("run starts");
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        assert!(
+            !worker.is_finished(),
+            "true-idle must be disabled while a handler is in flight"
+        );
+        release.notify_one();
+        let reply = tokio::time::timeout(Duration::from_secs(2), parent.next_message())
+            .await
+            .expect("reply arrives")
+            .expect("reply present");
+        assert_eq!(reply.correlation_id, Some(request_id));
+
+        let reason = tokio::time::timeout(Duration::from_secs(2), worker)
+            .await
+            .expect("worker exits after becoming idle")
+            .expect("worker task")
+            .expect("clean lifecycle exit");
+        assert_eq!(reason, ServeExitReason::IdleTimeout);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_reports_connection_closed_separately_from_idle() {
+        let (endpoint, _dir, core, connection) = start_single_connection().await;
+        let worker_endpoint = endpoint.clone();
+        let worker = tokio::spawn(async move {
+            serve_executor_with_lifecycle(
+                &worker_endpoint,
+                AgentRef {
+                    session_id: "disconnect-worker".into(),
+                    role: Some("disconnect-test".into()),
+                },
+                TOKEN,
+                Arc::new(bamboo_subagent::EchoExecutor),
+                CancellationToken::new(),
+                Some(Duration::from_secs(30)),
+            )
+            .await
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if core
+                    .connected_by_role("disconnect-test")
+                    .await
+                    .iter()
+                    .any(|id| id == "disconnect-worker")
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("worker subscribes");
+
+        connection.abort();
+        let reason = tokio::time::timeout(Duration::from_secs(2), worker)
+            .await
+            .expect("worker observes connection loss")
+            .expect("worker task")
+            .expect("clean connection-close lifecycle exit");
+        assert_eq!(reason, ServeExitReason::ConnectionClosed);
     }
 
     /// Graceful shutdown (#49): tripping the shutdown token while an Ask is in

--- a/crates/app/bamboo-broker/src/server.rs
+++ b/crates/app/bamboo-broker/src/server.rs
@@ -223,7 +223,7 @@ impl BrokerServer {
     /// serves both bare `TcpStream` (`ws://`) and `TlsStream<TcpStream>`
     /// (`wss://`) connections (#48) — mirrors
     /// `bamboo_subagent::transport::handle_conn`'s same genericization.
-    async fn handle_conn<S>(&self, stream: S) -> BrokerResult<()>
+    pub(crate) async fn handle_conn<S>(&self, stream: S) -> BrokerResult<()>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -12,8 +12,9 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use bamboo_agent_core::{AgentError, AgentEvent, Role, Session};
@@ -47,9 +48,19 @@ pub const MAX_SPAWN_DEPTH: u32 = 4;
 /// Default cap on idle pooled (warm, reusable) workers kept per fingerprint.
 const DEFAULT_MAX_IDLE_PER_KEY: usize = 4;
 
+/// Process-wide-per-runner cap across every reuse fingerprint. Without this,
+/// workloads that continually change role/model/workspace can leave one parked
+/// worker in an unbounded number of otherwise-small buckets.
+const DEFAULT_MAX_IDLE_TOTAL: usize = DEFAULT_MAX_CONCURRENT_ACTORS;
+
 /// How long a pooled worker waits for its next assignment before reclaiming
 /// itself (must comfortably exceed the gap between sibling spawns).
 const POOLED_IDLE_TIMEOUT_SECS: u64 = 300;
+
+/// Sweep often enough to retire an expired/dead pool entry even when no later
+/// child checks out the same fingerprint. The worker's own idle deadline is the
+/// primary process-side guard; this task closes the parent handle and pool entry.
+const POOLED_REAPER_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Deadline for a local worker's FIRST frame after a Run is dispatched. A warm
 /// worker answers in seconds; a cold spawn within tens. Total silence past this
@@ -343,6 +354,98 @@ struct PooledWorker {
     worker: SpawnedChild,
     /// The bus mailbox this worker subscribes to (where its `Run`s are delivered).
     mailbox_id: String,
+    /// Set only while the worker is parked. Checked both at checkout and by the
+    /// background pool sweep; cleared before the worker is handed to a run.
+    parked_at: Option<Instant>,
+}
+
+type WorkerPool = HashMap<String, Vec<PooledWorker>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PoolReapReason {
+    ProcessExited,
+    IdleTimeout,
+}
+
+impl PoolReapReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ProcessExited => "process_exited_while_parked",
+            Self::IdleTimeout => "pool_idle_timeout",
+        }
+    }
+}
+
+fn parked_worker_expired(parked_at: Option<Instant>, now: Instant, timeout: Duration) -> bool {
+    parked_at.is_some_and(|parked_at| now.saturating_duration_since(parked_at) >= timeout)
+}
+
+fn idle_pool_limit_reason(
+    pool: &WorkerPool,
+    key: &str,
+    max_per_key: usize,
+    max_total: usize,
+) -> Option<&'static str> {
+    if pool.get(key).map_or(0, Vec::len) >= max_per_key {
+        Some("pool_per_key_limit")
+    } else if pool.values().map(Vec::len).sum::<usize>() >= max_total {
+        Some("pool_global_limit")
+    } else {
+        None
+    }
+}
+
+fn take_reapable_workers(
+    pool: &mut WorkerPool,
+    now: Instant,
+    timeout: Duration,
+) -> Vec<(String, PoolReapReason, PooledWorker)> {
+    let mut reaped = Vec::new();
+    for (key, bucket) in pool.iter_mut() {
+        let mut retained = Vec::with_capacity(bucket.len());
+        for mut worker in std::mem::take(bucket) {
+            let reason = if !worker.worker.is_alive() {
+                Some(PoolReapReason::ProcessExited)
+            } else if parked_worker_expired(worker.parked_at, now, timeout) {
+                Some(PoolReapReason::IdleTimeout)
+            } else {
+                None
+            };
+            if let Some(reason) = reason {
+                reaped.push((key.clone(), reason, worker));
+            } else {
+                retained.push(worker);
+            }
+        }
+        *bucket = retained;
+    }
+    pool.retain(|_, bucket| !bucket.is_empty());
+    reaped
+}
+
+async fn reap_worker_pool_once(pool: &Arc<tokio::sync::Mutex<WorkerPool>>) -> usize {
+    let now = Instant::now();
+    let timeout = Duration::from_secs(POOLED_IDLE_TIMEOUT_SECS);
+    let reaped = {
+        let mut pool = pool.lock().await;
+        take_reapable_workers(&mut pool, now, timeout)
+    };
+    let count = reaped.len();
+    for (pool_key, reason, worker) in reaped {
+        let idle_ms = worker
+            .parked_at
+            .map(|parked_at| now.saturating_duration_since(parked_at).as_millis() as u64);
+        tracing::info!(
+            pool_key,
+            mailbox_id = %worker.mailbox_id,
+            worker_pid = ?worker.worker.pid(),
+            worker_idle_ms = ?idle_ms,
+            shutdown_reason = reason.as_str(),
+            "reaping parked sub-agent worker"
+        );
+        worker.worker.kill().await;
+    }
+    count
 }
 
 /// A role pinned to a remote resident worker (remote-actor-plan §3.4 / P1.5,
@@ -413,8 +516,10 @@ pub struct ActorChildRunner {
     /// parks its bus worker here so the next interchangeable child reuses it
     /// (delivers its `Run` to the same mailbox) instead of spawning a fresh
     /// process — collapsing N sibling sub-agents onto a few warm workers.
-    pool: Arc<tokio::sync::Mutex<HashMap<String, Vec<PooledWorker>>>>,
+    pool: Arc<tokio::sync::Mutex<WorkerPool>>,
     max_idle_per_key: usize,
+    max_idle_total: usize,
+    pool_reaper_started: AtomicBool,
     /// Host-side decision for a child's gated-tool approval request (Phase 2).
     /// `None` ⇒ fail-closed DENY (the safe default). A wired decider (policy or
     /// human-routing bridge) returns approve/deny over the actor WS.
@@ -555,6 +660,8 @@ impl ActorChildRunner {
             concurrency: std::sync::Arc::new(tokio::sync::Semaphore::new(max_concurrent.max(1))),
             pool: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             max_idle_per_key: DEFAULT_MAX_IDLE_PER_KEY,
+            max_idle_total: DEFAULT_MAX_IDLE_TOTAL,
+            pool_reaper_started: AtomicBool::new(false),
             approval_decider: None,
             approval_reviewer: None,
             escalation_bridge: Arc::new(std::sync::Mutex::new(None)),
@@ -693,6 +800,33 @@ impl ActorChildRunner {
         )
     }
 
+    /// Start one weakly-owned sweep task for this runner. It does not keep the
+    /// runner/pool alive, and it never holds the pool lock while killing a child.
+    fn ensure_pool_reaper(&self) {
+        if self
+            .pool_reaper_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let pool = Arc::downgrade(&self.pool);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(POOLED_REAPER_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // Tokio intervals tick immediately once; consume that tick so a new
+            // runner does not scan an empty pool before its first worker parks.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let Some(pool) = pool.upgrade() else {
+                    break;
+                };
+                let _ = reap_worker_pool_once(&pool).await;
+            }
+        });
+    }
+
     /// Check out a warm bus worker for `key`, reusing a live parked one if any,
     /// else spawning a fresh one that dials the bus. The returned worker is OWNED
     /// by the caller for the run's duration (checkout removes it from the pool, so
@@ -703,19 +837,43 @@ impl ActorChildRunner {
         key: &str,
         spec: &ProvisionSpec,
     ) -> crate::runtime::runner::Result<PooledWorker> {
+        self.ensure_pool_reaper();
         // Drain the bucket, skipping (and reaping) any worker whose process exited
-        // while parked. A live one is handed straight out for reuse.
+        // or crossed its idle deadline while parked. A live, fresh one is handed
+        // straight out for reuse.
         loop {
             let candidate = {
                 let mut pool = self.pool.lock().await;
-                pool.get_mut(key).and_then(|bucket| bucket.pop())
+                let candidate = pool.get_mut(key).and_then(|bucket| bucket.pop());
+                if pool.get(key).is_some_and(Vec::is_empty) {
+                    pool.remove(key);
+                }
+                candidate
             };
             let Some(mut candidate) = candidate else {
                 break;
             };
-            if candidate.worker.is_alive() {
+            let now = Instant::now();
+            let expired = parked_worker_expired(
+                candidate.parked_at,
+                now,
+                Duration::from_secs(POOLED_IDLE_TIMEOUT_SECS),
+            );
+            if candidate.worker.is_alive() && !expired {
+                candidate.parked_at = None;
                 return Ok(candidate);
             }
+            tracing::info!(
+                pool_key = key,
+                mailbox_id = %candidate.mailbox_id,
+                worker_pid = ?candidate.worker.pid(),
+                shutdown_reason = if expired {
+                    PoolReapReason::IdleTimeout.as_str()
+                } else {
+                    PoolReapReason::ProcessExited.as_str()
+                },
+                "discarding unusable parked sub-agent worker during checkout"
+            );
             candidate.worker.kill().await;
         }
 
@@ -726,6 +884,7 @@ impl ActorChildRunner {
         Ok(PooledWorker {
             worker: spawned,
             mailbox_id,
+            parked_at: None,
         })
     }
 
@@ -733,18 +892,41 @@ impl ActorChildRunner {
     /// (or it died), kill it instead. The worker stays dialed-in + subscribed
     /// while parked, so a reusing child just delivers a new `Run` to its mailbox.
     async fn release_bus_worker(&self, key: &str, mut worker: PooledWorker) {
+        self.ensure_pool_reaper();
         if !worker.worker.is_alive() {
+            tracing::info!(
+                pool_key = key,
+                mailbox_id = %worker.mailbox_id,
+                worker_pid = ?worker.worker.pid(),
+                shutdown_reason = "process_exited_before_park",
+                "discarding sub-agent worker instead of parking"
+            );
             worker.worker.kill().await;
             return;
         }
+        worker.parked_at = Some(Instant::now());
         let mut pool = self.pool.lock().await;
-        let bucket = pool.entry(key.to_string()).or_default();
-        if bucket.len() >= self.max_idle_per_key {
+        let key_count = pool.get(key).map_or(0, Vec::len);
+        let total_count = pool.values().map(Vec::len).sum::<usize>();
+        let limit_reason =
+            idle_pool_limit_reason(&pool, key, self.max_idle_per_key, self.max_idle_total);
+        if let Some(shutdown_reason) = limit_reason {
             drop(pool);
+            tracing::info!(
+                pool_key = key,
+                mailbox_id = %worker.mailbox_id,
+                worker_pid = ?worker.worker.pid(),
+                idle_workers_for_key = key_count,
+                idle_workers_total = total_count,
+                max_idle_per_key = self.max_idle_per_key,
+                max_idle_total = self.max_idle_total,
+                shutdown_reason,
+                "discarding sub-agent worker because the warm pool is full"
+            );
             worker.worker.kill().await;
             return;
         }
-        bucket.push(worker);
+        pool.entry(key.to_string()).or_default().push(worker);
     }
 
     /// Assemble the parent-resolved provisioning document for this child.
@@ -1287,6 +1469,7 @@ impl ExternalChildRunner for ActorChildRunner {
                     let actor = PooledWorker {
                         worker: SpawnedChild::remote(record),
                         mailbox_id: job.child_session_id.clone(),
+                        parked_at: None,
                     };
                     let client: Box<dyn bamboo_subagent::ChildLink> = Box::new(client);
                     (actor, client)
@@ -1337,6 +1520,7 @@ impl ExternalChildRunner for ActorChildRunner {
                             lease_expires_at: chrono::Utc::now(),
                         }),
                         mailbox_id,
+                        parked_at: None,
                     };
                     let client: Box<dyn bamboo_subagent::ChildLink> = Box::new(link);
                     (actor, client)
@@ -2551,6 +2735,78 @@ mod tests {
     use super::*;
     use crate::SessionActivationRouter;
     use bamboo_domain::{RuntimeSessionPersistence, SessionInboxPort, Storage};
+
+    fn processless_pool_worker(mailbox_id: &str) -> PooledWorker {
+        PooledWorker {
+            worker: SpawnedChild::remote(AgentRecord {
+                agent_id: mailbox_id.to_string(),
+                role: "test".to_string(),
+                labels: Vec::new(),
+                endpoint: "ws://127.0.0.1:1".to_string(),
+                pid: 0,
+                version: String::new(),
+                started_at: chrono::Utc::now(),
+                lease_expires_at: chrono::Utc::now(),
+            }),
+            mailbox_id: mailbox_id.to_string(),
+            parked_at: None,
+        }
+    }
+
+    #[test]
+    fn parked_worker_deadline_is_inclusive_and_ignores_checked_out_workers() {
+        let now = Instant::now();
+        let timeout = Duration::from_secs(300);
+        assert!(!parked_worker_expired(None, now, timeout));
+        assert!(!parked_worker_expired(
+            Some(now - timeout + Duration::from_millis(1)),
+            now,
+            timeout
+        ));
+        assert!(parked_worker_expired(Some(now - timeout), now, timeout));
+    }
+
+    #[test]
+    fn idle_pool_global_cap_bounds_distinct_fingerprints() {
+        let mut pool = WorkerPool::new();
+        pool.insert(
+            "fingerprint-a".to_string(),
+            vec![processless_pool_worker("a")],
+        );
+        pool.insert(
+            "fingerprint-b".to_string(),
+            vec![processless_pool_worker("b")],
+        );
+
+        assert_eq!(
+            idle_pool_limit_reason(&pool, "fingerprint-c", 4, 2),
+            Some("pool_global_limit")
+        );
+        assert_eq!(idle_pool_limit_reason(&pool, "fingerprint-c", 4, 3), None);
+        assert_eq!(
+            idle_pool_limit_reason(&pool, "fingerprint-a", 1, 8),
+            Some("pool_per_key_limit")
+        );
+    }
+
+    #[test]
+    fn pool_sweep_removes_dead_workers_and_empty_fingerprint_buckets() {
+        let mut pool = WorkerPool::new();
+        pool.insert(
+            "fingerprint-a".to_string(),
+            vec![processless_pool_worker("dead")],
+        );
+
+        let reaped = take_reapable_workers(
+            &mut pool,
+            Instant::now(),
+            Duration::from_secs(POOLED_IDLE_TIMEOUT_SECS),
+        );
+
+        assert!(pool.is_empty());
+        assert_eq!(reaped.len(), 1);
+        assert_eq!(reaped[0].1, PoolReapReason::ProcessExited);
+    }
 
     #[test]
     fn actor_preflight_counts_only_current_session_scoped_denies() {

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -3707,6 +3707,26 @@ mod tests {
         Ok(skill_dir)
     }
 
+    async fn wait_for_watcher_quiescence(store: &SkillStore) {
+        let stable_for = super::SKILL_WATCH_MAX_BATCH + super::SKILL_WATCH_QUIET_PERIOD;
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let mut last_activity = store.watcher_activity();
+            let mut last_change = tokio::time::Instant::now();
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                let activity = store.watcher_activity();
+                if activity != last_activity {
+                    last_activity = activity;
+                    last_change = tokio::time::Instant::now();
+                } else if last_change.elapsed() >= stable_for {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("skill watcher should become quiescent");
+    }
+
     fn orchestration_yaml(id: &str, revision: u64) -> String {
         format!(
             "workflow_schema: 1\nid: {id}\nrevision: {revision}\ninput_schema:\n  type: object\n  properties:\n    path:\n      type: string\n  required: [path]\n  additionalProperties: false\nsteps:\n  - id: inspect\n    type: tool\n    tool: read_file\n    args:\n      path:\n        from: args\n        pointer: /path\n    capabilities: [read]\n    output_schema:\n      type: object\n      additionalProperties: true\nplan:\n  type: step\n  step: inspect\nbudgets:\n  max_concurrency: 1\n  max_agents: 0\n  max_steps: 4\n  max_retries: 1\n  max_nesting_depth: 2\n  wall_time_ms: 10000\n"
@@ -5015,7 +5035,7 @@ Use this skill for testing.
         .await
         .expect("recursive plugin watch should publish removal");
 
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        wait_for_watcher_quiescence(manager.store()).await;
         let stable_revision = manager.store().skill_catalog_snapshot().await.revision;
         let stable_activity = manager.store().watcher_activity();
         fs::create_dir_all(directory.path().join("data/sessions"))
@@ -5024,7 +5044,7 @@ Use this skill for testing.
         fs::write(directory.path().join("data/sessions/unrelated.json"), "{}")
             .await
             .expect("unrelated write");
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        wait_for_watcher_quiescence(manager.store()).await;
         assert_eq!(
             manager.store().skill_catalog_snapshot().await.revision,
             stable_revision,
@@ -5091,7 +5111,7 @@ Use this skill for testing.
         // so it can notice `.bamboo` being recreated. A project build tree may
         // therefore yield a cheap top-level event, but its recursive churn must
         // never cause catalog reloads or event-path canonicalization.
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        wait_for_watcher_quiescence(store.as_ref()).await;
         let stable_revision = store.workflow_catalog_snapshot().await.revision;
         let stable_activity = store.watcher_activity();
         let build_output = workspace.join("target/debug/build/example/out");
@@ -5103,7 +5123,7 @@ Use this skill for testing.
                 .await
                 .expect("project build artifact");
         }
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        wait_for_watcher_quiescence(store.as_ref()).await;
         let after_churn = store.watcher_activity();
         assert_eq!(
             store.workflow_catalog_snapshot().await.revision,

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -653,6 +653,186 @@ fn preserve_catalog_entry_revisions(
 type ProjectWorkspaceStoreKey = (String, PathBuf, Option<PathBuf>);
 type SharedSkillStore = std::sync::Arc<SkillStore>;
 
+const SKILL_WATCH_CHANNEL_CAPACITY: usize = 256;
+const SKILL_WATCH_QUIET_PERIOD: std::time::Duration = std::time::Duration::from_millis(120);
+const SKILL_WATCH_MAX_BATCH: std::time::Duration = std::time::Duration::from_secs(1);
+
+#[derive(Debug, Default)]
+struct SkillWatcherCounters {
+    received_events: AtomicU64,
+    rejected_events: AtomicU64,
+    coalesced_events: AtomicU64,
+    overflowed_events: AtomicU64,
+    reloads: AtomicU64,
+    reload_failures: AtomicU64,
+    registration_canonicalizations: AtomicU64,
+    watch_rebinds: AtomicU64,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SkillWatcherActivity {
+    pub received_events: u64,
+    pub rejected_events: u64,
+    pub coalesced_events: u64,
+    pub overflowed_events: u64,
+    pub reloads: u64,
+    pub reload_failures: u64,
+    pub registration_canonicalizations: u64,
+    pub watch_rebinds: u64,
+}
+
+impl SkillWatcherCounters {
+    fn snapshot(&self) -> SkillWatcherActivity {
+        SkillWatcherActivity {
+            received_events: self.received_events.load(Ordering::Relaxed),
+            rejected_events: self.rejected_events.load(Ordering::Relaxed),
+            coalesced_events: self.coalesced_events.load(Ordering::Relaxed),
+            overflowed_events: self.overflowed_events.load(Ordering::Relaxed),
+            reloads: self.reloads.load(Ordering::Relaxed),
+            reload_failures: self.reload_failures.load(Ordering::Relaxed),
+            registration_canonicalizations: self
+                .registration_canonicalizations
+                .load(Ordering::Relaxed),
+            watch_rebinds: self.watch_rebinds.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CatalogWatchPlan {
+    /// Actual catalog roots. Existing roots are watched recursively; missing
+    /// roots are discovered through a shallow nearest-existing ancestor.
+    catalog_roots: Vec<PathBuf>,
+    /// Structural containers whose creation makes a missing catalog root
+    /// reachable (for example `<workspace>/.bamboo`). Exact-match only.
+    container_paths: Vec<PathBuf>,
+}
+
+impl CatalogWatchPlan {
+    fn is_relevant(&self, path: &Path) -> bool {
+        self.catalog_roots
+            .iter()
+            .any(|root| path == root || path.starts_with(root))
+            || self
+                .container_paths
+                .iter()
+                .any(|container| path == container)
+    }
+}
+
+fn lexical_normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() && !path.is_absolute() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
+}
+
+fn nearest_existing_directory(path: &Path) -> Option<PathBuf> {
+    let mut candidate = Some(path);
+    while let Some(current) = candidate {
+        if current.is_dir() {
+            return Some(current.to_path_buf());
+        }
+        candidate = current.parent();
+    }
+    None
+}
+
+fn desired_catalog_watch_registrations(
+    plan: &CatalogWatchPlan,
+) -> BTreeMap<PathBuf, notify::RecursiveMode> {
+    fn insert(
+        registrations: &mut BTreeMap<PathBuf, notify::RecursiveMode>,
+        path: PathBuf,
+        mode: notify::RecursiveMode,
+    ) {
+        registrations
+            .entry(path)
+            .and_modify(|existing| {
+                if matches!(mode, notify::RecursiveMode::Recursive) {
+                    *existing = mode;
+                }
+            })
+            .or_insert(mode);
+    }
+
+    let mut desired = BTreeMap::new();
+    for root in &plan.catalog_roots {
+        if root.is_dir() {
+            insert(&mut desired, root.clone(), notify::RecursiveMode::Recursive);
+        }
+        if let Some(parent) = root.parent().and_then(nearest_existing_directory) {
+            insert(&mut desired, parent, notify::RecursiveMode::NonRecursive);
+        }
+    }
+    for container in &plan.container_paths {
+        if container.is_dir() {
+            insert(
+                &mut desired,
+                container.clone(),
+                notify::RecursiveMode::NonRecursive,
+            );
+        }
+        if let Some(parent) = container.parent().and_then(nearest_existing_directory) {
+            insert(&mut desired, parent, notify::RecursiveMode::NonRecursive);
+        }
+    }
+    desired
+}
+
+fn sync_catalog_watch_registrations<W: notify::Watcher>(
+    watcher: &mut W,
+    plan: &CatalogWatchPlan,
+    registered: &mut HashMap<PathBuf, notify::RecursiveMode>,
+    counters: &SkillWatcherCounters,
+) {
+    let desired = desired_catalog_watch_registrations(plan);
+    let stale: Vec<_> = registered
+        .iter()
+        .filter(|(path, mode)| desired.get(*path) != Some(*mode))
+        .map(|(path, _)| path.clone())
+        .collect();
+    for path in stale {
+        let _ = watcher.unwatch(&path);
+        registered.remove(&path);
+        counters.watch_rebinds.fetch_add(1, Ordering::Relaxed);
+    }
+
+    for (path, mode) in desired {
+        if registered.get(&path) == Some(&mode) {
+            continue;
+        }
+        match watcher.watch(&path, mode) {
+            Ok(()) => {
+                registered.insert(path.clone(), mode);
+                counters.watch_rebinds.fetch_add(1, Ordering::Relaxed);
+                tracing::debug!(
+                    watch_root = %path.display(),
+                    recursive = matches!(mode, notify::RecursiveMode::Recursive),
+                    "skill watcher registration bound"
+                );
+            }
+            Err(error) => tracing::warn!(
+                "Failed to watch skill catalog root {}: {error}",
+                path.display()
+            ),
+        }
+    }
+}
+
 pub struct SkillStore {
     store_token: u64,
     /// Serializes publication and observation of the correlated snapshot maps below.
@@ -678,6 +858,7 @@ pub struct SkillStore {
     pinned_activations: RwLock<PinnedSkillActivations>,
     next_revision: AtomicU64,
     watcher_started: AtomicBool,
+    watcher_counters: Arc<SkillWatcherCounters>,
     catalog_events: tokio::sync::broadcast::Sender<WorkflowCatalogEvent>,
     reload_lock: tokio::sync::Mutex<()>,
     mode_stores: RwLock<HashMap<String, std::sync::Arc<SkillStore>>>,
@@ -933,6 +1114,7 @@ impl SkillStore {
             pinned_activations: RwLock::new(PinnedSkillActivations::default()),
             next_revision: AtomicU64::new(1),
             watcher_started: AtomicBool::new(false),
+            watcher_counters: Arc::new(SkillWatcherCounters::default()),
             catalog_events,
             reload_lock: tokio::sync::Mutex::new(()),
             mode_stores: RwLock::new(HashMap::new()),
@@ -2587,96 +2769,128 @@ impl SkillStore {
             .await)
     }
 
-    /// Roots watched for skill, workflow metadata, project, and plugin changes.
-    pub(crate) fn watch_roots(&self) -> Vec<PathBuf> {
-        let mut roots = vec![self
-            .config
-            .skills_dir
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| self.config.skills_dir.clone())];
-        if let Some(project_home) = self.project_home_dir.as_ref() {
-            roots.push(project_home.clone());
+    fn normalize_catalog_watch_root(&self, path: &Path) -> PathBuf {
+        let mut cursor = path.to_path_buf();
+        let mut missing = Vec::new();
+        loop {
+            if let Ok(mut canonical) = std::fs::canonicalize(&cursor) {
+                for component in missing.iter().rev() {
+                    canonical.push(component);
+                }
+                self.watcher_counters
+                    .registration_canonicalizations
+                    .fetch_add(1, Ordering::Relaxed);
+                return canonical;
+            }
+            let Some(name) = cursor.file_name().map(|name| name.to_os_string()) else {
+                return lexical_normalize_path(path);
+            };
+            missing.push(name);
+            if !cursor.pop() {
+                return lexical_normalize_path(path);
+            }
+            if cursor.as_os_str().is_empty() {
+                cursor.push(".");
+            }
+        }
+    }
+
+    /// Catalog sources and structural containers, normalized once when the
+    /// native watcher is registered. Event filtering remains purely lexical.
+    fn catalog_watch_plan(&self) -> CatalogWatchPlan {
+        let mut raw_roots: BTreeSet<PathBuf> = self
+            .discovery_dirs_for_mode(None)
+            .into_iter()
+            .map(|source| source.dir)
+            .collect();
+        let plugins_root = Self::plugins_root_dir(&self.config.skills_dir);
+        raw_roots.insert(plugins_root);
+        if let Some(data_dir) = self.config.skills_dir.parent() {
+            raw_roots.insert(data_dir.join("workflows"));
         }
         if let Some(workspace) = self.workspace_overlay_dir.as_ref() {
-            roots.push(workspace.clone());
-        }
-        roots
-    }
-
-    fn is_catalog_watch_path(&self, path: &Path) -> bool {
-        fn normalized(path: &Path) -> std::borrow::Cow<'_, Path> {
-            std::fs::canonicalize(path)
-                .map(std::borrow::Cow::Owned)
-                .unwrap_or_else(|_| std::borrow::Cow::Borrowed(path))
-        }
-        fn starts_with(path: &Path, root: &Path) -> bool {
-            path.starts_with(root) || normalized(path).starts_with(normalized(root).as_ref())
+            raw_roots.insert(workspace.join(".bamboo").join("workflows"));
         }
 
-        if starts_with(path, &self.config.skills_dir) {
-            return true;
+        let mut raw_containers = BTreeSet::new();
+        if let Some(workspace) = self.workspace_overlay_dir.as_ref() {
+            raw_containers.insert(workspace.join(".bamboo"));
         }
-        if let Some(data_dir) = self.config.skills_dir.parent() {
-            if starts_with(path, &data_dir.join("workflows"))
-                || starts_with(path, &data_dir.join("plugins"))
-            {
-                return true;
-            }
-            let normalized_path = normalized(path);
-            let normalized_data = normalized(data_dir);
-            if normalized_path
-                .strip_prefix(normalized_data.as_ref())
-                .ok()
-                .is_some_and(|relative| {
-                    relative
-                        .components()
-                        .next()
-                        .and_then(|component| component.as_os_str().to_str())
-                        .is_some_and(|name| name.starts_with("skills-"))
-                })
-            {
-                return true;
+        if self.config.skills_dir == bamboo_config::paths::bamboo_dir().join("skills") {
+            if let Some(agents_skills) = bamboo_config::paths::agents_skills_dir() {
+                if let Some(agents_root) = agents_skills.parent() {
+                    raw_containers.insert(agents_root.to_path_buf());
+                }
             }
         }
-        let project_match = self.project_home_dir.as_ref().is_some_and(|project_home| {
-            let normalized_path = normalized(path);
-            let normalized_project = normalized(project_home);
-            let relative = normalized_path
-                .strip_prefix(normalized_project.as_ref())
-                .ok()
-                .and_then(|relative| relative.components().next())
-                .and_then(|component| component.as_os_str().to_str());
-            relative.is_some_and(|name| name == "skills" || name.starts_with("skills-"))
-        });
-        project_match
-            || self
-                .workspace_overlay_dir
-                .as_ref()
-                .is_some_and(|workspace| {
-                    normalized(path)
-                        .strip_prefix(normalized(&workspace.join(".bamboo")).as_ref())
-                        .ok()
-                        .and_then(|relative| relative.components().next())
-                        .and_then(|component| component.as_os_str().to_str())
-                        .is_some_and(|name| {
-                            name == "skills" || name.starts_with("skills-") || name == "workflows"
-                        })
-                })
+
+        let catalog_roots: Vec<_> = raw_roots
+            .into_iter()
+            .map(|path| self.normalize_catalog_watch_root(&path))
+            .collect();
+        let mut container_paths: BTreeSet<_> = raw_containers
+            .into_iter()
+            .map(|path| self.normalize_catalog_watch_root(&path))
+            .collect();
+        // If more than the catalog leaf is missing (for example an as-yet
+        // uncreated project home), retain each missing intermediate directory
+        // as an exact structural trigger. This advances the shallow watch one
+        // level at a time without treating unrelated siblings as catalog churn.
+        for root in &catalog_roots {
+            let mut parent = root.parent();
+            while let Some(path) = parent {
+                if path.is_dir() {
+                    break;
+                }
+                container_paths.insert(path.to_path_buf());
+                parent = path.parent();
+            }
+        }
+
+        CatalogWatchPlan {
+            catalog_roots,
+            container_paths: container_paths.into_iter().collect(),
+        }
     }
 
-    /// Start an OS-backed recursive watcher. Debouncing coalesces editor atomic-renames and
-    /// avoids reloading once per low-level self-write event.
+    #[cfg(test)]
+    pub(crate) fn watcher_activity(&self) -> SkillWatcherActivity {
+        self.watcher_counters.snapshot()
+    }
+
+    /// Start an OS-backed catalog watcher. Existing catalog directories alone
+    /// are recursive; their nearest existing parents are shallow anchors that
+    /// let missing roots be created and dynamically rebound. Raw events enter a
+    /// bounded queue, coalesce to a trailing-edge batch, and only then undergo
+    /// lexical filtering. Queue overflow marks the batch dirty and forces a
+    /// conservative full reload rather than losing a relevant change.
     pub fn start_live_reload(self: &std::sync::Arc<Self>) {
-        use notify::{RecursiveMode, Watcher};
         if self.watcher_started.swap(true, Ordering::SeqCst) {
             return;
         }
         let weak = std::sync::Arc::downgrade(self);
-        let roots = self.watch_roots();
-        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let plan = self.catalog_watch_plan();
+        let counters = self.watcher_counters.clone();
+        let overflow_dirty = Arc::new(AtomicBool::new(false));
+        let callback_overflow = overflow_dirty.clone();
+        let callback_counters = counters.clone();
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<notify::Result<notify::Event>>(
+            SKILL_WATCH_CHANNEL_CAPACITY,
+        );
         let mut watcher = match notify::recommended_watcher(move |event| {
-            let _ = sender.send(event);
+            callback_counters
+                .received_events
+                .fetch_add(1, Ordering::Relaxed);
+            match sender.try_send(event) {
+                Ok(()) => {}
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                    callback_counters
+                        .overflowed_events
+                        .fetch_add(1, Ordering::Relaxed);
+                    callback_overflow.store(true, Ordering::Release);
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+            }
         }) {
             Ok(watcher) => watcher,
             Err(error) => {
@@ -2685,42 +2899,96 @@ impl SkillStore {
                 return;
             }
         };
-        for root in roots {
-            if root.exists() {
-                if let Err(error) = watcher.watch(&root, RecursiveMode::Recursive) {
-                    tracing::warn!(
-                        "Failed to watch skill catalog root {}: {error}",
-                        root.display()
-                    );
-                }
-            }
-        }
+        let mut registered = HashMap::new();
+        sync_catalog_watch_registrations(&mut watcher, &plan, &mut registered, counters.as_ref());
+
         tokio::spawn(async move {
             // Keep the native watcher alive for exactly as long as the receiver loop.
-            let _watcher = watcher;
-            while let Some(event) = receiver.recv().await {
-                let event = match event {
-                    Ok(event) => event,
-                    Err(error) => {
-                        tracing::warn!("Skill catalog watcher error: {error}");
-                        continue;
+            let mut watcher = watcher;
+            while let Some(first) = receiver.recv().await {
+                let mut batch = vec![first];
+                let quiet = tokio::time::sleep(SKILL_WATCH_QUIET_PERIOD);
+                let maximum = tokio::time::sleep(SKILL_WATCH_MAX_BATCH);
+                tokio::pin!(quiet);
+                tokio::pin!(maximum);
+                loop {
+                    tokio::select! {
+                        maybe = receiver.recv() => match maybe {
+                            Some(event) => {
+                                batch.push(event);
+                                quiet.as_mut().reset(
+                                    tokio::time::Instant::now() + SKILL_WATCH_QUIET_PERIOD,
+                                );
+                            }
+                            None => break,
+                        },
+                        _ = &mut quiet => break,
+                        _ = &mut maximum => break,
                     }
-                };
+                }
+
+                counters
+                    .coalesced_events
+                    .fetch_add(batch.len().saturating_sub(1) as u64, Ordering::Relaxed);
+                let overflowed = overflow_dirty.swap(false, Ordering::AcqRel);
+                let mut relevant = overflowed;
+                let mut rejected = 0u64;
+                for event in batch {
+                    match event {
+                        Ok(event) => {
+                            let event_relevant = event
+                                .paths
+                                .iter()
+                                .any(|path| plan.is_relevant(&lexical_normalize_path(path)));
+                            relevant |= event_relevant;
+                            rejected += u64::from(!event_relevant);
+                        }
+                        Err(error) => {
+                            // A backend error can mean the native watcher lost
+                            // events or a registration. Reconcile registrations
+                            // and publish one conservative full snapshot.
+                            relevant = true;
+                            tracing::warn!("Skill catalog watcher error: {error}");
+                        }
+                    }
+                }
+                counters
+                    .rejected_events
+                    .fetch_add(rejected, Ordering::Relaxed);
+
                 let Some(store) = weak.upgrade() else { break };
-                if !event
-                    .paths
-                    .iter()
-                    .any(|path| store.is_catalog_watch_path(path))
-                {
-                    continue;
+                if relevant {
+                    sync_catalog_watch_registrations(
+                        &mut watcher,
+                        &plan,
+                        &mut registered,
+                        counters.as_ref(),
+                    );
+                    match store.reload().await {
+                        Ok(_) => {
+                            counters.reloads.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Err(error) => {
+                            counters.reload_failures.fetch_add(1, Ordering::Relaxed);
+                            tracing::warn!("Live skill catalog reload failed: {error}");
+                        }
+                    }
                 }
-                // Editors commonly emit write + chmod + rename. Publish one snapshot after the
-                // filesystem has settled, while still reacting promptly to external changes.
-                tokio::time::sleep(std::time::Duration::from_millis(120)).await;
-                while receiver.try_recv().is_ok() {}
-                if let Err(error) = store.reload().await {
-                    tracing::warn!("Live skill catalog reload failed: {error}");
-                }
+                let activity = counters.snapshot();
+                tracing::debug!(
+                    store_token = store.store_token,
+                    watcher_received = activity.received_events,
+                    watcher_rejected = activity.rejected_events,
+                    watcher_coalesced = activity.coalesced_events,
+                    watcher_overflowed = activity.overflowed_events,
+                    watcher_reloads = activity.reloads,
+                    watcher_reload_failures = activity.reload_failures,
+                    watcher_registration_canonicalizations =
+                        activity.registration_canonicalizations,
+                    watcher_event_canonicalizations = 0,
+                    watcher_rebinds = activity.watch_rebinds,
+                    "skill watcher batch processed"
+                );
             }
         });
     }
@@ -3399,7 +3667,7 @@ mod tests {
 
     use tokio::fs;
 
-    use super::SkillStore;
+    use super::{lexical_normalize_path, RetainedResourceBudget, SkillSnapshotLimits, SkillStore};
     use crate::store::builtin::{
         load_builtin_skill_bundles, BuiltinSkillBundle, WORKFLOW_BUILTINS,
     };
@@ -4596,7 +4864,74 @@ Use this skill for testing.
     }
 
     #[tokio::test]
-    async fn os_watcher_hot_discovers_plugin_installed_after_startup() {
+    async fn watcher_plan_accepts_catalog_sources_and_rejects_workspace_build_churn() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(directory.path()).expect("canonical tempdir");
+        let skills_dir = root.join("data/skills");
+        let project_home = root.join("project-home");
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&skills_dir).await.expect("skills dir");
+        fs::create_dir_all(&project_home)
+            .await
+            .expect("project home");
+        fs::create_dir_all(&workspace).await.expect("workspace");
+        let store = SkillStore::new_with_resource_scope(
+            SkillStoreConfig {
+                skills_dir: skills_dir.clone(),
+                active_mode: Some("code".to_string()),
+                ..Default::default()
+            },
+            Arc::new(RetainedResourceBudget::default()),
+            SkillSnapshotLimits::default(),
+            Some(project_home.clone()),
+            Some(workspace.clone()),
+        );
+        let plan = store.catalog_watch_plan();
+        let relevant = [
+            skills_dir.join("global/SKILL.md"),
+            root.join("data/skills-code/mode/SKILL.md"),
+            root.join("data/plugins/example/skills/plugin/SKILL.md"),
+            root.join("data/workflows/legacy.md"),
+            project_home.join("skills/project/SKILL.md"),
+            project_home.join("skills-code/project-mode/SKILL.md"),
+            workspace.join(".bamboo/skills/local/SKILL.md"),
+            workspace.join(".bamboo/skills-code/local-mode/SKILL.md"),
+            workspace.join(".bamboo/workflows/legacy.md"),
+            workspace.join(".bamboo"),
+        ];
+        for path in relevant {
+            assert!(
+                plan.is_relevant(&lexical_normalize_path(&path)),
+                "catalog path should be relevant: {}",
+                path.display()
+            );
+        }
+
+        let irrelevant = [
+            root.join("data/sessions/session.json"),
+            project_home.join("memory/index.json"),
+            workspace.join("target/debug/build/output"),
+            workspace.join("node_modules/pkg/index.js"),
+        ];
+        let canonicalizations = store.watcher_activity().registration_canonicalizations;
+        for _ in 0..10 {
+            for path in &irrelevant {
+                assert!(
+                    !plan.is_relevant(&lexical_normalize_path(path)),
+                    "non-catalog churn should be rejected: {}",
+                    path.display()
+                );
+            }
+        }
+        assert_eq!(
+            store.watcher_activity().registration_canonicalizations,
+            canonicalizations,
+            "event classification must remain lexical and filesystem-free"
+        );
+    }
+
+    #[tokio::test]
+    async fn os_watcher_rebinds_missing_plugin_root_and_tracks_add_edit_remove() {
         let directory = tempfile::tempdir().expect("tempdir");
         let skills_dir = directory.path().join("data/skills");
         fs::create_dir_all(&skills_dir).await.expect("skills dir");
@@ -4606,8 +4941,9 @@ Use this skill for testing.
         });
         manager.initialize().await.expect("initialize manager");
         let initial_revision = manager.store().skill_catalog_snapshot().await.revision;
+        let initial_activity = manager.store().watcher_activity();
         let plugin_skills = directory.path().join("data/plugins/late/skills");
-        write_skill(&plugin_skills, "hot-plugin", "hot discovered", "Prompt")
+        let plugin_root = write_skill(&plugin_skills, "hot-plugin", "hot discovered", "Prompt")
             .await
             .expect("plugin skill");
 
@@ -4628,8 +4964,60 @@ Use this skill for testing.
         .await
         .expect("watcher should publish plugin without explicit refresh");
 
+        let added_activity = manager.store().watcher_activity();
+        assert!(added_activity.reloads > initial_activity.reloads);
+        assert!(
+            added_activity.watch_rebinds > initial_activity.watch_rebinds,
+            "creating the missing plugins root must bind its recursive watch"
+        );
+        fs::write(
+            plugin_root.join("SKILL.md"),
+            "---\nname: hot-plugin\ndescription: hot edited\n---\nEdited prompt\n",
+        )
+        .await
+        .expect("edit plugin skill");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if manager
+                    .store()
+                    .skill_catalog_snapshot()
+                    .await
+                    .entries
+                    .iter()
+                    .any(|entry| entry.id == "hot-plugin" && entry.description == "hot edited")
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            }
+        })
+        .await
+        .expect("recursive plugin watch should publish an edit");
+
+        fs::remove_dir_all(&plugin_root)
+            .await
+            .expect("remove plugin skill");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if !manager
+                    .store()
+                    .skill_catalog_snapshot()
+                    .await
+                    .entries
+                    .iter()
+                    .any(|entry| entry.id == "hot-plugin")
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            }
+        })
+        .await
+        .expect("recursive plugin watch should publish removal");
+
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         let stable_revision = manager.store().skill_catalog_snapshot().await.revision;
+        let stable_activity = manager.store().watcher_activity();
         fs::create_dir_all(directory.path().join("data/sessions"))
             .await
             .expect("sessions dir");
@@ -4641,6 +5029,16 @@ Use this skill for testing.
             manager.store().skill_catalog_snapshot().await.revision,
             stable_revision,
             "unrelated data-dir writes must not publish a catalog revision"
+        );
+        let final_activity = manager.store().watcher_activity();
+        assert_eq!(
+            final_activity.reloads, stable_activity.reloads,
+            "unrelated shallow-anchor events must be rejected after batching"
+        );
+        assert_eq!(
+            final_activity.registration_canonicalizations,
+            stable_activity.registration_canonicalizations,
+            "event filtering and dynamic rebinding must not canonicalize event paths"
         );
     }
 
@@ -4688,6 +5086,39 @@ Use this skill for testing.
         })
         .await
         .expect("watcher should publish workspace legacy workflow");
+
+        // The watcher keeps only a shallow registration on the workspace root
+        // so it can notice `.bamboo` being recreated. A project build tree may
+        // therefore yield a cheap top-level event, but its recursive churn must
+        // never cause catalog reloads or event-path canonicalization.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let stable_revision = store.workflow_catalog_snapshot().await.revision;
+        let stable_activity = store.watcher_activity();
+        let build_output = workspace.join("target/debug/build/example/out");
+        fs::create_dir_all(&build_output)
+            .await
+            .expect("project build output");
+        for index in 0..64 {
+            fs::write(build_output.join(format!("artifact-{index}")), b"churn")
+                .await
+                .expect("project build artifact");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let after_churn = store.watcher_activity();
+        assert_eq!(
+            store.workflow_catalog_snapshot().await.revision,
+            stable_revision,
+            "project build churn must not publish a catalog revision"
+        );
+        assert_eq!(
+            after_churn.reloads, stable_activity.reloads,
+            "project build churn must not reload the catalog"
+        );
+        assert_eq!(
+            after_churn.registration_canonicalizations,
+            stable_activity.registration_canonicalizations,
+            "project build churn must not canonicalize delivered event paths"
+        );
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -657,6 +657,19 @@ const SKILL_WATCH_CHANNEL_CAPACITY: usize = 256;
 const SKILL_WATCH_QUIET_PERIOD: std::time::Duration = std::time::Duration::from_millis(120);
 const SKILL_WATCH_MAX_BATCH: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// Access events (and access-time metadata updates) cannot change a catalog.
+/// Reject them in the native callback so a Linux reload's own file reads do
+/// not refill the queue and trigger an unbounded reload feedback loop.
+fn watcher_event_can_change_catalog(event: &notify::Event) -> bool {
+    !matches!(
+        event.kind,
+        notify::EventKind::Access(_)
+            | notify::EventKind::Modify(notify::event::ModifyKind::Metadata(
+                notify::event::MetadataKind::AccessTime
+            ))
+    )
+}
+
 #[derive(Debug, Default)]
 struct SkillWatcherCounters {
     received_events: AtomicU64,
@@ -679,6 +692,13 @@ pub(crate) struct SkillWatcherActivity {
     pub reload_failures: u64,
     pub registration_canonicalizations: u64,
     pub watch_rebinds: u64,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone)]
+struct ProcessedWatcherBatch {
+    paths: Vec<PathBuf>,
+    relevant: bool,
 }
 
 impl SkillWatcherCounters {
@@ -859,6 +879,8 @@ pub struct SkillStore {
     next_revision: AtomicU64,
     watcher_started: AtomicBool,
     watcher_counters: Arc<SkillWatcherCounters>,
+    #[cfg(test)]
+    processed_watcher_batches: tokio::sync::broadcast::Sender<ProcessedWatcherBatch>,
     catalog_events: tokio::sync::broadcast::Sender<WorkflowCatalogEvent>,
     reload_lock: tokio::sync::Mutex<()>,
     mode_stores: RwLock<HashMap<String, std::sync::Arc<SkillStore>>>,
@@ -1100,6 +1122,8 @@ impl SkillStore {
         workspace_overlay_dir: Option<PathBuf>,
     ) -> Self {
         let (catalog_events, _) = tokio::sync::broadcast::channel(128);
+        #[cfg(test)]
+        let (processed_watcher_batches, _) = tokio::sync::broadcast::channel(128);
         Self {
             store_token: NEXT_SKILL_STORE_TOKEN.fetch_add(1, Ordering::Relaxed),
             snapshot_publish_lock: RwLock::new(()),
@@ -1115,6 +1139,8 @@ impl SkillStore {
             next_revision: AtomicU64::new(1),
             watcher_started: AtomicBool::new(false),
             watcher_counters: Arc::new(SkillWatcherCounters::default()),
+            #[cfg(test)]
+            processed_watcher_batches,
             catalog_events,
             reload_lock: tokio::sync::Mutex::new(()),
             mode_stores: RwLock::new(HashMap::new()),
@@ -2858,6 +2884,13 @@ impl SkillStore {
         self.watcher_counters.snapshot()
     }
 
+    #[cfg(test)]
+    fn subscribe_processed_watcher_batches(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<ProcessedWatcherBatch> {
+        self.processed_watcher_batches.subscribe()
+    }
+
     /// Start an OS-backed catalog watcher. Existing catalog directories alone
     /// are recursive; their nearest existing parents are shallow anchors that
     /// let missing roots be created and dynamically rebound. Raw events enter a
@@ -2874,31 +2907,43 @@ impl SkillStore {
         let overflow_dirty = Arc::new(AtomicBool::new(false));
         let callback_overflow = overflow_dirty.clone();
         let callback_counters = counters.clone();
+        #[cfg(test)]
+        let processed_watcher_batches = self.processed_watcher_batches.clone();
         let (sender, mut receiver) = tokio::sync::mpsc::channel::<notify::Result<notify::Event>>(
             SKILL_WATCH_CHANNEL_CAPACITY,
         );
-        let mut watcher = match notify::recommended_watcher(move |event| {
-            callback_counters
-                .received_events
-                .fetch_add(1, Ordering::Relaxed);
-            match sender.try_send(event) {
-                Ok(()) => {}
-                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+        let mut watcher =
+            match notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+                callback_counters
+                    .received_events
+                    .fetch_add(1, Ordering::Relaxed);
+                if event
+                    .as_ref()
+                    .is_ok_and(|event| !watcher_event_can_change_catalog(event))
+                {
                     callback_counters
-                        .overflowed_events
+                        .rejected_events
                         .fetch_add(1, Ordering::Relaxed);
-                    callback_overflow.store(true, Ordering::Release);
+                    return;
                 }
-                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
-            }
-        }) {
-            Ok(watcher) => watcher,
-            Err(error) => {
-                tracing::warn!("Failed to start skill catalog watcher: {error}");
-                self.watcher_started.store(false, Ordering::SeqCst);
-                return;
-            }
-        };
+                match sender.try_send(event) {
+                    Ok(()) => {}
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        callback_counters
+                            .overflowed_events
+                            .fetch_add(1, Ordering::Relaxed);
+                        callback_overflow.store(true, Ordering::Release);
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+                }
+            }) {
+                Ok(watcher) => watcher,
+                Err(error) => {
+                    tracing::warn!("Failed to start skill catalog watcher: {error}");
+                    self.watcher_started.store(false, Ordering::SeqCst);
+                    return;
+                }
+            };
         let mut registered = HashMap::new();
         sync_catalog_watch_registrations(&mut watcher, &plan, &mut registered, counters.as_ref());
 
@@ -2933,6 +2978,8 @@ impl SkillStore {
                 let overflowed = overflow_dirty.swap(false, Ordering::AcqRel);
                 let mut relevant = overflowed;
                 let mut rejected = 0u64;
+                #[cfg(test)]
+                let mut observed_paths = Vec::new();
                 for event in batch {
                     match event {
                         Ok(event) => {
@@ -2940,6 +2987,10 @@ impl SkillStore {
                                 .paths
                                 .iter()
                                 .any(|path| plan.is_relevant(&lexical_normalize_path(path)));
+                            #[cfg(test)]
+                            observed_paths.extend(
+                                event.paths.iter().map(|path| lexical_normalize_path(path)),
+                            );
                             relevant |= event_relevant;
                             rejected += u64::from(!event_relevant);
                         }
@@ -2952,6 +3003,11 @@ impl SkillStore {
                         }
                     }
                 }
+                #[cfg(test)]
+                let processed_batch = ProcessedWatcherBatch {
+                    paths: observed_paths,
+                    relevant,
+                };
                 counters
                     .rejected_events
                     .fetch_add(rejected, Ordering::Relaxed);
@@ -2974,6 +3030,8 @@ impl SkillStore {
                         }
                     }
                 }
+                #[cfg(test)]
+                let _ = processed_watcher_batches.send(processed_batch);
                 let activity = counters.snapshot();
                 tracing::debug!(
                     store_token = store.store_token,
@@ -3667,7 +3725,10 @@ mod tests {
 
     use tokio::fs;
 
-    use super::{lexical_normalize_path, RetainedResourceBudget, SkillSnapshotLimits, SkillStore};
+    use super::{
+        lexical_normalize_path, ProcessedWatcherBatch, RetainedResourceBudget, SkillSnapshotLimits,
+        SkillStore,
+    };
     use crate::store::builtin::{
         load_builtin_skill_bundles, BuiltinSkillBundle, WORKFLOW_BUILTINS,
     };
@@ -3707,24 +3768,73 @@ mod tests {
         Ok(skill_dir)
     }
 
-    async fn wait_for_watcher_quiescence(store: &SkillStore) {
-        let stable_for = super::SKILL_WATCH_MAX_BATCH + super::SKILL_WATCH_QUIET_PERIOD;
+    async fn wait_for_processed_watcher_path(
+        batches: &mut tokio::sync::broadcast::Receiver<ProcessedWatcherBatch>,
+        expected_path: &Path,
+    ) -> ProcessedWatcherBatch {
+        let mut existing_prefix = expected_path;
+        let mut missing_suffix = Vec::new();
+        while !existing_prefix.exists() {
+            if let Some(name) = existing_prefix.file_name() {
+                missing_suffix.push(name.to_os_string());
+            }
+            existing_prefix = existing_prefix
+                .parent()
+                .expect("a watcher test path should have an existing ancestor");
+        }
+        let mut expected_path = std::fs::canonicalize(existing_prefix)
+            .unwrap_or_else(|_| lexical_normalize_path(existing_prefix));
+        for component in missing_suffix.iter().rev() {
+            expected_path.push(component);
+        }
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            let mut last_activity = store.watcher_activity();
-            let mut last_change = tokio::time::Instant::now();
             loop {
-                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
-                let activity = store.watcher_activity();
-                if activity != last_activity {
-                    last_activity = activity;
-                    last_change = tokio::time::Instant::now();
-                } else if last_change.elapsed() >= stable_for {
-                    break;
+                match batches.recv().await {
+                    Ok(batch)
+                        if batch.paths.iter().any(|path| {
+                            path == &expected_path
+                                || path.starts_with(&expected_path)
+                                || expected_path.starts_with(path)
+                        }) =>
+                    {
+                        return batch;
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        panic!("skill watcher test observation lagged by {skipped} batches")
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        panic!("skill watcher stopped before processing the expected path")
+                    }
                 }
             }
         })
         .await
-        .expect("skill watcher should become quiescent");
+        .unwrap_or_else(|_| {
+            panic!(
+                "skill watcher should process the filesystem event touching {}",
+                expected_path.display()
+            )
+        })
+    }
+
+    #[test]
+    fn watcher_event_filter_rejects_non_mutating_access() {
+        use notify::event::{AccessKind, DataChange, MetadataKind, ModifyKind};
+        use notify::{Event, EventKind};
+
+        let access = Event::new(EventKind::Access(AccessKind::Read));
+        let access_time = Event::new(EventKind::Modify(ModifyKind::Metadata(
+            MetadataKind::AccessTime,
+        )));
+        let content = Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content)));
+
+        assert!(!super::watcher_event_can_change_catalog(&access));
+        assert!(!super::watcher_event_can_change_catalog(&access_time));
+        assert!(super::watcher_event_can_change_catalog(&content));
+        assert!(super::watcher_event_can_change_catalog(&Event::new(
+            EventKind::Any
+        )));
     }
 
     fn orchestration_yaml(id: &str, revision: u64) -> String {
@@ -4963,9 +5073,11 @@ Use this skill for testing.
         let initial_revision = manager.store().skill_catalog_snapshot().await.revision;
         let initial_activity = manager.store().watcher_activity();
         let plugin_skills = directory.path().join("data/plugins/late/skills");
+        let mut added_batches = manager.store().subscribe_processed_watcher_batches();
         let plugin_root = write_skill(&plugin_skills, "hot-plugin", "hot discovered", "Prompt")
             .await
             .expect("plugin skill");
+        let plugin_file = plugin_root.join("SKILL.md");
 
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
@@ -4983,6 +5095,12 @@ Use this skill for testing.
         })
         .await
         .expect("watcher should publish plugin without explicit refresh");
+        assert!(
+            wait_for_processed_watcher_path(&mut added_batches, &plugin_file)
+                .await
+                .relevant,
+            "a plugin skill addition must be classified as catalog-relevant"
+        );
 
         let added_activity = manager.store().watcher_activity();
         assert!(added_activity.reloads > initial_activity.reloads);
@@ -4990,8 +5108,9 @@ Use this skill for testing.
             added_activity.watch_rebinds > initial_activity.watch_rebinds,
             "creating the missing plugins root must bind its recursive watch"
         );
+        let mut edited_batches = manager.store().subscribe_processed_watcher_batches();
         fs::write(
-            plugin_root.join("SKILL.md"),
+            &plugin_file,
             "---\nname: hot-plugin\ndescription: hot edited\n---\nEdited prompt\n",
         )
         .await
@@ -5013,7 +5132,14 @@ Use this skill for testing.
         })
         .await
         .expect("recursive plugin watch should publish an edit");
+        assert!(
+            wait_for_processed_watcher_path(&mut edited_batches, &plugin_file)
+                .await
+                .relevant,
+            "a plugin skill edit must be classified as catalog-relevant"
+        );
 
+        let mut removed_batches = manager.store().subscribe_processed_watcher_batches();
         fs::remove_dir_all(&plugin_root)
             .await
             .expect("remove plugin skill");
@@ -5034,31 +5160,11 @@ Use this skill for testing.
         })
         .await
         .expect("recursive plugin watch should publish removal");
-
-        wait_for_watcher_quiescence(manager.store()).await;
-        let stable_revision = manager.store().skill_catalog_snapshot().await.revision;
-        let stable_activity = manager.store().watcher_activity();
-        fs::create_dir_all(directory.path().join("data/sessions"))
-            .await
-            .expect("sessions dir");
-        fs::write(directory.path().join("data/sessions/unrelated.json"), "{}")
-            .await
-            .expect("unrelated write");
-        wait_for_watcher_quiescence(manager.store()).await;
-        assert_eq!(
-            manager.store().skill_catalog_snapshot().await.revision,
-            stable_revision,
-            "unrelated data-dir writes must not publish a catalog revision"
-        );
-        let final_activity = manager.store().watcher_activity();
-        assert_eq!(
-            final_activity.reloads, stable_activity.reloads,
-            "unrelated shallow-anchor events must be rejected after batching"
-        );
-        assert_eq!(
-            final_activity.registration_canonicalizations,
-            stable_activity.registration_canonicalizations,
-            "event filtering and dynamic rebinding must not canonicalize event paths"
+        assert!(
+            wait_for_processed_watcher_path(&mut removed_batches, &plugin_root)
+                .await
+                .relevant,
+            "a plugin skill removal must be classified as catalog-relevant"
         );
     }
 
@@ -5081,13 +5187,12 @@ Use this skill for testing.
         let initial_revision = store.workflow_catalog_snapshot().await.revision;
 
         let workflows = workspace.join(".bamboo/workflows");
+        let workflow_file = workflows.join("live-review.md");
+        let mut workflow_batches = store.subscribe_processed_watcher_batches();
         fs::create_dir_all(&workflows).await.expect("workflow dir");
-        fs::write(
-            workflows.join("live-review.md"),
-            "Review the live change.\n",
-        )
-        .await
-        .expect("legacy workflow");
+        fs::write(&workflow_file, "Review the live change.\n")
+            .await
+            .expect("legacy workflow");
 
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
@@ -5106,15 +5211,22 @@ Use this skill for testing.
         })
         .await
         .expect("watcher should publish workspace legacy workflow");
+        assert!(
+            wait_for_processed_watcher_path(&mut workflow_batches, &workflow_file)
+                .await
+                .relevant,
+            "a workspace workflow write must be classified as catalog-relevant"
+        );
 
         // The watcher keeps only a shallow registration on the workspace root
         // so it can notice `.bamboo` being recreated. A project build tree may
         // therefore yield a cheap top-level event, but its recursive churn must
         // never cause catalog reloads or event-path canonicalization.
-        wait_for_watcher_quiescence(store.as_ref()).await;
         let stable_revision = store.workflow_catalog_snapshot().await.revision;
         let stable_activity = store.watcher_activity();
         let build_output = workspace.join("target/debug/build/example/out");
+        let build_root = workspace.join("target");
+        let mut build_batches = store.subscribe_processed_watcher_batches();
         fs::create_dir_all(&build_output)
             .await
             .expect("project build output");
@@ -5123,7 +5235,12 @@ Use this skill for testing.
                 .await
                 .expect("project build artifact");
         }
-        wait_for_watcher_quiescence(store.as_ref()).await;
+        assert!(
+            !wait_for_processed_watcher_path(&mut build_batches, &build_root)
+                .await
+                .relevant,
+            "a project build directory must be classified as catalog-irrelevant"
+        );
         let after_churn = store.watcher_activity();
         assert_eq!(
             store.workflow_catalog_snapshot().await.revision,

--- a/crates/infra/bamboo-subagent/Cargo.toml
+++ b/crates/infra/bamboo-subagent/Cargo.toml
@@ -29,7 +29,11 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rustls-pemfile = "2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/infra/bamboo-subagent/src/fleet.rs
+++ b/crates/infra/bamboo-subagent/src/fleet.rs
@@ -32,12 +32,10 @@ fn local_owner_instance_id() -> &'static str {
 /// cached spec cannot carry a stale PID/instance into a later spawn.
 fn provision_for_local_spawn(spec: &ProvisionSpec) -> ProvisionSpec {
     let mut provisioned = spec.clone();
-    provisioned.owner = Some(WorkerOwner {
-        process_id: std::process::id(),
-        instance_id: local_owner_instance_id().to_string(),
-        session_id: spec.identity.parent_id.clone(),
-        worker_spawned_at: chrono::Utc::now(),
-    });
+    provisioned.owner = Some(WorkerOwner::for_current_process(
+        local_owner_instance_id().to_string(),
+        spec.identity.parent_id.clone(),
+    ));
     provisioned
 }
 
@@ -231,6 +229,11 @@ mod tests {
         assert_eq!(first_owner.process_id, std::process::id());
         assert_eq!(first_owner.instance_id, second_owner.instance_id);
         assert_eq!(first_owner.session_id.as_deref(), Some("parent-session"));
+        #[cfg(windows)]
+        assert!(first_owner.process_start_id.is_some());
+        #[cfg(not(windows))]
+        assert!(first_owner.process_start_id.is_none());
+        assert_eq!(first_owner.process_start_id, second_owner.process_start_id);
         assert!(second_owner.worker_spawned_at >= first_owner.worker_spawned_at);
     }
 }

--- a/crates/infra/bamboo-subagent/src/fleet.rs
+++ b/crates/infra/bamboo-subagent/src/fleet.rs
@@ -9,6 +9,7 @@
 
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
@@ -17,8 +18,28 @@ use tokio::time::{sleep, Instant};
 
 use crate::discovery::Fabric;
 use crate::proto::AgentRecord;
-use crate::provision::ProvisionSpec;
+use crate::provision::{ProvisionSpec, WorkerOwner};
 use crate::transport::{TransportError, TransportResult};
+
+fn local_owner_instance_id() -> &'static str {
+    static INSTANCE_ID: OnceLock<String> = OnceLock::new();
+    INSTANCE_ID
+        .get_or_init(|| uuid::Uuid::new_v4().to_string())
+        .as_str()
+}
+
+/// Stamp physical owner metadata at the last possible moment so a cloned or
+/// cached spec cannot carry a stale PID/instance into a later spawn.
+fn provision_for_local_spawn(spec: &ProvisionSpec) -> ProvisionSpec {
+    let mut provisioned = spec.clone();
+    provisioned.owner = Some(WorkerOwner {
+        process_id: std::process::id(),
+        instance_id: local_owner_instance_id().to_string(),
+        session_id: spec.identity.parent_id.clone(),
+        worker_spawned_at: chrono::Utc::now(),
+    });
+    provisioned
+}
 
 /// A launched actor plus its discovered record.
 ///
@@ -81,7 +102,7 @@ pub async fn spawn_worker(
     let fabric_dir = Path::new(&spec.fabric_dir);
     tokio::fs::create_dir_all(fabric_dir).await.ok();
 
-    let spec_json = spec
+    let spec_json = provision_for_local_spawn(spec)
         .to_json()
         .map_err(|e| TransportError::Protocol(format!("provision spec encode: {e}")))?;
 
@@ -142,7 +163,7 @@ pub async fn spawn_worker_on_bus(
     worker_args: &[String],
     spec: &ProvisionSpec,
 ) -> TransportResult<SpawnedChild> {
-    let spec_json = spec
+    let spec_json = provision_for_local_spawn(spec)
         .to_json()
         .map_err(|e| TransportError::Protocol(format!("provision spec encode: {e}")))?;
 
@@ -181,4 +202,35 @@ pub async fn spawn_worker_on_bus(
         record,
         process: Some(process),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provision::{ChildIdentity, ExecutorSpec};
+
+    #[test]
+    fn local_spawn_stamps_current_process_instance_and_parent_session() {
+        let spec = ProvisionSpec::new(
+            ChildIdentity {
+                child_id: "child".into(),
+                parent_id: Some("parent-session".into()),
+                project_key: None,
+                role: "worker".into(),
+                depth: 1,
+            },
+            ExecutorSpec::Echo,
+            "fabric".into(),
+        );
+
+        let first = provision_for_local_spawn(&spec);
+        let second = provision_for_local_spawn(&spec);
+        assert!(spec.owner.is_none(), "caller-owned spec remains reusable");
+        let first_owner = first.owner.expect("physical owner metadata");
+        let second_owner = second.owner.expect("physical owner metadata");
+        assert_eq!(first_owner.process_id, std::process::id());
+        assert_eq!(first_owner.instance_id, second_owner.instance_id);
+        assert_eq!(first_owner.session_id.as_deref(), Some("parent-session"));
+        assert!(second_owner.worker_spawned_at >= first_owner.worker_spawned_at);
+    }
 }

--- a/crates/infra/bamboo-subagent/src/lib.rs
+++ b/crates/infra/bamboo-subagent/src/lib.rs
@@ -42,7 +42,7 @@ pub use proto::{
 };
 pub use provision::{
     BusEndpoint, Capabilities, ChildIdentity, ExecutorSpec, Limits, McpProxyConfig, ModelRefSpec,
-    Placement, ProvisionSpec, ScopedCredential, SecretsEnvelope, PROVISION_VERSION,
+    Placement, ProvisionSpec, ScopedCredential, SecretsEnvelope, WorkerOwner, PROVISION_VERSION,
 };
 pub use store::{
     ChildEntry, ChildFields, ChildStatus, ChildrenIndex, MetaExtractor, ProjectIndex, ProjectKey,

--- a/crates/infra/bamboo-subagent/src/provision.rs
+++ b/crates/infra/bamboo-subagent/src/provision.rs
@@ -253,15 +253,62 @@ pub struct BusEndpoint {
 ///
 /// `session_id` is diagnostic context for the activation that caused the
 /// spawn. A reusable worker can later serve other sessions, so durable child
-/// lifecycle remains authoritative elsewhere; `process_id` + `instance_id`
-/// are the physical ownership lease used by the orphan guard.
+/// lifecycle remains authoritative elsewhere; `process_id` plus the optional
+/// OS start identity form the physical ownership lease used by the orphan
+/// guard. `instance_id` remains useful for process-scoped diagnostics.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkerOwner {
     pub process_id: u32,
     pub instance_id: String,
+    /// Opaque OS process-creation identity used with `process_id` to reject PID
+    /// reuse. Windows represents this as the creation `FILETIME` tick value;
+    /// other platforms currently rely on direct-parent/reparent detection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_start_id: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
     pub worker_spawned_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl WorkerOwner {
+    pub fn for_current_process(instance_id: String, session_id: Option<String>) -> Self {
+        Self {
+            process_id: std::process::id(),
+            instance_id,
+            process_start_id: current_process_start_id(),
+            session_id,
+            worker_spawned_at: chrono::Utc::now(),
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn current_process_start_id() -> Option<u64> {
+    None
+}
+
+#[cfg(windows)]
+fn current_process_start_id() -> Option<u64> {
+    use windows_sys::Win32::Foundation::FILETIME;
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, GetProcessTimes};
+
+    let mut creation: FILETIME = unsafe { std::mem::zeroed() };
+    let mut exit: FILETIME = unsafe { std::mem::zeroed() };
+    let mut kernel: FILETIME = unsafe { std::mem::zeroed() };
+    let mut user: FILETIME = unsafe { std::mem::zeroed() };
+    if unsafe {
+        GetProcessTimes(
+            GetCurrentProcess(),
+            &mut creation,
+            &mut exit,
+            &mut kernel,
+            &mut user,
+        )
+    } == 0
+    {
+        return None;
+    }
+    Some(((creation.dwHighDateTime as u64) << 32) | creation.dwLowDateTime as u64)
 }
 
 /// How a worker reaches the orchestrator's MCP proxy over the broker.

--- a/crates/infra/bamboo-subagent/src/provision.rs
+++ b/crates/infra/bamboo-subagent/src/provision.rs
@@ -37,6 +37,13 @@ pub struct ProvisionSpec {
     /// unified actor+mailbox transport); the parent drives it by mailbox id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bus: Option<BusEndpoint>,
+    /// Physical owner of a locally spawned worker. This is independent from
+    /// the durable parent/child session lifecycle: it lets the worker reclaim
+    /// its OS process if the spawning Bamboo instance disappears without
+    /// dropping the `Child` handle normally. Missing for older specs and for
+    /// operator-managed resident workers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<WorkerOwner>,
     /// Isolated storage root for this actor's own session/mailbox files.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_dir: Option<String>,
@@ -242,6 +249,21 @@ pub struct BusEndpoint {
     pub token: String,
 }
 
+/// Process-instance identity attached immediately before a local worker spawn.
+///
+/// `session_id` is diagnostic context for the activation that caused the
+/// spawn. A reusable worker can later serve other sessions, so durable child
+/// lifecycle remains authoritative elsewhere; `process_id` + `instance_id`
+/// are the physical ownership lease used by the orphan guard.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkerOwner {
+    pub process_id: u32,
+    pub instance_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    pub worker_spawned_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// How a worker reaches the orchestrator's MCP proxy over the broker.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct McpProxyConfig {
@@ -438,6 +460,7 @@ impl ProvisionSpec {
             executor,
             fabric_dir,
             bus: None,
+            owner: None,
             storage_dir: None,
             workspace: None,
             model: None,
@@ -583,6 +606,7 @@ mod tests {
         assert!(parsed.model.is_none());
         assert!(parsed.secrets.provider_credentials.is_empty());
         assert_eq!(parsed.limits, Limits::default());
+        assert!(parsed.owner.is_none());
         // Placement defaults to Local for a spec that predates the field.
         assert_eq!(parsed.placement, Placement::Local);
     }

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -158,60 +158,6 @@ fn parse_nonzero_u32(s: &str) -> Result<u32, String> {
     Ok(n)
 }
 
-/// Spawn the sidecar orphan guard: a dedicated OS thread that exits the process
-/// when the shell that spawned us goes away.
-///
-/// The primary signal is `getppid()`: when our parent terminates — even via
-/// SIGKILL / force-quit, even while it lingers as an unreaped zombie — the
-/// kernel reparents us to init/launchd *at the moment of termination*, so
-/// `getppid()` changes. That is reap-independent, unlike `kill(pid, 0)` (which
-/// still reports a zombie as alive). The recorded shell PID fully disappearing
-/// is kept as a secondary trigger.
-#[cfg(unix)]
-fn spawn_orphan_guard(shell_pid: u32) {
-    std::thread::spawn(move || {
-        let initial_parent = unsafe { libc::getppid() };
-        loop {
-            let current_parent = unsafe { libc::getppid() };
-            // Reparented away from our original parent (it terminated → the kernel
-            // handed us to init/launchd). This is immediate at the parent's exit and
-            // independent of when its zombie is reaped — unlike `kill(pid, 0)`, which
-            // still reports a not-yet-reaped zombie as alive. The shell PID fully
-            // disappearing is kept as a secondary trigger.
-            let reparented = current_parent != initial_parent || current_parent <= 1;
-            let shell_gone = {
-                let r = unsafe { libc::kill(shell_pid as libc::pid_t, 0) };
-                r != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
-            };
-            if reparented || shell_gone {
-                std::process::exit(0);
-            }
-            std::thread::sleep(std::time::Duration::from_millis(300));
-        }
-    });
-}
-
-#[cfg(windows)]
-fn spawn_orphan_guard(shell_pid: u32) {
-    use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::Threading::{
-        OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
-    };
-    // Open a synchronizable handle to the shell and block until it exits, then take
-    // the sidecar down with it. Covers normal quit AND hard kills (the shell runs no
-    // cleanup). If the shell is already gone, OpenProcess fails and we exit at once.
-    std::thread::spawn(move || unsafe {
-        let handle = OpenProcess(PROCESS_SYNCHRONIZE, 0, shell_pid);
-        if handle.is_null() {
-            std::process::exit(0);
-        }
-        // INFINITE (0xFFFF_FFFF): wait until the shell process terminates.
-        WaitForSingleObject(handle, u32::MAX);
-        let _ = CloseHandle(handle);
-        std::process::exit(0);
-    });
-}
-
 #[derive(Subcommand)]
 enum Commands {
     /// Start the Bamboo HTTP server
@@ -1496,7 +1442,7 @@ async fn main() {
             // how the parent wired our stdio — a Tauri sidecar does not hand us a
             // pipe whose EOF we could watch, so a PID poll is the portable signal.
             if let Some(ppid) = parent_pid {
-                spawn_orphan_guard(ppid);
+                bamboo_agent::process_owner::spawn_orphan_guard(ppid, "bamboo-sidecar", None, None);
             }
             // Desktop notification sink default posture (see
             // `notify_sinks::desktop::desktop_enabled`): a sidecar runs under a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub mod error;
 
 pub mod commands;
 
+#[doc(hidden)]
+pub mod process_owner;
 pub mod project_worktree;
 /// The `bamboo subagent-worker` actor worker (provision via stdin, serve over WS).
 pub mod subagent_worker;

--- a/src/process_owner.rs
+++ b/src/process_owner.rs
@@ -5,6 +5,7 @@
 //! runtime; the guard only ensures a local subprocess cannot survive the Bamboo
 //! process that physically spawned it.
 
+#[cfg(any(unix, test))]
 fn owner_lost_from_observation(
     initial_parent: u32,
     current_parent: u32,
@@ -15,6 +16,34 @@ fn owner_lost_from_observation(
         || current_parent != initial_parent
         || current_parent <= 1
         || !watched_process_exists
+}
+
+#[cfg(any(windows, test))]
+fn owner_process_identity_matches(
+    require_exact_identity: bool,
+    expected_start_id: Option<u64>,
+    observed_start_id: Option<u64>,
+) -> bool {
+    !require_exact_identity
+        || matches!(
+            (expected_start_id, observed_start_id),
+            (Some(expected), Some(observed)) if expected == observed
+        )
+}
+
+#[cfg(windows)]
+unsafe fn windows_process_start_id(handle: windows_sys::Win32::Foundation::HANDLE) -> Option<u64> {
+    use windows_sys::Win32::Foundation::FILETIME;
+    use windows_sys::Win32::System::Threading::GetProcessTimes;
+
+    let mut creation: FILETIME = unsafe { std::mem::zeroed() };
+    let mut exit: FILETIME = unsafe { std::mem::zeroed() };
+    let mut kernel: FILETIME = unsafe { std::mem::zeroed() };
+    let mut user: FILETIME = unsafe { std::mem::zeroed() };
+    if unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) } == 0 {
+        return None;
+    }
+    Some(((creation.dwHighDateTime as u64) << 32) | creation.dwLowDateTime as u64)
 }
 
 /// Exit this process when `owner_pid` terminates, including abrupt termination
@@ -30,6 +59,7 @@ fn spawn_owner_guard(
     owner_instance_id: Option<String>,
     owner_session_id: Option<String>,
     require_direct_parent: bool,
+    _owner_process_start_id: Option<u64>,
 ) {
     let guard_started = std::time::Instant::now();
     std::thread::spawn(move || {
@@ -71,20 +101,38 @@ fn spawn_owner_guard(
     component: &'static str,
     owner_instance_id: Option<String>,
     owner_session_id: Option<String>,
-    _require_direct_parent: bool,
+    require_direct_parent: bool,
+    owner_process_start_id: Option<u64>,
 ) {
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::Threading::{
-        OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+        OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
     };
 
     let guard_started = std::time::Instant::now();
     std::thread::spawn(move || unsafe {
-        // Holding the handle pins the exact process object, so PID reuse cannot
-        // make a replacement process look like the original owner.
-        let handle = OpenProcess(PROCESS_SYNCHRONIZE, 0, owner_pid);
-        if !handle.is_null() {
+        // The creation identity closes the startup window before this thread
+        // opens its handle: a reused PID cannot impersonate the stamped owner.
+        // Once validated, holding the handle pins that exact process object.
+        let handle = OpenProcess(
+            PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+            0,
+            owner_pid,
+        );
+        let observed_start_id = if handle.is_null() {
+            None
+        } else {
+            windows_process_start_id(handle)
+        };
+        let identity_matches = owner_process_identity_matches(
+            require_direct_parent,
+            owner_process_start_id,
+            observed_start_id,
+        );
+        if !handle.is_null() && identity_matches {
             WaitForSingleObject(handle, u32::MAX);
+            let _ = CloseHandle(handle);
+        } else if !handle.is_null() {
             let _ = CloseHandle(handle);
         }
         tracing::warn!(
@@ -92,6 +140,8 @@ fn spawn_owner_guard(
             owner_pid,
             owner_instance_id = owner_instance_id.as_deref().unwrap_or("unknown"),
             owner_session_id = owner_session_id.as_deref().unwrap_or("none"),
+            owner_process_start_id,
+            observed_owner_process_start_id = observed_start_id,
             worker_age_ms = guard_started.elapsed().as_millis() as u64,
             shutdown_reason = "owner_lost",
             "owned Bamboo subprocess detected owner loss"
@@ -113,6 +163,7 @@ pub fn spawn_orphan_guard(
         owner_instance_id,
         owner_session_id,
         false,
+        None,
     );
 }
 
@@ -127,6 +178,7 @@ pub fn spawn_direct_owner_guard(
     component: &'static str,
     owner_instance_id: Option<String>,
     owner_session_id: Option<String>,
+    owner_process_start_id: Option<u64>,
 ) {
     spawn_owner_guard(
         owner_pid,
@@ -134,6 +186,7 @@ pub fn spawn_direct_owner_guard(
         owner_instance_id,
         owner_session_id,
         true,
+        owner_process_start_id,
     );
 }
 
@@ -157,5 +210,43 @@ mod tests {
     fn direct_owner_loss_detects_worker_already_reparented_before_guard_start() {
         assert!(owner_lost_from_observation(1, 1, Some(42), true));
         assert!(!owner_lost_from_observation(42, 42, Some(42), true));
+    }
+
+    #[test]
+    fn exact_owner_identity_requires_matching_start_ids() {
+        assert!(owner_process_identity_matches(true, Some(123), Some(123)));
+        assert!(!owner_process_identity_matches(true, Some(123), Some(456)));
+        assert!(!owner_process_identity_matches(true, Some(123), None));
+        assert!(!owner_process_identity_matches(true, None, Some(123)));
+        assert!(owner_process_identity_matches(false, None, None));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_stamped_owner_identity_matches_open_process_object() {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
+        };
+
+        let owner = bamboo_subagent::provision::WorkerOwner::for_current_process(
+            "windows-owner-test".to_string(),
+            None,
+        );
+        let handle = unsafe {
+            OpenProcess(
+                PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+                0,
+                owner.process_id,
+            )
+        };
+        assert!(!handle.is_null());
+        let observed_start_id = unsafe { windows_process_start_id(handle) };
+        assert!(owner_process_identity_matches(
+            true,
+            owner.process_start_id,
+            observed_start_id
+        ));
+        let _ = unsafe { CloseHandle(handle) };
     }
 }

--- a/src/process_owner.rs
+++ b/src/process_owner.rs
@@ -1,0 +1,161 @@
+//! Process-owner guards shared by the desktop sidecar and local sub-agent workers.
+//!
+//! This is deliberately an OS lifecycle primitive, not a child-session state
+//! machine. Durable parent/child `lost` reconciliation remains owned by the
+//! runtime; the guard only ensures a local subprocess cannot survive the Bamboo
+//! process that physically spawned it.
+
+fn owner_lost_from_observation(
+    initial_parent: u32,
+    current_parent: u32,
+    expected_direct_parent: Option<u32>,
+    watched_process_exists: bool,
+) -> bool {
+    expected_direct_parent.is_some_and(|owner_pid| initial_parent != owner_pid)
+        || current_parent != initial_parent
+        || current_parent <= 1
+        || !watched_process_exists
+}
+
+/// Exit this process when `owner_pid` terminates, including abrupt termination
+/// paths that cannot drop a `tokio::process::Child` handle.
+///
+/// `owner_instance_id` and `owner_session_id` are diagnostic identities only;
+/// a warm worker may serve later sessions, so they never mutate durable child
+/// lifecycle state.
+#[cfg(unix)]
+fn spawn_owner_guard(
+    owner_pid: u32,
+    component: &'static str,
+    owner_instance_id: Option<String>,
+    owner_session_id: Option<String>,
+    require_direct_parent: bool,
+) {
+    let guard_started = std::time::Instant::now();
+    std::thread::spawn(move || {
+        let initial_parent = unsafe { libc::getppid() } as u32;
+        loop {
+            let current_parent = unsafe { libc::getppid() } as u32;
+            // Signal 0 probes existence without delivering a signal. EPERM means
+            // the process exists but is not signalable; only ESRCH is owner loss.
+            let owner_exists = {
+                let result = unsafe { libc::kill(owner_pid as libc::pid_t, 0) };
+                result == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+            };
+            let expected_direct_parent = require_direct_parent.then_some(owner_pid);
+            if owner_lost_from_observation(
+                initial_parent,
+                current_parent,
+                expected_direct_parent,
+                owner_exists,
+            ) {
+                tracing::warn!(
+                    component,
+                    owner_pid,
+                    owner_instance_id = owner_instance_id.as_deref().unwrap_or("unknown"),
+                    owner_session_id = owner_session_id.as_deref().unwrap_or("none"),
+                    worker_age_ms = guard_started.elapsed().as_millis() as u64,
+                    shutdown_reason = "owner_lost",
+                    "owned Bamboo subprocess detected owner loss"
+                );
+                std::process::exit(0);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        }
+    });
+}
+
+#[cfg(windows)]
+fn spawn_owner_guard(
+    owner_pid: u32,
+    component: &'static str,
+    owner_instance_id: Option<String>,
+    owner_session_id: Option<String>,
+    _require_direct_parent: bool,
+) {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+    };
+
+    let guard_started = std::time::Instant::now();
+    std::thread::spawn(move || unsafe {
+        // Holding the handle pins the exact process object, so PID reuse cannot
+        // make a replacement process look like the original owner.
+        let handle = OpenProcess(PROCESS_SYNCHRONIZE, 0, owner_pid);
+        if !handle.is_null() {
+            WaitForSingleObject(handle, u32::MAX);
+            let _ = CloseHandle(handle);
+        }
+        tracing::warn!(
+            component,
+            owner_pid,
+            owner_instance_id = owner_instance_id.as_deref().unwrap_or("unknown"),
+            owner_session_id = owner_session_id.as_deref().unwrap_or("none"),
+            worker_age_ms = guard_started.elapsed().as_millis() as u64,
+            shutdown_reason = "owner_lost",
+            "owned Bamboo subprocess detected owner loss"
+        );
+        std::process::exit(0);
+    });
+}
+
+/// Watch an owner that may be an indirect ancestor (the desktop sidecar case).
+pub fn spawn_orphan_guard(
+    owner_pid: u32,
+    component: &'static str,
+    owner_instance_id: Option<String>,
+    owner_session_id: Option<String>,
+) {
+    spawn_owner_guard(
+        owner_pid,
+        component,
+        owner_instance_id,
+        owner_session_id,
+        false,
+    );
+}
+
+/// Watch the process that directly spawned this subprocess.
+///
+/// The startup parent check closes the narrow race where the owner terminates
+/// after writing the provision document but before the guard thread captures
+/// its initial parent. An already-reparented worker exits immediately instead
+/// of accepting init/launchd as its legitimate owner.
+pub fn spawn_direct_owner_guard(
+    owner_pid: u32,
+    component: &'static str,
+    owner_instance_id: Option<String>,
+    owner_session_id: Option<String>,
+) {
+    spawn_owner_guard(
+        owner_pid,
+        component,
+        owner_instance_id,
+        owner_session_id,
+        true,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_loss_detects_reparenting_even_while_recorded_pid_still_exists() {
+        assert!(owner_lost_from_observation(42, 1, None, true));
+        assert!(owner_lost_from_observation(42, 99, None, true));
+    }
+
+    #[test]
+    fn owner_loss_detects_disappeared_pid_and_keeps_stable_owner() {
+        assert!(owner_lost_from_observation(42, 42, None, false));
+        assert!(!owner_lost_from_observation(42, 42, None, true));
+    }
+
+    #[test]
+    fn direct_owner_loss_detects_worker_already_reparented_before_guard_start() {
+        assert!(owner_lost_from_observation(1, 1, Some(42), true));
+        assert!(!owner_lost_from_observation(42, 42, Some(42), true));
+    }
+}

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -62,11 +62,13 @@ pub async fn run() -> std::result::Result<(), String> {
             "subagent-worker",
             Some(owner.instance_id.clone()),
             owner.session_id.clone(),
+            owner.process_start_id,
         );
         tracing::info!(
             worker_id = %spec.identity.child_id,
             owner_pid = owner.process_id,
             owner_instance_id = %owner.instance_id,
+            owner_process_start_id = owner.process_start_id,
             owner_session_id = owner.session_id.as_deref().unwrap_or("none"),
             worker_spawned_at = %owner.worker_spawned_at,
             "subagent worker owner guard armed"

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -50,11 +50,33 @@ const STORAGE_RETENTION: std::time::Duration = std::time::Duration::from_secs(7 
 
 /// Worker entry point: provision from stdin, build the executor, serve one run, clean up.
 pub async fn run() -> std::result::Result<(), String> {
+    let worker_started = std::time::Instant::now();
     // Stage 1: provision (one JSON document on stdin; the parent closes the pipe).
     let mut spec = ProvisionSpec::read_from_stdin()
         .await
         .map_err(|e| format!("read ProvisionSpec from stdin: {e}"))?;
     let provisioned_permission = spec.capabilities.permission_resolution()?;
+    if let Some(owner) = spec.owner.as_ref() {
+        crate::process_owner::spawn_direct_owner_guard(
+            owner.process_id,
+            "subagent-worker",
+            Some(owner.instance_id.clone()),
+            owner.session_id.clone(),
+        );
+        tracing::info!(
+            worker_id = %spec.identity.child_id,
+            owner_pid = owner.process_id,
+            owner_instance_id = %owner.instance_id,
+            owner_session_id = owner.session_id.as_deref().unwrap_or("none"),
+            worker_spawned_at = %owner.worker_spawned_at,
+            "subagent worker owner guard armed"
+        );
+    } else {
+        tracing::debug!(
+            worker_id = %spec.identity.child_id,
+            "subagent worker has no physical owner metadata (legacy or resident spec)"
+        );
+    }
 
     // Preserve an explicit parent-selected storage root. Otherwise bind
     // project workers to `<git-root>/.bamboo/tmp/subagents/<child-id>` and
@@ -227,9 +249,35 @@ pub async fn run() -> std::result::Result<(), String> {
             session_id: spec.identity.child_id.clone(),
             role: Some(spec.identity.role.clone()),
         };
-        return bamboo_broker::serve_executor(&bus.endpoint, me, &bus.token, executor)
-            .await
-            .map_err(|e| format!("bus serve: {e}"));
+        let idle_timeout = spec
+            .limits
+            .idle_timeout_secs
+            .map(std::time::Duration::from_secs)
+            .or_else(|| spec.reusable.then(|| std::time::Duration::from_secs(300)));
+        let reason = bamboo_broker::serve_executor_with_lifecycle(
+            &bus.endpoint,
+            me,
+            &bus.token,
+            executor,
+            CancellationToken::new(),
+            idle_timeout,
+        )
+        .await
+        .map_err(|e| format!("bus serve: {e}"))?;
+        let shutdown_reason = match reason {
+            bamboo_broker::ServeExitReason::ShutdownRequested => "shutdown_requested",
+            bamboo_broker::ServeExitReason::ConnectionClosed => "connection_closed",
+            bamboo_broker::ServeExitReason::IdleTimeout => "idle_timeout",
+        };
+        tracing::info!(
+            worker_id = %spec.identity.child_id,
+            owner_pid = spec.owner.as_ref().map(|owner| owner.process_id),
+            worker_age_ms = worker_started.elapsed().as_millis() as u64,
+            idle_timeout_secs = idle_timeout.map(|timeout| timeout.as_secs()),
+            shutdown_reason,
+            "subagent bus worker stopped"
+        );
+        return Ok(());
     }
 
     // Stage 3 (legacy direct-WS): bind, self-register (with lease renewal), serve.

--- a/tests/subagent_worker_e2e.rs
+++ b/tests/subagent_worker_e2e.rs
@@ -7,13 +7,42 @@
 //! the same factory with a provisioned credential.
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
-use bamboo_subagent::fleet::spawn_worker;
+use bamboo_broker::{BrokerCore, BrokerServer};
+#[cfg(unix)]
+use bamboo_subagent::discovery::Fabric;
+use bamboo_subagent::fleet::{spawn_worker, spawn_worker_on_bus};
 use bamboo_subagent::proto::{ChildFrame, ParentFrame, RunSpec, TerminalStatus};
-use bamboo_subagent::provision::{ChildIdentity, ExecutorSpec, ProvisionSpec};
+#[cfg(unix)]
+use bamboo_subagent::provision::WorkerOwner;
+use bamboo_subagent::provision::{BusEndpoint, ChildIdentity, ExecutorSpec, ProvisionSpec};
 use bamboo_subagent::transport::ChildClient;
 use tempfile::TempDir;
+use tokio::net::TcpListener;
+
+#[cfg(unix)]
+fn process_exists(pid: u32) -> bool {
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+/// Failure-only cleanup for the exact worker PID learned from its Fabric
+/// registration. Never targets a process group or an unresolved child handle.
+#[cfg(unix)]
+struct ExactPidCleanup(Option<u32>);
+
+#[cfg(unix)]
+impl Drop for ExactPidCleanup {
+    fn drop(&mut self) {
+        if let Some(pid) = self.0.take() {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+        }
+    }
+}
 
 #[tokio::test]
 async fn real_bamboo_binary_serves_a_subagent_run() {
@@ -90,4 +119,184 @@ async fn real_bamboo_binary_serves_a_subagent_run() {
 
     let _ = client.close().await;
     spawned.kill().await;
+}
+
+/// A production worker must not survive abrupt loss of the Bamboo process that
+/// physically spawned it. The shell deliberately has another command after the
+/// worker (`; :`) so it stays the direct parent instead of exec-optimizing the
+/// worker into the shell process.
+#[cfg(unix)]
+#[tokio::test]
+async fn real_bamboo_worker_exits_when_its_direct_owner_is_sigkilled() {
+    use std::process::Stdio;
+    use tokio::io::AsyncWriteExt;
+    use tokio::process::Command;
+
+    let bamboo_bin = Path::new(env!("CARGO_BIN_EXE_bamboo"));
+    let dir = TempDir::new().expect("tempdir");
+    let fabric_dir = dir.path().join("agents");
+    tokio::fs::create_dir_all(&fabric_dir)
+        .await
+        .expect("fabric dir");
+    let mut shell = Command::new("/bin/sh")
+        .arg("-c")
+        .arg("\"$1\" subagent-worker; :")
+        .arg("owner-shell")
+        .arg(bamboo_bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn direct owner shell");
+    let shell_pid = shell.id().expect("owner shell pid");
+
+    let mut spec = ProvisionSpec::new(
+        ChildIdentity {
+            child_id: "owner-loss-e2e".into(),
+            parent_id: Some("owner-session".into()),
+            project_key: None,
+            role: "owner-loss".into(),
+            depth: 0,
+        },
+        ExecutorSpec::Echo,
+        fabric_dir.to_string_lossy().into_owned(),
+    );
+    spec.owner = Some(WorkerOwner {
+        process_id: shell_pid,
+        instance_id: "owner-loss-e2e-instance".into(),
+        session_id: Some("owner-session".into()),
+        worker_spawned_at: chrono::Utc::now(),
+    });
+    let spec_json = spec.to_json().expect("encode provision spec");
+    let mut shell_stdin = shell.stdin.take().expect("owner shell stdin");
+    shell_stdin
+        .write_all(spec_json.as_bytes())
+        .await
+        .expect("write provision spec");
+    shell_stdin.shutdown().await.expect("close provision stdin");
+    drop(shell_stdin);
+
+    let fabric = Fabric::at(&fabric_dir);
+    let record = tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            if let Some(record) = fabric
+                .resolve("owner-loss-e2e")
+                .await
+                .expect("resolve worker")
+            {
+                break record;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("production worker registers in Fabric");
+    let worker_pid = record.pid;
+    assert!(worker_pid > 1, "worker must report a killable process PID");
+    assert_ne!(worker_pid, shell_pid, "shell must not exec the worker");
+    assert_ne!(
+        worker_pid,
+        std::process::id(),
+        "never target the test process"
+    );
+    assert!(
+        shell.try_wait().expect("query owner shell").is_none(),
+        "direct owner shell must still be waiting on the worker"
+    );
+    let mut worker_cleanup = ExactPidCleanup(Some(worker_pid));
+
+    let killed = unsafe { libc::kill(shell_pid as libc::pid_t, libc::SIGKILL) };
+    assert_eq!(killed, 0, "SIGKILL the direct owner shell");
+    tokio::time::timeout(Duration::from_secs(5), shell.wait())
+        .await
+        .expect("owner shell is reaped")
+        .expect("wait for owner shell");
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while process_exists(worker_pid) {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("worker exits promptly after owner loss");
+    worker_cleanup.0 = None;
+}
+
+#[tokio::test]
+async fn real_bamboo_bus_worker_exits_after_true_idle_timeout_and_leaves_presence() {
+    let bamboo_bin = Path::new(env!("CARGO_BIN_EXE_bamboo"));
+    let dir = TempDir::new().expect("tempdir");
+    let core = Arc::new(BrokerCore::new(dir.path().join("broker")));
+    let token = "idle-e2e-token";
+    let server = Arc::new(BrokerServer::new(core.clone(), token));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind broker");
+    let address = listener.local_addr().expect("broker address");
+    let server_task = tokio::spawn(async move {
+        let _ = server.serve(listener).await;
+    });
+    let endpoint = format!("ws://{address}");
+
+    let mut spec = ProvisionSpec::new(
+        ChildIdentity {
+            child_id: "bus-idle-e2e".into(),
+            parent_id: Some("bus-idle-parent".into()),
+            project_key: None,
+            role: "bus-idle".into(),
+            depth: 0,
+        },
+        ExecutorSpec::Echo,
+        dir.path().join("fabric").to_string_lossy().into_owned(),
+    );
+    spec.bus = Some(BusEndpoint {
+        endpoint,
+        token: token.into(),
+    });
+    spec.reusable = true;
+    spec.limits.idle_timeout_secs = Some(1);
+    let mut spawned = spawn_worker_on_bus(bamboo_bin, &["subagent-worker".to_string()], &spec)
+        .await
+        .expect("spawn production bus worker");
+
+    tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            if core
+                .connected_by_role("bus-idle")
+                .await
+                .iter()
+                .any(|id| id == "bus-idle-e2e")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("production worker announces broker presence");
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while spawned.is_alive() {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("idle production worker process exits");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if !core
+                .connected_by_role("bus-idle")
+                .await
+                .iter()
+                .any(|id| id == "bus-idle-e2e")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("idle worker presence is removed after disconnect");
+
+    spawned.kill().await;
+    server_task.abort();
 }

--- a/tests/subagent_worker_e2e.rs
+++ b/tests/subagent_worker_e2e.rs
@@ -165,6 +165,7 @@ async fn real_bamboo_worker_exits_when_its_direct_owner_is_sigkilled() {
     spec.owner = Some(WorkerOwner {
         process_id: shell_pid,
         instance_id: "owner-loss-e2e-instance".into(),
+        process_start_id: None,
         session_id: Some("owner-session".into()),
         worker_spawned_at: chrono::Utc::now(),
     });


### PR DESCRIPTION
## Summary

- stamp every locally spawned worker with explicit process/instance/session ownership and make direct subagent workers exit when that owner disappears, including the startup reparenting/PID-reuse race; Windows binds the PID to its process creation identity before waiting
- give mailbox-bus workers a configured true-idle lifetime, structured shutdown reasons, and bounded local-process pooling with periodic expiry while leaving remote/schedulable workers untouched
- replace broad recursive project/data watches with catalog-scoped roots, shallow missing-root rebinding, bounded event coalescing, lexical filtering, and watcher activity counters
- add real-process owner-loss and bus-idle E2E coverage plus watcher churn/relevant-change and pool-bound regression tests

## Root Cause

The mailbox-bus path had no idle lifetime, and `kill_on_drop` only covered normal owner teardown. A crashed owner could therefore leave a reparented worker alive. Retained local workers also lacked a global idle bound. Each surviving worker could host a skill store whose watcher recursively observed broad project/data roots and performed filesystem canonicalization before event rejection and debounce, multiplying CPU and metadata work under unrelated build churn.

## User Impact

Orphaned or unused local subagent workers now converge to termination, idle process counts stay bounded, and unrelated project output no longer drives catalog reload or per-event canonicalization. Relevant skill and workflow additions, edits, removals, and late-created roots remain hot-reloaded.

## Test Plan

- `cargo fmt --all -- --check`
- strict `cargo clippy --all-features` with the repository CI deny/allow set
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo test --all-features --lib --tests`
- `cargo test --tests`
- `cargo build --examples`
- focused `bamboo-broker`, `bamboo-subagent`, `bamboo-skills`, actor-adapter, process-owner, and real `subagent_worker_e2e` suites
- Windows production-path cross-checks: `cargo check --target x86_64-pc-windows-gnu -p bamboo-subagent --lib` and `cargo check --target x86_64-pc-windows-gnu -p bamboo-agent --lib`

Closes #696