### PR TITLE
fix: add session-scoped Responses cache key (#758)

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -33,6 +33,7 @@ use bamboo_llm::{
     SegmentRole,
 };
 use bamboo_tools::exposure::activated_discoverable_tools;
+use sha2::{Digest, Sha256};
 
 /// LLM-stream frame bundling per-request identification, observability, and
 /// model configuration parameters.  Passed into [`execute_llm_stream`] to
@@ -52,6 +53,8 @@ pub(in crate::runtime::runner) struct LlmStreamFrame<'a> {
 const SESSION_RESPONSES_PREVIOUS_RESPONSE_ID_KEY: &str = "responses.previous_response_id";
 const CONVERSATION_SUMMARY_START_MARKER: &str = "<!-- CONVERSATION_SUMMARY_START -->";
 const INTERRUPTED_ASSISTANT_OUTPUT_KIND: &str = "interrupted_assistant_output";
+const AGENT_LOOP_REQUEST_PURPOSE: &str = "agent_loop";
+const PROMPT_CACHE_KEY_DOMAIN: &[u8] = b"bamboo/openai/responses/prompt-cache-key/v1\0";
 
 fn interruption_kind(error: &AgentError) -> &'static str {
     match error {
@@ -151,6 +154,26 @@ fn engine_responses_policy() -> ResponsesRequestOptions {
         include: Some(vec!["reasoning.encrypted_content".to_string()]),
         ..Default::default()
     }
+}
+
+/// Derive the privacy-preserving OpenAI Responses cache-affinity hint for an
+/// agent-loop session. This is a routing hint only, not a cache-hit guarantee.
+/// Length-prefixing the purpose and session beneath a versioned protocol domain
+/// prevents concatenation ambiguity and cross-purpose reuse.
+fn agent_loop_prompt_cache_key(
+    session_id: Option<&str>,
+    request_purpose: Option<&str>,
+) -> Option<String> {
+    let purpose = request_purpose.filter(|purpose| *purpose == AGENT_LOOP_REQUEST_PURPOSE)?;
+    let session_id = session_id.filter(|session_id| !session_id.trim().is_empty())?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(PROMPT_CACHE_KEY_DOMAIN);
+    for component in [purpose.as_bytes(), session_id.as_bytes()] {
+        hasher.update((component.len() as u64).to_be_bytes());
+        hasher.update(component);
+    }
+    Some(hex::encode(hasher.finalize()))
 }
 
 /// Whether the stateful Responses continuation (`previous_response_id`) may be
@@ -718,7 +741,9 @@ fn plan_llm_request(
     // The engine sets request POLICY only. The Responses prompt wire view
     // (instructions / input_messages / previous_response_id) is derived by the
     // OpenAI/Copilot adapter from the IR via `responses_request_options`.
-    let responses_options = engine_responses_policy();
+    let mut responses_options = engine_responses_policy();
+    responses_options.prompt_cache_key =
+        agent_loop_prompt_cache_key(Some(session_id), Some(AGENT_LOOP_REQUEST_PURPOSE));
 
     let request_options = LLMRequestOptions {
         session_id: Some(session_id.to_string()),
@@ -726,7 +751,7 @@ fn plan_llm_request(
         parallel_tool_calls: Some(required_tool.is_none()),
         required_tool: required_tool.map(str::to_string),
         responses: Some(responses_options),
-        request_purpose: Some("agent_loop".to_string()),
+        request_purpose: Some(AGENT_LOOP_REQUEST_PURPOSE.to_string()),
         cache: Some(envelope.ir.cache.clone()),
     };
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -1142,6 +1142,38 @@ fn zero_tools_fallback_keeps_merged_system_string_and_no_blocks() {
 }
 
 #[test]
+fn agent_loop_prompt_cache_key_is_stable_isolated_and_private() {
+    let raw_session_id = "session-secret-alpha";
+    let first = super::agent_loop_prompt_cache_key(Some(raw_session_id), Some("agent_loop"))
+        .expect("agent-loop session gets an affinity key");
+    let resumed = super::agent_loop_prompt_cache_key(Some(raw_session_id), Some("agent_loop"))
+        .expect("resumed session gets the same affinity key");
+    let other_session =
+        super::agent_loop_prompt_cache_key(Some("session-secret-beta"), Some("agent_loop"))
+            .expect("different session gets an affinity key");
+
+    assert_eq!(first, resumed);
+    assert_eq!(
+        first,
+        "29665ec5c5f0fc1c3f89fb420c578cf217757f6a3d4f52b57ca711c94f15e599"
+    );
+    assert_eq!(first.len(), 64);
+    assert!(first
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)));
+    assert_ne!(first, other_session);
+    assert!(!first.contains(raw_session_id));
+    assert!(super::agent_loop_prompt_cache_key(None, Some("agent_loop")).is_none());
+    assert!(super::agent_loop_prompt_cache_key(Some(""), Some("agent_loop")).is_none());
+    assert!(super::agent_loop_prompt_cache_key(Some("   "), Some("agent_loop")).is_none());
+    assert!(super::agent_loop_prompt_cache_key(Some(raw_session_id), None).is_none());
+    assert!(
+        super::agent_loop_prompt_cache_key(Some(raw_session_id), Some("title_generation"))
+            .is_none()
+    );
+}
+
+#[test]
 fn plan_llm_request_lanes_path_records_observability() {
     // The single request-planning seam: a normal request takes the canonical
     // lanes path and the render descriptor captures the system shape + cache plan.
@@ -1172,7 +1204,17 @@ fn plan_llm_request_lanes_path_records_observability() {
     assert!(planned.render.cache_system);
     assert_eq!(planned.render.cache_ttl, "1h");
     assert!(planned.request_options.cache.is_some());
-    assert!(planned.request_options.responses.is_some());
+    let responses = planned
+        .request_options
+        .responses
+        .as_ref()
+        .expect("agent loop carries Responses policy");
+    let cache_key = responses
+        .prompt_cache_key
+        .as_deref()
+        .expect("agent loop carries a session-scoped cache-affinity key");
+    assert_eq!(cache_key.len(), 64);
+    assert!(!cache_key.contains("session-plan"));
 }
 
 #[test]

--- a/crates/infra/bamboo-llm/src/prompt_ir.rs
+++ b/crates/infra/bamboo-llm/src/prompt_ir.rs
@@ -372,6 +372,7 @@ mod tests {
         let base = ResponsesRequestOptions {
             store: Some(false),
             text_verbosity: Some("high".to_string()),
+            prompt_cache_key: Some("session-affinity-hash".to_string()),
             ..Default::default()
         };
         let ir = PromptIR {
@@ -386,6 +387,10 @@ mod tests {
         // Policy preserved.
         assert_eq!(options.store, Some(false));
         assert_eq!(options.text_verbosity.as_deref(), Some("high"));
+        assert_eq!(
+            options.prompt_cache_key.as_deref(),
+            Some("session-affinity-hash")
+        );
         // Prompt wire view derived from the IR.
         assert_eq!(options.instructions.as_deref(), Some("SYSTEM"));
         assert_eq!(

--- a/crates/infra/bamboo-llm/src/provider.rs
+++ b/crates/infra/bamboo-llm/src/provider.rs
@@ -100,8 +100,8 @@ pub struct ResponsesRequestOptions {
     /// (e.g. "low", "medium", "high").
     pub text_verbosity: Option<String>,
     /// Stable affinity key for OpenAI prompt caching. Callers should provide a
-    /// privacy-preserving value; Bamboo never derives one from raw session
-    /// identity in this generic request DTO.
+    /// privacy-preserving value. The agent loop supplies a domain-separated hash,
+    /// never its raw session identity, through this generic request DTO.
     pub prompt_cache_key: Option<String>,
     /// OpenAI request-wide cache policy (currently `mode` and optional `ttl`).
     /// Kept as JSON so newly added official policy keys survive proxying.

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -209,8 +209,12 @@ impl OpenAIProvider {
         }
         // Last-moment scan: mask every text value in the fully-assembled body.
         crate::masking::mask_outbound_body(&mut body, &self.masking_config);
+        let prompt_cache_affinity_hint = body
+            .get("prompt_cache_key")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty());
         tracing::info!(
-            "[{}] OpenAI request protocol=responses model='{}' reasoning_effort={} reasoning_source={} request_reasoning_enabled={} max_output_tokens={} input_source={} input_messages_before={} input_messages_after={} duplicate_system_fallback={} explicit_prompt_cache={} [{}]",
+            "[{}] OpenAI request protocol=responses model='{}' reasoning_effort={} reasoning_source={} request_reasoning_enabled={} max_output_tokens={} input_source={} input_messages_before={} input_messages_after={} duplicate_system_fallback={} explicit_prompt_cache={} prompt_cache_affinity_hint={} cache_hit_guaranteed=false [{}]",
             session_log_id,
             model,
             reasoning_effort
@@ -226,6 +230,7 @@ impl OpenAIProvider {
             input_selection.effective_len,
             input_selection.fallback_removed_duplicate_system,
             self.explicit_prompt_cache,
+            prompt_cache_affinity_hint,
             request_purpose
         );
 
@@ -700,6 +705,9 @@ impl LLMProvider for OpenAIProvider {
 mod tests {
     use super::*;
     use crate::providers::common::openai_compat::parse_openai_compat_sse_data_strict;
+    use bamboo_config::{
+        BodyPatch, BodyPatchOp, PatchValue, RequestOverridesConfig, RequestScopeOverride,
+    };
     use bamboo_domain::Message;
     use bamboo_domain::{FunctionSchema, ToolSchema};
 
@@ -1027,6 +1035,8 @@ mod tests {
     const RESPONSES_SSE_OK: &str = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_new\"}}\n\n";
     const CHAT_SSE_OK: &str =
         "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+    const SESSION_CACHE_KEY: &str =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn load_skill_tool() -> ToolSchema {
         ToolSchema {
@@ -1071,6 +1081,112 @@ mod tests {
         OpenAIProvider::new("test-key")
             .with_base_url(server.uri())
             .with_responses_only_models(vec!["gpt-5*".to_string()])
+    }
+
+    fn planned_agent_loop_options() -> LLMRequestOptions {
+        LLMRequestOptions {
+            session_id: Some("raw-session-must-not-reach-wire".to_string()),
+            request_purpose: Some("agent_loop".to_string()),
+            responses: Some(ResponsesRequestOptions {
+                prompt_cache_key: Some(SESSION_CACHE_KEY.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn prompt_cache_key_override(patch: BodyPatch) -> RequestOverridesConfig {
+        RequestOverridesConfig {
+            common: RequestScopeOverride {
+                headers: Default::default(),
+                body_patch: vec![patch],
+            },
+            endpoints: Default::default(),
+            rules: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_loop_cache_affinity_key_reaches_actual_responses_body_without_session_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(RESPONSES_SSE_OK),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = responses_provider(&server);
+        let options = planned_agent_loop_options();
+        let _stream = provider
+            .chat_stream_with_options(
+                &[Message::user("hello")],
+                &[],
+                None,
+                "gpt-5.6-sol",
+                Some(&options),
+            )
+            .await
+            .expect("agent-loop Responses request");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(body["prompt_cache_key"], SESSION_CACHE_KEY);
+        assert!(!body.to_string().contains("raw-session-must-not-reach-wire"));
+    }
+
+    #[tokio::test]
+    async fn responses_request_overrides_replace_or_remove_generated_affinity_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(RESPONSES_SSE_OK),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let replace_provider = responses_provider(&server).with_request_overrides(Some(
+            prompt_cache_key_override(BodyPatch {
+                path: "prompt_cache_key".to_string(),
+                op: BodyPatchOp::Set,
+                value: Some(PatchValue::Json(json!("operator-key"))),
+            }),
+        ));
+        let remove_provider = responses_provider(&server).with_request_overrides(Some(
+            prompt_cache_key_override(BodyPatch {
+                path: "prompt_cache_key".to_string(),
+                op: BodyPatchOp::Remove,
+                value: None,
+            }),
+        ));
+        let options = planned_agent_loop_options();
+
+        for provider in [&replace_provider, &remove_provider] {
+            let _stream = provider
+                .chat_stream_with_options(
+                    &[Message::user("hello")],
+                    &[],
+                    None,
+                    "gpt-5.6-sol",
+                    Some(&options),
+                )
+                .await
+                .expect("overridden Responses request");
+        }
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        let replaced: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        let removed: serde_json::Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(replaced["prompt_cache_key"], "operator-key");
+        assert!(removed.get("prompt_cache_key").is_none());
     }
 
     #[tokio::test]
@@ -1129,7 +1245,13 @@ mod tests {
             .await;
         let provider = OpenAIProvider::new("test-key").with_base_url(server.uri());
         let tools = vec![load_skill_tool()];
-        let options = require_load_skill_options();
+        let mut options = require_load_skill_options();
+        options.session_id = Some("raw-session-must-not-reach-chat-wire".to_string());
+        options.request_purpose = Some("agent_loop".to_string());
+        options.responses = Some(ResponsesRequestOptions {
+            prompt_cache_key: Some(SESSION_CACHE_KEY.to_string()),
+            ..Default::default()
+        });
 
         let _stream = provider
             .chat_stream_with_options(
@@ -1153,6 +1275,10 @@ mod tests {
         );
         assert_eq!(body["parallel_tool_calls"], false);
         assert_eq!(body["reasoning_effort"], "high");
+        assert!(body.get("prompt_cache_key").is_none());
+        assert!(!body
+            .to_string()
+            .contains("raw-session-must-not-reach-chat-wire"));
     }
 
     #[tokio::test]
@@ -1305,13 +1431,20 @@ mod tests {
             .await;
 
         let provider = responses_provider(&server);
-        let options = options_with_previous_response_id(Some("resp_stale"));
+        let mut options = options_with_previous_response_id(Some("resp_stale"));
+        options.session_id = Some("resumed-session".to_string());
+        options.request_purpose = Some("agent_loop".to_string());
+        options
+            .responses
+            .as_mut()
+            .expect("Responses options")
+            .prompt_cache_key = Some(SESSION_CACHE_KEY.to_string());
         let stream = provider
             .chat_stream_with_options(
                 &[Message::user("hello")],
                 &[],
                 None,
-                "gpt-5.2",
+                "gpt-5.6",
                 Some(&options),
             )
             .await
@@ -1328,6 +1461,10 @@ mod tests {
         assert_eq!(first["previous_response_id"], "resp_stale");
         assert!(second.get("previous_response_id").is_none());
         assert_eq!(first["input"], second["input"]);
+        assert_eq!(first["prompt_cache_key"], SESSION_CACHE_KEY);
+        assert_eq!(second["prompt_cache_key"], SESSION_CACHE_KEY);
+        assert!(!first.to_string().contains("resumed-session"));
+        assert!(!second.to_string().contains("resumed-session"));
     }
 
     #[tokio::test]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -127,6 +127,14 @@ openai/anthropic/gemini the Bodhi proxy should present as). `CopilotConfig`
 has no `api_key` at all — it authenticates via a cached OAuth token
 (`headless_auth` for headless/CI login).
 
+For GPT-5.6+ OpenAI Responses requests from the agent loop, Bamboo derives a
+stable, session-scoped `prompt_cache_key` as a domain-separated SHA-256 hash.
+The raw session identifier is never serialized into the provider request, and
+non-agent requests do not receive a generated key. The key is only a cache
+affinity hint that can improve routing to a matching prefix; it does not
+guarantee a cache hit. `request_overrides` body patches run afterward, so an
+operator may replace the generated key or remove `prompt_cache_key` entirely.
+
 For more than one instance of a provider type (e.g. two separate Anthropic
 keys/workspaces), use `provider_instances` instead:
 


### PR DESCRIPTION
## Summary

- derive a stable, domain-separated SHA-256 `prompt_cache_key` from the agent-loop session ID so OpenAI Responses requests keep cache affinity across turns and resumed sessions without sending the raw session ID
- carry the key through request planning and PromptIR lowering while preserving the existing compatible-model gate and request-level replace/remove override semantics
- document the routing-affinity behavior and add regression coverage for stability, privacy, fallback/retry paths, overrides, and Chat Completions isolation

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code`
- `cargo test --all-features --lib --tests`
- `cargo build --examples`

## Screenshots

N/A (backend request-planning change)

Closes #758
