### PR TITLE
fix(tools): refresh read snapshots after writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,6 +1584,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",

--- a/crates/engine/bamboo-tools/Cargo.toml
+++ b/crates/engine/bamboo-tools/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "2"
 anyhow = "1"
 regex = "1"
 dashmap = "6"
+sha2 = { workspace = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 walkdir = "2"
 globset = "0.4"

--- a/crates/engine/bamboo-tools/src/tools/edit.rs
+++ b/crates/engine/bamboo-tools/src/tools/edit.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use std::collections::HashSet;
 use std::path::Path;
 
-use super::read_tracker::ReadState;
+use super::read_tracker::{BaselineAdvance, ReadState};
 use super::{content_diagnostics, file_change, read_tracker};
 
 const MAX_PATCH_BYTES: usize = 256 * 1024;
@@ -562,26 +562,35 @@ impl Tool for EditTool {
             ));
         }
 
-        if let Some(session_id) = ctx.session_id() {
-            match read_tracker::read_state(session_id, file_path).await {
-                ReadState::Unread => {
+        let session_id = ctx.session_id().map(str::to_owned);
+        let validated_read = if let Some(session_id) = session_id.as_deref() {
+            match read_tracker::read_if_fresh(session_id, file_path).await {
+                Ok(validated) => Some(validated),
+                Err(ReadState::Unread) => {
                     return Err(ToolError::Execution(
                         "Edit requires reading the target file first via Read".to_string(),
                     ));
                 }
-                ReadState::Stale => {
+                Err(ReadState::Stale) => {
                     return Err(ToolError::Execution(
                         "Target file changed after last Read; call Read again before Edit"
                             .to_string(),
                     ));
                 }
-                ReadState::Fresh => {}
+                Err(ReadState::Fresh) => unreachable!("Fresh is returned as a validated read"),
             }
-        }
+        } else {
+            None
+        };
 
-        let content = tokio::fs::read_to_string(path)
-            .await
-            .map_err(|e| ToolError::Execution(format!("Failed to read file: {}", e)))?;
+        let content = if let Some(validated) = validated_read.as_ref() {
+            String::from_utf8(validated.bytes().to_vec())
+                .map_err(|e| ToolError::Execution(format!("Failed to read file: {}", e)))?
+        } else {
+            tokio::fs::read_to_string(path)
+                .await
+                .map_err(|e| ToolError::Execution(format!("Failed to read file: {}", e)))?
+        };
 
         let patch = parsed
             .patch
@@ -635,7 +644,30 @@ impl Tool for EditTool {
 
         let checkpoint = file_change::create_checkpoint(path, Some(content.as_bytes())).await?;
 
-        file_change::atomic_write_text(path, &updated).await?;
+        let write_expectation = validated_read.as_ref().map_or(
+            file_change::AtomicWriteExpectation::Unchecked,
+            |validated| file_change::AtomicWriteExpectation::Exact(validated.bytes()),
+        );
+        file_change::atomic_write_text_with_expectation(path, &updated, write_expectation).await?;
+
+        if session_id.is_some() {
+            let validated = validated_read
+                .as_ref()
+                .expect("a session-scoped Edit always has a validated Read");
+            if read_tracker::advance_after_verified_write(
+                file_path,
+                validated.slot(),
+                updated.as_bytes(),
+            )
+            .await
+                == BaselineAdvance::Conflict
+            {
+                return Err(ToolError::Execution(
+                    "Edit committed, but the target changed before it could be verified; call Read again"
+                        .to_string(),
+                ));
+            }
+        }
 
         let changed_bytes = updated.len().abs_diff(content.len());
         let changed_lines = updated.lines().count().abs_diff(content.lines().count());
@@ -680,6 +712,21 @@ mod tests {
     use super::*;
     use crate::tools::ReadTool;
     use serde_json::json;
+
+    fn ctx(session_id: &str) -> ToolCtx {
+        ToolCtx {
+            session_id: Some(std::sync::Arc::from(session_id)),
+            tool_call_id: std::sync::Arc::from("call_1"),
+            event_tx: None,
+            available_tool_schemas: std::sync::Arc::from(Vec::new()),
+            bypass_permissions: false,
+            auto_approve_permissions: false,
+            plan_read_only: false,
+            can_async_resume: false,
+            async_completion_sink: None,
+            bash_completion_sink: None,
+        }
+    }
 
     async fn run(tool: &EditTool, args: serde_json::Value) -> Result<ToolResult, ToolError> {
         match tool.invoke(args, ToolCtx::none("t")).await? {
@@ -905,6 +952,207 @@ mod tests {
         };
 
         assert!(allowed.success);
+    }
+
+    #[tokio::test]
+    async fn read_edit_edit_succeeds_without_an_external_change() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "alpha\nbeta\ngamma\n")
+            .await
+            .unwrap();
+        let session = format!("edit-twice-{}", uuid::Uuid::new_v4());
+        let read_tool = ReadTool::new();
+        let edit_tool = EditTool::new();
+
+        read_tool
+            .invoke(json!({"file_path": file.path()}), ctx(&session))
+            .await
+            .unwrap();
+        edit_tool
+            .invoke(
+                json!({
+                    "file_path": file.path(),
+                    "old_string": "alpha",
+                    "new_string": "alpha-one"
+                }),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+        edit_tool
+            .invoke(
+                json!({
+                    "file_path": file.path(),
+                    "old_string": "beta",
+                    "new_string": "beta-two"
+                }),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tokio::fs::read_to_string(file.path()).await.unwrap(),
+            "alpha-one\nbeta-two\ngamma\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_read_of_edited_version_is_idempotent() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "alpha\nbeta\n")
+            .await
+            .unwrap();
+        let path = file.path().to_path_buf();
+        let path_str = path.to_string_lossy().into_owned();
+        let session = format!("edit-concurrent-read-{}", uuid::Uuid::new_v4());
+
+        ReadTool::new()
+            .invoke(json!({"file_path": path}), ctx(&session))
+            .await
+            .unwrap();
+        let (advance_reached, resume_advance) =
+            read_tracker::pause_next_advance_for_test(&session, &path_str).await;
+
+        let edit_path = path.clone();
+        let edit_session = session.clone();
+        let editor = tokio::spawn(async move {
+            EditTool::new()
+                .invoke(
+                    json!({
+                        "file_path": edit_path,
+                        "old_string": "alpha",
+                        "new_string": "ALPHA"
+                    }),
+                    ctx(&edit_session),
+                )
+                .await
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            advance_reached.notified(),
+        )
+        .await
+        .expect("Edit did not reach post-write baseline advancement");
+        ReadTool::new()
+            .invoke(json!({"file_path": path}), ctx(&session))
+            .await
+            .unwrap();
+        resume_advance.notify_one();
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), editor)
+            .await
+            .expect("Edit did not resume")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(first, ToolOutcome::Completed(result) if result.success));
+
+        EditTool::new()
+            .invoke(
+                json!({
+                    "file_path": path,
+                    "old_string": "beta",
+                    "new_string": "BETA"
+                }),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(path).await.unwrap(),
+            "ALPHA\nBETA\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_rejects_external_change_after_a_successful_edit() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "alpha\nbeta\n")
+            .await
+            .unwrap();
+        let session = format!("edit-external-{}", uuid::Uuid::new_v4());
+        let read_tool = ReadTool::new();
+        let edit_tool = EditTool::new();
+
+        read_tool
+            .invoke(json!({"file_path": file.path()}), ctx(&session))
+            .await
+            .unwrap();
+        edit_tool
+            .invoke(
+                json!({
+                    "file_path": file.path(),
+                    "old_string": "alpha",
+                    "new_string": "ALPHA"
+                }),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+
+        tokio::fs::write(file.path(), "ALPHA\nBETA\n")
+            .await
+            .unwrap();
+        let stale = edit_tool
+            .invoke(
+                json!({
+                    "file_path": file.path(),
+                    "old_string": "ALPHA",
+                    "new_string": "alpha-two"
+                }),
+                ctx(&session),
+            )
+            .await;
+
+        assert!(matches!(stale, Err(ToolError::Execution(message)) if message.contains("changed")));
+        assert_eq!(
+            tokio::fs::read_to_string(file.path()).await.unwrap(),
+            "ALPHA\nBETA\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_edit_does_not_break_the_existing_fresh_baseline() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "alpha\nbeta\n")
+            .await
+            .unwrap();
+        let session = format!("edit-failure-{}", uuid::Uuid::new_v4());
+        let read_tool = ReadTool::new();
+        let edit_tool = EditTool::new();
+
+        read_tool
+            .invoke(json!({"file_path": file.path()}), ctx(&session))
+            .await
+            .unwrap();
+        let failed = edit_tool
+            .invoke(
+                json!({
+                    "file_path": file.path(),
+                    "old_string": "not-present",
+                    "new_string": "replacement"
+                }),
+                ctx(&session),
+            )
+            .await;
+        assert!(failed.is_err());
+
+        edit_tool
+            .invoke(
+                json!({
+                    "file_path": file.path(),
+                    "old_string": "beta",
+                    "new_string": "beta-two"
+                }),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(file.path()).await.unwrap(),
+            "alpha\nbeta-two\n"
+        );
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-tools/src/tools/file_change.rs
+++ b/crates/engine/bamboo-tools/src/tools/file_change.rs
@@ -2,7 +2,7 @@ use bamboo_agent_core::ToolError;
 use chrono::Utc;
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const CONTEXT_LINES: usize = 3;
 const MAX_DIFF_LINES: usize = 400;
@@ -16,6 +16,19 @@ pub async fn read_existing_bytes(path: &Path) -> Result<Option<Vec<u8>>, ToolErr
             "Failed to read file before checkpoint: {error}"
         ))),
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum AtomicWriteExpectation<'a> {
+    /// Preserve the historical behavior for callers without a read-before-write
+    /// baseline (for example NotebookEdit).
+    Unchecked,
+    /// Refuse to replace a path that appeared after the caller observed it as
+    /// missing.
+    Missing,
+    /// Refuse to replace a path unless its bytes still exactly match the version
+    /// used to compute the mutation.
+    Exact(&'a [u8]),
 }
 
 pub fn ensure_no_symlink_components(path: &Path) -> Result<(), ToolError> {
@@ -57,6 +70,14 @@ pub fn ensure_no_symlink_components(path: &Path) -> Result<(), ToolError> {
 }
 
 pub async fn atomic_write_text(path: &Path, content: &str) -> Result<(), ToolError> {
+    atomic_write_text_with_expectation(path, content, AtomicWriteExpectation::Unchecked).await
+}
+
+pub(crate) async fn atomic_write_text_with_expectation(
+    path: &Path,
+    content: &str,
+    expectation: AtomicWriteExpectation<'_>,
+) -> Result<(), ToolError> {
     if !path.is_absolute() {
         return Err(ToolError::InvalidArguments(
             "file path must be absolute".to_string(),
@@ -117,10 +138,60 @@ pub async fn atomic_write_text(path: &Path, content: &str) -> Result<(), ToolErr
             }
         }
 
+        // Validate as late as the portable temp-file + rename strategy allows:
+        // after the replacement is fully written and synced, immediately before
+        // rename. This closes the larger validation -> temp-write/fsync window.
+        // The Exact check still has an unavoidable check -> rename race: an
+        // external write in that interval can be overwritten. Post-write
+        // verification only controls tracker advancement; it cannot detect or
+        // recover an external version that our rename replaced.
+        match expectation {
+            AtomicWriteExpectation::Unchecked => {}
+            AtomicWriteExpectation::Missing => {
+                match tokio::fs::symlink_metadata(path).await {
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Ok(_) => {
+                        return Err(ToolError::Execution(
+                            "Target file was created concurrently; call Read before Write"
+                                .to_string(),
+                        ));
+                    }
+                    Err(error) => {
+                        return Err(ToolError::Execution(format!(
+                            "Failed to verify that the target is still missing: {error}"
+                        )));
+                    }
+                }
+            }
+            AtomicWriteExpectation::Exact(expected) => {
+                let file = tokio::fs::File::open(path).await.map_err(|error| {
+                    ToolError::Execution(format!(
+                        "Target file changed before atomic replacement; call Read again: {error}"
+                    ))
+                })?;
+                let max_bytes = u64::try_from(expected.len()).unwrap_or(u64::MAX);
+                let mut reader = file.take(max_bytes.saturating_add(1));
+                let mut current = Vec::new();
+                reader.read_to_end(&mut current).await.map_err(|error| {
+                    ToolError::Execution(format!(
+                        "Target file changed before atomic replacement; call Read again: {error}"
+                    ))
+                })?;
+                if current != expected {
+                    return Err(ToolError::Execution(
+                        "Target file changed before atomic replacement; call Read again"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+
         match tokio::fs::rename(&tmp_path, path).await {
             Ok(()) => Ok(()),
             #[cfg(windows)]
             Err(error) if std::fs::metadata(path).is_ok() => {
+                // This inherited remove+rename fallback is not atomic and has
+                // the same check -> replacement race described above.
                 tokio::fs::remove_file(path).await.map_err(|remove_error| {
                     ToolError::Execution(format!(
                         "Failed to replace target file (rename failed with {error}; remove failed with {remove_error})"
@@ -412,5 +483,43 @@ mod tests {
     fn touched_line_count_reports_added_plus_removed_lines() {
         assert_eq!(touched_line_count("a\nb\nc\n", "a\nx\ny\nc\n"), 3);
         assert_eq!(touched_line_count("same\n", "same\n"), 0);
+    }
+
+    #[tokio::test]
+    async fn guarded_atomic_write_rejects_unexpected_existing_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("guarded.txt");
+        tokio::fs::write(&path, "external").await.unwrap();
+
+        let result = atomic_write_text_with_expectation(
+            &path,
+            "replacement",
+            AtomicWriteExpectation::Exact(b"expected"),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(ToolError::Execution(message)) if message.contains("changed"))
+        );
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), "external");
+    }
+
+    #[tokio::test]
+    async fn guarded_atomic_write_rejects_a_concurrently_created_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("created.txt");
+        tokio::fs::write(&path, "external").await.unwrap();
+
+        let result = atomic_write_text_with_expectation(
+            &path,
+            "replacement",
+            AtomicWriteExpectation::Missing,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(ToolError::Execution(message)) if message.contains("created concurrently"))
+        );
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), "external");
     }
 }

--- a/crates/engine/bamboo-tools/src/tools/read.rs
+++ b/crates/engine/bamboo-tools/src/tools/read.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde_json::json;
 use std::path::Path;
 
-use super::read_tracker;
+use super::read_tracker::{self, MAX_TRACKED_FILE_SIZE};
 
 const BLOCKED_DEVICE_PATHS: &[&str] = &[
     "/dev/zero",
@@ -20,8 +20,6 @@ const BLOCKED_DEVICE_PATHS: &[&str] = &[
     "/dev/fd/1",
     "/dev/fd/2",
 ];
-
-const MAX_READ_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 
 #[derive(Debug, Deserialize)]
 struct ReadArgs {
@@ -232,23 +230,35 @@ impl Tool for ReadTool {
             }));
         }
 
-        if metadata.len() > MAX_READ_SIZE {
+        if metadata.len() > MAX_TRACKED_FILE_SIZE {
             return Err(ToolError::Execution(format!(
                 "File is {} bytes, which exceeds the maximum readable size of {} bytes ({} MB). \
                  Use Grep to search within this file instead.",
                 metadata.len(),
-                MAX_READ_SIZE,
-                MAX_READ_SIZE / 1024 / 1024
+                MAX_TRACKED_FILE_SIZE,
+                MAX_TRACKED_FILE_SIZE / 1024 / 1024
             )));
         }
 
-        let bytes = tokio::fs::read(path)
+        let stable = read_tracker::stable_read(parsed.file_path.trim())
             .await
-            .map_err(|e| ToolError::Execution(format!("Failed to read file: {}", e)))?;
+            .map_err(|e| ToolError::Execution(format!("Failed to read stable file: {}", e)))?;
+
+        if stable.bytes().len() as u64 > MAX_TRACKED_FILE_SIZE {
+            return Err(ToolError::Execution(format!(
+                "File is {} bytes, which exceeds the maximum readable size of {} bytes ({} MB). \
+                 Use Grep to search within this file instead.",
+                stable.bytes().len(),
+                MAX_TRACKED_FILE_SIZE,
+                MAX_TRACKED_FILE_SIZE / 1024 / 1024
+            )));
+        }
 
         if let Some(session_id) = ctx.session_id() {
-            read_tracker::mark_read(session_id, parsed.file_path.trim()).await;
+            read_tracker::mark_stable_read(session_id, parsed.file_path.trim(), &stable).await;
         }
+
+        let bytes = stable.bytes();
 
         if bytes.contains(&0) {
             return Ok(ToolOutcome::Completed(ToolResult {
@@ -259,7 +269,7 @@ impl Tool for ReadTool {
             }));
         }
 
-        let content = String::from_utf8_lossy(&bytes).to_string();
+        let content = String::from_utf8_lossy(bytes).to_string();
         let rendered =
             render_file_with_line_numbers(&content, parsed.offset.unwrap_or(0), parsed.limit);
 

--- a/crates/engine/bamboo-tools/src/tools/read_tracker.rs
+++ b/crates/engine/bamboo-tools/src/tools/read_tracker.rs
@@ -1,10 +1,19 @@
 use dashmap::DashMap;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
+use tokio::io::AsyncReadExt;
 use tokio::sync::Mutex;
+#[cfg(test)]
+use tokio::sync::Notify;
 
 const MAX_TRACKED_SESSIONS: usize = 2_000;
+const STABLE_READ_ATTEMPTS: usize = 3;
+pub(crate) const MAX_TRACKED_FILE_SIZE: u64 = 10 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReadState {
@@ -13,16 +22,86 @@ pub enum ReadState {
     Fresh,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct FileSnapshot {
     size_bytes: u64,
     modified_ns: Option<u128>,
+    content_digest: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TrackedSnapshot {
+    Present(FileSnapshot),
+    Missing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrackedEntry {
+    generation: u64,
+    snapshot: TrackedSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BaselineAdvance {
+    Advanced,
+    AlreadyCurrent,
+    Conflict,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MutationSlot {
+    session_id: String,
+    normalized_path: String,
+    session_reads: Arc<Mutex<SessionReads>>,
+    generation: Option<u64>,
+}
+
+#[derive(Debug)]
+pub(crate) struct StableFileRead {
+    bytes: Vec<u8>,
+    snapshot: FileSnapshot,
+}
+
+impl StableFileRead {
+    pub(crate) fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ValidatedFileRead {
+    slot: MutationSlot,
+    bytes: Vec<u8>,
+}
+
+impl ValidatedFileRead {
+    pub(crate) fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub(crate) fn slot(&self) -> &MutationSlot {
+        &self.slot
+    }
 }
 
 #[derive(Debug, Default)]
 struct SessionReads {
-    files: HashMap<String, FileSnapshot>,
+    files: HashMap<String, TrackedEntry>,
+    next_generation: u64,
     last_touched: Option<Instant>,
+}
+
+impl SessionReads {
+    fn store(&mut self, path: String, snapshot: TrackedSnapshot) {
+        self.next_generation = self.next_generation.checked_add(1).unwrap_or(1);
+        self.files.insert(
+            path,
+            TrackedEntry {
+                generation: self.next_generation,
+                snapshot,
+            },
+        );
+    }
 }
 
 fn tracker() -> &'static DashMap<String, Arc<Mutex<SessionReads>>> {
@@ -31,25 +110,127 @@ fn tracker() -> &'static DashMap<String, Arc<Mutex<SessionReads>>> {
 }
 
 async fn normalize_path(path: &str) -> String {
-    tokio::fs::canonicalize(path)
-        .await
-        .ok()
-        .and_then(|value| value.to_str().map(|s| s.to_string()))
-        .unwrap_or_else(|| path.to_string())
+    let original = PathBuf::from(path);
+    if let Ok(canonical) = tokio::fs::canonicalize(&original).await {
+        return canonical.to_string_lossy().into_owned();
+    }
+
+    // A missing target cannot itself be canonicalized. Canonicalize the nearest
+    // existing ancestor and append the unresolved suffix so the key is stable
+    // before and after creation (notably `/tmp` -> `/private/tmp` on macOS).
+    let mut ancestor: &Path = &original;
+    let mut suffix: Vec<OsString> = Vec::new();
+    loop {
+        if let Ok(canonical) = tokio::fs::canonicalize(ancestor).await {
+            let mut normalized = canonical;
+            for component in suffix.iter().rev() {
+                normalized.push(component);
+            }
+            return normalized.to_string_lossy().into_owned();
+        }
+
+        let Some(name) = ancestor.file_name() else {
+            break;
+        };
+        suffix.push(name.to_os_string());
+        let Some(parent) = ancestor.parent() else {
+            break;
+        };
+        ancestor = parent;
+    }
+
+    original.to_string_lossy().into_owned()
 }
 
-async fn snapshot_for_path(path: &str) -> Option<FileSnapshot> {
-    let metadata = tokio::fs::metadata(path).await.ok()?;
-    let modified_ns = metadata
+fn modified_ns(metadata: &std::fs::Metadata) -> Option<u128> {
+    metadata
         .modified()
         .ok()
         .and_then(|value| value.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos());
+        .map(|duration| duration.as_nanos())
+}
 
-    Some(FileSnapshot {
+fn metadata_matches(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    left.len() == right.len()
+        && left.file_type() == right.file_type()
+        && modified_ns(left) == modified_ns(right)
+}
+
+fn snapshot_from_bytes(metadata: &std::fs::Metadata, bytes: &[u8]) -> FileSnapshot {
+    let content_digest = Sha256::digest(bytes).into();
+
+    FileSnapshot {
         size_bytes: metadata.len(),
-        modified_ns,
-    })
+        modified_ns: modified_ns(metadata),
+        content_digest,
+    }
+}
+
+async fn read_bounded(path: &str, max_bytes: u64) -> io::Result<Vec<u8>> {
+    let file = tokio::fs::File::open(path).await?;
+    let mut reader = file.take(max_bytes.saturating_add(1));
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes).await?;
+
+    if bytes.len() as u64 > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("file exceeds maximum tracked size of {max_bytes} bytes"),
+        ));
+    }
+
+    Ok(bytes)
+}
+
+/// Read one coherent version of a path.
+///
+/// Metadata-only checks miss same-size rewrites and a single `metadata -> read`
+/// sequence can pair bytes from one version with metadata from another. Two
+/// byte-identical reads bracketed by unchanged metadata give the tracker a
+/// content-backed baseline. A writer can still arrive after this function
+/// returns; that is safe because the next validation compares both metadata and
+/// the digest and rejects the now-stale baseline.
+pub(crate) async fn stable_read(path: &str) -> io::Result<StableFileRead> {
+    for _ in 0..STABLE_READ_ATTEMPTS {
+        let before = tokio::fs::metadata(path).await?;
+        if !before.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "tracked path is not a regular file",
+            ));
+        }
+        if before.len() > MAX_TRACKED_FILE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "file exceeds maximum tracked size of {} bytes",
+                    MAX_TRACKED_FILE_SIZE
+                ),
+            ));
+        }
+
+        let first = read_bounded(path, MAX_TRACKED_FILE_SIZE).await?;
+        let middle = tokio::fs::metadata(path).await?;
+        if !metadata_matches(&before, &middle) || first.len() as u64 != middle.len() {
+            continue;
+        }
+
+        let second = read_bounded(path, MAX_TRACKED_FILE_SIZE).await?;
+        let after = tokio::fs::metadata(path).await?;
+        if metadata_matches(&middle, &after)
+            && second.len() as u64 == after.len()
+            && first == second
+        {
+            return Ok(StableFileRead {
+                snapshot: snapshot_from_bytes(&after, &second),
+                bytes: second,
+            });
+        }
+    }
+
+    Err(io::Error::other(
+        "file changed while a stable snapshot was being captured",
+    ))
 }
 
 async fn cleanup_if_needed() {
@@ -74,9 +255,8 @@ async fn cleanup_if_needed() {
     }
 }
 
-pub async fn mark_read(session_id: &str, path: &str) {
+async fn store_snapshot(session_id: &str, path: &str, snapshot: TrackedSnapshot) {
     let normalized = normalize_path(path).await;
-    let snapshot = snapshot_for_path(path).await;
     let entry = tracker()
         .entry(session_id.to_string())
         .or_insert_with(|| Arc::new(Mutex::new(SessionReads::default())))
@@ -85,21 +265,29 @@ pub async fn mark_read(session_id: &str, path: &str) {
     {
         let mut guard = entry.lock().await;
         guard.last_touched = Some(Instant::now());
-        if let Some(snapshot) = snapshot {
-            guard.files.insert(normalized, snapshot);
-        } else {
-            // Keep a sentinel entry so we still know a read happened.
-            guard.files.insert(
-                normalized,
-                FileSnapshot {
-                    size_bytes: 0,
-                    modified_ns: None,
-                },
-            );
-        }
+        guard.store(normalized, snapshot);
     }
 
     cleanup_if_needed().await;
+}
+
+pub(crate) async fn mark_stable_read(session_id: &str, path: &str, stable: &StableFileRead) {
+    store_snapshot(
+        session_id,
+        path,
+        TrackedSnapshot::Present(stable.snapshot.clone()),
+    )
+    .await;
+}
+
+pub async fn mark_read(session_id: &str, path: &str) -> io::Result<()> {
+    let snapshot = match stable_read(path).await {
+        Ok(stable) => TrackedSnapshot::Present(stable.snapshot),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => TrackedSnapshot::Missing,
+        Err(error) => return Err(error),
+    };
+    store_snapshot(session_id, path, snapshot).await;
+    Ok(())
 }
 
 pub async fn has_read(session_id: &str, path: &str) -> bool {
@@ -114,25 +302,184 @@ pub async fn has_read(session_id: &str, path: &str) -> bool {
 }
 
 pub async fn read_state(session_id: &str, path: &str) -> ReadState {
+    match read_if_fresh(session_id, path).await {
+        Ok(_) => ReadState::Fresh,
+        Err(state) => state,
+    }
+}
+
+pub(crate) async fn read_if_fresh(
+    session_id: &str,
+    path: &str,
+) -> Result<ValidatedFileRead, ReadState> {
     let normalized = normalize_path(path).await;
     let Some(entry) = tracker().get(session_id).map(|value| value.clone()) else {
-        return ReadState::Unread;
+        return Err(ReadState::Unread);
     };
 
-    let mut guard = entry.lock().await;
+    let baseline = {
+        let mut guard = entry.lock().await;
+        guard.last_touched = Some(Instant::now());
+        match guard.files.get(&normalized) {
+            Some(TrackedEntry {
+                generation,
+                snapshot: TrackedSnapshot::Present(snapshot),
+            }) => (*generation, snapshot.clone()),
+            Some(TrackedEntry {
+                snapshot: TrackedSnapshot::Missing,
+                ..
+            }) => return Err(ReadState::Stale),
+            None => return Err(ReadState::Unread),
+        }
+    };
+
+    let current = stable_read(path).await.map_err(|_| ReadState::Stale)?;
+    if baseline.1 != current.snapshot {
+        return Err(ReadState::Stale);
+    }
+
+    Ok(ValidatedFileRead {
+        slot: MutationSlot {
+            session_id: session_id.to_string(),
+            normalized_path: normalized,
+            session_reads: entry,
+            generation: Some(baseline.0),
+        },
+        bytes: current.bytes,
+    })
+}
+
+/// Capture the tracker slot before creating a path. The generation is a CAS
+/// token even when the slot is absent, so a concurrent same-session Read cannot
+/// be silently overwritten by the writer's post-write baseline update.
+pub(crate) async fn capture_write_slot(session_id: &str, path: &str) -> MutationSlot {
+    let normalized = normalize_path(path).await;
+    let entry = tracker()
+        .entry(session_id.to_string())
+        .or_insert_with(|| Arc::new(Mutex::new(SessionReads::default())))
+        .clone();
+    let generation = {
+        let mut guard = entry.lock().await;
+        guard.last_touched = Some(Instant::now());
+        guard.files.get(&normalized).map(|value| value.generation)
+    };
+
+    cleanup_if_needed().await;
+    MutationSlot {
+        session_id: session_id.to_string(),
+        normalized_path: normalized,
+        session_reads: entry,
+        generation,
+    }
+}
+
+/// Advance a session baseline only after the path stably reads back as the
+/// exact bytes the tool committed. The pre-mutation slot generation is a CAS
+/// token for both existing and newly-created files. If a concurrent Read has
+/// already registered the exact verified version, the operation is idempotently
+/// successful; any other generation change is a conflict and leaves that newer
+/// baseline untouched.
+pub(crate) async fn advance_after_verified_write(
+    path: &str,
+    slot: &MutationSlot,
+    expected_bytes: &[u8],
+) -> BaselineAdvance {
+    let normalized = normalize_path(path).await;
+    if slot.normalized_path != normalized {
+        return BaselineAdvance::Conflict;
+    }
+
+    let Ok(current) = stable_read(path).await else {
+        return BaselineAdvance::Conflict;
+    };
+    if current.bytes != expected_bytes {
+        return BaselineAdvance::Conflict;
+    }
+
+    #[cfg(test)]
+    pause_before_advance_if_requested(slot).await;
+
+    let Some(active_entry) = tracker().get(&slot.session_id).map(|value| value.clone()) else {
+        return BaselineAdvance::Conflict;
+    };
+    if !Arc::ptr_eq(&active_entry, &slot.session_reads) {
+        return BaselineAdvance::Conflict;
+    }
+
+    let mut guard = slot.session_reads.lock().await;
     guard.last_touched = Some(Instant::now());
-    let Some(snapshot) = guard.files.get(&normalized).copied() else {
-        return ReadState::Unread;
+    let slot_is_unchanged = match (slot.generation, guard.files.get(&normalized)) {
+        (None, None) => true,
+        (Some(expected), Some(entry)) => entry.generation == expected,
+        _ => false,
     };
 
-    let Some(current) = snapshot_for_path(path).await else {
-        return ReadState::Stale;
-    };
+    if slot_is_unchanged {
+        guard.store(
+            normalized,
+            TrackedSnapshot::Present(current.snapshot.clone()),
+        );
+        return BaselineAdvance::Advanced;
+    }
 
-    if snapshot == current {
-        ReadState::Fresh
+    if guard.files.get(&normalized).is_some_and(|entry| {
+        matches!(
+            &entry.snapshot,
+            TrackedSnapshot::Present(snapshot) if snapshot == &current.snapshot
+        )
+    }) {
+        BaselineAdvance::AlreadyCurrent
     } else {
-        ReadState::Stale
+        BaselineAdvance::Conflict
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct TestAdvancePause {
+    session_id: String,
+    normalized_path: String,
+    reached: Arc<Notify>,
+    resume: Arc<Notify>,
+}
+
+#[cfg(test)]
+fn test_advance_pauses() -> &'static std::sync::Mutex<Vec<TestAdvancePause>> {
+    static PAUSES: OnceLock<std::sync::Mutex<Vec<TestAdvancePause>>> = OnceLock::new();
+    PAUSES.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+#[cfg(test)]
+pub(crate) async fn pause_next_advance_for_test(
+    session_id: &str,
+    path: &str,
+) -> (Arc<Notify>, Arc<Notify>) {
+    let pause = TestAdvancePause {
+        session_id: session_id.to_string(),
+        normalized_path: normalize_path(path).await,
+        reached: Arc::new(Notify::new()),
+        resume: Arc::new(Notify::new()),
+    };
+    let handles = (pause.reached.clone(), pause.resume.clone());
+    test_advance_pauses().lock().unwrap().push(pause);
+    handles
+}
+
+#[cfg(test)]
+async fn pause_before_advance_if_requested(slot: &MutationSlot) {
+    let pause = {
+        let mut pauses = test_advance_pauses().lock().unwrap();
+        pauses
+            .iter()
+            .position(|pause| {
+                pause.session_id == slot.session_id && pause.normalized_path == slot.normalized_path
+            })
+            .map(|position| pauses.swap_remove(position))
+    };
+
+    if let Some(pause) = pause {
+        pause.reached.notify_one();
+        pause.resume.notified().await;
     }
 }
 
@@ -151,11 +498,113 @@ mod tests {
         let path = file.path().to_string_lossy().to_string();
         let session = session_id("fresh-stale");
 
-        mark_read(&session, &path).await;
+        mark_read(&session, &path).await.unwrap();
         assert!(has_read(&session, &path).await);
         assert_eq!(read_state(&session, &path).await, ReadState::Fresh);
 
         tokio::fs::write(file.path(), "v2 changed").await.unwrap();
+        assert_eq!(read_state(&session, &path).await, ReadState::Stale);
+    }
+
+    #[tokio::test]
+    async fn same_size_rewrite_is_stale_even_when_mtime_is_restored() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "aaaa").await.unwrap();
+        let original_modified = std::fs::metadata(file.path()).unwrap().modified().unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let session = session_id("same-size-digest");
+
+        mark_read(&session, &path).await.unwrap();
+        tokio::fs::write(file.path(), "bbbb").await.unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(file.path())
+            .unwrap()
+            .set_modified(original_modified)
+            .unwrap();
+
+        let rewritten = std::fs::metadata(file.path()).unwrap();
+        assert_eq!(rewritten.len(), 4);
+        assert_eq!(rewritten.modified().unwrap(), original_modified);
+        assert_eq!(read_state(&session, &path).await, ReadState::Stale);
+    }
+
+    #[tokio::test]
+    async fn verified_write_advances_the_exact_previous_baseline() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "before").await.unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let session = session_id("advance");
+
+        mark_read(&session, &path).await.unwrap();
+        let validated = read_if_fresh(&session, &path).await.unwrap();
+        tokio::fs::write(file.path(), "after").await.unwrap();
+
+        assert_eq!(
+            advance_after_verified_write(&path, validated.slot(), b"after").await,
+            BaselineAdvance::Advanced
+        );
+        assert_eq!(read_state(&session, &path).await, ReadState::Fresh);
+    }
+
+    #[tokio::test]
+    async fn post_write_verification_mismatch_does_not_advance_baseline() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "before").await.unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let session = session_id("verify-mismatch");
+
+        mark_read(&session, &path).await.unwrap();
+        let validated = read_if_fresh(&session, &path).await.unwrap();
+        tokio::fs::write(file.path(), "external").await.unwrap();
+
+        assert_eq!(
+            advance_after_verified_write(&path, validated.slot(), b"intended").await,
+            BaselineAdvance::Conflict
+        );
+        assert_eq!(read_state(&session, &path).await, ReadState::Stale);
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_session_read_of_verified_version_is_idempotent() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "before").await.unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let session = session_id("concurrent-read-cas");
+
+        mark_read(&session, &path).await.unwrap();
+        let old_validation = read_if_fresh(&session, &path).await.unwrap();
+
+        tokio::fs::write(file.path(), "after").await.unwrap();
+        let concurrent_read = stable_read(&path).await.unwrap();
+        mark_stable_read(&session, &path, &concurrent_read).await;
+
+        assert_eq!(
+            advance_after_verified_write(&path, old_validation.slot(), b"after").await,
+            BaselineAdvance::AlreadyCurrent
+        );
+        assert_eq!(read_state(&session, &path).await, ReadState::Fresh);
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_session_read_of_other_version_is_a_conflict() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "before").await.unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let session = session_id("concurrent-other-cas");
+
+        mark_read(&session, &path).await.unwrap();
+        let old_validation = read_if_fresh(&session, &path).await.unwrap();
+
+        tokio::fs::write(file.path(), "other").await.unwrap();
+        let concurrent_read = stable_read(&path).await.unwrap();
+        mark_stable_read(&session, &path, &concurrent_read).await;
+        tokio::fs::write(file.path(), "intended").await.unwrap();
+
+        assert_eq!(
+            advance_after_verified_write(&path, old_validation.slot(), b"intended").await,
+            BaselineAdvance::Conflict
+        );
         assert_eq!(read_state(&session, &path).await, ReadState::Stale);
     }
 
@@ -166,13 +615,39 @@ mod tests {
         let path_str = path.to_string_lossy().to_string();
         let session = session_id("missing");
 
-        mark_read(&session, &path_str).await;
+        mark_read(&session, &path_str).await.unwrap();
         assert!(has_read(&session, &path_str).await);
         assert_eq!(read_state(&session, &path_str).await, ReadState::Stale);
     }
 
     #[tokio::test]
-    async fn normalize_path_canonicalizes_real_file_and_falls_back_for_missing() {
+    async fn failed_non_missing_mark_does_not_overwrite_the_prior_baseline() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "v1").await.unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let session = session_id("failed-mark");
+
+        mark_read(&session, &path).await.unwrap();
+        let normalized = normalize_path(&path).await;
+        let entry = tracker().get(&session).unwrap().clone();
+        let before_generation = entry.lock().await.files[&normalized].generation;
+
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(file.path())
+            .unwrap()
+            .set_len(MAX_TRACKED_FILE_SIZE + 1)
+            .unwrap();
+        let error = mark_read(&session, &path).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+
+        let after_generation = entry.lock().await.files[&normalized].generation;
+        assert_eq!(after_generation, before_generation);
+        assert_eq!(read_state(&session, &path).await, ReadState::Stale);
+    }
+
+    #[tokio::test]
+    async fn normalize_path_canonicalizes_real_and_missing_paths() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("real.txt");
         tokio::fs::write(&file_path, "hello").await.unwrap();
@@ -183,10 +658,34 @@ mod tests {
         let canonical = tokio::fs::canonicalize(&file_path).await.unwrap();
         assert_eq!(normalized, canonical.to_string_lossy().to_string());
 
-        // A non-existent path cannot be canonicalized and falls back to the
-        // input string unchanged (preserves the prior std::fs behavior).
+        // A missing target uses its canonical parent plus unresolved suffix.
         let missing = dir.path().join("does_not_exist.txt");
         let missing_str = missing.to_string_lossy().to_string();
-        assert_eq!(normalize_path(&missing_str).await, missing_str);
+        assert_eq!(
+            normalize_path(&missing_str).await,
+            canonical
+                .parent()
+                .unwrap()
+                .join("does_not_exist.txt")
+                .to_string_lossy()
+                .into_owned()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn missing_path_key_is_stable_across_creation_through_tmp_alias() {
+        let dir = tempfile::Builder::new()
+            .prefix("bamboo-read-tracker-")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let path = dir.path().join("created.txt");
+        let path_str = path.to_string_lossy().to_string();
+
+        let before = normalize_path(&path_str).await;
+        tokio::fs::write(&path, "created").await.unwrap();
+        let after = normalize_path(&path_str).await;
+
+        assert_eq!(before, after);
     }
 }

--- a/crates/engine/bamboo-tools/src/tools/write.rs
+++ b/crates/engine/bamboo-tools/src/tools/write.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde_json::json;
 use std::path::Path;
 
-use super::read_tracker::ReadState;
+use super::read_tracker::{BaselineAdvance, ReadState};
 use super::{content_diagnostics, file_change, read_tracker};
 
 #[derive(Debug, Deserialize)]
@@ -72,30 +72,77 @@ impl Tool for WriteTool {
             ));
         }
 
-        if path.exists() {
-            if let Some(session_id) = ctx.session_id() {
-                match read_tracker::read_state(session_id, file_path).await {
-                    ReadState::Unread => {
+        let session_id = ctx.session_id().map(str::to_owned);
+        let target_existed = tokio::fs::try_exists(path)
+            .await
+            .map_err(|e| ToolError::Execution(format!("Failed to inspect target file: {}", e)))?;
+        let validated_read = if target_existed {
+            if let Some(session_id) = session_id.as_deref() {
+                match read_tracker::read_if_fresh(session_id, file_path).await {
+                    Ok(validated) => Some(validated),
+                    Err(ReadState::Unread) => {
                         return Err(ToolError::Execution(
                             "Write requires reading the target file first via Read".to_string(),
                         ));
                     }
-                    ReadState::Stale => {
+                    Err(ReadState::Stale) => {
                         return Err(ToolError::Execution(
                             "Target file changed after last Read; call Read again before Write"
                                 .to_string(),
                         ));
                     }
-                    ReadState::Fresh => {}
+                    Err(ReadState::Fresh) => {
+                        unreachable!("Fresh is returned as a validated read")
+                    }
                 }
+            } else {
+                None
             }
-        }
+        } else {
+            None
+        };
+        let new_file_slot =
+            if let (Some(session_id), false) = (session_id.as_deref(), target_existed) {
+                Some(read_tracker::capture_write_slot(session_id, file_path).await)
+            } else {
+                None
+            };
 
-        let previous_bytes = file_change::read_existing_bytes(path).await?;
+        let previous_bytes = if let Some(validated) = validated_read.as_ref() {
+            Some(validated.bytes().to_vec())
+        } else if target_existed {
+            file_change::read_existing_bytes(path).await?
+        } else {
+            None
+        };
         let checkpoint = file_change::create_checkpoint(path, previous_bytes.as_deref()).await?;
         let next_content = parsed.content;
 
-        file_change::atomic_write_text(path, &next_content).await?;
+        let write_expectation = if let Some(validated) = validated_read.as_ref() {
+            file_change::AtomicWriteExpectation::Exact(validated.bytes())
+        } else if session_id.is_some() && !target_existed {
+            file_change::AtomicWriteExpectation::Missing
+        } else {
+            file_change::AtomicWriteExpectation::Unchecked
+        };
+        file_change::atomic_write_text_with_expectation(path, &next_content, write_expectation)
+            .await?;
+
+        let mutation_slot = validated_read
+            .as_ref()
+            .map(|validated| validated.slot())
+            .or(new_file_slot.as_ref());
+        if let Some(slot) = mutation_slot {
+            if read_tracker::advance_after_verified_write(file_path, slot, next_content.as_bytes())
+                .await
+                == BaselineAdvance::Conflict
+            {
+                return Err(ToolError::Execution(
+                    "Write committed, but the target changed before it could be verified; call Read again"
+                        .to_string(),
+                ));
+            }
+        }
 
         let previous_text = file_change::bytes_to_lossy_text(previous_bytes.as_deref());
         let mut payload = file_change::build_file_change_payload_value(
@@ -185,6 +232,227 @@ mod tests {
             panic!("expected Completed")
         };
         assert!(ok.success);
+    }
+
+    #[tokio::test]
+    async fn read_write_write_succeeds_without_an_external_change() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "v1").await.unwrap();
+        let session = format!("write-twice-{}", uuid::Uuid::new_v4());
+        let read_tool = ReadTool::new();
+        let write_tool = WriteTool::new();
+
+        read_tool
+            .invoke(json!({"file_path": file.path()}), ctx(&session))
+            .await
+            .unwrap();
+        write_tool
+            .invoke(
+                json!({"file_path": file.path(), "content": "v2"}),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+        write_tool
+            .invoke(
+                json!({"file_path": file.path(), "content": "v3"}),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(tokio::fs::read_to_string(file.path()).await.unwrap(), "v3");
+    }
+
+    #[tokio::test]
+    async fn write_rejects_external_change_after_a_successful_write() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "aa").await.unwrap();
+        let session = format!("write-external-{}", uuid::Uuid::new_v4());
+        let read_tool = ReadTool::new();
+        let write_tool = WriteTool::new();
+
+        read_tool
+            .invoke(json!({"file_path": file.path()}), ctx(&session))
+            .await
+            .unwrap();
+        write_tool
+            .invoke(
+                json!({"file_path": file.path(), "content": "bb"}),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+
+        tokio::fs::write(file.path(), "cc").await.unwrap();
+        let stale = write_tool
+            .invoke(
+                json!({"file_path": file.path(), "content": "dd"}),
+                ctx(&session),
+            )
+            .await;
+
+        assert!(matches!(stale, Err(ToolError::Execution(message)) if message.contains("changed")));
+        assert_eq!(tokio::fs::read_to_string(file.path()).await.unwrap(), "cc");
+    }
+
+    #[tokio::test]
+    async fn stale_write_failure_does_not_advance_the_baseline() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "v1").await.unwrap();
+        let session = format!("write-stale-failure-{}", uuid::Uuid::new_v4());
+        let read_tool = ReadTool::new();
+        let write_tool = WriteTool::new();
+
+        read_tool
+            .invoke(json!({"file_path": file.path()}), ctx(&session))
+            .await
+            .unwrap();
+        tokio::fs::write(file.path(), "external").await.unwrap();
+
+        for intended in ["first-attempt", "second-attempt"] {
+            let stale = write_tool
+                .invoke(
+                    json!({"file_path": file.path(), "content": intended}),
+                    ctx(&session),
+                )
+                .await;
+            assert!(
+                matches!(stale, Err(ToolError::Execution(message)) if message.contains("changed"))
+            );
+        }
+        assert_eq!(
+            tokio::fs::read_to_string(file.path()).await.unwrap(),
+            "external"
+        );
+    }
+
+    #[tokio::test]
+    async fn consecutive_writes_to_a_new_file_use_the_verified_first_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new.txt");
+        let session = format!("write-new-twice-{}", uuid::Uuid::new_v4());
+        let write_tool = WriteTool::new();
+
+        write_tool
+            .invoke(
+                json!({"file_path": path, "content": "first"}),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+        write_tool
+            .invoke(
+                json!({"file_path": path, "content": "second"}),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(tokio::fs::read_to_string(path).await.unwrap(), "second");
+    }
+
+    #[tokio::test]
+    async fn concurrent_read_of_new_file_is_idempotent_for_first_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new-concurrent.txt");
+        let path_str = path.to_string_lossy().into_owned();
+        let session = format!("write-new-concurrent-{}", uuid::Uuid::new_v4());
+        let (advance_reached, resume_advance) =
+            read_tracker::pause_next_advance_for_test(&session, &path_str).await;
+
+        let writer_path = path.clone();
+        let writer_session = session.clone();
+        let writer = tokio::spawn(async move {
+            WriteTool::new()
+                .invoke(
+                    json!({"file_path": writer_path, "content": "first"}),
+                    ctx(&writer_session),
+                )
+                .await
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            advance_reached.notified(),
+        )
+        .await
+        .expect("Write did not reach post-write baseline advancement");
+        ReadTool::new()
+            .invoke(json!({"file_path": path}), ctx(&session))
+            .await
+            .unwrap();
+        resume_advance.notify_one();
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), writer)
+            .await
+            .expect("Write did not resume")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(first, ToolOutcome::Completed(result) if result.success));
+
+        WriteTool::new()
+            .invoke(
+                json!({"file_path": path, "content": "second"}),
+                ctx(&session),
+            )
+            .await
+            .unwrap();
+        assert_eq!(tokio::fs::read_to_string(path).await.unwrap(), "second");
+    }
+
+    #[tokio::test]
+    async fn committed_postverify_conflict_is_clear_and_leaves_baseline_stale() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(file.path(), "before").await.unwrap();
+        let path = file.path().to_path_buf();
+        let path_str = path.to_string_lossy().into_owned();
+        let session = format!("write-postverify-conflict-{}", uuid::Uuid::new_v4());
+
+        ReadTool::new()
+            .invoke(json!({"file_path": path}), ctx(&session))
+            .await
+            .unwrap();
+        let (advance_reached, resume_advance) =
+            read_tracker::pause_next_advance_for_test(&session, &path_str).await;
+
+        let writer_path = path.clone();
+        let writer_session = session.clone();
+        let writer = tokio::spawn(async move {
+            WriteTool::new()
+                .invoke(
+                    json!({"file_path": writer_path, "content": "intended"}),
+                    ctx(&writer_session),
+                )
+                .await
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            advance_reached.notified(),
+        )
+        .await
+        .expect("Write did not reach post-write baseline advancement");
+        tokio::fs::write(&path, "other").await.unwrap();
+        ReadTool::new()
+            .invoke(json!({"file_path": path}), ctx(&session))
+            .await
+            .unwrap();
+        tokio::fs::write(&path, "intended").await.unwrap();
+        resume_advance.notify_one();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), writer)
+            .await
+            .expect("Write did not resume")
+            .unwrap();
+        assert!(
+            matches!(result, Err(ToolError::Execution(message)) if message.contains("Write committed"))
+        );
+        assert_eq!(
+            read_tracker::read_state(&session, &path_str).await,
+            ReadState::Stale
+        );
+        assert_eq!(tokio::fs::read_to_string(path).await.unwrap(), "intended");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- refresh a session's read baseline only after Edit or Write has committed and the exact resulting bytes have been verified
- use digest-backed, bounded stable snapshots so same-size rewrites and concurrent mutations remain fail-closed
- support consecutive Read → Edit → Edit, Read → Write → Write, and new-file Write → Write flows without requiring a redundant Read
- add deterministic race and regression coverage for idempotent concurrent reads, stale generations, post-write conflicts, oversized reads, and path normalization

## Root Cause

Successful Edit and Write calls changed the file but left the per-session read tracker at the pre-mutation snapshot. The next mutation therefore compared disk state against stale metadata and rejected the agent's own prior successful write.

## Impact

Agents can now perform consecutive verified file mutations in one session while external or concurrent changes are still detected before a later write is allowed.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo metadata --locked --all-features --format-version 1`
- CI-aligned strict `cargo clippy --all-features` with repository warning policy
- `cargo test --all-features --lib --tests`
- `cargo test --tests`
- `cargo build --examples`
- `cargo test -p bamboo-tools`
- Windows GNU cross-target check

## Screenshots

Not applicable; backend tool-state fix.

Closes #761