### PR TITLE
fix(metrics): persist canonical round usage (#688)

### DIFF
--- a/crates/core/bamboo-domain/src/lib.rs
+++ b/crates/core/bamboo-domain/src/lib.rs
@@ -45,7 +45,7 @@ pub use reasoning::{ReasoningEffort, DEFAULT_REASONING_EFFORT};
 pub use schedule::*;
 pub use session::*;
 pub use storage::*;
-pub use token_usage::TokenUsage;
+pub use token_usage::{TokenUsage, MAX_DURABLE_TOKEN_COUNT};
 pub use tool_names::*;
 pub use tool_types::*;
 pub use workflow::*;

--- a/crates/core/bamboo-domain/src/token_usage.rs
+++ b/crates/core/bamboo-domain/src/token_usage.rs
@@ -2,6 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Largest token counter that can be represented losslessly by the signed
+/// 64-bit integer columns used by durable metrics stores.
+///
+/// Keeping this boundary beside the shared value object lets runtime budgets
+/// and persistence apply one policy instead of allowing `u64 as i64` wraparound
+/// or storage-specific divergence.
+pub const MAX_DURABLE_TOKEN_COUNT: u64 = i64::MAX as u64;
+
 /// Token consumption statistics for a single LLM call or aggregated period.
 ///
 /// This is a stable, cross-layer value object. Every crate that needs to
@@ -30,6 +38,38 @@ impl TokenUsage {
     /// Recompute `total_tokens` from the two component fields.
     pub fn recompute_total(&mut self) {
         self.total_tokens = self.prompt_tokens.saturating_add(self.completion_tokens);
+    }
+
+    /// Normalize all counters to the lossless signed-64 durable range.
+    ///
+    /// Components saturate independently and the total is recomputed from the
+    /// saturated components, then saturated to the same boundary. This makes
+    /// the policy deterministic even if an upstream supplied an inconsistent
+    /// total and keeps round, session, and runtime views reconcilable.
+    pub fn clamped_for_durable_metrics(mut self) -> Self {
+        self.prompt_tokens = self.prompt_tokens.min(MAX_DURABLE_TOKEN_COUNT);
+        self.completion_tokens = self.completion_tokens.min(MAX_DURABLE_TOKEN_COUNT);
+        self.total_tokens = self
+            .prompt_tokens
+            .saturating_add(self.completion_tokens)
+            .min(MAX_DURABLE_TOKEN_COUNT);
+        self
+    }
+
+    /// Accumulate usage with the same saturation policy used by durable stores.
+    pub fn add_assign_durable(&mut self, other: TokenUsage) {
+        self.prompt_tokens = self
+            .prompt_tokens
+            .saturating_add(other.prompt_tokens)
+            .min(MAX_DURABLE_TOKEN_COUNT);
+        self.completion_tokens = self
+            .completion_tokens
+            .saturating_add(other.completion_tokens)
+            .min(MAX_DURABLE_TOKEN_COUNT);
+        self.total_tokens = self
+            .prompt_tokens
+            .saturating_add(self.completion_tokens)
+            .min(MAX_DURABLE_TOKEN_COUNT);
     }
 }
 
@@ -72,5 +112,37 @@ mod tests {
         };
         usage.recompute_total();
         assert_eq!(usage.total_tokens, u64::MAX);
+    }
+
+    #[test]
+    fn durable_metrics_policy_clamps_components_and_recomputes_total() {
+        let usage = TokenUsage {
+            prompt_tokens: u64::MAX,
+            completion_tokens: u64::MAX,
+            total_tokens: 1,
+        }
+        .clamped_for_durable_metrics();
+
+        assert_eq!(usage.prompt_tokens, MAX_DURABLE_TOKEN_COUNT);
+        assert_eq!(usage.completion_tokens, MAX_DURABLE_TOKEN_COUNT);
+        assert_eq!(usage.total_tokens, MAX_DURABLE_TOKEN_COUNT);
+    }
+
+    #[test]
+    fn durable_accumulation_saturates_without_wraparound() {
+        let mut usage = TokenUsage {
+            prompt_tokens: MAX_DURABLE_TOKEN_COUNT - 2,
+            completion_tokens: MAX_DURABLE_TOKEN_COUNT - 3,
+            total_tokens: MAX_DURABLE_TOKEN_COUNT,
+        };
+        usage.add_assign_durable(TokenUsage {
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            total_tokens: 30,
+        });
+
+        assert_eq!(usage.prompt_tokens, MAX_DURABLE_TOKEN_COUNT);
+        assert_eq!(usage.completion_tokens, MAX_DURABLE_TOKEN_COUNT);
+        assert_eq!(usage.total_tokens, MAX_DURABLE_TOKEN_COUNT);
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm.rs
@@ -46,6 +46,10 @@ impl LlmManager for DefaultLlmManager {
         )
         .await?;
 
+        if let Some(error) = result.terminal_validation_error {
+            return Err(error);
+        }
+
         let (content, reasoning_content, tool_calls) = {
             let stream = &result.stream_output;
             (
@@ -62,7 +66,7 @@ impl LlmManager for DefaultLlmManager {
             prompt_tokens: result.prompt_tokens,
             completion_tokens: result.completion_tokens,
             response_id: None,
-            round_usage: result.round_usage,
+            round_usage: result.attempt_usage,
         })
     }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -47,6 +47,32 @@ use crate::runtime::runner::state_bridge;
 const MAX_LLM_TURN_ATTEMPTS: usize = 3;
 const LLM_RETRY_BASE_DELAY_MS: u64 = 400;
 
+#[cfg(test)]
+const TEST_POST_LLM_RETRY_FAILURES_KEY: &str = "test.pipeline.post_llm_retry_failures";
+
+#[cfg(test)]
+fn take_test_post_llm_retry_failure(session: &mut Session) -> Option<AgentError> {
+    let remaining = session
+        .metadata
+        .get(TEST_POST_LLM_RETRY_FAILURES_KEY)?
+        .parse::<usize>()
+        .ok()?;
+    if remaining == 0 {
+        return None;
+    }
+    if remaining == 1 {
+        session.metadata.remove(TEST_POST_LLM_RETRY_FAILURES_KEY);
+    } else {
+        session.metadata.insert(
+            TEST_POST_LLM_RETRY_FAILURES_KEY.to_string(),
+            (remaining - 1).to_string(),
+        );
+    }
+    Some(AgentError::LLM(
+        "transient test-injected post-LLM handler failure".to_string(),
+    ))
+}
+
 // ---- Error classification (from rounds.rs) ----
 
 fn should_retry_turn_error(error: &AgentError) -> bool {
@@ -124,7 +150,7 @@ struct RunBudgetExceeded {
     actual: u64,
 }
 
-/// One round's ACTUAL (provider-reported) usage + activity, accumulated
+/// One round's canonical usage + activity, accumulated
 /// across the round's retry attempts for the per-run budget guardrails
 /// (issue #221).
 ///
@@ -149,13 +175,15 @@ impl RoundActivity {
     /// totals. Called once per successful `execute_llm_round` return, the
     /// moment `stream_output` becomes available — before it is consumed by
     /// `handle_no_tool_calls`/`handle_tool_calls_path`.
-    fn absorb_attempt(&mut self, stream_output: &StreamHandlingOutput) {
-        self.prompt_tokens = self
-            .prompt_tokens
-            .saturating_add(stream_output.prompt_tokens_for_runtime_budget());
-        self.completion_tokens = self
-            .completion_tokens
-            .saturating_add(stream_output.completion_tokens_for_runtime_budget());
+    fn absorb_attempt(
+        &mut self,
+        stream_output: &StreamHandlingOutput,
+        attempt_usage: MetricsTokenUsage,
+    ) {
+        let mut accumulated = self.token_usage();
+        accumulated.add_assign_durable(attempt_usage);
+        self.prompt_tokens = accumulated.prompt_tokens;
+        self.completion_tokens = accumulated.completion_tokens;
         self.tool_call_count = self
             .tool_call_count
             .saturating_add(stream_output.tool_calls.len() as u32);
@@ -166,6 +194,41 @@ impl RoundActivity {
                 .filter(|call| is_subagent_create_call(call))
                 .count() as u32,
         );
+    }
+
+    /// The exact token value persisted for this round. Runtime budget totals
+    /// consume these same two components via `commit_to_runtime`, making the
+    /// canonical policy impossible to fork between the two consumers.
+    fn token_usage(&self) -> MetricsTokenUsage {
+        MetricsTokenUsage {
+            prompt_tokens: self.prompt_tokens,
+            completion_tokens: self.completion_tokens,
+            total_tokens: self.prompt_tokens.saturating_add(self.completion_tokens),
+        }
+        .clamped_for_durable_metrics()
+    }
+
+    /// Commit a round exactly once, including terminal rounds. A billed stream
+    /// followed by validation or post-LLM failure must still affect the runtime
+    /// budget just as it affects durable metrics.
+    fn commit_to_runtime(&self, runtime_state: &mut AgentRuntimeState) {
+        let mut accumulated = MetricsTokenUsage {
+            prompt_tokens: runtime_state.round.total_prompt_tokens,
+            completion_tokens: runtime_state.round.total_completion_tokens,
+            total_tokens: 0,
+        }
+        .clamped_for_durable_metrics();
+        accumulated.add_assign_durable(self.token_usage());
+        runtime_state.round.total_prompt_tokens = accumulated.prompt_tokens;
+        runtime_state.round.total_completion_tokens = accumulated.completion_tokens;
+        runtime_state.round.total_tool_calls = runtime_state
+            .round
+            .total_tool_calls
+            .saturating_add(self.tool_call_count);
+        runtime_state.round.total_subagents_spawned = runtime_state
+            .round
+            .total_subagents_spawned
+            .saturating_add(self.subagent_spawn_count);
     }
 }
 
@@ -181,7 +244,8 @@ fn check_run_budget_exceeded(
 ) -> Option<RunBudgetExceeded> {
     let total_tokens = round
         .total_prompt_tokens
-        .saturating_add(round.total_completion_tokens);
+        .saturating_add(round.total_completion_tokens)
+        .min(bamboo_domain::MAX_DURABLE_TOKEN_COUNT);
     if let Some(limit) = budget.max_total_tokens {
         if total_tokens >= limit {
             return Some(RunBudgetExceeded {
@@ -664,6 +728,7 @@ fn record_turn_failure(
     round_id: &str,
     session_id: &str,
     message_count: u32,
+    round_usage: MetricsTokenUsage,
     error: &AgentError,
 ) {
     let (round_status, session_status) = map_turn_error_status(error);
@@ -673,6 +738,7 @@ fn record_turn_failure(
         session_id,
         message_count,
         round_status,
+        round_usage,
         Some(error.to_string()),
         session_status,
     );
@@ -1728,11 +1794,11 @@ pub(super) async fn run_pipeline(
         let mut overflow_recovery_attempted = false;
         let mut turn_outcome: Option<TurnOutcome> = None;
         let mut terminal_error: Option<AgentError> = None;
+        let mut hook_suspension: Option<AgentError> = None;
 
-        // Actual (provider-reported) usage + activity for THIS round for the
-        // per-run budget guardrails (issue #221) — real numbers, not the
-        // heuristic `round_usage` estimate used for metrics. Reset every
-        // round; accumulated across the retry attempts below (see
+        // Canonical usage + activity for THIS round, shared by runtime budget
+        // totals and durable metrics. Reset every round; accumulated across
+        // the retry attempts below (see
         // `RoundActivity` for why it must sum, never overwrite); an attempt
         // that errors before streaming contributes 0.
         let mut round_activity = RoundActivity::default();
@@ -1796,16 +1862,11 @@ pub(super) async fn run_pipeline(
                             {
                                 Ok(recovered) => recovered,
                                 Err(error) => {
-                                    // Early exit before the post-loop drain — abort
-                                    // any in-flight eval so it does not detach and
-                                    // keep spending (issue #347).
-                                    abort_in_flight_evaluations(
-                                        state,
-                                        event_tx,
-                                        "terminal_error",
-                                    )
-                                    .await;
-                                    return Err(error);
+                                    // Route through the shared terminal path so
+                                    // any earlier billed retry attempt is retained
+                                    // in both runtime and durable usage.
+                                    terminal_error = Some(error);
+                                    break;
                                 }
                             };
                         if recovered {
@@ -1900,7 +1961,11 @@ pub(super) async fn run_pipeline(
             let stream_output = llm_output.stream_output;
             // Every successful provider call is billed, including an explicit
             // activation attempt that the fail-closed guard rejects below.
-            round_activity.absorb_attempt(&stream_output);
+            round_activity.absorb_attempt(&stream_output, llm_output.attempt_usage);
+            if let Some(error) = llm_output.terminal_validation_error {
+                terminal_error = Some(error);
+                break;
+            }
             let activation_attempt =
                 match validate_explicit_activation_first_step(session, &stream_output.tool_calls) {
                     Ok(attempt) => attempt,
@@ -1949,28 +2014,44 @@ pub(super) async fn run_pipeline(
                     .fast_model_name
                     .clone()
                     .unwrap_or_else(|| state.model_name.clone());
-                turn_outcome = Some(
-                    handle_no_tool_calls(
-                        stream_output.content,
-                        reasoning,
-                        reasoning_signature,
-                        llm_output.prompt_tokens,
-                        llm_output.completion_tokens,
-                        llm_output.round_usage,
-                        session,
-                        &mut state.runtime_state,
-                        event_tx,
-                        state.metrics_collector.as_ref(),
-                        &round_id,
-                        &state.session_id,
-                        config,
-                        &state.task_context,
-                        &eval_model,
-                        turn_counter + 1,
-                        llm.clone(),
-                    )
-                    .await?,
-                );
+                match handle_no_tool_calls(
+                    stream_output.content,
+                    reasoning,
+                    reasoning_signature,
+                    llm_output.prompt_tokens,
+                    llm_output.completion_tokens,
+                    round_activity.token_usage(),
+                    session,
+                    &mut state.runtime_state,
+                    event_tx,
+                    state.metrics_collector.as_ref(),
+                    &round_id,
+                    &state.session_id,
+                    config,
+                    &state.task_context,
+                    &eval_model,
+                    turn_counter + 1,
+                    llm.clone(),
+                )
+                .await
+                {
+                    Ok(outcome) => turn_outcome = Some(outcome),
+                    Err(error) if error.is_hook_suspended() => {
+                        // Preserve the control-flow contract consumed by the
+                        // outer loop finalizer. The provider round itself
+                        // completed successfully, so retain its usage without
+                        // misclassifying the intentional suspension as Error.
+                        record_no_tool_calls_round_completed(
+                            state.metrics_collector.as_ref(),
+                            &round_id,
+                            &state.session_id,
+                            session,
+                            round_activity.token_usage(),
+                        );
+                        hook_suspension = Some(error);
+                    }
+                    Err(error) => terminal_error = Some(error),
+                }
                 break;
             }
 
@@ -1986,19 +2067,29 @@ pub(super) async fn run_pipeline(
                 tools: &tools,
             };
 
-            match handle_tool_calls_path(
-                &frame,
-                stream_output,
-                llm_output.round_usage,
-                session,
-                &mut state.runtime_state,
-                &state.auxiliary_models,
-                &state.model_name,
-                &mut state.task_context,
-                cancel_token,
-            )
-            .await
-            {
+            #[cfg(test)]
+            let injected_handler_error = take_test_post_llm_retry_failure(session);
+            #[cfg(not(test))]
+            let injected_handler_error: Option<AgentError> = None;
+            let handler_result = match injected_handler_error {
+                Some(error) => Err(error),
+                None => {
+                    handle_tool_calls_path(
+                        &frame,
+                        stream_output,
+                        round_activity.token_usage(),
+                        session,
+                        &mut state.runtime_state,
+                        &state.auxiliary_models,
+                        &state.model_name,
+                        &mut state.task_context,
+                        cancel_token,
+                    )
+                    .await
+                }
+            };
+
+            match handler_result {
                 Ok(outcome) => {
                     if let Some(attempt) = activation_attempt.as_ref() {
                         if !outcome.should_break {
@@ -2047,13 +2138,27 @@ pub(super) async fn run_pipeline(
             }
         }
 
+        // Commit once for every exit from the attempt loop. In particular, a
+        // terminal validation/post-LLM failure must retain the same accumulated
+        // usage that its durable round record receives below.
+        round_activity.commit_to_runtime(&mut state.runtime_state);
+
+        if let Some(error) = hook_suspension {
+            return Err(error);
+        }
+
         // --- Handle terminal error ---
         if let Some(error) = terminal_error {
+            // Terminal activations skip normal finalization, so mirror the
+            // just-committed runtime usage onto the Session before the outer
+            // execute boundary checkpoints it.
+            state_bridge::write_runtime_state(session, &state.runtime_state);
             record_turn_failure(
                 state.metrics_collector.as_ref(),
                 &round_id,
                 &state.session_id,
                 session.messages.len() as u32,
+                round_activity.token_usage(),
                 &error,
             );
             // Early exit before the post-loop drain — abort in-flight evals so a
@@ -2068,11 +2173,13 @@ pub(super) async fn run_pipeline(
                 state.session_id,
                 turn_counter + 1
             ));
+            state_bridge::write_runtime_state(session, &state.runtime_state);
             record_turn_failure(
                 state.metrics_collector.as_ref(),
                 &round_id,
                 &state.session_id,
                 session.messages.len() as u32,
+                round_activity.token_usage(),
                 &error,
             );
             // Early exit before the post-loop drain — abort in-flight evals (#347).
@@ -2242,32 +2349,6 @@ pub(super) async fn run_pipeline(
             }
             _ => {}
         }
-
-        // Accumulate this round's actual usage/activity into the run-level
-        // totals BEFORE persisting the runtime state snapshot below, so the
-        // per-run budget guardrails (issue #221) — checked further down — see
-        // up-to-date numbers, and a resumed/inspected session's runtime state
-        // reflects them immediately.
-        state.runtime_state.round.total_prompt_tokens = state
-            .runtime_state
-            .round
-            .total_prompt_tokens
-            .saturating_add(round_activity.prompt_tokens);
-        state.runtime_state.round.total_completion_tokens = state
-            .runtime_state
-            .round
-            .total_completion_tokens
-            .saturating_add(round_activity.completion_tokens);
-        state.runtime_state.round.total_tool_calls = state
-            .runtime_state
-            .round
-            .total_tool_calls
-            .saturating_add(round_activity.tool_call_count);
-        state.runtime_state.round.total_subagents_spawned = state
-            .runtime_state
-            .round
-            .total_subagents_spawned
-            .saturating_add(round_activity.subagent_spawn_count);
 
         if !config.hook_runner.is_empty() {
             crate::runtime::hooks::merge_session_hook_checkpoints(
@@ -3966,6 +4047,584 @@ mod tests {
         }
     }
 
+    /// One completed provider stream whose authoritative usage deliberately
+    /// differs from the local tokenizer estimate. `content=None` produces the
+    /// billed empty-response validation failure path.
+    struct CanonicalUsageProvider {
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        content: Option<&'static str>,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for CanonicalUsageProvider {
+        async fn chat_stream(
+            &self,
+            _: &[Message],
+            _: &[bamboo_agent_core::tools::ToolSchema],
+            _: Option<u32>,
+            _: &str,
+        ) -> Result<LLMStream, LLMError> {
+            let mut chunks = vec![
+                Ok(LLMChunk::ProviderUsage {
+                    input_tokens: Some(self.prompt_tokens),
+                    output_tokens: Some(self.completion_tokens),
+                    // Deliberately inconsistent: canonical totals are derived
+                    // from the selected components, not this wire convenience.
+                    total_tokens: Some(9_999),
+                    reasoning_tokens: None,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                    cache_write_input_tokens: None,
+                }),
+                Ok(LLMChunk::ResponseId("canonical-usage-response".to_string())),
+            ];
+            if let Some(content) = self.content {
+                chunks.push(Ok(LLMChunk::Token(content.to_string())));
+            }
+            chunks.push(Ok(LLMChunk::Done));
+            Ok(Box::pin(stream::iter(chunks)))
+        }
+    }
+
+    struct IntentionalFinalizeSuspendHook;
+
+    #[async_trait::async_trait]
+    impl AgentHook for IntentionalFinalizeSuspendHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::BeforeFinalize
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            _payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            HookResult::Suspend {
+                reason: "wait for external approval".to_string(),
+            }
+        }
+    }
+
+    struct AbortFinalizeHook;
+
+    #[async_trait::async_trait]
+    impl AgentHook for AbortFinalizeHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::BeforeFinalize
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            _payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            HookResult::Abort {
+                reason: "injected terminal policy failure".to_string(),
+            }
+        }
+    }
+
+    struct BilledRetryProvider {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for BilledRetryProvider {
+        async fn chat_stream(
+            &self,
+            _: &[Message],
+            _: &[bamboo_agent_core::tools::ToolSchema],
+            _: Option<u32>,
+            _: &str,
+        ) -> Result<LLMStream, LLMError> {
+            let attempt = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let usage = match attempt {
+                0 => LLMChunk::ProviderUsage {
+                    input_tokens: Some(10),
+                    output_tokens: Some(3),
+                    total_tokens: Some(13),
+                    reasoning_tokens: None,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                    cache_write_input_tokens: None,
+                },
+                1 => LLMChunk::ProviderUsage {
+                    input_tokens: Some(20),
+                    output_tokens: Some(5),
+                    total_tokens: Some(25),
+                    reasoning_tokens: None,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                    cache_write_input_tokens: None,
+                },
+                other => panic!("unexpected provider attempt {other}"),
+            };
+            let mut chunks = vec![Ok(usage)];
+            if attempt == 0 {
+                chunks.push(Ok(LLMChunk::ToolCalls(vec![
+                    bamboo_agent_core::tools::ToolCall {
+                        id: "retry-tool-attempt-1".to_string(),
+                        tool_type: "function".to_string(),
+                        function: bamboo_agent_core::tools::FunctionCall {
+                            name: "noop".to_string(),
+                            arguments: "{}".to_string(),
+                        },
+                    },
+                ])));
+            } else {
+                chunks.push(Ok(LLMChunk::Token(
+                    "second billed attempt completed".to_string(),
+                )));
+            }
+            chunks.push(Ok(LLMChunk::Done));
+            Ok(Box::pin(stream::iter(chunks)))
+        }
+    }
+
+    struct FailBeforeUsageProvider;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for FailBeforeUsageProvider {
+        async fn chat_stream(
+            &self,
+            _: &[Message],
+            _: &[bamboo_agent_core::tools::ToolSchema],
+            _: Option<u32>,
+            _: &str,
+        ) -> Result<LLMStream, LLMError> {
+            Err(LLMError::Api(
+                "authentication error before a stream was created".to_string(),
+            ))
+        }
+    }
+
+    async fn create_pipeline_metrics() -> (
+        tempfile::TempDir,
+        bamboo_metrics::MetricsCollector,
+        Arc<bamboo_metrics::SqliteMetricsStorage>,
+    ) {
+        use bamboo_metrics::storage::MetricsStorage;
+
+        let dir = tempfile::tempdir().expect("temp metrics dir");
+        let storage = Arc::new(bamboo_metrics::SqliteMetricsStorage::new(
+            dir.path().join("metrics.db"),
+        ));
+        storage.init().await.expect("init metrics storage");
+        let collector = bamboo_metrics::MetricsCollector::spawn(storage.clone(), 7);
+        (dir, collector, storage)
+    }
+
+    async fn wait_for_pipeline_metrics(
+        storage: &bamboo_metrics::SqliteMetricsStorage,
+        session_id: &str,
+        expected_status: MetricsRoundStatus,
+        expected_usage: MetricsTokenUsage,
+    ) -> bamboo_metrics::types::SessionDetail {
+        use bamboo_metrics::storage::MetricsStorage;
+
+        for _ in 0..100 {
+            if let Some(detail) = storage
+                .session_detail(session_id)
+                .await
+                .expect("session detail query")
+            {
+                if detail.rounds.first().is_some_and(|round| {
+                    round.status == expected_status && round.token_usage == expected_usage
+                }) && detail.session.total_token_usage == expected_usage
+                {
+                    return detail;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!(
+            "session {session_id} did not persist a {expected_status:?} round with usage {expected_usage:?}"
+        );
+    }
+
+    fn canonical_usage_pipeline_config() -> AgentLoopConfig {
+        use crate::runtime::config::PromptMemoryFlags;
+
+        AgentLoopConfig {
+            model_name: Some("model".to_string()),
+            prompt_memory_flags: PromptMemoryFlags {
+                project_prompt_injection: false,
+                relevant_recall: false,
+                relevant_recall_rerank: false,
+                project_first_dream: false,
+                ledger_agenda: false,
+            },
+            ..AgentLoopConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_success_clamps_overflow_and_reconciles_runtime_round_and_session() {
+        let session_id = "canonical-success";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        crate::runtime::runner::metrics_lifecycle::record_session_started(
+            Some(&collector),
+            session_id,
+            "model",
+            chrono::Utc::now(),
+            1,
+        );
+
+        let mut session = Session::new(session_id, "model");
+        session.add_message(Message::user(
+            "provider reports values beyond the durable signed range",
+        ));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let llm: Arc<dyn LLMProvider> = Arc::new(CanonicalUsageProvider {
+            prompt_tokens: u64::MAX,
+            completion_tokens: u64::MAX,
+            content: Some("provider-backed answer"),
+        });
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let mut state = e2e_loop_state(session_id);
+        state.metrics_collector = Some(collector);
+
+        super::run_pipeline(
+            &mut session,
+            &tx,
+            llm,
+            tools,
+            &tokio_util::sync::CancellationToken::new(),
+            &canonical_usage_pipeline_config(),
+            &mut state,
+        )
+        .await
+        .expect("successful pipeline");
+        drop(tx);
+        drain(&mut rx).await;
+
+        let max = bamboo_domain::MAX_DURABLE_TOKEN_COUNT;
+        let expected = MetricsTokenUsage {
+            prompt_tokens: max,
+            completion_tokens: max,
+            total_tokens: max,
+        };
+        let detail = wait_for_pipeline_metrics(
+            storage.as_ref(),
+            session_id,
+            MetricsRoundStatus::Success,
+            expected,
+        )
+        .await;
+        assert_eq!(detail.rounds.len(), 1);
+        assert_eq!(detail.rounds[0].token_usage, expected);
+        assert_eq!(detail.session.total_token_usage, expected);
+        assert_eq!(state.runtime_state.round.total_prompt_tokens, max);
+        assert_eq!(state.runtime_state.round.total_completion_tokens, max);
+    }
+
+    #[tokio::test]
+    async fn pipeline_billed_retry_attempts_persist_exactly_once_across_all_consumers() {
+        let session_id = "canonical-billed-retry";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        crate::runtime::runner::metrics_lifecycle::record_session_started(
+            Some(&collector),
+            session_id,
+            "model",
+            chrono::Utc::now(),
+            1,
+        );
+
+        let mut session = Session::new(session_id, "model");
+        session.add_message(Message::user("retry after post-LLM handler failure"));
+        session.metadata.insert(
+            super::TEST_POST_LLM_RETRY_FAILURES_KEY.to_string(),
+            "1".to_string(),
+        );
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let provider = Arc::new(BilledRetryProvider {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let mut state = e2e_loop_state(session_id);
+        state.metrics_collector = Some(collector);
+
+        super::run_pipeline(
+            &mut session,
+            &tx,
+            provider.clone(),
+            tools,
+            &tokio_util::sync::CancellationToken::new(),
+            &canonical_usage_pipeline_config(),
+            &mut state,
+        )
+        .await
+        .expect("second billed attempt completes the same round");
+        drop(tx);
+        drain(&mut rx).await;
+
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "one completed attempt fails in post-LLM handling and exactly one retry is billed"
+        );
+        let expected = MetricsTokenUsage {
+            prompt_tokens: 30,
+            completion_tokens: 8,
+            total_tokens: 38,
+        };
+        let detail = wait_for_pipeline_metrics(
+            storage.as_ref(),
+            session_id,
+            MetricsRoundStatus::Success,
+            expected,
+        )
+        .await;
+        assert_eq!(detail.rounds.len(), 1, "both attempts belong to one round");
+        assert_eq!(detail.rounds[0].token_usage, expected);
+        assert_eq!(detail.session.total_token_usage, expected);
+        assert_eq!(state.runtime_state.round.total_prompt_tokens, 30);
+        assert_eq!(state.runtime_state.round.total_completion_tokens, 8);
+    }
+
+    #[tokio::test]
+    async fn pipeline_terminal_validation_retains_billed_usage_in_runtime_and_metrics() {
+        let session_id = "canonical-terminal";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        crate::runtime::runner::metrics_lifecycle::record_session_started(
+            Some(&collector),
+            session_id,
+            "model",
+            chrono::Utc::now(),
+            1,
+        );
+
+        let mut session = Session::new(session_id, "model");
+        session.add_message(Message::user("returning no answer is terminal"));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let llm: Arc<dyn LLMProvider> = Arc::new(CanonicalUsageProvider {
+            prompt_tokens: 31,
+            completion_tokens: 7,
+            content: None,
+        });
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let mut state = e2e_loop_state(session_id);
+        state.metrics_collector = Some(collector);
+
+        let error = super::run_pipeline(
+            &mut session,
+            &tx,
+            llm,
+            tools,
+            &tokio_util::sync::CancellationToken::new(),
+            &canonical_usage_pipeline_config(),
+            &mut state,
+        )
+        .await
+        .expect_err("empty assistant response is terminal");
+        assert!(matches!(error, AgentError::EmptyAssistantResponse { .. }));
+        drop(tx);
+        drain(&mut rx).await;
+
+        let expected = MetricsTokenUsage {
+            prompt_tokens: 31,
+            completion_tokens: 7,
+            total_tokens: 38,
+        };
+        let detail = wait_for_pipeline_metrics(
+            storage.as_ref(),
+            session_id,
+            MetricsRoundStatus::Error,
+            expected,
+        )
+        .await;
+        assert_eq!(detail.rounds.len(), 1);
+        assert_eq!(detail.rounds[0].token_usage, expected);
+        assert_eq!(detail.session.total_token_usage, expected);
+        assert_eq!(state.runtime_state.round.total_prompt_tokens, 31);
+        assert_eq!(state.runtime_state.round.total_completion_tokens, 7);
+        let persisted_runtime = session
+            .agent_runtime_state
+            .as_ref()
+            .expect("terminal runtime state mirrored to session");
+        assert_eq!(persisted_runtime.round.total_prompt_tokens, 31);
+        assert_eq!(persisted_runtime.round.total_completion_tokens, 7);
+    }
+
+    #[tokio::test]
+    async fn pipeline_post_llm_hook_abort_retains_usage_in_terminal_metrics_and_runtime() {
+        let session_id = "canonical-post-llm-abort";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        crate::runtime::runner::metrics_lifecycle::record_session_started(
+            Some(&collector),
+            session_id,
+            "model",
+            chrono::Utc::now(),
+            1,
+        );
+
+        let mut session = Session::new(session_id, "model");
+        session.add_message(Message::user("abort only after the stream completes"));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let llm: Arc<dyn LLMProvider> = Arc::new(CanonicalUsageProvider {
+            prompt_tokens: 23,
+            completion_tokens: 6,
+            content: Some("completed provider response"),
+        });
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let mut state = e2e_loop_state(session_id);
+        state.metrics_collector = Some(collector);
+        let mut config = canonical_usage_pipeline_config();
+        let mut hook_runner = crate::runtime::hooks::HookRunner::new();
+        hook_runner.register(Arc::new(AbortFinalizeHook));
+        config.hook_runner = Arc::new(hook_runner);
+
+        let error = super::run_pipeline(
+            &mut session,
+            &tx,
+            llm,
+            tools,
+            &tokio_util::sync::CancellationToken::new(),
+            &config,
+            &mut state,
+        )
+        .await
+        .expect_err("finalize hook aborts after the completed stream");
+        assert!(matches!(error, AgentError::Tool(message) if message.contains("hook aborted")));
+        drop(tx);
+        drain(&mut rx).await;
+
+        let expected = MetricsTokenUsage {
+            prompt_tokens: 23,
+            completion_tokens: 6,
+            total_tokens: 29,
+        };
+        let detail = wait_for_pipeline_metrics(
+            storage.as_ref(),
+            session_id,
+            MetricsRoundStatus::Error,
+            expected,
+        )
+        .await;
+        assert_eq!(detail.rounds[0].token_usage, expected);
+        assert_eq!(detail.session.total_token_usage, expected);
+        assert_eq!(state.runtime_state.round.total_prompt_tokens, 23);
+        assert_eq!(state.runtime_state.round.total_completion_tokens, 6);
+    }
+
+    #[tokio::test]
+    async fn pipeline_hook_suspension_keeps_success_usage_without_error_status() {
+        let session_id = "canonical-hook-suspend";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        crate::runtime::runner::metrics_lifecycle::record_session_started(
+            Some(&collector),
+            session_id,
+            "model",
+            chrono::Utc::now(),
+            1,
+        );
+
+        let mut session = Session::new(session_id, "model");
+        session.add_message(Message::user("pause before finalizing"));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let llm: Arc<dyn LLMProvider> = Arc::new(CanonicalUsageProvider {
+            prompt_tokens: 19,
+            completion_tokens: 4,
+            content: Some("ready, pending approval"),
+        });
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let mut state = e2e_loop_state(session_id);
+        state.metrics_collector = Some(collector);
+        let mut config = canonical_usage_pipeline_config();
+        let mut hook_runner = crate::runtime::hooks::HookRunner::new();
+        hook_runner.register(Arc::new(IntentionalFinalizeSuspendHook));
+        config.hook_runner = Arc::new(hook_runner);
+
+        let error = super::run_pipeline(
+            &mut session,
+            &tx,
+            llm,
+            tools,
+            &tokio_util::sync::CancellationToken::new(),
+            &config,
+            &mut state,
+        )
+        .await
+        .expect_err("hook suspension remains a control-flow signal");
+        assert!(error.is_hook_suspended());
+        drop(tx);
+        drain(&mut rx).await;
+
+        let expected = MetricsTokenUsage {
+            prompt_tokens: 19,
+            completion_tokens: 4,
+            total_tokens: 23,
+        };
+        let detail = wait_for_pipeline_metrics(
+            storage.as_ref(),
+            session_id,
+            MetricsRoundStatus::Success,
+            expected,
+        )
+        .await;
+        assert_eq!(detail.rounds[0].token_usage, expected);
+        assert_eq!(detail.session.total_token_usage, expected);
+        assert_eq!(
+            detail.session.status,
+            MetricsSessionStatus::Running,
+            "the outer finalizer, not terminal-error metrics, owns suspension status"
+        );
+        assert_eq!(state.runtime_state.round.total_prompt_tokens, 19);
+        assert_eq!(state.runtime_state.round.total_completion_tokens, 4);
+    }
+
+    #[tokio::test]
+    async fn pipeline_failure_before_provider_usage_remains_zero_everywhere() {
+        let session_id = "canonical-pre-stream-error";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        crate::runtime::runner::metrics_lifecycle::record_session_started(
+            Some(&collector),
+            session_id,
+            "model",
+            chrono::Utc::now(),
+            1,
+        );
+
+        let mut session = Session::new(session_id, "model");
+        session.add_message(Message::user("this request fails before streaming"));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let mut state = e2e_loop_state(session_id);
+        state.metrics_collector = Some(collector);
+
+        super::run_pipeline(
+            &mut session,
+            &tx,
+            Arc::new(FailBeforeUsageProvider),
+            tools,
+            &tokio_util::sync::CancellationToken::new(),
+            &canonical_usage_pipeline_config(),
+            &mut state,
+        )
+        .await
+        .expect_err("provider authentication error is terminal");
+        drop(tx);
+        drain(&mut rx).await;
+
+        let detail = wait_for_pipeline_metrics(
+            storage.as_ref(),
+            session_id,
+            MetricsRoundStatus::Error,
+            MetricsTokenUsage::default(),
+        )
+        .await;
+        assert_eq!(detail.rounds[0].token_usage, MetricsTokenUsage::default());
+        assert_eq!(
+            detail.session.total_token_usage,
+            MetricsTokenUsage::default()
+        );
+        assert_eq!(state.runtime_state.round.total_prompt_tokens, 0);
+        assert_eq!(state.runtime_state.round.total_completion_tokens, 0);
+    }
+
     #[tokio::test]
     async fn run_budget_token_limit_stops_run_gracefully() {
         use crate::runtime::config::PromptMemoryFlags;
@@ -4269,7 +4928,10 @@ mod tests {
         let mut activity = super::RoundActivity::default();
 
         // Attempt 1: billed 100 in / 50 out, one Bash + one SubAgent create.
-        activity.absorb_attempt(&attempt(100, 50, vec!["Bash", "SubAgent"]));
+        let attempt_1 = attempt(100, 50, vec!["Bash", "SubAgent"]);
+        let attempt_1_usage =
+            crate::runtime::runner::round_lifecycle::canonical_attempt_usage(&attempt_1, 999, 999);
+        activity.absorb_attempt(&attempt_1, attempt_1_usage);
         assert_eq!(activity.prompt_tokens, 100);
         assert_eq!(activity.completion_tokens, 50);
         assert_eq!(activity.tool_call_count, 2);
@@ -4277,19 +4939,43 @@ mod tests {
 
         // Post-LLM handling fails retryably; attempt 2 is billed too. Totals
         // must be the SUM of both attempts, not attempt 2's numbers alone.
-        activity.absorb_attempt(&attempt(120, 30, vec!["Bash"]));
+        let attempt_2 = attempt(120, 30, vec!["Bash"]);
+        let attempt_2_usage =
+            crate::runtime::runner::round_lifecycle::canonical_attempt_usage(&attempt_2, 999, 999);
+        activity.absorb_attempt(&attempt_2, attempt_2_usage);
         assert_eq!(
             activity.prompt_tokens, 220,
             "attempt 1's billed prompt tokens must not be dropped on retry"
         );
         assert_eq!(activity.completion_tokens, 80);
+        assert_eq!(
+            activity.token_usage(),
+            MetricsTokenUsage {
+                prompt_tokens: 220,
+                completion_tokens: 80,
+                total_tokens: 300,
+            },
+            "durable usage must contain every billed retry attempt exactly once"
+        );
         assert_eq!(activity.tool_call_count, 3);
         assert_eq!(activity.subagent_spawn_count, 1);
 
         // Saturates rather than wrapping on absurd totals.
-        activity.absorb_attempt(&attempt(u64::MAX, u64::MAX, vec![]));
-        assert_eq!(activity.prompt_tokens, u64::MAX);
-        assert_eq!(activity.completion_tokens, u64::MAX);
+        let saturating_attempt = attempt(u64::MAX, u64::MAX, vec![]);
+        let saturating_usage = crate::runtime::runner::round_lifecycle::canonical_attempt_usage(
+            &saturating_attempt,
+            1,
+            1,
+        );
+        activity.absorb_attempt(&saturating_attempt, saturating_usage);
+        assert_eq!(
+            activity.prompt_tokens,
+            bamboo_domain::MAX_DURABLE_TOKEN_COUNT
+        );
+        assert_eq!(
+            activity.completion_tokens,
+            bamboo_domain::MAX_DURABLE_TOKEN_COUNT
+        );
     }
 
     #[test]
@@ -4322,7 +5008,8 @@ mod tests {
         };
 
         let mut activity = super::RoundActivity::default();
-        activity.absorb_attempt(&output);
+        let usage = crate::runtime::runner::round_lifecycle::canonical_attempt_usage(&output, 7, 9);
+        activity.absorb_attempt(&output, usage);
 
         assert_eq!(activity.prompt_tokens, 1000);
         assert_eq!(
@@ -4336,10 +5023,50 @@ mod tests {
             .expect("provider usage")
             .output_tokens = Some(0);
         let mut zero_activity = super::RoundActivity::default();
-        zero_activity.absorb_attempt(&output);
+        let zero_usage =
+            crate::runtime::runner::round_lifecycle::canonical_attempt_usage(&output, 7, 9);
+        zero_activity.absorb_attempt(&output, zero_usage);
         assert_eq!(
             zero_activity.completion_tokens, 0,
             "explicit provider zero must beat a nonzero legacy flat value"
+        );
+    }
+
+    #[test]
+    fn canonical_attempt_usage_falls_back_per_component_only_when_unreported() {
+        use crate::runtime::stream::handler::{ProviderUsageSnapshot, StreamHandlingOutput};
+
+        let output = StreamHandlingOutput {
+            response_id: None,
+            content: "answer".to_string(),
+            reasoning_content: String::new(),
+            reasoning_signature: None,
+            token_count: 6,
+            tool_calls: Vec::new(),
+            output_tokens: 0,
+            thinking_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            provider_usage: Some(ProviderUsageSnapshot {
+                input_tokens: Some(41),
+                output_tokens: None,
+                total_tokens: Some(999),
+                reasoning_tokens: None,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+                cache_write_input_tokens: None,
+            }),
+            input_tokens: 0,
+        };
+
+        assert_eq!(
+            crate::runtime::runner::round_lifecycle::canonical_attempt_usage(&output, 3, 5),
+            MetricsTokenUsage {
+                prompt_tokens: 41,
+                completion_tokens: 5,
+                total_tokens: 46,
+            },
+            "reported prompt wins, missing completion estimates, and provider total is not trusted"
         );
     }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/metrics_lifecycle/round_metrics.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/metrics_lifecycle/round_metrics.rs
@@ -49,12 +49,14 @@ pub(in crate::runtime::runner) fn record_round_completed(
     metrics.session_message_count(session_id.to_string(), message_count, Utc::now());
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::runtime::runner) fn record_round_and_session_error(
     metrics_collector: Option<&MetricsCollector>,
     round_id: &str,
     session_id: &str,
     message_count: u32,
     round_status: MetricsRoundStatus,
+    round_usage: MetricsTokenUsage,
     round_error: Option<String>,
     session_status: MetricsSessionStatus,
 ) {
@@ -66,7 +68,7 @@ pub(in crate::runtime::runner) fn record_round_and_session_error(
         round_id.to_string(),
         Utc::now(),
         round_status,
-        MetricsTokenUsage::default(),
+        round_usage,
         0,
         0,
         round_error,

--- a/crates/engine/bamboo-engine/src/runtime/runner/metrics_lifecycle/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/metrics_lifecycle/tests.rs
@@ -121,6 +121,11 @@ async fn record_round_and_session_error_marks_round_and_session_as_error() {
         "metrics-s2",
         5,
         RoundStatus::Error,
+        TokenUsage {
+            prompt_tokens: 21,
+            completion_tokens: 8,
+            total_tokens: 29,
+        },
         Some("boom".to_string()),
         SessionStatus::Error,
     );
@@ -135,7 +140,50 @@ async fn record_round_and_session_error_marks_round_and_session_as_error() {
     assert_eq!(detail.rounds.len(), 1);
     assert_eq!(detail.rounds[0].status, RoundStatus::Error);
     assert_eq!(detail.rounds[0].error.as_deref(), Some("boom"));
+    let expected_usage = TokenUsage {
+        prompt_tokens: 21,
+        completion_tokens: 8,
+        total_tokens: 29,
+    };
+    assert_eq!(detail.rounds[0].token_usage, expected_usage);
+    assert_eq!(
+        detail.session.total_token_usage, expected_usage,
+        "the durable session aggregate must reconcile to its terminal round"
+    );
+}
+
+#[tokio::test]
+async fn record_pre_stream_error_keeps_zero_usage() {
+    let (_dir, collector, storage) = create_collector_with_storage().await;
+    let started_at = Utc::now();
+
+    record_session_started(
+        Some(&collector),
+        "metrics-s-zero",
+        "test-model",
+        started_at,
+        1,
+    );
+    record_round_started(
+        Some(&collector),
+        "metrics-r-zero",
+        "metrics-s-zero",
+        "test-model",
+    );
+    record_round_and_session_error(
+        Some(&collector),
+        "metrics-r-zero",
+        "metrics-s-zero",
+        1,
+        RoundStatus::Error,
+        TokenUsage::default(),
+        Some("provider failed before usage".to_string()),
+        SessionStatus::Error,
+    );
+
+    let detail = wait_for_session_detail(storage.as_ref(), "metrics-s-zero").await;
     assert_eq!(detail.rounds[0].token_usage, TokenUsage::default());
+    assert_eq!(detail.session.total_token_usage, TokenUsage::default());
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
@@ -27,7 +27,46 @@ pub(crate) struct RoundLlmExecutionOutput {
     pub stream_output: StreamHandlingOutput,
     pub prompt_tokens: u64,
     pub completion_tokens: u64,
-    pub round_usage: MetricsTokenUsage,
+    /// Canonical usage for this single billed provider attempt.
+    pub attempt_usage: MetricsTokenUsage,
+    /// Validation that can only run after a provider stream has completed.
+    ///
+    /// The pipeline must absorb `attempt_usage` before surfacing this error so
+    /// a billed response is not turned into a zero-usage terminal round.
+    pub terminal_validation_error: Option<AgentError>,
+}
+
+/// Resolve one billed attempt's canonical token usage.
+///
+/// Availability is decided independently for prompt and completion tokens:
+/// an authoritative provider snapshot wins (including an explicit zero), a
+/// non-zero legacy provider counter is the compatibility fallback, and the
+/// local tokenizer estimate is used only when that component was not reported.
+/// The total is always recomputed from the selected components so runtime
+/// budgets and durable metrics cannot disagree with an inconsistent provider
+/// `total_tokens` field.
+pub(crate) fn canonical_attempt_usage(
+    stream_output: &StreamHandlingOutput,
+    estimated_prompt_tokens: u64,
+    estimated_completion_tokens: u64,
+) -> MetricsTokenUsage {
+    let prompt_tokens = stream_output
+        .provider_usage
+        .and_then(|usage| usage.input_tokens)
+        .or_else(|| (stream_output.input_tokens > 0).then_some(stream_output.input_tokens))
+        .unwrap_or(estimated_prompt_tokens);
+    let completion_tokens = stream_output
+        .provider_usage
+        .and_then(|usage| usage.output_tokens)
+        .or_else(|| (stream_output.output_tokens > 0).then_some(stream_output.output_tokens))
+        .unwrap_or(estimated_completion_tokens);
+
+    MetricsTokenUsage {
+        prompt_tokens,
+        completion_tokens,
+        total_tokens: prompt_tokens.saturating_add(completion_tokens),
+    }
+    .clamped_for_durable_metrics()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -80,35 +119,36 @@ pub(crate) async fn execute_llm_round(
     )
     .await?;
 
-    if stream_output.tool_calls.is_empty() && stream_output.content.trim().is_empty() {
-        return Err(AgentError::EmptyAssistantResponse {
-            response_id: stream_output.response_id.clone(),
-        });
-    }
+    // This is a terminal validation error, but the completed stream was still
+    // billed. Return it alongside the canonical attempt usage so the runner can
+    // account for the attempt before ending the round.
+    let terminal_validation_error = (stream_output.tool_calls.is_empty()
+        && stream_output.content.trim().is_empty())
+    .then(|| AgentError::EmptyAssistantResponse {
+        response_id: stream_output.response_id.clone(),
+    });
 
     let prompt_tokens = estimate_prompt_tokens(&prepared.prepared_context.messages);
     let completion_tokens =
         estimate_completion_tokens(&stream_output.content, &stream_output.tool_calls);
-    let round_usage = MetricsTokenUsage {
-        prompt_tokens,
-        completion_tokens,
-        total_tokens: prompt_tokens.saturating_add(completion_tokens),
-    };
+    let attempt_usage = canonical_attempt_usage(&stream_output, prompt_tokens, completion_tokens);
 
     tracing::debug!(
-        "[{}] LLM response completed in {}ms, answer_chars={}, reasoning_chars={}, {} estimated tokens",
+        "[{}] LLM response completed in {}ms, answer_chars={}, reasoning_chars={}, estimated_tokens={}, canonical_tokens={}",
         session_id,
         llm_duration,
         stream_output.token_count,
         stream_output.reasoning_content.len(),
-        round_usage.total_tokens
+        prompt_tokens.saturating_add(completion_tokens),
+        attempt_usage.total_tokens,
     );
 
     Ok(RoundLlmExecutionOutput {
         stream_output,
         prompt_tokens,
         completion_tokens,
-        round_usage,
+        attempt_usage,
+        terminal_validation_error,
     })
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -188,28 +188,6 @@ pub struct StreamHandlingOutput {
     pub input_tokens: u64,
 }
 
-impl StreamHandlingOutput {
-    /// Prompt usage for runtime budget enforcement.
-    ///
-    /// Provider-reported totals are authoritative when present. Legacy streams
-    /// retain their historical fallback to the flat fresh-input counter.
-    pub(crate) fn prompt_tokens_for_runtime_budget(&self) -> u64 {
-        self.provider_usage
-            .and_then(|usage| usage.input_tokens)
-            .unwrap_or(self.input_tokens)
-    }
-
-    /// Completion usage for runtime budget enforcement.
-    ///
-    /// A provider-reported output total (including explicit zero) wins over
-    /// legacy summaries. Reasoning is a subset breakdown and is never added.
-    pub(crate) fn completion_tokens_for_runtime_budget(&self) -> u64 {
-        self.provider_usage
-            .and_then(|usage| usage.output_tokens)
-            .unwrap_or(self.output_tokens)
-    }
-}
-
 #[derive(Debug, Clone, serde::Serialize)]
 pub(crate) struct PartialToolCallSnapshot {
     pub id: String,

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
@@ -1065,12 +1065,14 @@ impl MetricsStorage for SqliteMetricsStorage {
         let completed_at_str = format_timestamp(completed_at);
 
         self.with_connection(move |connection| {
-            refresh_session_aggregates(connection, &session_id, completed_at)?;
-            connection.execute(
-                "UPDATE session_metrics SET status = ?1, completed_at = ?2, updated_at = ?2 WHERE session_id = ?3",
-                params![status.as_str(), completed_at_str, session_id],
-            )?;
-            Ok(())
+            with_immediate_transaction(connection, || {
+                refresh_session_aggregates(connection, &session_id, completed_at)?;
+                connection.execute(
+                    "UPDATE session_metrics SET status = ?1, completed_at = ?2, updated_at = ?2 WHERE session_id = ?3",
+                    params![status.as_str(), completed_at_str, session_id],
+                )?;
+                Ok(())
+            })
         })
         .await
     }
@@ -1088,17 +1090,19 @@ impl MetricsStorage for SqliteMetricsStorage {
         let started_at_str = format_timestamp(started_at);
 
         self.with_connection(move |connection| {
-            connection.execute(
-                r#"
-                INSERT INTO round_metrics (
-                    round_id, session_id, model, started_at, status
-                ) VALUES (?1, ?2, ?3, ?4, 'running')
-                ON CONFLICT(round_id) DO NOTHING
-                "#,
-                params![round_id, session_id, model, started_at_str],
-            )?;
-            refresh_session_aggregates(connection, &session_id, started_at)?;
-            Ok(())
+            with_immediate_transaction(connection, || {
+                connection.execute(
+                    r#"
+                    INSERT INTO round_metrics (
+                        round_id, session_id, model, started_at, status
+                    ) VALUES (?1, ?2, ?3, ?4, 'running')
+                    ON CONFLICT(round_id) DO NOTHING
+                    "#,
+                    params![round_id, session_id, model, started_at_str],
+                )?;
+                refresh_session_aggregates(connection, &session_id, started_at)?;
+                Ok(())
+            })
         })
         .await
     }
@@ -1115,44 +1119,55 @@ impl MetricsStorage for SqliteMetricsStorage {
     ) -> MetricsResult<()> {
         let round_id = round_id.to_string();
         let completed_at_str = format_timestamp(completed_at);
+        // SQLite INTEGER is signed 64-bit. Normalize before conversion so
+        // extreme provider values saturate instead of wrapping negative.
+        let usage = usage.clamped_for_durable_metrics();
+        let prompt_tokens = durable_token_to_i64(usage.prompt_tokens);
+        let completion_tokens = durable_token_to_i64(usage.completion_tokens);
+        let total_tokens = durable_token_to_i64(usage.total_tokens);
 
         self.with_connection(move |connection| {
-            let session_id: String = connection.query_row(
-                "SELECT session_id FROM round_metrics WHERE round_id = ?1",
-                params![round_id],
-                |row| row.get(0),
-            )?;
+            with_immediate_transaction(connection, || {
+                #[cfg(test)]
+                signal_complete_round_transaction_entered(&round_id);
 
-            connection.execute(
-                r#"
-                UPDATE round_metrics
-                SET completed_at = ?1,
-                    status = ?2,
-                    prompt_tokens = ?3,
-                    completion_tokens = ?4,
-                    total_tokens = ?5,
-                    prompt_cached_tool_outputs = ?6,
-                    prompt_cached_tool_tokens_saved = COALESCE(prompt_cached_tool_tokens_saved, 0) + ?7,
-                    tokens_saved = COALESCE(tokens_saved, 0) + ?8,
-                    error = ?9
-                WHERE round_id = ?10
-                "#,
-                params![
-                    completed_at_str,
-                    status.as_str(),
-                    usage.prompt_tokens as i64,
-                    usage.completion_tokens as i64,
-                    usage.total_tokens as i64,
-                    i64::from(prompt_cached_tool_outputs),
-                    i64::from(prompt_cached_tool_tokens_saved),
-                    i64::from(prompt_cached_tool_tokens_saved),
-                    error,
-                    round_id,
-                ],
-            )?;
+                let session_id: String = connection.query_row(
+                    "SELECT session_id FROM round_metrics WHERE round_id = ?1",
+                    params![round_id],
+                    |row| row.get(0),
+                )?;
 
-            refresh_session_aggregates(connection, &session_id, completed_at)?;
-            Ok(())
+                connection.execute(
+                    r#"
+                    UPDATE round_metrics
+                    SET completed_at = ?1,
+                        status = ?2,
+                        prompt_tokens = ?3,
+                        completion_tokens = ?4,
+                        total_tokens = ?5,
+                        prompt_cached_tool_outputs = ?6,
+                        prompt_cached_tool_tokens_saved = COALESCE(prompt_cached_tool_tokens_saved, 0) + ?7,
+                        tokens_saved = COALESCE(tokens_saved, 0) + ?8,
+                        error = ?9
+                    WHERE round_id = ?10
+                    "#,
+                    params![
+                        completed_at_str,
+                        status.as_str(),
+                        prompt_tokens,
+                        completion_tokens,
+                        total_tokens,
+                        i64::from(prompt_cached_tool_outputs),
+                        i64::from(prompt_cached_tool_tokens_saved),
+                        i64::from(prompt_cached_tool_tokens_saved),
+                        error,
+                        round_id,
+                    ],
+                )?;
+
+                refresh_session_aggregates(connection, &session_id, completed_at)?;
+                Ok(())
+            })
         })
         .await
     }
@@ -1166,24 +1181,26 @@ impl MetricsStorage for SqliteMetricsStorage {
         let round_id = round_id.to_string();
 
         self.with_connection(move |connection| {
-            let session_id: String = connection.query_row(
-                "SELECT session_id FROM round_metrics WHERE round_id = ?1",
-                params![round_id],
-                |row| row.get(0),
-            )?;
+            with_immediate_transaction(connection, || {
+                let session_id: String = connection.query_row(
+                    "SELECT session_id FROM round_metrics WHERE round_id = ?1",
+                    params![round_id],
+                    |row| row.get(0),
+                )?;
 
-            connection.execute(
-                r#"
-                UPDATE round_metrics
-                SET compression_count = COALESCE(compression_count, 0) + 1,
-                    tokens_saved = COALESCE(tokens_saved, 0) + ?1
-                WHERE round_id = ?2
-                "#,
-                params![i64::from(tokens_saved), round_id],
-            )?;
+                connection.execute(
+                    r#"
+                    UPDATE round_metrics
+                    SET compression_count = COALESCE(compression_count, 0) + 1,
+                        tokens_saved = COALESCE(tokens_saved, 0) + ?1
+                    WHERE round_id = ?2
+                    "#,
+                    params![i64::from(tokens_saved), round_id],
+                )?;
 
-            refresh_session_aggregates(connection, &session_id, compressed_at)?;
-            Ok(())
+                refresh_session_aggregates(connection, &session_id, compressed_at)?;
+                Ok(())
+            })
         })
         .await
     }
@@ -1238,19 +1255,21 @@ impl MetricsStorage for SqliteMetricsStorage {
         let error = completion.error;
 
         self.with_connection(move |connection| {
-            let session_id: String = connection.query_row(
-                "SELECT session_id FROM tool_call_metrics WHERE tool_call_id = ?1",
-                params![tool_call_id],
-                |row| row.get(0),
-            )?;
+            with_immediate_transaction(connection, || {
+                let session_id: String = connection.query_row(
+                    "SELECT session_id FROM tool_call_metrics WHERE tool_call_id = ?1",
+                    params![tool_call_id],
+                    |row| row.get(0),
+                )?;
 
-            connection.execute(
-                "UPDATE tool_call_metrics SET completed_at = ?1, success = ?2, error = ?3 WHERE tool_call_id = ?4",
-                params![completed_at, success, error, tool_call_id],
-            )?;
+                connection.execute(
+                    "UPDATE tool_call_metrics SET completed_at = ?1, success = ?2, error = ?3 WHERE tool_call_id = ?4",
+                    params![completed_at, success, error, tool_call_id],
+                )?;
 
-            refresh_session_aggregates(connection, &session_id, completion.completed_at)?;
-            Ok(())
+                refresh_session_aggregates(connection, &session_id, completion.completed_at)?;
+                Ok(())
+            })
         })
         .await
     }
@@ -2023,8 +2042,7 @@ impl MetricsStorage for SqliteMetricsStorage {
             // SELECT and the DELETE (backfill/replay/clock skew) would be deleted
             // yet miss re-aggregation, leaving session_metrics overcounting. Wrap
             // the whole select→delete→refresh in a single IMMEDIATE transaction.
-            connection.execute_batch("BEGIN IMMEDIATE")?;
-            let outcome = (|| -> MetricsResult<u64> {
+            with_immediate_transaction(connection, || {
                 // Only sessions that actually lose rounds need re-aggregation
                 // (was nine correlated subqueries × ALL sessions per pass).
                 let affected_sessions: Vec<String> = {
@@ -2047,18 +2065,7 @@ impl MetricsStorage for SqliteMetricsStorage {
                 }
 
                 Ok(deleted as u64)
-            })();
-
-            match outcome {
-                Ok(deleted) => {
-                    connection.execute_batch("COMMIT")?;
-                    Ok(deleted)
-                }
-                Err(error) => {
-                    let _ = connection.execute_batch("ROLLBACK");
-                    Err(error)
-                }
-            }
+            })
         })
         .await
     }
@@ -2072,47 +2079,52 @@ impl MetricsStorage for SqliteMetricsStorage {
         let awaiting_response_session_ids = awaiting_response_session_ids.to_vec();
 
         self.with_connection(move |connection| {
-            let reconciled_at = Utc::now();
-            let reconciled_at_str = format_timestamp(reconciled_at);
+            with_immediate_transaction(connection, || {
+                let reconciled_at = Utc::now();
+                let reconciled_at_str = format_timestamp(reconciled_at);
 
-            let mut stmt = connection.prepare(
-                "SELECT session_id FROM session_metrics WHERE status = 'running'",
-            )?;
-            let running_session_ids: Vec<String> = stmt
-                .query_map([], |row| row.get(0))?
-                .collect::<Result<Vec<String>, _>>()?;
-
-            for session_id in running_session_ids {
-                if active_session_ids.iter().any(|id| id == &session_id) {
-                    continue;
-                }
-
-                let status = if awaiting_response_session_ids
-                    .iter()
-                    .any(|id| id == &session_id)
-                {
-                    SessionStatus::AwaitingResponse
-                } else {
-                    SessionStatus::Completed
+                let running_session_ids: Vec<String> = {
+                    let mut stmt = connection.prepare(
+                        "SELECT session_id FROM session_metrics WHERE status = 'running'",
+                    )?;
+                    let ids = stmt
+                        .query_map([], |row| row.get(0))?
+                        .collect::<Result<Vec<String>, _>>()?;
+                    ids
                 };
 
+                for session_id in running_session_ids {
+                    if active_session_ids.iter().any(|id| id == &session_id) {
+                        continue;
+                    }
+
+                    let status = if awaiting_response_session_ids
+                        .iter()
+                        .any(|id| id == &session_id)
+                    {
+                        SessionStatus::AwaitingResponse
+                    } else {
+                        SessionStatus::Completed
+                    };
+
+                    connection.execute(
+                        "UPDATE session_metrics SET status = ?1, completed_at = COALESCE(completed_at, ?2), updated_at = ?2 WHERE session_id = ?3",
+                        params![status.as_str(), reconciled_at_str, session_id],
+                    )?;
+                    refresh_session_aggregates(connection, &session_id, reconciled_at)?;
+                }
+
                 connection.execute(
-                    "UPDATE session_metrics SET status = ?1, completed_at = COALESCE(completed_at, ?2), updated_at = ?2 WHERE session_id = ?3",
-                    params![status.as_str(), reconciled_at_str, session_id],
+                    "UPDATE round_metrics SET status = 'error', completed_at = COALESCE(completed_at, ?1), error = COALESCE(error, 'reconciled_stale_round') WHERE status = 'running'",
+                    params![reconciled_at_str],
                 )?;
-                refresh_session_aggregates(connection, &session_id, reconciled_at)?;
-            }
+                connection.execute(
+                    "UPDATE forward_request_metrics SET status = 'error', completed_at = COALESCE(completed_at, ?1), error = COALESCE(error, 'reconciled_stale_forward'), updated_at = ?1 WHERE status = 'pending' AND completed_at IS NULL",
+                    params![reconciled_at_str],
+                )?;
 
-            connection.execute(
-                "UPDATE round_metrics SET status = 'error', completed_at = COALESCE(completed_at, ?1), error = COALESCE(error, 'reconciled_stale_round') WHERE status = 'running'",
-                params![reconciled_at_str],
-            )?;
-            connection.execute(
-                "UPDATE forward_request_metrics SET status = 'error', completed_at = COALESCE(completed_at, ?1), error = COALESCE(error, 'reconciled_stale_forward'), updated_at = ?1 WHERE status = 'pending' AND completed_at IS NULL",
-                params![reconciled_at_str],
-            )?;
-
-            Ok(())
+                Ok(())
+            })
         })
         .await
     }
@@ -2403,6 +2415,141 @@ fn ensure_nullable_integer_column(
     Ok(())
 }
 
+#[cfg(test)]
+struct SessionTokenFoldPause {
+    session_id: String,
+    entered: std::sync::mpsc::Sender<()>,
+    release: std::sync::mpsc::Receiver<()>,
+}
+
+#[cfg(test)]
+static SESSION_TOKEN_FOLD_PAUSE: std::sync::OnceLock<
+    std::sync::Mutex<Option<SessionTokenFoldPause>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+fn install_session_token_fold_pause(
+    session_id: &str,
+) -> (std::sync::mpsc::Receiver<()>, std::sync::mpsc::Sender<()>) {
+    let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let mut slot = SESSION_TOKEN_FOLD_PAUSE
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("session token fold test hook lock");
+    assert!(slot.is_none(), "session token fold test hook already set");
+    *slot = Some(SessionTokenFoldPause {
+        session_id: session_id.to_string(),
+        entered: entered_tx,
+        release: release_rx,
+    });
+    (entered_rx, release_tx)
+}
+
+#[cfg(test)]
+fn pause_after_session_token_fold(session_id: &str) {
+    let pause = {
+        let mut slot = SESSION_TOKEN_FOLD_PAUSE
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("session token fold test hook lock");
+        if slot
+            .as_ref()
+            .is_some_and(|pause| pause.session_id == session_id)
+        {
+            slot.take()
+        } else {
+            None
+        }
+    };
+
+    if let Some(pause) = pause {
+        let _ = pause.entered.send(());
+        let _ = pause.release.recv();
+    }
+}
+
+#[cfg(test)]
+struct CompleteRoundTransactionEnteredHook {
+    round_id: String,
+    entered: std::sync::mpsc::Sender<()>,
+}
+
+#[cfg(test)]
+static COMPLETE_ROUND_TRANSACTION_ENTERED_HOOK: std::sync::OnceLock<
+    std::sync::Mutex<Option<CompleteRoundTransactionEnteredHook>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+fn install_complete_round_transaction_entered_hook(
+    round_id: &str,
+) -> std::sync::mpsc::Receiver<()> {
+    let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+    let mut slot = COMPLETE_ROUND_TRANSACTION_ENTERED_HOOK
+        .get_or_init(|| std::sync::Mutex::new(None))
+        .lock()
+        .expect("complete round transaction test hook lock");
+    assert!(
+        slot.is_none(),
+        "complete round transaction test hook already set"
+    );
+    *slot = Some(CompleteRoundTransactionEnteredHook {
+        round_id: round_id.to_string(),
+        entered: entered_tx,
+    });
+    entered_rx
+}
+
+#[cfg(test)]
+fn signal_complete_round_transaction_entered(round_id: &str) {
+    let hook = {
+        let mut slot = COMPLETE_ROUND_TRANSACTION_ENTERED_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None))
+            .lock()
+            .expect("complete round transaction test hook lock");
+        if slot.as_ref().is_some_and(|hook| hook.round_id == round_id) {
+            slot.take()
+        } else {
+            None
+        }
+    };
+
+    if let Some(hook) = hook {
+        let _ = hook.entered.send(());
+    }
+}
+
+/// Runs a metrics mutation under the SQLite write lock unless the caller
+/// already owns a transaction.
+///
+/// Aggregate refreshes read child rows and then update their cached parent
+/// row. `BEGIN IMMEDIATE` serializes that read-modify-write sequence across
+/// independent connections, while the autocommit check lets larger operations
+/// such as pruning reuse their existing transaction.
+fn with_immediate_transaction<T>(
+    connection: &Connection,
+    operation: impl FnOnce() -> MetricsResult<T>,
+) -> MetricsResult<T> {
+    if !connection.is_autocommit() {
+        return operation();
+    }
+
+    connection.execute_batch("BEGIN IMMEDIATE")?;
+    match operation() {
+        Ok(value) => match connection.execute_batch("COMMIT") {
+            Ok(()) => Ok(value),
+            Err(error) => {
+                let _ = connection.execute_batch("ROLLBACK");
+                Err(error.into())
+            }
+        },
+        Err(error) => {
+            let _ = connection.execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
+}
+
 /// Refreshes aggregated metrics for a session by recalculating from child entities.
 ///
 /// This function updates the session's aggregate columns by summing values
@@ -2435,26 +2582,83 @@ fn refresh_session_aggregates(
     session_id: &str,
     updated_at: DateTime<Utc>,
 ) -> MetricsResult<()> {
+    with_immediate_transaction(connection, || {
+        refresh_session_aggregates_in_transaction(connection, session_id, updated_at)
+    })
+}
+
+fn refresh_session_aggregates_in_transaction(
+    connection: &Connection,
+    session_id: &str,
+    updated_at: DateTime<Utc>,
+) -> MetricsResult<()> {
+    // Do not use SQLite SUM for token counters: summing otherwise-valid i64
+    // round rows can overflow before an outer MIN/CASE can clamp it. Fold in
+    // Rust with the same signed-64 saturation policy used by the runtime.
+    let token_usage = load_session_token_aggregate(connection, session_id)?;
+    #[cfg(test)]
+    pause_after_session_token_fold(session_id);
     let updated_at = format_timestamp(updated_at);
     connection.execute(
         r#"
         UPDATE session_metrics
         SET
             total_rounds = COALESCE((SELECT COUNT(*) FROM round_metrics WHERE session_id = ?1), 0),
-            prompt_tokens = COALESCE((SELECT SUM(prompt_tokens) FROM round_metrics WHERE session_id = ?1), 0),
-            completion_tokens = COALESCE((SELECT SUM(completion_tokens) FROM round_metrics WHERE session_id = ?1), 0),
-            total_tokens = COALESCE((SELECT SUM(total_tokens) FROM round_metrics WHERE session_id = ?1), 0),
+            prompt_tokens = ?2,
+            completion_tokens = ?3,
+            total_tokens = ?4,
             prompt_cached_tool_outputs = COALESCE((SELECT SUM(prompt_cached_tool_outputs) FROM round_metrics WHERE session_id = ?1), 0),
             prompt_cached_tool_tokens_saved = COALESCE((SELECT SUM(prompt_cached_tool_tokens_saved) FROM round_metrics WHERE session_id = ?1), 0),
             total_compression_events = COALESCE((SELECT SUM(compression_count) FROM round_metrics WHERE session_id = ?1), 0),
             total_tokens_saved = COALESCE((SELECT SUM(tokens_saved) FROM round_metrics WHERE session_id = ?1), 0),
             tool_call_count = COALESCE((SELECT COUNT(*) FROM tool_call_metrics WHERE session_id = ?1), 0),
-            updated_at = ?2
+            updated_at = ?5
         WHERE session_id = ?1
         "#,
-        params![session_id, updated_at],
+        params![
+            session_id,
+            durable_token_to_i64(token_usage.prompt_tokens),
+            durable_token_to_i64(token_usage.completion_tokens),
+            durable_token_to_i64(token_usage.total_tokens),
+            updated_at,
+        ],
     )?;
     Ok(())
+}
+
+fn durable_token_to_i64(value: u64) -> i64 {
+    i64::try_from(value.min(bamboo_domain::MAX_DURABLE_TOKEN_COUNT))
+        .expect("durable token count is clamped to i64::MAX")
+}
+
+fn durable_token_from_i64(column: &str, value: i64) -> MetricsResult<u64> {
+    u64::try_from(value).map_err(|_| {
+        MetricsError::InvalidData(format!(
+            "negative durable token counter in {column}: {value}"
+        ))
+    })
+}
+
+fn load_session_token_aggregate(
+    connection: &Connection,
+    session_id: &str,
+) -> MetricsResult<TokenUsage> {
+    let mut stmt = connection.prepare(
+        "SELECT prompt_tokens, completion_tokens, total_tokens FROM round_metrics WHERE session_id = ?1",
+    )?;
+    let mut rows = stmt.query(params![session_id])?;
+    let mut aggregate = TokenUsage::default();
+    while let Some(row) = rows.next()? {
+        let prompt = durable_token_from_i64("round_metrics.prompt_tokens", row.get(0)?)?;
+        let completion = durable_token_from_i64("round_metrics.completion_tokens", row.get(1)?)?;
+        let total = durable_token_from_i64("round_metrics.total_tokens", row.get(2)?)?;
+        aggregate.add_assign_durable(TokenUsage {
+            prompt_tokens: prompt,
+            completion_tokens: completion,
+            total_tokens: total,
+        });
+    }
+    Ok(aggregate)
 }
 
 /// Loads tool call breakdown (tool_name -> count) for a session.
@@ -2811,6 +3015,273 @@ mod tests {
         assert_eq!(detail.session.prompt_cached_tool_outputs, 3);
         assert_eq!(detail.rounds.len(), 1);
         assert_eq!(detail.rounds[0].prompt_cached_tool_outputs, 3);
+    }
+
+    #[tokio::test]
+    async fn durable_round_write_and_session_sum_saturate_at_signed_storage_boundary() {
+        let dir = tempdir().expect("temp dir");
+        let storage = SqliteMetricsStorage::new(dir.path().join("metrics.db"));
+        storage.init().await.expect("init storage");
+        let now = Utc::now();
+
+        storage
+            .upsert_session_start("overflow-session", "model", now)
+            .await
+            .expect("session start");
+        storage
+            .insert_round_start("overflow-r1", "overflow-session", "model", now)
+            .await
+            .expect("round 1 start");
+        storage
+            .complete_round(
+                "overflow-r1",
+                now,
+                RoundStatus::Success,
+                TokenUsage {
+                    prompt_tokens: u64::MAX,
+                    completion_tokens: 3,
+                    total_tokens: 1,
+                },
+                0,
+                0,
+                None,
+            )
+            .await
+            .expect("round 1 clamps instead of wrapping");
+        storage
+            .insert_round_start("overflow-r2", "overflow-session", "model", now)
+            .await
+            .expect("round 2 start");
+        storage
+            .complete_round(
+                "overflow-r2",
+                now,
+                RoundStatus::Success,
+                TokenUsage {
+                    prompt_tokens: 7,
+                    completion_tokens: 11,
+                    total_tokens: 18,
+                },
+                0,
+                0,
+                None,
+            )
+            .await
+            .expect("session aggregate saturates instead of SQL SUM overflow");
+
+        let detail = storage
+            .session_detail("overflow-session")
+            .await
+            .expect("session detail query")
+            .expect("session detail");
+        let max = bamboo_domain::MAX_DURABLE_TOKEN_COUNT;
+        assert_eq!(detail.rounds.len(), 2);
+        assert_eq!(
+            detail.rounds[0].token_usage,
+            TokenUsage {
+                prompt_tokens: max,
+                completion_tokens: 3,
+                total_tokens: max,
+            },
+            "u64 values clamp before the checked SQLite conversion"
+        );
+        assert_eq!(
+            detail.session.total_token_usage,
+            TokenUsage {
+                prompt_tokens: max,
+                completion_tokens: 14,
+                total_tokens: max,
+            },
+            "multi-row aggregation uses the same saturation policy without SQLite SUM overflow"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_round_completions_serialize_fold_and_session_update() {
+        let dir = tempdir().expect("temp dir");
+        let database_path = dir.path().join("metrics.db");
+        let storage_a = SqliteMetricsStorage::new(&database_path);
+        let storage_b = SqliteMetricsStorage::new(&database_path);
+        storage_a.init().await.expect("init storage");
+        let now = Utc::now();
+
+        storage_a
+            .upsert_session_start("concurrent-session", "model", now)
+            .await
+            .expect("session start");
+        storage_a
+            .insert_round_start("concurrent-r1", "concurrent-session", "model", now)
+            .await
+            .expect("round 1 start");
+        storage_a
+            .insert_round_start("concurrent-r2", "concurrent-session", "model", now)
+            .await
+            .expect("round 2 start");
+
+        // Hold the first writer after it has folded round rows but before it
+        // updates session_metrics. A second independent storage/connection must
+        // not enter its complete_round transaction until the first commits.
+        let (first_folded, release_first) =
+            super::install_session_token_fold_pause("concurrent-session");
+        let first_storage = storage_a.clone();
+        let first = tokio::spawn(async move {
+            first_storage
+                .complete_round(
+                    "concurrent-r1",
+                    now,
+                    RoundStatus::Success,
+                    TokenUsage {
+                        prompt_tokens: 10,
+                        completion_tokens: 1,
+                        total_tokens: 11,
+                    },
+                    0,
+                    0,
+                    None,
+                )
+                .await
+        });
+        tokio::task::spawn_blocking(move || {
+            first_folded.recv_timeout(std::time::Duration::from_secs(2))
+        })
+        .await
+        .expect("wait for first fold task")
+        .expect("first completion reached aggregate fold");
+
+        let second_entered =
+            super::install_complete_round_transaction_entered_hook("concurrent-r2");
+        let second = tokio::spawn(async move {
+            storage_b
+                .complete_round(
+                    "concurrent-r2",
+                    now,
+                    RoundStatus::Success,
+                    TokenUsage {
+                        prompt_tokens: 20,
+                        completion_tokens: 2,
+                        total_tokens: 22,
+                    },
+                    0,
+                    0,
+                    None,
+                )
+                .await
+        });
+
+        let (entry_while_first_locked, second_entered) = tokio::task::spawn_blocking(move || {
+            let result = second_entered.recv_timeout(std::time::Duration::from_millis(250));
+            (result, second_entered)
+        })
+        .await
+        .expect("wait for second transaction attempt");
+        let was_serialized = matches!(
+            entry_while_first_locked,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        );
+
+        release_first.send(()).expect("release first completion");
+        first
+            .await
+            .expect("first completion task")
+            .expect("first completion");
+        second
+            .await
+            .expect("second completion task")
+            .expect("second completion");
+
+        if was_serialized {
+            tokio::task::spawn_blocking(move || {
+                second_entered.recv_timeout(std::time::Duration::from_secs(2))
+            })
+            .await
+            .expect("wait for serialized second transaction")
+            .expect("second transaction entered after first committed");
+        }
+        assert!(
+            was_serialized,
+            "a competing connection entered between aggregate fold and parent update"
+        );
+
+        let detail = storage_a
+            .session_detail("concurrent-session")
+            .await
+            .expect("session detail query")
+            .expect("session detail");
+        assert_eq!(
+            detail.session.total_token_usage,
+            TokenUsage {
+                prompt_tokens: 30,
+                completion_tokens: 3,
+                total_tokens: 33,
+            },
+            "the last session writer must include both completed rounds"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_round_rolls_back_child_update_when_aggregate_refresh_fails() {
+        let dir = tempdir().expect("temp dir");
+        let database_path = dir.path().join("metrics.db");
+        let storage = SqliteMetricsStorage::new(&database_path);
+        storage.init().await.expect("init storage");
+        let now = Utc::now();
+
+        storage
+            .upsert_session_start("rollback-session", "model", now)
+            .await
+            .expect("session start");
+        storage
+            .insert_round_start("rollback-target", "rollback-session", "model", now)
+            .await
+            .expect("target round start");
+        storage
+            .insert_round_start("rollback-corrupt", "rollback-session", "model", now)
+            .await
+            .expect("corrupt round start");
+
+        let connection = super::open_connection(&database_path).expect("open database");
+        connection
+            .execute(
+                "UPDATE round_metrics SET prompt_tokens = -1 WHERE round_id = 'rollback-corrupt'",
+                [],
+            )
+            .expect("inject invalid durable counter");
+        drop(connection);
+
+        let error = storage
+            .complete_round(
+                "rollback-target",
+                now,
+                RoundStatus::Success,
+                TokenUsage {
+                    prompt_tokens: 5,
+                    completion_tokens: 7,
+                    total_tokens: 12,
+                },
+                0,
+                0,
+                None,
+            )
+            .await
+            .expect_err("aggregate validation should fail");
+        assert!(
+            matches!(error, super::MetricsError::InvalidData(_)),
+            "unexpected completion error: {error}"
+        );
+
+        let connection = super::open_connection(&database_path).expect("reopen database");
+        let target: (String, Option<String>, i64, i64, i64) = connection
+            .query_row(
+                "SELECT status, completed_at, prompt_tokens, completion_tokens, total_tokens FROM round_metrics WHERE round_id = 'rollback-target'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+            )
+            .expect("read rolled-back target round");
+        assert_eq!(
+            target,
+            (String::from("running"), None, 0, 0, 0),
+            "the round mutation must roll back with the failed parent refresh"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- make provider-reported usage the canonical per-attempt source, with legacy counters and local estimates as explicit fallbacks
- accumulate every billed retry exactly once and use the same canonical totals for runtime budgets, round metrics, and session metrics
- retain billed usage on post-stream terminal errors and hook suspension while keeping pre-stream failures at zero
- saturate durable counters at SQLite's signed 64-bit boundary and serialize aggregate refreshes with nested `BEGIN IMMEDIATE` transactions

## Root cause and impact

Round metrics previously finalized from the last attempt's local counters. Retries and terminal post-stream failures could therefore lose provider-billed usage, causing runtime budgets, round rows, and session aggregates to disagree with provider billing. Concurrent round completions could also race while folding session totals.

This change introduces one canonical usage policy across all consumers and makes each child-row mutation plus parent aggregate refresh atomic.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code`
- `cargo test -p bamboo-engine --lib pipeline_` (8 passed)
- `cargo test -p bamboo-domain token_usage` (5 passed)
- `cargo test -p bamboo-infrastructure metrics::storage::tests` (12 passed)
- `cargo test -p bamboo-engine` (1311 passed plus doctests)
- `cargo test -p bamboo-infrastructure` (98 passed)
- `cargo test --all-features --lib --tests` reached one unrelated scheduler timeout after 1795 server tests passed; the timing-sensitive failed test passed when rerun alone in both default and `--all-features` configurations

## Screenshots

N/A - backend metrics and persistence change.

Closes #688
