### PR TITLE
fix: distinguish max reasoning effort

### DIFF
--- a/crates/core/bamboo-domain/src/reasoning.rs
+++ b/crates/core/bamboo-domain/src/reasoning.rs
@@ -56,7 +56,9 @@ impl ReasoningEffort {
     /// Return the provider/model-appropriate wire-format string.
     ///
     /// Different model families expect different reasoning effort values:
-    /// - **GPT / o-series / default**: `low`, `medium`, `high`, `xhigh` (`max` → `xhigh`)
+    /// - **GPT-5.6 family**: `low`, `medium`, `high`, `xhigh`, `max`
+    /// - **Other OpenAI-compatible models**: `low`, `medium`, `high`, `xhigh`
+    ///   (`max` → `xhigh` until the model advertises/supports it)
     /// - **Gemini**: `low`, `medium`, `high` (`xhigh`/`max` → `high`)
     ///
     /// This method only keeps the Gemini-specific mapping. All other models use
@@ -72,16 +74,23 @@ impl ReasoningEffort {
             };
         }
 
-        // Default: GPT / o-series / unknown → OpenAI format
-        // GPT doesn't support "max", so map it to "xhigh"
-        match self {
-            Self::Max => "xhigh",
-            other => other.as_str(),
+        if matches!(self, Self::Max) && !Self::supports_max_reasoning_effort(&model_lower) {
+            return "xhigh";
         }
+
+        self.as_str()
     }
 
     fn is_gemini_model(model_lower: &str) -> bool {
         model_lower.starts_with("gemini") || model_lower.contains("google")
+    }
+
+    fn supports_max_reasoning_effort(model_lower: &str) -> bool {
+        // GPT-5.6 is the first OpenAI model family whose published effort enum
+        // includes `max`. `contains` also covers gateway-qualified identifiers
+        // such as `openai/gpt-5.6-sol` without treating unknown compatible
+        // endpoints as capable by default.
+        model_lower.contains("gpt-5.6")
     }
 }
 
@@ -293,10 +302,19 @@ mod tests {
         assert_eq!(ReasoningEffort::Medium.to_wire_format("gpt-4o"), "medium");
         assert_eq!(ReasoningEffort::High.to_wire_format("gpt-4o"), "high");
         assert_eq!(ReasoningEffort::Xhigh.to_wire_format("gpt-4o"), "xhigh");
-        // Max → xhigh for GPT (GPT doesn't support "max")
         assert_eq!(ReasoningEffort::Max.to_wire_format("gpt-4o"), "xhigh");
         assert_eq!(ReasoningEffort::Max.to_wire_format("o1-preview"), "xhigh");
         assert_eq!(ReasoningEffort::Max.to_wire_format("o3-mini"), "xhigh");
+    }
+
+    #[test]
+    fn max_is_preserved_for_gpt_5_6_family_and_gateway_ids() {
+        assert_eq!(ReasoningEffort::Max.to_wire_format("gpt-5.6"), "max");
+        assert_eq!(ReasoningEffort::Max.to_wire_format("gpt-5.6-sol"), "max");
+        assert_eq!(
+            ReasoningEffort::Max.to_wire_format("openai/gpt-5.6-terra"),
+            "max"
+        );
     }
 
     #[test]
@@ -382,5 +400,6 @@ mod tests {
         );
         assert_eq!(ReasoningEffort::Xhigh.to_wire_format("GPT-4o"), "xhigh");
         assert_eq!(ReasoningEffort::Max.to_wire_format("GPT-4o"), "xhigh");
+        assert_eq!(ReasoningEffort::Max.to_wire_format("GPT-5.6-SOL"), "max");
     }
 }

--- a/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
@@ -48,6 +48,28 @@ pub(crate) fn reasoning_effort_for_required_tool(
     }
 }
 
+/// Return the reasoning effort that will still need a numeric thinking budget
+/// after Anthropic's request-scoped compatibility downgrades run.
+///
+/// Keep the original effort for the request builder so it can emit the existing
+/// #520 warning and apply its full history conversion. This helper is only for
+/// deciding whether an impossible Max budget should reject the request before
+/// that builder runs.
+pub(crate) fn reasoning_effort_for_budget_validation(
+    reasoning_effort: Option<ReasoningEffort>,
+    messages: &[Message],
+    thinking_replay_always: bool,
+) -> Option<ReasoningEffort> {
+    if reasoning_effort.is_some()
+        && !thinking_replay_always
+        && must_downgrade_thinking_for_unsigned_tool_turn(messages)
+    {
+        None
+    } else {
+        reasoning_effort
+    }
+}
+
 pub(crate) fn apply_required_tool_choice(body: &mut Value, required_tool: Option<&str>) {
     if let Some(name) = required_tool {
         // Anthropic-compatible reasoning models (including DeepSeek through an
@@ -288,6 +310,15 @@ impl AnthropicProvider {
             .or(self.default_reasoning_effort);
         let reasoning_effort =
             reasoning_effort_for_required_tool(configured_reasoning_effort, required_tool);
+        let budget_reasoning_effort = reasoning_effort_for_budget_validation(
+            reasoning_effort,
+            messages,
+            self.thinking_replay_always,
+        );
+        crate::providers::common::validate_max_thinking_budget(
+            budget_reasoning_effort,
+            Some(max_tokens),
+        )?;
         let request_reasoning_effort = reasoning_effort_for_required_tool(
             options.and_then(|o| o.reasoning_effort),
             required_tool,
@@ -872,23 +903,13 @@ fn anthropic_thinking_from_effort(
     reasoning_effort: Option<ReasoningEffort>,
     max_tokens: u32,
 ) -> Option<Value> {
-    let effort = reasoning_effort?;
-    let target_budget = match effort {
-        ReasoningEffort::Low => return None,
-        ReasoningEffort::Medium => 1024,
-        ReasoningEffort::High => 4096,
-        ReasoningEffort::Xhigh | ReasoningEffort::Max => 8192,
-    };
-
-    // Keep some room for final answer tokens.
-    let available_budget = max_tokens.saturating_sub(128);
-    if available_budget == 0 {
-        return None;
-    }
+    let budget = reasoning_effort.and_then(|effort| {
+        crate::providers::common::bounded_thinking_budget(effort, Some(max_tokens))
+    })?;
 
     Some(json!({
         "type": "enabled",
-        "budget_tokens": target_budget.min(available_budget),
+        "budget_tokens": budget,
     }))
 }
 
@@ -1835,6 +1856,81 @@ mod anthropic_request_building {
     use bamboo_domain::Message;
     use bamboo_domain::{FunctionCall, ToolCall};
     use bamboo_domain::{FunctionSchema, ToolSchema};
+
+    #[test]
+    fn max_reasoning_uses_a_distinct_larger_thinking_budget() {
+        let xhigh = super::anthropic_thinking_from_effort(
+            Some(bamboo_domain::ReasoningEffort::Xhigh),
+            32_000,
+        )
+        .expect("xhigh enables thinking");
+        let max = super::anthropic_thinking_from_effort(
+            Some(bamboo_domain::ReasoningEffort::Max),
+            32_000,
+        )
+        .expect("max enables thinking");
+
+        assert_eq!(xhigh["budget_tokens"], 8192);
+        assert_eq!(max["budget_tokens"], 16384);
+
+        let xhigh_at_default = super::anthropic_thinking_from_effort(
+            Some(bamboo_domain::ReasoningEffort::Xhigh),
+            16_384,
+        )
+        .expect("xhigh fits the common 16K output limit");
+        let max_at_default = super::anthropic_thinking_from_effort(
+            Some(bamboo_domain::ReasoningEffort::Max),
+            16_384,
+        )
+        .expect("max fits while reserving visible output");
+        assert_eq!(xhigh_at_default["budget_tokens"], 8_192);
+        assert_eq!(max_at_default["budget_tokens"], 12_288);
+
+        let xhigh_at_tight = super::anthropic_thinking_from_effort(
+            Some(bamboo_domain::ReasoningEffort::Xhigh),
+            8_320,
+        )
+        .expect("xhigh scales under a tight limit");
+        let max_at_tight =
+            super::anthropic_thinking_from_effort(Some(bamboo_domain::ReasoningEffort::Max), 8_320)
+                .expect("max remains distinct under a tight limit");
+        assert_eq!(xhigh_at_tight["budget_tokens"], 4_160);
+        assert_eq!(max_at_tight["budget_tokens"], 6_240);
+
+        assert!(super::anthropic_thinking_from_effort(
+            Some(bamboo_domain::ReasoningEffort::Max),
+            2_048,
+        )
+        .is_none());
+        assert!(super::anthropic_thinking_from_effort(
+            Some(bamboo_domain::ReasoningEffort::Max),
+            1_024,
+        )
+        .is_none());
+
+        let request = super::build_anthropic_request(
+            &[bamboo_domain::Message::user("hello")],
+            &[],
+            "claude-sonnet-4-5",
+            16_384,
+            true,
+            Some(bamboo_domain::ReasoningEffort::Max),
+            None,
+        );
+        assert_eq!(request["max_tokens"], 16_384);
+        assert_eq!(request["thinking"]["budget_tokens"], 12_288);
+
+        let impossible = super::build_anthropic_request(
+            &[bamboo_domain::Message::user("hello")],
+            &[],
+            "claude-sonnet-4-5",
+            1_024,
+            true,
+            Some(bamboo_domain::ReasoningEffort::Max),
+            None,
+        );
+        assert!(impossible.get("thinking").is_none());
+    }
 
     #[test]
     fn system_messages_are_extracted_into_blocks_with_cache_control() {
@@ -4075,6 +4171,25 @@ mod anthropic_provider_tests {
         }
     }
 
+    fn unsigned_tool_loop_messages() -> Vec<Message> {
+        vec![
+            Message::user("run a tool"),
+            Message::assistant_with_reasoning(
+                "",
+                Some(vec![bamboo_domain::ToolCall {
+                    id: "call_1".to_string(),
+                    tool_type: "function".to_string(),
+                    function: bamboo_domain::FunctionCall {
+                        name: "search".to_string(),
+                        arguments: r#"{"q":"test"}"#.to_string(),
+                    },
+                }]),
+                Some("Foreign unsigned reasoning.".to_string()),
+            ),
+            Message::tool_result("call_1", r#"{"ok":true}"#),
+        ]
+    }
+
     #[tokio::test]
     async fn forced_named_tool_retries_exact_thinking_error_with_auto_choice() {
         let server = MockServer::start().await;
@@ -4117,6 +4232,71 @@ mod anthropic_provider_tests {
         assert_eq!(fallback["tool_choice"]["disable_parallel_tool_use"], true);
         assert_eq!(fallback["tools"].as_array().map(Vec::len), Some(1));
         assert_eq!(fallback["tools"][0]["name"], "load_skill");
+    }
+
+    #[tokio::test]
+    async fn unsigned_tool_turn_disables_max_before_small_budget_validation() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(ANTHROPIC_SSE_OK),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let provider = AnthropicProvider::new("test-key")
+            .with_base_url(server.uri())
+            .with_reasoning_effort(Some(ReasoningEffort::Max));
+
+        let _stream = provider
+            .chat_stream(
+                &unsigned_tool_loop_messages(),
+                &[],
+                Some(2_048),
+                "claude-sonnet-4-5",
+            )
+            .await
+            .expect("unsigned tool turn should disable thinking before Max validation");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        assert_eq!(requests.len(), 1);
+        let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert!(body.get("thinking").is_none());
+        assert_eq!(body["max_tokens"], 2_048);
+    }
+
+    #[tokio::test]
+    async fn compat_replay_keeps_max_small_budget_validation_enabled() {
+        let server = MockServer::start().await;
+        let provider = AnthropicProvider::new("test-key")
+            .with_base_url(server.uri())
+            .with_reasoning_effort(Some(ReasoningEffort::Max))
+            .with_thinking_replay_always(true);
+
+        let result = provider
+            .chat_stream(
+                &unsigned_tool_loop_messages(),
+                &[],
+                Some(2_048),
+                "glm-compatible",
+            )
+            .await;
+
+        match result {
+            Err(LLMError::Api(message)) => {
+                assert!(message.contains("requires max_output_tokens of at least 2049"));
+            }
+            Err(other) => panic!("unexpected error: {other}"),
+            Ok(_) => panic!("compat replay still requires a valid Max thinking budget"),
+        }
+        assert!(server
+            .received_requests()
+            .await
+            .expect("requests recorded")
+            .is_empty());
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
@@ -157,6 +157,10 @@ impl LLMProvider for BodhiProvider {
                 .await
             }
             "gemini" => {
+                crate::providers::common::validate_max_thinking_budget(
+                    reasoning_effort,
+                    max_output_tokens,
+                )?;
                 self.proxy_gemini(
                     messages,
                     tools,
@@ -259,11 +263,18 @@ impl BodhiProvider {
         use crate::providers::anthropic::{
             apply_required_tool_auto_fallback, apply_required_tool_choice, build_anthropic_request,
             looks_like_thinking_forced_tool_choice_error, parse_anthropic_sse_event,
-            reasoning_effort_for_required_tool, AnthropicStreamState,
+            reasoning_effort_for_budget_validation, reasoning_effort_for_required_tool,
+            AnthropicStreamState,
         };
 
         let max_tokens = max_output_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
         let reasoning_effort = reasoning_effort_for_required_tool(reasoning_effort, required_tool);
+        let budget_reasoning_effort =
+            reasoning_effort_for_budget_validation(reasoning_effort, messages, false);
+        crate::providers::common::validate_max_thinking_budget(
+            budget_reasoning_effort,
+            Some(max_tokens),
+        )?;
 
         let mut body = build_anthropic_request(
             messages,
@@ -351,7 +362,8 @@ impl BodhiProvider {
         use crate::protocol::gemini::GeminiRequest;
         use crate::protocol::ToProvider;
         use crate::providers::gemini::{
-            apply_required_tool_choice, parse_gemini_sse_event, GeminiStreamState,
+            apply_generation_config, apply_required_tool_choice, parse_gemini_sse_event,
+            GeminiStreamState,
         };
 
         let messages_vec: Vec<Message> = messages.to_vec();
@@ -362,25 +374,7 @@ impl BodhiProvider {
             request.tools = Some(tools_vec.to_provider()?);
         }
 
-        if max_output_tokens.is_some()
-            || reasoning_effort
-                .and_then(Self::thinking_budget_for_effort)
-                .is_some()
-        {
-            let mut generation_config = serde_json::Map::new();
-            if let Some(max_tokens) = max_output_tokens {
-                generation_config.insert("maxOutputTokens".to_string(), json!(max_tokens));
-            }
-            if let Some(thinking_budget) =
-                reasoning_effort.and_then(Self::thinking_budget_for_effort)
-            {
-                generation_config.insert(
-                    "thinkingConfig".to_string(),
-                    json!({ "thinkingBudget": thinking_budget }),
-                );
-            }
-            request.generation_config = Some(serde_json::Value::Object(generation_config));
-        }
+        apply_generation_config(&mut request, max_output_tokens, reasoning_effort);
 
         // Serialize then run the last-moment scan over the body Value before send.
         let mut request_json = serde_json::to_value(&request).map_err(LLMError::Json)?;
@@ -424,13 +418,12 @@ impl BodhiProvider {
         Ok(stream)
     }
 
-    fn thinking_budget_for_effort(effort: ReasoningEffort) -> Option<u32> {
-        match effort {
-            ReasoningEffort::Low => None,
-            ReasoningEffort::Medium => Some(1024),
-            ReasoningEffort::High => Some(4096),
-            ReasoningEffort::Xhigh | ReasoningEffort::Max => Some(8192),
-        }
+    #[cfg(test)]
+    fn thinking_budget_for_effort(
+        effort: ReasoningEffort,
+        max_output_tokens: Option<u32>,
+    ) -> Option<u32> {
+        crate::providers::common::bounded_thinking_budget(effort, max_output_tokens)
     }
 }
 
@@ -443,6 +436,38 @@ mod tests {
     use serde_json::Value;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    #[test]
+    fn max_reasoning_uses_a_distinct_larger_gemini_thinking_budget() {
+        assert_eq!(
+            BodhiProvider::thinking_budget_for_effort(ReasoningEffort::Xhigh, None),
+            Some(8_192)
+        );
+        assert_eq!(
+            BodhiProvider::thinking_budget_for_effort(ReasoningEffort::Max, None),
+            Some(16_384)
+        );
+        assert_eq!(
+            BodhiProvider::thinking_budget_for_effort(ReasoningEffort::Xhigh, Some(16_384)),
+            Some(8_192)
+        );
+        assert_eq!(
+            BodhiProvider::thinking_budget_for_effort(ReasoningEffort::Max, Some(16_384)),
+            Some(12_288)
+        );
+        assert_eq!(
+            BodhiProvider::thinking_budget_for_effort(ReasoningEffort::Xhigh, Some(8_320)),
+            Some(4_160)
+        );
+        assert_eq!(
+            BodhiProvider::thinking_budget_for_effort(ReasoningEffort::Max, Some(8_320)),
+            Some(6_240)
+        );
+        assert_eq!(
+            BodhiProvider::thinking_budget_for_effort(ReasoningEffort::Max, Some(1_024)),
+            None
+        );
+    }
 
     struct ThinkingToolChoiceResponder;
 
@@ -470,6 +495,25 @@ mod tests {
                 parameters: serde_json::json!({"type": "object"}),
             },
         }
+    }
+
+    fn unsigned_tool_loop_messages() -> Vec<Message> {
+        vec![
+            Message::user("run a tool"),
+            Message::assistant_with_reasoning(
+                "",
+                Some(vec![bamboo_domain::ToolCall {
+                    id: "call_1".to_string(),
+                    tool_type: "function".to_string(),
+                    function: bamboo_domain::FunctionCall {
+                        name: "search".to_string(),
+                        arguments: r#"{"q":"test"}"#.to_string(),
+                    },
+                }]),
+                Some("Foreign unsigned reasoning.".to_string()),
+            ),
+            Message::tool_result("call_1", r#"{"ok":true}"#),
+        ]
     }
 
     #[tokio::test]
@@ -563,5 +607,114 @@ mod tests {
         assert_eq!(fallback["tool_choice"]["disable_parallel_tool_use"], true);
         assert_eq!(fallback["tools"].as_array().map(Vec::len), Some(1));
         assert_eq!(fallback["tools"][0]["name"], "load_skill");
+    }
+
+    #[tokio::test]
+    async fn anthropic_required_tool_disables_max_before_small_budget_validation() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/proxy/anthropic/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let provider = BodhiProvider::new("test-key")
+            .with_base_url(server.uri())
+            .with_target_provider("anthropic")
+            .with_reasoning_effort(Some(ReasoningEffort::Max));
+        let tools = vec![load_skill_tool()];
+        let options = LLMRequestOptions {
+            required_tool: Some("load_skill".to_string()),
+            ..Default::default()
+        };
+
+        let _stream = provider
+            .chat_stream_with_options(
+                &[Message::user("activate")],
+                &tools,
+                Some(2_048),
+                "claude-sonnet-4-5",
+                Some(&options),
+            )
+            .await
+            .expect("required tool should disable thinking before Max budget validation");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        assert_eq!(requests.len(), 1);
+        let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert!(body.get("thinking").is_none());
+        assert_eq!(body["max_tokens"], 2_048);
+        assert_eq!(body["tool_choice"]["type"], "tool");
+        assert_eq!(body["tool_choice"]["name"], "load_skill");
+    }
+
+    #[tokio::test]
+    async fn anthropic_max_without_required_tool_rejects_impossible_small_budget() {
+        let server = MockServer::start().await;
+        let provider = BodhiProvider::new("test-key")
+            .with_base_url(server.uri())
+            .with_target_provider("anthropic")
+            .with_reasoning_effort(Some(ReasoningEffort::Max));
+
+        let result = provider
+            .chat_stream(
+                &[Message::user("hello")],
+                &[],
+                Some(2_048),
+                "claude-sonnet-4-5",
+            )
+            .await;
+
+        match result {
+            Err(LLMError::Api(message)) => {
+                assert!(message.contains("requires max_output_tokens of at least 2049"));
+            }
+            Err(other) => panic!("unexpected error: {other}"),
+            Ok(_) => panic!("impossible Max budget should fail before the request"),
+        }
+        assert!(server
+            .received_requests()
+            .await
+            .expect("requests recorded")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn anthropic_unsigned_tool_turn_disables_max_before_small_budget_validation() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/proxy/anthropic/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let provider = BodhiProvider::new("test-key")
+            .with_base_url(server.uri())
+            .with_target_provider("anthropic")
+            .with_reasoning_effort(Some(ReasoningEffort::Max));
+
+        let _stream = provider
+            .chat_stream(
+                &unsigned_tool_loop_messages(),
+                &[],
+                Some(2_048),
+                "claude-sonnet-4-5",
+            )
+            .await
+            .expect("unsigned tool turn should disable thinking before Max validation");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        assert_eq!(requests.len(), 1);
+        let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert!(body.get("thinking").is_none());
+        assert_eq!(body["max_tokens"], 2_048);
     }
 }

--- a/crates/infra/bamboo-llm/src/providers/common/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/mod.rs
@@ -9,6 +9,74 @@ pub mod sse;
 pub mod stream_tool_accumulator;
 pub mod tool_schema;
 
+use bamboo_domain::ReasoningEffort;
+
+use crate::provider::{LLMError, Result};
+
+const MIN_NUMERIC_THINKING_TOKENS: u32 = 1_024;
+const MIN_VISIBLE_OUTPUT_TOKENS: u32 = 1_024;
+
+/// Map Bamboo effort levels to provider numeric thinking budgets while
+/// preserving space for a visible answer inside the provider's total output
+/// limit.
+///
+/// At roomy/unspecified limits the canonical targets remain 1K/4K/8K/16K.
+/// Under a tighter limit, Xhigh may consume at most half of the total and Max
+/// at most three quarters, with at least 1K left for visible output. If a Max
+/// request is too small to remain strictly above Xhigh under those constraints,
+/// no numeric budget is returned instead of silently collapsing the two levels.
+pub(crate) fn bounded_thinking_budget(
+    effort: ReasoningEffort,
+    max_output_tokens: Option<u32>,
+) -> Option<u32> {
+    let target = match effort {
+        ReasoningEffort::Low => return None,
+        ReasoningEffort::Medium => 1_024,
+        ReasoningEffort::High => 4_096,
+        ReasoningEffort::Xhigh => 8_192,
+        ReasoningEffort::Max => 16_384,
+    };
+    let Some(total) = max_output_tokens else {
+        return Some(target);
+    };
+
+    let ratio_cap = match effort {
+        ReasoningEffort::Low => unreachable!("low returned before budget calculation"),
+        ReasoningEffort::Medium | ReasoningEffort::High | ReasoningEffort::Xhigh => total / 2,
+        ReasoningEffort::Max => ((u64::from(total) * 3) / 4) as u32,
+    };
+    let available_after_output = total.saturating_sub(MIN_VISIBLE_OUTPUT_TOKENS);
+    let budget = target.min(ratio_cap).min(available_after_output);
+    if budget < MIN_NUMERIC_THINKING_TOKENS {
+        return None;
+    }
+
+    if matches!(effort, ReasoningEffort::Max) {
+        let xhigh_budget = 8_192.min(total / 2).min(available_after_output);
+        if budget <= xhigh_budget {
+            return None;
+        }
+    }
+
+    Some(budget)
+}
+
+pub(crate) fn validate_max_thinking_budget(
+    effort: Option<ReasoningEffort>,
+    max_output_tokens: Option<u32>,
+) -> Result<()> {
+    let (Some(ReasoningEffort::Max), Some(total)) = (effort, max_output_tokens) else {
+        return Ok(());
+    };
+    if bounded_thinking_budget(ReasoningEffort::Max, Some(total)).is_some() {
+        return Ok(());
+    }
+
+    Err(LLMError::Api(format!(
+        "max reasoning effort requires max_output_tokens of at least 2049 so its thinking budget can remain above xhigh while reserving 1024 visible output tokens; got {total}"
+    )))
+}
+
 /// Whether an error response means the model/endpoint doesn't support the
 /// reasoning/thinking parameter, so a retry with reasoning stripped is warranted.
 ///
@@ -143,5 +211,37 @@ mod reasoning_heuristic_tests {
             StatusCode::INTERNAL_SERVER_ERROR,
             "reasoning not supported"
         ));
+    }
+}
+
+#[cfg(test)]
+mod bounded_thinking_budget_tests {
+    use super::{bounded_thinking_budget as budget, validate_max_thinking_budget};
+    use bamboo_domain::ReasoningEffort;
+
+    #[test]
+    fn roomy_or_unspecified_limits_keep_the_canonical_targets() {
+        assert_eq!(budget(ReasoningEffort::Xhigh, None), Some(8_192));
+        assert_eq!(budget(ReasoningEffort::Max, None), Some(16_384));
+        assert_eq!(budget(ReasoningEffort::Max, Some(32_000)), Some(16_384));
+    }
+
+    #[test]
+    fn common_and_tight_limits_keep_max_distinct_and_reserve_output() {
+        assert_eq!(budget(ReasoningEffort::Xhigh, Some(16_384)), Some(8_192));
+        assert_eq!(budget(ReasoningEffort::Max, Some(16_384)), Some(12_288));
+        assert_eq!(budget(ReasoningEffort::Xhigh, Some(8_320)), Some(4_160));
+        assert_eq!(budget(ReasoningEffort::Max, Some(8_320)), Some(6_240));
+        assert_eq!(budget(ReasoningEffort::Xhigh, Some(2_049)), Some(1_024));
+        assert_eq!(budget(ReasoningEffort::Max, Some(2_049)), Some(1_025));
+    }
+
+    #[test]
+    fn impossible_limits_disable_max_instead_of_collapsing_to_xhigh() {
+        assert_eq!(budget(ReasoningEffort::Xhigh, Some(2_048)), Some(1_024));
+        assert_eq!(budget(ReasoningEffort::Max, Some(2_048)), None);
+        assert_eq!(budget(ReasoningEffort::Max, Some(1_024)), None);
+        assert!(validate_max_thinking_budget(Some(ReasoningEffort::Max), Some(2_048)).is_err());
+        assert!(validate_max_thinking_budget(Some(ReasoningEffort::Max), Some(2_049)).is_ok());
     }
 }

--- a/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
@@ -123,6 +123,27 @@ pub fn tools_to_openai_compat_json(tools: &[ToolSchema]) -> Vec<Value> {
         .collect()
 }
 
+pub(crate) fn set_openai_compat_token_limit(
+    body: &mut Value,
+    max_output_tokens: Option<u32>,
+    reasoning_enabled: bool,
+) {
+    let Some(max_tokens) = max_output_tokens else {
+        return;
+    };
+
+    // Reasoning models count hidden reasoning and visible answer tokens in the
+    // Chat Completions `max_completion_tokens` limit. The legacy `max_tokens`
+    // field is incompatible with o-series models, but remains the
+    // broadest-compatible field for ordinary chat requests.
+    let field = if reasoning_enabled {
+        "max_completion_tokens"
+    } else {
+        "max_tokens"
+    };
+    body[field] = json!(max_tokens);
+}
+
 /// Build a standard OpenAI-compatible streaming chat request body.
 pub fn build_openai_compat_body(
     model: &str,
@@ -148,9 +169,7 @@ pub fn build_openai_compat_body(
         body["tool_choice"] = tool_choice;
     }
 
-    if let Some(max_tokens) = max_output_tokens {
-        body["max_tokens"] = json!(max_tokens);
-    }
+    set_openai_compat_token_limit(&mut body, max_output_tokens, reasoning_effort.is_some());
 
     if let Some(reasoning_effort) = reasoning_effort {
         body["reasoning_effort"] = json!(reasoning_effort.to_wire_format(model));
@@ -524,6 +543,40 @@ mod tests {
                 arguments: "{}".to_string(),
             },
         }
+    }
+
+    #[test]
+    fn build_openai_compat_body_preserves_max_reasoning_effort() {
+        let body = super::build_openai_compat_body(
+            "gpt-5.6-sol",
+            &[],
+            &[],
+            None,
+            Some(32_000),
+            Some(bamboo_domain::ReasoningEffort::Max),
+            None,
+        );
+
+        assert_eq!(body["reasoning_effort"], "max");
+        assert_eq!(body["max_completion_tokens"], 32_000);
+        assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn build_openai_compat_body_keeps_legacy_models_on_xhigh() {
+        let body = super::build_openai_compat_body(
+            "gpt-4o",
+            &[],
+            &[],
+            None,
+            Some(16_384),
+            Some(bamboo_domain::ReasoningEffort::Max),
+            None,
+        );
+
+        assert_eq!(body["reasoning_effort"], "xhigh");
+        assert_eq!(body["max_completion_tokens"], 16_384);
+        assert!(body.get("max_tokens").is_none());
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -1908,6 +1908,40 @@ mod tests {
     }
 
     #[test]
+    fn build_responses_body_preserves_max_reasoning_effort() {
+        let body = build_responses_body(
+            "gpt-5.6-sol",
+            &[],
+            &[],
+            Some(32_000),
+            Some(ReasoningEffort::Max),
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(body["reasoning"]["effort"], "max");
+        assert_eq!(body["max_output_tokens"], 32_000);
+    }
+
+    #[test]
+    fn build_responses_body_keeps_legacy_models_on_xhigh() {
+        let body = build_responses_body(
+            "gpt-4o",
+            &[],
+            &[],
+            Some(16_384),
+            Some(ReasoningEffort::Max),
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(body["reasoning"]["effort"], "xhigh");
+        assert_eq!(body["max_output_tokens"], 16_384);
+    }
+
+    #[test]
     fn build_responses_body_with_parallel_tool_calls() {
         let body = build_responses_body("gpt-5.4", &[], &[], None, None, None, Some(false), None);
         assert_eq!(body["parallel_tool_calls"], false);

--- a/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
@@ -20,7 +20,8 @@ use bamboo_domain::ToolSchema;
 
 use super::common::openai_compat::{
     messages_to_openai_compat_json, openai_compat_chat_stream_from_sse,
-    parse_openai_compat_sse_data_lenient_multi, tools_to_openai_compat_json,
+    parse_openai_compat_sse_data_lenient_multi, set_openai_compat_token_limit,
+    tools_to_openai_compat_json,
 };
 use super::common::openai_responses::{
     build_responses_body, select_responses_input_messages, ResponsesInputSource, ResponsesSseParser,
@@ -1199,9 +1200,7 @@ impl LLMProvider for CopilotProvider {
             body["parallel_tool_calls"] = json!(parallel_tool_calls);
         }
 
-        if let Some(max_tokens) = max_output_tokens {
-            body["max_tokens"] = json!(max_tokens);
-        }
+        set_openai_compat_token_limit(&mut body, max_output_tokens, reasoning_effort.is_some());
 
         if let Some(reasoning_effort) = reasoning_effort {
             body["reasoning_effort"] = json!(reasoning_effort.to_wire_format(upstream_model));

--- a/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
@@ -31,6 +31,32 @@ pub(crate) fn apply_required_tool_choice(body: &mut Value, required_tool: Option
         });
     }
 }
+
+pub(crate) fn apply_generation_config(
+    request: &mut GeminiRequest,
+    max_output_tokens: Option<u32>,
+    reasoning_effort: Option<ReasoningEffort>,
+) -> Option<u32> {
+    let thinking_budget = reasoning_effort.and_then(|effort| {
+        crate::providers::common::bounded_thinking_budget(effort, max_output_tokens)
+    });
+    if max_output_tokens.is_none() && thinking_budget.is_none() {
+        return None;
+    }
+
+    let mut generation_config = serde_json::Map::new();
+    if let Some(max_tokens) = max_output_tokens {
+        generation_config.insert("maxOutputTokens".to_string(), json!(max_tokens));
+    }
+    if let Some(thinking_budget) = thinking_budget {
+        generation_config.insert(
+            "thinkingConfig".to_string(),
+            json!({ "thinkingBudget": thinking_budget }),
+        );
+    }
+    request.generation_config = Some(Value::Object(generation_config));
+    thinking_budget
+}
 use bamboo_domain::ToolSchema;
 
 /// Google Gemini API provider.
@@ -132,13 +158,11 @@ impl GeminiProvider {
         format!("{}/models", self.base_url.trim_end_matches('/'))
     }
 
-    fn thinking_budget_for_effort(effort: ReasoningEffort) -> Option<u32> {
-        match effort {
-            ReasoningEffort::Low => None,
-            ReasoningEffort::Medium => Some(1024),
-            ReasoningEffort::High => Some(4096),
-            ReasoningEffort::Xhigh | ReasoningEffort::Max => Some(8192),
-        }
+    fn thinking_budget_for_effort(
+        effort: ReasoningEffort,
+        max_output_tokens: Option<u32>,
+    ) -> Option<u32> {
+        crate::providers::common::bounded_thinking_budget(effort, max_output_tokens)
     }
 
     fn looks_like_reasoning_unsupported_error(status: reqwest::StatusCode, body: &str) -> bool {
@@ -173,6 +197,10 @@ impl LLMProvider for GeminiProvider {
         let reasoning_effort = options
             .and_then(|o| o.reasoning_effort)
             .or(self.default_reasoning_effort);
+        crate::providers::common::validate_max_thinking_budget(
+            reasoning_effort,
+            max_output_tokens,
+        )?;
         let request_reasoning_effort = options.and_then(|o| o.reasoning_effort);
         let required_tool = crate::provider::required_tool_from_options(options, tools)?;
         let reasoning_source = if request_reasoning_effort.is_some() {
@@ -189,8 +217,8 @@ impl LLMProvider for GeminiProvider {
             .and_then(|o| o.session_id.as_deref())
             .unwrap_or("unknown-session");
         let mut applied_reasoning_effort = reasoning_effort;
-        let mut applied_thinking_budget =
-            reasoning_effort.and_then(Self::thinking_budget_for_effort);
+        let mut applied_thinking_budget = reasoning_effort
+            .and_then(|effort| Self::thinking_budget_for_effort(effort, max_output_tokens));
 
         // Auth is supplied via the x-goog-api-key header (see build_headers).
         let url = self.stream_url(model);
@@ -206,21 +234,7 @@ impl LLMProvider for GeminiProvider {
                 request.tools = Some(tools_vec.to_provider()?);
             }
 
-            // Add generation config if max_output_tokens or reasoning effort is specified.
-            let thinking_budget = effort.and_then(Self::thinking_budget_for_effort);
-            if max_output_tokens.is_some() || thinking_budget.is_some() {
-                let mut generation_config = serde_json::Map::new();
-                if let Some(max_tokens) = max_output_tokens {
-                    generation_config.insert("maxOutputTokens".to_string(), json!(max_tokens));
-                }
-                if let Some(thinking_budget) = thinking_budget {
-                    generation_config.insert(
-                        "thinkingConfig".to_string(),
-                        json!({ "thinkingBudget": thinking_budget }),
-                    );
-                }
-                request.generation_config = Some(serde_json::Value::Object(generation_config));
-            }
+            apply_generation_config(&mut request, max_output_tokens, effort);
 
             Ok(request)
         };
@@ -411,6 +425,69 @@ impl LLMProvider for GeminiProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn max_reasoning_uses_a_distinct_larger_thinking_budget() {
+        assert_eq!(
+            GeminiProvider::thinking_budget_for_effort(ReasoningEffort::Xhigh, None),
+            Some(8_192)
+        );
+        assert_eq!(
+            GeminiProvider::thinking_budget_for_effort(ReasoningEffort::Max, None),
+            Some(16_384)
+        );
+        assert_eq!(
+            GeminiProvider::thinking_budget_for_effort(ReasoningEffort::Xhigh, Some(16_384)),
+            Some(8_192)
+        );
+        assert_eq!(
+            GeminiProvider::thinking_budget_for_effort(ReasoningEffort::Max, Some(16_384)),
+            Some(12_288)
+        );
+        assert_eq!(
+            GeminiProvider::thinking_budget_for_effort(ReasoningEffort::Xhigh, Some(8_320)),
+            Some(4_160)
+        );
+        assert_eq!(
+            GeminiProvider::thinking_budget_for_effort(ReasoningEffort::Max, Some(8_320)),
+            Some(6_240)
+        );
+        assert_eq!(
+            GeminiProvider::thinking_budget_for_effort(ReasoningEffort::Max, Some(1_024)),
+            None
+        );
+    }
+
+    #[test]
+    fn max_reasoning_request_reserves_visible_output_at_the_wire() {
+        let mut request: GeminiRequest = vec![Message::user("hello")]
+            .to_provider()
+            .expect("Gemini request");
+        let applied =
+            apply_generation_config(&mut request, Some(16_384), Some(ReasoningEffort::Max));
+        let body = serde_json::to_value(request).expect("serialized Gemini request");
+
+        assert_eq!(applied, Some(12_288));
+        assert_eq!(body["generationConfig"]["maxOutputTokens"], 16_384);
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["thinkingBudget"],
+            12_288
+        );
+    }
+
+    #[test]
+    fn impossible_max_reasoning_limit_omits_numeric_budget_at_the_wire() {
+        let mut request: GeminiRequest = vec![Message::user("hello")]
+            .to_provider()
+            .expect("Gemini request");
+        let applied =
+            apply_generation_config(&mut request, Some(1_024), Some(ReasoningEffort::Max));
+        let body = serde_json::to_value(request).expect("serialized Gemini request");
+
+        assert_eq!(applied, None);
+        assert_eq!(body["generationConfig"]["maxOutputTokens"], 1_024);
+        assert!(body["generationConfig"].get("thinkingConfig").is_none());
+    }
 
     #[test]
     fn required_tool_choice_uses_gemini_any_allowlist_shape() {


### PR DESCRIPTION
## Summary

- preserve `max` for the GPT-5.6 family while retaining the existing `xhigh` fallback for older and unknown models
- give Anthropic, Gemini, and Bodhi distinct, output-cap-aware Max thinking budgets while reserving visible answer capacity
- use `max_completion_tokens` for reasoning-enabled OpenAI-compatible Chat requests, including Copilot
- preserve required-tool and unsigned tool-turn compatibility downgrades before validating numeric Max budgets

## Root Cause

The domain serializer normalized Max to Xhigh for every OpenAI-compatible model, and numeric-thinking adapters mapped Max to the same 8K budget as Xhigh. Raising the numeric budget without considering the total output cap could also consume the entire answer budget, while preflight validation had to respect existing request-scoped reasoning downgrades.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-domain -p bamboo-llm --all-features --all-targets -- -D warnings ...`
- `cargo test -p bamboo-domain reasoning` (25 passed)
- `cargo test -p bamboo-llm --all-features` (580 passed; 20 doc tests ignored)
- full workspace `cargo test --all-features --lib --tests` regression completed during implementation; final request-path revisions were revalidated by the full affected suites above

Closes #658