### PR TITLE
fix: reconcile reappeared legacy config root (#735)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -71,7 +71,9 @@ impl AppState {
                 (config, Some(facade))
             }
             Err(error) => {
-                if bamboo_config::section_layout_is_active(&bamboo_home_dir).unwrap_or(false) {
+                if bamboo_config::modular_authority_boundary_present(&bamboo_home_dir)
+                    .unwrap_or(true)
+                {
                     return Err(AppError::InternalError(anyhow::anyhow!(
                         "modular configuration authority is unavailable: {error}"
                     )));

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -292,8 +292,8 @@ pub(super) fn load_facade_effective_config(
 }
 
 fn load_committed_effective_config(data_dir: &Path) -> Result<Config, ConfigStoreError> {
-    if bamboo_config::section_layout_is_active(data_dir)? {
-        let facade = bamboo_config::ConfigFacade::open(data_dir)?;
+    if bamboo_config::modular_authority_boundary_present(data_dir)? {
+        let facade = bamboo_config::ConfigFacade::open_or_migrate(data_dir)?;
         let config = load_facade_effective_config(&facade, data_dir);
         Ok(config)
     } else {
@@ -324,6 +324,9 @@ pub struct ConfigWatcherRuntime {
 struct ConfigPathChanges {
     paths: Vec<PathBuf>,
     initial_mcp: bool,
+    startup_legacy_root: Option<bamboo_config::LegacyRootReconciliationOutcome>,
+    startup_recoveries: BTreeMap<SectionId, u64>,
+    legacy_root_retry_attempt: u8,
 }
 
 /// Owned handles needed to publish provider and MCP effects for one committed
@@ -397,6 +400,9 @@ impl ConfigWatcherRuntime {
         // thread after aborting the async consumer, so a bounded blocking_send
         // could deadlock shutdown if its queue were full.
         let self_write_marker = watcher.self_write_marker();
+        let startup_legacy_root = config_facade
+            .as_ref()
+            .and_then(|facade| facade.take_startup_legacy_root_reconciliation());
         let (changes_tx, mut changes_rx) =
             tokio::sync::mpsc::unbounded_channel::<ConfigPathChanges>();
         let initial_changes = changes_tx.clone();
@@ -409,6 +415,9 @@ impl ConfigWatcherRuntime {
                             .send(ConfigPathChanges {
                                 paths,
                                 initial_mcp: false,
+                                startup_legacy_root: None,
+                                startup_recoveries: BTreeMap::new(),
+                                legacy_root_retry_attempt: 0,
                             })
                             .is_err()
                         {
@@ -426,18 +435,60 @@ impl ConfigWatcherRuntime {
         // events; parse-only initial health must never be mistaken for a
         // published runtime snapshot.
         let initial_mcp_path = data_dir.join("mcp.json");
+        let mut initial_paths = Vec::new();
         if initial_mcp_path.exists() {
+            initial_paths.push(initial_mcp_path);
+        }
+        let rejected = bamboo_config::legacy_root_rejected_sections(&data_dir);
+        let startup_recoveries = match (config_facade.as_ref(), rejected.as_ref()) {
+            (Some(facade), Ok(rejected)) => {
+                durable_invalid_recoveries(&account_sink, facade, rejected)
+            }
+            _ => BTreeMap::new(),
+        };
+        if let (Some(facade), Ok(rejected)) = (config_facade.as_ref(), rejected.as_ref()) {
+            if let Ok(health) = facade.registry().health() {
+                initial_paths.extend(
+                    health
+                        .into_iter()
+                        .filter(|health| {
+                            health.status != SectionStatus::Healthy
+                                && !rejected.contains(&health.section)
+                        })
+                        .map(|health| data_dir.join(health.section.descriptor().file_name)),
+                );
+            }
+        }
+        initial_paths.extend(
+            startup_recoveries
+                .keys()
+                .map(|id| data_dir.join(id.descriptor().file_name)),
+        );
+        // Every modular watcher start performs one catch-up pass. This is the
+        // recovery seam for crashes after a canonical outbox/rejection update
+        // but before its runtime or account-feed publication. The pass is
+        // content-deduped and does not make config.json authoritative again.
+        let legacy_root_needs_reconciliation = config_facade.is_some();
+        if legacy_root_needs_reconciliation {
+            initial_paths.push(data_dir.join("config.json"));
+        }
+        if !initial_paths.is_empty() {
             let _ = initial_changes.send(ConfigPathChanges {
-                paths: vec![initial_mcp_path],
-                initial_mcp: true,
+                paths: initial_paths,
+                initial_mcp: data_dir.join("mcp.json").exists(),
+                startup_legacy_root,
+                startup_recoveries,
+                legacy_root_retry_attempt: 0,
             });
         }
 
         let apply_provider_health = provider_health.clone();
         let apply_mcp_health = mcp_health.clone();
+        let catchup_changes = initial_changes.clone();
         let apply_task = tokio::spawn(async move {
-            while let Some(changes) = changes_rx.recv().await {
-                let watched_sections = config_facade
+            let mut reported_root_runtime_failures = BTreeSet::<(SectionId, u64)>::new();
+            while let Some(mut changes) = changes_rx.recv().await {
+                let mut watched_sections = config_facade
                     .as_ref()
                     .map(|_| {
                         changes
@@ -451,18 +502,30 @@ impl ConfigWatcherRuntime {
                             .collect::<BTreeSet<_>>()
                     })
                     .unwrap_or_default();
-                let provider_watched = changes.paths.iter().any(|path| {
+                let direct_watched_sections = watched_sections.clone();
+                let legacy_root_watched = config_facade.is_some()
+                    && changes.paths.iter().any(|path| {
+                        matches!(
+                            path.file_name().and_then(|name| name.to_str()),
+                            Some(
+                                "config.json"
+                                    | "config.json.bak"
+                                    | "config.json.bak.1"
+                                    | "config.json.bak.2"
+                            )
+                        )
+                    });
+                let mut provider_watched = changes.paths.iter().any(|path| {
                     path.file_name().and_then(|name| name.to_str()) == Some("providers.json")
                 });
-                let mcp_watched = changes.paths.iter().any(|path| {
+                let mut mcp_watched = changes.paths.iter().any(|path| {
                     path.file_name().and_then(|name| name.to_str()) == Some("mcp.json")
                 });
-                let ordinary_watched = watched_sections
-                    .iter()
-                    .copied()
-                    .filter(|id| !matches!(id, SectionId::Providers | SectionId::Mcp))
-                    .collect::<Vec<_>>();
-                if !provider_watched && !mcp_watched && ordinary_watched.is_empty() {
+                if !provider_watched
+                    && !mcp_watched
+                    && watched_sections.is_empty()
+                    && !legacy_root_watched
+                {
                     continue;
                 }
 
@@ -470,24 +533,252 @@ impl ConfigWatcherRuntime {
                 // writers. Otherwise a slow provider build could later publish
                 // a clone taken before an unrelated API update and clobber it.
                 let _io = config_io_lock.lock().await;
+                let mut synthetic_root_events = BTreeMap::<SectionId, ConfigSectionEvent>::new();
+                let mut pending_root_publications =
+                    BTreeMap::<SectionId, ConfigSectionEvent>::new();
+                let startup_root_batch = changes.startup_legacy_root.is_some();
+                let mut requeue_legacy_root = false;
+                let mut retry_legacy_root_publication = false;
+                let mut canonical_root_rejections = BTreeSet::new();
+                if legacy_root_watched {
+                    let reconciliation = match changes.startup_legacy_root.take() {
+                        Some(outcome) => Ok(Some(outcome)),
+                        None => {
+                            let reconcile_facade = config_facade
+                                .as_ref()
+                                .expect("legacy root watching requires a facade")
+                                .clone();
+                            tokio::task::spawn_blocking(move || {
+                                reconcile_facade.reconcile_reappeared_legacy_root()
+                            })
+                            .await
+                            .map_err(|_| {
+                                ConfigStoreError::Validation(
+                                    "legacy root reconciliation task failed".to_string(),
+                                )
+                            })
+                            .and_then(|result| result)
+                        }
+                    };
+                    match reconciliation {
+                        Ok(Some(outcome)) if !outcome.duplicate => {
+                            requeue_legacy_root = outcome.partial || startup_root_batch;
+                            for event in &outcome.committed {
+                                let section = match event {
+                                    ConfigSectionEvent::Changed { section, .. }
+                                    | ConfigSectionEvent::Invalid { section, .. }
+                                    | ConfigSectionEvent::Recovered { section, .. } => section,
+                                };
+                                if let Some(id) = SectionId::from_name(section) {
+                                    watched_sections.insert(id);
+                                    synthetic_root_events.insert(id, event.clone());
+                                    if matches!(
+                                        event,
+                                        ConfigSectionEvent::Changed { .. }
+                                            | ConfigSectionEvent::Recovered { .. }
+                                    ) {
+                                        pending_root_publications.insert(id, event.clone());
+                                    }
+                                }
+                            }
+                            if let Some(facade) = config_facade.as_ref() {
+                                for id in &outcome.recovered {
+                                    queue_legacy_root_recovery(
+                                        facade,
+                                        *id,
+                                        None,
+                                        &mut watched_sections,
+                                        &mut synthetic_root_events,
+                                    );
+                                }
+                                for rejection in outcome.rejected {
+                                    canonical_root_rejections.insert(rejection.section);
+                                    if rejection.reason
+                                        == bamboo_config::LegacyRootRejectionReason::RevisionConflict
+                                    {
+                                        watched_sections.insert(rejection.section);
+                                    }
+                                    if let Some(event) = legacy_root_rejection_event(
+                                        facade,
+                                        rejection.section,
+                                        rejection.reason.diagnostic(),
+                                        startup_root_batch,
+                                    ) {
+                                        publish_registry_event(&account_sink, &event);
+                                    }
+                                }
+                            }
+                            if outcome.partial {
+                                tracing::warn!(
+                                    "legacy config root changed during reconciliation; awaiting the newer generation"
+                                );
+                            }
+                        }
+                        Ok(Some(outcome)) => {
+                            requeue_legacy_root = outcome.partial || startup_root_batch;
+                            // Another facade/process may have committed this
+                            // exact root while this process registry still
+                            // lags. Keep its outbox pending and synthesize only
+                            // when the process already owns the exact healthy
+                            // revision; otherwise the normal reload path must
+                            // install it before the durable event is acked.
+                            if let Some(facade) = config_facade.as_ref() {
+                                for id in &outcome.recovered {
+                                    queue_legacy_root_recovery(
+                                        facade,
+                                        *id,
+                                        None,
+                                        &mut watched_sections,
+                                        &mut synthetic_root_events,
+                                    );
+                                }
+                                for event in &outcome.committed {
+                                    let (section, revision) = match event {
+                                        ConfigSectionEvent::Changed { section, revision }
+                                        | ConfigSectionEvent::Recovered { section, revision } => {
+                                            (section, *revision)
+                                        }
+                                        ConfigSectionEvent::Invalid { .. } => continue,
+                                    };
+                                    let Some(id) = SectionId::from_name(section) else {
+                                        continue;
+                                    };
+                                    watched_sections.insert(id);
+                                    pending_root_publications.insert(id, event.clone());
+                                    if facade.registry().envelope_value(id).is_ok_and(|envelope| {
+                                        envelope.revision == revision
+                                            && envelope.status == SectionStatus::Healthy
+                                    }) {
+                                        synthetic_root_events.insert(id, event.clone());
+                                    }
+                                }
+                                for rejection in outcome.rejected {
+                                    canonical_root_rejections.insert(rejection.section);
+                                    if rejection.reason
+                                        == bamboo_config::LegacyRootRejectionReason::RevisionConflict
+                                    {
+                                        watched_sections.insert(rejection.section);
+                                    }
+                                    if let Some(event) = legacy_root_rejection_event(
+                                        facade,
+                                        rejection.section,
+                                        rejection.reason.diagnostic(),
+                                        startup_root_batch,
+                                    ) {
+                                        publish_registry_event(&account_sink, &event);
+                                    }
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            if bamboo_config::modular_authority_boundary_present(&data_dir)
+                                .unwrap_or(false)
+                            {
+                                if let Some(facade) = config_facade.as_ref() {
+                                    if let Some(event) = facade.registry().mark_runtime_degraded(
+                                        SectionId::Core,
+                                        "completed modular configuration reconciliation is unavailable",
+                                    ) {
+                                        publish_registry_event(&account_sink, &event);
+                                    }
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            if let Some(facade) = config_facade.as_ref() {
+                                if let Some(event) = facade.registry().mark_runtime_degraded(
+                                    SectionId::Core,
+                                    "legacy config root reconciliation is unavailable",
+                                ) {
+                                    publish_registry_event(&account_sink, &event);
+                                }
+                            }
+                        }
+                    }
+                    if let Some(facade) = config_facade.as_ref() {
+                        for (id, event) in pending_root_publications.clone() {
+                            let revision = config_section_event_revision(&event);
+                            if !pending_root_publication_matches_fresh_durable(
+                                &data_dir, facade, id, revision,
+                            ) {
+                                // A typed writer advanced after root
+                                // reconciliation released the migration lock.
+                                // Never materialize or journal the superseded
+                                // root revision. Catch the typed generation up
+                                // now, then requeue the root so its durable
+                                // outbox is rejected as a revision conflict.
+                                pending_root_publications.remove(&id);
+                                synthetic_root_events.remove(&id);
+                                watched_sections.insert(id);
+                                requeue_legacy_root = true;
+                            }
+                        }
+                    }
+                    provider_watched |= watched_sections.contains(&SectionId::Providers);
+                    mcp_watched |= watched_sections.contains(&SectionId::Mcp);
+                }
                 if let Some(facade) = config_facade.as_ref() {
-                    reload_and_apply_ordinary_sections(
+                    for (id, revision) in std::mem::take(&mut changes.startup_recoveries) {
+                        if !canonical_root_rejections.contains(&id) {
+                            queue_legacy_root_recovery(
+                                facade,
+                                id,
+                                Some(revision),
+                                &mut watched_sections,
+                                &mut synthetic_root_events,
+                            );
+                        }
+                    }
+                    provider_watched |= watched_sections.contains(&SectionId::Providers);
+                    mcp_watched |= watched_sections.contains(&SectionId::Mcp);
+                }
+                // If notify coalesced the compatibility root and a later
+                // direct typed generation, process the root's exact adopted
+                // snapshot first, then queue one bounded catch-up pass. The
+                // next pass has no synthetic root event and therefore cannot
+                // recursively requeue itself.
+                let catchup_paths = synthetic_root_events
+                    .keys()
+                    .filter(|id| startup_root_batch || direct_watched_sections.contains(id))
+                    .map(|id| data_dir.join(id.descriptor().file_name))
+                    .collect::<Vec<_>>();
+                let ordinary_watched = watched_sections
+                    .iter()
+                    .copied()
+                    .filter(|id| !matches!(id, SectionId::Providers | SectionId::Mcp))
+                    .collect::<Vec<_>>();
+                if let Some(facade) = config_facade.as_ref() {
+                    retry_legacy_root_publication |= reload_and_apply_ordinary_sections(
                         &data_dir,
                         &config,
                         facade,
                         &account_sink,
                         ordinary_watched,
+                        OrdinarySectionReloadState {
+                            synthetic_events: &mut synthetic_root_events,
+                            pending_root_publications: &mut pending_root_publications,
+                            reported_root_runtime_failures: &mut reported_root_runtime_failures,
+                        },
                     )
                     .await;
                 }
                 if provider_watched {
                     if let Some(facade) = config_facade.as_ref() {
                         wait_for_section_file_settle(&data_dir, SectionId::Providers).await;
-                        if let Some(event) =
-                            facade.registry().reload_if_changed(SectionId::Providers)
+                        if let Some(observed) = synthetic_root_events
+                            .remove(&SectionId::Providers)
+                            .or_else(|| facade.registry().reload_if_changed(SectionId::Providers))
                         {
-                            if matches!(event, ConfigSectionEvent::Invalid { .. }) {
-                                publish_section_failure(
+                            if let Some(event) = pending_root_publication_event(
+                                &data_dir,
+                                facade,
+                                &account_sink,
+                                &pending_root_publications,
+                                SectionId::Providers,
+                                observed,
+                            ) {
+                                if matches!(event, ConfigSectionEvent::Invalid { .. }) {
+                                    publish_section_failure(
                                 &apply_provider_health,
                                 &account_sink,
                                 "providers",
@@ -495,69 +786,116 @@ impl ConfigWatcherRuntime {
                                 "provider section is invalid; retaining last-known-good runtime"
                                     .to_string(),
                             );
-                            } else {
-                                self_write_marker.mark_self_write(provider_store.path());
-                                let materialized =
-                                    materialize_facade_effective_config(facade, &data_dir);
-                                if materialized.failures.contains(&SectionId::Providers) {
-                                    facade.registry().mark_runtime_degraded(
-                                    SectionId::Providers,
-                                    "provider credential hydration failed; retaining last-known-good runtime",
-                                );
-                                    publish_section_failure(
-                                    &apply_provider_health,
-                                    &account_sink,
-                                    "providers",
-                                    SectionStatus::Degraded,
-                                    "provider credential hydration failed; retaining last-known-good runtime"
-                                        .to_string(),
-                                );
                                 } else {
-                                    let mut candidate = config.read().await.clone();
-                                    apply_runtime_section(
-                                        SectionId::Providers,
-                                        &materialized.config,
-                                        &mut candidate,
-                                    );
-                                    match prepare_provider_candidate(candidate, &data_dir).await {
-                                        Ok((candidate, registry, next_provider)) => {
-                                            let mut live_config = config.write().await;
-                                            let mut live_provider = provider.write().await;
-                                            let recovered =
-                                                section_is_unhealthy(&apply_provider_health);
-                                            candidate.publish_env_vars();
-                                            *live_config = candidate;
-                                            provider_registry.replace_with(registry);
-                                            *live_provider = next_provider;
-                                            drop(live_provider);
-                                            drop(live_config);
-                                            let revision =
-                                                facade.registry().providers.snapshot().revision;
-                                            publish_section_success(
-                                                &apply_provider_health,
-                                                &account_sink,
-                                                "providers",
-                                                data_dir.join("providers.json"),
-                                                recovered,
-                                                Some(revision),
-                                            );
-                                        }
-                                        Err(_) => {
-                                            facade.registry().mark_runtime_degraded(
+                                    self_write_marker.mark_self_write(provider_store.path());
+                                    let materialized =
+                                        materialize_facade_effective_config(facade, &data_dir);
+                                    if materialized.failures.contains(&SectionId::Providers) {
+                                        retry_legacy_root_publication |=
+                                        publish_staged_facade_section_failure(
+                                            &data_dir,
+                                            facade,
                                             SectionId::Providers,
-                                            "provider runtime initialization failed; retaining last-known-good runtime",
+                                            "provider credential hydration failed; retaining last-known-good runtime",
+                                            StagedFacadeSectionFailureContext {
+                                                health: &apply_provider_health,
+                                                account_sink: &account_sink,
+                                                section: "providers",
+                                                pending_root_publications: &pending_root_publications,
+                                            },
+                                        )
+                                        .await;
+                                    } else {
+                                        let mut candidate = config.read().await.clone();
+                                        apply_runtime_section(
+                                            SectionId::Providers,
+                                            &materialized.config,
+                                            &mut candidate,
                                         );
-                                            publish_section_failure(
-                                            &apply_provider_health,
-                                            &account_sink,
-                                            "providers",
-                                            SectionStatus::Degraded,
-                                            "provider runtime initialization failed; retaining last-known-good runtime"
-                                                .to_string(),
-                                        );
+                                        match prepare_provider_candidate(candidate, &data_dir).await
+                                        {
+                                            Ok((candidate, registry, next_provider)) => {
+                                                let mut live_config = config.write().await;
+                                                let mut live_provider = provider.write().await;
+                                                let recovered =
+                                                    section_is_unhealthy(&apply_provider_health);
+                                                candidate.publish_env_vars();
+                                                *live_config = candidate;
+                                                provider_registry.replace_with(registry);
+                                                *live_provider = next_provider;
+                                                drop(live_provider);
+                                                drop(live_config);
+                                                let revision =
+                                                    facade.registry().providers.snapshot().revision;
+                                                if pending_root_publications
+                                                    .get(&SectionId::Providers)
+                                                    .is_some_and(|event| {
+                                                        config_section_event_revision(event)
+                                                            == revision
+                                                    })
+                                                {
+                                                    set_live_health_revision(
+                                                        &apply_provider_health,
+                                                        revision,
+                                                        Some((
+                                                            data_dir.join("providers.json"),
+                                                            SectionSourceKind::File,
+                                                        )),
+                                                    );
+                                                    retry_legacy_root_publication |=
+                                                        publish_registry_event_with_root_ack(
+                                                            &data_dir,
+                                                            &account_sink,
+                                                            &mut pending_root_publications,
+                                                            SectionId::Providers,
+                                                            &event,
+                                                        )
+                                                        .await;
+                                                } else if matches!(
+                                                    event,
+                                                    ConfigSectionEvent::Recovered { .. }
+                                                ) {
+                                                    set_live_health_revision(
+                                                        &apply_provider_health,
+                                                        revision,
+                                                        Some((
+                                                            data_dir.join("providers.json"),
+                                                            SectionSourceKind::File,
+                                                        )),
+                                                    );
+                                                    publish_registry_event(&account_sink, &event);
+                                                } else {
+                                                    publish_section_success(
+                                                        &apply_provider_health,
+                                                        &account_sink,
+                                                        "providers",
+                                                        data_dir.join("providers.json"),
+                                                        recovered,
+                                                        Some(revision),
+                                                    );
+                                                }
+                                            }
+                                            Err(_) => {
+                                                retry_legacy_root_publication |=
+                                                publish_staged_facade_section_failure(
+                                                    &data_dir,
+                                                    facade,
+                                                    SectionId::Providers,
+                                                    "provider runtime initialization failed; retaining last-known-good runtime",
+                                                    StagedFacadeSectionFailureContext {
+                                                        health: &apply_provider_health,
+                                                        account_sink: &account_sink,
+                                                        section: "providers",
+                                                        pending_root_publications: &pending_root_publications,
+                                                    },
+                                                )
+                                                .await;
+                                            }
                                         }
                                     }
                                 }
+                            } else {
+                                retry_legacy_root_publication = true;
                             }
                         }
                     } else {
@@ -611,104 +949,164 @@ impl ConfigWatcherRuntime {
                 if mcp_watched {
                     if let Some(facade) = config_facade.as_ref() {
                         wait_for_section_file_settle(&data_dir, SectionId::Mcp).await;
-                        let event =
-                            facade
-                                .registry()
-                                .reload_if_changed(SectionId::Mcp)
-                                .or_else(|| {
-                                    changes.initial_mcp.then(|| ConfigSectionEvent::Changed {
-                                        section: "mcp".to_string(),
-                                        revision: facade.registry().mcp.snapshot().revision,
-                                    })
-                                });
-                        let Some(event) = event else {
-                            continue;
-                        };
-                        if matches!(event, ConfigSectionEvent::Invalid { .. }) {
-                            publish_section_failure(
-                                &apply_mcp_health,
+                        let startup_root_mcp = synthetic_root_events.contains_key(&SectionId::Mcp);
+                        let event = synthetic_root_events
+                            .remove(&SectionId::Mcp)
+                            .or_else(|| facade.registry().reload_if_changed(SectionId::Mcp))
+                            .or_else(|| {
+                                changes.initial_mcp.then(|| ConfigSectionEvent::Changed {
+                                    section: "mcp".to_string(),
+                                    revision: facade.registry().mcp.snapshot().revision,
+                                })
+                            });
+                        if let Some(observed) = event {
+                            if let Some(event) = pending_root_publication_event(
+                                &data_dir,
+                                facade,
                                 &account_sink,
-                                "mcp",
-                                facade.registry().mcp.snapshot().status,
-                                "MCP section is invalid; retaining last-known-good runtime"
-                                    .to_string(),
-                            );
-                        } else {
-                            self_write_marker.mark_self_write(mcp_store.path());
-                            let materialized =
-                                materialize_facade_effective_config(facade, &data_dir);
-                            if materialized.failures.contains(&SectionId::Mcp) {
-                                facade.registry().mark_runtime_degraded(
-                                    SectionId::Mcp,
-                                    "MCP credential hydration failed; retaining last-known-good runtime",
-                                );
-                                publish_section_failure(
-                                    &apply_mcp_health,
-                                    &account_sink,
-                                    "mcp",
-                                    SectionStatus::Degraded,
-                                    "MCP credential hydration failed; retaining last-known-good runtime"
-                                        .to_string(),
-                                );
-                                continue;
-                            }
-                            let next_mcp = materialized.config.mcp.clone();
-                            let publish_config = config.clone();
-                            match mcp_manager
-                                .reconcile_from_config_transactional_after(
-                                    &materialized.config.mcp,
-                                    || async move {
-                                        publish_config.write().await.mcp = next_mcp;
-                                        Ok(())
-                                    },
-                                )
-                                .await
-                            {
-                                Ok(()) => {
-                                    let recovered = section_is_unhealthy(&apply_mcp_health);
-                                    let snapshot = facade.registry().mcp.snapshot();
-                                    let revision = snapshot.revision;
-                                    if changes.initial_mcp
-                                        && snapshot.status == SectionStatus::Healthy
-                                    {
-                                        // Startup reconciliation makes the
-                                        // already-materialized section live in
-                                        // the MCP manager; it is not a config
-                                        // mutation and must not consume an
-                                        // account-feed sequence number.
-                                        set_live_health_revision(
-                                            &apply_mcp_health,
-                                            revision,
-                                            Some((
-                                                data_dir.join("mcp.json"),
-                                                SectionSourceKind::File,
-                                            )),
-                                        );
-                                    } else {
-                                        publish_section_success(
-                                            &apply_mcp_health,
-                                            &account_sink,
-                                            "mcp",
-                                            data_dir.join("mcp.json"),
-                                            recovered,
-                                            Some(revision),
-                                        );
-                                    }
-                                }
-                                Err(_) => {
-                                    facade.registry().mark_runtime_degraded(
-                                        SectionId::Mcp,
-                                        "MCP runtime initialization failed; retaining last-known-good runtime",
-                                    );
+                                &pending_root_publications,
+                                SectionId::Mcp,
+                                observed,
+                            ) {
+                                if matches!(event, ConfigSectionEvent::Invalid { .. }) {
                                     publish_section_failure(
                                         &apply_mcp_health,
                                         &account_sink,
                                         "mcp",
-                                        SectionStatus::Degraded,
-                                        "MCP runtime initialization failed; retaining last-known-good runtime"
+                                        facade.registry().mcp.snapshot().status,
+                                        "MCP section is invalid; retaining last-known-good runtime"
                                             .to_string(),
-                                    )
+                                    );
+                                } else {
+                                    self_write_marker.mark_self_write(mcp_store.path());
+                                    let materialized =
+                                        materialize_facade_effective_config(facade, &data_dir);
+                                    if materialized.failures.contains(&SectionId::Mcp) {
+                                        retry_legacy_root_publication |=
+                                        publish_staged_facade_section_failure(
+                                            &data_dir,
+                                            facade,
+                                            SectionId::Mcp,
+                                            "MCP credential hydration failed; retaining last-known-good runtime",
+                                            StagedFacadeSectionFailureContext {
+                                                health: &apply_mcp_health,
+                                                account_sink: &account_sink,
+                                                section: "mcp",
+                                                pending_root_publications: &pending_root_publications,
+                                            },
+                                        )
+                                        .await;
+                                    } else {
+                                        let next_mcp = materialized.config.mcp.clone();
+                                        let publish_config = config.clone();
+                                        match mcp_manager
+                                            .reconcile_from_config_transactional_after(
+                                                &materialized.config.mcp,
+                                                || async move {
+                                                    publish_config.write().await.mcp = next_mcp;
+                                                    Ok(())
+                                                },
+                                            )
+                                            .await
+                                        {
+                                            Ok(()) => {
+                                                let recovered =
+                                                    section_is_unhealthy(&apply_mcp_health);
+                                                let snapshot = facade.registry().mcp.snapshot();
+                                                let revision = snapshot.revision;
+                                                if changes.initial_mcp
+                                                    && !startup_root_mcp
+                                                    && !pending_root_publications
+                                                        .contains_key(&SectionId::Mcp)
+                                                    && snapshot.status == SectionStatus::Healthy
+                                                {
+                                                    // Startup reconciliation makes the
+                                                    // already-materialized section live in
+                                                    // the MCP manager; it is not a config
+                                                    // mutation and must not consume an
+                                                    // account-feed sequence number.
+                                                    set_live_health_revision(
+                                                        &apply_mcp_health,
+                                                        revision,
+                                                        Some((
+                                                            data_dir.join("mcp.json"),
+                                                            SectionSourceKind::File,
+                                                        )),
+                                                    );
+                                                } else {
+                                                    if pending_root_publications
+                                                        .get(&SectionId::Mcp)
+                                                        .is_some_and(|event| {
+                                                            config_section_event_revision(event)
+                                                                == revision
+                                                        })
+                                                    {
+                                                        set_live_health_revision(
+                                                            &apply_mcp_health,
+                                                            revision,
+                                                            Some((
+                                                                data_dir.join("mcp.json"),
+                                                                SectionSourceKind::File,
+                                                            )),
+                                                        );
+                                                        retry_legacy_root_publication |=
+                                                            publish_registry_event_with_root_ack(
+                                                                &data_dir,
+                                                                &account_sink,
+                                                                &mut pending_root_publications,
+                                                                SectionId::Mcp,
+                                                                &event,
+                                                            )
+                                                            .await;
+                                                    } else if matches!(
+                                                        event,
+                                                        ConfigSectionEvent::Recovered { .. }
+                                                    ) {
+                                                        set_live_health_revision(
+                                                            &apply_mcp_health,
+                                                            revision,
+                                                            Some((
+                                                                data_dir.join("mcp.json"),
+                                                                SectionSourceKind::File,
+                                                            )),
+                                                        );
+                                                        publish_registry_event(
+                                                            &account_sink,
+                                                            &event,
+                                                        );
+                                                    } else {
+                                                        publish_section_success(
+                                                            &apply_mcp_health,
+                                                            &account_sink,
+                                                            "mcp",
+                                                            data_dir.join("mcp.json"),
+                                                            recovered,
+                                                            Some(revision),
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                            Err(_) => {
+                                                retry_legacy_root_publication |=
+                                                publish_staged_facade_section_failure(
+                                                    &data_dir,
+                                                    facade,
+                                                    SectionId::Mcp,
+                                                    "MCP runtime initialization failed; retaining last-known-good runtime",
+                                                    StagedFacadeSectionFailureContext {
+                                                        health: &apply_mcp_health,
+                                                        account_sink: &account_sink,
+                                                        section: "mcp",
+                                                        pending_root_publications: &pending_root_publications,
+                                                    },
+                                                )
+                                                .await;
+                                            }
+                                        }
+                                    }
                                 }
+                            } else {
+                                retry_legacy_root_publication = true;
                             }
                         }
                     } else {
@@ -788,6 +1186,40 @@ impl ConfigWatcherRuntime {
                         }
                     }
                 }
+                if !catchup_paths.is_empty() {
+                    let _ = catchup_changes.send(ConfigPathChanges {
+                        paths: catchup_paths,
+                        initial_mcp: false,
+                        startup_legacy_root: None,
+                        startup_recoveries: BTreeMap::new(),
+                        legacy_root_retry_attempt: 0,
+                    });
+                }
+                if requeue_legacy_root && pending_root_publications.is_empty() {
+                    let _ = catchup_changes.send(ConfigPathChanges {
+                        paths: vec![data_dir.join("config.json")],
+                        initial_mcp: false,
+                        startup_legacy_root: None,
+                        startup_recoveries: BTreeMap::new(),
+                        legacy_root_retry_attempt: 0,
+                    });
+                }
+                if retry_legacy_root_publication {
+                    let retry_changes = catchup_changes.clone();
+                    let retry_path = data_dir.join("config.json");
+                    let retry_attempt = changes.legacy_root_retry_attempt.saturating_add(1);
+                    let delay = Duration::from_millis(50_u64 << retry_attempt.min(5));
+                    tokio::spawn(async move {
+                        tokio::time::sleep(delay).await;
+                        let _ = retry_changes.send(ConfigPathChanges {
+                            paths: vec![retry_path],
+                            initial_mcp: false,
+                            startup_legacy_root: None,
+                            startup_recoveries: BTreeMap::new(),
+                            legacy_root_retry_attempt: retry_attempt,
+                        });
+                    });
+                }
             }
         });
 
@@ -801,6 +1233,95 @@ impl ConfigWatcherRuntime {
             mcp_health,
         )
     }
+}
+
+fn durable_invalid_recoveries(
+    account_sink: &bamboo_engine::events::AccountEventSink,
+    facade: &bamboo_config::ConfigFacade,
+    rejected: &BTreeSet<SectionId>,
+) -> BTreeMap<SectionId, u64> {
+    let Ok(durable_facade) = bamboo_config::ConfigFacade::open(facade.data_dir()) else {
+        return BTreeMap::new();
+    };
+    let mut latest = BTreeMap::<SectionId, (bool, u64)>::new();
+    if let Ok(events) = bamboo_engine::events::journal::read_since(account_sink.events_dir(), 0) {
+        for change in events {
+            let state = match change.event {
+                AgentEvent::ConfigInvalid { section, revision } => Some((section, true, revision)),
+                AgentEvent::ConfigChanged { section, revision }
+                | AgentEvent::ConfigRecovered { section, revision } => {
+                    Some((section, false, revision))
+                }
+                _ => None,
+            };
+            if let Some((section, invalid, revision)) = state {
+                if let Some(id) = SectionId::from_name(&section) {
+                    latest.insert(id, (invalid, revision));
+                }
+            }
+        }
+    }
+    latest
+        .into_iter()
+        .filter_map(|(id, (invalid, invalid_revision))| {
+            if !invalid || rejected.contains(&id) {
+                return None;
+            }
+            let envelope = durable_facade.registry().envelope_value(id).ok()?;
+            (envelope.revision >= invalid_revision
+                && envelope.status == SectionStatus::Healthy
+                && envelope.source_kind == SectionSourceKind::File)
+                .then_some((id, envelope.revision))
+        })
+        .collect()
+}
+
+fn queue_legacy_root_recovery(
+    facade: &bamboo_config::ConfigFacade,
+    id: SectionId,
+    minimum_revision: Option<u64>,
+    watched_sections: &mut BTreeSet<SectionId>,
+    synthetic_events: &mut BTreeMap<SectionId, ConfigSectionEvent>,
+) {
+    watched_sections.insert(id);
+    // A same-facade watcher restart may retain process-local Degraded health;
+    // reload the healthy typed authority before its runtime is installed.
+    let _ = facade.registry().reload(id);
+    let Ok(envelope) = facade.registry().envelope_value(id) else {
+        return;
+    };
+    if envelope.status != SectionStatus::Healthy
+        || envelope.source_kind != SectionSourceKind::File
+        || minimum_revision.is_some_and(|minimum| envelope.revision < minimum)
+    {
+        return;
+    }
+    synthetic_events
+        .entry(id)
+        .or_insert_with(|| ConfigSectionEvent::Recovered {
+            section: id.descriptor().name.to_string(),
+            revision: envelope.revision,
+        });
+}
+
+fn pending_root_publication_matches_fresh_durable(
+    data_dir: &Path,
+    process_facade: &bamboo_config::ConfigFacade,
+    id: SectionId,
+    revision: u64,
+) -> bool {
+    let Ok(process) = process_facade.registry().envelope_value(id) else {
+        return false;
+    };
+    if process.revision != revision {
+        return false;
+    }
+    let event = ConfigSectionEvent::Changed {
+        section: id.descriptor().name.to_string(),
+        revision,
+    };
+    bamboo_config::legacy_root_publication_matches_snapshot(data_dir, &event, &process.data)
+        .unwrap_or(false)
 }
 
 async fn wait_for_section_file_settle(data_dir: &Path, id: SectionId) {
@@ -818,17 +1339,44 @@ async fn wait_for_section_file_settle(data_dir: &Path, id: SectionId) {
 ///
 /// The caller owns `config_io_lock`; keeping this sequence shared by the live
 /// watcher and focused regressions makes the event/runtime ordering explicit.
+struct OrdinarySectionReloadState<'a> {
+    synthetic_events: &'a mut BTreeMap<SectionId, ConfigSectionEvent>,
+    pending_root_publications: &'a mut BTreeMap<SectionId, ConfigSectionEvent>,
+    reported_root_runtime_failures: &'a mut BTreeSet<(SectionId, u64)>,
+}
+
 async fn reload_and_apply_ordinary_sections(
     data_dir: &Path,
     config: &Arc<RwLock<Config>>,
     facade: &bamboo_config::ConfigFacade,
     account_sink: &bamboo_engine::events::AccountEventSink,
     sections: impl IntoIterator<Item = SectionId>,
-) {
+    state: OrdinarySectionReloadState<'_>,
+) -> bool {
+    let OrdinarySectionReloadState {
+        synthetic_events,
+        pending_root_publications,
+        reported_root_runtime_failures,
+    } = state;
+    let mut retry_legacy_root_publication = false;
     let mut publishable = Vec::new();
     for id in sections {
         wait_for_section_file_settle(data_dir, id).await;
-        let Some(event) = facade.registry().reload_if_changed(id) else {
+        let Some(event) = synthetic_events
+            .remove(&id)
+            .or_else(|| facade.registry().reload_if_changed(id))
+        else {
+            continue;
+        };
+        let Some(event) = pending_root_publication_event(
+            data_dir,
+            facade,
+            account_sink,
+            pending_root_publications,
+            id,
+            event,
+        ) else {
+            retry_legacy_root_publication = true;
             continue;
         };
         if matches!(event, ConfigSectionEvent::Invalid { .. }) {
@@ -838,7 +1386,7 @@ async fn reload_and_apply_ordinary_sections(
         }
     }
     if publishable.is_empty() {
-        return;
+        return retry_legacy_root_publication;
     }
 
     let materialized = materialize_facade_effective_config(facade, data_dir);
@@ -846,19 +1394,34 @@ async fn reload_and_apply_ordinary_sections(
     let mut applied = Vec::new();
     for (id, event) in publishable {
         if materialized.failures.contains(&id) {
-            if let Some(invalid) = facade.registry().mark_runtime_degraded(
+            let revision = facade
+                .registry()
+                .envelope_value(id)
+                .map(|envelope| envelope.revision)
+                .unwrap_or_default();
+            let invalid = facade.registry().mark_runtime_degraded(
                 id,
                 "configuration runtime hydration failed; retaining last-known-good runtime",
-            ) {
-                publish_registry_event(account_sink, &invalid);
+            );
+            if let Some(invalid) = invalid {
+                if pending_root_publications
+                    .get(&id)
+                    .is_some_and(|event| config_section_event_revision(event) == revision)
+                {
+                    let _ =
+                        confirm_legacy_root_runtime_failure(data_dir, account_sink, &invalid).await;
+                } else if reported_root_runtime_failures.insert((id, revision)) {
+                    publish_registry_event(account_sink, &invalid);
+                }
             }
+            retry_legacy_root_publication |= pending_root_publications.contains_key(&id);
             continue;
         }
         apply_runtime_section(id, &materialized.config, &mut current);
         applied.push((id, event));
     }
     if applied.is_empty() {
-        return;
+        return retry_legacy_root_publication;
     }
 
     let publishes_env = applied.iter().any(|(id, _)| *id == SectionId::Env);
@@ -871,8 +1434,93 @@ async fn reload_and_apply_ordinary_sections(
     if enforcement_newly_off {
         warn_plugin_trust_enforcement_off();
     }
-    for (_, event) in applied {
-        publish_registry_event(account_sink, &event);
+    for (id, event) in applied {
+        retry_legacy_root_publication |= publish_registry_event_with_root_ack(
+            data_dir,
+            account_sink,
+            pending_root_publications,
+            id,
+            &event,
+        )
+        .await;
+        reported_root_runtime_failures.retain(|(failed_id, _)| *failed_id != id);
+    }
+    retry_legacy_root_publication
+}
+
+fn pending_root_publication_event(
+    data_dir: &Path,
+    facade: &bamboo_config::ConfigFacade,
+    account_sink: &bamboo_engine::events::AccountEventSink,
+    pending: &BTreeMap<SectionId, ConfigSectionEvent>,
+    id: SectionId,
+    observed: ConfigSectionEvent,
+) -> Option<ConfigSectionEvent> {
+    let Some(pending_event) = pending.get(&id) else {
+        return Some(observed);
+    };
+    let revision = config_section_event_revision(pending_event);
+    let Ok(envelope) = facade.registry().envelope_value(id) else {
+        return None;
+    };
+    if envelope.revision != revision || envelope.status != SectionStatus::Healthy {
+        return None;
+    }
+    let pending = ConfigSectionEvent::Changed {
+        section: id.descriptor().name.to_string(),
+        revision,
+    };
+    if account_sink.latest_config_transition_is_invalid(id.descriptor().name, revision) {
+        let invalid = ConfigSectionEvent::Invalid {
+            section: id.descriptor().name.to_string(),
+            revision,
+        };
+        match bamboo_config::mark_legacy_root_publication_runtime_degraded(data_dir, &invalid) {
+            Ok(true) => {}
+            Ok(false) => return None,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    section = id.descriptor().name,
+                    revision,
+                    "failed to repair canonical root runtime-degraded proof from the durable journal"
+                );
+                return None;
+            }
+        }
+    }
+    bamboo_config::legacy_root_publication_success_event(data_dir, &pending, &envelope.data)
+        .ok()
+        .flatten()
+}
+
+async fn publish_registry_event_with_root_ack(
+    data_dir: &Path,
+    account_sink: &bamboo_engine::events::AccountEventSink,
+    pending: &mut BTreeMap<SectionId, ConfigSectionEvent>,
+    id: SectionId,
+    event: &ConfigSectionEvent,
+) -> bool {
+    if matches!(event, ConfigSectionEvent::Invalid { .. }) {
+        publish_registry_event(account_sink, event);
+        return false;
+    }
+    if pending.get(&id).is_none_or(|pending_event| {
+        config_section_event_revision(pending_event) != config_section_event_revision(event)
+    }) {
+        publish_registry_event(account_sink, event);
+        return false;
+    }
+    let durable = account_sink
+        .record_confirmed(None, &registry_agent_event(event))
+        .await;
+    if durable
+        && bamboo_config::acknowledge_legacy_root_publication(data_dir, event).unwrap_or(false)
+    {
+        pending.remove(&id);
+        false
+    } else {
+        true
     }
 }
 
@@ -880,7 +1528,75 @@ pub(super) fn publish_registry_event(
     account_sink: &bamboo_engine::events::AccountEventSink,
     event: &ConfigSectionEvent,
 ) {
-    let event = match event {
+    let event = registry_agent_event(event);
+    account_sink.record(None, &event);
+}
+
+async fn confirm_legacy_root_runtime_failure(
+    data_dir: &Path,
+    account_sink: &bamboo_engine::events::AccountEventSink,
+    event: &ConfigSectionEvent,
+) -> bool {
+    if !account_sink
+        .record_confirmed(None, &registry_agent_event(event))
+        .await
+    {
+        return false;
+    }
+    match bamboo_config::mark_legacy_root_publication_runtime_degraded(data_dir, event) {
+        Ok(marked) => marked,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "failed to mark canonical root publication runtime-degraded"
+            );
+            false
+        }
+    }
+}
+
+fn legacy_root_rejection_event(
+    facade: &bamboo_config::ConfigFacade,
+    id: SectionId,
+    diagnostic: &str,
+    force_publication: bool,
+) -> Option<ConfigSectionEvent> {
+    let already_reported = facade.registry().envelope_value(id).is_ok_and(|envelope| {
+        envelope.status == SectionStatus::Degraded
+            && envelope.last_error.as_deref() == Some(diagnostic)
+    });
+    if already_reported && !force_publication {
+        return None;
+    }
+    facade
+        .registry()
+        .mark_runtime_degraded(id, diagnostic)
+        .or_else(|| {
+            // Defensive fallback for section implementations that cannot
+            // expose process-local degraded health.
+            force_publication
+                .then(|| {
+                    facade.registry().envelope_value(id).ok().map(|envelope| {
+                        ConfigSectionEvent::Invalid {
+                            section: id.descriptor().name.to_string(),
+                            revision: envelope.revision,
+                        }
+                    })
+                })
+                .flatten()
+        })
+}
+
+fn config_section_event_revision(event: &ConfigSectionEvent) -> u64 {
+    match event {
+        ConfigSectionEvent::Changed { revision, .. }
+        | ConfigSectionEvent::Invalid { revision, .. }
+        | ConfigSectionEvent::Recovered { revision, .. } => *revision,
+    }
+}
+
+fn registry_agent_event(event: &ConfigSectionEvent) -> AgentEvent {
+    match event {
         ConfigSectionEvent::Changed { section, revision } => AgentEvent::ConfigChanged {
             section: section.clone(),
             revision: *revision,
@@ -893,8 +1609,7 @@ pub(super) fn publish_registry_event(
             section: section.clone(),
             revision: *revision,
         },
-    };
-    account_sink.record(None, &event);
+    }
 }
 
 fn publish_exact_facade_events(
@@ -1133,7 +1848,16 @@ fn publish_section_failure(
     status: SectionStatus,
     message: String,
 ) {
+    let duplicate = {
+        let health = health
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        health.status == status && health.last_error.as_deref() == Some(message.as_str())
+    };
     let revision = update_live_health(health, status, Some(message), false, None);
+    if duplicate {
+        return;
+    }
     account_sink.record(
         None,
         &AgentEvent::ConfigInvalid {
@@ -1141,6 +1865,66 @@ fn publish_section_failure(
             revision,
         },
     );
+}
+
+struct StagedFacadeSectionFailureContext<'a> {
+    health: &'a std::sync::RwLock<ConfigLiveHealth>,
+    account_sink: &'a bamboo_engine::events::AccountEventSink,
+    section: &'a str,
+    pending_root_publications: &'a BTreeMap<SectionId, ConfigSectionEvent>,
+}
+
+async fn publish_staged_facade_section_failure(
+    data_dir: &Path,
+    facade: &bamboo_config::ConfigFacade,
+    id: SectionId,
+    message: &str,
+    context: StagedFacadeSectionFailureContext<'_>,
+) -> bool {
+    let StagedFacadeSectionFailureContext {
+        health,
+        account_sink,
+        section,
+        pending_root_publications,
+    } = context;
+    let event = facade
+        .registry()
+        .mark_runtime_degraded(id, message)
+        .expect("every facade section exposes runtime health");
+    let exact_pending = matches!(
+        &event,
+        ConfigSectionEvent::Invalid { revision, .. }
+            if pending_root_publications
+                .get(&id)
+                .is_some_and(|event| config_section_event_revision(event) == *revision)
+    );
+    if exact_pending {
+        // Keep ConfigLiveHealth's revision as the last installed runtime, but
+        // publish the exact typed candidate revision that failed its runtime
+        // hook. AccountSink's transition state dedupes delayed retries.
+        update_live_health(
+            health,
+            SectionStatus::Degraded,
+            Some(message.to_string()),
+            false,
+            None,
+        );
+        if !confirm_legacy_root_runtime_failure(data_dir, account_sink, &event).await {
+            tracing::warn!(
+                section,
+                "root runtime failure was not confirmed against its canonical publication"
+            );
+        }
+    } else {
+        publish_section_failure(
+            health,
+            account_sink,
+            section,
+            SectionStatus::Degraded,
+            message.to_string(),
+        );
+    }
+    exact_pending
 }
 
 fn publish_mcp_backup_lkg(
@@ -1721,12 +2505,20 @@ impl AppState {
             .config_facade
             .as_ref()
             .expect("test ordinary reload requires the modular facade");
+        let mut synthetic_events = BTreeMap::new();
+        let mut pending_root_publications = BTreeMap::new();
+        let mut reported_root_runtime_failures = BTreeSet::new();
         reload_and_apply_ordinary_sections(
             &self.app_data_dir,
             &self.config,
             facade,
             &self.account_sink,
             std::iter::once(id),
+            OrdinarySectionReloadState {
+                synthetic_events: &mut synthetic_events,
+                pending_root_publications: &mut pending_root_publications,
+                reported_root_runtime_failures: &mut reported_root_runtime_failures,
+            },
         )
         .await;
     }
@@ -5655,6 +6447,22 @@ mod live_reload_tests {
         }
     }
 
+    fn restart_config_watcher(state: &mut AppState) {
+        let (runtime, provider_health, mcp_health) = ConfigWatcherRuntime::start(
+            state.app_data_dir.clone(),
+            state.config.clone(),
+            state.config_facade.clone(),
+            state.config_io_lock.clone(),
+            state.provider_registry.clone(),
+            state.provider.clone(),
+            state.mcp_manager.clone(),
+            state.account_sink.clone(),
+        );
+        state.config_watcher = runtime;
+        state.config_live_health = provider_health;
+        state.mcp_config_live_health = mcp_health;
+    }
+
     async fn insert_registry_worker(state: &AppState, key: String, worker_id: &str) {
         #[cfg(unix)]
         let child = tokio::process::Command::new("/bin/sleep")
@@ -6057,6 +6865,19 @@ for line in sys.stdin:
         feed: &mut tokio::sync::broadcast::Receiver<Arc<bamboo_engine::events::ChangeEvent>>,
     ) -> AgentEvent {
         next_config_event(feed, "mcp").await
+    }
+
+    async fn wait_for_root_outbox_to_clear(data_dir: &Path) {
+        tokio::time::timeout(Duration::from_secs(6), async {
+            loop {
+                if !bamboo_config::has_pending_legacy_root_publications(data_dir).unwrap() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("legacy root outbox did not clear");
     }
 
     #[tokio::test]
@@ -10429,5 +11250,813 @@ for line in sys.stdin:
             next_mcp_config_event(&mut feed).await,
             AgentEvent::ConfigInvalid { revision: 1, .. }
         ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stopped_root_commit_is_installed_before_one_confirmed_event_on_same_facade_restart() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x52; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":25201}}"#,
+        )
+        .unwrap();
+        let committed = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .reconcile_reappeared_legacy_root()
+            .unwrap()
+            .unwrap();
+        assert_eq!(committed.committed.len(), 1);
+        assert_ne!(state.config.read().await.server.port, 25_201);
+
+        let mut feed = state.account_sink.subscribe();
+        let config = state.config.clone();
+        let read_guard = config.read().await;
+        restart_config_watcher(&mut state);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(350),
+                next_config_event(&mut feed, "core")
+            )
+            .await
+            .is_err(),
+            "the account event must wait for the runtime write"
+        );
+        drop(read_guard);
+
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigChanged { revision: 1, .. }
+        ));
+        assert_eq!(state.config.read().await.server.port, 25_201);
+        wait_for_root_outbox_to_clear(dir.path()).await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let events =
+            bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, revision }
+                        if section == "core" && *revision == 1
+                ))
+                .count(),
+            1
+        );
+
+        stop_config_watcher(&mut state);
+        restart_config_watcher(&mut state);
+        assert!(tokio::time::timeout(
+            Duration::from_millis(500),
+            next_config_event(&mut feed, "core")
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn pending_root_resolver_unavailable_keeps_lkg_silent_and_requests_retry() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x59; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        let old_port = state.config.read().await.server.port;
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":25901}}"#,
+        )
+        .unwrap();
+        let committed = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .reconcile_reappeared_legacy_root()
+            .unwrap()
+            .unwrap();
+        let event = committed.committed[0].clone();
+        let mut synthetic_events = BTreeMap::from([(SectionId::Core, event.clone())]);
+        let mut pending_root_publications = BTreeMap::from([(SectionId::Core, event)]);
+        let mut reported_root_runtime_failures = BTreeSet::new();
+        let mut feed = state.account_sink.subscribe();
+        std::fs::remove_file(dir.path().join("config-section-layout-completion.json")).unwrap();
+
+        let retry = reload_and_apply_ordinary_sections(
+            dir.path(),
+            &state.config,
+            state.config_facade.as_ref().unwrap(),
+            &state.account_sink,
+            std::iter::once(SectionId::Core),
+            OrdinarySectionReloadState {
+                synthetic_events: &mut synthetic_events,
+                pending_root_publications: &mut pending_root_publications,
+                reported_root_runtime_failures: &mut reported_root_runtime_failures,
+            },
+        )
+        .await;
+
+        assert!(retry);
+        assert_eq!(state.config.read().await.server.port, old_port);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), feed.recv())
+                .await
+                .is_err()
+        );
+        assert!(pending_root_publications.contains_key(&SectionId::Core));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn pending_root_then_new_root_survives_coalesced_mcp_noop_and_requeues() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x53; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        wait_for_mcp_health(&state, SectionStatus::Healthy, 0).await;
+        let mut feed = state.account_sink.subscribe();
+        let io = state.config_io_lock.clone().lock_owned().await;
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":25301}}"#,
+        )
+        .unwrap();
+        let first = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .reconcile_reappeared_legacy_root()
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.committed.len(), 1);
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":25302}}"#,
+        )
+        .unwrap();
+        let mcp_bytes = std::fs::read(dir.path().join("mcp.json")).unwrap();
+        std::fs::write(dir.path().join("mcp.json"), mcp_bytes).unwrap();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        drop(io);
+
+        let first_event = next_config_event(&mut feed, "core").await;
+        let second_event = next_config_event(&mut feed, "core").await;
+        assert!(matches!(
+            first_event,
+            AgentEvent::ConfigChanged { revision: 1, .. }
+        ));
+        assert!(matches!(
+            second_event,
+            AgentEvent::ConfigChanged { revision: 2, .. }
+        ));
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if state.config.read().await.server.port == 25_302 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap();
+        wait_for_root_outbox_to_clear(dir.path()).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn startup_handoff_always_catches_root_generation_written_before_watcher_registration() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x56; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":25601}}"#,
+        )
+        .unwrap();
+        let startup_facade =
+            Arc::new(bamboo_config::ConfigFacade::open_or_migrate(dir.path()).unwrap());
+        assert!(bamboo_config::has_pending_legacy_root_publications(dir.path()).unwrap());
+        state.config_facade = Some(startup_facade);
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":25602}}"#,
+        )
+        .unwrap();
+        let mut feed = state.account_sink.subscribe();
+
+        restart_config_watcher(&mut state);
+
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigChanged { revision: 1, .. }
+        ));
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigChanged { revision: 2, .. }
+        ));
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if state.config.read().await.server.port == 25_602 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap();
+        wait_for_root_outbox_to_clear(dir.path()).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn same_facade_restart_replays_one_rejection_and_one_lost_recovery() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x54; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"vendor_api_key":"never-persist-this"}}"#,
+        )
+        .unwrap();
+        let rejected = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .reconcile_reappeared_legacy_root()
+            .unwrap()
+            .unwrap();
+        assert_eq!(rejected.rejected.len(), 1);
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .core
+                .snapshot()
+                .status,
+            SectionStatus::Healthy
+        );
+        let mut feed = state.account_sink.subscribe();
+        restart_config_watcher(&mut state);
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigInvalid { revision: 0, .. }
+        ));
+        stop_config_watcher(&mut state);
+
+        std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        let recovered = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .reconcile_reappeared_legacy_root()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recovered.recovered, vec![SectionId::Core]);
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .core
+                .snapshot()
+                .status,
+            SectionStatus::Degraded
+        );
+        restart_config_watcher(&mut state);
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigRecovered { revision: 0, .. }
+        ));
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .core
+                .snapshot()
+                .status,
+            SectionStatus::Healthy
+        );
+
+        stop_config_watcher(&mut state);
+        restart_config_watcher(&mut state);
+        assert!(tokio::time::timeout(
+            Duration::from_millis(500),
+            next_config_event(&mut feed, "core")
+        )
+        .await
+        .is_err());
+        let events =
+            bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigInvalid { section, .. } if section == "core"
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigRecovered { section, .. } if section == "core"
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn degraded_root_mcp_is_carried_while_new_root_core_commits_then_recovers() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x57; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        wait_for_mcp_health(&state, SectionStatus::Healthy, 0).await;
+        let failing = working_stdio_mcp_config(dir.path(), "root-carry", None);
+        let script = match &failing.servers[0].transport {
+            TransportConfig::Stdio(stdio) => PathBuf::from(&stdio.args[0]),
+            _ => unreachable!(),
+        };
+        std::fs::remove_file(&script).unwrap();
+        let mut feed = state.account_sink.subscribe();
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({"mcp": failing})).unwrap(),
+        )
+        .unwrap();
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigInvalid { revision: 1, .. }
+        ));
+
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":25701}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigChanged { revision: 1, .. }
+        ));
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if state.config.read().await.server.port == 25_701 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(bamboo_config::has_pending_legacy_root_publications(dir.path()).unwrap());
+
+        let repaired = working_stdio_mcp_config(dir.path(), "root-carry", None);
+        assert_eq!(repaired.servers[0].id, "root-carry");
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigRecovered { revision: 1, .. }
+        ));
+        wait_for_root_outbox_to_clear(dir.path()).await;
+        let events =
+            bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigInvalid { section, revision }
+                        if section == "mcp" && *revision == 1
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigRecovered { section, revision }
+                        if section == "mcp" && *revision == 1
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn rejected_new_mcp_keeps_old_degraded_publication_dormant_until_clean_root() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x5b; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        wait_for_mcp_health(&state, SectionStatus::Healthy, 0).await;
+        let failing = working_stdio_mcp_config(dir.path(), "root-dormant", None);
+        let script = match &failing.servers[0].transport {
+            TransportConfig::Stdio(stdio) => PathBuf::from(&stdio.args[0]),
+            _ => unreachable!(),
+        };
+        std::fs::remove_file(&script).unwrap();
+        let mut feed = state.account_sink.subscribe();
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({"mcp": failing})).unwrap(),
+        )
+        .unwrap();
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigInvalid { revision: 1, .. }
+        ));
+
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "server": {"port": 25801},
+                "mcpServers": {
+                    "rejected-next": {
+                        "command": "unused-rejected-command",
+                        "disabled": true,
+                        "access_token_value": "must-not-cross"
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigChanged { revision: 1, .. }
+        ));
+        assert_eq!(state.config.read().await.server.port, 25_801);
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let dormant_events =
+            bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
+        assert!(!dormant_events.iter().any(|event| matches!(
+            &event.event,
+            AgentEvent::ConfigRecovered { section, revision }
+                if section == "mcp" && *revision == 1
+        )));
+        assert!(bamboo_config::has_pending_legacy_root_publications(dir.path()).unwrap());
+
+        std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if !bamboo_config::legacy_root_rejected_sections(dir.path())
+                    .unwrap()
+                    .contains(&SectionId::Mcp)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap();
+        let repaired = working_stdio_mcp_config(dir.path(), "root-dormant", None);
+        assert_eq!(repaired.servers[0].id, "root-dormant");
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigRecovered { revision: 1, .. }
+        ));
+        wait_for_root_outbox_to_clear(dir.path()).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn changed_before_ack_then_runtime_failure_recovers_with_exact_kind() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x58; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        wait_for_mcp_health(&state, SectionStatus::Healthy, 0).await;
+        stop_config_watcher(&mut state);
+        let failing = working_stdio_mcp_config(dir.path(), "root-crash-window", None);
+        let script = match &failing.servers[0].transport {
+            TransportConfig::Stdio(stdio) => PathBuf::from(&stdio.args[0]),
+            _ => unreachable!(),
+        };
+        std::fs::remove_file(&script).unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({"mcp": failing})).unwrap(),
+        )
+        .unwrap();
+        let committed = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .reconcile_reappeared_legacy_root()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            committed.committed,
+            vec![ConfigSectionEvent::Changed {
+                section: "mcp".to_string(),
+                revision: 1,
+            }]
+        );
+        assert!(
+            state
+                .account_sink
+                .record_confirmed(None, &registry_agent_event(&committed.committed[0]))
+                .await
+        );
+        assert!(bamboo_config::has_pending_legacy_root_publications(dir.path()).unwrap());
+
+        let events_dir = state.account_sink.events_dir().to_path_buf();
+        state.account_sink = bamboo_engine::events::AccountEventSink::new(events_dir).unwrap();
+        tokio::task::yield_now().await;
+        let mut feed = state.account_sink.subscribe();
+        restart_config_watcher(&mut state);
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigInvalid { revision: 1, .. }
+        ));
+        let repaired = working_stdio_mcp_config(dir.path(), "root-crash-window", None);
+        assert_eq!(repaired.servers[0].id, "root-crash-window");
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigRecovered { revision: 1, .. }
+        ));
+        wait_for_root_outbox_to_clear(dir.path()).await;
+
+        let events =
+            bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
+        let transitions = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ConfigChanged { section, revision } if section == "mcp" => {
+                    Some(("changed", *revision))
+                }
+                AgentEvent::ConfigInvalid { section, revision } if section == "mcp" => {
+                    Some(("invalid", *revision))
+                }
+                AgentEvent::ConfigRecovered { section, revision } if section == "mcp" => {
+                    Some(("recovered", *revision))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            transitions,
+            vec![("changed", 1), ("invalid", 1), ("recovered", 1)]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn invalid_journaled_before_canonical_mark_restarts_as_recovered_only() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x5b; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        wait_for_mcp_health(&state, SectionStatus::Healthy, 0).await;
+        stop_config_watcher(&mut state);
+        let candidate = disabled_mcp_config("root-invalid-mark-crash");
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({"mcp": candidate})).unwrap(),
+        )
+        .unwrap();
+        let committed = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .reconcile_reappeared_legacy_root()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            committed.committed,
+            vec![ConfigSectionEvent::Changed {
+                section: "mcp".to_string(),
+                revision: 1,
+            }]
+        );
+        let invalid = ConfigSectionEvent::Invalid {
+            section: "mcp".to_string(),
+            revision: 1,
+        };
+        assert!(
+            state
+                .account_sink
+                .record_confirmed(None, &registry_agent_event(&invalid))
+                .await
+        );
+        let envelope = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .envelope_value(SectionId::Mcp)
+            .unwrap();
+        assert!(matches!(
+            bamboo_config::legacy_root_publication_success_event(
+                dir.path(),
+                &committed.committed[0],
+                &envelope.data,
+            )
+            .unwrap(),
+            Some(ConfigSectionEvent::Changed { revision: 1, .. })
+        ));
+
+        let events_dir = state.account_sink.events_dir().to_path_buf();
+        state.account_sink = bamboo_engine::events::AccountEventSink::new(events_dir).unwrap();
+        assert!(state
+            .account_sink
+            .latest_config_transition_is_invalid("mcp", 1));
+        let mut feed = state.account_sink.subscribe();
+        restart_config_watcher(&mut state);
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigRecovered { revision: 1, .. }
+        ));
+        wait_for_root_outbox_to_clear(dir.path()).await;
+
+        let events =
+            bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
+        let transitions = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ConfigChanged { section, revision } if section == "mcp" => {
+                    Some(("changed", *revision))
+                }
+                AgentEvent::ConfigInvalid { section, revision } if section == "mcp" => {
+                    Some(("invalid", *revision))
+                }
+                AgentEvent::ConfigRecovered { section, revision } if section == "mcp" => {
+                    Some(("recovered", *revision))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(transitions, vec![("invalid", 1), ("recovered", 1)]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn startup_lagging_mcp_facade_installs_and_acknowledges_root_publication() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x5a; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        wait_for_mcp_health(&state, SectionStatus::Healthy, 0).await;
+        stop_config_watcher(&mut state);
+        let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let candidate = disabled_mcp_config("startup-lag-root");
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({"mcp": candidate})).unwrap(),
+        )
+        .unwrap();
+        let committed = external
+            .reconcile_reappeared_legacy_root()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            committed.committed,
+            vec![ConfigSectionEvent::Changed {
+                section: "mcp".to_string(),
+                revision: 1,
+            }]
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .mcp
+                .snapshot()
+                .revision,
+            0
+        );
+
+        let mut feed = state.account_sink.subscribe();
+        restart_config_watcher(&mut state);
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigChanged { revision: 1, .. }
+        ));
+        wait_for_root_outbox_to_clear(dir.path()).await;
+        assert!(state
+            .config
+            .read()
+            .await
+            .mcp
+            .servers
+            .iter()
+            .any(|server| server.id == "startup-lag-root"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn persistent_root_mcp_runtime_failure_retries_without_invalid_event_storm() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x55; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        wait_for_mcp_health(&state, SectionStatus::Healthy, 0).await;
+        let failing = working_stdio_mcp_config(dir.path(), "root-retry", None);
+        let script = match &failing.servers[0].transport {
+            TransportConfig::Stdio(stdio) => PathBuf::from(&stdio.args[0]),
+            _ => unreachable!(),
+        };
+        std::fs::remove_file(&script).unwrap();
+        let mut feed = state.account_sink.subscribe();
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({"mcp": failing})).unwrap(),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            next_mcp_config_event(&mut feed).await,
+            AgentEvent::ConfigInvalid { revision: 1, .. }
+        ));
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        let failed_events =
+            bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
+        assert_eq!(
+            failed_events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigInvalid { section, .. } if section == "mcp"
+                ))
+                .count(),
+            1
+        );
+        assert!(bamboo_config::has_pending_legacy_root_publications(dir.path()).unwrap());
+
+        let mut repaired = working_stdio_mcp_config(dir.path(), "root-retry-fixed", None);
+        repaired.servers[0].id = "root-retry".to_string();
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({"mcp": repaired})).unwrap(),
+        )
+        .unwrap();
+        let repaired_root_event = next_mcp_config_event(&mut feed).await;
+        let repaired_health = state
+            .mcp_config_live_health
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        let repaired_snapshot = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .mcp
+            .snapshot();
+        assert!(
+            matches!(
+                repaired_root_event,
+                AgentEvent::ConfigChanged { revision: 2, .. }
+            ),
+            "unexpected repaired root event: {repaired_root_event:?}; health: {repaired_health:?}; typed: {:?}",
+            repaired_snapshot.data
+        );
+        wait_for_root_outbox_to_clear(dir.path()).await;
+        assert!(state.config.read().await.mcp.servers.iter().any(|server| {
+            server.id == "root-retry"
+                && matches!(
+                    &server.transport,
+                    TransportConfig::Stdio(stdio)
+                        if stdio.args.iter().any(|arg| arg.contains("root-retry-fixed"))
+                )
+        }));
+        let events =
+            bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigInvalid { section, .. } if section == "mcp"
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, revision }
+                        if section == "mcp" && *revision == 2
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, revision }
+                        if section == "mcp" && *revision == 1
+                ))
+                .count(),
+            0
+        );
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
@@ -48,7 +48,9 @@ pub(super) async fn write_model_limits_file(
     value: Option<&Value>,
 ) -> Result<(), AppError> {
     let path = model_limits_file_path(app_data_dir);
-    if bamboo_config::section_layout_is_active(app_data_dir).map_err(map_config_store_error)? {
+    if bamboo_config::modular_authority_boundary_present(app_data_dir)
+        .map_err(map_config_store_error)?
+    {
         let rows = match value {
             Some(value) => {
                 let limits: Vec<ModelLimit> = serde_json::from_value(value.clone())?;
@@ -61,7 +63,7 @@ pub(super) async fn write_model_limits_file(
         };
         let data_dir = app_data_dir.to_path_buf();
         tokio::task::spawn_blocking(move || {
-            let facade = bamboo_config::ConfigFacade::open(&data_dir)?;
+            let facade = bamboo_config::ConfigFacade::open_or_migrate(&data_dir)?;
             let snapshot = facade.registry().model_limits.snapshot();
             if snapshot.data.0 != rows {
                 facade

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/get.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/get.rs
@@ -7,7 +7,7 @@ use super::common::{config_file_path, redacted_config_json};
 pub async fn get_bamboo_config(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
     let path = config_file_path(&app_state.app_data_dir);
     if !path.exists()
-        && !bamboo_config::section_layout_is_active(&app_state.app_data_dir)
+        && !bamboo_config::modular_authority_boundary_present(&app_state.app_data_dir)
             .map_err(|error| AppError::InternalError(anyhow::anyhow!(error.to_string())))?
     {
         return Ok(HttpResponse::Ok().json(serde_json::json!({})));

--- a/crates/engine/bamboo-engine/src/events/account_sink.rs
+++ b/crates/engine/bamboo-engine/src/events/account_sink.rs
@@ -11,13 +11,15 @@
 //! order == seq order" holds trivially without scattering the invariant across
 //! concurrent callers.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use bamboo_agent_core::AgentEvent;
 use chrono::Utc;
+use tokio::sync::oneshot;
 use tokio::sync::{broadcast, mpsc};
 
 use super::change_feed::ChangeEvent;
@@ -42,6 +44,17 @@ const RETAINED_FILES: usize = 64;
 /// event)`. The session id is the caller's known routing context.
 pub type PendingEvent = (Option<String>, AgentEvent);
 
+type ConfirmationWaiter = (u64, oneshot::Sender<bool>);
+type ConfirmationWaiters = Arc<Mutex<HashMap<String, Vec<ConfirmationWaiter>>>>;
+type LatestConfigStates = Arc<Mutex<HashMap<String, ConfigEventKind>>>;
+
+struct WriterDedupState {
+    delivered_lifecycle_ids: HashSet<String>,
+    latest_config_states: LatestConfigStates,
+    delivered_changed_ids: HashSet<String>,
+    confirmation_waiters: ConfirmationWaiters,
+}
+
 /// Account-wide durable change-feed sink. Construct once per [`AppState`].
 pub struct AccountEventSink {
     /// Last-assigned seq. The writer task owns assignment; this is exposed only
@@ -55,6 +68,9 @@ pub struct AccountEventSink {
     events_dir: PathBuf,
     /// Count of events dropped due to a full inbox (should remain 0).
     dropped: Arc<AtomicU64>,
+    confirmation_waiters: ConfirmationWaiters,
+    latest_config_states: LatestConfigStates,
+    next_waiter_id: AtomicU64,
 }
 
 impl AccountEventSink {
@@ -64,15 +80,27 @@ impl AccountEventSink {
         if let Err(e) = super::journal::prune(&events_dir, RETAINED_FILES) {
             tracing::warn!("change-feed journal prune failed: {e}");
         }
-        let delivered_lifecycle_ids = super::journal::read_since(&events_dir, 0)
-            .unwrap_or_default()
-            .into_iter()
+        let durable_events = super::journal::read_since(&events_dir, 0).unwrap_or_default();
+        let delivered_lifecycle_ids = durable_events
+            .iter()
             .filter_map(|change| lifecycle_event_id(&change.event).map(str::to_string))
+            .collect::<HashSet<_>>();
+        let mut durable_config_states = HashMap::new();
+        for change in &durable_events {
+            if let Some((key, kind)) = config_event_state(&change.event) {
+                durable_config_states.insert(key, kind);
+            }
+        }
+        let delivered_changed_ids = durable_events
+            .iter()
+            .filter_map(|change| config_event_id(&change.event))
             .collect::<HashSet<_>>();
         let (journal, max_seq) = EventJournal::open(events_dir.clone())?;
         let seq = Arc::new(AtomicU64::new(max_seq));
         let (tx, rx) = mpsc::channel(INBOX_CAPACITY);
         let (btx, _brx) = broadcast::channel(BROADCAST_CAPACITY);
+        let confirmation_waiters = Arc::new(Mutex::new(HashMap::new()));
+        let latest_config_states = Arc::new(Mutex::new(durable_config_states));
 
         let sink = Arc::new(Self {
             seq: seq.clone(),
@@ -80,9 +108,23 @@ impl AccountEventSink {
             broadcast: btx.clone(),
             events_dir,
             dropped: Arc::new(AtomicU64::new(0)),
+            confirmation_waiters: Arc::clone(&confirmation_waiters),
+            latest_config_states: Arc::clone(&latest_config_states),
+            next_waiter_id: AtomicU64::new(1),
         });
 
-        tokio::spawn(writer_loop(rx, journal, seq, btx, delivered_lifecycle_ids));
+        tokio::spawn(writer_loop(
+            rx,
+            journal,
+            seq,
+            btx,
+            WriterDedupState {
+                delivered_lifecycle_ids,
+                latest_config_states,
+                delivered_changed_ids,
+                confirmation_waiters,
+            },
+        ));
         Ok(sink)
     }
 
@@ -103,6 +145,39 @@ impl AccountEventSink {
         if self.tx.try_send((sid, event.clone())).is_err() {
             self.dropped.fetch_add(1, Ordering::Relaxed);
             tracing::warn!("account change-feed inbox full or closed; event dropped");
+        }
+    }
+
+    /// Enqueue one event and wait until the single writer has either appended
+    /// it durably or confirmed that the same configuration transition already
+    /// exists in the journal. `false` is returned on queue/append failure, so
+    /// callers must retain their durable outbox entry for a later retry.
+    pub async fn record_confirmed(&self, session_id: Option<&str>, event: &AgentEvent) -> bool {
+        let Some(confirmation_id) = config_confirmation_id(event) else {
+            return false;
+        };
+        let sid = session_id
+            .map(str::to_string)
+            .or_else(|| event.session_id().map(str::to_string));
+        let (receipt, confirmation) = oneshot::channel();
+        let waiter_id = self.next_waiter_id.fetch_add(1, Ordering::Relaxed);
+        self.confirmation_waiters
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entry(confirmation_id.clone())
+            .or_default()
+            .push((waiter_id, receipt));
+        if self.tx.send((sid, event.clone())).await.is_err() {
+            remove_confirmation_waiter(&self.confirmation_waiters, &confirmation_id, waiter_id);
+            return false;
+        }
+        match tokio::time::timeout(Duration::from_secs(30), confirmation).await {
+            Ok(Ok(durable)) => durable,
+            Ok(Err(_)) => false,
+            Err(_) => {
+                remove_confirmation_waiter(&self.confirmation_waiters, &confirmation_id, waiter_id);
+                false
+            }
         }
     }
 
@@ -134,6 +209,17 @@ impl AccountEventSink {
     pub fn dropped_count(&self) -> u64 {
         self.dropped.load(Ordering::Relaxed)
     }
+
+    /// Whether the durable journal's latest transition for this exact config
+    /// generation is Invalid. This state is rebuilt before the writer starts
+    /// and updated immediately after every successful append.
+    pub fn latest_config_transition_is_invalid(&self, section: &str, revision: u64) -> bool {
+        self.latest_config_states
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&format!("{section}:{revision}"))
+            == Some(&ConfigEventKind::Invalid)
+    }
 }
 
 fn lifecycle_event_id(event: &AgentEvent) -> Option<&str> {
@@ -144,18 +230,108 @@ fn lifecycle_event_id(event: &AgentEvent) -> Option<&str> {
     }
 }
 
+fn config_event_id(event: &AgentEvent) -> Option<String> {
+    let (section, revision) = match event {
+        AgentEvent::ConfigChanged { section, revision } => (section, revision),
+        _ => return None,
+    };
+    Some(format!("{section}:{revision}"))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigEventKind {
+    Changed,
+    Invalid,
+    Recovered,
+}
+
+fn config_event_state(event: &AgentEvent) -> Option<(String, ConfigEventKind)> {
+    let (section, revision, kind) = match event {
+        AgentEvent::ConfigChanged { section, revision } => {
+            (section, revision, ConfigEventKind::Changed)
+        }
+        AgentEvent::ConfigInvalid { section, revision } => {
+            (section, revision, ConfigEventKind::Invalid)
+        }
+        AgentEvent::ConfigRecovered { section, revision } => {
+            (section, revision, ConfigEventKind::Recovered)
+        }
+        _ => return None,
+    };
+    Some((format!("{section}:{revision}"), kind))
+}
+
+fn config_confirmation_id(event: &AgentEvent) -> Option<String> {
+    let (key, kind) = config_event_state(event)?;
+    let kind = match kind {
+        ConfigEventKind::Changed => "changed",
+        ConfigEventKind::Invalid => "invalid",
+        ConfigEventKind::Recovered => "recovered",
+    };
+    Some(format!("{kind}:{key}"))
+}
+
+fn complete_confirmation_waiters(waiters: &ConfirmationWaiters, config_id: &str, durable: bool) {
+    let pending = waiters
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(config_id)
+        .unwrap_or_default();
+    for (_, waiter) in pending {
+        let _ = waiter.send(durable);
+    }
+}
+
+fn remove_confirmation_waiter(waiters: &ConfirmationWaiters, config_id: &str, waiter_id: u64) {
+    let mut waiters = waiters
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut remove_entry = false;
+    if let Some(pending) = waiters.get_mut(config_id) {
+        pending.retain(|(id, _)| *id != waiter_id);
+        remove_entry = pending.is_empty();
+    }
+    if remove_entry {
+        waiters.remove(config_id);
+    }
+}
+
 async fn writer_loop(
     mut rx: mpsc::Receiver<PendingEvent>,
     mut journal: EventJournal,
     seq: Arc<AtomicU64>,
     broadcast: broadcast::Sender<Arc<ChangeEvent>>,
-    mut delivered_lifecycle_ids: HashSet<String>,
+    state: WriterDedupState,
 ) {
+    let WriterDedupState {
+        mut delivered_lifecycle_ids,
+        latest_config_states,
+        mut delivered_changed_ids,
+        confirmation_waiters,
+    } = state;
     while let Some((session_id, event)) = rx.recv().await {
-        if lifecycle_event_id(&event)
-            .is_some_and(|event_id| !delivered_lifecycle_ids.insert(event_id.to_string()))
+        let lifecycle_id = lifecycle_event_id(&event).map(str::to_string);
+        let config_id = config_event_id(&event);
+        let config_state = config_event_state(&event);
+        let confirmation_id = config_confirmation_id(&event);
+        if lifecycle_id
+            .as_ref()
+            .is_some_and(|id| delivered_lifecycle_ids.contains(id))
+            || config_id
+                .as_ref()
+                .is_some_and(|id| delivered_changed_ids.contains(id))
+            || config_state.as_ref().is_some_and(|(key, kind)| {
+                latest_config_states
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .get(key)
+                    == Some(kind)
+            })
         {
-            tracing::debug!("duplicate workflow lifecycle event suppressed");
+            tracing::debug!("duplicate durable change event suppressed");
+            if let Some(confirmation_id) = confirmation_id.as_deref() {
+                complete_confirmation_waiters(&confirmation_waiters, confirmation_id, true);
+            }
             continue;
         }
         // Single writer → fetch_add is the seq allocator. 1-based.
@@ -168,10 +344,29 @@ async fn writer_loop(
         };
         if let Err(e) = journal.append(&ce) {
             tracing::error!("failed to append change event {} to journal: {e}", ce.seq);
+            if let Some(confirmation_id) = confirmation_id.as_deref() {
+                complete_confirmation_waiters(&confirmation_waiters, confirmation_id, false);
+            }
+            continue;
+        }
+        if let Some(id) = lifecycle_id {
+            delivered_lifecycle_ids.insert(id);
+        }
+        if let Some((key, kind)) = config_state {
+            latest_config_states
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(key, kind);
+        }
+        if let Some(id) = config_id.as_ref() {
+            delivered_changed_ids.insert(id.clone());
         }
         // Lossy by design: with no live subscribers, or if all lag, the durable
         // journal remains the source of truth for resume.
         let _ = broadcast.send(Arc::new(ce));
+        if let Some(confirmation_id) = confirmation_id.as_deref() {
+            complete_confirmation_waiters(&confirmation_waiters, confirmation_id, true);
+        }
     }
 }
 
@@ -193,6 +388,27 @@ mod tests {
             workflow_id: "review".to_string(),
             revision: 7,
             invoked_by: "model".to_string(),
+        }
+    }
+
+    fn config_changed(section: &str, revision: u64) -> AgentEvent {
+        AgentEvent::ConfigChanged {
+            section: section.to_string(),
+            revision,
+        }
+    }
+
+    fn config_invalid(section: &str, revision: u64) -> AgentEvent {
+        AgentEvent::ConfigInvalid {
+            section: section.to_string(),
+            revision,
+        }
+    }
+
+    fn config_recovered(section: &str, revision: u64) -> AgentEvent {
+        AgentEvent::ConfigRecovered {
+            section: section.to_string(),
+            revision,
         }
     }
 
@@ -230,6 +446,169 @@ mod tests {
                 .is_err()
         );
         assert_eq!(restarted.latest_seq(), 1);
+    }
+
+    #[tokio::test]
+    async fn confirmed_config_publication_is_deduped_after_journal_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let event = config_changed("core", 7);
+        let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
+        assert!(sink.record_confirmed(None, &event).await);
+        assert_eq!(journal::read_since(sink.events_dir(), 0).unwrap().len(), 1);
+        drop(sink);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let restarted = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
+        assert!(restarted.record_confirmed(None, &event).await);
+        assert_eq!(
+            journal::read_since(restarted.events_dir(), 0)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn confirmed_config_publications_preserve_fifo_revision_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
+        let first = config_changed("core", 1);
+        let second = config_changed("core", 2);
+        let (first_confirmed, second_confirmed) = tokio::join!(
+            sink.record_confirmed(None, &first),
+            sink.record_confirmed(None, &second)
+        );
+        assert!(first_confirmed && second_confirmed);
+        let events = journal::read_since(sink.events_dir(), 0).unwrap();
+        assert!(matches!(
+            &events[0].event,
+            AgentEvent::ConfigChanged { revision: 1, .. }
+        ));
+        assert!(matches!(
+            &events[1].event,
+            AgentEvent::ConfigChanged { revision: 2, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn config_health_state_dedupes_only_consecutive_same_kind_across_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
+        let invalid = config_invalid("mcp", 7);
+        sink.record(None, &invalid);
+        sink.record(None, &invalid);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(journal::read_since(sink.events_dir(), 0).unwrap().len(), 1);
+        drop(sink);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let restarted = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
+        restarted.record(None, &invalid);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            journal::read_since(restarted.events_dir(), 0)
+                .unwrap()
+                .len(),
+            1,
+            "same failure stays deduped after watcher/sink restart"
+        );
+
+        restarted.record(None, &config_recovered("mcp", 7));
+        restarted.record(None, &invalid);
+        restarted.record(None, &config_changed("mcp", 7));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let events = journal::read_since(restarted.events_dir(), 0).unwrap();
+        assert_eq!(events.len(), 4);
+        assert!(matches!(
+            events[1].event,
+            AgentEvent::ConfigRecovered { .. }
+        ));
+        assert!(matches!(events[2].event, AgentEvent::ConfigInvalid { .. }));
+        assert!(matches!(events[3].event, AgentEvent::ConfigChanged { .. }));
+    }
+
+    #[tokio::test]
+    async fn confirmed_changed_is_exactly_once_even_after_same_revision_invalid_transition() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
+        let changed = config_changed("core", 11);
+        assert!(sink.record_confirmed(None, &changed).await);
+        sink.record(None, &config_invalid("core", 11));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(sink.record_confirmed(None, &changed).await);
+        let events = journal::read_since(sink.events_dir(), 0).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event.event,
+                    AgentEvent::ConfigChanged { revision: 11, .. }
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn confirmed_invalid_is_kind_qualified_from_same_revision_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
+        let changed = config_changed("core", 1);
+        let invalid = config_invalid("core", 1);
+
+        assert!(sink.record_confirmed(None, &changed).await);
+        assert!(sink.record_confirmed(None, &invalid).await);
+        assert!(sink.record_confirmed(None, &invalid).await);
+
+        let events = journal::read_since(sink.events_dir(), 0).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0].event,
+            AgentEvent::ConfigChanged { revision: 1, .. }
+        ));
+        assert!(matches!(
+            events[1].event,
+            AgentEvent::ConfigInvalid { revision: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn removing_a_closed_confirmation_waiter_clears_its_map_entry() {
+        let waiters: ConfirmationWaiters = Arc::new(Mutex::new(HashMap::new()));
+        let (sender, receiver) = oneshot::channel();
+        drop(receiver);
+        waiters
+            .lock()
+            .unwrap()
+            .insert("core:1".to_string(), vec![(9, sender)]);
+        remove_confirmation_waiter(&waiters, "core:1", 9);
+        assert!(waiters.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn normal_inbox_drains_after_confirmed_sender_closes() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
+        let events_dir = sink.events_dir().to_path_buf();
+        let inbox = sink.inbox();
+        drop(sink);
+        inbox
+            .send((None, deletion("after-confirmed-close")))
+            .await
+            .unwrap();
+        drop(inbox);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if journal::read_since(&events_dir, 0).is_ok_and(|events| events.len() == 1) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("normal inbox remains serviced");
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -61,7 +61,7 @@ use bamboo_domain::poison::PoisonRecover;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
 
 use crate::keyword_masking::KeywordMaskingConfig;
@@ -3310,6 +3310,75 @@ impl Config {
         Self::from_data_dir(None)
     }
 
+    fn from_completed_facade(data_dir: &Path, publish: bool, apply_env: bool) -> Self {
+        let mut config = match crate::ConfigFacade::open_or_migrate(data_dir) {
+            Ok(facade) => facade.effective_config(),
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "completed modular configuration is unavailable; refusing legacy-root fallback"
+                );
+                Self::create_default()
+            }
+        };
+
+        if let Err(error) = config.hydrate_proxy_auth_from_store(data_dir) {
+            tracing::warn!(error = %error, "proxy auth credential hydration unavailable");
+            config.proxy_auth = None;
+        }
+        if let Err(error) = config.hydrate_provider_credentials_from_store(data_dir) {
+            tracing::warn!(error = %error, "provider credential hydration unavailable");
+        }
+        if let Err(error) = config.hydrate_mcp_credentials_from_store(data_dir) {
+            tracing::warn!(error = %error, "MCP credential hydration unavailable");
+        }
+        if let Err(error) = config.hydrate_env_var_credentials_from_store(data_dir) {
+            tracing::warn!(error = %error, "env credential hydration unavailable");
+            for entry in &mut config.env_vars {
+                if entry.secret {
+                    entry.value.clear();
+                }
+            }
+        }
+        if let Err(error) = config.hydrate_cluster_credentials_from_store(data_dir) {
+            tracing::warn!(error = %error, "cluster credential hydration unavailable");
+            config.clear_cluster_runtime_credentials();
+        }
+        if let Err(error) = config.hydrate_notification_credentials_from_store(data_dir) {
+            tracing::warn!(error = %error, "notification credential hydration unavailable");
+            config.notifications.ntfy.token = None;
+            config.notifications.bark.device_key = None;
+        }
+        if let Err(error) = config.hydrate_connect_credentials_from_store(data_dir) {
+            tracing::warn!(error = %error, "connect credential hydration unavailable");
+            for platform in &mut config.connect.platforms {
+                platform.token = None;
+                platform.app_secret = None;
+            }
+        }
+        if let Err(error) = config.hydrate_access_control_credentials_from_store(data_dir) {
+            tracing::warn!(error = %error, "access-control credential hydration unavailable");
+            config.clear_access_control_runtime_verifiers();
+        }
+        if let Some(broker) = config.subagents_mut().broker.as_mut() {
+            if let Err(error) = broker.hydrate_credential_from_store(data_dir) {
+                tracing::warn!(error = %error, "external broker credential hydration unavailable");
+                broker.token.clear();
+            }
+        }
+        config.normalize_tool_settings();
+        config.normalize_skill_settings();
+        config.normalize_plugin_trust_settings();
+        config.extra.remove("data_dir");
+        if apply_env {
+            config.apply_env_overrides();
+        }
+        if publish {
+            config.publish_env_vars();
+        }
+        config
+    }
+
     /// Load configuration from a specific data directory.
     ///
     /// Use [`Config::from_data_dir`] (publishes env vars to the global cache, for
@@ -3323,6 +3392,25 @@ impl Config {
         let data_dir = data_dir
             .or_else(|| std::env::var("BAMBOO_DATA_DIR").ok().map(PathBuf::from))
             .unwrap_or_else(default_data_dir);
+
+        match crate::modular_authority_boundary_present(&data_dir) {
+            Ok(true) => return Self::from_completed_facade(&data_dir, publish, apply_env),
+            Ok(false) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "modular configuration marker is unavailable; refusing legacy-root fallback"
+                );
+                let mut config = Self::create_default();
+                if apply_env {
+                    config.apply_env_overrides();
+                }
+                if publish {
+                    config.publish_env_vars();
+                }
+                return config;
+            }
+        }
 
         // Finish any shared manifest-committed credential extraction before
         // reading even one member of the transaction, then plan only the
@@ -3342,6 +3430,29 @@ impl Config {
                 error
             })
             .is_ok();
+
+        // A recovery performed by either legacy credential planner may have
+        // completed the modular split. Reclassify immediately before touching
+        // config.json so a pending split cannot race this compatibility load
+        // back into legacy authority.
+        match crate::modular_authority_boundary_present(&data_dir) {
+            Ok(true) => return Self::from_completed_facade(&data_dir, publish, apply_env),
+            Ok(false) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "modular configuration boundary is unavailable; refusing legacy-root fallback"
+                );
+                let mut config = Self::create_default();
+                if apply_env {
+                    config.apply_env_overrides();
+                }
+                if publish {
+                    config.publish_env_vars();
+                }
+                return config;
+            }
+        }
 
         let config_path = data_dir.join("config.json");
 
@@ -4576,6 +4687,16 @@ impl Config {
             anyhow::bail!(
                 "notification secrets require the isolated credential transaction before persistence"
             );
+        }
+
+        if crate::modular_authority_boundary_present(&data_dir)
+            .context("Failed to inspect modular configuration authority boundary")?
+        {
+            crate::ConfigFacade::open_or_migrate(&data_dir)
+                .context("Failed to recover modular configuration before persistence")?;
+            crate::persist_facade_effective_config(&data_dir, self)
+                .context("Failed to persist modular configuration sections")?;
+            return Ok(());
         }
 
         if crate::section_layout_is_active(&data_dir)

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -1077,7 +1077,7 @@ impl Config {
         data_dir: &std::path::Path,
     ) -> crate::ConfigStoreResult<()> {
         let store = crate::CredentialStore::open(data_dir);
-        let allow_legacy_runtime_value = !crate::section_layout_is_active(data_dir)?;
+        let allow_legacy_runtime_value = !crate::modular_authority_boundary_present(data_dir)?;
         self.hydrate_connect_credentials_from_resolver(&store, allow_legacy_runtime_value)
     }
 

--- a/crates/infra/bamboo-config/src/config_store.rs
+++ b/crates/infra/bamboo-config/src/config_store.rs
@@ -1952,6 +1952,12 @@ fn is_internal_store_path(path: &Path) -> bool {
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("");
+    if matches!(
+        name,
+        "config.json" | "config.json.bak" | "config.json.bak.1" | "config.json.bak.2"
+    ) {
+        return false;
+    }
     name.starts_with('.')
         || name.contains(".tmp.")
         || name.ends_with(".lock")
@@ -2133,6 +2139,26 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     struct Example {
         value: String,
+    }
+
+    #[test]
+    fn watcher_only_exposes_the_fixed_legacy_root_backup_family() {
+        for name in [
+            "config.json",
+            "config.json.bak",
+            "config.json.bak.1",
+            "config.json.bak.2",
+        ] {
+            assert!(!is_internal_store_path(Path::new(name)), "{name}");
+        }
+        for name in [
+            "config.json.bak.3",
+            "providers.json.bak",
+            "config.json.corrupt.1",
+            ".config.json.tmp",
+        ] {
+            assert!(is_internal_store_path(Path::new(name)), "{name}");
+        }
     }
 
     fn store_with_two_revisions(dir: &TempDir) -> (PathBuf, AtomicJsonStore<Example>) {

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -133,6 +133,11 @@ struct SectionLayoutCompletionLedger {
     legacy_cleanup: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     legacy_source_guards: BTreeMap<String, FacadeSourceBase>,
+    /// Canonical secret-free outbox/health for compatibility-root
+    /// reconciliation. The sibling status file is only a diagnostic mirror;
+    /// deleting it cannot erase a pending publication or rejection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    legacy_root_reconciliation: Option<crate::section_facade::LegacyRootReconciliationRecord>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -420,6 +425,49 @@ impl FacadeSourceSnapshot {
         })
     }
 
+    fn capture_stable(data_dir: &Path) -> ConfigStoreResult<Self> {
+        for _ in 0..4 {
+            let before = crate::section_facade::preflight_source_hashes(data_dir)?;
+            let snapshot = Self::capture(data_dir)?;
+            let captured = snapshot
+                .files
+                .iter()
+                .map(|(name, state)| {
+                    let bytes = match state {
+                        FacadeSourceState::Missing => None,
+                        FacadeSourceState::Regular(bytes) => Some(bytes.as_slice()),
+                    };
+                    (
+                        name.clone(),
+                        crate::section_facade::source_state_hash(bytes),
+                    )
+                })
+                .collect::<Vec<_>>();
+            if captured == before
+                && crate::section_facade::preflight_source_hashes(data_dir)? == before
+            {
+                return Ok(snapshot);
+            }
+        }
+        Err(ConfigStoreError::Validation(
+            "configuration sources changed repeatedly while capturing recovery preflight"
+                .to_string(),
+        ))
+    }
+
+    fn into_strict_source_overrides(self) -> BTreeMap<String, Option<Vec<u8>>> {
+        self.files
+            .into_iter()
+            .map(|(name, state)| {
+                let bytes = match state {
+                    FacadeSourceState::Missing => None,
+                    FacadeSourceState::Regular(bytes) => Some(bytes),
+                };
+                (name, bytes)
+            })
+            .collect()
+    }
+
     fn attestation(&self) -> BTreeMap<String, FacadeSourceBase> {
         self.files
             .iter()
@@ -449,7 +497,7 @@ pub(crate) struct FacadeCredentialPlan {
     pub source_snapshot: FacadeSourceSnapshot,
     pub credential_original: FacadeSourceState,
     pub credential_candidate: Vec<u8>,
-    pub source_overrides: BTreeMap<String, Vec<u8>>,
+    pub source_overrides: BTreeMap<String, Option<Vec<u8>>>,
     pub legacy_cleanups: Vec<PlannedLegacyCleanup>,
 }
 
@@ -695,20 +743,20 @@ pub(crate) fn plan_facade_compound_credentials(
         primary_authority.providers = providers;
         primary_authority.provider_instances = owns_instances;
         if let Some(section) = plan_provider_document(original, &mut primary_extracted, 1)? {
-            source_overrides.insert(PROVIDERS_FILE.to_string(), section.bytes);
+            source_overrides.insert(PROVIDERS_FILE.to_string(), Some(section.bytes));
         }
     }
     if let Some(original) = source_snapshot.bytes(MCP_FILE)?.map(ToOwned::to_owned) {
         primary_authority.mcp = true;
         primary_authority.mcp_servers = mcp_document_server_ids(&original)?;
         if let Some(section) = plan_mcp_document(original, &mut primary_extracted, 1)? {
-            source_overrides.insert(MCP_FILE.to_string(), section.bytes);
+            source_overrides.insert(MCP_FILE.to_string(), Some(section.bytes));
         }
     }
     if let Some(original) = source_snapshot.bytes(CONNECT_FILE)?.map(ToOwned::to_owned) {
         primary_authority.connect_platforms = connect_platform_ids(&original)?;
         if let Some(section) = plan_connect_document(original, &mut primary_extracted, 1)? {
-            source_overrides.insert(CONNECT_FILE.to_string(), section.bytes);
+            source_overrides.insert(CONNECT_FILE.to_string(), Some(section.bytes));
         }
     }
     if let Some(original) = source_snapshot
@@ -719,7 +767,7 @@ pub(crate) fn plan_facade_compound_credentials(
         if let Some(section) =
             plan_access_control_document(original, &mut primary_extracted, 1, "section")?
         {
-            source_overrides.insert(ACCESS_CONTROL_FILE.to_string(), section.bytes);
+            source_overrides.insert(ACCESS_CONTROL_FILE.to_string(), Some(section.bytes));
         }
     }
 
@@ -735,7 +783,7 @@ pub(crate) fn plan_facade_compound_credentials(
         discard_shadowed_root_secrets(&mut root_extracted, &primary_authority);
         if planned.is_some() || metadata_changed {
             primary_extracted.extend(root_extracted);
-            source_overrides.insert(CONFIG_FILE.to_string(), candidate.clone());
+            source_overrides.insert(CONFIG_FILE.to_string(), Some(candidate.clone()));
             legacy_cleanups.push(PlannedLegacyCleanup {
                 name: CONFIG_FILE.to_string(),
                 original: source_snapshot.state(CONFIG_FILE)?.clone(),
@@ -752,7 +800,7 @@ pub(crate) fn plan_facade_compound_credentials(
                 plan_broker_document(data_dir, original, &mut broker_extracted, 1)?
             {
                 primary_extracted.extend(broker_extracted);
-                source_overrides.insert(BROKER_FILE.to_string(), section.bytes.clone());
+                source_overrides.insert(BROKER_FILE.to_string(), Some(section.bytes.clone()));
                 legacy_cleanups.push(PlannedLegacyCleanup {
                     name: BROKER_FILE.to_string(),
                     original: source_snapshot.state(BROKER_FILE)?.clone(),
@@ -1236,10 +1284,37 @@ fn cluster_abort_record_test_fault(data_dir: &Path) -> bool {
 pub fn migrate_provider_mcp_credentials(
     data_dir: impl AsRef<Path>,
 ) -> ConfigStoreResult<CredentialMigrationOutcome> {
+    let data_dir = data_dir.as_ref();
+    if validate_completed_modular_authority(data_dir)? {
+        return with_migration_lock(data_dir, || {
+            migrate_active_provider_mcp_credentials_for_facade_locked(data_dir)
+        });
+    }
     #[cfg(test)]
-    return migrate_with_fault(data_dir.as_ref(), MigrationFault::None);
+    return migrate_with_fault(data_dir, MigrationFault::None);
     #[cfg(not(test))]
-    migrate_inner(data_dir.as_ref(), None)
+    migrate_inner(data_dir, None)
+}
+
+fn validate_completed_modular_authority(data_dir: &Path) -> ConfigStoreResult<bool> {
+    if !crate::modular_authority_boundary_present(data_dir)? {
+        return Ok(false);
+    }
+    if !crate::has_completed_section_layout_marker(data_dir)? {
+        return Err(ConfigStoreError::Validation(
+            "modular configuration authority evidence is incomplete; legacy fallback is forbidden"
+                .to_string(),
+        ));
+    }
+    if !crate::section_layout_is_active(data_dir)?
+        && !crate::section_facade::completed_layout_allows_legacy_root_reconciliation(data_dir)?
+    {
+        return Err(ConfigStoreError::Validation(
+            "completed modular configuration evidence is inconsistent".to_string(),
+        ));
+    }
+    crate::section_facade::validate_legacy_root_reconciliation_state(data_dir)?;
+    Ok(true)
 }
 
 pub(crate) fn with_migration_lock<T>(
@@ -1249,10 +1324,13 @@ pub(crate) fn with_migration_lock<T>(
     with_provider_mcp_migration_lock(data_dir, operation)
 }
 
-pub(crate) fn migrate_provider_mcp_credentials_for_facade_locked(
+/// Repair only the typed provider and MCP authorities of an already-completed
+/// modular layout. A reappeared `config.json` belongs exclusively to section
+/// reconciliation and is never credential-migration input here.
+pub(crate) fn migrate_active_provider_mcp_credentials_for_facade_locked(
     data_dir: &Path,
 ) -> ConfigStoreResult<CredentialMigrationOutcome> {
-    migrate_inner_with_root_builtins_locked(data_dir, None, true)
+    migrate_inner_with_root_builtins_locked(data_dir, None, false, false)
 }
 
 pub(crate) fn migrate_external_broker_credentials_locked(
@@ -1261,26 +1339,10 @@ pub(crate) fn migrate_external_broker_credentials_locked(
     migrate_broker_locked(data_dir, None)
 }
 
-pub(crate) fn migrate_cluster_credentials_locked(
-    data_dir: &Path,
-) -> ConfigStoreResult<CredentialMigrationOutcome> {
-    migrate_cluster_locked(data_dir, None)
-}
-
 pub(crate) fn migrate_access_control_credentials_for_facade_locked(
     data_dir: &Path,
 ) -> ConfigStoreResult<CredentialMigrationOutcome> {
     migrate_access_control_locked(data_dir, None)
-}
-
-pub(crate) fn access_control_requires_opaque_repair(data_dir: &Path) -> ConfigStoreResult<bool> {
-    let Some(bytes) = read_optional_target(&data_dir.join(ACCESS_CONTROL_FILE))? else {
-        return Ok(false);
-    };
-    let Ok(mut document) = serde_json::from_slice::<Value>(&bytes) else {
-        return Ok(true);
-    };
-    Ok(section_data_mut(&mut document).is_err())
 }
 
 /// Run the provider/MCP/root planner and every ownership/decryption check
@@ -1364,7 +1426,24 @@ pub fn migrate_external_broker_credentials(
 pub fn migrate_cluster_credentials(
     data_dir: impl AsRef<Path>,
 ) -> ConfigStoreResult<CredentialMigrationOutcome> {
-    migrate_cluster_inner(data_dir.as_ref(), None)
+    let data_dir = data_dir.as_ref();
+    if validate_completed_modular_authority(data_dir)? {
+        return with_migration_lock(data_dir, || {
+            cleanup_orphan_transaction_dirs(data_dir)?;
+            let resumed = recover_committed(
+                data_dir,
+                #[cfg(test)]
+                None,
+            )?
+            .is_some();
+            discard_uncommitted(data_dir)?;
+            Ok(CredentialMigrationOutcome {
+                migrated_credentials: 0,
+                resumed,
+            })
+        });
+    }
+    migrate_cluster_inner(data_dir, None)
 }
 
 /// Validate the complete cluster credential migration without creating the
@@ -1516,11 +1595,22 @@ fn install_section_split_migration_locked_inner(
         Some(fault),
     )?
     .is_some();
-    if crate::section_layout_is_active(data_dir)? {
-        return Ok(SectionMigrationOutcome {
-            activated: false,
-            resumed,
-        });
+    if crate::modular_authority_boundary_present(data_dir)? {
+        if !crate::has_completed_section_layout_marker(data_dir)? {
+            return Err(ConfigStoreError::Validation(
+                "modular configuration authority evidence is incomplete; initial section migration is forbidden"
+                    .to_string(),
+            ));
+        }
+        if crate::section_layout_is_active(data_dir)? {
+            return Ok(SectionMigrationOutcome {
+                activated: false,
+                resumed,
+            });
+        }
+        return Err(ConfigStoreError::Validation(
+            "completed modular configuration cannot re-enter initial section migration".to_string(),
+        ));
     }
     discard_uncommitted(data_dir)?;
     validate_section_split_plan(data_dir, &plan)?;
@@ -1856,6 +1946,130 @@ pub(crate) fn recover_pending_config_transaction(
             None,
         )
         .map(|outcome| outcome.is_some())
+    })
+}
+
+pub(crate) struct FacadePendingConfigRecovery {
+    pub(crate) recovered: bool,
+    pub(crate) initial_layout_sources: Option<BTreeMap<String, Option<Vec<u8>>>>,
+}
+
+#[cfg(test)]
+type FacadeRecoverySnapshotTestHook = Box<dyn FnOnce(&Path) + Send + 'static>;
+
+#[cfg(test)]
+fn facade_recovery_snapshot_test_hooks(
+) -> &'static Mutex<BTreeMap<PathBuf, FacadeRecoverySnapshotTestHook>> {
+    static HOOKS: std::sync::OnceLock<Mutex<BTreeMap<PathBuf, FacadeRecoverySnapshotTestHook>>> =
+        std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+#[cfg(test)]
+pub(crate) fn set_facade_recovery_after_snapshot_test_hook(
+    data_dir: &Path,
+    hook: impl FnOnce(&Path) + Send + 'static,
+) {
+    facade_recovery_snapshot_test_hooks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(data_dir.to_path_buf(), Box::new(hook));
+}
+
+#[cfg(test)]
+fn run_facade_recovery_after_snapshot_test_hook(data_dir: &Path) {
+    if let Some(hook) = facade_recovery_snapshot_test_hooks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(data_dir)
+    {
+        hook(data_dir);
+    }
+}
+
+/// Recover a committed layout transaction and bind its historical strict
+/// preflight to one migration-lock epoch. Established modular layouts and
+/// unrelated provider/exact manifests never capture compatibility-root bytes.
+pub(crate) fn recover_pending_config_transaction_for_facade(
+    data_dir: impl AsRef<Path>,
+) -> ConfigStoreResult<FacadePendingConfigRecovery> {
+    let data_dir = data_dir.as_ref();
+    let data_dir = if data_dir.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        data_dir
+    };
+    // Keep the no-transaction startup path strictly read-only. Besides being
+    // unnecessary, acquiring the migration lock creates its lock file and
+    // would turn validation failures into observable writes. The manifest is
+    // read again under the lock below, so a concurrent recovery or removal is
+    // still handled safely.
+    if read_optional_migration_file(&data_dir.join(MANIFEST_FILE))?.is_none() {
+        if read_optional_migration_file(&data_dir.join(CLUSTER_ABORT_FILE))?.is_some() {
+            return Err(ConfigStoreError::Validation(
+                "cluster abort recovery metadata has no committed manifest".to_string(),
+            ));
+        }
+        return Ok(FacadePendingConfigRecovery {
+            recovered: false,
+            initial_layout_sources: None,
+        });
+    }
+    with_provider_mcp_migration_lock(data_dir, || {
+        let Some(manifest_bytes) = read_optional_migration_file(&data_dir.join(MANIFEST_FILE))?
+        else {
+            if read_optional_migration_file(&data_dir.join(CLUSTER_ABORT_FILE))?.is_some() {
+                return Err(ConfigStoreError::Validation(
+                    "cluster abort recovery metadata has no committed manifest".to_string(),
+                ));
+            }
+            return Ok(FacadePendingConfigRecovery {
+                recovered: false,
+                initial_layout_sources: None,
+            });
+        };
+        let manifest: MigrationManifest = serde_json::from_slice(&manifest_bytes)?;
+        validate_manifest(&manifest)?;
+        let capture_initial_layout = manifest.state == MigrationState::Pending
+            && is_section_layout_scope(manifest.migration_scope)
+            && !crate::modular_authority_boundary_present(data_dir)?;
+        let mut before = capture_initial_layout
+            .then(|| FacadeSourceSnapshot::capture_stable(data_dir))
+            .transpose()?;
+        #[cfg(test)]
+        if capture_initial_layout {
+            run_facade_recovery_after_snapshot_test_hook(data_dir);
+        }
+        let transaction_targets = manifest
+            .files
+            .iter()
+            .map(|file| file.name.clone())
+            .collect::<BTreeSet<_>>();
+        let recovered = recover_committed(
+            data_dir,
+            #[cfg(test)]
+            None,
+        )?
+        .is_some();
+        let initial_layout_sources = if recovered {
+            if let Some(mut before) = before.take() {
+                let after = FacadeSourceSnapshot::capture_stable(data_dir)?;
+                for (name, state) in after.files {
+                    if !transaction_targets.contains(&name) {
+                        before.files.insert(name, state);
+                    }
+                }
+                Some(before.into_strict_source_overrides())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        Ok(FacadePendingConfigRecovery {
+            recovered,
+            initial_layout_sources,
+        })
     })
 }
 
@@ -3957,6 +4171,21 @@ fn persist_exact_credential_transaction_inner(
     )?;
     discard_uncommitted(data_dir)?;
 
+    if crate::modular_authority_boundary_present(data_dir)? {
+        if !crate::has_completed_section_layout_marker(data_dir)? {
+            return Err(ConfigStoreError::Validation(
+                "modular configuration authority evidence is incomplete; credential mutation is forbidden"
+                    .to_string(),
+            ));
+        }
+        if !crate::section_layout_is_active(data_dir)? {
+            return Err(ConfigStoreError::Validation(
+                "completed modular configuration requires legacy-root reconciliation before credential mutation"
+                    .to_string(),
+            ));
+        }
+    }
+
     let exact_scope = if let Some((scope, _)) = reset_scope {
         Some(scope)
     } else if proxy_only {
@@ -5307,6 +5536,13 @@ fn migrate_cluster_locked(
     .is_some();
     discard_uncommitted(data_dir)?;
 
+    if crate::modular_authority_boundary_present(data_dir)? {
+        return Err(ConfigStoreError::Validation(
+            "modular configuration authority appeared during cluster migration; legacy root access is forbidden"
+                .to_string(),
+        ));
+    }
+
     let mut extracted = Vec::new();
     let section = plan_cluster_section(data_dir, &mut extracted, 1, true)?;
     let credential_original = read_optional_target(&data_dir.join(CREDENTIALS_FILE))?;
@@ -5502,7 +5738,7 @@ fn migrate_inner_with_root_builtins(
     include_root_builtins: bool,
 ) -> ConfigStoreResult<CredentialMigrationOutcome> {
     with_migration_lock(data_dir, || {
-        migrate_inner_with_root_builtins_locked(data_dir, fault, include_root_builtins)
+        migrate_inner_with_root_builtins_locked(data_dir, fault, include_root_builtins, true)
     })
 }
 
@@ -5510,6 +5746,7 @@ fn migrate_inner_with_root_builtins_locked(
     data_dir: &Path,
     #[cfg_attr(not(test), allow(unused_variables))] fault: Option<MigrationFault>,
     include_root_builtins: bool,
+    include_root_document: bool,
 ) -> ConfigStoreResult<CredentialMigrationOutcome> {
     cleanup_orphan_transaction_dirs(data_dir)?;
     match recover_committed(
@@ -5538,11 +5775,21 @@ fn migrate_inner_with_root_builtins_locked(
     }
     discard_uncommitted(data_dir)?;
 
+    if include_root_document && crate::modular_authority_boundary_present(data_dir)? {
+        return Err(ConfigStoreError::Validation(
+            "modular configuration authority appeared during credential migration; legacy root access is forbidden"
+                .to_string(),
+        ));
+    }
+
     let mut extracted = Vec::new();
     let providers = plan_provider_section(data_dir, &mut extracted, 1)?;
     let mcp = plan_mcp_section(data_dir, &mut extracted, 1)?;
-    let provider_instances =
-        plan_provider_instance_section(data_dir, &mut extracted, 1, true, include_root_builtins)?;
+    let provider_instances = if include_root_document {
+        plan_provider_instance_section(data_dir, &mut extracted, 1, true, include_root_builtins)?
+    } else {
+        None
+    };
     let provider_facade_scope = include_root_builtins && provider_instances.is_some();
     let credential_original = read_optional_target(&data_dir.join(CREDENTIALS_FILE))?;
     let credential_store = CredentialStore::open(data_dir);
@@ -5559,14 +5806,18 @@ fn migrate_inner_with_root_builtins_locked(
         &extracted,
         &prospective_documents,
     )?;
-    ensure_backup_legacy_proxy_extractions_are_safe(data_dir, &credential_store)?;
+    if include_root_document {
+        ensure_backup_legacy_proxy_extractions_are_safe(data_dir, &credential_store)?;
+    }
     if providers.is_none() && mcp.is_none() && provider_instances.is_none() {
-        scrub_provider_instance_credentials_from_backups(
-            data_dir,
-            &BTreeSet::new(),
-            &BTreeSet::new(),
-            &BTreeSet::new(),
-        )?;
+        if include_root_document {
+            scrub_provider_instance_credentials_from_backups(
+                data_dir,
+                &BTreeSet::new(),
+                &BTreeSet::new(),
+                &BTreeSet::new(),
+            )?;
+        }
         return Ok(CredentialMigrationOutcome {
             migrated_credentials: 0,
             resumed: false,
@@ -11077,15 +11328,62 @@ fn persist_section_layout_completion_ledger(
                 (file.name.clone(), base)
             })
             .collect(),
+        legacy_root_reconciliation: None,
     };
-    let bytes = serde_json::to_vec_pretty(&ledger)?;
-    if read_optional_migration_file(&data_dir.join(SECTION_LAYOUT_COMPLETION_FILE))?
-        .is_some_and(|current| current == bytes)
-    {
+    let path = data_dir.join(SECTION_LAYOUT_COMPLETION_FILE);
+    if let Some(current) = read_optional_migration_file(&path)? {
+        let current: SectionLayoutCompletionLedger =
+            serde_json::from_slice(&current).map_err(|_| {
+                ConfigStoreError::Validation(
+                    "section layout completion ledger is invalid".to_string(),
+                )
+            })?;
+        let immutable_matches = current.version == ledger.version
+            && current.state == ledger.state
+            && current.facade_compound == ledger.facade_compound
+            && current.marker_sha256 == ledger.marker_sha256
+            && current.completion == ledger.completion;
+        let evidence_names = current
+            .legacy_cleanup
+            .keys()
+            .chain(current.legacy_source_guards.keys())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let expected_names = if current.facade_compound {
+            durable_legacy_authority_names()
+        } else {
+            BTreeSet::new()
+        };
+        let mutable_shape_valid = evidence_names == expected_names
+            && current
+                .legacy_cleanup
+                .keys()
+                .all(|name| !current.legacy_source_guards.contains_key(name))
+            && current
+                .legacy_cleanup
+                .values()
+                .all(|hash| is_sha256_hex(hash))
+            && current
+                .legacy_source_guards
+                .values()
+                .all(|base| match base {
+                    FacadeSourceBase::Missing => true,
+                    FacadeSourceBase::Regular { sha256 } => is_sha256_hex(sha256),
+                });
+        if !immutable_matches || !mutable_shape_valid {
+            return Err(ConfigStoreError::Validation(
+                "section layout completion ledger does not match its immutable transaction"
+                    .to_string(),
+            ));
+        }
+        // Root reconciliation legitimately advances the guard maps and owns a
+        // canonical publication outbox in this ledger. A completed manifest
+        // recovery must preserve that mutable state rather than reconstructing
+        // the original post-split bytes.
         return Ok(());
     }
-    AtomicFileStore::new(data_dir.join(SECTION_LAYOUT_COMPLETION_FILE))
-        .write_bytes_without_backup(&bytes)
+    let bytes = serde_json::to_vec_pretty(&ledger)?;
+    AtomicFileStore::new(path).write_bytes_without_backup(&bytes)
 }
 
 pub(crate) fn section_layout_completion_evidence_matches(
@@ -11164,6 +11462,261 @@ pub(crate) fn section_layout_completion_evidence_matches(
                 _ => false,
             }
         }))
+}
+
+pub(crate) fn read_embedded_legacy_root_reconciliation(
+    data_dir: &Path,
+) -> ConfigStoreResult<Option<crate::section_facade::LegacyRootReconciliationRecord>> {
+    let Some(bytes) = read_optional_migration_file(&data_dir.join(SECTION_LAYOUT_COMPLETION_FILE))?
+    else {
+        return Ok(None);
+    };
+    let ledger: SectionLayoutCompletionLedger = serde_json::from_slice(&bytes)?;
+    Ok(ledger.legacy_root_reconciliation)
+}
+
+/// Read config.json only when the returned bytes themselves match the exact
+/// initial-split guard embedded in the canonical completion ledger. The
+/// caller holds the migration lock and has already validated the completed
+/// layout; comparing the captured bytes closes swap-and-restore races that a
+/// second path-based active-layout check cannot detect.
+pub(crate) fn read_initial_guarded_legacy_root_locked(
+    data_dir: &Path,
+) -> ConfigStoreResult<Option<Vec<u8>>> {
+    let Some(ledger_bytes) =
+        read_optional_migration_file(&data_dir.join(SECTION_LAYOUT_COMPLETION_FILE))?
+    else {
+        return Ok(None);
+    };
+    let ledger: SectionLayoutCompletionLedger = serde_json::from_slice(&ledger_bytes)?;
+    let Some(guard) = ledger.legacy_source_guards.get(CONFIG_FILE) else {
+        return Ok(None);
+    };
+    match guard {
+        FacadeSourceBase::Missing => Ok(None),
+        FacadeSourceBase::Regular { sha256: expected } if is_sha256_hex(expected) => {
+            let Some(bytes) = read_optional_target(&data_dir.join(CONFIG_FILE))? else {
+                return Ok(None);
+            };
+            Ok((sha256(&bytes) == *expected).then_some(bytes))
+        }
+        FacadeSourceBase::Regular { .. } => Ok(None),
+    }
+}
+
+/// Update the canonical reconciliation outbox inside the completion ledger.
+/// The caller holds the shared migration lock, so guard and outbox rewrites
+/// are serialized as one authority stream even though each file replacement
+/// remains independently atomic.
+pub(crate) fn write_embedded_legacy_root_reconciliation_locked(
+    data_dir: &Path,
+    record: crate::section_facade::LegacyRootReconciliationRecord,
+) -> ConfigStoreResult<()> {
+    let path = data_dir.join(SECTION_LAYOUT_COMPLETION_FILE);
+    let bytes = read_optional_migration_file(&path)?.ok_or_else(|| {
+        ConfigStoreError::Validation("section layout completion ledger is unavailable".to_string())
+    })?;
+    let mut ledger: SectionLayoutCompletionLedger = serde_json::from_slice(&bytes)?;
+    ledger.legacy_root_reconciliation = Some(record);
+    AtomicFileStore::new(path).write_bytes_without_backup(&serde_json::to_vec_pretty(&ledger)?)
+}
+
+/// Return whether the durable modular layout was completed and every piece of
+/// completion evidence except the legacy `config.json` generation still
+/// matches.  A reappeared compatibility root is deliberately *not* an initial
+/// migration input: callers use this seam to enter the revisioned
+/// reconciliation path while the ordinary active-layout predicate is false.
+pub(crate) fn section_layout_allows_legacy_root_reconciliation(
+    data_dir: &Path,
+    marker: &[u8],
+    completion: &crate::section_facade::SectionLayoutCompletion,
+) -> ConfigStoreResult<bool> {
+    let marker_sha256 = sha256(marker);
+    let manifest_scope = if let Some(manifest_bytes) =
+        read_optional_migration_file(&data_dir.join(MANIFEST_FILE))?
+    {
+        let manifest: MigrationManifest = match serde_json::from_slice(&manifest_bytes) {
+            Ok(manifest) => manifest,
+            Err(_) => return Ok(false),
+        };
+        if validate_manifest(&manifest).is_err() || manifest.state != MigrationState::Complete {
+            return Ok(false);
+        }
+        if is_section_layout_scope(manifest.migration_scope)
+            && !section_split_manifest_matches_completion(&manifest, &marker_sha256, completion)?
+        {
+            return Ok(false);
+        }
+        manifest.migration_scope
+    } else {
+        None
+    };
+
+    let Some(bytes) = read_optional_migration_file(&data_dir.join(SECTION_LAYOUT_COMPLETION_FILE))?
+    else {
+        return Ok(false);
+    };
+    let ledger: SectionLayoutCompletionLedger = match serde_json::from_slice(&bytes) {
+        Ok(ledger) => ledger,
+        Err(_) => return Ok(false),
+    };
+    let durable_evidence_names = ledger
+        .legacy_cleanup
+        .keys()
+        .chain(ledger.legacy_source_guards.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let expected_durable_names = durable_legacy_authority_names();
+    let durable_evidence_shape_valid = ledger.facade_compound
+        && durable_evidence_names == expected_durable_names
+        && ledger
+            .legacy_cleanup
+            .keys()
+            .all(|name| !ledger.legacy_source_guards.contains_key(name))
+        && manifest_scope.is_none_or(|scope| scope == MigrationScope::FacadeCompound);
+    if ledger.version != SECTION_LAYOUT_COMPLETION_LEDGER_VERSION
+        || ledger.state != MigrationState::Complete
+        || ledger.marker_sha256 != marker_sha256
+        || &ledger.completion != completion
+        || !durable_evidence_shape_valid
+    {
+        return Ok(false);
+    }
+
+    let cleanups_match = ledger
+        .legacy_cleanup
+        .iter()
+        .filter(|(name, _)| !is_durable_legacy_authority(name))
+        .all(|(name, expected)| {
+            is_sha256_hex(expected)
+                && read_target_or_empty(&data_dir.join(name))
+                    .map(|bytes| sha256(&bytes) == *expected)
+                    .unwrap_or(false)
+        });
+    let guards_match = ledger
+        .legacy_source_guards
+        .iter()
+        .filter(|(name, _)| !is_durable_legacy_authority(name))
+        .all(|(name, expected)| {
+            let current = read_optional_target(&data_dir.join(name));
+            match (expected, current) {
+                (FacadeSourceBase::Missing, Ok(None)) => true,
+                (
+                    FacadeSourceBase::Regular {
+                        sha256: expected_hash,
+                    },
+                    Ok(Some(bytes)),
+                ) => is_sha256_hex(expected_hash) && sha256(&bytes) == *expected_hash,
+                _ => false,
+            }
+        });
+    Ok(cleanups_match && guards_match)
+}
+
+/// Bind one already-reconciled compatibility-root generation (and the backup
+/// generations rotated by compatibility writers) into the durable completion
+/// ledger without rewriting any of those bytes.
+///
+/// The caller holds the provider/MCP migration lock.  Returning `false` means
+/// an external writer changed or removed `config.json` before the guard could
+/// be advanced; the newer generation remains inactive and must be planned
+/// again rather than being acknowledged under the stale hash.
+pub(crate) fn advance_legacy_root_completion_guard_locked(
+    data_dir: &Path,
+    expected_sha256: Option<&str>,
+) -> ConfigStoreResult<bool> {
+    if expected_sha256.is_some_and(|expected| !is_sha256_hex(expected)) {
+        return Err(ConfigStoreError::Validation(
+            "legacy root reconciliation fingerprint is invalid".to_string(),
+        ));
+    }
+    let marker = match read_optional_target(&data_dir.join(crate::SECTION_LAYOUT_FILE))? {
+        Some(marker) => marker,
+        None => return Ok(false),
+    };
+    let completion = match crate::section_facade::validate_completed_section_layout_marker(&marker)
+    {
+        Ok(completion) => completion,
+        Err(_) => return Ok(false),
+    };
+    if !section_layout_allows_legacy_root_reconciliation(data_dir, &marker, &completion)? {
+        return Ok(false);
+    }
+    let root = read_optional_target(&data_dir.join(CONFIG_FILE))?;
+    let root_matches = match (expected_sha256, root.as_deref()) {
+        (Some(expected), Some(root)) => sha256(root) == expected,
+        (None, None) => true,
+        _ => false,
+    };
+    if !root_matches {
+        return Ok(false);
+    }
+
+    let path = data_dir.join(SECTION_LAYOUT_COMPLETION_FILE);
+    let bytes = read_optional_migration_file(&path)?.ok_or_else(|| {
+        ConfigStoreError::Validation("section layout completion ledger is unavailable".to_string())
+    })?;
+    let mut ledger: SectionLayoutCompletionLedger = serde_json::from_slice(&bytes)?;
+    for name in durable_legacy_authority_names() {
+        ledger.legacy_cleanup.remove(&name);
+        let guard = if name == CONFIG_FILE {
+            match expected_sha256 {
+                Some(expected) => FacadeSourceBase::Regular {
+                    sha256: expected.to_string(),
+                },
+                None => FacadeSourceBase::Missing,
+            }
+        } else {
+            match read_optional_target(&data_dir.join(&name))? {
+                Some(bytes) => FacadeSourceBase::Regular {
+                    sha256: sha256(&bytes),
+                },
+                None => FacadeSourceBase::Missing,
+            }
+        };
+        ledger.legacy_source_guards.insert(name, guard);
+    }
+    AtomicFileStore::new(path).write_bytes_without_backup(&serde_json::to_vec_pretty(&ledger)?)?;
+    #[cfg(test)]
+    run_legacy_root_guard_after_write_test_hook(data_dir);
+    // A compatibility writer can rotate root/backups while the family is
+    // sampled. Revalidate the fully written ledger so a mixed generation is
+    // never reported complete; the watcher will requeue the newer family.
+    crate::section_facade::section_layout_is_active(data_dir)
+}
+
+#[cfg(test)]
+type LegacyRootGuardTestHook = Box<dyn FnOnce(&Path) + Send + 'static>;
+
+#[cfg(test)]
+fn legacy_root_guard_after_write_test_hooks(
+) -> &'static std::sync::Mutex<std::collections::HashMap<PathBuf, LegacyRootGuardTestHook>> {
+    static HOOKS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<PathBuf, LegacyRootGuardTestHook>>,
+    > = std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+pub(crate) fn set_legacy_root_guard_after_write_test_hook(
+    data_dir: &Path,
+    hook: impl FnOnce(&Path) + Send + 'static,
+) {
+    legacy_root_guard_after_write_test_hooks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(data_dir.to_path_buf(), Box::new(hook));
+}
+
+#[cfg(test)]
+fn run_legacy_root_guard_after_write_test_hook(data_dir: &Path) {
+    if let Some(hook) = legacy_root_guard_after_write_test_hooks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(data_dir)
+    {
+        hook(data_dir);
+    }
 }
 
 fn capture_durable_section_split_credentials(

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -19,14 +19,14 @@ use uuid::Uuid;
 use crate::config_crypto::{access_device_credential_ref, access_password_credential_ref};
 use crate::credential_store::{CredentialDocumentLkg, CredentialMutation};
 use crate::{
-    AccessControlConfig, AnthropicModelMapping, AtomicJsonStore, BrokerClientConfig,
-    ClusterFabricConfig, Config, ConfigSectionEvent, ConfigStoreResult, ConfigValues,
-    ConnectConfig, CredentialRef, CredentialSource, CredentialStatus, CredentialStore,
-    CredentialStoreHealth, DefaultWorkAreaConfig, DefaultsConfig, EnvVarEntry, FeatureFlags,
-    GeminiModelMapping, HooksConfig, KeywordMaskingConfig, LifecycleHooksConfig, LiveSection,
-    MemoryConfig, NotificationsConfig, PluginTrustConfig, ProviderConfigs, ProviderInstanceConfig,
-    RunBudgetConfig, SectionEnvelope, SectionSourceKind, SectionStatus, ServerConfig, SkillsConfig,
-    StreamTimeoutConfig, SubagentsConfig, ToolsConfig,
+    AccessControlConfig, AnthropicModelMapping, AtomicFileStore, AtomicJsonStore,
+    BrokerClientConfig, ClusterFabricConfig, Config, ConfigSectionEvent, ConfigStoreResult,
+    ConfigValues, ConnectConfig, CredentialRef, CredentialSource, CredentialStatus,
+    CredentialStore, CredentialStoreHealth, DefaultWorkAreaConfig, DefaultsConfig, EnvVarEntry,
+    FeatureFlags, GeminiModelMapping, HooksConfig, KeywordMaskingConfig, LifecycleHooksConfig,
+    LiveSection, MemoryConfig, NotificationsConfig, PluginTrustConfig, ProviderConfigs,
+    ProviderInstanceConfig, RunBudgetConfig, SectionEnvelope, SectionSourceKind, SectionStatus,
+    ServerConfig, SkillsConfig, StreamTimeoutConfig, SubagentsConfig, ToolsConfig,
 };
 
 pub(crate) const SECTION_SCHEMA_VERSION: u32 = 1;
@@ -775,7 +775,8 @@ where
     let planning_bytes = overrides
         .and_then(|overrides| overrides.get(name))
         .cloned()
-        .unwrap_or_else(|| original.clone());
+        .unwrap_or_else(|| Some(original.clone()))
+        .unwrap_or_default();
     let (existing_revision, existing_data) = compatible_section_data(&planning_bytes)?;
     let existing_envelope = serde_json::from_slice::<Value>(&planning_bytes)
         .ok()
@@ -824,7 +825,7 @@ where
             )
         })?
     };
-    validate_ordinary_section_json(&merged_data)?;
+    validate_ordinary_section_json_for_file(name, &merged_data)?;
     let typed: T = serde_json::from_value(merged_data.clone())?;
     validate(&typed).map_err(crate::ConfigStoreError::Validation)?;
     let candidate = serde_json::to_vec_pretty(&SectionDocument {
@@ -957,27 +958,32 @@ fn deep_merge_typed_over_raw(base: &mut Value, overlay: Value) {
 }
 
 fn validate_ordinary_section_json(value: &Value) -> ConfigStoreResult<()> {
-    fn walk(value: &Value, classify_object_keys: bool) -> Result<(), String> {
+    fn walk(
+        value: &Value,
+        classify_object_keys: bool,
+        credential_context: CredentialScanContext,
+    ) -> Result<(), String> {
+        if credential_context != CredentialScanContext::None
+            && is_nonliteral_runtime_template(value)
+        {
+            return Ok(());
+        }
         match value {
             Value::Object(object) => {
                 for (key, value) in object {
-                    let normalized_key = key
-                        .chars()
-                        .filter(|ch| ch.is_ascii_alphanumeric())
-                        .flat_map(char::to_lowercase)
-                        .collect::<String>();
-                    let forbidden_key = classify_object_keys
-                        && (key.to_ascii_lowercase().ends_with("_encrypted")
-                            || normalized_key.ends_with("encrypted")
-                            || normalized_key.ends_with("token")
-                            || normalized_key.ends_with("password")
-                            || normalized_key.ends_with("secret")
-                            || matches!(
-                                normalized_key.as_str(),
-                                "apikey" | "proxyauth" | "privatekey" | "passphrase" | "devicekey"
-                            ));
-                    let boolean_secret_metadata = normalized_key == "secret" && value.is_boolean();
-                    if forbidden_key && !boolean_secret_metadata && !value_is_empty(value) {
+                    let normalized_key = normalized_credential_key(key);
+                    let reference_metadata = credential_reference_metadata_key(key);
+                    if classify_object_keys && key_contains_literal_credential_material(key, value)
+                    {
+                        return Err(format!(
+                            "ordinary section contains forbidden credential material in {key}"
+                        ));
+                    }
+                    if classify_object_keys
+                        && credential_context != CredentialScanContext::None
+                        && NORMALIZED_CREDENTIAL_PAYLOAD_SUFFIXES.contains(&normalized_key.as_str())
+                        && !value_is_empty(value)
+                    {
                         return Err(format!(
                             "ordinary section contains forbidden credential material in {key}"
                         ));
@@ -1031,6 +1037,30 @@ fn validate_ordinary_section_json(value: &Value) -> ConfigStoreResult<()> {
                             normalized_key.as_str(),
                             "headers" | "providerinstances" | "credentialrefs"
                         ) || normalized_key.ends_with("credentialrefs"));
+                    let key_credential_context = if value.is_object() || value.is_array() {
+                        credential_context_key(key)
+                    } else {
+                        credential_literal_key(key)
+                    };
+                    let key_metadata_context = (value.is_object() || value.is_array())
+                        && credential_metadata_container_key(key);
+                    let child_credential_context = if !classify_object_keys || reference_metadata {
+                        CredentialScanContext::None
+                    } else if credential_context == CredentialScanContext::Strong
+                        && credential_public_metadata_key(key)
+                    {
+                        CredentialScanContext::Adjacent
+                    } else if credential_context == CredentialScanContext::Strong
+                        || key_credential_context
+                    {
+                        CredentialScanContext::Strong
+                    } else if credential_context == CredentialScanContext::Adjacent
+                        || key_metadata_context
+                    {
+                        CredentialScanContext::Adjacent
+                    } else {
+                        CredentialScanContext::None
+                    };
                     if child_keys_are_identifiers {
                         if normalized_key == "headers" {
                             if let Some(headers) = value.as_object() {
@@ -1049,18 +1079,36 @@ fn validate_ordinary_section_json(value: &Value) -> ConfigStoreResult<()> {
                         match value {
                             Value::Object(entries) => {
                                 for entry in entries.values() {
-                                    walk(entry, true)?;
+                                    let entry_context = if reference_metadata {
+                                        if entry.is_object() || entry.is_array() {
+                                            CredentialScanContext::Adjacent
+                                        } else {
+                                            CredentialScanContext::None
+                                        }
+                                    } else {
+                                        child_credential_context
+                                    };
+                                    walk(entry, true, entry_context)?;
                                 }
                             }
                             Value::Array(entries) => {
                                 for entry in entries {
-                                    walk(entry, true)?;
+                                    let entry_context = if reference_metadata
+                                        && (entry.is_object() || entry.is_array())
+                                    {
+                                        CredentialScanContext::Adjacent
+                                    } else if reference_metadata {
+                                        CredentialScanContext::None
+                                    } else {
+                                        child_credential_context
+                                    };
+                                    walk(entry, true, entry_context)?;
                                 }
                             }
-                            _ => walk(value, true)?,
+                            _ => walk(value, true, child_credential_context)?,
                         }
                     } else {
-                        walk(value, true)?;
+                        walk(value, true, child_credential_context)?;
                     }
                 }
                 if classify_object_keys {
@@ -1069,12 +1117,23 @@ fn validate_ordinary_section_json(value: &Value) -> ConfigStoreResult<()> {
                     Ok(())
                 }
             }
-            Value::Array(values) => values.iter().try_for_each(|value| walk(value, true)),
+            Value::Array(values) => values
+                .iter()
+                .try_for_each(|value| walk(value, true, credential_context)),
+            Value::String(value)
+                if credential_context == CredentialScanContext::Strong
+                    && !value.trim().is_empty() =>
+            {
+                Err("ordinary section contains forbidden credential material".to_string())
+            }
+            Value::Number(_) if credential_context == CredentialScanContext::Strong => {
+                Err("ordinary section contains forbidden credential material".to_string())
+            }
             _ => Ok(()),
         }
     }
 
-    walk(value, true).map_err(crate::ConfigStoreError::Validation)?;
+    walk(value, true, CredentialScanContext::None).map_err(crate::ConfigStoreError::Validation)?;
     validate_provider_override_credentials(value).map_err(crate::ConfigStoreError::Validation)
 }
 
@@ -1082,11 +1141,344 @@ pub(crate) fn validate_ordinary_section_raw(value: &Value) -> Result<(), String>
     validate_ordinary_section_json(value).map_err(|error| error.to_string())
 }
 
+fn validate_ordinary_mcp_section_json(value: &Value) -> ConfigStoreResult<()> {
+    let Some(servers) = value.as_object() else {
+        return validate_ordinary_section_json(value);
+    };
+    for server in servers.values() {
+        validate_ordinary_section_json(server)?;
+    }
+    Ok(())
+}
+
+fn validate_ordinary_mcp_section_raw(value: &Value) -> Result<(), String> {
+    validate_ordinary_mcp_section_json(value).map_err(|error| error.to_string())
+}
+
+fn validate_ordinary_section_json_for_file(name: &str, value: &Value) -> ConfigStoreResult<()> {
+    if name == SectionId::Mcp.descriptor().file_name {
+        validate_ordinary_mcp_section_json(value)
+    } else {
+        validate_ordinary_section_json(value)
+    }
+}
+
 fn value_is_empty(value: &Value) -> bool {
     value.is_null()
         || value.as_str().is_some_and(|value| value.trim().is_empty())
         || value.as_object().is_some_and(serde_json::Map::is_empty)
         || value.as_array().is_some_and(Vec::is_empty)
+}
+
+fn normalized_credential_key(key: &str) -> String {
+    key.chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn credential_key_tokens(key: &str) -> Vec<String> {
+    let characters = key.chars().collect::<Vec<_>>();
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for (index, character) in characters.iter().copied().enumerate() {
+        if !character.is_ascii_alphanumeric() {
+            if !current.is_empty() {
+                tokens.push(current.to_ascii_lowercase());
+                current.clear();
+            }
+            continue;
+        }
+        let previous = index.checked_sub(1).and_then(|index| characters.get(index));
+        let next = characters.get(index + 1);
+        let camel_boundary = character.is_ascii_uppercase()
+            && !current.is_empty()
+            && (previous.is_some_and(|previous| previous.is_ascii_lowercase())
+                || (previous.is_some_and(|previous| previous.is_ascii_uppercase())
+                    && next.is_some_and(|next| next.is_ascii_lowercase())));
+        if camel_boundary {
+            tokens.push(current.to_ascii_lowercase());
+            current.clear();
+        }
+        current.push(character);
+    }
+    if !current.is_empty() {
+        tokens.push(current.to_ascii_lowercase());
+    }
+    tokens
+}
+
+fn credential_reference_metadata_key(key: &str) -> bool {
+    let normalized = normalized_credential_key(key);
+    normalized == "credentialref"
+        || normalized.ends_with("credentialref")
+        || normalized == "credentialrefs"
+        || normalized.ends_with("credentialrefs")
+}
+
+const SAFE_CREDENTIAL_METADATA_SUFFIXES: &[&str] = &[
+    "mode",
+    "env",
+    "environment",
+    "ref",
+    "refs",
+    "configured",
+    "enabled",
+    "disabled",
+    "type",
+    "kind",
+    "scheme",
+    "method",
+    "source",
+    "name",
+    "id",
+    "ids",
+    "state",
+    "status",
+    "server",
+    "servers",
+    "provider",
+    "url",
+    "uri",
+    "endpoint",
+    "path",
+    "file",
+    "domain",
+    "scope",
+    "scopes",
+    "format",
+    "algorithm",
+    "version",
+    "timeout",
+    "ttl",
+    "expiry",
+    "expiration",
+    "duration",
+    "interval",
+    "usage",
+    "store",
+    "storage",
+    "backend",
+    "network",
+    "callback",
+    "control",
+    "level",
+    "policy",
+    "strategy",
+    "flow",
+    "site",
+    "model",
+];
+
+const NORMALIZED_CREDENTIAL_PAYLOAD_SUFFIXES: &[&str] = &[
+    "value", "literal", "fallback", "header", "headers", "hash", "salt", "verifier", "payload",
+    "material", "data",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CredentialScanContext {
+    None,
+    /// A credential-adjacent metadata container. Public metadata such as
+    /// `name`, `url`, and `model` remains allowed, but credential payload keys
+    /// below the container are still fail-closed.
+    Adjacent,
+    /// A direct credential container whose non-empty primitive values are
+    /// themselves treated as credential material.
+    Strong,
+}
+
+fn credential_token_is_sensitive(token: &str) -> bool {
+    matches!(
+        token,
+        "auth"
+            | "authentication"
+            | "authorization"
+            | "oauth"
+            | "oauth2"
+            | "bearer"
+            | "credential"
+            | "credentials"
+            | "secret"
+            | "token"
+            | "password"
+            | "private"
+            | "access"
+            | "ciphertext"
+            | "encrypted"
+            | "cookie"
+            | "passphrase"
+    )
+}
+
+fn credential_key_compound_is_sensitive(tokens: &[String]) -> bool {
+    tokens.windows(2).any(|tokens| {
+        matches!(
+            (tokens[0].as_str(), tokens[1].as_str()),
+            ("api", "key")
+                | ("auth", "key")
+                | ("access", "key")
+                | ("private", "key")
+                | ("device", "key")
+                | ("secret", "key")
+                | ("signing", "key")
+                | ("encryption", "key")
+        )
+    })
+}
+
+fn credential_name_has_sensitive_tokens(tokens: &[String]) -> bool {
+    tokens
+        .iter()
+        .any(|token| credential_token_is_sensitive(token))
+        || credential_key_compound_is_sensitive(tokens)
+}
+
+fn credential_name_has_terminal_sensitive_tokens(tokens: &[String]) -> bool {
+    tokens
+        .last()
+        .is_some_and(|token| credential_token_is_sensitive(token))
+        || (tokens.len() >= 2 && credential_key_compound_is_sensitive(&tokens[tokens.len() - 2..]))
+}
+
+fn normalized_terminal_credential_name(normalized: &str) -> bool {
+    normalized.ends_with("auth")
+        || normalized.ends_with("authentication")
+        || normalized.ends_with("authorization")
+        || normalized.ends_with("oauth")
+        || normalized.ends_with("oauth2")
+        || normalized.ends_with("bearer")
+        || normalized.ends_with("credential")
+        || normalized.ends_with("credentials")
+        || normalized.ends_with("secret")
+        || normalized.ends_with("token")
+        || normalized.ends_with("password")
+        || normalized.ends_with("private")
+        || normalized.ends_with("access")
+        || normalized.ends_with("ciphertext")
+        || normalized.ends_with("encrypted")
+        || normalized.ends_with("cookie")
+        || normalized.ends_with("passphrase")
+        || normalized.ends_with("apikey")
+        || normalized.ends_with("accesskey")
+        || normalized.ends_with("authkey")
+        || normalized.ends_with("privatekey")
+        || normalized.ends_with("devicekey")
+        || normalized.ends_with("secretkey")
+        || normalized.ends_with("signingkey")
+        || normalized.ends_with("encryptionkey")
+        || normalized.ends_with("passwordhash")
+        || normalized.ends_with("passwordsalt")
+        || normalized.ends_with("tokenhash")
+        || normalized.ends_with("tokensalt")
+}
+
+fn normalized_credential_context_name(normalized: &str) -> bool {
+    if SAFE_CREDENTIAL_METADATA_SUFFIXES
+        .iter()
+        .any(|suffix| normalized.ends_with(suffix))
+    {
+        return false;
+    }
+    let mut candidate = normalized;
+    while let Some(stripped) = NORMALIZED_CREDENTIAL_PAYLOAD_SUFFIXES
+        .iter()
+        .find_map(|suffix| candidate.strip_suffix(suffix))
+    {
+        if stripped.is_empty() || stripped == candidate {
+            break;
+        }
+        candidate = stripped;
+    }
+    normalized_terminal_credential_name(candidate)
+}
+
+fn credential_metadata_container_key(key: &str) -> bool {
+    if credential_reference_metadata_key(key) {
+        return false;
+    }
+    let tokens = credential_key_tokens(key);
+    let tokenized_metadata = credential_name_has_sensitive_tokens(&tokens)
+        && tokens
+            .last()
+            .is_some_and(|suffix| SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&suffix.as_str()));
+    let normalized = normalized_credential_key(key);
+    let normalized_metadata = SAFE_CREDENTIAL_METADATA_SUFFIXES.iter().any(|suffix| {
+        normalized
+            .strip_suffix(suffix)
+            .is_some_and(|prefix| !prefix.is_empty() && normalized_terminal_credential_name(prefix))
+    });
+    tokenized_metadata || normalized_metadata
+}
+
+fn credential_public_metadata_key(key: &str) -> bool {
+    let normalized = normalized_credential_key(key);
+    SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&normalized.as_str())
+        || credential_key_tokens(key)
+            .last()
+            .is_some_and(|token| SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&token.as_str()))
+}
+
+fn credential_context_key(key: &str) -> bool {
+    if credential_reference_metadata_key(key) {
+        return false;
+    }
+    let tokens = credential_key_tokens(key);
+    let tokenized_context = credential_name_has_sensitive_tokens(&tokens)
+        && !tokens
+            .last()
+            .is_some_and(|suffix| SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&suffix.as_str()));
+    tokenized_context || normalized_credential_context_name(&normalized_credential_key(key))
+}
+
+fn credential_literal_key(key: &str) -> bool {
+    if credential_reference_metadata_key(key) {
+        return false;
+    }
+    let tokens = credential_key_tokens(key);
+    if tokens
+        .last()
+        .is_some_and(|suffix| SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&suffix.as_str()))
+    {
+        return false;
+    }
+    let tokenized_literal = credential_name_has_terminal_sensitive_tokens(&tokens)
+        || tokens.last().is_some_and(|suffix| {
+            NORMALIZED_CREDENTIAL_PAYLOAD_SUFFIXES.contains(&suffix.as_str())
+                && credential_name_has_sensitive_tokens(&tokens[..tokens.len().saturating_sub(1)])
+        });
+    tokenized_literal || normalized_credential_context_name(&normalized_credential_key(key))
+}
+
+fn key_contains_literal_credential_material(key: &str, value: &Value) -> bool {
+    let normalized = normalized_credential_key(key);
+    let credential_reference_metadata = credential_reference_metadata_key(key);
+    let contextual_literal =
+        (value.is_string() || value.is_number()) && credential_literal_key(key);
+    let credential_owned = key.to_ascii_lowercase().ends_with("_encrypted")
+        || normalized.ends_with("encrypted")
+        || normalized.ends_with("token")
+        || normalized.ends_with("password")
+        || normalized.ends_with("secret")
+        || matches!(
+            normalized.as_str(),
+            "apikey"
+                | "proxyauth"
+                | "passwordhash"
+                | "passwordsalt"
+                | "tokenhash"
+                | "tokensalt"
+                | "privatekey"
+                | "passphrase"
+                | "devicekey"
+        )
+        || contextual_literal;
+    let boolean_secret_metadata = normalized == "secret" && value.is_boolean();
+    let boolean_configured_metadata = normalized.ends_with("configured") && value.is_boolean();
+    credential_owned
+        && !credential_reference_metadata
+        && !boolean_secret_metadata
+        && !boolean_configured_metadata
+        && !value_is_empty(value)
 }
 
 fn validate_configured_reference_coherence(
@@ -2093,7 +2485,7 @@ pub(crate) fn validate_section_envelope(
 }
 
 fn validate_section_data(name: &str, data: &Value) -> ConfigStoreResult<()> {
-    validate_ordinary_section_json(data)?;
+    validate_ordinary_section_json_for_file(name, data)?;
 
     macro_rules! validate_typed {
         ($ty:ty, $validate:expr) => {{
@@ -2139,16 +2531,21 @@ fn read_optional_bytes(path: &Path) -> ConfigStoreResult<Vec<u8>> {
     }
 }
 
-fn file_hash(path: &Path) -> ConfigStoreResult<String> {
+pub(crate) fn source_state_hash(bytes: Option<&[u8]>) -> String {
     let mut digest = Sha256::new();
-    match read_existing_bytes(path)? {
+    match bytes {
         Some(bytes) => {
             digest.update([1]);
             digest.update(bytes);
         }
         None => digest.update([0]),
     }
-    Ok(hex::encode(digest.finalize()))
+    hex::encode(digest.finalize())
+}
+
+fn file_hash(path: &Path) -> ConfigStoreResult<String> {
+    let bytes = crate::credential_migration::read_section_attestation_target(path)?;
+    Ok(source_state_hash(bytes.as_deref()))
 }
 
 pub(crate) fn migration_source_hashes(data_dir: &Path) -> ConfigStoreResult<Vec<(String, String)>> {
@@ -2213,7 +2610,11 @@ struct StrictPlanningInput {
     authoritative_sidecars: BTreeSet<SectionId>,
 }
 
-type StrictSourceOverrides = BTreeMap<String, Vec<u8>>;
+/// A complete or partial view of strict planning sources. A present `None`
+/// records that the source was absent; only a missing map key falls back to
+/// disk. This distinction matters when recovery creates typed sidecars after
+/// an initial legacy-root snapshot was captured.
+type StrictSourceOverrides = BTreeMap<String, Option<Vec<u8>>>;
 
 fn read_existing_bytes(path: &Path) -> ConfigStoreResult<Option<Vec<u8>>> {
     match std::fs::read(path) {
@@ -2229,7 +2630,7 @@ fn read_planning_source(
     overrides: Option<&StrictSourceOverrides>,
 ) -> ConfigStoreResult<Option<Vec<u8>>> {
     if let Some(bytes) = overrides.and_then(|overrides| overrides.get(name)) {
-        return Ok(Some(bytes.clone()));
+        return Ok(bytes.clone());
     }
     read_existing_bytes(&data_dir.join(name))
 }
@@ -2307,10 +2708,6 @@ fn load_strict_root(
         ))
     })?;
     Ok((config, raw))
-}
-
-fn load_strict_sidecar_value(data_dir: &Path, name: &str) -> ConfigStoreResult<Option<Value>> {
-    load_strict_sidecar_value_from(data_dir, name, None)
 }
 
 fn load_strict_sidecar_value_from(
@@ -2600,6 +2997,7 @@ fn scrub_preflight_access_control_secrets(raw: &mut Value) -> ConfigStoreResult<
 fn preflight_legacy_root_sections(
     data_dir: &Path,
     input: &StrictPlanningInput,
+    overrides: Option<&StrictSourceOverrides>,
 ) -> ConfigStoreResult<()> {
     let sanitized_config = scrub_preflight_config_secrets(&input.config)?;
     let projection = SectionProjection::from_config(&sanitized_config, input.model_limits.clone())?;
@@ -2608,7 +3006,8 @@ fn preflight_legacy_root_sections(
     if let Some(providers) = sections.get(&SectionId::Providers) {
         validate_preflight_provider_secret_consistency(providers)?;
     }
-    if let Some(providers) = load_strict_sidecar_value(data_dir, "providers.json")? {
+    if let Some(providers) = load_strict_sidecar_value_from(data_dir, "providers.json", overrides)?
+    {
         validate_preflight_provider_secret_consistency(&providers)?;
     }
     let instance_native_providers = projection
@@ -2648,7 +3047,8 @@ fn preflight_legacy_root_sections(
             }
             None => typed_baseline,
         };
-        if let Some(mut existing) = load_strict_sidecar_value(data_dir, id.descriptor().file_name)?
+        if let Some(mut existing) =
+            load_strict_sidecar_value_from(data_dir, id.descriptor().file_name, overrides)?
         {
             if id == SectionId::Providers && instance_native_providers {
                 remove_instance_native_legacy_provider_fields(&mut existing);
@@ -3087,22 +3487,85 @@ fn run_facade_epoch_test_hook(data_dir: &Path) {
 /// Idempotently split the compatibility documents through the existing
 /// credential migration lock/journal/manifest. Security-sensitive preflights
 /// run after recovery-only handling and before any new migration may write.
+fn repair_completed_config_facade_layout(
+    data_dir: &Path,
+    recovered: bool,
+) -> ConfigStoreResult<crate::SectionMigrationOutcome> {
+    let broker_ready = preflight_broker_document(data_dir)?;
+    crate::credential_migration::with_migration_lock(data_dir, || {
+        let provider =
+            crate::credential_migration::migrate_active_provider_mcp_credentials_for_facade_locked(
+                data_dir,
+            )?;
+        let access =
+            crate::credential_migration::migrate_access_control_credentials_for_facade_locked(
+                data_dir,
+            )?;
+        let mut broker_resumed = false;
+        if broker_ready {
+            match crate::credential_migration::migrate_external_broker_credentials_locked(data_dir)
+            {
+                Ok(outcome) => {
+                    broker_resumed = outcome.resumed;
+                    sync_active_external_broker(data_dir)?;
+                }
+                Err(crate::ConfigStoreError::Json(_) | crate::ConfigStoreError::Validation(_)) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(crate::SectionMigrationOutcome {
+            activated: false,
+            resumed: recovered || provider.resumed || access.resumed || broker_resumed,
+        })
+    })
+}
+
 pub fn migrate_config_facade_layout(
     data_dir: impl AsRef<Path>,
 ) -> ConfigStoreResult<crate::SectionMigrationOutcome> {
     let data_dir = data_dir.as_ref();
     let mut recovered = false;
     for _ in 0..4 {
-        recovered |= crate::recover_pending_config_transaction(data_dir)?;
-        if section_layout_is_active(data_dir)?
-            && crate::credential_migration::access_control_requires_opaque_repair(data_dir)?
-        {
-            let access = crate::credential_migration::with_migration_lock(data_dir, || {
-                crate::credential_migration::migrate_access_control_credentials_for_facade_locked(
+        let recovery =
+            crate::credential_migration::recover_pending_config_transaction_for_facade(data_dir)?;
+        let recovered_now = recovery.recovered;
+        let pre_recovery_sources = recovery.initial_layout_sources;
+        recovered |= recovered_now;
+        let authority_boundary = modular_authority_boundary_present(data_dir)?;
+        let completed_marker = has_completed_section_layout_marker(data_dir)?;
+        if authority_boundary && !completed_marker {
+            return Err(crate::ConfigStoreError::Validation(
+                "modular configuration authority evidence is incomplete; legacy fallback is forbidden"
+                    .to_string(),
+            ));
+        }
+        if completed_marker {
+            if !section_layout_is_active(data_dir)?
+                && !completed_layout_allows_legacy_root_reconciliation(data_dir)?
+            {
+                return Err(crate::ConfigStoreError::Validation(
+                    "completed modular configuration evidence is inconsistent; repair is forbidden"
+                        .to_string(),
+                ));
+            }
+            // Validate the embedded outbox/health payload before any repair
+            // can mutate a typed authority. The completion transcript alone
+            // does not make a malformed mutable record writable.
+            let _ = read_legacy_reconciliation_record(data_dir)?;
+            if let Some(pre_recovery_sources) = pre_recovery_sources.as_ref() {
+                // A committed initial split wins before any later editor
+                // bytes are interpreted. Preserve the historical strict-root
+                // preflight result for this same recovery call. Any modular
+                // evidence present at entry is a one-way boundary, even when
+                // the marker itself is missing or damaged, so established
+                // layouts never reauthorize the compatibility root here.
+                let input = load_strict_planning_input_with_overrides(
                     data_dir,
-                )
-            })?;
-            recovered |= access.resumed;
+                    Some(pre_recovery_sources),
+                )?;
+                preflight_legacy_root_sections(data_dir, &input, Some(pre_recovery_sources))?;
+            }
+            return repair_completed_config_facade_layout(data_dir, recovered);
         }
         let source_before = preflight_source_hashes(data_dir)?;
         let preflight = (|| {
@@ -3110,7 +3573,7 @@ pub fn migrate_config_facade_layout(
             // Decode every planner input now so malformed roots or sidecars
             // fail byte-for-byte unchanged when no committed recovery exists.
             let input = load_strict_planning_input(data_dir)?;
-            preflight_legacy_root_sections(data_dir, &input)?;
+            preflight_legacy_root_sections(data_dir, &input, None)?;
             crate::credential_migration::preflight_provider_mcp_credential_migration(data_dir)?;
             crate::credential_migration::preflight_cluster_credential_migration(data_dir)?;
             Ok::<bool, crate::ConfigStoreError>(broker_ready)
@@ -3140,39 +3603,6 @@ pub fn migrate_config_facade_layout(
             if preflight_source_hashes(data_dir)? != source_after {
                 return Ok(None);
             }
-            if section_layout_is_active(data_dir)? {
-                let provider = crate::credential_migration::
-                    migrate_provider_mcp_credentials_for_facade_locked(data_dir)?;
-                let cluster =
-                    crate::credential_migration::migrate_cluster_credentials_locked(data_dir)?;
-                let access = crate::credential_migration::
-                    migrate_access_control_credentials_for_facade_locked(data_dir)?;
-                let mut broker_resumed = false;
-                if broker_ready {
-                    match crate::credential_migration::migrate_external_broker_credentials_locked(
-                        data_dir,
-                    ) {
-                        Ok(outcome) => {
-                            broker_resumed = outcome.resumed;
-                            sync_active_external_broker(data_dir)?;
-                        }
-                        Err(
-                            crate::ConfigStoreError::Json(_)
-                            | crate::ConfigStoreError::Validation(_),
-                        ) => {}
-                        Err(error) => return Err(error),
-                    }
-                }
-                return Ok(Some(crate::SectionMigrationOutcome {
-                    activated: false,
-                    resumed: recovered
-                        || provider.resumed
-                        || cluster.resumed
-                        || access.resumed
-                        || broker_resumed,
-                }));
-            }
-
             let source_snapshot =
                 crate::credential_migration::FacadeSourceSnapshot::capture(data_dir)?;
             let credential_plan = crate::credential_migration::plan_facade_compound_credentials(
@@ -3888,6 +4318,35 @@ impl CredentialSection {
         }
     }
 
+    /// Attach a process-local reconciliation failure to the credential
+    /// authority without changing its encrypted document, immutable LKG, or
+    /// repair permissions. A later watched reload of the same durable
+    /// revision clears this health overlay and emits `Recovered`.
+    pub fn mark_runtime_degraded(&self, message: impl Into<String>) -> ConfigSectionEvent {
+        let _operation = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let current = self.snapshot();
+        *self
+            .snapshot
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Arc::new(CredentialSectionSnapshot {
+                data: current.data.clone(),
+                revision: current.revision,
+                loaded_at: Utc::now(),
+                source_path: current.source_path.clone(),
+                source_kind: current.source_kind,
+                status: SectionStatus::Degraded,
+                last_error: Some(message.into()),
+            });
+        ConfigSectionEvent::Invalid {
+            section: SectionId::Credentials.descriptor().name.to_string(),
+            revision: current.revision,
+        }
+    }
+
     pub fn replace(
         &self,
         credential_ref: CredentialRef,
@@ -4184,7 +4643,19 @@ impl SectionRegistry {
                     validate_ordinary_section_raw,
                 )?)
             },
-            mcp: open!(Mcp, McpSection, validate_mcp),
+            mcp: {
+                let descriptor = SectionId::Mcp.descriptor();
+                Arc::new(LiveSection::open_with_raw_validator(
+                    descriptor.name,
+                    AtomicJsonStore::<McpSection>::new(
+                        data_dir.join(descriptor.file_name),
+                        SECTION_SCHEMA_VERSION,
+                    ),
+                    McpSection::default(),
+                    validate_mcp,
+                    validate_ordinary_mcp_section_raw,
+                )?)
+            },
             tools_skills: open!(ToolsSkills, ToolsSkillsSection, validate_tools_skills),
             memory: open!(Memory, MemorySection, validate_memory),
             subagents: open!(Subagents, SubagentsSection, validate_subagents),
@@ -4459,7 +4930,7 @@ impl SectionRegistry {
             SectionId::Hooks => Some(self.hooks.mark_runtime_degraded(message)),
             SectionId::ModelPolicy => Some(self.model_policy.mark_runtime_degraded(message)),
             SectionId::ModelLimits => Some(self.model_limits.mark_runtime_degraded(message)),
-            SectionId::Credentials => None,
+            SectionId::Credentials => Some(self.credentials.mark_runtime_degraded(message)),
         }
     }
 
@@ -4567,6 +5038,8 @@ pub(crate) fn load_durable_effective_section_snapshot_under_migration_lock(
 /// Effective compatibility facade assembled from immutable section snapshots.
 pub struct ConfigFacade {
     registry: Arc<SectionRegistry>,
+    data_dir: PathBuf,
+    startup_legacy_root: Mutex<Option<LegacyRootReconciliationOutcome>>,
 }
 
 impl ConfigFacade {
@@ -4601,13 +5074,121 @@ impl ConfigFacade {
             })?;
         Ok(Self {
             registry: Arc::new(registry),
+            data_dir: data_dir.to_path_buf(),
+            startup_legacy_root: Mutex::new(None),
         })
     }
 
     pub fn open_or_migrate(data_dir: impl AsRef<Path>) -> ConfigStoreResult<Self> {
-        migrate_config_facade_layout(data_dir.as_ref())?;
-        migrate_copilot_oauth_cache(data_dir.as_ref())?;
-        Self::open(data_dir)
+        let data_dir = data_dir.as_ref();
+        // Recovery-only pass first: a valid completed marker can coexist with
+        // a crash-window Pending manifest. Resolve that state before making
+        // the one-way initial-vs-completed authority classification.
+        for _ in 0..4 {
+            if !crate::recover_pending_config_transaction(data_dir)? {
+                break;
+            }
+        }
+        if modular_authority_boundary_present(data_dir)?
+            && !has_completed_section_layout_marker(data_dir)?
+        {
+            return Err(crate::ConfigStoreError::Validation(
+                "modular configuration authority evidence is incomplete; legacy fallback is forbidden"
+                    .to_string(),
+            ));
+        }
+        // A valid completion marker makes this call recovery/repair-only;
+        // `migrate_config_facade_layout` branches before reading any legacy
+        // root input. Without the marker it performs the one-time split.
+        migrate_config_facade_layout(data_dir)?;
+        // This migration can advance the credential section. Complete it
+        // before capturing the startup registry so the returned facade never
+        // owns a stale pre-migration credential snapshot.
+        migrate_copilot_oauth_cache(data_dir)?;
+        let completed_marker = has_completed_section_layout_marker(data_dir)?;
+        let completed = completed_layout_allows_legacy_root_reconciliation(data_dir)?;
+        let mut startup = None::<LegacyRootReconciliationOutcome>;
+        let active = section_layout_is_active(data_dir)?;
+        if completed_marker && !active && !completed {
+            return Err(crate::ConfigStoreError::Validation(
+                "completed modular configuration evidence is inconsistent; legacy fallback is forbidden"
+                    .to_string(),
+            ));
+        }
+        let startup_registry = if completed && !active {
+            let (registry, outcome) =
+                crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+                    let registry = SectionRegistry::open_configured(data_dir, true)?;
+                    let outcome =
+                        reconcile_reappeared_legacy_root_locked(data_dir, Some(&registry))?
+                            .ok_or_else(|| {
+                                crate::ConfigStoreError::Validation(
+                                    "completed modular configuration reconciliation is unavailable"
+                                        .to_string(),
+                                )
+                            })?;
+                    Ok((registry, outcome))
+                })?;
+            startup = Some(outcome);
+            Some(registry)
+        } else {
+            None
+        };
+        let facade = match startup_registry {
+            Some(registry) => Self {
+                registry: Arc::new(registry),
+                data_dir: data_dir.to_path_buf(),
+                startup_legacy_root: Mutex::new(None),
+            },
+            None => Self::open(data_dir)?,
+        };
+        let mut startup = match startup {
+            Some(startup) => Some(startup),
+            None => current_legacy_root_reconciliation_outcome(data_dir)?
+                .filter(|outcome| !outcome.committed.is_empty() || !outcome.rejected.is_empty()),
+        };
+        if let Some(outcome) = startup.as_mut() {
+            let stale = outcome
+                .committed
+                .iter()
+                .filter_map(|event| {
+                    let ConfigSectionEvent::Changed { section, revision } = event else {
+                        return None;
+                    };
+                    let id = SectionId::from_name(section)?;
+                    let envelope = facade.registry.envelope_value(id).ok()?;
+                    (envelope.revision != *revision
+                        || envelope.status != SectionStatus::Healthy
+                        || !legacy_root_publication_matches_durable(data_dir, event)
+                            .unwrap_or(false))
+                    .then(|| (id, event.clone()))
+                })
+                .collect::<Vec<_>>();
+            for (id, event) in stale {
+                if reject_stale_legacy_root_publication(data_dir, &event)? {
+                    outcome.committed.retain(|candidate| candidate != &event);
+                    outcome.rejected.push(LegacyRootSectionRejection {
+                        section: id,
+                        reason: LegacyRootRejectionReason::RevisionConflict,
+                    });
+                    outcome.guard_advanced = false;
+                }
+            }
+            outcome.rejected.sort_by_key(|rejection| rejection.section);
+            outcome.rejected.dedup_by_key(|rejection| rejection.section);
+            for rejection in &outcome.rejected {
+                facade
+                    .registry
+                    .mark_runtime_degraded(rejection.section, rejection.reason.diagnostic());
+            }
+        }
+        if let Some(outcome) = startup {
+            *facade
+                .startup_legacy_root
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(outcome);
+        }
+        Ok(facade)
     }
 
     pub fn registry(&self) -> &Arc<SectionRegistry> {
@@ -4616,6 +5197,32 @@ impl ConfigFacade {
 
     pub fn effective_config(&self) -> Config {
         self.registry.projection().into_config()
+    }
+
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    /// Consume the boot-time reconciliation handoff. The server publishes
+    /// these section outcomes only after the corresponding initial runtimes
+    /// have been installed.
+    pub fn take_startup_legacy_root_reconciliation(
+        &self,
+    ) -> Option<LegacyRootReconciliationOutcome> {
+        self.startup_legacy_root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    }
+
+    /// Reconcile a compatibility-root generation through this process's live
+    /// section registry. Successful CAS writes therefore install the exact
+    /// committed snapshot before the server builds and publishes its runtime;
+    /// a later external typed revision remains queued for the normal watcher.
+    pub fn reconcile_reappeared_legacy_root(
+        &self,
+    ) -> ConfigStoreResult<Option<LegacyRootReconciliationOutcome>> {
+        reconcile_reappeared_legacy_root_with_registry(&self.data_dir, Some(&self.registry))
     }
 
     /// Publish the exact cluster-fabric snapshot installed by the credential
@@ -5419,7 +6026,6 @@ fn capture_layout_member_states(
 fn layout_not_committed() -> crate::ConfigStoreError {
     crate::ConfigStoreError::Validation("modular configuration layout is not committed".to_string())
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -8012,6 +8618,100 @@ mod tests {
     }
 
     #[test]
+    fn locked_pending_split_rechecks_root_changed_after_snapshot() {
+        use crate::credential_migration::{
+            install_section_split_migration_with_fault,
+            set_facade_recovery_after_snapshot_test_hook, SectionSplitTestFault,
+        };
+
+        let _key = crate::encryption::set_test_encryption_key([74; 32]);
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({"server": {"port": 21_002}}),
+        );
+        let plan = plan_config_facade_layout(dir.path()).unwrap();
+        assert!(install_section_split_migration_with_fault(
+            dir.path(),
+            plan,
+            SectionSplitTestFault::Manifest,
+        )
+        .is_err());
+        let raced_root = br#"{
+            "server": {"port": 29995},
+            "connect": {"platforms": "invalid"}
+        }"#;
+        let raced_root_for_hook = raced_root.to_vec();
+        set_facade_recovery_after_snapshot_test_hook(dir.path(), move |data_dir| {
+            std::fs::write(data_dir.join("config.json"), raced_root_for_hook).unwrap();
+        });
+
+        assert!(migrate_config_facade_layout(dir.path()).is_err());
+        assert!(section_layout_is_active(dir.path()).unwrap());
+        assert_eq!(
+            std::fs::read(dir.path().join("config.json")).unwrap(),
+            raced_root
+        );
+        migrate_config_facade_layout(dir.path())
+            .expect("an established modular boundary must not reauthorize the raced root");
+        assert_eq!(
+            ConfigFacade::open(dir.path())
+                .unwrap()
+                .effective_config()
+                .server
+                .port,
+            21_002
+        );
+    }
+
+    #[test]
+    fn pending_split_with_modular_quorum_never_reopens_legacy_root() {
+        use crate::credential_migration::{
+            install_section_split_migration_with_fault, SectionSplitTestFault,
+        };
+
+        let _key = crate::encryption::set_test_encryption_key([73; 32]);
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({"server": {"port": 21_001}}),
+        );
+        let plan = plan_config_facade_layout(dir.path()).unwrap();
+        assert!(install_section_split_migration_with_fault(
+            dir.path(),
+            plan,
+            SectionSplitTestFault::LayoutMarker,
+        )
+        .is_err());
+
+        std::fs::remove_file(dir.path().join(SECTION_LAYOUT_FILE)).unwrap();
+        assert!(modular_authority_boundary_present(dir.path()).unwrap());
+        assert!(!has_completed_section_layout_marker(dir.path()).unwrap());
+        let hostile_root = br#"{
+            "server": {"port": 29994},
+            "connect": {"platforms": "invalid"},
+            "oauth_client_secret_value": "must-never-be-read"
+        }"#;
+        std::fs::write(dir.path().join("config.json"), hostile_root).unwrap();
+
+        let recovered = migrate_config_facade_layout(dir.path()).unwrap();
+        assert!(recovered.resumed);
+        assert!(has_completed_section_layout_marker(dir.path()).unwrap());
+        assert_eq!(
+            std::fs::read(dir.path().join("config.json")).unwrap(),
+            hostile_root
+        );
+        assert_eq!(
+            ConfigFacade::open(dir.path())
+                .unwrap()
+                .effective_config()
+                .server
+                .port,
+            21_001
+        );
+    }
+
+    #[test]
     fn connect_secret_preflight_is_zero_write_even_with_other_legacy_secrets() {
         let _key = crate::encryption::set_test_encryption_key([81; 32]);
         let dir = TempDir::new().unwrap();
@@ -10220,4 +10920,3611 @@ mod tests {
         assert_eq!(durable.registry().core.snapshot().revision, core_before);
         assert_ne!(durable.effective_config().server.port, 22_223);
     }
+
+    #[test]
+    fn reappeared_root_reconciles_independent_sections_preserves_bytes_and_deduplicates() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let root = br#"{
+  "server": { "port": 23456 },
+  "memory": { "background_model": "legacy-memory-model" },
+  "future_owner": { "opaque": "must-stay-only-in-root" }
+}
+"#;
+        std::fs::write(dir.path().join("config.json"), root).unwrap();
+        assert!(!section_layout_is_active(dir.path()).unwrap());
+
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .expect("completed layout uses the reconciliation path");
+        assert!(outcome.guard_advanced);
+        assert!(!outcome.duplicate);
+        assert!(outcome.rejected.is_empty());
+        assert_eq!(
+            outcome
+                .committed
+                .iter()
+                .map(|event| match event {
+                    ConfigSectionEvent::Changed { section, .. } => section.as_str(),
+                    _ => panic!("successful reconciliation emits changed events"),
+                })
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from(["core", "memory"])
+        );
+        assert_eq!(std::fs::read(dir.path().join("config.json")).unwrap(), root);
+        assert!(section_layout_is_active(dir.path()).unwrap());
+
+        let reopened = ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(reopened.effective_config().server.port, 23_456);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .memory()
+                .as_ref()
+                .and_then(|memory| memory.background_model.as_deref()),
+            Some("legacy-memory-model")
+        );
+        assert!(!reopened
+            .effective_config()
+            .extra
+            .contains_key("future_owner"));
+        let status =
+            std::fs::read_to_string(dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE)).unwrap();
+        assert!(!status.contains("must-stay-only-in-root"));
+        assert!(!status.contains("future_owner"));
+
+        for event in &outcome.committed {
+            assert!(acknowledge_legacy_root_publication(dir.path(), event).unwrap());
+        }
+
+        let duplicate = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .expect("the guarded root remains a recognized generation");
+        assert!(duplicate.duplicate);
+        assert!(duplicate.committed.is_empty());
+        assert!(duplicate.rejected.is_empty());
+        assert_eq!(
+            ConfigFacade::open(dir.path())
+                .unwrap()
+                .registry()
+                .core
+                .snapshot()
+                .revision,
+            1
+        );
+    }
+
+    #[test]
+    fn reappeared_root_allows_safe_core_provider_and_mcp_drift() {
+        let core_dir = TempDir::new().unwrap();
+        let core_facade = ConfigFacade::open_or_migrate(core_dir.path()).unwrap();
+        let core_snapshot = core_facade.registry().core.snapshot();
+        let mut core = core_snapshot.data.as_ref().clone();
+        core.proxy_auth_credential_ref =
+            Some(crate::CredentialRef::parse("proxy.safe.auth").unwrap());
+        core.server
+            .extra
+            .insert("vendor_api_key_configured".to_string(), json!(true));
+        core.server.extra.insert(
+            "vendor_api_key_credential_ref".to_string(),
+            json!("vendor.safe.api_key"),
+        );
+        core_facade
+            .registry()
+            .core
+            .commit(core_snapshot.revision, core)
+            .unwrap();
+        std::fs::write(
+            core_dir.path().join("config.json"),
+            br#"{"proxy_auth_credential_ref":"proxy.safe.auth","server":{"port":23458,"vendor_api_key_configured":true,"vendor_api_key_credential_ref":"vendor.safe.api_key"}}"#,
+        )
+        .unwrap();
+
+        let core_outcome = reconcile_reappeared_legacy_root(core_dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            core_outcome.committed,
+            vec![ConfigSectionEvent::Changed {
+                section: "core".to_string(),
+                revision: 2,
+            }]
+        );
+        let core_restarted = ConfigFacade::open(core_dir.path()).unwrap();
+        assert_eq!(core_restarted.effective_config().server.port, 23_458);
+        assert_eq!(
+            core_restarted.effective_config().proxy_auth_credential_ref,
+            Some(crate::CredentialRef::parse("proxy.safe.auth").unwrap())
+        );
+
+        let section_dir = TempDir::new().unwrap();
+        let section_facade = ConfigFacade::open_or_migrate(section_dir.path()).unwrap();
+        let providers = section_facade
+            .registry()
+            .envelope_value(SectionId::Providers)
+            .unwrap();
+        let mut provider_data = providers.data;
+        provider_data["provider"] = json!("openai");
+        provider_data["provider_instances"]["token"] = json!({
+            "provider_type": "openai",
+            "model": "gpt-authoritative",
+            "credential_ref": "provider.token.api_key"
+        });
+        section_facade
+            .registry()
+            .providers
+            .commit(
+                providers.revision,
+                serde_json::from_value(provider_data).unwrap(),
+            )
+            .unwrap();
+        let mcp = section_facade
+            .registry()
+            .envelope_value(SectionId::Mcp)
+            .unwrap();
+        section_facade
+            .registry()
+            .mcp
+            .commit(
+                mcp.revision,
+                serde_json::from_value(json!({
+                    "TOKEN": {
+                        "command": "unused-safe-command",
+                        "disabled": true,
+                        "env_credential_refs": {"TOKEN": "mcp.TOKEN.env_TOKEN"}
+                    }
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        std::fs::write(
+            section_dir.path().join("config.json"),
+            serde_json::to_vec(&json!({
+                "provider": "openai",
+                "provider_instances": {
+                    "token": {
+                        "provider_type": "openai",
+                        "model": "gpt-safe-drift",
+                        "credential_ref": "provider.token.api_key"
+                    }
+                },
+                "mcpServers": {
+                    "TOKEN": {
+                        "command": "unused-safe-command",
+                        "args": ["--safe-drift"],
+                        "env_credential_refs": {"TOKEN": "mcp.TOKEN.env_TOKEN"},
+                        "disabled": true
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let outcome = reconcile_reappeared_legacy_root(section_dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            outcome
+                .committed
+                .iter()
+                .map(|event| match event {
+                    ConfigSectionEvent::Changed { section, .. } => section.as_str(),
+                    _ => panic!("safe reconciliation emits changed events"),
+                })
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from(["mcp", "providers"])
+        );
+        let restarted = ConfigFacade::open(section_dir.path()).unwrap();
+        assert_eq!(
+            restarted
+                .effective_config()
+                .provider_instances
+                .get("token")
+                .and_then(|provider| provider.model.as_deref()),
+            Some("gpt-safe-drift")
+        );
+        let mcp = restarted.registry().envelope_value(SectionId::Mcp).unwrap();
+        assert_eq!(mcp.data["TOKEN"]["args"], json!(["--safe-drift"]));
+        assert_eq!(
+            mcp.data["TOKEN"]["env_credential_refs"]["TOKEN"],
+            "mcp.TOKEN.env_TOKEN"
+        );
+    }
+
+    #[test]
+    fn reappeared_root_allows_exact_model_policy_mask_pattern() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let root = serde_json::to_vec(&json!({
+            "keyword_masking": {
+                "entries": [{"pattern": "***", "match_type": "exact"}]
+            }
+        }))
+        .unwrap();
+        std::fs::write(dir.path().join("config.json"), &root).unwrap();
+
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+
+        assert!(outcome.rejected.is_empty());
+        assert_eq!(
+            outcome.committed,
+            vec![ConfigSectionEvent::Changed {
+                section: "model-policy".to_string(),
+                revision: 1,
+            }]
+        );
+        assert_eq!(std::fs::read(dir.path().join("config.json")).unwrap(), root);
+        let policy = ConfigFacade::open(dir.path())
+            .unwrap()
+            .registry()
+            .envelope_value(SectionId::ModelPolicy)
+            .unwrap();
+        assert_eq!(
+            policy.data["keyword_masking"]["entries"][0]["pattern"],
+            "***"
+        );
+    }
+
+    #[test]
+    fn runtime_degraded_root_publication_is_carried_until_a_clean_distinct_replacement_commits() {
+        #[derive(Clone, Copy)]
+        enum Replacement {
+            Omitted,
+            Same,
+            Invalid,
+            Distinct,
+        }
+
+        for replacement in [
+            Replacement::Omitted,
+            Replacement::Same,
+            Replacement::Invalid,
+            Replacement::Distinct,
+        ] {
+            let dir = TempDir::new().unwrap();
+            ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let first_mcp = json!({
+                "root-first": {
+                    "command": "unused-first-command",
+                    "disabled": true
+                }
+            });
+            std::fs::write(
+                dir.path().join("config.json"),
+                serde_json::to_vec(&json!({"mcpServers": first_mcp})).unwrap(),
+            )
+            .unwrap();
+            let first = reconcile_reappeared_legacy_root(dir.path())
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                first.committed,
+                vec![ConfigSectionEvent::Changed {
+                    section: "mcp".to_string(),
+                    revision: 1,
+                }]
+            );
+            let invalid = ConfigSectionEvent::Invalid {
+                section: "mcp".to_string(),
+                revision: 1,
+            };
+            assert!(mark_legacy_root_publication_runtime_degraded(dir.path(), &invalid).unwrap());
+
+            let next_root = match replacement {
+                Replacement::Omitted => json!({"server": {"port": 24501}}),
+                Replacement::Same => json!({
+                    "server": {"port": 24502},
+                    "mcpServers": first_mcp
+                }),
+                Replacement::Invalid => json!({
+                    "server": {"port": 24503},
+                    "mcpServers": {
+                        "root-next": {
+                            "command": "unused-next-command",
+                            "disabled": true,
+                            "access_token_value": "must-not-cross"
+                        }
+                    }
+                }),
+                Replacement::Distinct => json!({
+                    "server": {"port": 24504},
+                    "mcpServers": {
+                        "root-next": {
+                            "command": "unused-next-command",
+                            "disabled": true
+                        }
+                    }
+                }),
+            };
+            std::fs::write(
+                dir.path().join("config.json"),
+                serde_json::to_vec(&next_root).unwrap(),
+            )
+            .unwrap();
+            let outcome = reconcile_reappeared_legacy_root(dir.path())
+                .unwrap()
+                .unwrap();
+            let mcp = ConfigFacade::open(dir.path())
+                .unwrap()
+                .registry()
+                .envelope_value(SectionId::Mcp)
+                .unwrap();
+
+            match replacement {
+                Replacement::Distinct => {
+                    assert_eq!(mcp.revision, 2);
+                    assert!(outcome.committed.contains(&ConfigSectionEvent::Changed {
+                        section: "mcp".to_string(),
+                        revision: 2,
+                    }));
+                    assert!(!acknowledge_legacy_root_publication(
+                        dir.path(),
+                        &ConfigSectionEvent::Recovered {
+                            section: "mcp".to_string(),
+                            revision: 2,
+                        },
+                    )
+                    .unwrap());
+                }
+                Replacement::Invalid => {
+                    assert_eq!(mcp.revision, 1);
+                    assert!(outcome.committed.iter().all(|event| !matches!(
+                        event,
+                        ConfigSectionEvent::Changed { section, revision }
+                            if section == "mcp" && *revision == 2
+                    )));
+                    assert!(outcome
+                        .rejected
+                        .iter()
+                        .any(|rejection| rejection.section == SectionId::Mcp));
+                    assert!(outcome.committed.iter().any(|event| matches!(
+                        event,
+                        ConfigSectionEvent::Changed { section, revision }
+                            if section == "core" && *revision == 1
+                    )));
+                    assert!(!acknowledge_legacy_root_publication(
+                        dir.path(),
+                        &ConfigSectionEvent::Recovered {
+                            section: "mcp".to_string(),
+                            revision: 1,
+                        },
+                    )
+                    .unwrap());
+                    assert!(has_pending_legacy_root_publications(dir.path()).unwrap());
+                    assert!(acknowledge_legacy_root_publication(
+                        dir.path(),
+                        &ConfigSectionEvent::Changed {
+                            section: "core".to_string(),
+                            revision: 1,
+                        },
+                    )
+                    .unwrap());
+
+                    std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
+                    let clean = reconcile_reappeared_legacy_root(dir.path())
+                        .unwrap()
+                        .unwrap();
+                    let recovered = ConfigSectionEvent::Recovered {
+                        section: "mcp".to_string(),
+                        revision: 1,
+                    };
+                    assert!(
+                        clean.committed.contains(&recovered),
+                        "clean committed: {:?}; rejected: {:?}",
+                        clean.committed,
+                        clean.rejected
+                    );
+                    assert!(clean.rejected.is_empty());
+                    assert!(acknowledge_legacy_root_publication(dir.path(), &recovered).unwrap());
+                }
+                Replacement::Omitted | Replacement::Same => {
+                    assert_eq!(mcp.revision, 1);
+                    assert!(outcome.committed.contains(&ConfigSectionEvent::Recovered {
+                        section: "mcp".to_string(),
+                        revision: 1,
+                    }));
+                    assert!(outcome.committed.iter().any(|event| matches!(
+                        event,
+                        ConfigSectionEvent::Changed { section, revision }
+                            if section == "core" && *revision == 1
+                    )));
+                    assert!(!acknowledge_legacy_root_publication(
+                        dir.path(),
+                        &ConfigSectionEvent::Changed {
+                            section: "mcp".to_string(),
+                            revision: 1,
+                        },
+                    )
+                    .unwrap());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn provider_credential_context_rejects_generic_payload_but_allows_model_sibling() {
+        for field in ["value", "fallback"] {
+            let dir = TempDir::new().unwrap();
+            let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let envelope = facade
+                .registry()
+                .envelope_value(SectionId::Providers)
+                .unwrap();
+            let mut providers = envelope.data;
+            providers["openai"] = json!({
+                "credential_ref": "provider.openai.api_key",
+                "model": "gpt-authoritative"
+            });
+            facade
+                .registry()
+                .providers
+                .commit(
+                    envelope.revision,
+                    serde_json::from_value(providers).unwrap(),
+                )
+                .unwrap();
+            let secret = format!("plain-{field}-secret");
+            std::fs::write(
+                dir.path().join("config.json"),
+                serde_json::to_vec(&json!({"providers": {"openai": {field: secret}}})).unwrap(),
+            )
+            .unwrap();
+
+            let outcome = reconcile_reappeared_legacy_root(dir.path())
+                .unwrap()
+                .unwrap();
+
+            assert!(outcome.committed.is_empty());
+            assert_eq!(
+                outcome.rejected,
+                vec![LegacyRootSectionRejection {
+                    section: SectionId::Providers,
+                    reason: LegacyRootRejectionReason::CredentialMaterial,
+                }]
+            );
+            let typed = std::fs::read_to_string(dir.path().join("providers.json")).unwrap();
+            let diagnostic =
+                std::fs::read_to_string(dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE)).unwrap();
+            assert!(!typed.contains(&secret));
+            assert!(!diagnostic.contains(&secret));
+        }
+
+        let dir = TempDir::new().unwrap();
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let envelope = facade
+            .registry()
+            .envelope_value(SectionId::Providers)
+            .unwrap();
+        let mut providers = envelope.data;
+        providers["openai"] = json!({
+            "credential_ref": "provider.openai.api_key",
+            "model": "gpt-authoritative"
+        });
+        facade
+            .registry()
+            .providers
+            .commit(
+                envelope.revision,
+                serde_json::from_value(providers).unwrap(),
+            )
+            .unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec(&json!({
+                "providers": {"openai": {
+                    "credential_ref": "provider.openai.api_key",
+                    "model": "gpt-safe-sibling"
+                }}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(outcome.rejected.is_empty());
+        assert_eq!(outcome.committed.len(), 1);
+        assert_eq!(
+            ConfigFacade::open(dir.path())
+                .unwrap()
+                .effective_config()
+                .providers()
+                .openai
+                .as_ref()
+                .and_then(|provider| provider.model.as_deref()),
+            Some("gpt-safe-sibling")
+        );
+    }
+
+    #[test]
+    fn reappeared_root_rejects_cluster_credentials_masks_and_alias_ambiguity_per_owner() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let root = br#"{
+  "server": { "port": 23457 },
+  "cluster_fabric": { "health_interval_secs": 31 },
+  "providers": { "openai": { "model": "gpt-safe", "api_key": "plaintext" } },
+  "tools": { "disabled": ["****...****"] },
+  "mcp": {},
+  "mcpServers": {}
+}
+"#;
+        std::fs::write(dir.path().join("config.json"), root).unwrap();
+
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            outcome
+                .committed
+                .iter()
+                .map(|event| match event {
+                    ConfigSectionEvent::Changed { section, .. } => section.as_str(),
+                    _ => panic!("successful reconciliation emits changed events"),
+                })
+                .collect::<Vec<_>>(),
+            vec!["core"]
+        );
+        let rejected = outcome
+            .rejected
+            .iter()
+            .map(|rejection| (rejection.section, rejection.reason))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            rejected.get(&SectionId::ClusterFabric),
+            Some(&LegacyRootRejectionReason::DedicatedAuthority)
+        );
+        assert_eq!(
+            rejected.get(&SectionId::Providers),
+            Some(&LegacyRootRejectionReason::CredentialMaterial)
+        );
+        assert_eq!(
+            rejected.get(&SectionId::ToolsSkills),
+            Some(&LegacyRootRejectionReason::CredentialMaterial)
+        );
+        assert_eq!(
+            rejected.get(&SectionId::Mcp),
+            Some(&LegacyRootRejectionReason::AmbiguousAlias)
+        );
+        assert_eq!(std::fs::read(dir.path().join("config.json")).unwrap(), root);
+        assert!(section_layout_is_active(dir.path()).unwrap());
+        migrate_config_facade_layout(dir.path())
+            .expect("completed layout repair must not parse or adopt the rejected root");
+        assert_eq!(std::fs::read(dir.path().join("config.json")).unwrap(), root);
+        let reopened = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(reopened.effective_config().server.port, 23_457);
+        assert!(reopened.effective_config().cluster_fabric.is_empty());
+        assert!(reopened.effective_config().providers().openai.is_none());
+        for id in [
+            SectionId::ClusterFabric,
+            SectionId::Providers,
+            SectionId::ToolsSkills,
+            SectionId::Mcp,
+        ] {
+            let envelope = reopened.registry().envelope_value(id).unwrap();
+            assert_eq!(envelope.status, SectionStatus::Degraded, "{id:?}");
+            assert_eq!(envelope.revision, 0, "{id:?}");
+        }
+        assert!(reopened.registry().credentials.statuses().is_empty());
+        let ordinary = ["providers.json", "tools-skills.json", "mcp.json"]
+            .into_iter()
+            .map(|name| std::fs::read_to_string(dir.path().join(name)).unwrap())
+            .collect::<String>();
+        for forbidden in ["plaintext", "****", "credential_ref", "api_key"] {
+            assert!(!ordinary.contains(forbidden));
+        }
+        let status =
+            std::fs::read_to_string(dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE)).unwrap();
+        for forbidden in ["plaintext", "****", "gpt-safe"] {
+            assert!(!status.contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn reappeared_root_rejects_secret_shaped_known_and_unknown_fragments_without_leak() {
+        let cases = [
+            json!({"server": {"vendor_api_key": "sk-known"}}),
+            json!({"vendor_api_key": "sk-unknown"}),
+            json!({"server": {"vendor_private_key": "private-known"}}),
+            json!({"server": {"vendor_secret_key": "secret-key-known"}}),
+            json!({"server": {"vendor_password_hash": "hash-known"}}),
+            json!({"server": {"vendor_token_salt": "salt-known"}}),
+            json!({"server": {"authorization": "Bearer raw-auth"}}),
+            json!({"server": {"authorization_header": "Bearer auth-header-secret"}}),
+            json!({"server": {"cookie_header": "session=cookie-header-secret"}}),
+            json!({"server": {"vendorapikey": "lower-vendor-api-key-secret"}}),
+            json!({"server": {"apikeyvalue": "lower-api-key-value-secret"}}),
+            json!({"server": {"authorizationheader": "Bearer lower-auth-header-secret"}}),
+            json!({"server": {"signingkey": "lower-signing-key-secret"}}),
+            json!({"server": {"callback_url": "https://alice:plain-secret@example.test/hook"}}),
+            json!({"server": {"auth": {"value": "nested-auth-secret"}}}),
+            json!({"server": {"basic_auth": {"literal": "nested-basic-secret"}}}),
+            json!({"server": {"authentication": {"value": "nested-authentication-secret"}}}),
+            json!({"server": {"authentication": "direct-authentication-secret"}}),
+            json!({"server": {"auth": ["array-auth-secret"]}}),
+            json!({"server": {"extra": {"oauth_client_secret_value": "oauth-secret-value"}}}),
+            json!({"server": {"extra": {"access_token_value": "access-token-secret"}}}),
+            json!({"server": {"extra": {"client_password_value": "client-password-secret"}}}),
+            json!({"server": {"extra": {"ciphertext_value": "ciphertext-secret"}}}),
+            json!({"server": {"extra": {"encrypted_value": "encrypted-secret"}}}),
+            json!({"server": {"extra": {"foo_encrypted_value": "foo-encrypted-secret"}}}),
+            json!({"server": {"extra": {"private_value": "private-value-secret"}}}),
+            json!({"server": {"extra": {"access_value": "access-value-secret"}}}),
+            json!({"server": {"extra": {"privateValue": "camel-private-secret"}}}),
+            json!({"server": {"extra": {"accessValue": "camel-access-secret"}}}),
+            json!({"server": {"extra": {"tokenValue": "camel-token-secret"}}}),
+            json!({"server": {"extra": {"authValue": "camel-auth-secret"}}}),
+            json!({"server": {"extra": {"clientTokenValue": "camel-client-token-secret"}}}),
+            json!({"server": {"extra": {"oauth": {"value": "oauth-context-secret"}}}}),
+            json!({"server": {"extra": {"bearer": {"value": "bearer-context-secret"}}}}),
+            json!({"server": {"extra": {"auth_provider": {"value": "metadata-container-secret"}}}}),
+            json!({"server": {"extra": {"credential_refs": {"work": {"value": "structured-ref-secret"}}}}}),
+        ];
+        for (index, root) in cases.into_iter().enumerate() {
+            let dir = TempDir::new().unwrap();
+            ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let root_bytes = serde_json::to_vec(&root).unwrap();
+            std::fs::write(dir.path().join("config.json"), &root_bytes).unwrap();
+
+            let outcome = reconcile_reappeared_legacy_root(dir.path())
+                .unwrap()
+                .unwrap();
+
+            assert!(outcome.committed.is_empty(), "case {index}");
+            assert_eq!(
+                outcome.rejected,
+                vec![LegacyRootSectionRejection {
+                    section: SectionId::Core,
+                    reason: LegacyRootRejectionReason::CredentialMaterial,
+                }],
+                "case {index}"
+            );
+            assert_eq!(
+                std::fs::read(dir.path().join("config.json")).unwrap(),
+                root_bytes
+            );
+            let core = std::fs::read_to_string(dir.path().join("core.json")).unwrap();
+            let status =
+                std::fs::read_to_string(dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE)).unwrap();
+            for secret in [
+                "sk-known",
+                "sk-unknown",
+                "private-known",
+                "secret-key-known",
+                "hash-known",
+                "salt-known",
+                "raw-auth",
+                "auth-header-secret",
+                "cookie-header-secret",
+                "lower-vendor-api-key-secret",
+                "lower-api-key-value-secret",
+                "lower-auth-header-secret",
+                "lower-signing-key-secret",
+                "plain-secret",
+                "nested-auth-secret",
+                "nested-basic-secret",
+                "nested-authentication-secret",
+                "direct-authentication-secret",
+                "array-auth-secret",
+                "oauth-secret-value",
+                "access-token-secret",
+                "client-password-secret",
+                "ciphertext-secret",
+                "encrypted-secret",
+                "foo-encrypted-secret",
+                "private-value-secret",
+                "access-value-secret",
+                "camel-private-secret",
+                "camel-access-secret",
+                "camel-token-secret",
+                "camel-auth-secret",
+                "camel-client-token-secret",
+                "oauth-context-secret",
+                "bearer-context-secret",
+                "metadata-container-secret",
+                "structured-ref-secret",
+                "vendor_api_key",
+                "vendor_private_key",
+                "authorization_header",
+                "cookie_header",
+                "vendorapikey",
+                "apikeyvalue",
+                "authorizationheader",
+                "signingkey",
+                "oauth_client_secret_value",
+                "access_token_value",
+                "client_password_value",
+                "ciphertext_value",
+                "encrypted_value",
+                "foo_encrypted_value",
+                "private_value",
+                "access_value",
+                "privateValue",
+                "accessValue",
+                "tokenValue",
+                "authValue",
+                "clientTokenValue",
+                "auth_provider",
+            ] {
+                assert!(!core.contains(secret), "case {index}: {secret}");
+                assert!(!status.contains(secret), "case {index}: {secret}");
+            }
+            let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let core = restarted.registry().core.snapshot();
+            assert_eq!(core.revision, 0, "case {index}");
+            assert_eq!(core.status, SectionStatus::Degraded, "case {index}");
+        }
+    }
+
+    #[test]
+    fn credential_key_tokenization_preserves_safe_metadata_and_words() {
+        let safe = json!({
+            "tokenizerValue": "sentence-piece",
+            "authoredValue": "documentation",
+            "credential-server": {"command": "node"},
+            "credentialserver": {"command": "node"},
+            "auth_provider": {
+                "name": "openai",
+                "url": "https://api.example.test",
+                "model": "gpt-safe",
+                "credential_refs": {"TOKEN": "provider.safe.api_key"}
+            },
+            "authprovider": {"name": "openai", "model": "gpt-safe"},
+            "auth": {
+                "method": "password",
+                "name": "public-auth-shape",
+                "client_id": "public-client",
+                "callbackUrl": "https://auth.example.test/callback"
+            },
+            "codex_auth_mode": "custom",
+            "codexauthmode": "custom",
+            "token_env": "WORKER_TOKEN",
+            "tokenenv": "WORKER_TOKEN",
+            "private_mode": "ephemeral",
+            "codex_network_access": true,
+            "authorization_url": "https://auth.example.test",
+            "oauth_client_id": "public-client-id",
+            "auth_method": "pkce",
+            "cookie_domain": "example.test",
+            "credential_ref": "provider.work.api_key",
+            "credential_refs": {
+                "string": "provider.work.api_key",
+                "structured": {"kind": "env_ref", "path": "WORKER_TOKEN", "name": "worker"}
+            },
+            "configured": true
+        });
+        assert!(!raw_reconciliation_secret_material_is_forbidden(&safe));
+        validate_ordinary_section_json(&safe).unwrap();
+
+        for suffix in SAFE_CREDENTIAL_METADATA_SUFFIXES {
+            let key = format!("auth_{suffix}");
+            assert!(!credential_context_key(&key), "safe metadata key {key}");
+            assert!(
+                credential_metadata_container_key(&key),
+                "credential-adjacent metadata container {key}"
+            );
+        }
+        for suffix in ["header", "headers", "value", "literal", "fallback"] {
+            let key = format!("authorization_{suffix}");
+            assert!(credential_context_key(&key), "credential payload key {key}");
+        }
+
+        for forbidden in [
+            json!({"tokenValue": "plain"}),
+            json!({"AuthValue": "plain"}),
+            json!({"client-token-value": "plain"}),
+            json!({"auth": "plain"}),
+            json!({"authentication": "plain"}),
+            json!({"private": "plain"}),
+            json!({"access": "plain"}),
+            json!({"ciphertext": "plain"}),
+            json!({"encrypted": "plain"}),
+            json!({"api_key_value": "plain"}),
+            json!({"apiKeyValue": "plain"}),
+            json!({"authorizationValue": "plain"}),
+            json!({"vendorapikey": "plain"}),
+            json!({"apikeyvalue": "plain"}),
+            json!({"authorizationheader": "plain"}),
+            json!({"signingkey": "plain"}),
+            json!({"cookieValue": "plain"}),
+            json!({"passphraseValue": "plain"}),
+            json!({"signingKeyValue": "plain"}),
+            json!({"encryptionKeyValue": "plain"}),
+            json!({"deviceKeyValue": "plain"}),
+            json!({"oauth": {"value": "plain"}}),
+            json!({"Bearer": {"fallback": "plain"}}),
+            json!({"auth_provider": {"value": "plain"}}),
+            json!({"authprovider": {"nested": {"fallback": "plain"}}}),
+            json!({"auth_provider": {"data": "plain"}}),
+            json!({"auth_provider": {"header": "plain"}}),
+            json!({"auth_provider": {"material": "plain"}}),
+            json!({"auth": {"unknown": "plain"}}),
+            json!({"auth": {"invalid": "plain"}}),
+            json!({"credential_refs": {"work": {"value": "plain"}}}),
+            json!({"credential_refs": {"work": {"material": "plain"}}}),
+        ] {
+            assert!(raw_reconciliation_secret_material_is_forbidden(&forbidden));
+            assert!(validate_ordinary_section_json(&forbidden).is_err());
+        }
+    }
+
+    #[test]
+    fn credential_header_templates_allow_only_runtime_materialization() {
+        for expression in [
+            json!({"type": "env_ref", "name": "WORKER_TOKEN"}),
+            json!({"type": "generated", "generator": "uuid"}),
+            json!({"type": "format", "template": "Bearer {env:WORKER_TOKEN}"}),
+        ] {
+            let safe = json!({"headers": {
+                "Authorization": expression,
+                "X-Token-Budget": "1000"
+            }});
+            assert!(!raw_reconciliation_secret_material_is_forbidden(&safe));
+            validate_ordinary_section_json(&safe).unwrap();
+        }
+
+        for expression in [
+            json!({"type": "literal", "value": "Bearer plain"}),
+            json!({"type": "env_ref", "name": "WORKER_TOKEN", "fallback": "plain"}),
+        ] {
+            let forbidden = json!({"headers": {"Authorization": expression}});
+            assert!(raw_reconciliation_secret_material_is_forbidden(&forbidden));
+            assert!(validate_ordinary_section_json(&forbidden).is_err());
+        }
+    }
+
+    #[test]
+    fn raw_reconciliation_respects_identifier_maps_and_model_policy_mask_patterns() {
+        let safe_cases = [
+            (
+                SectionId::Providers,
+                json!({
+                    "provider": "openai",
+                    "provider_instances": {
+                        "token": {
+                            "provider_type": "openai",
+                            "model": "gpt-safe",
+                            "credential_ref": "provider.token.api_key"
+                        }
+                    }
+                }),
+            ),
+            (
+                SectionId::Mcp,
+                json!({
+                    "TOKEN": {
+                        "command": "unused-safe-command",
+                        "disabled": true,
+                        "env_credential_refs": {"TOKEN": "mcp.TOKEN.env_TOKEN"}
+                    }
+                }),
+            ),
+            (
+                SectionId::ModelPolicy,
+                json!({
+                    "keyword_masking": {
+                        "entries": [{"pattern": "***", "match_type": "exact"}]
+                    }
+                }),
+            ),
+        ];
+
+        for (section, value) in safe_cases {
+            assert!(
+                !raw_reconciliation_secret_material_is_forbidden_for_section(section, &value),
+                "safe {section:?} identifiers or metadata were rejected"
+            );
+        }
+        assert!(raw_reconciliation_secret_material_is_forbidden(&json!({
+            "keyword_masking": {
+                "entries": [{"pattern": "***", "match_type": "exact"}]
+            }
+        })));
+    }
+
+    #[test]
+    fn reappeared_root_cannot_mutate_credential_bearing_server_extra_subtrees() {
+        for (authority, delta, secret) in [
+            (
+                json!({"secret": true}),
+                json!({"value": "plain-secret"}),
+                "plain-secret",
+            ),
+            (
+                json!({"credential_ref": "vendor.safe.ref", "configured": true}),
+                json!({"fallback": "literal-fallback"}),
+                "literal-fallback",
+            ),
+            (
+                json!({"credential_ref": "vendor.safe.ref", "configured": true}),
+                json!({"foo": {"value": "nested-adjacent-secret"}}),
+                "nested-adjacent-secret",
+            ),
+        ] {
+            let dir = TempDir::new().unwrap();
+            let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let mut core = facade
+                .registry()
+                .envelope_value(SectionId::Core)
+                .unwrap()
+                .data;
+            core["server"]["vendor"] = authority.clone();
+            facade
+                .registry()
+                .commit_value(SectionId::Core, 0, core)
+                .unwrap();
+            std::fs::write(
+                dir.path().join("config.json"),
+                serde_json::to_vec(&json!({"server": {"vendor": delta}})).unwrap(),
+            )
+            .unwrap();
+
+            let outcome = reconcile_reappeared_legacy_root(dir.path())
+                .unwrap()
+                .unwrap();
+
+            assert!(outcome.committed.is_empty());
+            assert_eq!(
+                outcome.rejected,
+                vec![LegacyRootSectionRejection {
+                    section: SectionId::Core,
+                    reason: LegacyRootRejectionReason::CredentialMaterial,
+                }]
+            );
+            let reopened = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let envelope = reopened.registry().envelope_value(SectionId::Core).unwrap();
+            assert_eq!(envelope.revision, 1);
+            assert_eq!(envelope.data["server"]["vendor"], authority);
+            assert!(!std::fs::read_to_string(dir.path().join("core.json"))
+                .unwrap()
+                .contains(secret));
+            assert!(
+                !std::fs::read_to_string(dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE))
+                    .unwrap()
+                    .contains(secret)
+            );
+        }
+    }
+
+    #[test]
+    fn reappeared_root_cannot_bypass_broker_or_subagent_credential_authority() {
+        for (field, value, reason) in [
+            (
+                "external_broker",
+                json!({"endpoint": "ws://attacker.test:9600"}),
+                LegacyRootRejectionReason::DedicatedAuthority,
+            ),
+            (
+                "broker",
+                json!({"endpoint": "ws://alias-attacker.test:9600"}),
+                LegacyRootRejectionReason::DedicatedAuthority,
+            ),
+            (
+                "codex_provider_key_ref",
+                json!("attacker.secret.ref"),
+                LegacyRootRejectionReason::CredentialMaterial,
+            ),
+        ] {
+            let dir = TempDir::new().unwrap();
+            ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let mut root = json!({"subagents": {}});
+            root["subagents"][field] = value;
+            std::fs::write(
+                dir.path().join("config.json"),
+                serde_json::to_vec(&root).unwrap(),
+            )
+            .unwrap();
+
+            let outcome = reconcile_reappeared_legacy_root(dir.path())
+                .unwrap()
+                .unwrap();
+
+            assert!(outcome.committed.is_empty());
+            assert_eq!(
+                outcome.rejected,
+                vec![LegacyRootSectionRejection {
+                    section: SectionId::Subagents,
+                    reason,
+                }]
+            );
+            let reopened = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let section = reopened.registry().subagents.snapshot();
+            assert_eq!(section.revision, 0);
+            assert_eq!(section.status, SectionStatus::Degraded);
+            assert!(reopened.effective_config().subagents().broker.is_none());
+            let typed = std::fs::read_to_string(dir.path().join("subagents.json")).unwrap();
+            let status =
+                std::fs::read_to_string(dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE)).unwrap();
+            for forbidden in ["attacker.test", "alias-attacker", "attacker.secret.ref"] {
+                assert!(!typed.contains(forbidden));
+                assert!(!status.contains(forbidden));
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_reappeared_root_is_acknowledged_without_wholesale_adoption() {
+        let dir = TempDir::new().unwrap();
+        let before = ConfigFacade::open_or_migrate(dir.path())
+            .unwrap()
+            .effective_config();
+        let root = b"{ invalid legacy root with token secret-value";
+        std::fs::write(dir.path().join("config.json"), root).unwrap();
+
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(outcome.committed.is_empty());
+        assert_eq!(
+            outcome.rejected,
+            vec![LegacyRootSectionRejection {
+                section: SectionId::Core,
+                reason: LegacyRootRejectionReason::InvalidDocument,
+            }]
+        );
+        assert!(outcome.guard_advanced);
+        assert!(section_layout_is_active(dir.path()).unwrap());
+        assert_eq!(std::fs::read(dir.path().join("config.json")).unwrap(), root);
+        migrate_config_facade_layout(dir.path())
+            .expect("completed repair must not strict-parse the rejected root");
+        let after = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(after.effective_config().server.port, before.server.port);
+        let core = after.registry().core.snapshot();
+        assert_eq!(core.status, SectionStatus::Degraded);
+        assert_eq!(core.revision, 0);
+        let mut typed = core.data.as_ref().clone();
+        typed.server.port = before.server.port.saturating_add(1);
+        assert_eq!(
+            after.registry().core.commit(core.revision, typed).unwrap(),
+            ConfigSectionEvent::Changed {
+                section: "core".to_string(),
+                revision: 1,
+            }
+        );
+        let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let restarted_core = restarted.registry().core.snapshot();
+        assert_eq!(restarted_core.revision, 1);
+        assert_eq!(restarted_core.status, SectionStatus::Degraded);
+
+        let next_root = br#"{"server":{"port":24572}}"#;
+        std::fs::write(dir.path().join("config.json"), next_root).unwrap();
+        assert!(!section_layout_is_active(dir.path()).unwrap());
+        let next = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            next.committed,
+            vec![ConfigSectionEvent::Changed {
+                section: "core".to_string(),
+                revision: 2,
+            }]
+        );
+        assert!(!next.recovered.contains(&SectionId::Core));
+        assert!(next.rejected.is_empty());
+        assert!(section_layout_is_active(dir.path()).unwrap());
+        let status =
+            std::fs::read_to_string(dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE)).unwrap();
+        assert!(!status.contains("secret-value"));
+        assert!(!status.contains("token"));
+    }
+
+    #[test]
+    fn root_intent_recovers_a_commit_before_status_update_without_revision_two() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":24567}}"#,
+        )
+        .unwrap();
+        set_legacy_root_after_commit_test_hook(dir.path(), |_| {
+            panic!("simulated process death after section CAS")
+        });
+
+        let crashed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = reconcile_reappeared_legacy_root(dir.path());
+        }));
+        assert!(crashed.is_err());
+        assert!(
+            ConfigFacade::open_stable(dir.path(), |_| {})
+                .err()
+                .is_some(),
+            "the unacknowledged root guard remains inactive"
+        );
+
+        let recovered = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            recovered.committed,
+            vec![ConfigSectionEvent::Changed {
+                section: "core".to_string(),
+                revision: 1,
+            }]
+        );
+        assert!(recovered.guard_advanced);
+        assert_eq!(
+            ConfigFacade::open(dir.path())
+                .unwrap()
+                .registry()
+                .core
+                .snapshot()
+                .revision,
+            1
+        );
+        assert!(acknowledge_legacy_root_publication(dir.path(), &recovered.committed[0]).unwrap());
+    }
+
+    #[test]
+    fn typed_memory_writer_wins_root_cas_without_lost_update() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"memory":{"background_model":"root-loser"}}"#,
+        )
+        .unwrap();
+        let memory_path = dir.path().join("memory.json");
+        set_legacy_root_before_commit_test_hook(dir.path(), move |id| {
+            assert_eq!(id, SectionId::Memory);
+            let winner = MemoryConfig {
+                background_model: Some("typed-winner".to_string()),
+                ..Default::default()
+            };
+            assert_eq!(
+                AtomicJsonStore::<MemorySection>::new(memory_path, SECTION_SCHEMA_VERSION)
+                    .commit(0, MemorySection(Some(winner)), |_| Ok(()))
+                    .unwrap(),
+                1
+            );
+        });
+
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(outcome.committed.is_empty());
+        assert_eq!(
+            outcome.rejected,
+            vec![LegacyRootSectionRejection {
+                section: SectionId::Memory,
+                reason: LegacyRootRejectionReason::RevisionConflict,
+            }]
+        );
+        let durable = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(durable.registry().memory.snapshot().revision, 1);
+        assert_eq!(
+            durable
+                .effective_config()
+                .memory()
+                .as_ref()
+                .and_then(|memory| memory.background_model.as_deref()),
+            Some("typed-winner")
+        );
+    }
+
+    #[test]
+    fn atomic_root_rotation_and_deletion_keep_completed_layout_identity() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let marker = std::fs::read(dir.path().join(SECTION_LAYOUT_FILE)).unwrap();
+        let transaction_id = validate_completed_section_layout_marker(&marker)
+            .unwrap()
+            .transaction_id;
+        let root_store = AtomicFileStore::new(dir.path().join("config.json"));
+
+        for value in [
+            json!({"future_generation": "A"}),
+            json!({"future_generation": "B"}),
+        ] {
+            root_store.write_json(&value).unwrap();
+            let outcome = reconcile_reappeared_legacy_root(dir.path())
+                .unwrap()
+                .unwrap();
+            assert!(outcome.guard_advanced);
+            assert!(outcome.committed.is_empty());
+            assert!(section_layout_is_active(dir.path()).unwrap());
+        }
+        assert!(dir.path().join("config.json.bak").exists());
+        std::fs::remove_file(dir.path().join("config.json")).unwrap();
+        let missing = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(missing.guard_advanced);
+        assert!(section_layout_is_active(dir.path()).unwrap());
+        let marker = std::fs::read(dir.path().join(SECTION_LAYOUT_FILE)).unwrap();
+        assert_eq!(
+            validate_completed_section_layout_marker(&marker)
+                .unwrap()
+                .transaction_id,
+            transaction_id
+        );
+    }
+
+    #[test]
+    fn full_safe_config_echo_only_commits_changed_core() {
+        let dir = TempDir::new().unwrap();
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let reference = CredentialRef::parse("env.API_TOKEN").unwrap();
+        facade
+            .registry()
+            .env
+            .commit(
+                0,
+                EnvSection(vec![EnvVarEntry {
+                    name: "API_TOKEN".to_string(),
+                    value: String::new(),
+                    secret: true,
+                    value_encrypted: None,
+                    credential_ref: Some(reference),
+                    configured: true,
+                    description: None,
+                }]),
+            )
+            .unwrap();
+        let env_revision = facade.registry().env.snapshot().revision;
+        let mut root = serde_json::to_value(facade.effective_config()).unwrap();
+        root["server"]["port"] = json!(24_568);
+        root["cluster_fabric"] = json!({});
+        AtomicFileStore::new(dir.path().join("config.json"))
+            .write_json(&root)
+            .unwrap();
+
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(outcome.rejected.is_empty(), "{:?}", outcome.rejected);
+        assert_eq!(
+            outcome.committed,
+            vec![ConfigSectionEvent::Changed {
+                section: "core".to_string(),
+                revision: 1,
+            }]
+        );
+        let reopened = ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(reopened.effective_config().server.port, 24_568);
+        assert_eq!(reopened.registry().env.snapshot().revision, env_revision);
+        assert!(reopened.effective_config().cluster_fabric.is_empty());
+    }
+
+    #[test]
+    fn startup_rejects_stale_pending_revision_instead_of_mixing_runtime() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":24569}}"#,
+        )
+        .unwrap();
+        let first = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.committed.len(), 1);
+
+        let current = ConfigFacade::open(dir.path()).unwrap();
+        let mut core: CoreSection = serde_json::from_value(
+            current
+                .registry()
+                .envelope_value(SectionId::Core)
+                .unwrap()
+                .data,
+        )
+        .unwrap();
+        core.server.port = 24_570;
+        assert_eq!(
+            AtomicJsonStore::<CoreSection>::new(
+                dir.path().join("core.json"),
+                SECTION_SCHEMA_VERSION,
+            )
+            .commit(1, core, |_| Ok(()))
+            .unwrap(),
+            2
+        );
+
+        let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(restarted.effective_config().server.port, 24_570);
+        let handoff = restarted.take_startup_legacy_root_reconciliation().unwrap();
+        assert!(handoff.committed.is_empty());
+        assert_eq!(
+            handoff.rejected,
+            vec![LegacyRootSectionRejection {
+                section: SectionId::Core,
+                reason: LegacyRootRejectionReason::RevisionConflict,
+            }]
+        );
+        assert!(section_layout_is_active(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn missing_root_restart_preserves_pending_publication_handoff() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":24571}}"#,
+        )
+        .unwrap();
+        let first = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.committed.len(), 1);
+        std::fs::remove_file(dir.path().join("config.json")).unwrap();
+        let missing = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(missing.committed, first.committed);
+        assert!(missing.guard_advanced);
+
+        let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(restarted.effective_config().server.port, 24_571);
+        assert_eq!(
+            restarted
+                .take_startup_legacy_root_reconciliation()
+                .unwrap()
+                .committed,
+            first.committed
+        );
+    }
+
+    #[test]
+    fn deleting_rejection_status_cannot_reactivate_legacy_fallback() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let root = b"{ invalid root with password never-adopt";
+        std::fs::write(dir.path().join("config.json"), root).unwrap();
+        let rejected = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(!rejected.rejected.is_empty());
+        assert!(section_layout_is_active(dir.path()).unwrap());
+        std::fs::remove_file(dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE)).unwrap();
+
+        let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let handoff = restarted.take_startup_legacy_root_reconciliation().unwrap();
+        assert_eq!(handoff.rejected[0].section, SectionId::Core);
+        assert!(section_layout_is_active(dir.path()).unwrap());
+        assert_eq!(std::fs::read(dir.path().join("config.json")).unwrap(), root);
+    }
+
+    #[test]
+    fn modular_section_set_keeps_legacy_boundary_after_control_evidence_loss() {
+        for remove_member in [false, true] {
+            let dir = TempDir::new().unwrap();
+            ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            std::fs::remove_file(dir.path().join(SECTION_LAYOUT_FILE)).unwrap();
+            std::fs::remove_file(
+                dir.path()
+                    .join(crate::credential_migration::SECTION_LAYOUT_COMPLETION_FILE),
+            )
+            .unwrap();
+            let member = dir.path().join("model_limits.json");
+            if remove_member {
+                std::fs::remove_file(member).unwrap();
+            } else {
+                std::fs::write(member, b"corrupt member").unwrap();
+            }
+            let root = br#"{"server":{"port":29991}}"#;
+            std::fs::write(dir.path().join("config.json"), root).unwrap();
+
+            assert!(modular_authority_boundary_present(dir.path()).unwrap());
+            assert!(ConfigFacade::open_or_migrate(dir.path()).is_err());
+            let loaded = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+            assert_ne!(loaded.server.port, 29_991);
+            let mut candidate = Config::default();
+            candidate.server.port = 29_992;
+            assert!(candidate.save_to_dir(dir.path().to_path_buf()).is_err());
+            assert_eq!(std::fs::read(dir.path().join("config.json")).unwrap(), root);
+        }
+    }
+
+    #[test]
+    fn corrupt_or_missing_marker_with_completion_ledger_never_reopens_legacy_authority() {
+        for remove_marker in [false, true] {
+            let dir = TempDir::new().unwrap();
+            ConfigFacade::open_or_migrate(dir.path()).unwrap();
+            let marker = dir.path().join(SECTION_LAYOUT_FILE);
+            if remove_marker {
+                std::fs::remove_file(&marker).unwrap();
+            } else {
+                std::fs::write(&marker, b"corrupt marker").unwrap();
+            }
+            let root = br#"{"server":{"port":29993}}"#;
+            std::fs::write(dir.path().join("config.json"), root).unwrap();
+
+            assert!(modular_authority_boundary_present(dir.path()).unwrap());
+            assert!(migrate_config_facade_layout(dir.path()).is_err());
+            assert!(ConfigFacade::open_or_migrate(dir.path()).is_err());
+            assert_ne!(
+                Config::from_data_dir_without_env(Some(dir.path().to_path_buf()))
+                    .server
+                    .port,
+                29_993
+            );
+            assert_eq!(std::fs::read(dir.path().join("config.json")).unwrap(), root);
+        }
+    }
+
+    #[test]
+    fn diagnostic_reconciliation_mirror_cannot_forge_pending_publication() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let forged = LegacyRootReconciliationRecord {
+            version: LEGACY_ROOT_RECONCILIATION_VERSION,
+            root_sha256: "0".repeat(64),
+            complete: true,
+            committed: BTreeMap::from([(
+                "core".to_string(),
+                LegacyRootCommittedPublication {
+                    revision: 99,
+                    candidate_sha256: "1".repeat(64),
+                    runtime_degraded: false,
+                },
+            )]),
+            planned: BTreeMap::new(),
+            rejected: vec![LegacyRootSectionRejection {
+                section: SectionId::Core,
+                reason: LegacyRootRejectionReason::CredentialMaterial,
+            }],
+            unknown_fields: 0,
+        };
+        std::fs::write(
+            dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE),
+            serde_json::to_vec_pretty(&forged).unwrap(),
+        )
+        .unwrap();
+
+        let reopened = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+
+        assert!(reopened.take_startup_legacy_root_reconciliation().is_none());
+        assert!(
+            crate::credential_migration::read_embedded_legacy_root_reconciliation(dir.path())
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(reopened.registry().core.snapshot().revision, 0);
+        assert_eq!(
+            reopened.registry().core.snapshot().status,
+            SectionStatus::Healthy
+        );
+    }
+
+    #[test]
+    fn unavailable_diagnostic_mirror_does_not_block_canonical_reconciliation() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let mirror = dir.path().join(LEGACY_ROOT_RECONCILIATION_FILE);
+        if mirror.exists() {
+            std::fs::remove_file(&mirror).unwrap();
+        }
+        std::fs::create_dir(&mirror).unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":29994}}"#,
+        )
+        .unwrap();
+
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(outcome.committed.len(), 1);
+        assert_eq!(
+            ConfigFacade::open(dir.path())
+                .unwrap()
+                .effective_config()
+                .server
+                .port,
+            29_994
+        );
+        assert!(has_pending_legacy_root_publications(dir.path()).unwrap());
+        assert!(mirror.is_dir());
+    }
+
+    #[test]
+    fn same_revision_content_substitution_invalidates_root_publication() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"server":{"port":29995}}"#,
+        )
+        .unwrap();
+        let outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        let event = outcome.committed.first().unwrap().clone();
+        assert!(legacy_root_publication_matches_durable(dir.path(), &event).unwrap());
+
+        let fresh = SectionRegistry::open(dir.path()).unwrap();
+        let mut replacement = fresh.envelope_value(SectionId::Core).unwrap().data;
+        replacement["server"]["port"] = json!(29_996);
+        AtomicFileStore::new(dir.path().join("core.json"))
+            .write_json(&json!({
+                "schema_version": SECTION_SCHEMA_VERSION,
+                "revision": 1,
+                "data": replacement,
+            }))
+            .unwrap();
+
+        assert!(!legacy_root_publication_matches_durable(dir.path(), &event).unwrap());
+        let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let handoff = restarted.take_startup_legacy_root_reconciliation().unwrap();
+        assert!(handoff.committed.is_empty());
+        assert_eq!(
+            handoff.rejected,
+            vec![LegacyRootSectionRejection {
+                section: SectionId::Core,
+                reason: LegacyRootRejectionReason::RevisionConflict,
+            }]
+        );
+    }
+
+    #[test]
+    fn root_family_rotation_after_guard_write_is_requeued() {
+        let dir = TempDir::new().unwrap();
+        ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let first = br#"{"server":{"port":29997}}"#;
+        let second = br#"{"server":{"port":29998}}"#.to_vec();
+        std::fs::write(dir.path().join("config.json"), first).unwrap();
+        crate::credential_migration::set_legacy_root_guard_after_write_test_hook(
+            dir.path(),
+            move |data_dir| {
+                std::fs::write(data_dir.join("config.json"), second).unwrap();
+            },
+        );
+
+        let first_outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(!first_outcome.guard_advanced);
+        assert!(first_outcome.partial);
+        assert_eq!(first_outcome.committed.len(), 1);
+        for event in &first_outcome.committed {
+            assert!(acknowledge_legacy_root_publication(dir.path(), event).unwrap());
+        }
+
+        let second_outcome = reconcile_reappeared_legacy_root(dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(second_outcome.guard_advanced);
+        assert_eq!(second_outcome.committed.len(), 1);
+        assert_eq!(
+            ConfigFacade::open(dir.path())
+                .unwrap()
+                .effective_config()
+                .server
+                .port,
+            29_998
+        );
+    }
+}
+pub const LEGACY_ROOT_RECONCILIATION_FILE: &str = "config-legacy-root-reconciliation.json";
+const LEGACY_ROOT_RECONCILIATION_VERSION: u32 = 1;
+
+/// Secret-free reason persisted for a rejected field owner.  Deliberately do
+/// not carry serde/parser messages: those may contain user-controlled keys or
+/// values from the compatibility document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LegacyRootRejectionReason {
+    InvalidDocument,
+    AmbiguousAlias,
+    CredentialMaterial,
+    DedicatedAuthority,
+    AuthorityUnavailable,
+    RevisionConflict,
+}
+
+impl LegacyRootRejectionReason {
+    pub fn diagnostic(self) -> &'static str {
+        match self {
+            Self::InvalidDocument => "legacy config root contains invalid section data",
+            Self::AmbiguousAlias => "legacy config root contains ambiguous aliases",
+            Self::CredentialMaterial => {
+                "legacy config root contains credential-owned or masked metadata; use the dedicated revisioned API"
+            }
+            Self::DedicatedAuthority => {
+                "legacy config root targets a dedicated authority; use its revisioned API"
+            }
+            Self::AuthorityUnavailable => {
+                "legacy config root reconciliation base is unavailable"
+            }
+            Self::RevisionConflict => {
+                "legacy config root lost a section revision race; the typed writer remains authoritative"
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LegacyRootSectionRejection {
+    pub section: SectionId,
+    pub reason: LegacyRootRejectionReason,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LegacyRootReconciliationOutcome {
+    pub fingerprint: String,
+    pub committed: Vec<ConfigSectionEvent>,
+    pub rejected: Vec<LegacyRootSectionRejection>,
+    pub recovered: Vec<SectionId>,
+    pub duplicate: bool,
+    pub guard_advanced: bool,
+    pub partial: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LegacyRootReconciliationRecord {
+    version: u32,
+    root_sha256: String,
+    /// False until every section in this exact root generation was attempted
+    /// and its completion guard was durably advanced.
+    #[serde(default = "default_true")]
+    complete: bool,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    committed: BTreeMap<String, LegacyRootCommittedPublication>,
+    /// Secret-free durable intent written before the first section CAS. A
+    /// restart can prove whether a crash-window CAS committed by comparing the
+    /// exact durable revision and canonical candidate hash.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    planned: BTreeMap<String, LegacyRootPlannedCommit>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    rejected: Vec<LegacyRootSectionRejection>,
+    /// Unknown keys remain byte-for-byte in `config.json`; only the count is
+    /// recorded so user-controlled key names cannot enter logs or events.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    unknown_fields: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyRootCommittedPublication {
+    revision: u64,
+    candidate_sha256: String,
+    /// Set only after the exact runtime-failure transition for this revision
+    /// is durable in the account journal. An unchanged root keeps retrying;
+    /// a newer root generation may safely supersede this publication.
+    #[serde(default, skip_serializing_if = "is_false")]
+    runtime_degraded: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyRootPlannedCommit {
+    expected_revision: u64,
+    candidate_sha256: String,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn is_zero_usize(value: &usize) -> bool {
+    *value == 0
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+#[derive(Debug)]
+struct PlannedLegacyRootSection {
+    id: SectionId,
+    expected_revision: u64,
+    expected_data: Value,
+    candidate: Value,
+}
+
+#[cfg(test)]
+type LegacyRootCommitTestHook = Box<dyn FnOnce(SectionId) + Send + 'static>;
+
+#[cfg(test)]
+fn legacy_root_before_commit_test_hooks(
+) -> &'static Mutex<HashMap<PathBuf, LegacyRootCommitTestHook>> {
+    static HOOKS: std::sync::OnceLock<Mutex<HashMap<PathBuf, LegacyRootCommitTestHook>>> =
+        std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+fn legacy_root_after_commit_test_hooks(
+) -> &'static Mutex<HashMap<PathBuf, LegacyRootCommitTestHook>> {
+    static HOOKS: std::sync::OnceLock<Mutex<HashMap<PathBuf, LegacyRootCommitTestHook>>> =
+        std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_legacy_root_before_commit_test_hook(
+    data_dir: &Path,
+    hook: impl FnOnce(SectionId) + Send + 'static,
+) {
+    legacy_root_before_commit_test_hooks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(data_dir.to_path_buf(), Box::new(hook));
+}
+
+#[cfg(test)]
+fn set_legacy_root_after_commit_test_hook(
+    data_dir: &Path,
+    hook: impl FnOnce(SectionId) + Send + 'static,
+) {
+    legacy_root_after_commit_test_hooks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(data_dir.to_path_buf(), Box::new(hook));
+}
+
+#[cfg(test)]
+fn run_legacy_root_commit_test_hook(
+    hooks: &'static Mutex<HashMap<PathBuf, LegacyRootCommitTestHook>>,
+    data_dir: &Path,
+    id: SectionId,
+) {
+    if let Some(hook) = hooks
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(data_dir)
+    {
+        hook(id);
+    }
+}
+
+fn parse_legacy_root_without_duplicate_keys(bytes: &[u8]) -> Result<Value, ()> {
+    struct StrictValue(Value);
+
+    impl<'de> Deserialize<'de> for StrictValue {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct StrictVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for StrictVisitor {
+                type Value = StrictValue;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    formatter.write_str("a JSON value without duplicate object keys")
+                }
+
+                fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+                    Ok(StrictValue(Value::Bool(value)))
+                }
+
+                fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+                    Ok(StrictValue(Value::Number(value.into())))
+                }
+
+                fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+                    Ok(StrictValue(Value::Number(value.into())))
+                }
+
+                fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    serde_json::Number::from_f64(value)
+                        .map(Value::Number)
+                        .map(StrictValue)
+                        .ok_or_else(|| E::custom("JSON number is not finite"))
+                }
+
+                fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+                    Ok(StrictValue(Value::String(value.to_string())))
+                }
+
+                fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+                    Ok(StrictValue(Value::String(value)))
+                }
+
+                fn visit_none<E>(self) -> Result<Self::Value, E> {
+                    Ok(StrictValue(Value::Null))
+                }
+
+                fn visit_unit<E>(self) -> Result<Self::Value, E> {
+                    Ok(StrictValue(Value::Null))
+                }
+
+                fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::SeqAccess<'de>,
+                {
+                    let mut values = Vec::new();
+                    while let Some(value) = sequence.next_element::<StrictValue>()? {
+                        values.push(value.0);
+                    }
+                    Ok(StrictValue(Value::Array(values)))
+                }
+
+                fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::MapAccess<'de>,
+                {
+                    use serde::de::Error as _;
+
+                    let mut object = Map::new();
+                    while let Some(key) = map.next_key::<String>()? {
+                        if object.contains_key(&key) {
+                            return Err(A::Error::custom("duplicate JSON object key"));
+                        }
+                        let value = map.next_value::<StrictValue>()?;
+                        object.insert(key, value.0);
+                    }
+                    Ok(StrictValue(Value::Object(object)))
+                }
+            }
+
+            deserializer.deserialize_any(StrictVisitor)
+        }
+    }
+
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let value = StrictValue::deserialize(&mut deserializer).map_err(|_| ())?;
+    deserializer.end().map_err(|_| ())?;
+    Ok(value.0)
+}
+
+/// True only for an already-completed modular layout whose durable completion
+/// evidence is intact apart from the current `config.json` generation.
+/// Callers use this to avoid ever routing a reappeared root through the
+/// initial split migration.
+pub fn completed_layout_allows_legacy_root_reconciliation(
+    data_dir: impl AsRef<Path>,
+) -> ConfigStoreResult<bool> {
+    let data_dir = data_dir.as_ref();
+    let Some(marker) = crate::credential_migration::read_section_attestation_target(
+        &data_dir.join(SECTION_LAYOUT_FILE),
+    )?
+    else {
+        return Ok(false);
+    };
+    let completion = match validate_completed_section_layout_marker(&marker) {
+        Ok(completion) => completion,
+        Err(_) => return Ok(false),
+    };
+    if !current_members_satisfy_completion(data_dir, &completion)? {
+        return Ok(false);
+    }
+    crate::credential_migration::section_layout_allows_legacy_root_reconciliation(
+        data_dir,
+        &marker,
+        &completion,
+    )
+}
+
+/// A valid completion marker is a one-way authority boundary.  Even if later
+/// legacy-root drift makes the stronger active-layout predicate false, callers
+/// must never route this directory back through initial legacy loading.
+pub fn has_completed_section_layout_marker(data_dir: impl AsRef<Path>) -> ConfigStoreResult<bool> {
+    let Some(marker) = crate::credential_migration::read_section_attestation_target(
+        &data_dir.as_ref().join(SECTION_LAYOUT_FILE),
+    )?
+    else {
+        return Ok(false);
+    };
+    Ok(validate_completed_section_layout_marker(&marker).is_ok())
+}
+
+/// Return whether this directory has crossed the one-way modular authority
+/// boundary. Presence is deliberately broader than validity: a missing or
+/// corrupt marker must not make an intact completion ledger fall back to the
+/// legacy root, and a corrupt marker itself is still authority evidence.
+pub fn modular_authority_boundary_present(data_dir: impl AsRef<Path>) -> ConfigStoreResult<bool> {
+    let data_dir = data_dir.as_ref();
+    if crate::credential_migration::read_section_attestation_target(
+        &data_dir.join(SECTION_LAYOUT_FILE),
+    )?
+    .is_some()
+    {
+        return Ok(true);
+    }
+    Ok(
+        crate::credential_migration::read_section_attestation_target(
+            &data_dir.join(crate::credential_migration::SECTION_LAYOUT_COMPLETION_FILE),
+        )?
+        .is_some()
+            || modular_section_authority_quorum_present(data_dir)?,
+    )
+}
+
+fn modular_section_authority_quorum_present(data_dir: &Path) -> ConfigStoreResult<bool> {
+    // These names were introduced by the modular facade and cannot be
+    // confused with the historical memory/providers/MCP sidecars. Requiring
+    // a quorum avoids reopening config.json when control evidence and one or
+    // more members are damaged, while not treating a lone unrelated file as a
+    // completed authority boundary.
+    let mut present = 0usize;
+    for name in [
+        "core.json",
+        "tools-skills.json",
+        "hooks.json",
+        "model-policy.json",
+    ] {
+        if crate::credential_migration::read_section_attestation_target(&data_dir.join(name))?
+            .is_some()
+        {
+            present += 1;
+        }
+    }
+    Ok(present >= 2)
+}
+
+fn current_legacy_root_reconciliation_outcome(
+    data_dir: &Path,
+) -> ConfigStoreResult<Option<LegacyRootReconciliationOutcome>> {
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        let Some(mut record) = read_legacy_reconciliation_record(data_dir)? else {
+            return Ok(None);
+        };
+        let durable_registry = SectionRegistry::open_configured(data_dir, true)?;
+        reject_stale_legacy_root_publications_locked(data_dir, &mut record, &durable_registry)?;
+        let root = crate::credential_migration::read_section_attestation_target(
+            &data_dir.join("config.json"),
+        )?;
+        let fingerprint = match root {
+            Some(root) => {
+                let current = hex::encode(Sha256::digest(&root));
+                if record.root_sha256 != current {
+                    return Ok(None);
+                }
+                current
+            }
+            None => record.root_sha256.clone(),
+        };
+        Ok(Some(LegacyRootReconciliationOutcome {
+            fingerprint,
+            committed: reconciliation_record_events(&record),
+            rejected: record.rejected,
+            recovered: Vec::new(),
+            duplicate: true,
+            guard_advanced: section_layout_is_active(data_dir)?,
+            partial: !record.complete,
+        }))
+    })
+}
+
+fn reconciliation_record_events(
+    record: &LegacyRootReconciliationRecord,
+) -> Vec<ConfigSectionEvent> {
+    record
+        .committed
+        .iter()
+        .filter(|(section, _)| {
+            SectionId::from_name(section).is_some_and(|id| {
+                !record
+                    .rejected
+                    .iter()
+                    .any(|rejection| rejection.section == id)
+            })
+        })
+        .map(|(section, publication)| {
+            if publication.runtime_degraded {
+                ConfigSectionEvent::Recovered {
+                    section: section.clone(),
+                    revision: publication.revision,
+                }
+            } else {
+                ConfigSectionEvent::Changed {
+                    section: section.clone(),
+                    revision: publication.revision,
+                }
+            }
+        })
+        .collect()
+}
+
+fn read_legacy_reconciliation_record(
+    data_dir: &Path,
+) -> ConfigStoreResult<Option<LegacyRootReconciliationRecord>> {
+    // The standalone file is a secret-free diagnostic mirror only. Trusting
+    // it when the completion ledger has no embedded record would let an
+    // external writer forge pending publications or health transitions.
+    let Some(record) =
+        crate::credential_migration::read_embedded_legacy_root_reconciliation(data_dir)?
+    else {
+        return Ok(None);
+    };
+    if record.version != LEGACY_ROOT_RECONCILIATION_VERSION
+        || record.root_sha256.len() != 64
+        || !record
+            .root_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        || record.committed.iter().any(|(section, publication)| {
+            SectionId::from_name(section).is_none()
+                || publication.revision == 0
+                || publication.candidate_sha256.len() != 64
+                || !publication
+                    .candidate_sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        })
+        || record.planned.iter().any(|(section, planned)| {
+            SectionId::from_name(section).is_none()
+                || planned.expected_revision == u64::MAX
+                || planned.candidate_sha256.len() != 64
+                || !planned
+                    .candidate_sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        })
+    {
+        return Err(crate::ConfigStoreError::Validation(
+            "legacy root reconciliation status is invalid".to_string(),
+        ));
+    }
+    Ok(Some(record))
+}
+
+pub(crate) fn validate_legacy_root_reconciliation_state(data_dir: &Path) -> ConfigStoreResult<()> {
+    let _ = read_legacy_reconciliation_record(data_dir)?;
+    Ok(())
+}
+
+fn canonical_value_sha256(value: &Value) -> ConfigStoreResult<String> {
+    Ok(hex::encode(Sha256::digest(serde_json::to_vec(value)?)))
+}
+
+fn write_legacy_reconciliation_record(
+    data_dir: &Path,
+    record: &LegacyRootReconciliationRecord,
+) -> ConfigStoreResult<()> {
+    crate::credential_migration::write_embedded_legacy_root_reconciliation_locked(
+        data_dir,
+        record.clone(),
+    )?;
+    let mirror = serde_json::to_vec_pretty(record)?;
+    if AtomicFileStore::new(data_dir.join(LEGACY_ROOT_RECONCILIATION_FILE))
+        .write_bytes_without_backup(&mirror)
+        .is_err()
+    {
+        tracing::warn!("legacy root reconciliation diagnostic mirror is unavailable");
+    }
+    Ok(())
+}
+
+fn legacy_root_publication_matches_durable_locked(
+    data_dir: &Path,
+    record: &LegacyRootReconciliationRecord,
+    section: &str,
+    revision: u64,
+) -> ConfigStoreResult<bool> {
+    let Some(publication) = record.committed.get(section) else {
+        return Ok(false);
+    };
+    if publication.revision != revision {
+        return Ok(false);
+    }
+    let id = SectionId::from_name(section).ok_or_else(|| {
+        crate::ConfigStoreError::Validation(
+            "legacy root publication section is invalid".to_string(),
+        )
+    })?;
+    let registry = SectionRegistry::open_configured(data_dir, true)?;
+    let envelope = registry.envelope_value(id)?;
+    Ok(envelope.revision == publication.revision
+        && envelope.status == SectionStatus::Healthy
+        && canonical_value_sha256(&envelope.data)? == publication.candidate_sha256)
+}
+
+/// Revalidate a root publication against its canonical outbox snapshot and a
+/// freshly opened durable section authority.
+pub fn legacy_root_publication_matches_durable(
+    data_dir: impl AsRef<Path>,
+    event: &ConfigSectionEvent,
+) -> ConfigStoreResult<bool> {
+    let (section, revision) = match event {
+        ConfigSectionEvent::Changed { section, revision } => (section.as_str(), *revision),
+        ConfigSectionEvent::Invalid { .. } | ConfigSectionEvent::Recovered { .. } => {
+            return Ok(false);
+        }
+    };
+    let data_dir = data_dir.as_ref();
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        let Some(record) = read_legacy_reconciliation_record(data_dir)? else {
+            return Ok(false);
+        };
+        legacy_root_publication_matches_durable_locked(data_dir, &record, section, revision)
+    })
+}
+
+/// Revalidate both the durable authority and the process snapshot that is
+/// about to become live against the canonical root-publication hash.
+pub fn legacy_root_publication_matches_snapshot(
+    data_dir: impl AsRef<Path>,
+    event: &ConfigSectionEvent,
+    process_data: &Value,
+) -> ConfigStoreResult<bool> {
+    let (section, revision) = match event {
+        ConfigSectionEvent::Changed { section, revision } => (section.as_str(), *revision),
+        ConfigSectionEvent::Invalid { .. } | ConfigSectionEvent::Recovered { .. } => {
+            return Ok(false);
+        }
+    };
+    let data_dir = data_dir.as_ref();
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        let Some(record) = read_legacy_reconciliation_record(data_dir)? else {
+            return Ok(false);
+        };
+        let process_matches = record.committed.get(section).is_some_and(|publication| {
+            publication.revision == revision
+                && canonical_value_sha256(process_data)
+                    .is_ok_and(|hash| hash == publication.candidate_sha256)
+        });
+        Ok(process_matches
+            && legacy_root_publication_matches_durable_locked(
+                data_dir, &record, section, revision,
+            )?)
+    })
+}
+
+/// Resolve the exact success transition for a pending root publication and
+/// the process snapshot that is about to become live. A publication whose
+/// runtime failure is already durable must recover before it can be
+/// acknowledged; an unfailed publication emits its original Changed event.
+pub fn legacy_root_publication_success_event(
+    data_dir: impl AsRef<Path>,
+    event: &ConfigSectionEvent,
+    process_data: &Value,
+) -> ConfigStoreResult<Option<ConfigSectionEvent>> {
+    let (section, revision) = match event {
+        ConfigSectionEvent::Changed { section, revision }
+        | ConfigSectionEvent::Recovered { section, revision } => (section.as_str(), *revision),
+        ConfigSectionEvent::Invalid { .. } => return Ok(None),
+    };
+    let data_dir = data_dir.as_ref();
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        let Some(record) = read_legacy_reconciliation_record(data_dir)? else {
+            return Ok(None);
+        };
+        let Some(publication) = record.committed.get(section) else {
+            return Ok(None);
+        };
+        let Some(id) = SectionId::from_name(section) else {
+            return Ok(None);
+        };
+        if record
+            .rejected
+            .iter()
+            .any(|rejection| rejection.section == id)
+        {
+            return Ok(None);
+        }
+        if publication.revision != revision
+            || canonical_value_sha256(process_data)? != publication.candidate_sha256
+            || !legacy_root_publication_matches_durable_locked(
+                data_dir, &record, section, revision,
+            )?
+        {
+            return Ok(None);
+        }
+        Ok(Some(if publication.runtime_degraded {
+            ConfigSectionEvent::Recovered {
+                section: section.to_string(),
+                revision,
+            }
+        } else {
+            ConfigSectionEvent::Changed {
+                section: section.to_string(),
+                revision,
+            }
+        }))
+    })
+}
+
+/// Return whether the canonical completion ledger still owns a root
+/// reconciliation intent, publication, or health transition that the runtime
+/// must finish.
+pub fn has_pending_legacy_root_publications(data_dir: impl AsRef<Path>) -> ConfigStoreResult<bool> {
+    let data_dir = data_dir.as_ref();
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        Ok(
+            read_legacy_reconciliation_record(data_dir)?.is_some_and(|record| {
+                !record.committed.is_empty()
+                    || !record.planned.is_empty()
+                    || !record.rejected.is_empty()
+            }),
+        )
+    })
+}
+
+/// Canonical root rejections whose process-local degraded health must remain
+/// in force until a later root generation clears them.
+pub fn legacy_root_rejected_sections(
+    data_dir: impl AsRef<Path>,
+) -> ConfigStoreResult<BTreeSet<SectionId>> {
+    let data_dir = data_dir.as_ref();
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        Ok(read_legacy_reconciliation_record(data_dir)?
+            .into_iter()
+            .flat_map(|record| record.rejected.into_iter())
+            .map(|rejection| rejection.section)
+            .collect())
+    })
+}
+
+/// Whether a non-facade legacy extension may perform its one-time import from
+/// the exact root generation guarded by the initial modular split. Any
+/// reconciliation record proves that config.json has already reappeared and
+/// is no longer an initial migration source.
+pub fn initial_legacy_root_extension_migration_allowed(
+    data_dir: impl AsRef<Path>,
+) -> ConfigStoreResult<bool> {
+    Ok(initial_legacy_root_extension_migration_source(data_dir)?.is_some())
+}
+
+/// Capture the exact root bytes guarded by the initial modular split for a
+/// non-facade extension's one-time import. Returning bytes rather than a bool
+/// prevents a raw editor from swapping a reappeared root between authority
+/// validation and parsing by the extension.
+pub fn initial_legacy_root_extension_migration_source(
+    data_dir: impl AsRef<Path>,
+) -> ConfigStoreResult<Option<Vec<u8>>> {
+    let data_dir = data_dir.as_ref();
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        if read_legacy_reconciliation_record(data_dir)?.is_some()
+            || !section_layout_is_active(data_dir)?
+        {
+            return Ok(None);
+        }
+        crate::credential_migration::read_initial_guarded_legacy_root_locked(data_dir)
+    })
+}
+
+/// Clear one durable root-reconciliation publication only after the server
+/// has accepted its post-runtime-install event for the account journal.
+///
+/// The enqueue and this status rewrite cannot be one filesystem transaction;
+/// a crash between them can replay once, while acknowledging before enqueue
+/// could lose the event entirely. Keeping the entry pending until enqueue is
+/// therefore the fail-safe side of that narrow crash window.
+pub fn acknowledge_legacy_root_publication(
+    data_dir: impl AsRef<Path>,
+    event: &ConfigSectionEvent,
+) -> ConfigStoreResult<bool> {
+    let data_dir = data_dir.as_ref();
+    let (section, revision, runtime_degraded) = match event {
+        ConfigSectionEvent::Changed { section, revision } => (section, revision, false),
+        ConfigSectionEvent::Recovered { section, revision } => (section, revision, true),
+        ConfigSectionEvent::Invalid { .. } => return Ok(false),
+    };
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        let Some(mut record) = read_legacy_reconciliation_record(data_dir)? else {
+            return Ok(false);
+        };
+        if record.committed.get(section).is_none_or(|publication| {
+            publication.revision != *revision || publication.runtime_degraded != runtime_degraded
+        }) {
+            return Ok(false);
+        }
+        let Some(id) = SectionId::from_name(section) else {
+            return Ok(false);
+        };
+        if record
+            .rejected
+            .iter()
+            .any(|rejection| rejection.section == id)
+        {
+            return Ok(false);
+        }
+        if !legacy_root_publication_matches_durable_locked(data_dir, &record, section, *revision)? {
+            return Ok(false);
+        }
+        record.committed.remove(section);
+        write_legacy_reconciliation_record(data_dir, &record)?;
+        Ok(true)
+    })
+}
+
+/// Mark one exact root publication as having failed its runtime hook only
+/// after the caller has durably confirmed the matching Invalid transition.
+///
+/// The publication remains pending while the same root bytes are present so
+/// transient dependencies can recover without another configuration edit.
+/// Reconciliation may supersede it only after a different root fingerprint is
+/// observed, at which point the durable Invalid is the handoff proof for the
+/// failed generation.
+pub fn mark_legacy_root_publication_runtime_degraded(
+    data_dir: impl AsRef<Path>,
+    event: &ConfigSectionEvent,
+) -> ConfigStoreResult<bool> {
+    let data_dir = data_dir.as_ref();
+    let (section, revision) = match event {
+        ConfigSectionEvent::Invalid { section, revision } => (section, *revision),
+        ConfigSectionEvent::Changed { .. } | ConfigSectionEvent::Recovered { .. } => {
+            return Ok(false);
+        }
+    };
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        let Some(mut record) = read_legacy_reconciliation_record(data_dir)? else {
+            return Ok(false);
+        };
+        if record
+            .committed
+            .get(section)
+            .is_none_or(|publication| publication.revision != revision)
+            || !legacy_root_publication_matches_durable_locked(
+                data_dir, &record, section, revision,
+            )?
+        {
+            return Ok(false);
+        }
+        let Some(id) = SectionId::from_name(section) else {
+            return Ok(false);
+        };
+        if record
+            .rejected
+            .iter()
+            .any(|rejection| rejection.section == id)
+        {
+            return Ok(false);
+        }
+        let publication = record
+            .committed
+            .get_mut(section)
+            .expect("matching root publication remains present");
+        if !publication.runtime_degraded {
+            publication.runtime_degraded = true;
+            write_legacy_reconciliation_record(data_dir, &record)?;
+        }
+        Ok(true)
+    })
+}
+
+fn reject_stale_legacy_root_publication(
+    data_dir: &Path,
+    event: &ConfigSectionEvent,
+) -> ConfigStoreResult<bool> {
+    let (section, revision) = match event {
+        ConfigSectionEvent::Changed { section, revision } => (section, revision),
+        ConfigSectionEvent::Invalid { .. } | ConfigSectionEvent::Recovered { .. } => {
+            return Ok(false);
+        }
+    };
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        let Some(mut record) = read_legacy_reconciliation_record(data_dir)? else {
+            return Ok(false);
+        };
+        if record
+            .committed
+            .get(section)
+            .is_none_or(|publication| publication.revision != *revision)
+        {
+            return Ok(false);
+        }
+        let id = SectionId::from_name(section).ok_or_else(|| {
+            crate::ConfigStoreError::Validation(
+                "legacy root publication section is invalid".to_string(),
+            )
+        })?;
+        record.committed.remove(section);
+        record.rejected.push(LegacyRootSectionRejection {
+            section: id,
+            reason: LegacyRootRejectionReason::RevisionConflict,
+        });
+        record.rejected.sort_by_key(|rejection| rejection.section);
+        record.rejected.dedup_by_key(|rejection| rejection.section);
+        write_legacy_reconciliation_record(data_dir, &record)?;
+        let _ = crate::credential_migration::advance_legacy_root_completion_guard_locked(
+            data_dir,
+            Some(&record.root_sha256),
+        )?;
+        Ok(true)
+    })
+}
+
+type ReconciliationRootSections = (
+    BTreeMap<SectionId, Value>,
+    usize,
+    Vec<LegacyRootSectionRejection>,
+);
+
+type ReconciliationRootSectionsResult =
+    Result<ReconciliationRootSections, Vec<LegacyRootSectionRejection>>;
+
+fn reconciliation_root_sections(root: &Value) -> ReconciliationRootSectionsResult {
+    let Some(root) = root.as_object() else {
+        return Err(vec![LegacyRootSectionRejection {
+            section: SectionId::Core,
+            reason: LegacyRootRejectionReason::InvalidDocument,
+        }]);
+    };
+    let mut sections = BTreeMap::<SectionId, Value>::new();
+    let mut object_sections = BTreeMap::<SectionId, Map<String, Value>>::new();
+    let mut unknown_fields = 0usize;
+    let mut rejected = Vec::new();
+    let ambiguous_mcp = root.contains_key("mcp") && root.contains_key("mcpServers");
+    if ambiguous_mcp {
+        rejected.push(LegacyRootSectionRejection {
+            section: SectionId::Mcp,
+            reason: LegacyRootRejectionReason::AmbiguousAlias,
+        });
+    }
+    for (key, value) in root {
+        let object =
+            |id: SectionId,
+             key: &str,
+             value: &Value,
+             object_sections: &mut BTreeMap<SectionId, Map<String, Value>>| {
+                object_sections
+                    .entry(id)
+                    .or_default()
+                    .insert(key.to_string(), value.clone());
+            };
+        match key.as_str() {
+            "http_proxy"
+            | "https_proxy"
+            | "proxy_auth"
+            | "proxy_auth_encrypted"
+            | "proxy_auth_credential_ref"
+            | "headless_auth"
+            | "server"
+            | "default_work_area"
+            | "run_budget"
+            | "stream_timeout" => object(SectionId::Core, key, value, &mut object_sections),
+            "provider"
+            | "defaults"
+            | "provider_instances"
+            | "default_provider_instance"
+            | "features" => object(SectionId::Providers, key, value, &mut object_sections),
+            "providers" => match value.as_object() {
+                Some(providers)
+                    if providers.keys().any(|key| {
+                        matches!(
+                            key.as_str(),
+                            "provider"
+                                | "defaults"
+                                | "provider_instances"
+                                | "default_provider_instance"
+                                | "features"
+                        )
+                    }) =>
+                {
+                    rejected.push(LegacyRootSectionRejection {
+                        section: SectionId::Providers,
+                        reason: LegacyRootRejectionReason::AmbiguousAlias,
+                    })
+                }
+                Some(providers) => object_sections
+                    .entry(SectionId::Providers)
+                    .or_default()
+                    .extend(providers.clone()),
+                None => rejected.push(LegacyRootSectionRejection {
+                    section: SectionId::Providers,
+                    reason: LegacyRootRejectionReason::InvalidDocument,
+                }),
+            },
+            "mcp" | "mcpServers" if !ambiguous_mcp => {
+                sections.insert(SectionId::Mcp, value.clone());
+            }
+            "mcp" | "mcpServers" => {}
+            "tools" | "skills" | "plugin_trust" => {
+                object(SectionId::ToolsSkills, key, value, &mut object_sections)
+            }
+            "memory" => {
+                sections.insert(SectionId::Memory, value.clone());
+            }
+            "subagents" => match value.as_object() {
+                Some(subagents) => {
+                    if subagents.contains_key("external_broker") || subagents.contains_key("broker")
+                    {
+                        rejected.push(LegacyRootSectionRejection {
+                            section: SectionId::Subagents,
+                            reason: LegacyRootRejectionReason::DedicatedAuthority,
+                        });
+                    }
+                    if subagents.contains_key("codex_provider_key_ref") {
+                        rejected.push(LegacyRootSectionRejection {
+                            section: SectionId::Subagents,
+                            reason: LegacyRootRejectionReason::CredentialMaterial,
+                        });
+                    }
+                    object_sections
+                        .entry(SectionId::Subagents)
+                        .or_default()
+                        .extend(subagents.clone());
+                }
+                None => rejected.push(LegacyRootSectionRejection {
+                    section: SectionId::Subagents,
+                    reason: LegacyRootRejectionReason::InvalidDocument,
+                }),
+            },
+            "notifications" => object(
+                SectionId::Notifications,
+                "notifications",
+                value,
+                &mut object_sections,
+            ),
+            "connect" => {
+                sections.insert(SectionId::Connect, value.clone());
+            }
+            "cluster_fabric" => {
+                sections.insert(SectionId::ClusterFabric, value.clone());
+            }
+            "credentials" => rejected.push(LegacyRootSectionRejection {
+                section: SectionId::Credentials,
+                reason: if raw_reconciliation_secret_material_is_forbidden_for_section(
+                    SectionId::Credentials,
+                    value,
+                ) || !server_metadata_inventory(value).is_empty()
+                {
+                    LegacyRootRejectionReason::CredentialMaterial
+                } else {
+                    LegacyRootRejectionReason::DedicatedAuthority
+                },
+            }),
+            "env_vars" => {
+                sections.insert(SectionId::Env, value.clone());
+            }
+            "access_control" => {
+                sections.insert(SectionId::AccessControl, value.clone());
+            }
+            "hooks" => match value.as_object() {
+                Some(hooks) if hooks.contains_key("lifecycle_hooks") => {
+                    rejected.push(LegacyRootSectionRejection {
+                        section: SectionId::Hooks,
+                        reason: LegacyRootRejectionReason::AmbiguousAlias,
+                    })
+                }
+                Some(hooks) => object_sections
+                    .entry(SectionId::Hooks)
+                    .or_default()
+                    .extend(hooks.clone()),
+                None => rejected.push(LegacyRootSectionRejection {
+                    section: SectionId::Hooks,
+                    reason: LegacyRootRejectionReason::InvalidDocument,
+                }),
+            },
+            "lifecycle_hooks" => object(SectionId::Hooks, key, value, &mut object_sections),
+            "keyword_masking" | "anthropic_model_mapping" | "gemini_model_mapping" => {
+                object(SectionId::ModelPolicy, key, value, &mut object_sections)
+            }
+            "model_limits" => {
+                sections.insert(SectionId::ModelLimits, value.clone());
+            }
+            _ => {
+                unknown_fields = unknown_fields.saturating_add(1);
+                let fragment = Value::Object(Map::from_iter([(key.clone(), value.clone())]));
+                if raw_reconciliation_secret_material_is_forbidden(&fragment)
+                    || !server_metadata_inventory(&fragment).is_empty()
+                {
+                    rejected.push(LegacyRootSectionRejection {
+                        // Unknown keys have no typed owner. Attribute the
+                        // generic fail-closed health to the root document
+                        // without persisting the user-controlled key or value.
+                        section: SectionId::Core,
+                        reason: LegacyRootRejectionReason::CredentialMaterial,
+                    });
+                }
+            }
+        }
+    }
+    sections.extend(
+        object_sections
+            .into_iter()
+            .map(|(id, object)| (id, Value::Object(object))),
+    );
+    rejected.sort_by_key(|rejection| rejection.section);
+    rejected.dedup_by_key(|rejection| rejection.section);
+    Ok((sections, unknown_fields, rejected))
+}
+
+fn raw_reconciliation_secret_material_is_forbidden(value: &Value) -> bool {
+    raw_reconciliation_secret_material_is_forbidden_for_section(SectionId::Core, value)
+}
+
+fn raw_reconciliation_secret_material_is_forbidden_for_section(
+    section: SectionId,
+    value: &Value,
+) -> bool {
+    raw_reconciliation_secret_material_is_forbidden_with_context(
+        section,
+        value,
+        CredentialScanContext::None,
+    )
+}
+
+fn raw_reconciliation_secret_material_is_forbidden_with_context(
+    section: SectionId,
+    value: &Value,
+    initial_context: CredentialScanContext,
+) -> bool {
+    fn is_exact_model_policy_mask_pattern(section: SectionId, path: &[String]) -> bool {
+        section == SectionId::ModelPolicy
+            && path
+                .iter()
+                .map(String::as_str)
+                .eq(["keyword_masking", "entries", "pattern"])
+    }
+
+    fn walk(
+        section: SectionId,
+        value: &Value,
+        credential_context: CredentialScanContext,
+        path: &mut Vec<String>,
+    ) -> bool {
+        if credential_context != CredentialScanContext::None
+            && is_nonliteral_runtime_template(value)
+        {
+            return false;
+        }
+        match value {
+            Value::Object(object) => {
+                if section == SectionId::Mcp && path.is_empty() {
+                    for (id, server) in object {
+                        path.push(id.clone());
+                        let forbidden = walk(section, server, credential_context, path);
+                        path.pop();
+                        if forbidden {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+                for (key, value) in object {
+                    path.push(key.clone());
+                    let normalized = normalized_credential_key(key);
+                    let reference_metadata = credential_reference_metadata_key(key);
+                    let child_keys_are_identifiers = matches!(
+                        normalized.as_str(),
+                        "headers" | "providerinstances" | "credentialrefs"
+                    ) || normalized.ends_with("credentialrefs");
+                    if child_keys_are_identifiers {
+                        let identifier_context = if reference_metadata {
+                            CredentialScanContext::None
+                        } else {
+                            credential_context
+                        };
+                        let forbidden = match value {
+                            Value::Object(entries) if normalized == "headers" => {
+                                let mut forbidden = false;
+                                for (name, expression) in entries {
+                                    path.push(name.clone());
+                                    forbidden = if is_credential_header(name) {
+                                        !value_is_empty(expression)
+                                            && !is_nonliteral_runtime_template(expression)
+                                    } else {
+                                        walk(section, expression, identifier_context, path)
+                                    };
+                                    path.pop();
+                                    if forbidden {
+                                        break;
+                                    }
+                                }
+                                forbidden
+                            }
+                            Value::Object(entries) => {
+                                let mut forbidden = false;
+                                for (name, entry) in entries {
+                                    path.push(name.clone());
+                                    let entry_context = if reference_metadata
+                                        && (entry.is_object() || entry.is_array())
+                                    {
+                                        CredentialScanContext::Adjacent
+                                    } else {
+                                        identifier_context
+                                    };
+                                    forbidden = walk(section, entry, entry_context, path);
+                                    path.pop();
+                                    if forbidden {
+                                        break;
+                                    }
+                                }
+                                forbidden
+                            }
+                            Value::Array(entries) => entries.iter().any(|entry| {
+                                let entry_context = if reference_metadata
+                                    && (entry.is_object() || entry.is_array())
+                                {
+                                    CredentialScanContext::Adjacent
+                                } else {
+                                    identifier_context
+                                };
+                                walk(section, entry, entry_context, path)
+                            }),
+                            _ => walk(section, value, identifier_context, path),
+                        };
+                        path.pop();
+                        if forbidden {
+                            return true;
+                        }
+                        continue;
+                    }
+
+                    let key_context = if value.is_object() || value.is_array() {
+                        credential_context_key(key)
+                    } else {
+                        credential_literal_key(key)
+                    };
+                    let key_metadata_context = (value.is_object() || value.is_array())
+                        && credential_metadata_container_key(key);
+                    let child_context = if reference_metadata {
+                        CredentialScanContext::None
+                    } else if credential_context == CredentialScanContext::Strong
+                        && credential_public_metadata_key(key)
+                    {
+                        CredentialScanContext::Adjacent
+                    } else if credential_context == CredentialScanContext::Strong || key_context {
+                        CredentialScanContext::Strong
+                    } else if credential_context == CredentialScanContext::Adjacent
+                        || key_metadata_context
+                    {
+                        CredentialScanContext::Adjacent
+                    } else {
+                        CredentialScanContext::None
+                    };
+                    let forbidden = key_contains_literal_credential_material(key, value)
+                        || (credential_context != CredentialScanContext::None
+                            && NORMALIZED_CREDENTIAL_PAYLOAD_SUFFIXES
+                                .contains(&normalized.as_str())
+                            && !value_is_empty(value))
+                        || (!reference_metadata && walk(section, value, child_context, path));
+                    path.pop();
+                    if forbidden {
+                        return true;
+                    }
+                }
+                false
+            }
+            Value::Array(values) => values
+                .iter()
+                .any(|value| walk(section, value, credential_context, path)),
+            Value::String(value) => {
+                (credential_context == CredentialScanContext::Strong && !value.trim().is_empty())
+                    || (!is_exact_model_policy_mask_pattern(section, path)
+                        && crate::patch::is_masked_api_key(value))
+                    || url::Url::parse(value)
+                        .ok()
+                        .is_some_and(|url| !url.username().is_empty() || url.password().is_some())
+            }
+            Value::Number(_) => credential_context == CredentialScanContext::Strong,
+            Value::Bool(_) | Value::Null => false,
+        }
+    }
+    walk(section, value, initial_context, &mut Vec::new())
+}
+
+fn credential_bearing_subtree_changed(authority: &Value, candidate: &Value) -> bool {
+    fn is_metadata_key(key: &str) -> bool {
+        let normalized = key
+            .chars()
+            .filter(|character| character.is_ascii_alphanumeric())
+            .flat_map(char::to_lowercase)
+            .collect::<String>();
+        normalized == "credentialref"
+            || normalized.ends_with("credentialref")
+            || normalized == "credentialrefs"
+            || normalized.ends_with("credentialrefs")
+            || normalized == "configured"
+            || normalized.ends_with("configured")
+            || normalized == "secret"
+    }
+
+    fn contains_metadata(value: &Value) -> bool {
+        match value {
+            Value::Object(object) => {
+                object.keys().any(|key| is_metadata_key(key))
+                    || object.values().any(contains_metadata)
+            }
+            Value::Array(values) => values.iter().any(contains_metadata),
+            _ => false,
+        }
+    }
+
+    match (authority, candidate) {
+        (Value::Object(authority), Value::Object(candidate)) => {
+            let credential_context = authority.keys().any(|key| is_metadata_key(key));
+            for (key, value) in authority {
+                if is_metadata_key(key) && candidate.get(key) != Some(value) {
+                    return true;
+                }
+            }
+            if credential_context {
+                if raw_reconciliation_secret_material_is_forbidden_with_context(
+                    SectionId::Core,
+                    &Value::Object(candidate.clone()),
+                    CredentialScanContext::Adjacent,
+                ) {
+                    return true;
+                }
+                for (key, candidate_value) in candidate {
+                    let normalized = key
+                        .chars()
+                        .filter(|character| character.is_ascii_alphanumeric())
+                        .flat_map(char::to_lowercase)
+                        .collect::<String>();
+                    let credential_payload =
+                        matches!(normalized.as_str(), "value" | "literal" | "fallback")
+                            || key_contains_literal_credential_material(key, candidate_value);
+                    if credential_payload
+                        && !value_is_empty(candidate_value)
+                        && authority.get(key) != Some(candidate_value)
+                    {
+                        return true;
+                    }
+                }
+            }
+            authority.iter().any(|(key, value)| {
+                candidate
+                    .get(key)
+                    .is_some_and(|candidate| credential_bearing_subtree_changed(value, candidate))
+            })
+        }
+        (Value::Array(authority), Value::Array(candidate)) => {
+            (authority.len() != candidate.len() && authority.iter().any(contains_metadata))
+                || authority
+                    .iter()
+                    .zip(candidate)
+                    .any(|(authority, candidate)| {
+                        credential_bearing_subtree_changed(authority, candidate)
+                    })
+        }
+        _ => authority != candidate && contains_metadata(authority),
+    }
+}
+
+fn server_metadata_inventory(value: &Value) -> BTreeMap<String, Value> {
+    fn walk(value: &Value, path: &mut Vec<String>, result: &mut BTreeMap<String, Value>) {
+        match value {
+            Value::Object(object) => {
+                for (key, value) in object {
+                    path.push(key.clone());
+                    let normalized = key
+                        .chars()
+                        .filter(|character| character.is_ascii_alphanumeric())
+                        .flat_map(char::to_lowercase)
+                        .collect::<String>();
+                    if normalized == "credentialref"
+                        || normalized.ends_with("credentialref")
+                        || normalized == "credentialrefs"
+                        || normalized.ends_with("credentialrefs")
+                        || normalized == "configured"
+                        || normalized.ends_with("configured")
+                        || normalized == "secret"
+                    {
+                        result.insert(path.join("/"), value.clone());
+                    }
+                    walk(value, path, result);
+                    path.pop();
+                }
+            }
+            Value::Array(values) => {
+                for (index, value) in values.iter().enumerate() {
+                    path.push(index.to_string());
+                    walk(value, path, result);
+                    path.pop();
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut result = BTreeMap::new();
+    walk(value, &mut Vec::new(), &mut result);
+    result
+}
+
+fn commit_planned_legacy_root_section(
+    registry: &SectionRegistry,
+    plan: PlannedLegacyRootSection,
+) -> ConfigStoreResult<ConfigSectionEvent> {
+    macro_rules! commit {
+        ($field:ident, $ty:ty) => {{
+            let expected: $ty = serde_json::from_value(plan.expected_data)?;
+            let candidate: $ty = serde_json::from_value(plan.candidate)?;
+            registry
+                .$field
+                .commit_from_durable_base_with_envelope(
+                    plan.expected_revision,
+                    &expected,
+                    candidate,
+                )
+                .map(|(event, _)| event)
+        }};
+    }
+    match plan.id {
+        SectionId::Core => commit!(core, CoreSection),
+        SectionId::Providers => commit!(providers, ProvidersSection),
+        SectionId::Mcp => commit!(mcp, McpSection),
+        SectionId::ToolsSkills => commit!(tools_skills, ToolsSkillsSection),
+        SectionId::Memory => commit!(memory, MemorySection),
+        SectionId::Subagents => commit!(subagents, SubagentsSection),
+        SectionId::Notifications => commit!(notifications, NotificationsSection),
+        SectionId::Connect => commit!(connect, ConnectSection),
+        SectionId::Env => commit!(env, EnvSection),
+        SectionId::AccessControl => commit!(access_control, AccessControlSection),
+        SectionId::Hooks => commit!(hooks, HooksSection),
+        SectionId::ModelPolicy => commit!(model_policy, ModelPolicySection),
+        SectionId::ModelLimits => commit!(model_limits, ModelLimitsSection),
+        SectionId::ClusterFabric | SectionId::Credentials => {
+            Err(crate::ConfigStoreError::Validation(
+                "legacy root targets a dedicated authority".to_string(),
+            ))
+        }
+    }
+}
+
+fn canonicalize_legacy_root_candidate(id: SectionId, value: Value) -> ConfigStoreResult<Value> {
+    macro_rules! canonicalize {
+        ($ty:ty) => {{
+            let typed: $ty = serde_json::from_value(value)?;
+            serde_json::to_value(typed).map_err(Into::into)
+        }};
+    }
+    match id {
+        SectionId::Core => canonicalize!(CoreSection),
+        SectionId::Providers => canonicalize!(ProvidersSection),
+        SectionId::Mcp => canonicalize!(McpSection),
+        SectionId::ToolsSkills => canonicalize!(ToolsSkillsSection),
+        SectionId::Memory => canonicalize!(MemorySection),
+        SectionId::Subagents => canonicalize!(SubagentsSection),
+        SectionId::Notifications => canonicalize!(NotificationsSection),
+        SectionId::Connect => canonicalize!(ConnectSection),
+        SectionId::Env => canonicalize!(EnvSection),
+        SectionId::AccessControl => canonicalize!(AccessControlSection),
+        SectionId::Hooks => canonicalize!(HooksSection),
+        SectionId::ModelPolicy => canonicalize!(ModelPolicySection),
+        SectionId::ModelLimits => canonicalize!(ModelLimitsSection),
+        SectionId::ClusterFabric | SectionId::Credentials => {
+            Err(crate::ConfigStoreError::Validation(
+                "legacy root targets a dedicated authority".to_string(),
+            ))
+        }
+    }
+}
+
+fn adopt_recovered_legacy_root_section(
+    registry: &SectionRegistry,
+    id: SectionId,
+    expected_revision: u64,
+    committed_revision: u64,
+    candidate: Value,
+) -> ConfigStoreResult<ConfigSectionEvent> {
+    let current = registry.envelope_value(id)?;
+    if current.revision == committed_revision && current.data == candidate {
+        if current.status != SectionStatus::Healthy {
+            let _ = registry.reload(id);
+            let reloaded = registry.envelope_value(id)?;
+            if reloaded.revision != committed_revision
+                || reloaded.data != current.data
+                || reloaded.status != SectionStatus::Healthy
+            {
+                return Err(crate::ConfigStoreError::Validation(
+                    "legacy root committed section could not be adopted as healthy".to_string(),
+                ));
+            }
+        }
+        return Ok(ConfigSectionEvent::Changed {
+            section: id.descriptor().name.to_string(),
+            revision: committed_revision,
+        });
+    }
+    macro_rules! adopt {
+        ($field:ident, $ty:ty) => {{
+            let candidate: $ty = serde_json::from_value(candidate)?;
+            registry.$field.adopt_committed_from_durable_base(
+                expected_revision,
+                committed_revision,
+                candidate,
+            )
+        }};
+    }
+    match id {
+        SectionId::Core => adopt!(core, CoreSection),
+        SectionId::Providers => adopt!(providers, ProvidersSection),
+        SectionId::Mcp => adopt!(mcp, McpSection),
+        SectionId::ToolsSkills => adopt!(tools_skills, ToolsSkillsSection),
+        SectionId::Memory => adopt!(memory, MemorySection),
+        SectionId::Subagents => adopt!(subagents, SubagentsSection),
+        SectionId::Notifications => adopt!(notifications, NotificationsSection),
+        SectionId::Connect => adopt!(connect, ConnectSection),
+        SectionId::Env => adopt!(env, EnvSection),
+        SectionId::AccessControl => adopt!(access_control, AccessControlSection),
+        SectionId::Hooks => adopt!(hooks, HooksSection),
+        SectionId::ModelPolicy => adopt!(model_policy, ModelPolicySection),
+        SectionId::ModelLimits => adopt!(model_limits, ModelLimitsSection),
+        SectionId::ClusterFabric | SectionId::Credentials => {
+            Err(crate::ConfigStoreError::Validation(
+                "legacy root targets a dedicated authority".to_string(),
+            ))
+        }
+    }
+}
+
+fn recover_legacy_root_planned_commits(
+    data_dir: &Path,
+    record: &mut LegacyRootReconciliationRecord,
+    durable_registry: &SectionRegistry,
+    process_registry: &SectionRegistry,
+) -> ConfigStoreResult<()> {
+    let mut changed = false;
+    for (section, planned) in record.planned.clone() {
+        let Some(id) = SectionId::from_name(&section) else {
+            continue;
+        };
+        let envelope = durable_registry.envelope_value(id)?;
+        let candidate_hash = canonical_value_sha256(&envelope.data)?;
+        let committed_revision = planned.expected_revision.checked_add(1).ok_or_else(|| {
+            crate::ConfigStoreError::Validation(
+                "legacy root planned revision counter exhausted".to_string(),
+            )
+        })?;
+        if envelope.revision == committed_revision && candidate_hash == planned.candidate_sha256 {
+            adopt_recovered_legacy_root_section(
+                process_registry,
+                id,
+                planned.expected_revision,
+                committed_revision,
+                envelope.data,
+            )?;
+            record.committed.insert(
+                section.clone(),
+                LegacyRootCommittedPublication {
+                    revision: committed_revision,
+                    candidate_sha256: planned.candidate_sha256.clone(),
+                    runtime_degraded: false,
+                },
+            );
+            record.planned.remove(&section);
+            changed = true;
+        } else if envelope.revision != planned.expected_revision {
+            record.planned.remove(&section);
+            record.rejected.push(LegacyRootSectionRejection {
+                section: id,
+                reason: LegacyRootRejectionReason::RevisionConflict,
+            });
+            changed = true;
+        }
+    }
+    if changed {
+        record.rejected.sort_by_key(|rejection| rejection.section);
+        record.rejected.dedup_by_key(|rejection| rejection.section);
+        write_legacy_reconciliation_record(data_dir, record)?;
+    }
+    Ok(())
+}
+
+/// Remove publication intents that no longer name the current healthy durable
+/// envelope. A process-local registry may lag another process's commit, so
+/// only the freshly opened durable registry is authoritative for this check.
+fn reject_stale_legacy_root_publications_locked(
+    data_dir: &Path,
+    record: &mut LegacyRootReconciliationRecord,
+    durable_registry: &SectionRegistry,
+) -> ConfigStoreResult<()> {
+    let mut stale = Vec::new();
+    for (section, publication) in &record.committed {
+        let id = SectionId::from_name(section).ok_or_else(|| {
+            crate::ConfigStoreError::Validation(
+                "legacy root publication section is invalid".to_string(),
+            )
+        })?;
+        let envelope = durable_registry.envelope_value(id)?;
+        let candidate_sha256 = canonical_value_sha256(&envelope.data)?;
+        if envelope.revision != publication.revision
+            || envelope.status != SectionStatus::Healthy
+            || candidate_sha256 != publication.candidate_sha256
+        {
+            stale.push((section.clone(), id));
+        }
+    }
+    if stale.is_empty() {
+        return Ok(());
+    }
+    for (section, id) in stale {
+        record.committed.remove(&section);
+        record.rejected.retain(|rejection| rejection.section != id);
+        record.rejected.push(LegacyRootSectionRejection {
+            section: id,
+            reason: LegacyRootRejectionReason::RevisionConflict,
+        });
+    }
+    record.rejected.sort_by_key(|rejection| rejection.section);
+    write_legacy_reconciliation_record(data_dir, record)?;
+    let _ = crate::credential_migration::advance_legacy_root_completion_guard_locked(
+        data_dir,
+        Some(&record.root_sha256),
+    )?;
+    Ok(())
+}
+
+fn adopt_pending_legacy_root_publications_locked(
+    record: &LegacyRootReconciliationRecord,
+    durable_registry: &SectionRegistry,
+    process_registry: &SectionRegistry,
+) -> ConfigStoreResult<()> {
+    for (section, publication) in &record.committed {
+        let id = SectionId::from_name(section).ok_or_else(|| {
+            crate::ConfigStoreError::Validation(
+                "legacy root publication section is invalid".to_string(),
+            )
+        })?;
+        let envelope = durable_registry.envelope_value(id)?;
+        if envelope.revision != publication.revision
+            || envelope.status != SectionStatus::Healthy
+            || canonical_value_sha256(&envelope.data)? != publication.candidate_sha256
+        {
+            return Err(crate::ConfigStoreError::Validation(
+                "legacy root publication no longer names a healthy durable section".to_string(),
+            ));
+        }
+        let expected_revision = publication.revision.checked_sub(1).ok_or_else(|| {
+            crate::ConfigStoreError::Validation(
+                "legacy root publication revision is invalid".to_string(),
+            )
+        })?;
+        adopt_recovered_legacy_root_section(
+            process_registry,
+            id,
+            expected_revision,
+            publication.revision,
+            envelope.data,
+        )?;
+    }
+    Ok(())
+}
+
+/// Reconcile one stable, externally-authored `config.json` generation into
+/// independently revisioned section authorities.
+///
+/// Planning is entirely read-only.  Only after every field has an unambiguous
+/// owner, raw credential metadata has been rejected and all candidates have
+/// passed typed validation do the independent content-aware section CAS writes
+/// begin. Unknown fields stay solely in the byte-preserved legacy root.
+pub fn reconcile_reappeared_legacy_root(
+    data_dir: impl AsRef<Path>,
+) -> ConfigStoreResult<Option<LegacyRootReconciliationOutcome>> {
+    reconcile_reappeared_legacy_root_with_registry(data_dir.as_ref(), None)
+}
+
+fn reconcile_reappeared_legacy_root_with_registry(
+    data_dir: &Path,
+    process_registry: Option<&SectionRegistry>,
+) -> ConfigStoreResult<Option<LegacyRootReconciliationOutcome>> {
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        reconcile_reappeared_legacy_root_locked(data_dir, process_registry)
+    })
+}
+
+fn reconcile_reappeared_legacy_root_locked(
+    data_dir: &Path,
+    process_registry: Option<&SectionRegistry>,
+) -> ConfigStoreResult<Option<LegacyRootReconciliationOutcome>> {
+    if !completed_layout_allows_legacy_root_reconciliation(data_dir)? {
+        return Ok(None);
+    }
+    let durable_registry = SectionRegistry::open_configured(data_dir, true)?;
+    let commit_registry = process_registry.unwrap_or(&durable_registry);
+    let mut previous_record = read_legacy_reconciliation_record(data_dir)?;
+    if let Some(record) = previous_record.as_mut() {
+        recover_legacy_root_planned_commits(data_dir, record, &durable_registry, commit_registry)?;
+        reject_stale_legacy_root_publications_locked(data_dir, record, &durable_registry)?;
+        adopt_pending_legacy_root_publications_locked(record, &durable_registry, commit_registry)?;
+    }
+    let Some(root_bytes) = crate::credential_migration::read_section_attestation_target(
+        &data_dir.join("config.json"),
+    )?
+    else {
+        let mut recovered = Vec::new();
+        if let Some(record) = previous_record.as_mut() {
+            recovered = record
+                .rejected
+                .iter()
+                .map(|rejection| rejection.section)
+                .collect();
+            if !record.planned.is_empty() {
+                // Remaining intents provably did not commit and the root
+                // that authorized them is gone.
+                if !record.planned.is_empty() {
+                    record.planned.clear();
+                    record.complete = false;
+                    write_legacy_reconciliation_record(data_dir, record)?;
+                }
+            }
+            record.rejected.clear();
+            record.complete = true;
+            write_legacy_reconciliation_record(data_dir, record)?;
+        }
+        let guard_advanced =
+            crate::credential_migration::advance_legacy_root_completion_guard_locked(
+                data_dir, None,
+            )?;
+        if !guard_advanced {
+            if let Some(record) = previous_record.as_mut() {
+                record.complete = false;
+                write_legacy_reconciliation_record(data_dir, record)?;
+            }
+        }
+        return Ok(Some(LegacyRootReconciliationOutcome {
+            fingerprint: previous_record
+                .as_ref()
+                .map(|record| record.root_sha256.clone())
+                .unwrap_or_default(),
+            committed: previous_record
+                .as_ref()
+                .map(reconciliation_record_events)
+                .unwrap_or_default(),
+            recovered,
+            guard_advanced,
+            duplicate: guard_advanced,
+            partial: !guard_advanced,
+            ..LegacyRootReconciliationOutcome::default()
+        }));
+    };
+    let fingerprint = hex::encode(Sha256::digest(&root_bytes));
+    if let Some(record) = previous_record.as_mut() {
+        if record.root_sha256 != fingerprint && !record.planned.is_empty() {
+            // No planned CAS committed (recovery above would have moved it
+            // into the outbox). A newer root supersedes these uncommitted
+            // intents, so cancel them before planning the newer bytes.
+            record.planned.clear();
+            record.complete = false;
+            write_legacy_reconciliation_record(data_dir, record)?;
+        }
+        if record.root_sha256 == fingerprint && record.complete {
+            let guard_advanced =
+                crate::credential_migration::advance_legacy_root_completion_guard_locked(
+                    data_dir,
+                    Some(&fingerprint),
+                )?;
+            if !guard_advanced {
+                record.complete = false;
+                write_legacy_reconciliation_record(data_dir, record)?;
+            }
+            return Ok(Some(LegacyRootReconciliationOutcome {
+                fingerprint,
+                committed: reconciliation_record_events(record),
+                rejected: record.rejected.clone(),
+                duplicate: guard_advanced,
+                guard_advanced,
+                partial: !guard_advanced,
+                ..LegacyRootReconciliationOutcome::default()
+            }));
+        }
+        if record.root_sha256 == fingerprint && !record.complete && record.planned.is_empty() {
+            let guard_advanced =
+                crate::credential_migration::advance_legacy_root_completion_guard_locked(
+                    data_dir,
+                    Some(&fingerprint),
+                )?;
+            record.complete = guard_advanced;
+            write_legacy_reconciliation_record(data_dir, record)?;
+            return Ok(Some(LegacyRootReconciliationOutcome {
+                fingerprint,
+                committed: reconciliation_record_events(record),
+                rejected: record.rejected.clone(),
+                duplicate: false,
+                guard_advanced,
+                partial: !guard_advanced,
+                ..LegacyRootReconciliationOutcome::default()
+            }));
+        }
+    }
+
+    let retry_planned = previous_record
+        .as_ref()
+        .filter(|record| record.root_sha256 == fingerprint && !record.complete)
+        .map(|record| record.planned.clone())
+        .unwrap_or_default();
+    let mut rejected = previous_record
+        .as_ref()
+        .filter(|record| record.root_sha256 == fingerprint)
+        .map(|record| record.rejected.clone())
+        .unwrap_or_default();
+    let root = match parse_legacy_root_without_duplicate_keys(&root_bytes) {
+        Ok(root) => root,
+        Err(_) => {
+            rejected.push(LegacyRootSectionRejection {
+                section: SectionId::Core,
+                reason: LegacyRootRejectionReason::InvalidDocument,
+            });
+            Value::Object(Map::new())
+        }
+    };
+    let (raw_sections, unknown_fields, mut ownership_rejections) =
+        match reconciliation_root_sections(&root) {
+            Ok(result) => result,
+            Err(mut errors) => {
+                rejected.append(&mut errors);
+                (BTreeMap::new(), 0, Vec::new())
+            }
+        };
+    rejected.append(&mut ownership_rejections);
+
+    // Planning always observes the freshly opened durable authority. The
+    // process registry may intentionally lag; its commit-from-durable-base
+    // seam can jump over those already-durable revisions while still
+    // installing this operation's exact successful CAS snapshot.
+    let rejected_ids = rejected
+        .iter()
+        .map(|rejection| rejection.section)
+        .collect::<BTreeSet<_>>();
+    let mut plans = Vec::new();
+    for (id, raw) in raw_sections {
+        if rejected_ids.contains(&id) {
+            continue;
+        }
+        if !retry_planned.is_empty() && !retry_planned.contains_key(id.descriptor().name) {
+            continue;
+        }
+        let envelope = durable_registry.envelope_value(id)?;
+        if envelope.status != SectionStatus::Healthy
+            || envelope.source_kind != SectionSourceKind::File
+        {
+            rejected.push(LegacyRootSectionRejection {
+                section: id,
+                reason: LegacyRootRejectionReason::AuthorityUnavailable,
+            });
+            continue;
+        }
+        let raw_has_secret_material =
+            raw_reconciliation_secret_material_is_forbidden_for_section(id, &raw);
+        let mut candidate = envelope.data.clone();
+        crate::patch::deep_merge_json(&mut candidate, raw);
+        if raw_has_secret_material {
+            rejected.push(LegacyRootSectionRejection {
+                section: id,
+                reason: LegacyRootRejectionReason::CredentialMaterial,
+            });
+            continue;
+        }
+        if credential_bearing_subtree_changed(&envelope.data, &candidate) {
+            rejected.push(LegacyRootSectionRejection {
+                section: id,
+                reason: LegacyRootRejectionReason::CredentialMaterial,
+            });
+            continue;
+        }
+        // Compatibility writers commonly echo the full safe projection.
+        // An exact echo is not an attempted mutation of a dedicated or
+        // credential-owned authority and therefore needs no rejection.
+        if candidate == envelope.data {
+            continue;
+        }
+        if id == SectionId::ClusterFabric {
+            rejected.push(LegacyRootSectionRejection {
+                section: id,
+                reason: LegacyRootRejectionReason::DedicatedAuthority,
+            });
+            continue;
+        }
+        if server_metadata_inventory(&candidate) != server_metadata_inventory(&envelope.data) {
+            rejected.push(LegacyRootSectionRejection {
+                section: id,
+                reason: LegacyRootRejectionReason::CredentialMaterial,
+            });
+            continue;
+        }
+        if validate_section_data(id.descriptor().file_name, &candidate).is_err() {
+            rejected.push(LegacyRootSectionRejection {
+                section: id,
+                reason: LegacyRootRejectionReason::InvalidDocument,
+            });
+            continue;
+        }
+        let candidate = canonicalize_legacy_root_candidate(id, candidate)?;
+        // Typed deserialization may intentionally discard a forward field.
+        // Compare again after canonicalization so a byte-preserved unknown
+        // fragment cannot manufacture a revision or Changed publication.
+        if candidate == envelope.data {
+            continue;
+        }
+        if let Some(intent) = retry_planned.get(id.descriptor().name) {
+            if canonical_value_sha256(&candidate)? != intent.candidate_sha256 {
+                rejected.push(LegacyRootSectionRejection {
+                    section: id,
+                    reason: LegacyRootRejectionReason::RevisionConflict,
+                });
+                continue;
+            }
+        }
+        plans.push(PlannedLegacyRootSection {
+            id,
+            expected_revision: envelope.revision,
+            expected_data: envelope.data,
+            candidate,
+        });
+    }
+
+    // Bind the pure plan to the exact root bytes before crossing the first
+    // section CAS boundary. A newer editor generation is planned afresh.
+    if crate::credential_migration::read_section_attestation_target(&data_dir.join("config.json"))?
+        .as_deref()
+        != Some(root_bytes.as_slice())
+    {
+        return Ok(Some(LegacyRootReconciliationOutcome {
+            fingerprint,
+            ..LegacyRootReconciliationOutcome::default()
+        }));
+    }
+
+    if let Some(record) = previous_record.as_mut() {
+        if record.root_sha256 != fingerprint && !record.committed.is_empty() {
+            // A successful exact Invalid append is the only proof that lets a
+            // newer root supersede a failed runtime handoff. Even then, the
+            // newer generation must pass every ownership/secret/typed gate,
+            // and must contain a distinct replacement plan for that exact
+            // section. Omission, an identical echo, or any rejection keeps
+            // the old publication pending so transient dependencies can
+            // recover without another edit.
+            if record
+                .committed
+                .values()
+                .any(|publication| !publication.runtime_degraded)
+            {
+                // The previous generation's exact runtime/event handoff is a
+                // durable outbox. It cannot cross a root fingerprint until a
+                // Changed transition or an exact Invalid transition makes the
+                // handoff durable.
+                return Ok(Some(LegacyRootReconciliationOutcome {
+                    fingerprint: record.root_sha256.clone(),
+                    committed: reconciliation_record_events(record),
+                    rejected: record.rejected.clone(),
+                    duplicate: false,
+                    guard_advanced: false,
+                    partial: true,
+                    ..LegacyRootReconciliationOutcome::default()
+                }));
+            }
+            if !rejected.is_empty() {
+                // A malformed/ambiguous/secret-bearing generation must never
+                // supersede an old failed publication, even when one of its
+                // per-section candidates happens to deserialize. Preserve
+                // those exact publications while allowing unrelated valid
+                // section plans to retain their normal independent semantics.
+                plans.retain(|plan| !record.committed.contains_key(plan.id.descriptor().name));
+            }
+            // Carry every old degraded publication into the new generation.
+            // A successful distinct rN+1 CAS atomically overwrites the same
+            // map entry below; omission, an identical echo, a crash, root
+            // race, or CAS conflict leaves the rN retry proof intact while
+            // unrelated section plans can still commit independently.
+        }
+    }
+
+    rejected.sort_by_key(|rejection| rejection.section);
+    rejected.dedup_by_key(|rejection| rejection.section);
+    let mut committed_by_section = previous_record
+        .as_ref()
+        .map(|record| record.committed.clone())
+        .unwrap_or_default();
+    let mut planned_by_section = BTreeMap::new();
+    for plan in &plans {
+        planned_by_section.insert(
+            plan.id.descriptor().name.to_string(),
+            LegacyRootPlannedCommit {
+                expected_revision: plan.expected_revision,
+                candidate_sha256: canonical_value_sha256(&plan.candidate)?,
+            },
+        );
+    }
+    let mut record = LegacyRootReconciliationRecord {
+        version: LEGACY_ROOT_RECONCILIATION_VERSION,
+        root_sha256: fingerprint.clone(),
+        complete: false,
+        committed: committed_by_section.clone(),
+        planned: planned_by_section,
+        rejected: rejected.clone(),
+        unknown_fields,
+    };
+    // Durable intent precedes every section CAS, closing the otherwise
+    // unrecoverable commit-before-outbox crash window.
+    write_legacy_reconciliation_record(data_dir, &record)?;
+
+    let mut committed = Vec::new();
+    let mut partial = false;
+    for plan in plans {
+        let id = plan.id;
+        let section = id.descriptor().name.to_string();
+        let candidate_sha256 = record
+            .planned
+            .get(&section)
+            .map(|planned| planned.candidate_sha256.clone())
+            .ok_or_else(|| {
+                crate::ConfigStoreError::Validation(
+                    "legacy root publication intent is unavailable".to_string(),
+                )
+            })?;
+        if crate::credential_migration::read_section_attestation_target(
+            &data_dir.join("config.json"),
+        )?
+        .as_deref()
+            != Some(root_bytes.as_slice())
+        {
+            partial = true;
+            break;
+        }
+        #[cfg(test)]
+        run_legacy_root_commit_test_hook(legacy_root_before_commit_test_hooks(), data_dir, id);
+        match commit_planned_legacy_root_section(commit_registry, plan) {
+            Ok(event) => {
+                #[cfg(test)]
+                run_legacy_root_commit_test_hook(
+                    legacy_root_after_commit_test_hooks(),
+                    data_dir,
+                    id,
+                );
+                let revision = match &event {
+                    ConfigSectionEvent::Changed { revision, .. }
+                    | ConfigSectionEvent::Invalid { revision, .. }
+                    | ConfigSectionEvent::Recovered { revision, .. } => *revision,
+                };
+                let publication = LegacyRootCommittedPublication {
+                    revision,
+                    candidate_sha256,
+                    runtime_degraded: false,
+                };
+                committed_by_section.insert(section.clone(), publication.clone());
+                record.committed.insert(section.clone(), publication);
+                record.planned.remove(&section);
+                write_legacy_reconciliation_record(data_dir, &record)?;
+                committed.push(event);
+            }
+            Err(crate::ConfigStoreError::Conflict { .. }) => {
+                rejected.push(LegacyRootSectionRejection {
+                    section: id,
+                    reason: LegacyRootRejectionReason::RevisionConflict,
+                });
+                record.planned.remove(&section);
+            }
+            Err(crate::ConfigStoreError::Json(_) | crate::ConfigStoreError::Validation(_)) => {
+                rejected.push(LegacyRootSectionRejection {
+                    section: id,
+                    reason: LegacyRootRejectionReason::InvalidDocument,
+                });
+                record.planned.remove(&section);
+            }
+            Err(error) => return Err(error),
+        }
+        record.rejected = rejected.clone();
+        write_legacy_reconciliation_record(data_dir, &record)?;
+    }
+    if crate::credential_migration::read_section_attestation_target(&data_dir.join("config.json"))?
+        .as_deref()
+        != Some(root_bytes.as_slice())
+    {
+        partial = true;
+    }
+    rejected.sort_by_key(|rejection| rejection.section);
+    rejected.dedup_by_key(|rejection| rejection.section);
+    let rejected_ids = rejected
+        .iter()
+        .map(|rejection| rejection.section)
+        .collect::<BTreeSet<_>>();
+    let recovered = previous_record
+        .as_ref()
+        .into_iter()
+        .flat_map(|record| record.rejected.iter())
+        .map(|rejection| rejection.section)
+        .filter(|section| !rejected_ids.contains(section))
+        .filter(|section| !record.committed.contains_key(section.descriptor().name))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    record.rejected = rejected.clone();
+    write_legacy_reconciliation_record(data_dir, &record)?;
+    let guard_advanced = !partial
+        && crate::credential_migration::advance_legacy_root_completion_guard_locked(
+            data_dir,
+            Some(&fingerprint),
+        )?;
+    if !partial {
+        record.complete = guard_advanced;
+        write_legacy_reconciliation_record(data_dir, &record)?;
+    }
+    let pending_publications = reconciliation_record_events(&record);
+    Ok(Some(LegacyRootReconciliationOutcome {
+        fingerprint,
+        committed: pending_publications,
+        rejected,
+        recovered,
+        duplicate: false,
+        guard_advanced,
+        partial: !record.complete,
+    }))
 }

--- a/crates/infra/bamboo-permission/src/storage.rs
+++ b/crates/infra/bamboo-permission/src/storage.rs
@@ -278,14 +278,43 @@ fn migrate_legacy_document(
         return install_migrated_document(canonical, &candidate);
     }
 
-    let root_path = config_dir.join("config.json");
-    if !root_path.exists() {
+    // The modular completion marker/ledger is a one-way authority boundary.
+    // Once either artifact exists, a reappeared compatibility root is never a
+    // permission-policy source, even when the marker itself is damaged.
+    let modular_boundary =
+        bamboo_config::modular_authority_boundary_present(config_dir).map_err(|source| {
+            PermissionStorageError::StoreError {
+                path: canonical.to_path_buf(),
+                source,
+            }
+        })?;
+    let initial_extension_source = if modular_boundary {
+        bamboo_config::initial_legacy_root_extension_migration_source(config_dir).map_err(
+            |source| PermissionStorageError::StoreError {
+                path: canonical.to_path_buf(),
+                source,
+            },
+        )?
+    } else {
+        None
+    };
+    if modular_boundary && initial_extension_source.is_none() {
         return Ok(());
     }
-    let bytes = std::fs::read(&root_path).map_err(|source| PermissionStorageError::ReadError {
-        path: root_path.clone(),
-        source,
-    })?;
+
+    let root_path = config_dir.join("config.json");
+    let bytes = match initial_extension_source {
+        Some(bytes) => bytes,
+        None => {
+            if !root_path.exists() {
+                return Ok(());
+            }
+            std::fs::read(&root_path).map_err(|source| PermissionStorageError::ReadError {
+                path: root_path.clone(),
+                source,
+            })?
+        }
+    };
     let root: serde_json::Value =
         serde_json::from_slice(&bytes).map_err(|source| PermissionStorageError::ParseError {
             path: root_path.clone(),
@@ -435,6 +464,57 @@ mod tests {
                 .unwrap();
         assert_eq!(after["unknown"]["keep"], true);
         assert!(after.get("permissions").is_some());
+    }
+
+    #[test]
+    fn completed_layout_never_adopts_reappeared_root_permission() {
+        let temp = tempdir().unwrap();
+        std::fs::write(temp.path().join("config.json"), b"{}").unwrap();
+        bamboo_config::migrate_config_facade_layout(temp.path()).unwrap();
+
+        let mut candidate = default_permission_document();
+        candidate.ask_rules = vec!["Bash(untrusted *)".to_string()];
+        std::fs::write(
+            temp.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({"permissions": candidate})).unwrap(),
+        )
+        .unwrap();
+
+        let section = PermissionSection::open(temp.path()).unwrap();
+
+        assert_eq!(section.snapshot().revision, 0);
+        assert_eq!(section.snapshot().status, SectionStatus::Missing);
+        assert!(section.snapshot().data.ask_rules.is_empty());
+        assert!(!temp.path().join("permissions.json").exists());
+    }
+
+    #[test]
+    fn initial_facade_split_preserves_legacy_root_permission_import() {
+        let temp = tempdir().unwrap();
+        let mut candidate = default_permission_document();
+        candidate.ask_rules = vec!["Bash(initial-safe *)".to_string()];
+        std::fs::write(
+            temp.path().join("config.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "server": {"port": 29562},
+                "permissions": candidate,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        bamboo_config::ConfigFacade::open_or_migrate(temp.path()).unwrap();
+        assert!(
+            bamboo_config::initial_legacy_root_extension_migration_allowed(temp.path()).unwrap()
+        );
+        let section = PermissionSection::open(temp.path()).unwrap();
+
+        assert_eq!(section.snapshot().revision, 1);
+        assert_eq!(
+            section.snapshot().data.ask_rules,
+            vec!["Bash(initial-safe *)".to_string()]
+        );
+        assert!(temp.path().join("permissions.json").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reconcile a reappeared legacy `config.json` through independently revisioned typed sections instead of adopting the root wholesale
- preserve exact runtime-before-event ordering with a durable reconciliation intent/outbox and restart recovery
- reject cluster-fabric, credential-owned, ambiguous, invalid, and secret-bearing root mutations while preserving unknown root bytes
- deduplicate watcher and in-process compatibility observations of the same root generation
- harden credential scanning for provider/MCP identifiers, structured credential references, runtime header templates, and model-policy mask patterns

## Root Cause

After modular configuration activation, a compatibility writer could recreate `config.json`. Existing exact section transactions correctly preserved those bytes, but there was no revisioned path to map the recreated root fields back to their typed owners. Publishing the entire root under one section event would violate section CAS authority and could install unrelated or credential-bearing state.

## Impact

Valid ordinary-section edits now converge through their own durable revisions and become observable only after the exact runtime generation is installed. Invalid or unauthorized root mutations fail closed with durable health diagnostics. Cluster and credential authorities remain restricted to their dedicated transactions, and reconciliation journals/events stay secret-free.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo check -p bamboo-config -p bamboo-permission -p bamboo-engine -p bamboo-server`
- [x] `cargo test -p bamboo-config -- --nocapture` — 665 passed
- [x] `cargo test -p bamboo-permission` — 260 unit tests passed; doc tests passed
- [x] `cargo test -p bamboo-engine` — 1,292 unit tests passed; doc tests passed
- [x] `cargo test -p bamboo-server -- --nocapture` — 1,766 unit tests passed, 1 ignored; integration and doc tests passed
- [x] post-lint-refactor focused regressions — config 3/3, server 4/4, AccountSink 11/11
- [x] standard Clippy for all affected packages; strict `-D warnings` checks pass for config/permission all targets and the engine library

The strict server-library lint run is otherwise clean for this diff and stops only on the pre-existing `connect/bridge.rs::create_connect_session` argument-count warning in an unchanged file.

Closes #735