### PR TITLE
[bamboo] fix: accept mixed-case skill display names

### DIFF
--- a/crates/infra/bamboo-skills/src/store/parser.rs
+++ b/crates/infra/bamboo-skills/src/store/parser.rs
@@ -180,17 +180,17 @@ fn validate_skill_name(name: &str) -> SkillResult<()> {
         )));
     }
 
-    if !is_valid_skill_id(primary) {
+    if !is_valid_skill_name_segment(primary) {
         return Err(SkillError::Validation(format!(
-            "Name '{}' must be kebab-case or '<namespace>:kebab-case'",
+            "Name '{}' must use ASCII letters and digits separated by single hyphens, optionally as '<namespace>:<name>'",
             name
         )));
     }
 
     if let Some(suffix) = secondary {
-        if !is_valid_skill_id(suffix) {
+        if !is_valid_skill_name_segment(suffix) {
             return Err(SkillError::Validation(format!(
-                "Name '{}' must be kebab-case or '<namespace>:kebab-case'",
+                "Name '{}' must use ASCII letters and digits separated by single hyphens, optionally as '<namespace>:<name>'",
                 name
             )));
         }
@@ -199,11 +199,15 @@ fn validate_skill_name(name: &str) -> SkillResult<()> {
     Ok(())
 }
 
+fn is_valid_skill_name_segment(segment: &str) -> bool {
+    is_valid_skill_id(&segment.to_ascii_lowercase())
+}
+
 fn matches_skill_name_directory(name: &str, dir_name: &str) -> bool {
-    name == dir_name
+    name.eq_ignore_ascii_case(dir_name)
         || name
             .rsplit_once(':')
-            .is_some_and(|(_, suffix)| suffix == dir_name)
+            .is_some_and(|(_, suffix)| suffix.eq_ignore_ascii_case(dir_name))
 }
 
 fn validate_skill_description(description: &str) -> SkillResult<()> {
@@ -325,6 +329,50 @@ Use this skill when users need design support.
         assert_eq!(parsed.id, "design");
         assert_eq!(parsed.name, "ckm:design");
         assert_eq!(parsed.description, "Design workflows.");
+    }
+
+    #[test]
+    fn parse_skill_accepts_mixed_case_name_matching_directory() {
+        let content = r#"---
+name: Surge
+description: Runs deployment workflows.
+---
+Deploy the application safely.
+"#;
+
+        let parsed = parse_markdown_skill(Path::new("surge/SKILL.md"), content)
+            .expect("mixed-case display name should match its directory");
+        assert_eq!(parsed.id, "surge");
+        assert_eq!(parsed.name, "Surge");
+    }
+
+    #[test]
+    fn parse_skill_accepts_mixed_case_namespaced_name() {
+        let content = r#"---
+name: OpenAI:Documents
+description: Creates and edits documents.
+---
+Use this skill for document work.
+"#;
+
+        let parsed = parse_markdown_skill(Path::new("documents/SKILL.md"), content)
+            .expect("mixed-case namespaced display name should parse");
+        assert_eq!(parsed.id, "documents");
+        assert_eq!(parsed.name, "OpenAI:Documents");
+    }
+
+    #[test]
+    fn parse_skill_rejects_malformed_mixed_case_name() {
+        let content = r#"---
+name: Skill_Creator
+description: Helps create and improve skills.
+---
+Use this skill when users want to create skills.
+"#;
+
+        let error = parse_markdown_skill(Path::new("skill-creator/SKILL.md"), content)
+            .expect_err("mixed case must not make malformed names valid");
+        assert!(error.to_string().contains("ASCII letters and digits"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- accept ASCII mixed-case skill display names while keeping directory-derived skill IDs strictly lowercase
- compare display names to skill directories case-insensitively, including namespaced names
- retain rejection of malformed names such as underscores and preserve the authored display name

## Test Plan

- `cargo test -p bamboo-skills --all-features`
- `cargo test --all-features --lib --tests`
- `cargo test --tests`
- `cargo build --examples`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
- `python3 scripts/check-msrv.py`
- `cargo check --locked --workspace --all-targets --all-features`
- CI-equivalent strict `cargo clippy --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

## Screenshots

N/A — parser-only backend change.

Closes #657