### PR TITLE
fix(tools): add WebSearch endpoint fallback (#661)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/engine/bamboo-tools/Cargo.toml
+++ b/crates/engine/bamboo-tools/Cargo.toml
@@ -42,6 +42,7 @@ colored = "2"
 
 [dev-dependencies]
 tempfile = "3"
+wiremock = "0.6"
 bamboo-infrastructure = { path = "../../infra/bamboo-infrastructure", features = ["test-utils"] }
 bamboo-llm = { path = "../../infra/bamboo-llm" }
 bamboo-config = { path = "../../infra/bamboo-config" }

--- a/crates/engine/bamboo-tools/src/tools/fixtures/web_search_antibot.html
+++ b/crates/engine/bamboo-tools/src/tools/fixtures/web_search_antibot.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="anomaly-modal">Unfortunately, bots use DuckDuckGo too.</div>
+  </body>
+</html>

--- a/crates/engine/bamboo-tools/src/tools/fixtures/web_search_html.html
+++ b/crates/engine/bamboo-tools/src/tools/fixtures/web_search_html.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <body class="body--html">
+    <div class="result results_links web-result">
+      <h2 class="result__title">
+        <a class="result__a" href="/l/?uddg=https%3A%2F%2Fexample.com%2Fguide&amp;rut=abc">
+          Example <b>Guide</b>
+        </a>
+      </h2>
+      <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fguide&amp;rut=abc">
+        A <b>useful</b> guide &amp; reference.
+      </a>
+    </div>
+    <div class="result results_links web-result">
+      <h2 class="result__title">
+        <a href="https://docs.rust-lang.org/book/" rel="nofollow" class="result__a">
+          The Rust Book
+        </a>
+      </h2>
+      <a href="https://docs.rust-lang.org/book/" class="result__snippet">
+        Learn <b>Rust</b> from the official book.
+      </a>
+    </div>
+  </body>
+</html>

--- a/crates/engine/bamboo-tools/src/tools/fixtures/web_search_lite.html
+++ b/crates/engine/bamboo-tools/src/tools/fixtures/web_search_lite.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <body>
+    <form action="/lite/" method="post">
+      <input class="query" name="q" value="rust" />
+    </form>
+    <table>
+      <tr>
+        <td>
+          <a rel="nofollow" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.net%2Flite&amp;rut=def" class="result-link">
+            Example Lite Result
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td class="result-snippet">A <b>compact</b> result &amp; summary.</td>
+      </tr>
+      <tr>
+        <td>
+          <a class="result-link" href="https://blocked.example.org/result">Blocked Result</a>
+        </td>
+      </tr>
+      <tr>
+        <td class="result-snippet">This result is used by domain-filter tests.</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/crates/engine/bamboo-tools/src/tools/web_search.rs
+++ b/crates/engine/bamboo-tools/src/tools/web_search.rs
@@ -7,11 +7,17 @@ use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
+use url::Url;
 
 const CACHE_TTL: Duration = Duration::from_secs(15 * 60);
 const DEFAULT_MAX_RESULTS: usize = 10;
 const ABSOLUTE_MAX_RESULTS: usize = 20;
 const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const WEB_SEARCH_ENDPOINTS_ENV: &str = "BAMBOO_WEB_SEARCH_ENDPOINTS";
+const DEFAULT_WEB_SEARCH_ENDPOINTS: [&str; 2] = [
+    "https://html.duckduckgo.com/html/",
+    "https://lite.duckduckgo.com/lite/",
+];
 
 #[derive(Debug, Deserialize)]
 struct WebSearchArgs {
@@ -29,6 +35,35 @@ struct CachedSearch {
     expires_at: Instant,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SearchResult {
+    title: String,
+    url: String,
+    domain: String,
+    snippet: Option<String>,
+}
+
+impl SearchResult {
+    fn into_json(self) -> serde_json::Value {
+        let mut value = json!({
+            "title": self.title,
+            "url": self.url,
+            "domain": self.domain,
+        });
+        if let Some(snippet) = self.snippet {
+            value["snippet"] = json!(snippet);
+        }
+        value
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ParsedSearchPage {
+    Results(Vec<SearchResult>),
+    AntiBot,
+    Unrecognized,
+}
+
 static SEARCH_CACHE: OnceLock<RwLock<HashMap<String, CachedSearch>>> = OnceLock::new();
 
 fn search_cache() -> &'static RwLock<HashMap<String, CachedSearch>> {
@@ -37,10 +72,11 @@ fn search_cache() -> &'static RwLock<HashMap<String, CachedSearch>> {
 
 // Static, compile-time-constant patterns: compile each exactly once and reuse.
 // `expect` is safe here because the patterns are hardcoded and verified valid.
-static LINK_RE: OnceLock<Regex> = OnceLock::new();
+static ANCHOR_RE: OnceLock<Regex> = OnceLock::new();
 static TAG_RE: OnceLock<Regex> = OnceLock::new();
-static SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
 static HREF_RE: OnceLock<Regex> = OnceLock::new();
+static CLASS_RE: OnceLock<Regex> = OnceLock::new();
+static LITE_SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
 
 pub struct WebSearchTool;
 
@@ -53,17 +89,12 @@ impl WebSearchTool {
         query: &str,
         allowed: &Option<Vec<String>>,
         blocked: &Option<Vec<String>>,
+        max_results: usize,
+        endpoints: &[Url],
     ) -> String {
-        let mut key = query.to_string();
-        if let Some(domains) = allowed {
-            key.push('|');
-            key.push_str(&domains.join(","));
-        }
-        key.push('|');
-        if let Some(domains) = blocked {
-            key.push_str(&domains.join(","));
-        }
-        key
+        let endpoints = endpoints.iter().map(Url::as_str).collect::<Vec<_>>();
+        serde_json::to_string(&(query, allowed, blocked, max_results, endpoints))
+            .expect("web search cache key components are serializable")
     }
 
     fn try_cache(key: &str) -> Option<serde_json::Value> {
@@ -87,18 +118,112 @@ impl WebSearchTool {
         );
     }
 
+    fn anchor_re() -> &'static Regex {
+        ANCHOR_RE
+            .get_or_init(|| Regex::new(r"(?is)<a\b([^>]*)>(.*?)</a>").expect("valid static regex"))
+    }
+
+    fn tag_re() -> &'static Regex {
+        TAG_RE.get_or_init(|| Regex::new(r"(?is)<[^>]+>").expect("valid static regex"))
+    }
+
+    fn href_re() -> &'static Regex {
+        HREF_RE.get_or_init(|| {
+            Regex::new(r#"(?i)\bhref\s*=\s*[\"']([^\"']+)[\"']"#).expect("valid static regex")
+        })
+    }
+
+    fn class_re() -> &'static Regex {
+        CLASS_RE.get_or_init(|| {
+            Regex::new(r#"(?i)\bclass\s*=\s*[\"']([^\"']+)[\"']"#).expect("valid static regex")
+        })
+    }
+
+    fn lite_snippet_re() -> &'static Regex {
+        LITE_SNIPPET_RE.get_or_init(|| {
+            Regex::new(
+                r#"(?is)<td\b[^>]*class\s*=\s*[\"'][^\"']*\bresult-snippet\b[^\"']*[\"'][^>]*>(.*?)</td>"#,
+            )
+            .expect("valid static regex")
+        })
+    }
+
+    fn attr_value<'a>(attrs: &'a str, pattern: &Regex) -> Option<&'a str> {
+        pattern
+            .captures(attrs)
+            .and_then(|capture| capture.get(1))
+            .map(|value| value.as_str())
+    }
+
+    fn has_class(attrs: &str, expected: &str) -> bool {
+        Self::attr_value(attrs, Self::class_re()).is_some_and(|classes| {
+            classes
+                .split_ascii_whitespace()
+                .any(|class| class == expected)
+        })
+    }
+
+    fn decode_html_entities(value: &str) -> String {
+        value
+            .replace("&quot;", "\"")
+            .replace("&#x27;", "'")
+            .replace("&#39;", "'")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&nbsp;", " ")
+            .replace("&amp;", "&")
+    }
+
+    fn clean_html_text(value: &str) -> String {
+        let without_tags = Self::tag_re().replace_all(value, " ");
+        Self::decode_html_entities(&without_tags)
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn make_absolute_url(raw: &str) -> Option<String> {
+        let raw = Self::decode_html_entities(raw.trim());
+        if raw.is_empty() {
+            return None;
+        }
+        if raw.starts_with("//") {
+            return Some(format!("https:{raw}"));
+        }
+        if raw.starts_with('/') {
+            return Url::parse("https://duckduckgo.com")
+                .ok()?
+                .join(&raw)
+                .ok()
+                .map(|url| url.to_string());
+        }
+        Some(raw)
+    }
+
     fn decode_duckduckgo_url(raw: &str) -> Option<String> {
-        if let Ok(url) = url::Url::parse(raw) {
-            if let Some(value) = url
+        let absolute = Self::make_absolute_url(raw)?;
+        let parsed = Url::parse(&absolute).ok()?;
+        if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+            return None;
+        }
+
+        let host = parsed.host_str()?.to_ascii_lowercase();
+        if Self::domain_matches(&host, "duckduckgo.com") && parsed.path() == "/l/" {
+            if let Some(value) = parsed
                 .query_pairs()
                 .find(|(key, _)| key == "uddg")
                 .map(|(_, value)| value.to_string())
             {
-                return Some(value);
+                let target = Self::make_absolute_url(&value)?;
+                let target = Url::parse(&target).ok()?;
+                if !matches!(target.scheme(), "http" | "https") || target.host_str().is_none() {
+                    return None;
+                }
+                return Some(target.to_string());
             }
         }
 
-        Some(raw.to_string())
+        Some(parsed.to_string())
     }
 
     fn host_of(url: &str) -> Option<String> {
@@ -109,6 +234,305 @@ impl WebSearchTool {
 
     fn domain_matches(host: &str, domain: &str) -> bool {
         host == domain || host.ends_with(&format!(".{}", domain))
+    }
+
+    fn result_from_parts(
+        raw_url: &str,
+        title_html: &str,
+        snippet_html: Option<&str>,
+        allowed: &Option<HashSet<String>>,
+        blocked: &HashSet<String>,
+    ) -> Option<SearchResult> {
+        let url = Self::decode_duckduckgo_url(raw_url)?;
+        let host = Self::host_of(&url)?;
+
+        if blocked
+            .iter()
+            .any(|blocked_domain| Self::domain_matches(&host, blocked_domain))
+        {
+            return None;
+        }
+        if let Some(allowed_set) = allowed {
+            if !allowed_set
+                .iter()
+                .any(|allowed_domain| Self::domain_matches(&host, allowed_domain))
+            {
+                return None;
+            }
+        }
+
+        let title = Self::clean_html_text(title_html);
+        let snippet = snippet_html
+            .map(Self::clean_html_text)
+            .filter(|value| !value.is_empty());
+        Some(SearchResult {
+            title: if title.is_empty() { url.clone() } else { title },
+            url,
+            domain: host,
+            snippet,
+        })
+    }
+
+    fn recognized_empty_page(html: &str, layout_path: &str) -> bool {
+        let lower = html.to_ascii_lowercase();
+        lower.contains(layout_path)
+            && (lower.contains("no results")
+                || lower.contains("no-results")
+                || lower.contains("result--no-result"))
+    }
+
+    fn parse_html_layout(
+        html: &str,
+        allowed: &Option<HashSet<String>>,
+        blocked: &HashSet<String>,
+        max_results: usize,
+    ) -> Option<Vec<SearchResult>> {
+        let mut snippets = HashMap::new();
+        let mut links = Vec::new();
+
+        for capture in Self::anchor_re().captures_iter(html) {
+            let attrs = capture.get(1)?.as_str();
+            let content = capture.get(2)?.as_str();
+            let Some(href) = Self::attr_value(attrs, Self::href_re()) else {
+                continue;
+            };
+            if Self::has_class(attrs, "result__snippet") {
+                if let Some(url) = Self::decode_duckduckgo_url(href) {
+                    snippets.insert(url, content.to_string());
+                }
+            } else if Self::has_class(attrs, "result__a") {
+                links.push((href.to_string(), content.to_string()));
+            }
+        }
+
+        if links.is_empty() {
+            return Self::recognized_empty_page(html, "/html/").then(Vec::new);
+        }
+        if !links
+            .iter()
+            .any(|(raw_url, _)| Self::decode_duckduckgo_url(raw_url).is_some())
+        {
+            return None;
+        }
+
+        let mut results = Vec::new();
+        for (raw_url, title) in links {
+            let decoded = Self::decode_duckduckgo_url(&raw_url);
+            let snippet = decoded.as_ref().and_then(|url| snippets.get(url));
+            if let Some(result) = Self::result_from_parts(
+                &raw_url,
+                &title,
+                snippet.map(String::as_str),
+                allowed,
+                blocked,
+            ) {
+                results.push(result);
+                if results.len() >= max_results {
+                    break;
+                }
+            }
+        }
+        Some(results)
+    }
+
+    fn parse_lite_layout(
+        html: &str,
+        allowed: &Option<HashSet<String>>,
+        blocked: &HashSet<String>,
+        max_results: usize,
+    ) -> Option<Vec<SearchResult>> {
+        let mut links = Vec::new();
+        for capture in Self::anchor_re().captures_iter(html) {
+            let full = capture.get(0)?;
+            let attrs = capture.get(1)?.as_str();
+            if !Self::has_class(attrs, "result-link") {
+                continue;
+            }
+            let Some(href) = Self::attr_value(attrs, Self::href_re()) else {
+                continue;
+            };
+            links.push((
+                full.start(),
+                full.end(),
+                href.to_string(),
+                capture.get(2)?.as_str().to_string(),
+            ));
+        }
+
+        if links.is_empty() {
+            return Self::recognized_empty_page(html, "/lite/").then(Vec::new);
+        }
+        if !links
+            .iter()
+            .any(|(_, _, raw_url, _)| Self::decode_duckduckgo_url(raw_url).is_some())
+        {
+            return None;
+        }
+
+        let mut results = Vec::new();
+        for (index, (_, end, raw_url, title)) in links.iter().enumerate() {
+            let next_start = links
+                .get(index + 1)
+                .map(|(start, _, _, _)| *start)
+                .unwrap_or(html.len());
+            let snippet = Self::lite_snippet_re()
+                .captures(&html[*end..next_start])
+                .and_then(|capture| capture.get(1))
+                .map(|value| value.as_str());
+            if let Some(result) = Self::result_from_parts(raw_url, title, snippet, allowed, blocked)
+            {
+                results.push(result);
+                if results.len() >= max_results {
+                    break;
+                }
+            }
+        }
+        Some(results)
+    }
+
+    fn is_anti_bot_page(html: &str) -> bool {
+        let lower = html.to_ascii_lowercase();
+        lower.contains("unfortunately, bots use duckduckgo too")
+            || lower.contains("anomaly-modal")
+            || lower.contains("challenge-form")
+    }
+
+    fn parse_search_page(
+        html: &str,
+        allowed: &Option<HashSet<String>>,
+        blocked: &HashSet<String>,
+        max_results: usize,
+    ) -> ParsedSearchPage {
+        if Self::is_anti_bot_page(html) {
+            return ParsedSearchPage::AntiBot;
+        }
+        if let Some(results) = Self::parse_html_layout(html, allowed, blocked, max_results) {
+            return ParsedSearchPage::Results(results);
+        }
+        if let Some(results) = Self::parse_lite_layout(html, allowed, blocked, max_results) {
+            return ParsedSearchPage::Results(results);
+        }
+        ParsedSearchPage::Unrecognized
+    }
+
+    fn parse_endpoint_list(override_value: Option<&str>) -> Result<Vec<Url>, String> {
+        let raw_endpoints: Vec<&str> = match override_value {
+            Some(value) => value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .collect(),
+            None => DEFAULT_WEB_SEARCH_ENDPOINTS.to_vec(),
+        };
+        if raw_endpoints.is_empty() {
+            return Err(format!(
+                "{WEB_SEARCH_ENDPOINTS_ENV} must contain at least one endpoint"
+            ));
+        }
+
+        raw_endpoints
+            .into_iter()
+            .enumerate()
+            .map(|(index, raw)| {
+                let url = Url::parse(raw).map_err(|_| {
+                    format!(
+                        "{WEB_SEARCH_ENDPOINTS_ENV} entry {} must be an absolute HTTP(S) URL",
+                        index + 1
+                    )
+                })?;
+                if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+                    return Err(format!(
+                        "{WEB_SEARCH_ENDPOINTS_ENV} entry {} must be an absolute HTTP(S) URL",
+                        index + 1
+                    ));
+                }
+                Ok(url)
+            })
+            .collect()
+    }
+
+    fn configured_endpoints() -> Result<Vec<Url>, String> {
+        match std::env::var(WEB_SEARCH_ENDPOINTS_ENV) {
+            Ok(value) => Self::parse_endpoint_list(Some(&value)),
+            Err(std::env::VarError::NotPresent) => Self::parse_endpoint_list(None),
+            Err(std::env::VarError::NotUnicode(_)) => Err(format!(
+                "{WEB_SEARCH_ENDPOINTS_ENV} must contain valid UTF-8"
+            )),
+        }
+    }
+
+    fn endpoint_label(endpoint: &Url) -> String {
+        let host = endpoint.host_str().unwrap_or("unknown-host");
+        let port = endpoint
+            .port()
+            .map(|port| format!(":{port}"))
+            .unwrap_or_default();
+        format!("{}://{host}{port}{}", endpoint.scheme(), endpoint.path())
+    }
+
+    fn build_http_client() -> Result<reqwest::Client, String> {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            // Configured endpoints are the complete trust boundary. Do not let a
+            // remote response replay the query POST to an unvalidated redirect.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| format!("Failed to build HTTP client: {error}"))
+    }
+
+    async fn search_endpoint_chain(
+        client: &reqwest::Client,
+        endpoints: &[Url],
+        query: &str,
+        allowed: &Option<HashSet<String>>,
+        blocked: &HashSet<String>,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, String> {
+        let mut failures = Vec::with_capacity(endpoints.len());
+        for endpoint in endpoints {
+            let label = Self::endpoint_label(endpoint);
+            let response = match client
+                .post(endpoint.clone())
+                .header("User-Agent", USER_AGENT)
+                .form(&[("q", query)])
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    failures.push(format!("{label}: request failed ({})", error.without_url()));
+                    continue;
+                }
+            };
+            if !response.status().is_success() {
+                failures.push(format!("{label}: HTTP {}", response.status()));
+                continue;
+            }
+            let html = match response.text().await {
+                Ok(html) => html,
+                Err(error) => {
+                    failures.push(format!(
+                        "{label}: response decode failed ({})",
+                        error.without_url()
+                    ));
+                    continue;
+                }
+            };
+            match Self::parse_search_page(&html, allowed, blocked, max_results) {
+                ParsedSearchPage::Results(results) => return Ok(results),
+                ParsedSearchPage::AntiBot => {
+                    failures.push(format!("{label}: blocked by anti-bot protection"));
+                }
+                ParsedSearchPage::Unrecognized => {
+                    failures.push(format!("{label}: unrecognized search response"));
+                }
+            }
+        }
+
+        Err(format!(
+            "all configured web search endpoints failed: {}",
+            failures.join("; ")
+        ))
     }
 }
 
@@ -191,9 +615,16 @@ impl Tool for WebSearchTool {
             .max_results
             .unwrap_or(DEFAULT_MAX_RESULTS)
             .min(ABSOLUTE_MAX_RESULTS);
+        let endpoints = Self::configured_endpoints().map_err(ToolError::Execution)?;
 
         // Check cache
-        let cache_key = Self::cache_key(query, &allowed_domains, &blocked_domains);
+        let cache_key = Self::cache_key(
+            query,
+            &allowed_domains,
+            &blocked_domains,
+            max_results,
+            &endpoints,
+        );
         if let Some(cached) = Self::try_cache(&cache_key) {
             ctx.emit_tool_token("Using cached search results\n").await;
             return Ok(ToolOutcome::Completed(ToolResult {
@@ -206,30 +637,7 @@ impl Tool for WebSearchTool {
 
         ctx.emit_tool_token(format!("Searching: {}\n", query)).await;
 
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .map_err(|e| ToolError::Execution(format!("Failed to build HTTP client: {}", e)))?;
-
-        let response = client
-            .get("https://duckduckgo.com/html/")
-            .header("User-Agent", USER_AGENT)
-            .query(&[("q", query)])
-            .send()
-            .await
-            .map_err(|e| ToolError::Execution(format!("Web search request failed: {}", e)))?;
-
-        let html = response.text().await.map_err(|e| {
-            ToolError::Execution(format!("Failed to decode web search body: {}", e))
-        })?;
-
-        // Detect anti-bot page
-        if html.contains("Unfortunately, bots use DuckDuckGo too") || html.contains("anomaly-modal")
-        {
-            return Err(ToolError::Execution(
-                "Search blocked by anti-bot protection. Please retry.".to_string(),
-            ));
-        }
+        let client = Self::build_http_client().map_err(ToolError::Execution)?;
 
         let allowed: Option<HashSet<String>> = allowed_domains.map(|domains| {
             domains
@@ -242,89 +650,16 @@ impl Tool for WebSearchTool {
             .into_iter()
             .map(|value| value.to_ascii_lowercase())
             .collect();
-
-        let link_re = LINK_RE.get_or_init(|| {
-            Regex::new(r#"<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>"#)
-                .expect("valid static regex")
-        });
-        let tag_re =
-            TAG_RE.get_or_init(|| Regex::new(r"(?is)<[^>]+>").expect("valid static regex"));
-        let snippet_re = SNIPPET_RE.get_or_init(|| {
-            Regex::new(r#"<a[^>]*class="result__snippet"[^>]*href="[^"]*"[^>]*>(.*?)</a>"#)
-                .expect("valid static regex")
-        });
-
-        // Build a map of snippet content by href (to match with result links)
-        let href_re =
-            HREF_RE.get_or_init(|| Regex::new(r#"href="([^"]+)""#).expect("valid static regex"));
-        let mut snippets: HashMap<String, String> = HashMap::new();
-        for cap in snippet_re.captures_iter(&html) {
-            if let Some(href_cap) = cap.get(0) {
-                let href_text = href_cap.as_str();
-                // Extract the href URL from the snippet anchor
-                if let Some(url_match) = href_re.find(href_text) {
-                    let raw_href = &href_text[url_match.start() + 6..url_match.end() - 1];
-                    if let Some(decoded) = Self::decode_duckduckgo_url(raw_href) {
-                        let snippet_text = cap
-                            .get(1)
-                            .map(|m| tag_re.replace_all(m.as_str(), "").trim().to_string())
-                            .unwrap_or_default();
-                        if !snippet_text.is_empty() {
-                            snippets.insert(decoded, snippet_text);
-                        }
-                    }
-                }
-            }
-        }
-
-        let mut results = Vec::new();
-        for capture in link_re.captures_iter(&html) {
-            let Some(raw_url) = capture.get(1).map(|m| m.as_str()) else {
-                continue;
-            };
-            let Some(url) = Self::decode_duckduckgo_url(raw_url) else {
-                continue;
-            };
-            let Some(host) = Self::host_of(&url) else {
-                continue;
-            };
-
-            if blocked
-                .iter()
-                .any(|blocked_domain| Self::domain_matches(&host, blocked_domain))
-            {
-                continue;
-            }
-            if let Some(allowed_set) = &allowed {
-                if !allowed_set
-                    .iter()
-                    .any(|allowed_domain| Self::domain_matches(&host, allowed_domain))
-                {
-                    continue;
-                }
-            }
-
-            let title = capture
-                .get(2)
-                .map(|m| tag_re.replace_all(m.as_str(), "").trim().to_string())
-                .unwrap_or_else(|| url.clone());
-
-            let snippet = snippets.get(&url).cloned().unwrap_or_default();
-
-            let mut result = json!({
-                "title": title,
-                "url": url,
-                "domain": host,
-            });
-            if !snippet.is_empty() {
-                result["snippet"] = json!(snippet);
-            }
-            results.push(result);
-
-            if results.len() >= max_results {
-                break;
-            }
-        }
+        let results = Self::search_endpoint_chain(
+            &client,
+            &endpoints,
+            query,
+            &allowed,
+            &blocked,
+            max_results,
+        )
+        .await
+        .map_err(ToolError::Execution)?;
 
         ctx.emit_tool_token(format!(
             "Found {} results for \"{}\"\n",
@@ -332,6 +667,9 @@ impl Tool for WebSearchTool {
             query
         ))
         .await;
+
+        let results: Vec<serde_json::Value> =
+            results.into_iter().map(SearchResult::into_json).collect();
 
         let result_value = if results.is_empty() {
             json!({
@@ -364,6 +702,16 @@ impl Tool for WebSearchTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const HTML_FIXTURE: &str = include_str!("fixtures/web_search_html.html");
+    const LITE_FIXTURE: &str = include_str!("fixtures/web_search_lite.html");
+    const ANTI_BOT_FIXTURE: &str = include_str!("fixtures/web_search_antibot.html");
+
+    fn empty_filters() -> (Option<HashSet<String>>, HashSet<String>) {
+        (None, HashSet::new())
+    }
 
     #[test]
     fn domain_matches_supports_subdomains() {
@@ -396,14 +744,339 @@ mod tests {
     }
 
     #[test]
-    fn cache_key_is_stable() {
-        let k1 =
-            WebSearchTool::cache_key("rust", &Some(vec!["doc.rust-lang.org".to_string()]), &None);
-        let k2 =
-            WebSearchTool::cache_key("rust", &Some(vec!["doc.rust-lang.org".to_string()]), &None);
+    fn decode_duckduckgo_url_handles_root_and_protocol_relative_links() {
+        let root_relative = "/l/?uddg=https%3A%2F%2Fexample.com%2Froot&amp;rut=irrelevant";
+        assert_eq!(
+            WebSearchTool::decode_duckduckgo_url(root_relative).as_deref(),
+            Some("https://example.com/root")
+        );
+
+        let protocol_relative = "//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fprotocol";
+        assert_eq!(
+            WebSearchTool::decode_duckduckgo_url(protocol_relative).as_deref(),
+            Some("https://example.com/protocol")
+        );
+    }
+
+    #[test]
+    fn decode_duckduckgo_url_rejects_non_http_schemes() {
+        for raw in [
+            "ftp://example.com/archive",
+            "file://example.com/private",
+            "javascript://example.com/alert",
+            "/l/?uddg=ftp%3A%2F%2Fexample.com%2Farchive",
+        ] {
+            assert_eq!(WebSearchTool::decode_duckduckgo_url(raw), None, "{raw}");
+        }
+    }
+
+    #[test]
+    fn html_fixture_parses_results_snippets_and_filters() {
+        let (allowed, blocked) = empty_filters();
+        let ParsedSearchPage::Results(results) =
+            WebSearchTool::parse_search_page(HTML_FIXTURE, &allowed, &blocked, 10)
+        else {
+            panic!("HTML fixture should be recognized");
+        };
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Example Guide");
+        assert_eq!(results[0].url, "https://example.com/guide");
+        assert_eq!(
+            results[0].snippet.as_deref(),
+            Some("A useful guide & reference.")
+        );
+
+        let allowed = Some(HashSet::from(["example.com".to_string()]));
+        let ParsedSearchPage::Results(filtered) =
+            WebSearchTool::parse_search_page(HTML_FIXTURE, &allowed, &blocked, 10)
+        else {
+            panic!("HTML fixture should be recognized after filtering");
+        };
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].domain, "example.com");
+    }
+
+    #[test]
+    fn lite_fixture_uses_lite_parser_and_block_filter() {
+        let allowed = None;
+        let blocked = HashSet::from(["example.org".to_string()]);
+        let ParsedSearchPage::Results(results) =
+            WebSearchTool::parse_search_page(LITE_FIXTURE, &allowed, &blocked, 10)
+        else {
+            panic!("Lite fixture should be recognized by cross-layout parsing");
+        };
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].url, "https://example.net/lite");
+        assert_eq!(
+            results[0].snippet.as_deref(),
+            Some("A compact result & summary.")
+        );
+    }
+
+    #[test]
+    fn anti_bot_and_unknown_pages_are_hard_endpoint_failures() {
+        let (allowed, blocked) = empty_filters();
+        assert_eq!(
+            WebSearchTool::parse_search_page(ANTI_BOT_FIXTURE, &allowed, &blocked, 10),
+            ParsedSearchPage::AntiBot
+        );
+        assert_eq!(
+            WebSearchTool::parse_search_page(
+                "<html><body>proxy login page</body></html>",
+                &allowed,
+                &blocked,
+                10,
+            ),
+            ParsedSearchPage::Unrecognized
+        );
+    }
+
+    #[test]
+    fn recognized_empty_page_is_a_successful_empty_result() {
+        let (allowed, blocked) = empty_filters();
+        let empty = r#"<html><body class="body--html"><form action="/html/"></form><div class="no-results">No results found</div></body></html>"#;
+        assert_eq!(
+            WebSearchTool::parse_search_page(empty, &allowed, &blocked, 10),
+            ParsedSearchPage::Results(Vec::new())
+        );
+    }
+
+    #[test]
+    fn malformed_result_links_are_unrecognized_but_filtered_http_links_are_valid() {
+        let (allowed, blocked) = empty_filters();
+        let malformed = r#"<html><body><form action="/html/"></form><a class="result__a" href="javascript:void(0)">Broken</a></body></html>"#;
+        assert_eq!(
+            WebSearchTool::parse_search_page(malformed, &allowed, &blocked, 10),
+            ParsedSearchPage::Unrecognized
+        );
+
+        let allowed = Some(HashSet::from(["allowed.example".to_string()]));
+        let filtered = r#"<html><body><form action="/html/"></form><a class="result__a" href="https://blocked.example/result">Filtered</a></body></html>"#;
+        assert_eq!(
+            WebSearchTool::parse_search_page(filtered, &allowed, &blocked, 10),
+            ParsedSearchPage::Results(Vec::new())
+        );
+    }
+
+    #[test]
+    fn endpoint_override_preserves_order_and_rejects_invalid_entries() {
+        let endpoints = WebSearchTool::parse_endpoint_list(Some(
+            " https://mirror.example/search , http://127.0.0.1:8080/lite ",
+        ))
+        .unwrap();
+        assert_eq!(endpoints.len(), 2);
+        assert_eq!(endpoints[0].as_str(), "https://mirror.example/search");
+        assert_eq!(endpoints[1].as_str(), "http://127.0.0.1:8080/lite");
+
+        assert!(WebSearchTool::parse_endpoint_list(Some("  , ")).is_err());
+        assert!(WebSearchTool::parse_endpoint_list(Some("file:///tmp/results.html")).is_err());
+        assert!(WebSearchTool::parse_endpoint_list(Some("not a url")).is_err());
+    }
+
+    #[test]
+    fn default_endpoint_chain_uses_html_then_lite() {
+        let endpoints = WebSearchTool::parse_endpoint_list(None).unwrap();
+        assert_eq!(
+            endpoints.iter().map(Url::as_str).collect::<Vec<_>>(),
+            DEFAULT_WEB_SEARCH_ENDPOINTS
+        );
+    }
+
+    #[tokio::test]
+    async fn endpoint_chain_falls_back_after_an_outage() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/unavailable"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/lite"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(LITE_FIXTURE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let endpoints = vec![
+            Url::parse(&format!("{}/unavailable", server.uri())).unwrap(),
+            Url::parse(&format!("{}/lite", server.uri())).unwrap(),
+        ];
+        let client = WebSearchTool::build_http_client().unwrap();
+        let (allowed, blocked) = empty_filters();
+        let results = WebSearchTool::search_endpoint_chain(
+            &client, &endpoints, "rust", &allowed, &blocked, 10,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results.len(), 2);
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        for request in requests {
+            assert_eq!(request.method.as_str(), "POST");
+            assert_eq!(String::from_utf8(request.body).unwrap(), "q=rust");
+        }
+    }
+
+    #[tokio::test]
+    async fn endpoint_chain_falls_back_after_anti_bot_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/blocked"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(ANTI_BOT_FIXTURE))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/html"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(HTML_FIXTURE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let endpoints = vec![
+            Url::parse(&format!("{}/blocked", server.uri())).unwrap(),
+            Url::parse(&format!("{}/html", server.uri())).unwrap(),
+        ];
+        let client = WebSearchTool::build_http_client().unwrap();
+        let (allowed, blocked) = empty_filters();
+        let results = WebSearchTool::search_endpoint_chain(
+            &client, &endpoints, "rust", &allowed, &blocked, 10,
+        )
+        .await
+        .unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn endpoint_chain_falls_back_after_malformed_result_links() {
+        let server = MockServer::start().await;
+        let malformed = r#"<html><body><form action="/html/"></form><a class="result__a" href="javascript:void(0)">Broken</a></body></html>"#;
+        Mock::given(method("POST"))
+            .and(path("/malformed"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(malformed))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/lite"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(LITE_FIXTURE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let endpoints = vec![
+            Url::parse(&format!("{}/malformed", server.uri())).unwrap(),
+            Url::parse(&format!("{}/lite", server.uri())).unwrap(),
+        ];
+        let client = WebSearchTool::build_http_client().unwrap();
+        let (allowed, blocked) = empty_filters();
+        let results = WebSearchTool::search_endpoint_chain(
+            &client, &endpoints, "rust", &allowed, &blocked, 10,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results[0].url, "https://example.net/lite");
+    }
+
+    #[tokio::test]
+    async fn endpoint_chain_reports_all_hard_failures() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/unavailable"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/unknown"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not a search page"))
+            .mount(&server)
+            .await;
+
+        let endpoints = vec![
+            Url::parse(&format!("{}/unavailable", server.uri())).unwrap(),
+            Url::parse(&format!("{}/unknown", server.uri())).unwrap(),
+        ];
+        let client = WebSearchTool::build_http_client().unwrap();
+        let (allowed, blocked) = empty_filters();
+        let error = WebSearchTool::search_endpoint_chain(
+            &client, &endpoints, "rust", &allowed, &blocked, 10,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("all configured web search endpoints failed"));
+        assert!(error.contains("HTTP 503"));
+        assert!(error.contains("unrecognized search response"));
+    }
+
+    #[tokio::test]
+    async fn endpoint_chain_does_not_follow_redirects_before_fallback() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/redirect"))
+            .respond_with(
+                ResponseTemplate::new(307)
+                    .insert_header("Location", format!("{}/trap", server.uri())),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/lite"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(LITE_FIXTURE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let endpoints = vec![
+            Url::parse(&format!("{}/redirect", server.uri())).unwrap(),
+            Url::parse(&format!("{}/lite", server.uri())).unwrap(),
+        ];
+        let client = WebSearchTool::build_http_client().unwrap();
+        let (allowed, blocked) = empty_filters();
+        let results = WebSearchTool::search_endpoint_chain(
+            &client, &endpoints, "rust", &allowed, &blocked, 10,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results[0].url, "https://example.net/lite");
+        let paths = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(paths, ["/redirect", "/lite"]);
+    }
+
+    #[test]
+    fn cache_key_is_stable_and_isolates_result_limits_and_endpoints() {
+        let endpoints = WebSearchTool::parse_endpoint_list(None).unwrap();
+        let allowed = Some(vec!["doc.rust-lang.org".to_string()]);
+        let k1 = WebSearchTool::cache_key("rust", &allowed, &None, 10, &endpoints);
+        let k2 = WebSearchTool::cache_key("rust", &allowed, &None, 10, &endpoints);
         assert_eq!(k1, k2);
 
-        let k3 = WebSearchTool::cache_key("rust", &None, &Some(vec!["bad.com".to_string()]));
+        let k3 = WebSearchTool::cache_key(
+            "rust",
+            &None,
+            &Some(vec!["bad.com".to_string()]),
+            10,
+            &endpoints,
+        );
         assert_ne!(k1, k3);
+
+        let fewer_results = WebSearchTool::cache_key("rust", &allowed, &None, 1, &endpoints);
+        assert_ne!(k1, fewer_results);
+
+        let mirror =
+            WebSearchTool::parse_endpoint_list(Some("https://mirror.example/search")).unwrap();
+        let other_endpoint = WebSearchTool::cache_key("rust", &allowed, &None, 10, &mirror);
+        assert_ne!(k1, other_endpoint);
     }
 }

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -614,6 +614,7 @@ for Docker/CI/secret-manager deploys):
 | `BAMBOO_CORS_ALLOW_ORIGINS` | CORS allowlist. |
 | `BAMBOO_ENABLE_DEV_ENDPOINTS` | Gate dev-only HTTP endpoints. |
 | `BAMBOO_WS_AUTH_DEADLINE_MS` | WS v2 auth handshake timeout. |
+| `BAMBOO_WEB_SEARCH_ENDPOINTS` | Ordered, comma-separated absolute HTTP(S) endpoints used by `WebSearch`. Each endpoint receives a `POST` form with the `q` field; the first recognized HTML/Lite response wins. Defaults to DuckDuckGo's HTML endpoint followed by its Lite endpoint. |
 
 **Workspace / paths:**
 


### PR DESCRIPTION
## Summary
- replace the single DuckDuckGo GET with an ordered HTML → Lite POST endpoint chain
- distinguish endpoint failures, anti-bot/unknown responses, and legitimate empty results
- add the `BAMBOO_WEB_SEARCH_ENDPOINTS` operator override, HTTP(S)-only result handling, redirect isolation, and cache-key isolation
- add offline HTML/Lite/anti-bot fixtures and regression coverage for outages, malformed links, redirects, filters, and aggregate failures

Closes #661

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p bamboo-tools --locked`
- `cargo clippy -p bamboo-tools --all-targets --locked -- -D warnings`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo test --all-features --lib --tests`
- `git diff --check`

## Screenshots
- Not applicable (backend/tooling change)