### PR TITLE
fix(metrics): keep resumed session round IDs unique

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/lifecycle.rs
@@ -27,8 +27,12 @@ impl DefaultLifecycleManager {
 
 #[async_trait]
 impl LifecycleManager for DefaultLifecycleManager {
-    fn initialize_run(&self, session: &Session, config: &AgentLoopConfig) -> AgentRuntimeState {
-        let mut state = AgentRuntimeState::new(&session.id);
+    fn initialize_run(&self, _session: &Session, config: &AgentLoopConfig) -> AgentRuntimeState {
+        // `AgentRuntimeState::run_id` is the existing per-execution identity on
+        // this adapter path. Give every initialized run a fresh value so round
+        // counters can safely restart for the same session.
+        let mut state =
+            AgentRuntimeState::new(crate::runtime::runner::round_prelude::new_execution_id());
         state.llm.model_name = config.model_name.clone();
         state.llm.provider_name = config.provider_name.clone();
         state.llm.fast_model_name = config.fast_model_name.clone();
@@ -43,7 +47,7 @@ impl LifecycleManager for DefaultLifecycleManager {
         &self,
         session: &mut Session,
         task_context: &mut Option<TaskLoopContext>,
-        _runtime_state: &mut AgentRuntimeState,
+        runtime_state: &mut AgentRuntimeState,
         round: usize,
         max_rounds: usize,
         config: &AgentLoopConfig,
@@ -61,6 +65,7 @@ impl LifecycleManager for DefaultLifecycleManager {
             self.llm.clone(),
             tools,
             &crate::runtime::runner::round_prelude::RoundPreludeFrame {
+                execution_id: &runtime_state.run_id,
                 round,
                 max_rounds,
                 debug_enabled: false, // debug logging handled at runner level, not via adapter
@@ -123,5 +128,42 @@ impl LifecycleManager for DefaultLifecycleManager {
             runtime_state,
         )
         .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_agent_core::Message;
+    use bamboo_llm::provider::LLMStream;
+    use futures::stream;
+
+    struct UnusedProvider;
+
+    #[async_trait]
+    impl LLMProvider for UnusedProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            Ok(Box::pin(stream::iter(vec![Ok(bamboo_llm::LLMChunk::Done)])))
+        }
+    }
+
+    #[test]
+    fn initialize_run_assigns_a_fresh_execution_identity() {
+        let manager = DefaultLifecycleManager::new(Arc::new(UnusedProvider));
+        let session = Session::new("same-session", "model");
+        let config = AgentLoopConfig::default();
+
+        let first = manager.initialize_run(&session, &config);
+        let second = manager.initialize_run(&session, &config);
+
+        assert!(!first.run_id.is_empty());
+        assert_ne!(first.run_id, session.id);
+        assert_ne!(first.run_id, second.run_id);
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
@@ -355,9 +355,11 @@ pub(super) async fn apply_completed_gold_evaluation(
 
     let usage = apply_gold_evaluation_result(session, &result.evaluation_result);
 
-    let synthetic_round_id = format!(
-        "{}-gold-evaluation-round-{}",
-        state.session_id, result.round_number
+    let synthetic_round_id = crate::runtime::runner::round_prelude::build_auxiliary_round_id(
+        &state.session_id,
+        &state.execution_id,
+        "gold-evaluation",
+        result.round_number,
     );
     crate::runtime::runner::metrics_lifecycle::record_round_started(
         state.metrics_collector.as_ref(),
@@ -1115,6 +1117,7 @@ mod tests {
 
         let mut state = crate::runtime::runner::loop_execution::startup::LoopRunState {
             session_id: "session-gold-eval".to_string(),
+            execution_id: "gold-eval-execution".to_string(),
             model_name: "model".to_string(),
             metrics_collector: None,
             debug_logger: crate::runtime::runner::logging::DebugLogger::new(false),

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -800,9 +800,11 @@ async fn apply_completed_task_evaluation(
         result.clone(),
     );
 
-    let synthetic_round_id = format!(
-        "{}-task-evaluation-round-{}",
-        state.session_id, result.round_number
+    let synthetic_round_id = crate::runtime::runner::round_prelude::build_auxiliary_round_id(
+        &state.session_id,
+        &state.execution_id,
+        "task-evaluation",
+        result.round_number,
     );
     crate::runtime::runner::metrics_lifecycle::record_round_started(
         state.metrics_collector.as_ref(),
@@ -1649,7 +1651,11 @@ pub(super) async fn run_pipeline(
 
         state.runtime_state.round.current_round = turn_counter;
 
-        let round_id = format!("{}-round-{}", state.session_id, turn_counter + 1);
+        let round_id = crate::runtime::runner::round_prelude::build_round_id(
+            &state.session_id,
+            &state.execution_id,
+            turn_counter as usize,
+        );
         state.runtime_state.round.last_round_id = Some(round_id.clone());
 
         if config
@@ -3733,6 +3739,7 @@ mod tests {
         };
         LoopRunState {
             session_id: session_id.to_string(),
+            execution_id: "test-execution".to_string(),
             model_name: "model".to_string(),
             metrics_collector: None,
             debug_logger: crate::runtime::runner::logging::DebugLogger::new(false),
@@ -5636,6 +5643,7 @@ mod tests {
 
         let mut state = super::super::startup::LoopRunState {
             session_id: "session-task-eval".to_string(),
+            execution_id: "task-eval-execution".to_string(),
             model_name: "model".to_string(),
             metrics_collector: None,
             debug_logger: crate::runtime::runner::logging::DebugLogger::new(false),
@@ -5704,11 +5712,43 @@ mod tests {
 
     #[test]
     fn test_build_round_id() {
-        let id = format!("{}-round-{}", "session-123", 1);
-        assert_eq!(id, "session-123-round-1");
+        let id =
+            crate::runtime::runner::round_prelude::build_round_id("session-123", "execution-a", 0);
+        assert_eq!(id, "session-123-run-execution-a-round-1");
 
-        let id = format!("{}-round-{}", "test", 4 + 1);
-        assert_eq!(id, "test-round-5");
+        let id = crate::runtime::runner::round_prelude::build_round_id("test", "execution-b", 4);
+        assert_eq!(id, "test-run-execution-b-round-5");
+
+        assert_ne!(
+            crate::runtime::runner::round_prelude::build_round_id("session-123", "execution-a", 0,),
+            crate::runtime::runner::round_prelude::build_round_id("session-123", "execution-b", 0,),
+            "the per-run round counter may reset, but the execution namespace must not"
+        );
+
+        let task_a = crate::runtime::runner::round_prelude::build_auxiliary_round_id(
+            "session-123",
+            "execution-a",
+            "task-evaluation",
+            1,
+        );
+        let task_b = crate::runtime::runner::round_prelude::build_auxiliary_round_id(
+            "session-123",
+            "execution-b",
+            "task-evaluation",
+            1,
+        );
+        let gold_a = crate::runtime::runner::round_prelude::build_auxiliary_round_id(
+            "session-123",
+            "execution-a",
+            "gold-evaluation",
+            1,
+        );
+        assert_eq!(
+            task_a,
+            "session-123-run-execution-a-task-evaluation-round-1"
+        );
+        assert_ne!(task_a, task_b);
+        assert_ne!(task_a, gold_a);
     }
 
     // --- Tests from round_prelude/cancellation.rs ---

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
@@ -69,6 +69,10 @@ pub(super) struct GoldEvaluationState {
 
 pub(super) struct LoopRunState {
     pub(super) session_id: String,
+    /// Collision-resistant namespace for metrics emitted by this logical
+    /// pipeline execution. Round counters restart on resume/re-execution, so
+    /// they are only unique within this private run scope.
+    pub(super) execution_id: String,
     pub(super) model_name: String,
     pub(super) metrics_collector: Option<MetricsCollector>,
     pub(super) debug_logger: DebugLogger,
@@ -194,6 +198,7 @@ pub(super) async fn initialize_loop_state(
 
     Ok(LoopRunState {
         session_id,
+        execution_id: crate::runtime::runner::round_prelude::new_execution_id(),
         model_name,
         metrics_collector,
         debug_logger,

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
@@ -22,6 +22,7 @@ use bamboo_agent_core::PromptSnapshot;
 /// parameters.  Passed into [`prepare_round`] to keep its parameter count
 /// below the clippy threshold.
 pub(crate) struct RoundPreludeFrame<'a> {
+    pub execution_id: &'a str,
     pub round: usize,
     pub max_rounds: usize,
     pub debug_enabled: bool,
@@ -96,8 +97,29 @@ pub(super) fn update_task_round_state(
     }
 }
 
-pub(super) fn build_round_id(session_id: &str, round: usize) -> String {
-    format!("{}-round-{}", session_id, round + 1)
+pub(crate) fn new_execution_id() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
+}
+
+pub(super) fn build_round_id(session_id: &str, execution_id: &str, round: usize) -> String {
+    debug_assert!(
+        !execution_id.is_empty(),
+        "round metrics require an execution identity"
+    );
+    format!("{session_id}-run-{execution_id}-round-{}", round + 1)
+}
+
+pub(super) fn build_auxiliary_round_id(
+    session_id: &str,
+    execution_id: &str,
+    purpose: &str,
+    round_number: usize,
+) -> String {
+    debug_assert!(
+        !execution_id.is_empty(),
+        "auxiliary round metrics require an execution identity"
+    );
+    format!("{session_id}-run-{execution_id}-{purpose}-round-{round_number}")
 }
 
 pub(super) fn log_round_start(
@@ -282,7 +304,7 @@ pub(crate) async fn prepare_round(
     .await?;
     update_task_round_state(task_context, round, max_rounds);
 
-    let round_id = build_round_id(session_id, round);
+    let round_id = build_round_id(session_id, frame.execution_id, round);
     log_round_start(
         debug_enabled,
         session_id,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
@@ -11,6 +11,7 @@ use crate::runtime::config::AgentLoopConfig;
 use bamboo_agent_core::tools::{FunctionCall, Tool, ToolCtx, ToolError, ToolOutcome, ToolResult};
 use bamboo_agent_core::{Message, Session};
 use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
+use bamboo_metrics::storage::MetricsStorage;
 use bamboo_tools::BuiltinToolExecutorBuilder;
 
 fn task_list_with_in_progress_item(session_id: &str, description: &str) -> TaskList {
@@ -847,4 +848,486 @@ async fn unsuccessful_model_issued_explicit_activation_stops_before_answer_and_r
         .activation_descriptor("unsuccessful-model-activation")
         .await
         .is_none());
+}
+
+struct MetricsQueueProvider {
+    queue: Mutex<Vec<Vec<bamboo_llm::provider::Result<LLMChunk>>>>,
+}
+
+#[async_trait]
+impl LLMProvider for MetricsQueueProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[bamboo_agent_core::tools::ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> bamboo_llm::provider::Result<LLMStream> {
+        let mut queue = self.queue.lock().await;
+        assert!(!queue.is_empty(), "metrics provider queue exhausted");
+        Ok(Box::pin(stream::iter(queue.remove(0))))
+    }
+}
+
+fn provider_usage(prompt: u64, completion: u64) -> LLMChunk {
+    LLMChunk::ProviderUsage {
+        input_tokens: Some(prompt),
+        output_tokens: Some(completion),
+        total_tokens: Some(prompt.saturating_add(completion)),
+        reasoning_tokens: None,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+        cache_write_input_tokens: None,
+    }
+}
+
+fn metric_execution_prefix(round_id: &str) -> &str {
+    round_id
+        .rsplit_once("-round-")
+        .map(|(prefix, _)| prefix)
+        .expect("round id suffix")
+}
+
+async fn create_runner_metrics() -> (
+    tempfile::TempDir,
+    bamboo_metrics::MetricsCollector,
+    Arc<bamboo_metrics::SqliteMetricsStorage>,
+) {
+    let directory = tempfile::tempdir().expect("metrics tempdir");
+    let storage = Arc::new(bamboo_metrics::SqliteMetricsStorage::new(
+        directory.path().join("metrics.db"),
+    ));
+    storage.init().await.expect("initialize metrics storage");
+    let collector = bamboo_metrics::MetricsCollector::spawn(storage.clone(), 7);
+    (directory, collector, storage)
+}
+
+fn runner_metrics_config(collector: &bamboo_metrics::MetricsCollector) -> AgentLoopConfig {
+    AgentLoopConfig {
+        max_rounds: 2,
+        system_prompt: Some("metrics regression test".to_string()),
+        model_name: Some("test-model".to_string()),
+        metrics_collector: Some(collector.clone()),
+        prompt_memory_flags: crate::runtime::config::PromptMemoryFlags {
+            project_prompt_injection: false,
+            relevant_recall: false,
+            relevant_recall_rerank: false,
+            project_first_dream: false,
+            ledger_agenda: false,
+        },
+        ..AgentLoopConfig::default()
+    }
+}
+
+async fn wait_for_runner_metrics(
+    storage: &bamboo_metrics::SqliteMetricsStorage,
+    session_id: &str,
+    expected_rounds: usize,
+    expected_usage: bamboo_metrics::types::TokenUsage,
+) -> bamboo_metrics::types::SessionDetail {
+    for _ in 0..100 {
+        if let Some(detail) = storage
+            .session_detail(session_id)
+            .await
+            .expect("session metrics query")
+        {
+            if detail.rounds.len() == expected_rounds
+                && detail
+                    .rounds
+                    .iter()
+                    .all(|round| round.completed_at.is_some())
+                && detail.session.total_token_usage == expected_usage
+            {
+                return detail;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!(
+        "session {session_id} did not persist {expected_rounds} completed rounds with usage {expected_usage:?}"
+    );
+}
+
+#[tokio::test]
+async fn repeated_execution_of_one_session_keeps_both_metric_rounds() {
+    let session_id = "metrics-repeated-execution";
+    let (_directory, collector, storage) = create_runner_metrics().await;
+    let provider = Arc::new(MetricsQueueProvider {
+        queue: Mutex::new(vec![
+            vec![
+                Ok(provider_usage(10, 2)),
+                Ok(LLMChunk::Token("first answer".to_string())),
+                Ok(LLMChunk::Done),
+            ],
+            vec![
+                Ok(provider_usage(20, 3)),
+                Ok(LLMChunk::Token("second answer".to_string())),
+                Ok(LLMChunk::Done),
+            ],
+        ]),
+    });
+    let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> =
+        Arc::new(bamboo_tools::BuiltinToolExecutor::new());
+    let mut session = Session::new(session_id, "test-model");
+
+    let (first_tx, _first_rx) = mpsc::channel(64);
+    super::run_agent_loop_with_config(
+        &mut session,
+        "first request".to_string(),
+        first_tx,
+        provider.clone(),
+        tools.clone(),
+        CancellationToken::new(),
+        runner_metrics_config(&collector),
+    )
+    .await
+    .expect("first execution");
+
+    let first_detail = wait_for_runner_metrics(
+        storage.as_ref(),
+        session_id,
+        1,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 10,
+            completion_tokens: 2,
+            total_tokens: 12,
+        },
+    )
+    .await;
+    let first_round_id = first_detail.rounds[0].round_id.clone();
+    assert_eq!(
+        first_detail.rounds[0].status,
+        bamboo_metrics::types::RoundStatus::Success
+    );
+
+    let (second_tx, _second_rx) = mpsc::channel(64);
+    super::run_agent_loop_with_config(
+        &mut session,
+        "second request".to_string(),
+        second_tx,
+        provider,
+        tools,
+        CancellationToken::new(),
+        runner_metrics_config(&collector),
+    )
+    .await
+    .expect("second execution");
+
+    let detail = wait_for_runner_metrics(
+        storage.as_ref(),
+        session_id,
+        2,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 30,
+            completion_tokens: 5,
+            total_tokens: 35,
+        },
+    )
+    .await;
+    let first = detail
+        .rounds
+        .iter()
+        .find(|round| round.round_id == first_round_id)
+        .expect("first execution round remains present");
+    assert_eq!(
+        first.token_usage,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 10,
+            completion_tokens: 2,
+            total_tokens: 12,
+        }
+    );
+
+    let second = detail
+        .rounds
+        .iter()
+        .find(|round| round.round_id != first_round_id)
+        .expect("second execution has a distinct round");
+    assert_ne!(first.round_id, second.round_id);
+    assert!(first.round_id.starts_with(&format!("{session_id}-run-")));
+    assert!(second.round_id.starts_with(&format!("{session_id}-run-")));
+    assert_eq!(
+        second.token_usage,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 20,
+            completion_tokens: 3,
+            total_tokens: 23,
+        }
+    );
+    assert_eq!(
+        session
+            .agent_runtime_state
+            .as_ref()
+            .and_then(|state| state.round.last_round_id.as_deref()),
+        Some(second.round_id.as_str())
+    );
+}
+
+struct PauseForHumanTool;
+
+#[async_trait]
+impl Tool for PauseForHumanTool {
+    fn name(&self) -> &str {
+        "pause_for_human"
+    }
+
+    fn description(&self) -> &str {
+        "pause this execution until a human responds"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn invoke(
+        &self,
+        _args: serde_json::Value,
+        ctx: ToolCtx,
+    ) -> Result<ToolOutcome, ToolError> {
+        Ok(ToolOutcome::NeedsHuman {
+            question: bamboo_agent_core::PendingQuestion {
+                tool_call_id: ctx.tool_call_id.to_string(),
+                tool_name: self.name().to_string(),
+                question: "Continue?".to_string(),
+                options: vec!["yes".to_string(), "no".to_string()],
+                allow_custom: false,
+                source: bamboo_agent_core::PendingQuestionSource::PauseTool,
+            },
+            result: ToolResult::text(false, "waiting for a response"),
+        })
+    }
+}
+
+struct ResumeCompleteTool;
+
+#[async_trait]
+impl Tool for ResumeCompleteTool {
+    fn name(&self) -> &str {
+        "complete_after_resume"
+    }
+
+    fn description(&self) -> &str {
+        "complete one tool call after the suspended execution resumes"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn invoke(
+        &self,
+        _args: serde_json::Value,
+        _ctx: ToolCtx,
+    ) -> Result<ToolOutcome, ToolError> {
+        Ok(ToolOutcome::Completed(ToolResult::text(
+            true,
+            "resume tool completed",
+        )))
+    }
+}
+
+#[tokio::test]
+async fn suspended_session_resume_uses_a_new_metric_round_and_preserves_tool_link() {
+    let session_id = "metrics-suspend-resume";
+    let (_directory, collector, storage) = create_runner_metrics().await;
+    let pause_call = bamboo_agent_core::tools::ToolCall {
+        id: "pause-call".to_string(),
+        tool_type: "function".to_string(),
+        function: FunctionCall {
+            name: "pause_for_human".to_string(),
+            arguments: "{}".to_string(),
+        },
+    };
+    let resume_call = bamboo_agent_core::tools::ToolCall {
+        id: "resume-call".to_string(),
+        tool_type: "function".to_string(),
+        function: FunctionCall {
+            name: "complete_after_resume".to_string(),
+            arguments: "{}".to_string(),
+        },
+    };
+    let provider = Arc::new(MetricsQueueProvider {
+        queue: Mutex::new(vec![
+            vec![
+                Ok(provider_usage(7, 2)),
+                Ok(LLMChunk::ToolCalls(vec![pause_call])),
+                Ok(LLMChunk::Done),
+            ],
+            vec![
+                Ok(provider_usage(13, 4)),
+                Ok(LLMChunk::ToolCalls(vec![resume_call])),
+                Ok(LLMChunk::Done),
+            ],
+            vec![
+                Ok(provider_usage(5, 1)),
+                Ok(LLMChunk::Token("resumed answer".to_string())),
+                Ok(LLMChunk::Done),
+            ],
+        ]),
+    });
+    let tools = BuiltinToolExecutorBuilder::new()
+        .with_tool(PauseForHumanTool)
+        .expect("register pause tool")
+        .with_tool(ResumeCompleteTool)
+        .expect("register resume tool")
+        .build();
+    let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(tools);
+    let mut session = Session::new(session_id, "test-model");
+
+    let (first_tx, _first_rx) = mpsc::channel(64);
+    super::run_agent_loop_with_config(
+        &mut session,
+        "need a decision".to_string(),
+        first_tx,
+        provider.clone(),
+        tools.clone(),
+        CancellationToken::new(),
+        runner_metrics_config(&collector),
+    )
+    .await
+    .expect("suspending execution");
+
+    assert!(session.has_pending_question());
+    assert_eq!(
+        session
+            .metadata
+            .get("runtime.suspend_reason")
+            .map(String::as_str),
+        Some("awaiting_clarification")
+    );
+    assert!(session.agent_runtime_state.as_ref().is_some_and(|state| {
+        matches!(state.status, bamboo_domain::AgentStatusState::Suspended)
+    }));
+
+    let first_detail = wait_for_runner_metrics(
+        storage.as_ref(),
+        session_id,
+        1,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 7,
+            completion_tokens: 2,
+            total_tokens: 9,
+        },
+    )
+    .await;
+    let first_round_id = first_detail.rounds[0].round_id.clone();
+    assert_eq!(first_detail.rounds[0].tool_calls.len(), 1);
+    assert_eq!(
+        first_detail.rounds[0].tool_calls[0].tool_call_id,
+        "pause-call"
+    );
+
+    // Mirror the response boundary: the resolved question and suspend marker
+    // are cleared, while the persisted Suspended control-plane state lets the
+    // next invocation take the real resume path.
+    session.clear_pending_question();
+    session.metadata.remove("runtime.suspend_reason");
+
+    let (second_tx, _second_rx) = mpsc::channel(64);
+    super::run_agent_loop_with_config(
+        &mut session,
+        "yes".to_string(),
+        second_tx,
+        provider,
+        tools,
+        CancellationToken::new(),
+        runner_metrics_config(&collector),
+    )
+    .await
+    .expect("resumed execution");
+
+    let detail = wait_for_runner_metrics(
+        storage.as_ref(),
+        session_id,
+        3,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 25,
+            completion_tokens: 7,
+            total_tokens: 32,
+        },
+    )
+    .await;
+    let first = detail
+        .rounds
+        .iter()
+        .find(|round| round.round_id == first_round_id)
+        .expect("suspended round remains present");
+    assert_eq!(first.tool_calls.len(), 1);
+    assert_eq!(first.tool_calls[0].tool_call_id, "pause-call");
+    assert_eq!(
+        first.token_usage,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 7,
+            completion_tokens: 2,
+            total_tokens: 9,
+        }
+    );
+
+    let resumed_tool_round = detail
+        .rounds
+        .iter()
+        .find(|round| {
+            round
+                .tool_calls
+                .iter()
+                .any(|tool| tool.tool_call_id == "resume-call")
+        })
+        .expect("resume tool remains linked to its new round");
+    assert_ne!(first.round_id, resumed_tool_round.round_id);
+    assert_eq!(
+        resumed_tool_round.token_usage,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 13,
+            completion_tokens: 4,
+            total_tokens: 17,
+        }
+    );
+    assert_eq!(resumed_tool_round.tool_calls.len(), 1);
+    assert_eq!(resumed_tool_round.tool_calls[0].tool_call_id, "resume-call");
+
+    let final_round_id = session
+        .agent_runtime_state
+        .as_ref()
+        .and_then(|state| state.round.last_round_id.as_deref())
+        .expect("resumed final round id");
+    let final_round = detail
+        .rounds
+        .iter()
+        .find(|round| round.round_id == final_round_id)
+        .expect("resumed final round remains present");
+    assert_eq!(
+        final_round.token_usage,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 5,
+            completion_tokens: 1,
+            total_tokens: 6,
+        }
+    );
+    assert!(final_round.tool_calls.is_empty());
+
+    assert_eq!(
+        metric_execution_prefix(&resumed_tool_round.round_id),
+        metric_execution_prefix(&final_round.round_id),
+        "all rounds in one resumed execution share the namespace"
+    );
+    assert_ne!(
+        metric_execution_prefix(&first.round_id),
+        metric_execution_prefix(&resumed_tool_round.round_id),
+        "the resume receives a fresh execution namespace"
+    );
+    assert_eq!(
+        session
+            .agent_runtime_state
+            .as_ref()
+            .and_then(|state| state.round.last_round_id.as_deref()),
+        Some(final_round.round_id.as_str())
+    );
 }

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
@@ -1146,8 +1146,15 @@ impl MetricsStorage for SqliteMetricsStorage {
                         completion_tokens = ?4,
                         total_tokens = ?5,
                         prompt_cached_tool_outputs = ?6,
-                        prompt_cached_tool_tokens_saved = COALESCE(prompt_cached_tool_tokens_saved, 0) + ?7,
-                        tokens_saved = COALESCE(tokens_saved, 0) + ?8,
+                        prompt_cached_tool_tokens_saved = ?7,
+                        -- `RoundCompleted` may be replayed. Replace its prompt-
+                        -- cache contribution while preserving tokens recorded by
+                        -- separate compression events, rather than adding the
+                        -- same completion payload again.
+                        tokens_saved = MAX(
+                            COALESCE(tokens_saved, 0) - COALESCE(prompt_cached_tool_tokens_saved, 0),
+                            0
+                        ) + ?8,
                         error = ?9
                     WHERE round_id = ?10
                     "#,
@@ -3015,6 +3022,170 @@ mod tests {
         assert_eq!(detail.session.prompt_cached_tool_outputs, 3);
         assert_eq!(detail.rounds.len(), 1);
         assert_eq!(detail.rounds[0].prompt_cached_tool_outputs, 3);
+    }
+
+    #[tokio::test]
+    async fn distinct_rounds_aggregate_and_same_event_replay_is_idempotent() {
+        let dir = tempdir().expect("temp dir");
+        let storage = SqliteMetricsStorage::new(dir.path().join("metrics.db"));
+        storage.init().await.expect("init storage");
+
+        let session_id = "resumed-session";
+        let first_started = Utc
+            .with_ymd_and_hms(2026, 8, 8, 10, 0, 0)
+            .single()
+            .expect("valid first timestamp");
+        let first_completed = first_started + chrono::Duration::seconds(2);
+        let second_started = first_started + chrono::Duration::minutes(1);
+        let second_completed = second_started + chrono::Duration::seconds(3);
+        let first_round = "resumed-session-run-exec-a-round-1";
+        let second_round = "resumed-session-run-exec-b-round-1";
+
+        storage
+            .upsert_session_start(session_id, "model-a", first_started)
+            .await
+            .expect("session start");
+        storage
+            .insert_round_start(first_round, session_id, "model-a", first_started)
+            .await
+            .expect("first round start");
+        storage
+            .insert_tool_start("tool-first", first_round, session_id, "Read", first_started)
+            .await
+            .expect("first tool start");
+        storage
+            .complete_tool_call(
+                "tool-first",
+                ToolCallCompletion {
+                    completed_at: first_completed,
+                    success: true,
+                    error: None,
+                },
+            )
+            .await
+            .expect("first tool completion");
+        storage
+            .record_round_compression(first_round, first_completed, 5)
+            .await
+            .expect("compression");
+
+        let first_usage = TokenUsage {
+            prompt_tokens: 10,
+            completion_tokens: 2,
+            total_tokens: 12,
+        };
+        storage
+            .complete_round(
+                first_round,
+                first_completed,
+                RoundStatus::Error,
+                first_usage,
+                1,
+                7,
+                Some("first failure".to_string()),
+            )
+            .await
+            .expect("first completion");
+
+        // Replay the exact same metrics events. Starts must remain insert-only,
+        // completion values must remain replacements (not additive), and the
+        // tool must stay linked to this same logical round.
+        storage
+            .insert_round_start(first_round, session_id, "model-a", first_started)
+            .await
+            .expect("replayed round start");
+        storage
+            .insert_tool_start("tool-first", first_round, session_id, "Read", first_started)
+            .await
+            .expect("replayed tool start");
+        storage
+            .complete_tool_call(
+                "tool-first",
+                ToolCallCompletion {
+                    completed_at: first_completed,
+                    success: true,
+                    error: None,
+                },
+            )
+            .await
+            .expect("replayed tool completion");
+        storage
+            .complete_round(
+                first_round,
+                first_completed,
+                RoundStatus::Error,
+                first_usage,
+                1,
+                7,
+                Some("first failure".to_string()),
+            )
+            .await
+            .expect("replayed round completion");
+
+        let second_usage = TokenUsage {
+            prompt_tokens: 20,
+            completion_tokens: 3,
+            total_tokens: 23,
+        };
+        storage
+            .insert_round_start(second_round, session_id, "model-b", second_started)
+            .await
+            .expect("second round start");
+        storage
+            .complete_round(
+                second_round,
+                second_completed,
+                RoundStatus::Success,
+                second_usage,
+                2,
+                11,
+                None,
+            )
+            .await
+            .expect("second completion");
+
+        let detail = storage
+            .session_detail(session_id)
+            .await
+            .expect("session detail query")
+            .expect("session detail");
+        assert_eq!(detail.rounds.len(), 2);
+        assert_eq!(detail.session.total_rounds, 2);
+        assert_eq!(
+            detail.session.total_token_usage,
+            TokenUsage {
+                prompt_tokens: 30,
+                completion_tokens: 5,
+                total_tokens: 35,
+            }
+        );
+        assert_eq!(detail.session.prompt_cached_tool_outputs, 3);
+        assert_eq!(detail.session.prompt_cached_tool_tokens_saved, 18);
+        assert_eq!(detail.session.total_tokens_saved, 23);
+        assert_eq!(detail.session.tool_call_count, 1);
+
+        let first = detail
+            .rounds
+            .iter()
+            .find(|round| round.round_id == first_round)
+            .expect("first round remains present");
+        assert_eq!(first.status, RoundStatus::Error);
+        assert_eq!(first.token_usage, first_usage);
+        assert_eq!(first.error.as_deref(), Some("first failure"));
+        assert_eq!(first.prompt_cached_tool_tokens_saved, 7);
+        assert_eq!(first.compression_count, 1);
+        assert_eq!(first.tokens_saved, 12);
+        assert_eq!(first.tool_calls.len(), 1);
+        assert_eq!(first.tool_calls[0].tool_call_id, "tool-first");
+
+        let second = detail
+            .rounds
+            .iter()
+            .find(|round| round.round_id == second_round)
+            .expect("second round remains present");
+        assert_eq!(second.status, RoundStatus::Success);
+        assert_eq!(second.token_usage, second_usage);
+        assert!(second.tool_calls.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- namespace primary and auxiliary metrics rounds by logical execution
- preserve distinct round rows across repeated execution and suspend/resume
- make replayed round-completion cache-savings updates idempotent

Fixes #689

## Test Plan
- `cargo test -p bamboo-engine --lib`
- `cargo test -p bamboo-infrastructure --lib`
- `cargo clippy -p bamboo-engine -p bamboo-infrastructure --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Screenshots
Not applicable (backend metrics fix).