### PR TITLE
fix(metrics): honor unified timeline granularity

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/filters.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/filters.rs
@@ -1,7 +1,7 @@
 use super::super::{ForwardMetricsQuery, MetricsSessionsQuery};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum TimelineGranularity {
+pub(in crate::handlers::agent::metrics) enum TimelineGranularity {
     Daily,
     Weekly,
     Monthly,
@@ -42,7 +42,7 @@ pub(super) fn build_forward_grouped_filter(
     }
 }
 
-pub(super) fn normalize_days(days: Option<u32>) -> u32 {
+pub(in crate::handlers::agent::metrics) fn normalize_days(days: Option<u32>) -> u32 {
     days.unwrap_or(30).clamp(1, 365)
 }
 
@@ -60,7 +60,9 @@ pub(super) fn normalize_limit(limit: Option<u32>) -> Option<u32> {
     )
 }
 
-pub(super) fn resolve_timeline_granularity(value: Option<&str>) -> TimelineGranularity {
+pub(in crate::handlers::agent::metrics) fn resolve_timeline_granularity(
+    value: Option<&str>,
+) -> TimelineGranularity {
     match value.unwrap_or("daily") {
         "weekly" => TimelineGranularity::Weekly,
         "monthly" => TimelineGranularity::Monthly,

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/mod.rs
@@ -1,5 +1,5 @@
 mod chat;
-mod filters;
+pub(super) mod filters;
 mod forward;
 pub(crate) mod memory;
 mod usage;

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/types.rs
@@ -34,7 +34,8 @@ pub struct MetricsDailyQuery {
     pub days: Option<u32>,
     /// End date for the range
     pub end_date: Option<NaiveDate>,
-    /// Granularity: "daily", "weekly", or "monthly" (default: "daily")
+    /// Granularity: "daily", "weekly", or "monthly" (default: "daily").
+    /// Unknown values follow the existing timeline policy and fall back to daily.
     pub granularity: Option<String>,
 }
 
@@ -398,10 +399,20 @@ pub struct CombinedSummary {
 }
 
 /// Unified timeline point combining chat and forward metrics
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnifiedTimelinePoint {
-    /// Date in YYYY-MM-DD format
+    /// Daily date or backward-compatible period label.
     pub date: String,
+    /// Explicit period start for weekly/monthly responses.
+    ///
+    /// Omitted for daily responses so their existing schema remains unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub period_start: Option<String>,
+    /// Explicit period end for weekly/monthly responses.
+    ///
+    /// Omitted for daily responses so their existing schema remains unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub period_end: Option<String>,
     /// Tokens used in chat sessions
     pub chat_tokens: u64,
     /// Number of chat sessions

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/unified_handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/unified_handlers.rs
@@ -1,6 +1,10 @@
+use std::collections::{BTreeMap, BTreeSet};
+
 use actix_web::{web, HttpResponse, Responder};
+use bamboo_metrics::{DailyMetrics, PeriodMetrics, TokenUsage};
 
 use super::{
+    core_handlers::filters::{normalize_days, resolve_timeline_granularity, TimelineGranularity},
     internal_error, CombinedSummary, MemoryMetricsQuery, MetricsDailyQuery, MetricsSummaryQuery,
     UnifiedSummary, UnifiedTimelinePoint,
 };
@@ -97,7 +101,8 @@ pub async fn v2_unified_timeline(
     state: web::Data<AppState>,
     query: web::Query<MetricsDailyQuery>,
 ) -> impl Responder {
-    let days = query.days.unwrap_or(30).clamp(1, 365);
+    let days = normalize_days(query.days);
+    let granularity = resolve_timeline_granularity(query.granularity.as_deref());
 
     let chat_result = state.metrics_service.daily(days, query.end_date).await;
     let forward_result = state
@@ -112,55 +117,212 @@ pub async fn v2_unified_timeline(
         .await;
 
     match (chat_result, forward_result) {
-        (Ok(chat_daily), Ok(forward_daily)) => {
-            // Build maps for efficient lookup.
-            let chat_map: std::collections::HashMap<String, &bamboo_metrics::DailyMetrics> =
-                chat_daily.iter().map(|d| (d.date.to_string(), d)).collect();
-
-            let forward_map: std::collections::HashMap<String, &bamboo_metrics::DailyMetrics> =
-                forward_daily
-                    .iter()
-                    .map(|d| (d.date.to_string(), d))
-                    .collect();
-
-            // Get all unique dates.
-            let mut dates: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-            for date in chat_map.keys() {
-                dates.insert(date.clone());
-            }
-            for date in forward_map.keys() {
-                dates.insert(date.clone());
-            }
-
-            let timeline: Vec<UnifiedTimelinePoint> = dates
-                .into_iter()
-                .map(|date| {
-                    let chat = chat_map.get(&date);
-                    let forward = forward_map.get(&date);
-
-                    let chat_tokens = chat.map(|d| d.total_token_usage.total_tokens).unwrap_or(0);
-                    let chat_sessions = chat.map(|d| d.total_sessions).unwrap_or(0);
-                    let forward_tokens = forward
-                        .map(|d| d.total_token_usage.total_tokens)
-                        .unwrap_or(0);
-                    let forward_requests = forward.map(|d| d.total_sessions).unwrap_or(0);
-
-                    UnifiedTimelinePoint {
-                        date: date.clone(),
-                        chat_tokens,
-                        chat_sessions,
-                        forward_tokens,
-                        forward_requests,
-                        total_tokens: chat_tokens + forward_tokens,
-                        prompt_cached_tool_outputs: chat
-                            .map(|d| d.prompt_cached_tool_outputs)
-                            .unwrap_or(0),
-                    }
-                })
-                .collect();
-
-            HttpResponse::Ok().json(timeline)
-        }
+        (Ok(chat_daily), Ok(forward_daily)) => HttpResponse::Ok().json(build_unified_timeline(
+            chat_daily,
+            forward_daily,
+            granularity,
+        )),
         (Err(e), _) | (_, Err(e)) => internal_error(e),
+    }
+}
+
+fn build_unified_timeline(
+    chat_daily: Vec<DailyMetrics>,
+    forward_daily: Vec<DailyMetrics>,
+    granularity: TimelineGranularity,
+) -> Vec<UnifiedTimelinePoint> {
+    let (chat_daily, forward_daily) = align_daily_inputs(chat_daily, forward_daily);
+
+    match granularity {
+        TimelineGranularity::Daily => chat_daily
+            .into_iter()
+            .zip(forward_daily)
+            .map(|(chat, forward)| unified_point(chat.date.to_string(), None, chat, forward))
+            .collect(),
+        TimelineGranularity::Weekly => merge_periods(
+            bamboo_metrics::aggregate_weekly(&chat_daily),
+            bamboo_metrics::aggregate_weekly(&forward_daily),
+        ),
+        TimelineGranularity::Monthly => merge_periods(
+            bamboo_metrics::aggregate_monthly(&chat_daily),
+            bamboo_metrics::aggregate_monthly(&forward_daily),
+        ),
+    }
+}
+
+/// Give both sources the same ordered date domain before aggregation.
+///
+/// Filling a missing source with a zero-valued day makes the existing metrics
+/// period aggregator the single boundary authority for both chat and forward.
+/// In particular, sparse activity on different dates can no longer produce
+/// different `period_end` values for the two sides of one unified bucket.
+fn align_daily_inputs(
+    chat_daily: Vec<DailyMetrics>,
+    forward_daily: Vec<DailyMetrics>,
+) -> (Vec<DailyMetrics>, Vec<DailyMetrics>) {
+    let mut chat_by_date = chat_daily
+        .into_iter()
+        .map(|metrics| (metrics.date, metrics))
+        .collect::<BTreeMap<_, _>>();
+    let mut forward_by_date = forward_daily
+        .into_iter()
+        .map(|metrics| (metrics.date, metrics))
+        .collect::<BTreeMap<_, _>>();
+    let dates = chat_by_date
+        .keys()
+        .chain(forward_by_date.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+
+    dates
+        .into_iter()
+        .map(|date| {
+            (
+                chat_by_date
+                    .remove(&date)
+                    .unwrap_or_else(|| empty_daily_metrics(date)),
+                forward_by_date
+                    .remove(&date)
+                    .unwrap_or_else(|| empty_daily_metrics(date)),
+            )
+        })
+        .unzip()
+}
+
+fn merge_periods(
+    chat_periods: Vec<PeriodMetrics>,
+    forward_periods: Vec<PeriodMetrics>,
+) -> Vec<UnifiedTimelinePoint> {
+    chat_periods
+        .into_iter()
+        .zip(forward_periods)
+        .map(|(chat, forward)| {
+            debug_assert_eq!(chat.period_start, forward.period_start);
+            debug_assert_eq!(chat.period_end, forward.period_end);
+
+            let period_start = chat.period_start.to_string();
+            let period_end = chat.period_end.to_string();
+            unified_point(
+                chat.label.clone(),
+                Some((period_start, period_end)),
+                period_as_daily(chat),
+                period_as_daily(forward),
+            )
+        })
+        .collect()
+}
+
+fn unified_point(
+    date: String,
+    period: Option<(String, String)>,
+    chat: DailyMetrics,
+    forward: DailyMetrics,
+) -> UnifiedTimelinePoint {
+    let chat_tokens = chat.total_token_usage.total_tokens;
+    let forward_tokens = forward.total_token_usage.total_tokens;
+    let (period_start, period_end) = period
+        .map(|(start, end)| (Some(start), Some(end)))
+        .unwrap_or((None, None));
+
+    UnifiedTimelinePoint {
+        date,
+        period_start,
+        period_end,
+        chat_tokens,
+        chat_sessions: chat.total_sessions,
+        forward_tokens,
+        forward_requests: forward.total_sessions,
+        total_tokens: chat_tokens + forward_tokens,
+        prompt_cached_tool_outputs: chat.prompt_cached_tool_outputs,
+    }
+}
+
+fn period_as_daily(period: PeriodMetrics) -> DailyMetrics {
+    DailyMetrics {
+        date: period.period_start,
+        total_sessions: period.total_sessions,
+        total_rounds: period.total_rounds,
+        total_token_usage: period.total_token_usage,
+        total_tool_calls: period.total_tool_calls,
+        prompt_cached_tool_outputs: period.prompt_cached_tool_outputs,
+        model_breakdown: period.model_breakdown,
+        tool_breakdown: period.tool_breakdown,
+    }
+}
+
+fn empty_daily_metrics(date: chrono::NaiveDate) -> DailyMetrics {
+    DailyMetrics {
+        date,
+        total_sessions: 0,
+        total_rounds: 0,
+        total_token_usage: TokenUsage::default(),
+        total_tool_calls: 0,
+        prompt_cached_tool_outputs: 0,
+        model_breakdown: Default::default(),
+        tool_breakdown: Default::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use super::*;
+
+    fn daily(date: (i32, u32, u32), requests: u32, tokens: u64) -> DailyMetrics {
+        DailyMetrics {
+            date: NaiveDate::from_ymd_opt(date.0, date.1, date.2).expect("valid fixture date"),
+            total_sessions: requests,
+            total_rounds: requests,
+            total_token_usage: TokenUsage {
+                prompt_tokens: tokens,
+                completion_tokens: 0,
+                total_tokens: tokens,
+            },
+            total_tool_calls: 0,
+            prompt_cached_tool_outputs: requests.into(),
+            model_breakdown: Default::default(),
+            tool_breakdown: Default::default(),
+        }
+    }
+
+    #[test]
+    fn daily_timeline_preserves_schema_and_combines_sources_by_date() {
+        let timeline = build_unified_timeline(
+            vec![daily((2099, 2, 1), 1, 10)],
+            vec![daily((2099, 2, 2), 2, 20)],
+            TimelineGranularity::Daily,
+        );
+
+        assert_eq!(timeline.len(), 2);
+        assert_eq!(timeline[0].date, "2099-02-01");
+        assert_eq!(timeline[0].chat_tokens, 10);
+        assert_eq!(timeline[0].forward_tokens, 0);
+        assert_eq!(timeline[1].chat_tokens, 0);
+        assert_eq!(timeline[1].forward_tokens, 20);
+        assert!(timeline.iter().all(|point| point.period_start.is_none()));
+        assert!(timeline.iter().all(|point| point.period_end.is_none()));
+
+        let json = serde_json::to_value(&timeline[0]).expect("serialize daily point");
+        assert!(json.get("period_start").is_none());
+        assert!(json.get("period_end").is_none());
+    }
+
+    #[test]
+    fn weekly_timeline_uses_one_boundary_contract_for_sparse_sources() {
+        // These dates are Saturday and Sunday in the same Monday-based week.
+        let timeline = build_unified_timeline(
+            vec![daily((2099, 1, 31), 1, 10)],
+            vec![daily((2099, 2, 1), 2, 20)],
+            TimelineGranularity::Weekly,
+        );
+
+        assert_eq!(timeline.len(), 1);
+        assert_eq!(timeline[0].date, "2099-01-26..2099-02-01");
+        assert_eq!(timeline[0].period_start.as_deref(), Some("2099-01-26"));
+        assert_eq!(timeline[0].period_end.as_deref(), Some("2099-02-01"));
+        assert_eq!(timeline[0].chat_sessions, 1);
+        assert_eq!(timeline[0].forward_requests, 2);
+        assert_eq!(timeline[0].total_tokens, 30);
     }
 }

--- a/tests/e2e/metrics/v2.rs
+++ b/tests/e2e/metrics/v2.rs
@@ -1,4 +1,123 @@
 use super::*;
+use bamboo_metrics::{
+    ForwardStatus, MetricsStorage, RoundStatus, SessionStatus, SqliteMetricsStorage, TokenUsage,
+};
+use chrono::{Duration, NaiveDate, TimeZone, Utc};
+
+async fn seed_chat_metrics(
+    storage: &SqliteMetricsStorage,
+    suffix: &str,
+    date: NaiveDate,
+    tokens: u64,
+) {
+    let started_at = Utc.from_utc_datetime(
+        &date
+            .and_hms_opt(12, 0, 0)
+            .expect("fixture date has a valid noon"),
+    );
+    let session_id = format!("timeline-session-{suffix}");
+    let round_id = format!("timeline-round-{suffix}");
+
+    storage
+        .upsert_session_start(&session_id, "chat-model", started_at)
+        .await
+        .expect("seed session start");
+    storage
+        .insert_round_start(&round_id, &session_id, "chat-model", started_at)
+        .await
+        .expect("seed round start");
+    storage
+        .complete_round(
+            &round_id,
+            started_at + Duration::seconds(1),
+            RoundStatus::Success,
+            TokenUsage {
+                prompt_tokens: tokens,
+                completion_tokens: 0,
+                total_tokens: tokens,
+            },
+            1,
+            0,
+            None,
+        )
+        .await
+        .expect("seed round completion");
+    storage
+        .complete_session(
+            &session_id,
+            SessionStatus::Completed,
+            started_at + Duration::seconds(2),
+        )
+        .await
+        .expect("seed session completion");
+}
+
+async fn seed_forward_metrics(
+    storage: &SqliteMetricsStorage,
+    suffix: &str,
+    date: NaiveDate,
+    tokens: u64,
+) {
+    let started_at = Utc.from_utc_datetime(
+        &date
+            .and_hms_opt(12, 0, 0)
+            .expect("fixture date has a valid noon"),
+    );
+    let forward_id = format!("timeline-forward-{suffix}");
+
+    storage
+        .insert_forward_start(
+            &forward_id,
+            "openai.chat_completions",
+            "forward-model",
+            false,
+            started_at,
+        )
+        .await
+        .expect("seed forward start");
+    storage
+        .complete_forward(
+            &forward_id,
+            started_at + Duration::seconds(1),
+            Some(200),
+            ForwardStatus::Success,
+            Some(TokenUsage {
+                prompt_tokens: tokens,
+                completion_tokens: 0,
+                total_tokens: tokens,
+            }),
+            None,
+            None,
+        )
+        .await
+        .expect("seed forward completion");
+}
+
+fn timeline_totals(
+    timeline: &[handlers::metrics::UnifiedTimelinePoint],
+) -> (u64, u64, u64, u32, u32, u64) {
+    timeline.iter().fold(
+        (0, 0, 0, 0, 0, 0),
+        |(
+            chat_tokens,
+            forward_tokens,
+            total_tokens,
+            chat_sessions,
+            forward_requests,
+            cached_outputs,
+        ),
+         point| {
+            (
+                chat_tokens + point.chat_tokens,
+                forward_tokens + point.forward_tokens,
+                total_tokens + point.total_tokens,
+                chat_sessions + point.chat_sessions,
+                forward_requests + point.forward_requests,
+                cached_outputs + point.prompt_cached_tool_outputs,
+            )
+        },
+    )
+}
 
 #[actix_web::test]
 async fn test_metrics_v2_summary_endpoint() {
@@ -36,4 +155,130 @@ async fn test_metrics_v2_timeline_endpoint() {
     let resp = test::call_service(&app, req).await;
 
     assert!(resp.status().is_success());
+}
+
+#[actix_web::test]
+async fn test_metrics_v2_timeline_honors_granularity_and_reconciles_totals() {
+    let state = crate::e2e::common::create_test_app().await;
+    let storage = SqliteMetricsStorage::new(state.app_data_dir.join("metrics.db"));
+    storage.init().await.expect("initialize metrics storage");
+
+    // The fixed future range is immune to the service's rolling retention
+    // worker. Jan 31/Feb 1 and Feb 28/Mar 1 are sparse chat/forward pairs in
+    // the same Monday-based weeks, while also crossing calendar months.
+    seed_chat_metrics(
+        &storage,
+        "jan-31",
+        NaiveDate::from_ymd_opt(2099, 1, 31).expect("valid date"),
+        10,
+    )
+    .await;
+    seed_forward_metrics(
+        &storage,
+        "feb-01",
+        NaiveDate::from_ymd_opt(2099, 2, 1).expect("valid date"),
+        20,
+    )
+    .await;
+    seed_chat_metrics(
+        &storage,
+        "feb-08",
+        NaiveDate::from_ymd_opt(2099, 2, 8).expect("valid date"),
+        30,
+    )
+    .await;
+    seed_forward_metrics(
+        &storage,
+        "feb-28",
+        NaiveDate::from_ymd_opt(2099, 2, 28).expect("valid date"),
+        40,
+    )
+    .await;
+    seed_chat_metrics(
+        &storage,
+        "mar-01",
+        NaiveDate::from_ymd_opt(2099, 3, 1).expect("valid date"),
+        50,
+    )
+    .await;
+
+    let app = test::init_service(App::new().app_data(state).route(
+        "/api/v1/metrics/v2/timeline",
+        web::get().to(handlers::metrics::v2_unified_timeline),
+    ))
+    .await;
+    let range = "days=40&end_date=2099-03-08";
+
+    let default: Vec<handlers::metrics::UnifiedTimelinePoint> = test::call_and_read_body_json(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/v1/metrics/v2/timeline?{range}"))
+            .to_request(),
+    )
+    .await;
+    let daily: Vec<handlers::metrics::UnifiedTimelinePoint> = test::call_and_read_body_json(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!(
+                "/api/v1/metrics/v2/timeline?{range}&granularity=daily"
+            ))
+            .to_request(),
+    )
+    .await;
+    let weekly: Vec<handlers::metrics::UnifiedTimelinePoint> = test::call_and_read_body_json(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!(
+                "/api/v1/metrics/v2/timeline?{range}&granularity=weekly"
+            ))
+            .to_request(),
+    )
+    .await;
+    let monthly: Vec<handlers::metrics::UnifiedTimelinePoint> = test::call_and_read_body_json(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!(
+                "/api/v1/metrics/v2/timeline?{range}&granularity=monthly"
+            ))
+            .to_request(),
+    )
+    .await;
+    let invalid: Vec<handlers::metrics::UnifiedTimelinePoint> = test::call_and_read_body_json(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!(
+                "/api/v1/metrics/v2/timeline?{range}&granularity=unexpected"
+            ))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(default, daily, "omitted granularity defaults to daily");
+    assert_eq!(invalid, daily, "unknown granularity follows /metrics/daily");
+    assert_eq!(daily.len(), 5);
+    assert!(daily.iter().all(|point| point.period_start.is_none()));
+    assert!(daily.iter().all(|point| point.period_end.is_none()));
+
+    assert_eq!(weekly.len(), 3);
+    assert_eq!(weekly[0].date, "2099-01-26..2099-02-01");
+    assert_eq!(weekly[0].period_start.as_deref(), Some("2099-01-26"));
+    assert_eq!(weekly[0].period_end.as_deref(), Some("2099-02-01"));
+    assert_eq!(weekly[0].chat_tokens, 10);
+    assert_eq!(weekly[0].forward_tokens, 20);
+    assert_eq!(weekly[2].date, "2099-02-23..2099-03-01");
+    assert_eq!(weekly[2].chat_tokens, 50);
+    assert_eq!(weekly[2].forward_tokens, 40);
+
+    assert_eq!(monthly.len(), 3);
+    assert_eq!(monthly[0].period_start.as_deref(), Some("2099-01-01"));
+    assert_eq!(monthly[0].period_end.as_deref(), Some("2099-01-31"));
+    assert_eq!(monthly[1].period_start.as_deref(), Some("2099-02-01"));
+    assert_eq!(monthly[1].period_end.as_deref(), Some("2099-02-28"));
+    assert_eq!(monthly[2].period_start.as_deref(), Some("2099-03-01"));
+    assert_eq!(monthly[2].period_end.as_deref(), Some("2099-03-01"));
+
+    let expected = (90, 60, 150, 3, 2, 3);
+    assert_eq!(timeline_totals(&daily), expected);
+    assert_eq!(timeline_totals(&weekly), expected);
+    assert_eq!(timeline_totals(&monthly), expected);
 }


### PR DESCRIPTION
## Summary
- honor the requested daily, weekly, or monthly granularity in the unified metrics timeline
- align chat and forwarding daily series before applying the shared weekly/monthly aggregators, so sparse sources use identical period boundaries
- expose explicit period boundaries for non-daily points while preserving the existing daily response shape
- document and test the existing invalid-granularity fallback to daily

## Test Plan
- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code`
- `cargo test --all-features --lib --tests`
- `cargo test -p bamboo-server handlers::agent::metrics --lib`
- `cargo test -p bamboo-agent --test e2e_tests metrics::v2`
- `cargo test -p bamboo-metrics --lib`
- `cargo build --examples`
- `git diff --check`

## Screenshots
Not applicable (server API behavior only).

Fixes #691