### PR TITLE
fix(engine): control task evaluation lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/core/bamboo-domain/src/session/persistence.rs
+++ b/crates/core/bamboo-domain/src/session/persistence.rs
@@ -230,10 +230,14 @@ pub trait RuntimeSessionPersistence: Send + Sync {
         Ok(false)
     }
 
-    /// Atomically compare-and-patch the executing session and its shared root.
+    /// Recoverably compare-and-patch the executing session and its shared root.
     /// Implementations must validate both generations before either target is
-    /// written. Root-session callers pass the same id twice and receive the
-    /// single-target CAS semantics above.
+    /// written and may return `Ok(true)` only after both Task generations are
+    /// durable with no undo record that could later revert them. An error after
+    /// one physical write must restore both originals before returning or retain
+    /// durable recovery state and fail subsequent paired access closed until
+    /// recovery completes. Root-session callers pass the same id twice and
+    /// receive the single-target CAS semantics above.
     async fn update_task_list_control_planes_if_version(
         &self,
         session_id: &str,

--- a/crates/core/bamboo-domain/src/session/persistence.rs
+++ b/crates/core/bamboo-domain/src/session/persistence.rs
@@ -213,7 +213,7 @@ pub trait RuntimeSessionPersistence: Send + Sync {
     }
 
     /// Atomically update Task-owned control-plane fields only when the durable
-    /// Task generation still matches `expected_version`.
+    /// Task generation and exact list still match the expected snapshot.
     ///
     /// `false` covers an unsupported atomic compare-and-patch, a missing target,
     /// or a version conflict. Callers must treat it as a stale write and must
@@ -223,10 +223,17 @@ pub trait RuntimeSessionPersistence: Send + Sync {
         &self,
         session_id: &str,
         expected_version: &str,
+        expected_task_list: &TaskList,
         task_list: &TaskList,
         version: &str,
     ) -> io::Result<bool> {
-        let _ = (session_id, expected_version, task_list, version);
+        let _ = (
+            session_id,
+            expected_version,
+            expected_task_list,
+            task_list,
+            version,
+        );
         Ok(false)
     }
 
@@ -243,6 +250,7 @@ pub trait RuntimeSessionPersistence: Send + Sync {
         session_id: &str,
         shared_session_id: &str,
         expected_version: &str,
+        expected_task_list: &TaskList,
         task_list: &TaskList,
         version: &str,
     ) -> io::Result<bool> {
@@ -251,6 +259,7 @@ pub trait RuntimeSessionPersistence: Send + Sync {
                 .update_task_list_control_plane_if_version(
                     session_id,
                     expected_version,
+                    expected_task_list,
                     task_list,
                     version,
                 )
@@ -260,6 +269,7 @@ pub trait RuntimeSessionPersistence: Send + Sync {
             session_id,
             shared_session_id,
             expected_version,
+            expected_task_list,
             task_list,
             version,
         );
@@ -365,6 +375,7 @@ impl<T: RuntimeSessionPersistence + ?Sized> RuntimeSessionPersistence for Arc<T>
         &self,
         session_id: &str,
         expected_version: &str,
+        expected_task_list: &TaskList,
         task_list: &TaskList,
         version: &str,
     ) -> io::Result<bool> {
@@ -372,6 +383,7 @@ impl<T: RuntimeSessionPersistence + ?Sized> RuntimeSessionPersistence for Arc<T>
             .update_task_list_control_plane_if_version(
                 session_id,
                 expected_version,
+                expected_task_list,
                 task_list,
                 version,
             )
@@ -383,6 +395,7 @@ impl<T: RuntimeSessionPersistence + ?Sized> RuntimeSessionPersistence for Arc<T>
         session_id: &str,
         shared_session_id: &str,
         expected_version: &str,
+        expected_task_list: &TaskList,
         task_list: &TaskList,
         version: &str,
     ) -> io::Result<bool> {
@@ -391,6 +404,7 @@ impl<T: RuntimeSessionPersistence + ?Sized> RuntimeSessionPersistence for Arc<T>
                 session_id,
                 shared_session_id,
                 expected_version,
+                expected_task_list,
                 task_list,
                 version,
             )

--- a/crates/core/bamboo-domain/src/session/persistence.rs
+++ b/crates/core/bamboo-domain/src/session/persistence.rs
@@ -212,6 +212,56 @@ pub trait RuntimeSessionPersistence: Send + Sync {
         Ok(true)
     }
 
+    /// Atomically update Task-owned control-plane fields only when the durable
+    /// Task generation still matches `expected_version`.
+    ///
+    /// `false` covers an unsupported atomic compare-and-patch, a missing target,
+    /// or a version conflict. Callers must treat it as a stale write and must
+    /// not publish their staged Task state. The default fails closed because a
+    /// load followed by a separately locked save is not an atomic CAS.
+    async fn update_task_list_control_plane_if_version(
+        &self,
+        session_id: &str,
+        expected_version: &str,
+        task_list: &TaskList,
+        version: &str,
+    ) -> io::Result<bool> {
+        let _ = (session_id, expected_version, task_list, version);
+        Ok(false)
+    }
+
+    /// Atomically compare-and-patch the executing session and its shared root.
+    /// Implementations must validate both generations before either target is
+    /// written. Root-session callers pass the same id twice and receive the
+    /// single-target CAS semantics above.
+    async fn update_task_list_control_planes_if_version(
+        &self,
+        session_id: &str,
+        shared_session_id: &str,
+        expected_version: &str,
+        task_list: &TaskList,
+        version: &str,
+    ) -> io::Result<bool> {
+        if session_id == shared_session_id {
+            return self
+                .update_task_list_control_plane_if_version(
+                    session_id,
+                    expected_version,
+                    task_list,
+                    version,
+                )
+                .await;
+        }
+        let _ = (
+            session_id,
+            shared_session_id,
+            expected_version,
+            task_list,
+            version,
+        );
+        Ok(false)
+    }
+
     /// Append-safe checkpoint used at the shared engine execute boundary.
     ///
     /// Unlike [`save_runtime_session`](Self::save_runtime_session), this must
@@ -304,6 +354,42 @@ impl<T: RuntimeSessionPersistence + ?Sized> RuntimeSessionPersistence for Arc<T>
     ) -> io::Result<bool> {
         (**self)
             .update_task_list_control_plane(session_id, task_list, version)
+            .await
+    }
+
+    async fn update_task_list_control_plane_if_version(
+        &self,
+        session_id: &str,
+        expected_version: &str,
+        task_list: &TaskList,
+        version: &str,
+    ) -> io::Result<bool> {
+        (**self)
+            .update_task_list_control_plane_if_version(
+                session_id,
+                expected_version,
+                task_list,
+                version,
+            )
+            .await
+    }
+
+    async fn update_task_list_control_planes_if_version(
+        &self,
+        session_id: &str,
+        shared_session_id: &str,
+        expected_version: &str,
+        task_list: &TaskList,
+        version: &str,
+    ) -> io::Result<bool> {
+        (**self)
+            .update_task_list_control_planes_if_version(
+                session_id,
+                shared_session_id,
+                expected_version,
+                task_list,
+                version,
+            )
             .await
     }
 

--- a/crates/core/bamboo-domain/src/storage.rs
+++ b/crates/core/bamboo-domain/src/storage.rs
@@ -46,6 +46,77 @@ pub trait Storage: Send + Sync {
         self.load_session(session_id).await
     }
 
+    /// Recover an interrupted two-session Task control-plane transaction for
+    /// this exact, lexically ordered session pair before either snapshot is
+    /// read. Backends without a recovery journal have nothing to do.
+    ///
+    /// Implementations that retain an undo journal after a failed rollback must
+    /// fail closed on ordinary control-plane reads/writes until this operation
+    /// succeeds; otherwise callers could continue from a permanently divergent
+    /// child/root Task generation in the same process.
+    async fn recover_task_control_plane_transaction(
+        &self,
+        first_session_id: &str,
+        second_session_id: &str,
+    ) -> std::io::Result<()> {
+        let _ = (first_session_id, second_session_id);
+        Ok(())
+    }
+
+    /// Final-CAS one Task-owned control-plane snapshot. The backend must
+    /// re-read the durable Task list/generation under the same lock as its
+    /// atomic sidecar replacement, compare them with `original`, and build the
+    /// physical write from that current snapshot while patching only Task-owned
+    /// fields from `updated`.
+    ///
+    /// `Ok(true)` commits, `Ok(false)` reports a stale/missing target without
+    /// writing, and unsupported backends must fail before mutation. This port
+    /// prevents independent [`crate::RuntimeSessionPersistence`] wrappers from
+    /// both publishing candidates staged from the same generation.
+    async fn save_task_control_plane_if_matches(
+        &self,
+        original: &Session,
+        updated: &Session,
+    ) -> std::io::Result<bool> {
+        let _ = (original, updated);
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "storage backend does not support atomic Task control-plane CAS",
+        ))
+    }
+
+    /// Commit two already-existing runtime control planes as one recoverable
+    /// Task transaction. Arguments must be ordered lexically by session id and
+    /// each updated snapshot must have the same id as its original snapshot.
+    ///
+    /// `Ok(true)` is the commit point: both Task lists/generations are durable
+    /// and no recovery journal may remain that could later undo them. The
+    /// backend must revalidate both Task-owned original snapshots while holding
+    /// its final transaction lock; `Ok(false)` reports a stale-generation
+    /// conflict and must not write either target or publish a journal. `Err`
+    /// requires both originals to remain durable, or a retained recovery
+    /// journal plus fail-closed access until recovery restores them.
+    /// Implementations unable to provide that contract must return
+    /// `Unsupported` before writing.
+    async fn save_task_control_planes_atomically(
+        &self,
+        first_original: &Session,
+        first_updated: &Session,
+        second_original: &Session,
+        second_updated: &Session,
+    ) -> std::io::Result<bool> {
+        let _ = (
+            first_original,
+            first_updated,
+            second_original,
+            second_updated,
+        );
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "storage backend does not support recoverable paired Task control-plane writes",
+        ))
+    }
+
     /// List `(child_session_id, last_run_status)` for every direct child of the
     /// given parent session, sourced from the index/metadata the backend keeps.
     ///

--- a/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
+++ b/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::config::GoldConfig;
-use crate::runtime::gold_evaluation::{evaluate_gold, GoldEvaluationResult};
+use crate::runtime::gold_evaluation::GoldEvaluationResult;
 use crate::TaskLoopContext;
 use bamboo_agent_core::{AgentEvent, Session};
 use bamboo_domain::reasoning::ReasoningEffort;
@@ -16,15 +16,20 @@ use crate::session_app::provider_model::session_effective_model_ref;
 use super::decision::{parse_gold_auto_answer_decision, GoldAutoAnswerDecision};
 use super::prompt::{build_gold_auto_answer_messages, get_gold_auto_answer_tools};
 
+pub(crate) struct GoldAuxiliaryTarget {
+    pub(crate) provider: Arc<dyn LLMProvider>,
+    pub(crate) model: String,
+    pub(crate) timeout_context: crate::runtime::stream::handler::StreamTimeoutContext,
+    pub(crate) configured_limit: usize,
+}
+
 pub(crate) async fn evaluate_gold_state_for_pending_question(
     state: &dyn AgentSessionContext,
     session_id: &str,
     session: &Session,
     gold_config: &GoldConfig,
 ) -> Result<GoldEvaluationResult, String> {
-    let task_context = TaskLoopContext::from_session(session);
-    let (provider, model, provider_name, stream_timeout) =
-        resolve_gold_provider_and_model(state, session, gold_config).await?;
+    let target = resolve_gold_provider_and_model(state, session, gold_config).await?;
     let iteration = session
         .agent_runtime_state
         .as_ref()
@@ -39,24 +44,13 @@ pub(crate) async fn evaluate_gold_state_for_pending_question(
         }
     });
 
-    let result = evaluate_gold(
+    let result = evaluate_gold_state_with_target(
+        session_id,
         session,
-        task_context.as_ref(),
         gold_config,
-        provider,
-        &crate::runtime::gold_evaluation::GoldEvalFrame {
-            event_tx: &event_tx,
-            session_id,
-            model: &model,
-            timeout_context: crate::runtime::stream::handler::StreamTimeoutContext::new(
-                stream_timeout,
-                Some(&provider_name),
-                Some(&model),
-            ),
-            reasoning_effort: session.reasoning_effort,
-            checkpoint: bamboo_agent_core::GoldCheckpoint::Terminal,
-            iteration,
-        },
+        target,
+        &event_tx,
+        iteration,
     )
     .await
     .map_err(|error| error.to_string());
@@ -66,6 +60,51 @@ pub(crate) async fn evaluate_gold_state_for_pending_question(
     result
 }
 
+pub(crate) async fn evaluate_gold_state_with_target(
+    session_id: &str,
+    session: &Session,
+    gold_config: &GoldConfig,
+    target: GoldAuxiliaryTarget,
+    event_tx: &mpsc::Sender<AgentEvent>,
+    iteration: u32,
+) -> Result<GoldEvaluationResult, bamboo_agent_core::AgentError> {
+    let GoldAuxiliaryTarget {
+        provider,
+        model,
+        timeout_context,
+        configured_limit,
+    } = target;
+    let task_context = TaskLoopContext::from_session(session);
+    let budget_provider = provider.clone();
+    let budget_model = model.clone();
+    let acquire_dispatch_guard = async move {
+        crate::runtime::runner::auxiliary_budget::acquire(
+            &budget_provider,
+            &budget_model,
+            configured_limit,
+        )
+        .await
+    };
+
+    crate::runtime::gold_evaluation::evaluate_gold_with_dispatch(
+        session,
+        task_context.as_ref(),
+        gold_config,
+        provider,
+        &crate::runtime::gold_evaluation::GoldEvalFrame {
+            event_tx,
+            session_id,
+            model: &model,
+            timeout_context,
+            reasoning_effort: session.reasoning_effort,
+            checkpoint: bamboo_agent_core::GoldCheckpoint::Terminal,
+            iteration,
+        },
+        acquire_dispatch_guard,
+    )
+    .await
+}
+
 pub(crate) async fn evaluate_gold_auto_answer_question(
     state: &dyn AgentSessionContext,
     session_id: &str,
@@ -73,14 +112,35 @@ pub(crate) async fn evaluate_gold_auto_answer_question(
     gold_config: &GoldConfig,
     state_evaluation: &GoldEvaluationResult,
 ) -> Result<GoldAutoAnswerDecision, String> {
+    if session.pending_question.is_none() {
+        return Ok(GoldAutoAnswerDecision::decline(
+            "no pending question available",
+        ));
+    }
+
+    let target = resolve_gold_provider_and_model(state, session, gold_config).await?;
+    evaluate_gold_auto_answer_question_with_target(
+        session_id,
+        session,
+        gold_config,
+        state_evaluation,
+        target,
+    )
+    .await
+}
+
+pub(crate) async fn evaluate_gold_auto_answer_question_with_target(
+    session_id: &str,
+    session: &Session,
+    gold_config: &GoldConfig,
+    state_evaluation: &GoldEvaluationResult,
+    target: GoldAuxiliaryTarget,
+) -> Result<GoldAutoAnswerDecision, String> {
     let Some(pending) = session.pending_question.as_ref() else {
         return Ok(GoldAutoAnswerDecision::decline(
             "no pending question available",
         ));
     };
-
-    let (provider, model, provider_name, stream_timeout) =
-        resolve_gold_provider_and_model(state, session, gold_config).await?;
     let messages = build_gold_auto_answer_messages(session, pending, state_evaluation, gold_config);
     let tools = get_gold_auto_answer_tools();
     let request_options = LLMRequestOptions {
@@ -93,19 +153,20 @@ pub(crate) async fn evaluate_gold_auto_answer_question(
         cache: None,
     };
 
-    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
-        stream_timeout,
-        Some(&provider_name),
-        Some(&model),
-    )
-    .begin_request();
     let cancel_token = CancellationToken::new();
+    let _dispatch_guard = crate::runtime::runner::auxiliary_budget::acquire(
+        &target.provider,
+        &target.model,
+        target.configured_limit,
+    )
+    .await;
+    let timeout_context = target.timeout_context.begin_request();
     let stream = crate::runtime::stream::handler::await_stream_bootstrap(
-        provider.chat_stream_with_options(
+        target.provider.chat_stream_with_options(
             &messages,
             &tools,
             Some(gold_config.max_output_tokens),
-            &model,
+            &target.model,
             Some(&request_options),
         ),
         &cancel_token,
@@ -138,21 +199,19 @@ async fn resolve_gold_provider_and_model(
     state: &dyn AgentSessionContext,
     session: &Session,
     gold_config: &GoldConfig,
-) -> Result<
-    (
-        Arc<dyn LLMProvider>,
-        String,
-        String,
-        bamboo_config::StreamTimeoutConfig,
-    ),
-    String,
-> {
+) -> Result<GoldAuxiliaryTarget, String> {
     // Resolve fast model eagerly for the fallback chain.
     let config_snapshot = state.config().read().await.clone();
     let provider_name = session_effective_model_ref(session)
         .map(|r| r.provider.clone())
         .unwrap_or_else(|| config_snapshot.provider.clone());
     let stream_timeout = config_snapshot.stream_timeout;
+    let configured_limit = crate::runtime::config::normalize_auxiliary_evaluation_max_concurrency(
+        config_snapshot
+            .extra
+            .get("auxiliary_evaluation_max_concurrency")
+            .and_then(serde_json::Value::as_u64),
+    );
     let fast_model_name = crate::model_config_helper::resolve_fast_model(
         &config_snapshot,
         &provider_name,
@@ -181,13 +240,31 @@ async fn resolve_gold_provider_and_model(
     if let Some(model_ref) = session_effective_model_ref(session) {
         let target = ProviderModelRef::new(model_ref.provider.clone(), model.clone());
         if let Some(provider) = state.get_provider_for_model_ref(&target) {
-            return Ok((provider, model, provider_name, stream_timeout));
+            return Ok(gold_auxiliary_target(
+                provider,
+                model,
+                provider_name,
+                stream_timeout,
+                configured_limit,
+            ));
         }
         if let Some(provider) = state.provider_registry().get(&model_ref.provider) {
-            return Ok((provider, model, provider_name, stream_timeout));
+            return Ok(gold_auxiliary_target(
+                provider,
+                model,
+                provider_name,
+                stream_timeout,
+                configured_limit,
+            ));
         }
         if let Some(provider) = state.get_provider_for_endpoint(&model_ref.provider).await {
-            return Ok((provider, model, provider_name, stream_timeout));
+            return Ok(gold_auxiliary_target(
+                provider,
+                model,
+                provider_name,
+                stream_timeout,
+                configured_limit,
+            ));
         }
     }
 
@@ -199,36 +276,65 @@ async fn resolve_gold_provider_and_model(
         .filter(|value| !value.is_empty())
     {
         if let Some(provider) = state.provider_registry().get(metadata_provider_name) {
-            return Ok((
+            return Ok(gold_auxiliary_target(
                 provider,
                 model,
                 metadata_provider_name.to_string(),
                 stream_timeout,
+                configured_limit,
             ));
         }
         if let Some(provider) = state
             .get_provider_for_endpoint(metadata_provider_name)
             .await
         {
-            return Ok((
+            return Ok(gold_auxiliary_target(
                 provider,
                 model,
                 metadata_provider_name.to_string(),
                 stream_timeout,
+                configured_limit,
             ));
         }
     }
 
     if let Some(provider) = state.provider_registry().get_default() {
-        return Ok((provider, model, provider_name, stream_timeout));
+        return Ok(gold_auxiliary_target(
+            provider,
+            model,
+            provider_name,
+            stream_timeout,
+            configured_limit,
+        ));
     }
 
-    Ok((
+    Ok(gold_auxiliary_target(
         state.get_provider().await,
         model,
         provider_name,
         stream_timeout,
+        configured_limit,
     ))
+}
+
+fn gold_auxiliary_target(
+    provider: Arc<dyn LLMProvider>,
+    model: String,
+    provider_name: String,
+    stream_timeout: bamboo_config::StreamTimeoutConfig,
+    configured_limit: usize,
+) -> GoldAuxiliaryTarget {
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
+        stream_timeout,
+        Some(&provider_name),
+        Some(&model),
+    );
+    GoldAuxiliaryTarget {
+        provider,
+        model,
+        timeout_context,
+        configured_limit,
+    }
 }
 
 fn normalize_lightweight_reasoning_effort(

--- a/crates/engine/bamboo-engine/src/gold_auto_answer/mod.rs
+++ b/crates/engine/bamboo-engine/src/gold_auto_answer/mod.rs
@@ -21,6 +21,11 @@ use decision::{
     canonicalize_pending_answer, session_is_awaiting_clarification, should_attempt_gold_auto_answer,
 };
 use evaluation::{evaluate_gold_auto_answer_question, evaluate_gold_state_for_pending_question};
+#[cfg(test)]
+pub(crate) use evaluation::{
+    evaluate_gold_auto_answer_question_with_target, evaluate_gold_state_with_target,
+    GoldAuxiliaryTarget,
+};
 use resume::{build_resume_config_snapshot, plan_mode_transition_event};
 
 const GOLD_AUTO_ANSWER_TOOL_NAME: &str = "report_gold_auto_answer";

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -19,6 +19,21 @@ use serde::{Deserialize, Serialize};
 
 use super::hooks::HookRunner;
 
+/// Default process-wide concurrency ceiling for low-priority auxiliary
+/// evaluations sharing one provider/model allocation.
+pub(crate) const DEFAULT_AUXILIARY_EVALUATION_MAX_CONCURRENCY: usize = 2;
+/// Defensive ceiling for operator-provided auxiliary concurrency. This stays
+/// far below Tokio semaphore's implementation maximum and prevents a malformed
+/// flattened config value from panicking process startup.
+pub(crate) const MAX_AUXILIARY_EVALUATION_MAX_CONCURRENCY: usize = 1024;
+
+pub(crate) fn normalize_auxiliary_evaluation_max_concurrency(value: Option<u64>) -> usize {
+    value
+        .filter(|value| *value > 0)
+        .map(|value| value.min(MAX_AUXILIARY_EVALUATION_MAX_CONCURRENCY as u64) as usize)
+        .unwrap_or(DEFAULT_AUXILIARY_EVALUATION_MAX_CONCURRENCY)
+}
+
 /// The live disabled tool and skill-id sets resolved at a round boundary.
 pub type DisabledFilterSets = (BTreeSet<String>, BTreeSet<String>);
 
@@ -382,6 +397,10 @@ pub struct AgentLoopConfig {
     pub(crate) fast_model_name: Option<String>,
     /// Optional provider override for lightweight fast-model LLM calls.
     pub(crate) fast_model_provider: Option<Arc<dyn LLMProvider>>,
+    /// Process-wide concurrency ceiling for low-priority auxiliary evaluation
+    /// requests sharing the same provider allocation and model. Foreground
+    /// requests do not acquire this budget.
+    pub(crate) auxiliary_evaluation_max_concurrency: usize,
     /// Fast/cheap model for memory/background tasks.
     ///
     /// This must not silently fall back to the main interaction model.
@@ -550,6 +569,7 @@ impl Default for AgentLoopConfig {
             model_name: None,
             fast_model_name: None,
             fast_model_provider: None,
+            auxiliary_evaluation_max_concurrency: DEFAULT_AUXILIARY_EVALUATION_MAX_CONCURRENCY,
             background_model_name: None,
             planning_model_name: None,
             search_model_name: None,

--- a/crates/engine/bamboo-engine/src/runtime/config/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config/tests.rs
@@ -1,7 +1,27 @@
 use bamboo_agent_core::Session;
 use bamboo_config::MemoryConfig;
 
-use super::{AgentLoopConfig, PromptMemoryFlags};
+use super::{
+    normalize_auxiliary_evaluation_max_concurrency, AgentLoopConfig, PromptMemoryFlags,
+    DEFAULT_AUXILIARY_EVALUATION_MAX_CONCURRENCY, MAX_AUXILIARY_EVALUATION_MAX_CONCURRENCY,
+};
+
+#[test]
+fn auxiliary_evaluation_concurrency_defaults_and_clamps_oversized_config() {
+    assert_eq!(
+        normalize_auxiliary_evaluation_max_concurrency(None),
+        DEFAULT_AUXILIARY_EVALUATION_MAX_CONCURRENCY
+    );
+    assert_eq!(
+        normalize_auxiliary_evaluation_max_concurrency(Some(0)),
+        DEFAULT_AUXILIARY_EVALUATION_MAX_CONCURRENCY
+    );
+    assert_eq!(normalize_auxiliary_evaluation_max_concurrency(Some(7)), 7);
+    assert_eq!(
+        normalize_auxiliary_evaluation_max_concurrency(Some(u64::MAX)),
+        MAX_AUXILIARY_EVALUATION_MAX_CONCURRENCY
+    );
+}
 
 #[test]
 fn agent_loop_config_model_name_defaults_to_none() {

--- a/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
@@ -247,9 +247,9 @@ where
         cache: None,
     };
 
-    let timeout_context = frame.timeout_context.clone().begin_request();
     let cancel_token = CancellationToken::new();
     let _dispatch_guard = acquire_dispatch_guard.await;
+    let timeout_context = frame.timeout_context.clone().begin_request();
     let stream = await_stream_bootstrap(
         llm.chat_stream_with_options(
             &messages,

--- a/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
@@ -136,8 +136,19 @@ pub(crate) async fn execute_async_gold_evaluation(
     request: AsyncGoldEvaluationRequest,
     llm: Arc<dyn LLMProvider>,
     event_tx: mpsc::Sender<AgentEvent>,
+    configured_limit: usize,
 ) -> AsyncGoldEvaluationResult {
-    let evaluation_result = match evaluate_gold(
+    let budget_provider = llm.clone();
+    let budget_model = request.model_name.clone();
+    let acquire_dispatch_guard = async move {
+        crate::runtime::runner::auxiliary_budget::acquire(
+            &budget_provider,
+            &budget_model,
+            configured_limit,
+        )
+        .await
+    };
+    let evaluation_result = match evaluate_gold_with_dispatch(
         &request.session_snapshot,
         request.task_context_snapshot.as_ref(),
         &request.gold_config,
@@ -151,6 +162,7 @@ pub(crate) async fn execute_async_gold_evaluation(
             checkpoint: request.checkpoint,
             iteration: request.round_number as u32,
         },
+        acquire_dispatch_guard,
     )
     .await
     {
@@ -182,6 +194,28 @@ pub async fn evaluate_gold(
     llm: Arc<dyn LLMProvider>,
     frame: &GoldEvalFrame<'_>,
 ) -> Result<GoldEvaluationResult, AgentError> {
+    evaluate_gold_with_dispatch(
+        session,
+        task_context,
+        config,
+        llm,
+        frame,
+        std::future::ready(()),
+    )
+    .await
+}
+
+pub(crate) async fn evaluate_gold_with_dispatch<G, Fut>(
+    session: &Session,
+    task_context: Option<&TaskLoopContext>,
+    config: &GoldConfig,
+    llm: Arc<dyn LLMProvider>,
+    frame: &GoldEvalFrame<'_>,
+    acquire_dispatch_guard: Fut,
+) -> Result<GoldEvaluationResult, AgentError>
+where
+    Fut: std::future::Future<Output = G>,
+{
     // Bind frame fields as locals so the rest of the function body stays unchanged.
     let event_tx = frame.event_tx;
     let session_id = frame.session_id;
@@ -215,6 +249,7 @@ pub async fn evaluate_gold(
 
     let timeout_context = frame.timeout_context.clone().begin_request();
     let cancel_token = CancellationToken::new();
+    let _dispatch_guard = acquire_dispatch_guard.await;
     let stream = await_stream_bootstrap(
         llm.chat_stream_with_options(
             &messages,

--- a/crates/engine/bamboo-engine/src/runtime/runner.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner.rs
@@ -6,6 +6,7 @@
 use bamboo_agent_core::TokenUsage;
 use bamboo_agent_core::{AgentError, Session};
 
+pub(crate) mod auxiliary_budget;
 pub mod image_fallback;
 mod logging;
 mod loop_execution;

--- a/crates/engine/bamboo-engine/src/runtime/runner/auxiliary_budget.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/auxiliary_budget.rs
@@ -348,6 +348,10 @@ mod tests {
                         shared_session_id: task_session.id.clone(),
                         round_number: 1,
                         based_on_task_context_version: task_context.version,
+                        based_on_task_list: task_session
+                            .task_list
+                            .clone()
+                            .expect("task session list"),
                         task_list_title: Some("Tasks".to_string()),
                         model_name: "shared-fast-model".to_string(),
                         timeout_context:
@@ -514,6 +518,10 @@ mod tests {
                         shared_session_id: task_session.id.clone(),
                         round_number: 1,
                         based_on_task_context_version: task_context.version,
+                        based_on_task_list: task_session
+                            .task_list
+                            .clone()
+                            .expect("task session list"),
                         task_list_title: Some("Tasks".to_string()),
                         model_name: model.to_string(),
                         timeout_context: timeout_context(),

--- a/crates/engine/bamboo-engine/src/runtime/runner/auxiliary_budget.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/auxiliary_budget.rs
@@ -1,0 +1,182 @@
+//! Process-wide low-priority concurrency budget for auxiliary LLM requests.
+//!
+//! The key uses the provider allocation identity plus model. Provider registry
+//! clones retain the same `Arc` allocation across sessions, while a provider
+//! reload receives a fresh identity. Weak semaphore entries disappear once no
+//! request is waiting/running, avoiding an unbounded per-reload registry.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use bamboo_llm::LLMProvider;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AuxiliaryBudgetKey {
+    provider_identity: usize,
+    model_name: String,
+}
+
+struct AuxiliaryBudgetEntry {
+    configured_limit: usize,
+    semaphore: Weak<Semaphore>,
+}
+
+static AUXILIARY_BUDGETS: OnceLock<Mutex<HashMap<AuxiliaryBudgetKey, AuxiliaryBudgetEntry>>> =
+    OnceLock::new();
+
+fn provider_identity(provider: &Arc<dyn LLMProvider>) -> usize {
+    Arc::as_ptr(provider) as *const () as usize
+}
+
+fn semaphore(
+    provider: &Arc<dyn LLMProvider>,
+    model_name: &str,
+    configured_limit: usize,
+) -> Arc<Semaphore> {
+    let configured_limit = configured_limit.clamp(
+        1,
+        crate::runtime::config::MAX_AUXILIARY_EVALUATION_MAX_CONCURRENCY,
+    );
+    let key = AuxiliaryBudgetKey {
+        provider_identity: provider_identity(provider),
+        model_name: model_name.to_string(),
+    };
+    let registry = AUXILIARY_BUDGETS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut registry = registry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry.retain(|_, entry| entry.semaphore.strong_count() > 0);
+
+    if let Some(entry) = registry.get(&key) {
+        if let Some(semaphore) = entry.semaphore.upgrade() {
+            if entry.configured_limit != configured_limit {
+                tracing::warn!(
+                    provider_identity = key.provider_identity,
+                    model = %key.model_name,
+                    active_limit = entry.configured_limit,
+                    requested_limit = configured_limit,
+                    "auxiliary evaluation budget already active with a different limit; retaining the active process-wide limit"
+                );
+            }
+            return semaphore;
+        }
+    }
+
+    let semaphore = Arc::new(Semaphore::new(configured_limit));
+    registry.insert(
+        key,
+        AuxiliaryBudgetEntry {
+            configured_limit,
+            semaphore: Arc::downgrade(&semaphore),
+        },
+    );
+    semaphore
+}
+
+/// Wait for one low-priority slot for this exact provider allocation/model.
+/// Foreground request paths never call this function.
+pub(crate) async fn acquire(
+    provider: &Arc<dyn LLMProvider>,
+    model_name: &str,
+    configured_limit: usize,
+) -> OwnedSemaphorePermit {
+    semaphore(provider, model_name, configured_limit)
+        .acquire_owned()
+        .await
+        .expect("auxiliary evaluation semaphore is never closed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::acquire;
+    use bamboo_agent_core::{Message, ToolSchema};
+    use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
+    use futures::stream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    struct ImmediateProvider;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for ImmediateProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)])))
+        }
+    }
+
+    #[tokio::test]
+    async fn task_and_gold_sessions_share_provider_model_limit_without_blocking_foreground() {
+        let provider: Arc<dyn LLMProvider> = Arc::new(ImmediateProvider);
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let mut handles = Vec::new();
+
+        // Alternate Task and Gold labels across distinct logical sessions. Both
+        // production call paths acquire this exact primitive.
+        for index in 0..6 {
+            let provider = provider.clone();
+            let active = active.clone();
+            let peak = peak.clone();
+            let entered = entered.clone();
+            let release = release.clone();
+            handles.push(tokio::spawn(async move {
+                let _kind = if index % 2 == 0 { "task" } else { "gold" };
+                let _session_id = format!("session-{index}");
+                let _permit = acquire(&provider, "shared-fast-model", 2).await;
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now, Ordering::SeqCst);
+                entered.fetch_add(1, Ordering::SeqCst);
+                let release_permit = release.acquire().await.expect("release gate stays open");
+                release_permit.forget();
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while entered.load(Ordering::SeqCst) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("two auxiliary evaluations should enter");
+        assert_eq!(peak.load(Ordering::SeqCst), 2);
+
+        // The budget is opt-in at auxiliary dispatch sites, not a wrapper on
+        // the provider itself. A foreground call therefore completes while all
+        // low-priority slots are occupied.
+        let _foreground_stream = tokio::time::timeout(
+            Duration::from_millis(100),
+            provider.chat_stream(&[], &[], None, "shared-fast-model"),
+        )
+        .await
+        .expect("foreground provider call must not wait for auxiliary permits")
+        .expect("foreground provider call succeeds");
+
+        for expected_entered in [4, 6] {
+            release.add_permits(2);
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while entered.load(Ordering::SeqCst) < expected_entered {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("next auxiliary batch should enter");
+            assert!(active.load(Ordering::SeqCst) <= 2);
+        }
+        release.add_permits(2);
+        for handle in handles {
+            handle.await.expect("auxiliary session joins");
+        }
+        assert_eq!(peak.load(Ordering::SeqCst), 2);
+    }
+}

--- a/crates/engine/bamboo-engine/src/runtime/runner/auxiliary_budget.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/auxiliary_budget.rs
@@ -90,9 +90,15 @@ pub(crate) async fn acquire(
 #[cfg(test)]
 mod tests {
     use super::acquire;
-    use bamboo_agent_core::{Message, ToolSchema};
-    use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
+    use bamboo_agent_core::{
+        FunctionCall, GoldCheckpoint, GoldConfidence, GoldDecision, Message, PendingQuestion,
+        PendingQuestionSource, Session, ToolCall, ToolSchema,
+    };
+    use bamboo_domain::{TaskItem, TaskItemStatus, TaskList};
+    use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMRequestOptions, LLMStream};
+    use chrono::Utc;
     use futures::stream;
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
@@ -109,6 +115,141 @@ mod tests {
             _model: &str,
         ) -> Result<LLMStream, LLMError> {
             Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)])))
+        }
+    }
+
+    struct BlockingAuxiliaryProvider {
+        active: AtomicUsize,
+        peak: AtomicUsize,
+        entered: AtomicUsize,
+        release: tokio::sync::Semaphore,
+    }
+
+    impl BlockingAuxiliaryProvider {
+        fn new() -> Self {
+            Self {
+                active: AtomicUsize::new(0),
+                peak: AtomicUsize::new(0),
+                entered: AtomicUsize::new(0),
+                release: tokio::sync::Semaphore::new(0),
+            }
+        }
+
+        async fn wait_for_entered(&self, expected: usize) {
+            tokio::time::timeout(Duration::from_secs(2), async {
+                while self.entered.load(Ordering::SeqCst) < expected {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("expected auxiliary provider dispatches should enter");
+        }
+
+        fn response_for(purpose: &str) -> ToolCall {
+            let (name, arguments) = match purpose {
+                "task_evaluation" => (
+                    "update_task_item",
+                    r#"{"item_id":"task-1","status":"completed","notes":"done"}"#,
+                ),
+                "gold_auto_answer" => (
+                    "report_gold_auto_answer",
+                    r#"{"apply":true,"answer":"OK","confidence":"high","reasoning":"supported"}"#,
+                ),
+                _ => (
+                    "report_gold_evaluation",
+                    r#"{"decision":"continue","confidence":"high","reasoning":"continue"}"#,
+                ),
+            };
+            ToolCall {
+                id: format!("{purpose}-call"),
+                tool_type: "function".to_string(),
+                function: FunctionCall {
+                    name: name.to_string(),
+                    arguments: arguments.to_string(),
+                },
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for BlockingAuxiliaryProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            // Foreground calls use this entry point in the regression test and
+            // never acquire the opt-in auxiliary budget.
+            Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)])))
+        }
+
+        async fn chat_stream_with_options(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+            options: Option<&LLMRequestOptions>,
+        ) -> Result<LLMStream, LLMError> {
+            let purpose = options
+                .and_then(|options| options.request_purpose.as_deref())
+                .unwrap_or("unknown")
+                .to_string();
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(active, Ordering::SeqCst);
+            self.entered.fetch_add(1, Ordering::SeqCst);
+            let release = self
+                .release
+                .acquire()
+                .await
+                .expect("release semaphore stays open");
+            release.forget();
+            self.active.fetch_sub(1, Ordering::SeqCst);
+
+            Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::ToolCalls(vec![Self::response_for(&purpose)])),
+                Ok(LLMChunk::Done),
+            ])))
+        }
+    }
+
+    fn task_session_and_context() -> (Session, crate::runtime::task_context::TaskLoopContext) {
+        let mut session = Session::new("task-session", "shared-fast-model");
+        session.set_task_list(TaskList {
+            session_id: session.id.clone(),
+            title: "Tasks".to_string(),
+            items: vec![TaskItem {
+                id: "task-1".to_string(),
+                description: "Finish the work".to_string(),
+                status: TaskItemStatus::InProgress,
+                ..TaskItem::default()
+            }],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+        session.set_task_list_version_meta("1");
+        let context = crate::runtime::task_context::TaskLoopContext::from_session(&session)
+            .expect("task context");
+        (session, context)
+    }
+
+    fn gold_config() -> crate::runtime::config::GoldConfig {
+        crate::runtime::config::GoldConfig {
+            enabled: true,
+            auto_answer_enabled: true,
+            model_name: Some("shared-fast-model".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn gold_target(provider: Arc<dyn LLMProvider>) -> crate::gold_auto_answer::GoldAuxiliaryTarget {
+        crate::gold_auto_answer::GoldAuxiliaryTarget {
+            provider,
+            model: "shared-fast-model".to_string(),
+            timeout_context: crate::runtime::stream::handler::StreamTimeoutContext::default(),
+            configured_limit: 2,
         }
     }
 
@@ -178,5 +319,315 @@ mod tests {
             handle.await.expect("auxiliary session joins");
         }
         assert_eq!(peak.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn all_production_auxiliary_paths_share_one_provider_model_budget() {
+        use crate::runtime::gold_evaluation::{
+            execute_async_gold_evaluation, AsyncGoldEvaluationRequest, GoldEvaluationResult,
+        };
+        use crate::runtime::runner::task_lifecycle::{
+            execute_async_task_evaluation, AsyncTaskEvaluationRequest,
+        };
+
+        let concrete = Arc::new(BlockingAuxiliaryProvider::new());
+        let provider: Arc<dyn LLMProvider> = concrete.clone();
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(32);
+        let gold_config = gold_config();
+
+        let (task_session, task_context) = task_session_and_context();
+        let task_handle = {
+            let provider = provider.clone();
+            let event_tx = event_tx.clone();
+            tokio::spawn(async move {
+                execute_async_task_evaluation(
+                    AsyncTaskEvaluationRequest {
+                        evaluation_id: "task-eval".to_string(),
+                        metrics_round_id: "task-metrics".to_string(),
+                        session_id: task_session.id.clone(),
+                        shared_session_id: task_session.id.clone(),
+                        round_number: 1,
+                        based_on_task_context_version: task_context.version,
+                        task_list_title: Some("Tasks".to_string()),
+                        model_name: "shared-fast-model".to_string(),
+                        timeout_context:
+                            crate::runtime::stream::handler::StreamTimeoutContext::default(),
+                        reasoning_effort: None,
+                        task_context_snapshot: task_context,
+                        session_snapshot: task_session,
+                    },
+                    provider,
+                    event_tx,
+                    2,
+                    None,
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(AtomicBool::new(false)),
+                )
+                .await
+            })
+        };
+
+        let gold_handle = {
+            let provider = provider.clone();
+            let event_tx = event_tx.clone();
+            let gold_config = gold_config.clone();
+            tokio::spawn(async move {
+                execute_async_gold_evaluation(
+                    AsyncGoldEvaluationRequest {
+                        session_id: "gold-session".to_string(),
+                        round_number: 1,
+                        model_name: "shared-fast-model".to_string(),
+                        timeout_context:
+                            crate::runtime::stream::handler::StreamTimeoutContext::default(),
+                        reasoning_effort: None,
+                        checkpoint: GoldCheckpoint::PostRound,
+                        session_snapshot: Session::new("gold-session", "shared-fast-model"),
+                        task_context_snapshot: None,
+                        gold_config,
+                    },
+                    provider,
+                    event_tx,
+                    2,
+                )
+                .await
+            })
+        };
+
+        let auto_state_handle = {
+            let provider = provider.clone();
+            let event_tx = event_tx.clone();
+            let gold_config = gold_config.clone();
+            tokio::spawn(async move {
+                crate::gold_auto_answer::evaluate_gold_state_with_target(
+                    "auto-state-session",
+                    &Session::new("auto-state-session", "shared-fast-model"),
+                    &gold_config,
+                    gold_target(provider),
+                    &event_tx,
+                    1,
+                )
+                .await
+            })
+        };
+
+        let auto_answer_handle = {
+            let provider = provider.clone();
+            let gold_config = gold_config.clone();
+            tokio::spawn(async move {
+                let mut session = Session::new("auto-answer-session", "shared-fast-model");
+                session.pending_question = Some(PendingQuestion {
+                    tool_call_id: "pending-call".to_string(),
+                    tool_name: "conclusion_with_options".to_string(),
+                    question: "Choose".to_string(),
+                    options: vec!["OK".to_string()],
+                    allow_custom: false,
+                    source: PendingQuestionSource::PauseTool,
+                });
+                crate::gold_auto_answer::evaluate_gold_auto_answer_question_with_target(
+                    "auto-answer-session",
+                    &session,
+                    &gold_config,
+                    &GoldEvaluationResult {
+                        checkpoint: GoldCheckpoint::Terminal,
+                        iteration: 1,
+                        decision: GoldDecision::Continue,
+                        confidence: GoldConfidence::High,
+                        reasoning: "continue".to_string(),
+                        missing_information: Vec::new(),
+                        next_action: None,
+                        prompt_tokens: 1,
+                        completion_tokens: 1,
+                    },
+                    gold_target(provider),
+                )
+                .await
+            })
+        };
+
+        concrete.wait_for_entered(2).await;
+        assert_eq!(concrete.peak.load(Ordering::SeqCst), 2);
+
+        let foreground = tokio::time::timeout(
+            Duration::from_millis(100),
+            provider.chat_stream(&[], &[], None, "shared-fast-model"),
+        )
+        .await
+        .expect("foreground dispatch must bypass the auxiliary budget")
+        .expect("foreground provider succeeds");
+        drop(foreground);
+
+        concrete.release.add_permits(2);
+        concrete.wait_for_entered(4).await;
+        assert!(concrete.active.load(Ordering::SeqCst) <= 2);
+        concrete.release.add_permits(2);
+
+        task_handle.await.expect("Task path joins");
+        gold_handle.await.expect("Gold path joins");
+        auto_state_handle
+            .await
+            .expect("Gold auto-answer state path joins")
+            .expect("Gold auto-answer state evaluation succeeds");
+        auto_answer_handle
+            .await
+            .expect("Gold auto-answer decision path joins")
+            .expect("Gold auto-answer decision succeeds");
+        assert_eq!(concrete.peak.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn auxiliary_permit_wait_does_not_consume_stream_request_timeout() {
+        use crate::runtime::gold_evaluation::{
+            execute_async_gold_evaluation, AsyncGoldEvaluationRequest, GoldEvaluationResult,
+        };
+        use crate::runtime::runner::task_lifecycle::{
+            execute_async_task_evaluation, AsyncTaskEvaluationRequest,
+        };
+
+        let concrete = Arc::new(BlockingAuxiliaryProvider::new());
+        let provider: Arc<dyn LLMProvider> = concrete.clone();
+        let model = "queued-fast-model";
+        let held_permit = acquire(&provider, model, 1).await;
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(32);
+        let timeout_context = || {
+            crate::runtime::stream::handler::StreamTimeoutContext::new(
+                bamboo_config::StreamTimeoutConfig {
+                    transport_idle_timeout_secs: 1,
+                    first_semantic_timeout_secs: 1,
+                    semantic_idle_timeout_secs: 1,
+                },
+                Some("queued-provider"),
+                Some(model),
+            )
+        };
+        let (task_session, task_context) = task_session_and_context();
+        let task_dispatched = Arc::new(AtomicBool::new(false));
+        let task_handle = {
+            let provider = provider.clone();
+            let event_tx = event_tx.clone();
+            let metrics_started = task_dispatched.clone();
+            tokio::spawn(async move {
+                execute_async_task_evaluation(
+                    AsyncTaskEvaluationRequest {
+                        evaluation_id: "queued-task".to_string(),
+                        metrics_round_id: "queued-task-metrics".to_string(),
+                        session_id: task_session.id.clone(),
+                        shared_session_id: task_session.id.clone(),
+                        round_number: 1,
+                        based_on_task_context_version: task_context.version,
+                        task_list_title: Some("Tasks".to_string()),
+                        model_name: model.to_string(),
+                        timeout_context: timeout_context(),
+                        reasoning_effort: None,
+                        task_context_snapshot: task_context,
+                        session_snapshot: task_session,
+                    },
+                    provider,
+                    event_tx,
+                    1,
+                    None,
+                    metrics_started,
+                    Arc::new(AtomicBool::new(false)),
+                )
+                .await
+            })
+        };
+
+        let gold_config = gold_config();
+        let gold_handle = {
+            let provider = provider.clone();
+            let event_tx = event_tx.clone();
+            let gold_config = gold_config.clone();
+            tokio::spawn(async move {
+                execute_async_gold_evaluation(
+                    AsyncGoldEvaluationRequest {
+                        session_id: "queued-gold".to_string(),
+                        round_number: 1,
+                        model_name: model.to_string(),
+                        timeout_context: timeout_context(),
+                        reasoning_effort: None,
+                        checkpoint: GoldCheckpoint::PostRound,
+                        session_snapshot: Session::new("queued-gold", model),
+                        task_context_snapshot: None,
+                        gold_config,
+                    },
+                    provider,
+                    event_tx,
+                    1,
+                )
+                .await
+            })
+        };
+
+        let auto_answer_handle = {
+            let provider = provider.clone();
+            let gold_config = gold_config.clone();
+            tokio::spawn(async move {
+                let mut session = Session::new("queued-auto-answer", model);
+                session.pending_question = Some(PendingQuestion {
+                    tool_call_id: "queued-pending".to_string(),
+                    tool_name: "conclusion_with_options".to_string(),
+                    question: "Choose".to_string(),
+                    options: vec!["OK".to_string()],
+                    allow_custom: false,
+                    source: PendingQuestionSource::PauseTool,
+                });
+                crate::gold_auto_answer::evaluate_gold_auto_answer_question_with_target(
+                    "queued-auto-answer",
+                    &session,
+                    &gold_config,
+                    &GoldEvaluationResult {
+                        checkpoint: GoldCheckpoint::Terminal,
+                        iteration: 1,
+                        decision: GoldDecision::Continue,
+                        confidence: GoldConfidence::High,
+                        reasoning: "continue".to_string(),
+                        missing_information: Vec::new(),
+                        next_action: None,
+                        prompt_tokens: 1,
+                        completion_tokens: 1,
+                    },
+                    crate::gold_auto_answer::GoldAuxiliaryTarget {
+                        provider,
+                        model: model.to_string(),
+                        timeout_context: timeout_context(),
+                        configured_limit: 1,
+                    },
+                )
+                .await
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(1_200)).await;
+        assert_eq!(
+            concrete.entered.load(Ordering::SeqCst),
+            0,
+            "no provider request may dispatch while the permit is held"
+        );
+        assert!(
+            !task_dispatched.load(Ordering::Acquire),
+            "Task dispatch metrics must start at the same post-permit boundary"
+        );
+
+        drop(held_permit);
+        for expected in 1..=3 {
+            concrete.wait_for_entered(expected).await;
+            concrete.release.add_permits(1);
+        }
+
+        let task = task_handle.await.expect("queued Task joins");
+        assert_eq!(
+            task.error, None,
+            "Task request should retain a fresh timeout"
+        );
+        let gold = gold_handle.await.expect("queued Gold joins");
+        assert!(
+            !gold.evaluation_result.reasoning.contains("failed"),
+            "Gold request should retain a fresh timeout: {}",
+            gold.evaluation_result.reasoning
+        );
+        auto_answer_handle
+            .await
+            .expect("queued auto-answer joins")
+            .expect("auto-answer request should retain a fresh timeout");
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
@@ -9,7 +9,7 @@ use crate::runtime::goal_state::{
     GoalState,
 };
 use crate::runtime::gold_evaluation::{
-    apply_gold_evaluation_result, build_async_gold_evaluation_request, evaluate_gold,
+    apply_gold_evaluation_result, build_async_gold_evaluation_request, evaluate_gold_with_dispatch,
     execute_async_gold_evaluation, AsyncGoldEvaluationRequest, GoldEvaluationResult,
 };
 use crate::runtime::runner::loop_execution::startup::{InFlightGoldEvaluation, LoopRunState};
@@ -110,7 +110,17 @@ pub(super) async fn evaluate_gold_terminal(
 
     // Side-channel double-check: re-verify achievement at the stop boundary.
     let model_name = gold_config.model_name.as_deref().unwrap_or(eval_model);
-    let verdict = match evaluate_gold(
+    let budget_provider = llm.clone();
+    let budget_model = model_name.to_string();
+    let acquire_dispatch_guard = async move {
+        crate::runtime::runner::auxiliary_budget::acquire(
+            &budget_provider,
+            &budget_model,
+            config.auxiliary_evaluation_max_concurrency,
+        )
+        .await
+    };
+    let verdict = match evaluate_gold_with_dispatch(
         session,
         task_context.as_ref(),
         gold_config,
@@ -128,6 +138,7 @@ pub(super) async fn evaluate_gold_terminal(
             checkpoint: GoldCheckpoint::Terminal,
             iteration,
         },
+        acquire_dispatch_guard,
     )
     .await
     {
@@ -405,6 +416,7 @@ fn spawn_gold_evaluation_request(
     request: AsyncGoldEvaluationRequest,
     llm: Arc<dyn LLMProvider>,
     cancel_token: CancellationToken,
+    configured_limit: usize,
 ) {
     let gold_round = request.round_number;
     let session_id = state.session_id.clone();
@@ -420,7 +432,12 @@ fn spawn_gold_evaluation_request(
         tokio::select! {
             biased;
             _ = cancel_token.cancelled() => None,
-            result = execute_async_gold_evaluation(request_for_spawn, llm, event_tx) => Some(result),
+            result = execute_async_gold_evaluation(
+                request_for_spawn,
+                llm,
+                event_tx,
+                configured_limit,
+            ) => Some(result),
         }
     });
 
@@ -441,6 +458,7 @@ pub(super) fn start_queued_gold_evaluation_if_idle(
     event_tx: &mpsc::Sender<AgentEvent>,
     llm: Arc<dyn LLMProvider>,
     cancel_token: CancellationToken,
+    configured_limit: usize,
 ) {
     if state.gold_evaluation.in_flight.is_some() {
         return;
@@ -450,7 +468,14 @@ pub(super) fn start_queued_gold_evaluation_if_idle(
         return;
     };
 
-    spawn_gold_evaluation_request(state, event_tx, request, llm, cancel_token);
+    spawn_gold_evaluation_request(
+        state,
+        event_tx,
+        request,
+        llm,
+        cancel_token,
+        configured_limit,
+    );
 }
 
 pub(super) fn spawn_gold_evaluation_if_needed(
@@ -503,7 +528,14 @@ pub(super) fn spawn_gold_evaluation_if_needed(
         return Ok(());
     }
 
-    spawn_gold_evaluation_request(state, event_tx, request, llm, cancel_token);
+    spawn_gold_evaluation_request(
+        state,
+        event_tx,
+        request,
+        llm,
+        cancel_token,
+        config.auxiliary_evaluation_max_concurrency,
+    );
     Ok(())
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -776,6 +776,38 @@ fn record_task_evaluation_terminal_metrics(
     }
 }
 
+fn task_evaluation_result_usage(
+    result: &crate::runtime::runner::task_lifecycle::AsyncTaskEvaluationResult,
+) -> MetricsTokenUsage {
+    let prompt_tokens = result.evaluation_result.prompt_tokens;
+    let completion_tokens = result.evaluation_result.completion_tokens;
+    MetricsTokenUsage {
+        prompt_tokens,
+        completion_tokens,
+        total_tokens: prompt_tokens.saturating_add(completion_tokens),
+    }
+}
+
+fn record_harvested_task_evaluation_metrics(
+    metrics_collector: Option<&MetricsCollector>,
+    result: &crate::runtime::runner::task_lifecycle::AsyncTaskEvaluationResult,
+) {
+    let (status, error) = match result.error.clone() {
+        Some(error) => (MetricsRoundStatus::Error, Some(error)),
+        None => (MetricsRoundStatus::Success, None),
+    };
+    record_task_evaluation_terminal_metrics(
+        metrics_collector,
+        &result.metrics_round_id,
+        result.metrics_started.as_ref(),
+        result.metrics_terminal.as_ref(),
+        result.finished_at,
+        status,
+        task_evaluation_result_usage(result),
+        error,
+    );
+}
+
 async fn poll_completed_task_evaluation(state: &mut LoopRunState) {
     let finished = state
         .task_evaluation
@@ -1006,35 +1038,99 @@ async fn abort_in_flight_evaluations(
     event_tx: &mpsc::Sender<AgentEvent>,
     reason: &'static str,
 ) {
-    let task_was_running = state.task_evaluation.in_flight.is_some();
-    let task_generation = state
-        .task_evaluation
-        .in_flight
-        .as_ref()
-        .map(|in_flight| in_flight.request.based_on_task_context_version);
-    let gold_was_running = state.gold_evaluation.in_flight.is_some();
+    let mut task_was_cancelled = false;
+    let mut task_generation = None;
+    let mut gold_was_cancelled = false;
     if let Some(in_flight) = state.task_evaluation.in_flight.take() {
-        in_flight.join_handle.abort();
+        task_generation = Some(in_flight.request.based_on_task_context_version);
+        let was_finished = in_flight.join_handle.is_finished();
+        if !was_finished {
+            in_flight.join_handle.abort();
+        }
         let metrics_round_id = in_flight.request.metrics_round_id.clone();
         let metrics_started = in_flight.metrics_started.clone();
         let metrics_terminal = in_flight.metrics_terminal.clone();
-        // Wait only for Tokio to observe the abort. This is not a provider
-        // drain, but it closes the race where dispatch starts immediately
-        // after an earlier `metrics_started` check.
-        let _ = in_flight.join_handle.await;
-        record_task_evaluation_terminal_metrics(
-            state.metrics_collector.as_ref(),
-            &metrics_round_id,
-            metrics_started.as_ref(),
-            metrics_terminal.as_ref(),
-            Utc::now(),
-            MetricsRoundStatus::Cancelled,
-            MetricsTokenUsage::default(),
-            Some(reason.to_string()),
-        );
+        // Awaiting a handle that was already finished is an immediate harvest,
+        // not a provider drain. For an active handle this wait only lets Tokio
+        // observe the abort. In either case the actual join outcome wins the
+        // is_finished/abort race: a completed result must never be rewritten as
+        // Cancelled or followed by a duplicate cancellation event.
+        match in_flight.join_handle.await {
+            Ok(Some(result)) => {
+                record_harvested_task_evaluation_metrics(state.metrics_collector.as_ref(), &result);
+            }
+            Ok(None) => {
+                task_was_cancelled = true;
+                record_task_evaluation_terminal_metrics(
+                    state.metrics_collector.as_ref(),
+                    &metrics_round_id,
+                    metrics_started.as_ref(),
+                    metrics_terminal.as_ref(),
+                    Utc::now(),
+                    MetricsRoundStatus::Cancelled,
+                    MetricsTokenUsage::default(),
+                    Some(reason.to_string()),
+                );
+            }
+            Err(error) if error.is_cancelled() => {
+                task_was_cancelled = true;
+                record_task_evaluation_terminal_metrics(
+                    state.metrics_collector.as_ref(),
+                    &metrics_round_id,
+                    metrics_started.as_ref(),
+                    metrics_terminal.as_ref(),
+                    Utc::now(),
+                    MetricsRoundStatus::Cancelled,
+                    MetricsTokenUsage::default(),
+                    Some(reason.to_string()),
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "[{}] Async task evaluation join failed during cleanup for round {}: {}",
+                    state.session_id,
+                    in_flight.request.round_number,
+                    error
+                );
+                record_task_evaluation_terminal_metrics(
+                    state.metrics_collector.as_ref(),
+                    &metrics_round_id,
+                    metrics_started.as_ref(),
+                    metrics_terminal.as_ref(),
+                    Utc::now(),
+                    MetricsRoundStatus::Error,
+                    MetricsTokenUsage::default(),
+                    Some(format!("task evaluation join failed: {error}")),
+                );
+                // A panic/failure is harvested as Error and must not receive a
+                // fabricated cancellation lifecycle event.
+            }
+        }
     }
     if let Some(in_flight) = state.gold_evaluation.in_flight.take() {
-        in_flight.join_handle.abort();
+        let was_finished = in_flight.join_handle.is_finished();
+        if !was_finished {
+            in_flight.join_handle.abort();
+        }
+        // As with Task evaluation, the join result is authoritative when abort
+        // races natural completion. A finished Gold evaluator has already
+        // emitted GoldEvaluationCompleted and must not receive a contradictory
+        // cancellation lifecycle event during run cleanup.
+        match in_flight.join_handle.await {
+            Ok(Some(_result)) => {}
+            Ok(None) => gold_was_cancelled = true,
+            Err(error) if error.is_cancelled() => gold_was_cancelled = true,
+            Err(error) => {
+                tracing::warn!(
+                    "[{}] Async Gold evaluation join failed during cleanup for round {}: {}",
+                    state.session_id,
+                    in_flight.request.round_number,
+                    error
+                );
+                // A panic/failure is terminal in its own right; its actual join
+                // outcome must never be rewritten as cancellation.
+            }
+        }
     }
     // Queued snapshots belong to this run. A later run rebuilds an evaluation
     // request from the current task-list generation instead of replaying stale
@@ -1045,7 +1141,7 @@ async fn abort_in_flight_evaluations(
     // A Started event may already be visible to clients. Always close that
     // lifecycle explicitly so a reconnecting/current UI never remains stuck in
     // "evaluating" after the owning run has reached a terminal/suspended state.
-    if task_was_running {
+    if task_was_cancelled {
         let _ = event_tx
             .send(AgentEvent::TaskEvaluationCancelled {
                 session_id: state.session_id.clone(),
@@ -1054,7 +1150,7 @@ async fn abort_in_flight_evaluations(
             })
             .await;
     }
-    if gold_was_running {
+    if gold_was_cancelled {
         let _ = event_tx
             .send(AgentEvent::GoldEvaluationCancelled {
                 session_id: state.session_id.clone(),
@@ -7275,6 +7371,153 @@ mod tests {
         );
     }
 
+    struct CompletedTaskEvaluationProvider;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for CompletedTaskEvaluationProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            let call = bamboo_agent_core::tools::ToolCall {
+                id: "completed-unharvested-evaluation".to_string(),
+                tool_type: "function".to_string(),
+                function: bamboo_agent_core::tools::FunctionCall {
+                    name: "update_task_item".to_string(),
+                    arguments: r#"{"item_id":"pending","status":"completed","notes":"verified"}"#
+                        .to_string(),
+                },
+            };
+            Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::ToolCalls(vec![call])),
+                Ok(LLMChunk::Done),
+            ])))
+        }
+    }
+
+    #[tokio::test]
+    async fn cleanup_harvests_finished_task_evaluation_without_false_cancellation() {
+        use bamboo_metrics::storage::MetricsStorage;
+
+        let session_id = "task-eval-finished-before-cleanup";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        collector.session_started(session_id, "model", Utc::now());
+
+        let mut session = Session::new(session_id, "model");
+        let mut state = e2e_loop_state(session_id);
+        seed_blocked_task_evaluation(&mut session, &mut state);
+        let (reset_tx, _reset_rx) = mpsc::channel(4);
+        super::abort_in_flight_evaluations(&mut state, &reset_tx, "test_reset").await;
+
+        let request = crate::runtime::runner::task_lifecycle::build_async_task_evaluation_request(
+            &state.task_context,
+            &session,
+            session_id,
+            1,
+            Some("fast-model"),
+            None,
+            crate::runtime::stream::handler::StreamTimeoutContext::default(),
+        )
+        .expect("request builds")
+        .expect("task context exists");
+        let metrics_round_id = request.metrics_round_id.clone();
+        state.metrics_collector = Some(collector);
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        super::spawn_task_evaluation_request(
+            &mut state,
+            &event_tx,
+            request,
+            Arc::new(CompletedTaskEvaluationProvider),
+            CancellationToken::new(),
+            1,
+        );
+        let metrics_started = state
+            .task_evaluation
+            .in_flight
+            .as_ref()
+            .expect("evaluation spawned")
+            .metrics_started
+            .clone();
+        let metrics_terminal = state
+            .task_evaluation
+            .in_flight
+            .as_ref()
+            .expect("evaluation spawned")
+            .metrics_terminal
+            .clone();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !state
+                .task_evaluation
+                .in_flight
+                .as_ref()
+                .expect("unharvested handle remains installed")
+                .join_handle
+                .is_finished()
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("evaluator should finish before cleanup");
+        assert!(metrics_started.load(Ordering::Acquire));
+        assert!(!metrics_terminal.load(Ordering::Acquire));
+
+        super::abort_in_flight_evaluations(&mut state, &event_tx, "run_completed").await;
+        assert!(state.task_evaluation.in_flight.is_none());
+        assert!(metrics_terminal.load(Ordering::Acquire));
+
+        let mut started_events = 0;
+        let mut completed_events = 0;
+        let mut cancelled_events = 0;
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                AgentEvent::TaskEvaluationStarted { .. } => started_events += 1,
+                AgentEvent::TaskEvaluationCompleted { .. } => completed_events += 1,
+                AgentEvent::TaskEvaluationCancelled { .. } => cancelled_events += 1,
+                _ => {}
+            }
+        }
+        assert_eq!(started_events, 1);
+        assert_eq!(completed_events, 1);
+        assert_eq!(
+            cancelled_events, 0,
+            "a completed evaluator must not receive a duplicate cancellation event"
+        );
+
+        let detail = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(detail) = storage
+                    .session_detail(session_id)
+                    .await
+                    .expect("session metrics query")
+                {
+                    if detail.rounds.len() == 1 && detail.rounds[0].completed_at.is_some() {
+                        break detail;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("harvested evaluator terminal metric persists");
+        let row = &detail.rounds[0];
+        assert_eq!(row.round_id, metrics_round_id);
+        assert_eq!(row.status, MetricsRoundStatus::Success);
+        assert!(row.error.is_none());
+        assert!(row.token_usage.prompt_tokens > 0);
+        assert!(row.token_usage.completion_tokens > 0);
+        assert_eq!(
+            row.token_usage.total_tokens,
+            row.token_usage
+                .prompt_tokens
+                .saturating_add(row.token_usage.completion_tokens)
+        );
+    }
+
     /// What the scripted main agent does on its SECOND round, once the Gold
     /// evaluation spawned after round 1 is genuinely in flight.
     #[derive(Clone, Copy)]
@@ -7412,6 +7655,95 @@ mod tests {
             max_rounds: 5,
             ..AgentLoopConfig::default()
         }
+    }
+
+    #[tokio::test]
+    async fn cleanup_harvests_finished_gold_evaluation_without_false_cancellation() {
+        let session_id = "gold-eval-finished-before-cleanup";
+        let mut state = e2e_loop_state(session_id);
+        let checkpoint = bamboo_agent_core::GoldCheckpoint::PostRound;
+        let request = crate::runtime::gold_evaluation::AsyncGoldEvaluationRequest {
+            session_id: session_id.to_string(),
+            round_number: 1,
+            model_name: "fast".to_string(),
+            reasoning_effort: None,
+            checkpoint,
+            timeout_context: crate::runtime::stream::handler::StreamTimeoutContext::default(),
+            session_snapshot: Session::new(session_id, "model"),
+            task_context_snapshot: None,
+            gold_config: crate::runtime::config::GoldConfig::default(),
+        };
+        let result = crate::runtime::gold_evaluation::AsyncGoldEvaluationResult {
+            round_number: 1,
+            model_name: "fast".to_string(),
+            evaluation_result: crate::runtime::gold_evaluation::GoldEvaluationResult {
+                checkpoint,
+                iteration: 1,
+                decision: bamboo_agent_core::GoldDecision::Continue,
+                confidence: bamboo_agent_core::GoldConfidence::High,
+                reasoning: "complete".to_string(),
+                missing_information: Vec::new(),
+                next_action: None,
+                prompt_tokens: 1,
+                completion_tokens: 1,
+            },
+        };
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(AgentEvent::GoldEvaluationStarted {
+            session_id: session_id.to_string(),
+            checkpoint,
+            iteration: 1,
+        })
+        .await
+        .expect("started event");
+        tx.send(AgentEvent::GoldEvaluationCompleted {
+            session_id: session_id.to_string(),
+            checkpoint,
+            iteration: 1,
+            decision: bamboo_agent_core::GoldDecision::Continue,
+            confidence: bamboo_agent_core::GoldConfidence::High,
+            reasoning: "complete".to_string(),
+        })
+        .await
+        .expect("completed event");
+        state.gold_evaluation.in_flight = Some(super::super::startup::InFlightGoldEvaluation {
+            request,
+            join_handle: tokio::spawn(async move { Some(result) }),
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !state
+                .gold_evaluation
+                .in_flight
+                .as_ref()
+                .expect("unharvested Gold handle")
+                .join_handle
+                .is_finished()
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("Gold evaluator should finish before cleanup");
+
+        super::abort_in_flight_evaluations(&mut state, &tx, "run_completed").await;
+        assert!(state.gold_evaluation.in_flight.is_none());
+        let mut started = 0;
+        let mut completed = 0;
+        let mut cancelled = 0;
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                AgentEvent::GoldEvaluationStarted { .. } => started += 1,
+                AgentEvent::GoldEvaluationCompleted { .. } => completed += 1,
+                AgentEvent::GoldEvaluationCancelled { .. } => cancelled += 1,
+                _ => {}
+            }
+        }
+        assert_eq!(started, 1);
+        assert_eq!(completed, 1);
+        assert_eq!(
+            cancelled, 0,
+            "a completed Gold evaluator must not receive a contradictory cancellation"
+        );
     }
 
     /// A run the user CANCELS with a Gold evaluation in flight must not run that

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -5,6 +5,7 @@
 //!
 //! "Round" is kept only as a counter for metrics compatibility.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -744,6 +745,37 @@ fn record_turn_failure(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
+fn record_task_evaluation_terminal_metrics(
+    metrics_collector: Option<&MetricsCollector>,
+    metrics_round_id: &str,
+    metrics_started: &AtomicBool,
+    metrics_terminal: &AtomicBool,
+    completed_at: chrono::DateTime<Utc>,
+    status: MetricsRoundStatus,
+    usage: MetricsTokenUsage,
+    error: Option<String>,
+) {
+    if !metrics_started.load(Ordering::Acquire)
+        || metrics_terminal
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+    {
+        return;
+    }
+    if let Some(metrics) = metrics_collector {
+        metrics.round_completed(
+            metrics_round_id.to_string(),
+            completed_at,
+            status,
+            usage,
+            0,
+            0,
+            error,
+        );
+    }
+}
+
 async fn poll_completed_task_evaluation(state: &mut LoopRunState) {
     let finished = state
         .task_evaluation
@@ -771,6 +803,16 @@ async fn poll_completed_task_evaluation(state: &mut LoopRunState) {
                 state.session_id,
                 in_flight.request.round_number
             );
+            record_task_evaluation_terminal_metrics(
+                state.metrics_collector.as_ref(),
+                &in_flight.request.metrics_round_id,
+                in_flight.metrics_started.as_ref(),
+                in_flight.metrics_terminal.as_ref(),
+                Utc::now(),
+                MetricsRoundStatus::Cancelled,
+                MetricsTokenUsage::default(),
+                Some("task evaluation cancelled".to_string()),
+            );
         }
         Err(error) => {
             tracing::warn!(
@@ -778,6 +820,16 @@ async fn poll_completed_task_evaluation(state: &mut LoopRunState) {
                 state.session_id,
                 in_flight.request.round_number,
                 error
+            );
+            record_task_evaluation_terminal_metrics(
+                state.metrics_collector.as_ref(),
+                &in_flight.request.metrics_round_id,
+                in_flight.metrics_started.as_ref(),
+                in_flight.metrics_terminal.as_ref(),
+                Utc::now(),
+                MetricsRoundStatus::Error,
+                MetricsTokenUsage::default(),
+                Some(format!("task evaluation join failed: {error}")),
             );
         }
     }
@@ -793,77 +845,102 @@ async fn apply_completed_task_evaluation(
         return;
     };
 
-    let apply_outcome = crate::runtime::runner::task_lifecycle::apply_task_evaluation_result(
-        &mut state.task_context,
-        session,
+    // Apply into staged clones first. An asynchronous evaluator only publishes
+    // its state after the durable Task generation compare-and-patch succeeds;
+    // a conflict must not leak stale changes into the live session or its next
+    // checkpoint.
+    let mut staged_task_context = state.task_context.clone();
+    let mut staged_session = session.clone();
+    let mut apply_outcome = crate::runtime::runner::task_lifecycle::apply_task_evaluation_result(
+        &mut staged_task_context,
+        &mut staged_session,
         &state.session_id,
         result.clone(),
     );
-
-    let synthetic_round_id = crate::runtime::runner::round_prelude::build_auxiliary_round_id(
-        &state.session_id,
-        &state.execution_id,
-        "task-evaluation",
-        result.round_number,
-    );
-    crate::runtime::runner::metrics_lifecycle::record_round_started(
-        state.metrics_collector.as_ref(),
-        &synthetic_round_id,
-        &state.session_id,
-        result.model_name.as_str(),
-    );
-    crate::runtime::runner::metrics_lifecycle::record_round_completed(
-        state.metrics_collector.as_ref(),
-        &synthetic_round_id,
-        &state.session_id,
-        session.messages.len() as u32,
-        if apply_outcome.stale {
-            MetricsRoundStatus::Cancelled
-        } else {
-            MetricsRoundStatus::Success
-        },
-        apply_outcome.usage,
-        session
-            .token_usage
-            .as_ref()
-            .map(|usage| usage.prompt_cached_tool_outputs)
-            .unwrap_or(0)
-            .min(u32::MAX as usize) as u32,
-        session
-            .token_usage
-            .as_ref()
-            .map(|usage| usage.prompt_cached_tool_tokens_saved)
-            .unwrap_or(0),
-        None,
-    );
-
+    let mut persistence_error = None;
     if !apply_outcome.stale && apply_outcome.applied_updates > 0 {
-        if let Some(ref ctx) = state.task_context {
+        if let Some(ref ctx) = staged_task_context {
             let task_list_title = result
                 .task_list_title
+                .clone()
                 .or_else(|| {
-                    session
+                    staged_session
                         .task_list
                         .as_ref()
                         .map(|task_list| task_list.title.clone())
                 })
                 .unwrap_or_else(|| "Agent Tasks".to_string());
-            session.set_task_list_version_meta(ctx.version.to_string());
             let task_list = ctx.to_task_list_with_title(task_list_title);
-            session.set_task_list(task_list.clone());
-            crate::runtime::runner::tool_execution::persist_shared_task_list(
-                config,
-                session,
-                &result.shared_session_id,
-                &state.session_id,
-                &task_list,
-            )
-            .await;
-            let _ = event_tx
-                .send(AgentEvent::TaskListUpdated { task_list })
-                .await;
+            let new_version = ctx.version.to_string();
+            let expected_version = result.based_on_task_context_version.to_string();
+            let persisted = if let Some(persistence) = config.persistence.as_ref() {
+                match persistence
+                    .update_task_list_control_planes_if_version(
+                        &state.session_id,
+                        &result.shared_session_id,
+                        &expected_version,
+                        &task_list,
+                        &new_version,
+                    )
+                    .await
+                {
+                    Ok(updated) => updated,
+                    Err(error) => {
+                        tracing::warn!(
+                            "[{}] Failed to compare-and-patch evaluated Task state on {}: {}",
+                            state.session_id,
+                            result.shared_session_id,
+                            error
+                        );
+                        persistence_error = Some(error.to_string());
+                        false
+                    }
+                }
+            } else {
+                true
+            };
+
+            if persisted {
+                state.task_context = staged_task_context;
+                session.set_task_list_version_meta(new_version);
+                session.set_task_list(task_list.clone());
+                let _ = event_tx
+                    .send(AgentEvent::TaskListUpdated { task_list })
+                    .await;
+            } else {
+                apply_outcome.stale = true;
+                tracing::debug!(
+                    "[{}] Dropping evaluated Task update because durable generation {} no longer matches",
+                    state.session_id,
+                    expected_version
+                );
+            }
         }
     }
+
+    let (metrics_status, completed_at, metrics_error) = if let Some(error) = result.error.clone() {
+        (MetricsRoundStatus::Error, result.finished_at, Some(error))
+    } else if let Some(error) = persistence_error {
+        (MetricsRoundStatus::Error, Utc::now(), Some(error))
+    } else if apply_outcome.stale {
+        (
+            MetricsRoundStatus::Cancelled,
+            Utc::now(),
+            Some("stale task evaluation result".to_string()),
+        )
+    } else {
+        (MetricsRoundStatus::Success, result.finished_at, None)
+    };
+    record_task_evaluation_terminal_metrics(
+        state.metrics_collector.as_ref(),
+        &result.metrics_round_id,
+        result.metrics_started.as_ref(),
+        result.metrics_terminal.as_ref(),
+        completed_at,
+        metrics_status,
+        apply_outcome.usage,
+        metrics_error,
+    );
 }
 
 fn spawn_task_evaluation_request(
@@ -872,11 +949,17 @@ fn spawn_task_evaluation_request(
     request: crate::runtime::runner::task_lifecycle::AsyncTaskEvaluationRequest,
     llm: Arc<dyn LLMProvider>,
     cancel_token: CancellationToken,
+    configured_limit: usize,
 ) {
     let task_round = request.round_number;
     let session_id = state.session_id.clone();
     let event_tx = event_tx.clone();
     let request_for_spawn = request.clone();
+    let metrics_collector = state.metrics_collector.clone();
+    let metrics_started = Arc::new(AtomicBool::new(false));
+    let metrics_terminal = Arc::new(AtomicBool::new(false));
+    let metrics_started_for_spawn = metrics_started.clone();
+    let metrics_terminal_for_spawn = metrics_terminal.clone();
     // Thread the run's cancel token into the detached eval so a cancelled run
     // drops the in-flight LLM request future at the first await point (`None`)
     // instead of running the evaluation — and its late `TaskListUpdated` event —
@@ -889,11 +972,16 @@ fn spawn_task_evaluation_request(
                 request_for_spawn,
                 llm,
                 event_tx,
+                configured_limit,
+                metrics_collector,
+                metrics_started_for_spawn,
+                metrics_terminal_for_spawn,
             ) => Some(result),
         }
     });
 
     tracing::debug!(
+        evaluation_id = %request.evaluation_id,
         "[{}] Spawned async task evaluation for round {}",
         session_id,
         task_round
@@ -901,6 +989,8 @@ fn spawn_task_evaluation_request(
 
     state.task_evaluation.in_flight = Some(InFlightTaskEvaluation {
         request,
+        metrics_started,
+        metrics_terminal,
         join_handle,
     });
 }
@@ -925,6 +1015,23 @@ async fn abort_in_flight_evaluations(
     let gold_was_running = state.gold_evaluation.in_flight.is_some();
     if let Some(in_flight) = state.task_evaluation.in_flight.take() {
         in_flight.join_handle.abort();
+        let metrics_round_id = in_flight.request.metrics_round_id.clone();
+        let metrics_started = in_flight.metrics_started.clone();
+        let metrics_terminal = in_flight.metrics_terminal.clone();
+        // Wait only for Tokio to observe the abort. This is not a provider
+        // drain, but it closes the race where dispatch starts immediately
+        // after an earlier `metrics_started` check.
+        let _ = in_flight.join_handle.await;
+        record_task_evaluation_terminal_metrics(
+            state.metrics_collector.as_ref(),
+            &metrics_round_id,
+            metrics_started.as_ref(),
+            metrics_terminal.as_ref(),
+            Utc::now(),
+            MetricsRoundStatus::Cancelled,
+            MetricsTokenUsage::default(),
+            Some(reason.to_string()),
+        );
     }
     if let Some(in_flight) = state.gold_evaluation.in_flight.take() {
         in_flight.join_handle.abort();
@@ -1014,7 +1121,14 @@ fn spawn_task_evaluation_if_needed(
         return Ok(());
     }
 
-    spawn_task_evaluation_request(state, event_tx, request, llm, cancel_token);
+    spawn_task_evaluation_request(
+        state,
+        event_tx,
+        request,
+        llm,
+        cancel_token,
+        config.auxiliary_evaluation_max_concurrency,
+    );
     Ok(())
 }
 
@@ -1597,6 +1711,35 @@ pub(super) async fn run_pipeline(
     config: &AgentLoopConfig,
     state: &mut LoopRunState,
 ) -> super::super::Result<bool> {
+    let result =
+        run_pipeline_inner(session, event_tx, llm, tools, cancel_token, config, state).await;
+
+    // This outer lifecycle fence deliberately catches every return from the
+    // implementation below, including `?` from prompt refresh and hook paths.
+    // The inner explicit calls remain useful for precise UI reasons and make
+    // this final pass idempotent.
+    let reason = if cancel_token.is_cancelled() {
+        "run_cancelled"
+    } else if result.is_err() {
+        "run_failed"
+    } else if session.metadata.contains_key("runtime.suspend_reason") {
+        "run_suspended"
+    } else {
+        "run_completed"
+    };
+    abort_in_flight_evaluations(state, event_tx, reason).await;
+    result
+}
+
+async fn run_pipeline_inner(
+    session: &mut Session,
+    event_tx: &mpsc::Sender<AgentEvent>,
+    llm: Arc<dyn LLMProvider>,
+    tools: Arc<dyn ToolExecutor>,
+    cancel_token: &CancellationToken,
+    config: &AgentLoopConfig,
+    state: &mut LoopRunState,
+) -> super::super::Result<bool> {
     let mut sent_complete = false;
     let mut turn_counter: u32 = 0;
     // One-shot sentinel for the max_rounds summary turn (see the guard at the
@@ -1633,6 +1776,7 @@ pub(super) async fn run_pipeline(
                     request,
                     eval_provider,
                     cancel_token.clone(),
+                    config.auxiliary_evaluation_max_concurrency,
                 );
             }
         }
@@ -1647,6 +1791,7 @@ pub(super) async fn run_pipeline(
                 .clone()
                 .unwrap_or_else(|| llm.clone()),
             cancel_token.clone(),
+            config.auxiliary_evaluation_max_concurrency,
         );
 
         state.runtime_state.round.current_round = turn_counter;
@@ -2631,7 +2776,7 @@ fn heuristic_complexity(
 
 #[cfg(test)]
 mod tests {
-    use super::super::startup::OverflowRecoveryState;
+    use super::super::startup::{InFlightTaskEvaluation, OverflowRecoveryState};
     use super::{
         apply_successful_explicit_activation, build_guardian_review_prompt,
         check_run_budget_exceeded, is_overflow_recoverable, is_subagent_create_call,
@@ -2658,6 +2803,7 @@ mod tests {
         RoundStatus as MetricsRoundStatus, SessionStatus as MetricsSessionStatus,
         TokenUsage as MetricsTokenUsage,
     };
+    use chrono::Utc;
     use futures::stream;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -4224,6 +4370,175 @@ mod tests {
         (dir, collector, storage)
     }
 
+    struct DelayedTaskMetricsProvider {
+        calls: std::sync::atomic::AtomicUsize,
+        windows: std::sync::Mutex<Vec<(chrono::DateTime<Utc>, chrono::DateTime<Utc>)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for DelayedTaskMetricsProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let started = Utc::now();
+            tokio::time::sleep(if call == 0 {
+                Duration::from_millis(60)
+            } else {
+                Duration::from_millis(150)
+            })
+            .await;
+            let completed = Utc::now();
+            self.windows
+                .lock()
+                .expect("metrics windows lock")
+                .push((started, completed));
+            Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)])))
+        }
+    }
+
+    #[tokio::test]
+    async fn repeated_task_evaluation_rounds_use_distinct_rows_and_dispatch_durations() {
+        use bamboo_metrics::storage::MetricsStorage;
+
+        let session_id = "task-evaluation-metrics-repeated-activation";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        let base = chrono::Utc::now();
+        collector.session_started(session_id, "model", base);
+
+        let mut session = Session::new(session_id, "model");
+        session.set_task_list(bamboo_domain::TaskList {
+            session_id: session_id.to_string(),
+            title: "Metrics task".to_string(),
+            items: vec![bamboo_domain::TaskItem {
+                id: "task-1".to_string(),
+                description: "measure evaluator".to_string(),
+                status: bamboo_domain::TaskItemStatus::InProgress,
+                ..bamboo_domain::TaskItem::default()
+            }],
+            created_at: base,
+            updated_at: base,
+        });
+        session.set_task_list_version_meta("1");
+        let task_context = crate::runtime::task_context::TaskLoopContext::from_session(&session);
+        let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
+            bamboo_config::StreamTimeoutConfig::default(),
+            Some("provider"),
+            Some("fast-model"),
+        );
+        let provider = Arc::new(DelayedTaskMetricsProvider {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            windows: std::sync::Mutex::new(Vec::new()),
+        });
+        let llm: Arc<dyn LLMProvider> = provider.clone();
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(16);
+        let mut metric_ids = Vec::new();
+
+        // Two real loop activations reuse the same session id and round number.
+        // Each executes through budget admission, the provider-dispatch metric
+        // callback, result.finished_at, and the normal apply terminal path.
+        for activation in 0..2 {
+            let request =
+                crate::runtime::runner::task_lifecycle::build_async_task_evaluation_request(
+                    &task_context,
+                    &session,
+                    session_id,
+                    1,
+                    Some("fast-model"),
+                    None,
+                    timeout_context.clone(),
+                )
+                .expect("activation request")
+                .expect("task context exists");
+            let request_id = request.evaluation_id.clone();
+            let result = crate::runtime::runner::task_lifecycle::execute_async_task_evaluation(
+                request,
+                llm.clone(),
+                event_tx.clone(),
+                1,
+                Some(collector.clone()),
+                Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            )
+            .await;
+            assert!(result.metrics_started.load(Ordering::Acquire));
+            metric_ids.push((request_id, result.metrics_round_id.clone()));
+
+            let mut activation_state = e2e_loop_state(session_id);
+            activation_state.execution_id = format!("activation-{activation}");
+            activation_state.task_context = task_context.clone();
+            activation_state.metrics_collector = Some(collector.clone());
+            activation_state.task_evaluation.completed = Some(result);
+            super::apply_completed_task_evaluation(
+                &mut session,
+                &event_tx,
+                &AgentLoopConfig::default(),
+                &mut activation_state,
+            )
+            .await;
+        }
+        assert_ne!(metric_ids[0].0, metric_ids[1].0);
+        assert_ne!(metric_ids[0].1, metric_ids[1].1);
+
+        let detail = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(detail) = storage
+                    .session_detail(session_id)
+                    .await
+                    .expect("session metrics query")
+                {
+                    if detail.rounds.len() == 2
+                        && detail
+                            .rounds
+                            .iter()
+                            .all(|round| round.completed_at.is_some())
+                    {
+                        break detail;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("two evaluator metric rows are persisted");
+        let first_row = detail
+            .rounds
+            .iter()
+            .find(|row| row.round_id == metric_ids[0].1)
+            .expect("first activation row");
+        let second_row = detail
+            .rounds
+            .iter()
+            .find(|row| row.round_id == metric_ids[1].1)
+            .expect("second activation row");
+        let windows = provider.windows.lock().expect("metrics windows lock");
+        assert_eq!(windows.len(), 2);
+        for (row, (provider_started, provider_completed)) in
+            [(first_row, windows[0]), (second_row, windows[1])]
+        {
+            assert!(row.started_at <= provider_started);
+            assert!(
+                provider_started - row.started_at < chrono::Duration::milliseconds(50),
+                "metric start must be adjacent to real provider dispatch"
+            );
+            let completed_at = row.completed_at.expect("terminal timestamp");
+            assert!(completed_at >= provider_completed);
+            assert!(
+                completed_at - provider_completed < chrono::Duration::milliseconds(50),
+                "metric completion must use the evaluator's real finish"
+            );
+        }
+        assert!(first_row.duration_ms.is_some_and(|duration| duration >= 60));
+        assert!(second_row
+            .duration_ms
+            .is_some_and(|duration| duration >= 150));
+        assert!(second_row.duration_ms.unwrap() > first_row.duration_ms.unwrap() + 50);
+    }
+
     async fn wait_for_pipeline_metrics(
         storage: &bamboo_metrics::SqliteMetricsStorage,
         session_id: &str,
@@ -5291,6 +5606,41 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct EvaluationCasPersistence {
+        full_saves: std::sync::atomic::AtomicUsize,
+        control_plane_saves: std::sync::atomic::AtomicUsize,
+        paired_task_patches: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl bamboo_domain::RuntimeSessionPersistence for EvaluationCasPersistence {
+        async fn save_runtime_session(&self, _session: &mut Session) -> std::io::Result<()> {
+            self.full_saves.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn save_runtime_control_plane(&self, _session: &mut Session) -> std::io::Result<()> {
+            self.control_plane_saves.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn update_task_list_control_planes_if_version(
+            &self,
+            session_id: &str,
+            shared_session_id: &str,
+            expected_version: &str,
+            _task_list: &bamboo_domain::TaskList,
+            version: &str,
+        ) -> std::io::Result<bool> {
+            assert_eq!(session_id, shared_session_id);
+            assert_eq!(expected_version, "1");
+            assert!(version.parse::<u64>().expect("numeric version") > 1);
+            self.paired_task_patches.fetch_add(1, Ordering::SeqCst);
+            Ok(true)
+        }
+    }
+
     #[tokio::test]
     async fn pending_injected_messages_are_merged_once_and_cleared_from_storage() {
         let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
@@ -5621,9 +5971,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_completed_task_evaluation_updates_task_list_and_emits_event() {
-        let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
-        let persistence: Arc<dyn bamboo_domain::RuntimeSessionPersistence> =
-            Arc::new(TestPersistence(storage.clone()));
+        let persistence = Arc::new(EvaluationCasPersistence::default());
         let mut session = Session::new("session-task-eval", "model");
         session.set_task_list(bamboo_domain::TaskList {
             session_id: "session-task-eval".to_string(),
@@ -5653,11 +6001,11 @@ mod tests {
                 in_flight: None,
                 completed: Some(
                     crate::runtime::runner::task_lifecycle::AsyncTaskEvaluationResult {
+                        metrics_round_id: "session-task-eval-task-evaluation-test".to_string(),
                         shared_session_id: "session-task-eval".to_string(),
                         round_number: 1,
                         based_on_task_context_version: 1,
                         task_list_title: Some("Eval Tasks".to_string()),
-                        model_name: "fast-model".to_string(),
                         evaluation_result: crate::runtime::task_evaluation::TaskEvaluationResult {
                             needs_evaluation: true,
                             updates: vec![crate::runtime::task_evaluation::TaskItemUpdate {
@@ -5672,6 +6020,14 @@ mod tests {
                             prompt_tokens: 4,
                             completion_tokens: 2,
                         },
+                        finished_at: chrono::Utc::now(),
+                        error: None,
+                        metrics_started: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                            true,
+                        )),
+                        metrics_terminal: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                            false,
+                        )),
                     },
                 ),
                 queued_request: None,
@@ -5681,8 +6037,7 @@ mod tests {
             runtime_state: AgentRuntimeState::new("session-task-eval"),
         };
         let config = crate::runtime::config::AgentLoopConfig {
-            storage: Some(storage.clone()),
-            persistence: Some(persistence),
+            persistence: Some(persistence.clone()),
             ..Default::default()
         };
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
@@ -5706,6 +6061,17 @@ mod tests {
             }
             other => panic!("unexpected event: {other:?}"),
         }
+        assert_eq!(
+            persistence.paired_task_patches.load(Ordering::SeqCst),
+            1,
+            "evaluation must persist exactly one targeted Task CAS"
+        );
+        assert_eq!(persistence.full_saves.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            persistence.control_plane_saves.load(Ordering::SeqCst),
+            0,
+            "evaluation must not add a child/root whole control-plane save"
+        );
     }
 
     // --- Tests from round_prelude/round_state.rs ---
@@ -6688,6 +7054,226 @@ mod tests {
     // and could fire a late event onto the already-ended stream. The fix threads
     // the run's cancel token into the spawned eval (a `select!` that resolves to
     // `None` on cancel) AND aborts any in-flight handle at every early return.
+
+    struct AbortBeforeRoundHook;
+
+    #[async_trait::async_trait]
+    impl AgentHook for AbortBeforeRoundHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::BeforeRound
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            _payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            HookResult::Abort {
+                reason: "injected before-round failure".to_string(),
+            }
+        }
+    }
+
+    struct EvalDropFlag(Arc<AtomicBool>);
+
+    impl Drop for EvalDropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn seed_blocked_task_evaluation(
+        session: &mut Session,
+        state: &mut super::super::startup::LoopRunState,
+    ) -> Arc<AtomicBool> {
+        let now = chrono::Utc::now();
+        session.set_task_list(bamboo_domain::TaskList {
+            session_id: session.id.clone(),
+            title: "Pending evaluator".to_string(),
+            items: vec![bamboo_domain::TaskItem {
+                id: "pending".to_string(),
+                description: "wait".to_string(),
+                status: bamboo_domain::TaskItemStatus::InProgress,
+                ..bamboo_domain::TaskItem::default()
+            }],
+            created_at: now,
+            updated_at: now,
+        });
+        session.set_task_list_version_meta("1");
+        state.task_context = crate::runtime::task_context::TaskLoopContext::from_session(session);
+        let request = crate::runtime::runner::task_lifecycle::build_async_task_evaluation_request(
+            &state.task_context,
+            session,
+            &state.session_id,
+            1,
+            Some("fast-model"),
+            None,
+            crate::runtime::stream::handler::StreamTimeoutContext::new(
+                bamboo_config::StreamTimeoutConfig::default(),
+                Some("provider"),
+                Some("fast-model"),
+            ),
+        )
+        .expect("evaluation request")
+        .expect("task context");
+        state.task_evaluation.queued_request = Some(request.clone());
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let drop_flag = EvalDropFlag(dropped.clone());
+        let join_handle = tokio::spawn(async move {
+            let _drop_flag = drop_flag;
+            futures::future::pending::<
+                Option<crate::runtime::runner::task_lifecycle::AsyncTaskEvaluationResult>,
+            >()
+            .await
+        });
+        state.task_evaluation.in_flight = Some(InFlightTaskEvaluation {
+            request,
+            metrics_started: Arc::new(AtomicBool::new(false)),
+            metrics_terminal: Arc::new(AtomicBool::new(false)),
+            join_handle,
+        });
+        dropped
+    }
+
+    #[tokio::test]
+    async fn before_round_hook_failure_aborts_task_eval_and_clears_latest_snapshot() {
+        let mut session = Session::new("task-eval-before-round-hook", "model");
+        let mut state = e2e_loop_state(&session.id);
+        let dropped = seed_blocked_task_evaluation(&mut session, &mut state);
+        let mut config = stop_hook_config(Arc::new(AbortBeforeRoundHook));
+        config.model_name = Some("model".to_string());
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+
+        let result = super::run_pipeline(
+            &mut session,
+            &tx,
+            Arc::new(StubProvider),
+            Arc::new(AlwaysOkExecutor),
+            &CancellationToken::new(),
+            &config,
+            &mut state,
+        )
+        .await;
+
+        assert!(result.is_err(), "BeforeRound abort must fail the run");
+        assert!(state.task_evaluation.in_flight.is_none());
+        assert!(state.task_evaluation.queued_request.is_none());
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "evaluator future was aborted"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_tool_finalize_hook_failure_aborts_task_eval_and_clears_latest_snapshot() {
+        let mut session = Session::new("task-eval-no-tool-hook", "model");
+        let mut state = e2e_loop_state(&session.id);
+        let dropped = seed_blocked_task_evaluation(&mut session, &mut state);
+        let mut config = stop_hook_config(Arc::new(AbortFinalizeHook));
+        config.model_name = Some("model".to_string());
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+
+        let result = super::run_pipeline(
+            &mut session,
+            &tx,
+            Arc::new(CanonicalUsageProvider {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                content: Some("final answer"),
+            }),
+            Arc::new(AlwaysOkExecutor),
+            &CancellationToken::new(),
+            &config,
+            &mut state,
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "BeforeFinalize abort must fail no-tool path"
+        );
+        assert!(state.task_evaluation.in_flight.is_none());
+        assert!(state.task_evaluation.queued_request.is_none());
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "evaluator future was aborted"
+        );
+    }
+
+    #[tokio::test]
+    async fn abort_while_waiting_for_auxiliary_permit_does_not_start_metric_row() {
+        use bamboo_metrics::storage::MetricsStorage;
+
+        let session_id = "task-eval-waiting-budget-cancel";
+        let (_dir, collector, storage) = create_pipeline_metrics().await;
+        collector.session_started(session_id, "model", Utc::now());
+        let provider: Arc<dyn LLMProvider> = Arc::new(StubProvider);
+        let held =
+            crate::runtime::runner::auxiliary_budget::acquire(&provider, "fast-model", 1).await;
+
+        let mut session = Session::new(session_id, "model");
+        let mut state = e2e_loop_state(session_id);
+        seed_blocked_task_evaluation(&mut session, &mut state);
+        let (reset_tx, _reset_rx) = mpsc::channel(4);
+        super::abort_in_flight_evaluations(&mut state, &reset_tx, "test_reset").await;
+        let request = crate::runtime::runner::task_lifecycle::build_async_task_evaluation_request(
+            &state.task_context,
+            &session,
+            session_id,
+            1,
+            Some("fast-model"),
+            None,
+            crate::runtime::stream::handler::StreamTimeoutContext::default(),
+        )
+        .expect("request builds")
+        .expect("task context exists");
+        state.metrics_collector = Some(collector);
+        let (event_tx, _event_rx) = mpsc::channel(8);
+        super::spawn_task_evaluation_request(
+            &mut state,
+            &event_tx,
+            request,
+            provider,
+            CancellationToken::new(),
+            1,
+        );
+        tokio::task::yield_now().await;
+        let started = state
+            .task_evaluation
+            .in_flight
+            .as_ref()
+            .expect("evaluation waits")
+            .metrics_started
+            .clone();
+        assert!(!started.load(Ordering::Acquire));
+
+        super::abort_in_flight_evaluations(&mut state, &event_tx, "run_cancelled").await;
+        drop(held);
+        assert!(!started.load(Ordering::Acquire));
+        assert!(state.task_evaluation.in_flight.is_none());
+        assert!(state.task_evaluation.queued_request.is_none());
+
+        let detail = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if let Some(detail) = storage
+                    .session_detail(session_id)
+                    .await
+                    .expect("session metrics query")
+                {
+                    break detail;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("session start metric persists");
+        assert!(
+            detail.rounds.is_empty(),
+            "permit-wait cancellation must not create a started evaluator row"
+        );
+    }
 
     /// What the scripted main agent does on its SECOND round, once the Gold
     /// evaluation spawned after round 1 is genuinely in flight.

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -911,6 +911,7 @@ async fn apply_completed_task_evaluation(
                         &state.session_id,
                         &result.shared_session_id,
                         &expected_version,
+                        &result.based_on_task_list,
                         &task_list,
                         &new_version,
                     )
@@ -5726,6 +5727,7 @@ mod tests {
             session_id: &str,
             shared_session_id: &str,
             expected_version: &str,
+            _expected_task_list: &bamboo_domain::TaskList,
             _task_list: &bamboo_domain::TaskList,
             version: &str,
         ) -> std::io::Result<bool> {
@@ -6084,6 +6086,7 @@ mod tests {
         session
             .metadata
             .insert("task_list_version".to_string(), "1".to_string());
+        let based_on_task_list = session.task_list.clone().expect("task list");
 
         let mut state = super::super::startup::LoopRunState {
             session_id: "session-task-eval".to_string(),
@@ -6101,6 +6104,7 @@ mod tests {
                         shared_session_id: "session-task-eval".to_string(),
                         round_number: 1,
                         based_on_task_context_version: 1,
+                        based_on_task_list,
                         task_list_title: Some("Eval Tasks".to_string()),
                         evaluation_result: crate::runtime::task_evaluation::TaskEvaluationResult {
                             needs_evaluation: true,

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
@@ -8,6 +8,8 @@ use bamboo_agent_core::tools::ToolExecutor;
 use bamboo_agent_core::{AgentEvent, Session};
 use bamboo_domain::{AgentRuntimeState, AgentStatusState};
 use bamboo_metrics::MetricsCollector;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use super::super::logging::DebugLogger;
 use crate::runtime::runner::state_bridge;
@@ -39,6 +41,11 @@ impl OverflowRecoveryState {
 
 pub(super) struct InFlightTaskEvaluation {
     pub(super) request: AsyncTaskEvaluationRequest,
+    /// Set only at the provider-dispatch boundary, after the low-priority
+    /// budget has admitted this request.
+    pub(super) metrics_started: Arc<AtomicBool>,
+    /// Exactly-once guard shared with the completed result.
+    pub(super) metrics_terminal: Arc<AtomicBool>,
     // `Option<..>` output: the spawned future `select!`s on the run's
     // `CancellationToken`, so a cancelled run yields `None` (the eval work was
     // dropped at an await point, stopping the wasted LLM spend) instead of a

--- a/crates/engine/bamboo-engine/src/runtime/runner/metrics_lifecycle/round_metrics.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/metrics_lifecycle/round_metrics.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 
 use bamboo_metrics::{
     MetricsCollector, RoundStatus as MetricsRoundStatus, SessionStatus as MetricsSessionStatus,
@@ -11,6 +11,22 @@ pub(in crate::runtime::runner) fn record_round_started(
     session_id: &str,
     model_name: &str,
 ) {
+    record_round_started_at(
+        metrics_collector,
+        round_id,
+        session_id,
+        model_name,
+        Utc::now(),
+    );
+}
+
+pub(in crate::runtime::runner) fn record_round_started_at(
+    metrics_collector: Option<&MetricsCollector>,
+    round_id: &str,
+    session_id: &str,
+    model_name: &str,
+    started_at: DateTime<Utc>,
+) {
     let Some(metrics) = metrics_collector else {
         return;
     };
@@ -18,7 +34,7 @@ pub(in crate::runtime::runner) fn record_round_started(
         round_id.to_string(),
         session_id.to_string(),
         model_name.to_string(),
-        Utc::now(),
+        started_at,
     );
 }
 
@@ -34,19 +50,46 @@ pub(in crate::runtime::runner) fn record_round_completed(
     prompt_cached_tool_tokens_saved: u32,
     round_error: Option<String>,
 ) {
+    record_round_completed_at(
+        metrics_collector,
+        round_id,
+        session_id,
+        message_count,
+        round_status,
+        round_usage,
+        prompt_cached_tool_outputs,
+        prompt_cached_tool_tokens_saved,
+        round_error,
+        Utc::now(),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::runtime::runner) fn record_round_completed_at(
+    metrics_collector: Option<&MetricsCollector>,
+    round_id: &str,
+    session_id: &str,
+    message_count: u32,
+    round_status: MetricsRoundStatus,
+    round_usage: MetricsTokenUsage,
+    prompt_cached_tool_outputs: u32,
+    prompt_cached_tool_tokens_saved: u32,
+    round_error: Option<String>,
+    completed_at: DateTime<Utc>,
+) {
     let Some(metrics) = metrics_collector else {
         return;
     };
     metrics.round_completed(
         round_id.to_string(),
-        Utc::now(),
+        completed_at,
         round_status,
         round_usage,
         prompt_cached_tool_outputs,
         prompt_cached_tool_tokens_saved,
         round_error,
     );
-    metrics.session_message_count(session_id.to_string(), message_count, Utc::now());
+    metrics.session_message_count(session_id.to_string(), message_count, completed_at);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/engine/bamboo-engine/src/runtime/runner/task_lifecycle/evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/task_lifecycle/evaluation.rs
@@ -1,15 +1,17 @@
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use tokio::sync::mpsc;
 
 use crate::runtime::task_context::TaskLoopContext;
-use crate::runtime::task_evaluation::{evaluate_task_progress, TaskEvaluationResult};
+use crate::runtime::task_evaluation::{evaluate_task_progress_with_dispatch, TaskEvaluationResult};
 use bamboo_agent_core::{AgentError, AgentEvent, Session, SessionKind};
 use bamboo_domain::task::{TaskBlocker, TaskBlockerKind, TaskEvidence, TaskEvidenceKind};
 use bamboo_domain::{ReasoningEffort, TaskItemStatus};
 use bamboo_llm::LLMProvider;
-use bamboo_metrics::TokenUsage as MetricsTokenUsage;
+use bamboo_metrics::{MetricsCollector, TokenUsage as MetricsTokenUsage};
 
 fn normalize_criterion(value: &str) -> Option<String> {
     let normalized = value
@@ -104,6 +106,8 @@ impl TaskEvaluationApplyOutcome {
 
 #[derive(Debug, Clone)]
 pub(in crate::runtime::runner) struct AsyncTaskEvaluationRequest {
+    pub(in crate::runtime::runner) evaluation_id: String,
+    pub(in crate::runtime::runner) metrics_round_id: String,
     pub(in crate::runtime::runner) session_id: String,
     pub(in crate::runtime::runner) shared_session_id: String,
     pub(in crate::runtime::runner) round_number: usize,
@@ -119,12 +123,16 @@ pub(in crate::runtime::runner) struct AsyncTaskEvaluationRequest {
 
 #[derive(Debug, Clone)]
 pub(in crate::runtime::runner) struct AsyncTaskEvaluationResult {
+    pub(in crate::runtime::runner) metrics_round_id: String,
     pub(in crate::runtime::runner) shared_session_id: String,
     pub(in crate::runtime::runner) round_number: usize,
     pub(in crate::runtime::runner) based_on_task_context_version: u64,
     pub(in crate::runtime::runner) task_list_title: Option<String>,
-    pub(in crate::runtime::runner) model_name: String,
     pub(in crate::runtime::runner) evaluation_result: TaskEvaluationResult,
+    pub(in crate::runtime::runner) finished_at: DateTime<Utc>,
+    pub(in crate::runtime::runner) error: Option<String>,
+    pub(in crate::runtime::runner) metrics_started: Arc<AtomicBool>,
+    pub(in crate::runtime::runner) metrics_terminal: Arc<AtomicBool>,
 }
 
 pub(in crate::runtime::runner) fn build_async_task_evaluation_request(
@@ -148,7 +156,12 @@ pub(in crate::runtime::runner) fn build_async_task_evaluation_request(
         SessionKind::Root => session.id.clone(),
     };
 
+    let evaluation_id = crate::runtime::runner::round_prelude::new_execution_id();
+    let metrics_round_id = format!("{session_id}-task-evaluation-{evaluation_id}");
+
     Ok(Some(AsyncTaskEvaluationRequest {
+        evaluation_id,
+        metrics_round_id,
         session_id: session_id.to_string(),
         shared_session_id,
         round_number,
@@ -169,8 +182,27 @@ pub(in crate::runtime::runner) async fn execute_async_task_evaluation(
     request: AsyncTaskEvaluationRequest,
     llm: Arc<dyn LLMProvider>,
     event_tx: mpsc::Sender<AgentEvent>,
+    configured_limit: usize,
+    metrics_collector: Option<MetricsCollector>,
+    metrics_started: Arc<AtomicBool>,
+    metrics_terminal: Arc<AtomicBool>,
 ) -> AsyncTaskEvaluationResult {
-    let evaluation_result = match evaluate_task_progress(
+    let budget_provider = llm.clone();
+    let budget_model = request.model_name.clone();
+    let acquire_dispatch_guard = async move {
+        crate::runtime::runner::auxiliary_budget::acquire(
+            &budget_provider,
+            &budget_model,
+            configured_limit,
+        )
+        .await
+    };
+    let metrics_for_dispatch = metrics_collector.clone();
+    let metrics_round_id = request.metrics_round_id.clone();
+    let metrics_session_id = request.session_id.clone();
+    let metrics_model_name = request.model_name.clone();
+    let metrics_started_for_dispatch = metrics_started.clone();
+    let evaluation = evaluate_task_progress_with_dispatch(
         &request.task_context_snapshot,
         &request.session_snapshot,
         llm,
@@ -181,26 +213,52 @@ pub(in crate::runtime::runner) async fn execute_async_task_evaluation(
             reasoning_effort: request.reasoning_effort,
             timeout_context: &request.timeout_context,
         },
-    )
-    .await
-    {
-        Ok(result) => result,
-        Err(error) => TaskEvaluationResult {
-            needs_evaluation: false,
-            updates: Vec::new(),
-            reasoning: format!("Evaluation failed: {error}"),
-            prompt_tokens: 0,
-            completion_tokens: 0,
+        acquire_dispatch_guard,
+        move || {
+            if let Some(metrics) = metrics_for_dispatch.as_ref() {
+                metrics.round_started(
+                    metrics_round_id,
+                    metrics_session_id,
+                    metrics_model_name,
+                    Utc::now(),
+                );
+            }
+            metrics_started_for_dispatch.store(true, Ordering::Release);
         },
+    )
+    .await;
+    let finished_at = Utc::now();
+    let (evaluation_result, error) = match evaluation {
+        Ok(result) => {
+            let error = result
+                .reasoning
+                .strip_prefix("Evaluation failed:")
+                .map(|_| result.reasoning.clone());
+            (result, error)
+        }
+        Err(error) => (
+            TaskEvaluationResult {
+                needs_evaluation: false,
+                updates: Vec::new(),
+                reasoning: format!("Evaluation failed: {error}"),
+                prompt_tokens: 0,
+                completion_tokens: 0,
+            },
+            Some(error.to_string()),
+        ),
     };
 
     AsyncTaskEvaluationResult {
+        metrics_round_id: request.metrics_round_id,
         shared_session_id: request.shared_session_id,
         round_number: request.round_number,
         based_on_task_context_version: request.based_on_task_context_version,
         task_list_title: request.task_list_title,
-        model_name: request.model_name,
         evaluation_result,
+        finished_at,
+        error,
+        metrics_started,
+        metrics_terminal,
     }
 }
 
@@ -379,13 +437,19 @@ pub(in crate::runtime::runner) fn apply_task_evaluation_result(
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_task_evaluation_result, missing_completion_criteria, AsyncTaskEvaluationResult,
+        apply_task_evaluation_result, build_async_task_evaluation_request,
+        execute_async_task_evaluation, missing_completion_criteria, AsyncTaskEvaluationResult,
     };
     use crate::runtime::task_context::TaskLoopContext;
-    use bamboo_agent_core::Session;
+    use bamboo_agent_core::{AgentEvent, Message, Session, ToolSchema};
     use bamboo_domain::task::{TaskPhase, TaskPriority};
     use bamboo_domain::{TaskItem, TaskItemStatus, TaskList};
+    use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
     use chrono::Utc;
+    use futures::stream;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
 
     fn session_with_single_in_progress_task() -> (Session, TaskLoopContext) {
         let mut session = Session::new("task-eval-session", "model");
@@ -410,6 +474,118 @@ mod tests {
         (session, context)
     }
 
+    struct BlockingEvaluationProvider {
+        active: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        entered: Arc<AtomicUsize>,
+        release: Arc<tokio::sync::Semaphore>,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for BlockingEvaluationProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(active, Ordering::SeqCst);
+            self.entered.fetch_add(1, Ordering::SeqCst);
+            let permit = self
+                .release
+                .acquire()
+                .await
+                .expect("provider release gate stays open");
+            permit.forget();
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)])))
+        }
+    }
+
+    #[tokio::test]
+    async fn task_evaluations_from_multiple_sessions_obey_shared_provider_model_limit() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let provider: Arc<dyn LLMProvider> = Arc::new(BlockingEvaluationProvider {
+            active: active.clone(),
+            peak: peak.clone(),
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel::<AgentEvent>(32);
+        let mut handles = Vec::new();
+
+        for index in 0..6 {
+            let session_id = format!("evaluation-session-{index}");
+            let mut session = Session::new(&session_id, "main-model");
+            let now = Utc::now();
+            session.set_task_list(TaskList {
+                session_id: session_id.clone(),
+                title: "Shared-budget task".to_string(),
+                items: vec![TaskItem {
+                    id: "task-1".to_string(),
+                    description: "evaluate me".to_string(),
+                    status: TaskItemStatus::InProgress,
+                    ..TaskItem::default()
+                }],
+                created_at: now,
+                updated_at: now,
+            });
+            session.set_task_list_version_meta("1");
+            let context = TaskLoopContext::from_session(&session);
+            let request = build_async_task_evaluation_request(
+                &context,
+                &session,
+                &session_id,
+                1,
+                Some("shared-fast-model"),
+                None,
+                crate::runtime::stream::handler::StreamTimeoutContext::default(),
+            )
+            .expect("request builds")
+            .expect("context exists");
+            let provider = provider.clone();
+            let event_tx = event_tx.clone();
+            handles.push(tokio::spawn(async move {
+                execute_async_task_evaluation(
+                    request,
+                    provider,
+                    event_tx,
+                    2,
+                    None,
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(AtomicBool::new(false)),
+                )
+                .await
+            }));
+        }
+
+        for expected_entered in [2, 4, 6] {
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while entered.load(Ordering::SeqCst) < expected_entered {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("next cross-session evaluation batch dispatches");
+            assert!(active.load(Ordering::SeqCst) <= 2);
+            assert_eq!(peak.load(Ordering::SeqCst), 2);
+            release.add_permits(2);
+        }
+
+        let mut metric_ids = std::collections::HashSet::new();
+        for handle in handles {
+            let result = handle.await.expect("evaluation session joins");
+            assert!(result.metrics_started.load(Ordering::Acquire));
+            assert!(metric_ids.insert(result.metrics_round_id));
+        }
+        assert_eq!(peak.load(Ordering::SeqCst), 2);
+    }
+
     #[test]
     fn apply_task_evaluation_result_rejects_stale_results() {
         let (mut session, mut context) = session_with_single_in_progress_task();
@@ -420,11 +596,11 @@ mod tests {
             &mut session,
             "task-eval-session",
             AsyncTaskEvaluationResult {
+                metrics_round_id: "stale-evaluation".to_string(),
                 shared_session_id: "task-eval-session".to_string(),
                 round_number: 2,
                 based_on_task_context_version: 4,
                 task_list_title: Some("Eval Tasks".to_string()),
-                model_name: "fast-model".to_string(),
                 evaluation_result: crate::runtime::task_evaluation::TaskEvaluationResult {
                     needs_evaluation: true,
                     updates: vec![crate::runtime::task_evaluation::TaskItemUpdate {
@@ -439,6 +615,10 @@ mod tests {
                     prompt_tokens: 12,
                     completion_tokens: 6,
                 },
+                finished_at: Utc::now(),
+                error: None,
+                metrics_started: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                metrics_terminal: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
         );
 
@@ -461,11 +641,11 @@ mod tests {
             &mut session,
             "task-eval-session",
             AsyncTaskEvaluationResult {
+                metrics_round_id: "matching-evaluation".to_string(),
                 shared_session_id: "task-eval-session".to_string(),
                 round_number: 2,
                 based_on_task_context_version: context.version,
                 task_list_title: Some("Eval Tasks".to_string()),
-                model_name: "fast-model".to_string(),
                 evaluation_result: crate::runtime::task_evaluation::TaskEvaluationResult {
                     needs_evaluation: true,
                     updates: vec![crate::runtime::task_evaluation::TaskItemUpdate {
@@ -480,6 +660,10 @@ mod tests {
                     prompt_tokens: 12,
                     completion_tokens: 6,
                 },
+                finished_at: Utc::now(),
+                error: None,
+                metrics_started: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                metrics_terminal: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
         );
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/task_lifecycle/evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/task_lifecycle/evaluation.rs
@@ -9,9 +9,19 @@ use crate::runtime::task_context::TaskLoopContext;
 use crate::runtime::task_evaluation::{evaluate_task_progress_with_dispatch, TaskEvaluationResult};
 use bamboo_agent_core::{AgentError, AgentEvent, Session, SessionKind};
 use bamboo_domain::task::{TaskBlocker, TaskBlockerKind, TaskEvidence, TaskEvidenceKind};
-use bamboo_domain::{ReasoningEffort, TaskItemStatus};
+use bamboo_domain::{ReasoningEffort, TaskItemStatus, TaskList};
 use bamboo_llm::LLMProvider;
 use bamboo_metrics::{MetricsCollector, TokenUsage as MetricsTokenUsage};
+
+fn task_lists_match(current: &TaskList, expected: &TaskList) -> bool {
+    match (
+        serde_json::to_value(current),
+        serde_json::to_value(expected),
+    ) {
+        (Ok(current), Ok(expected)) => current == expected,
+        _ => false,
+    }
+}
 
 fn normalize_criterion(value: &str) -> Option<String> {
     let normalized = value
@@ -112,6 +122,7 @@ pub(in crate::runtime::runner) struct AsyncTaskEvaluationRequest {
     pub(in crate::runtime::runner) shared_session_id: String,
     pub(in crate::runtime::runner) round_number: usize,
     pub(in crate::runtime::runner) based_on_task_context_version: u64,
+    pub(in crate::runtime::runner) based_on_task_list: TaskList,
     pub(in crate::runtime::runner) task_list_title: Option<String>,
     pub(in crate::runtime::runner) model_name: String,
     pub(in crate::runtime::runner) timeout_context:
@@ -127,6 +138,7 @@ pub(in crate::runtime::runner) struct AsyncTaskEvaluationResult {
     pub(in crate::runtime::runner) shared_session_id: String,
     pub(in crate::runtime::runner) round_number: usize,
     pub(in crate::runtime::runner) based_on_task_context_version: u64,
+    pub(in crate::runtime::runner) based_on_task_list: TaskList,
     pub(in crate::runtime::runner) task_list_title: Option<String>,
     pub(in crate::runtime::runner) evaluation_result: TaskEvaluationResult,
     pub(in crate::runtime::runner) finished_at: DateTime<Utc>,
@@ -145,6 +157,9 @@ pub(in crate::runtime::runner) fn build_async_task_evaluation_request(
     timeout_context: crate::runtime::stream::handler::StreamTimeoutContext,
 ) -> Result<Option<AsyncTaskEvaluationRequest>, AgentError> {
     let Some(task_context_snapshot) = task_context.clone() else {
+        return Ok(None);
+    };
+    let Some(based_on_task_list) = session.task_list.clone() else {
         return Ok(None);
     };
 
@@ -166,6 +181,7 @@ pub(in crate::runtime::runner) fn build_async_task_evaluation_request(
         shared_session_id,
         round_number,
         based_on_task_context_version: task_context_snapshot.version,
+        based_on_task_list,
         task_list_title: session
             .task_list
             .as_ref()
@@ -253,6 +269,7 @@ pub(in crate::runtime::runner) async fn execute_async_task_evaluation(
         shared_session_id: request.shared_session_id,
         round_number: request.round_number,
         based_on_task_context_version: request.based_on_task_context_version,
+        based_on_task_list: request.based_on_task_list,
         task_list_title: request.task_list_title,
         evaluation_result,
         finished_at,
@@ -328,13 +345,26 @@ pub(in crate::runtime::runner) fn apply_task_evaluation_result(
         return TaskEvaluationApplyOutcome::stale(usage);
     };
 
-    if ctx.version != evaluation.based_on_task_context_version {
+    let session_matches_snapshot = session
+        .task_list
+        .as_ref()
+        .is_some_and(|task_list| task_lists_match(task_list, &evaluation.based_on_task_list));
+    let context_matches_snapshot = task_lists_match(
+        &ctx.to_task_list_with_title(evaluation.based_on_task_list.title.clone()),
+        &evaluation.based_on_task_list,
+    );
+    if ctx.version != evaluation.based_on_task_context_version
+        || !session_matches_snapshot
+        || !context_matches_snapshot
+    {
         tracing::debug!(
-            "[{}] Dropping stale async task evaluation for round {} (snapshot version={}, current version={})",
+            "[{}] Dropping stale async task evaluation for round {} (snapshot version={}, current version={}, session_snapshot_match={}, context_snapshot_match={})",
             session_id,
             evaluation.round_number,
             evaluation.based_on_task_context_version,
-            ctx.version
+            ctx.version,
+            session_matches_snapshot,
+            context_matches_snapshot,
         );
         return TaskEvaluationApplyOutcome::stale(usage);
     }
@@ -590,6 +620,7 @@ mod tests {
     fn apply_task_evaluation_result_rejects_stale_results() {
         let (mut session, mut context) = session_with_single_in_progress_task();
         context.version = 5;
+        let based_on_task_list = session.task_list.clone().expect("task list");
 
         let outcome = apply_task_evaluation_result(
             &mut Some(context.clone()),
@@ -600,6 +631,7 @@ mod tests {
                 shared_session_id: "task-eval-session".to_string(),
                 round_number: 2,
                 based_on_task_context_version: 4,
+                based_on_task_list,
                 task_list_title: Some("Eval Tasks".to_string()),
                 evaluation_result: crate::runtime::task_evaluation::TaskEvaluationResult {
                     needs_evaluation: true,
@@ -632,9 +664,60 @@ mod tests {
     }
 
     #[test]
+    fn apply_task_evaluation_result_rejects_same_version_divergent_snapshot() {
+        let (mut session, original_context) = session_with_single_in_progress_task();
+        let based_on_task_list = session.task_list.clone().expect("task list");
+        session.task_list.as_mut().expect("live task list").items[0].description =
+            "Competing same-generation winner".to_string();
+        let winner_context =
+            TaskLoopContext::from_session(&session).expect("winner context should exist");
+        assert_eq!(winner_context.version, original_context.version);
+        let mut maybe_context = Some(winner_context);
+
+        let outcome = apply_task_evaluation_result(
+            &mut maybe_context,
+            &mut session,
+            "task-eval-session",
+            AsyncTaskEvaluationResult {
+                metrics_round_id: "same-version-stale-evaluation".to_string(),
+                shared_session_id: "task-eval-session".to_string(),
+                round_number: 2,
+                based_on_task_context_version: original_context.version,
+                based_on_task_list,
+                task_list_title: Some("Eval Tasks".to_string()),
+                evaluation_result: crate::runtime::task_evaluation::TaskEvaluationResult {
+                    needs_evaluation: true,
+                    updates: vec![crate::runtime::task_evaluation::TaskItemUpdate {
+                        item_id: "task-1".to_string(),
+                        status: TaskItemStatus::Completed,
+                        notes: Some("stale result must not apply".to_string()),
+                        evidence: Some("stale evidence".to_string()),
+                        blocker: None,
+                        criteria_met: None,
+                    }],
+                    reasoning: "stale".to_string(),
+                    prompt_tokens: 7,
+                    completion_tokens: 3,
+                },
+                finished_at: Utc::now(),
+                error: None,
+                metrics_started: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                metrics_terminal: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            },
+        );
+
+        assert!(outcome.stale);
+        assert_eq!(outcome.applied_updates, 0);
+        let live_item = &session.task_list.as_ref().expect("live task list").items[0];
+        assert_eq!(live_item.status, TaskItemStatus::InProgress);
+        assert_eq!(live_item.description, "Competing same-generation winner");
+    }
+
+    #[test]
     fn apply_task_evaluation_result_applies_matching_results() {
         let (mut session, context) = session_with_single_in_progress_task();
         let mut maybe_context = Some(context.clone());
+        let based_on_task_list = session.task_list.clone().expect("task list");
 
         let outcome = apply_task_evaluation_result(
             &mut maybe_context,
@@ -645,6 +728,7 @@ mod tests {
                 shared_session_id: "task-eval-session".to_string(),
                 round_number: 2,
                 based_on_task_context_version: context.version,
+                based_on_task_list,
                 task_list_title: Some("Eval Tasks".to_string()),
                 evaluation_result: crate::runtime::task_evaluation::TaskEvaluationResult {
                     needs_evaluation: true,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -54,7 +54,6 @@ mod output_compressor;
 mod per_call;
 mod policy;
 mod task;
-pub(in crate::runtime::runner) use task::persist_shared_task_list;
 pub(crate) mod tool_error_collector;
 
 use loop_state::RoundExecutionState;

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task.rs
@@ -8,8 +8,6 @@ use bamboo_agent_core::{AgentEvent, Session};
 mod progress;
 mod taskwrite;
 
-pub(in crate::runtime::runner) use taskwrite::persist_shared_task_list;
-
 pub(super) async fn track_task_progress(
     task_context: &mut Option<TaskLoopContext>,
     event_tx: &mpsc::Sender<AgentEvent>,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/taskwrite.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/taskwrite.rs
@@ -75,7 +75,7 @@ pub(super) async fn maybe_handle_taskwrite(
     reinitialize_task_context(task_context, session, session_id);
 }
 
-pub(in crate::runtime::runner) async fn persist_shared_task_list(
+async fn persist_shared_task_list(
     config: &AgentLoopConfig,
     session: &mut Session,
     shared_session_id: &str,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/taskwrite.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/taskwrite.rs
@@ -6,6 +6,24 @@ use bamboo_agent_core::tools::{ToolCall, ToolResult};
 use bamboo_agent_core::{AgentEvent, Session, SessionKind};
 use bamboo_tools::TaskTool;
 
+enum TaskPersistenceOutcome {
+    Publish(bamboo_domain::TaskList),
+    Suppress,
+}
+
+fn task_list_matches(
+    current: Option<&bamboo_domain::TaskList>,
+    expected: &bamboo_domain::TaskList,
+) -> bool {
+    match (
+        current.map(serde_json::to_value),
+        serde_json::to_value(expected),
+    ) {
+        (Some(Ok(current)), Ok(expected)) => current == expected,
+        _ => false,
+    }
+}
+
 pub(super) async fn maybe_handle_taskwrite(
     tool_call: &ToolCall,
     result: &ToolResult,
@@ -64,15 +82,22 @@ pub(super) async fn maybe_handle_taskwrite(
         task_list.items.len()
     );
 
-    persist_shared_task_list(config, session, &shared_session_id, session_id, &task_list).await;
-
-    let _ = event_tx
-        .send(AgentEvent::TaskListUpdated {
-            task_list: task_list.clone(),
-        })
-        .await;
-
-    reinitialize_task_context(task_context, session, session_id);
+    match persist_shared_task_list(config, session, &shared_session_id, session_id).await {
+        TaskPersistenceOutcome::Publish(authoritative_task_list) => {
+            let _ = event_tx
+                .send(AgentEvent::TaskListUpdated {
+                    task_list: authoritative_task_list,
+                })
+                .await;
+            reinitialize_task_context(task_context, session, session_id, true);
+        }
+        TaskPersistenceOutcome::Suppress => {
+            // A failed reconciliation must not emit or mark the losing staged
+            // Task list dirty. Keep the live context aligned with whichever
+            // durable child snapshot the reconciliation helper could reload.
+            reinitialize_task_context(task_context, session, session_id, false);
+        }
+    }
 }
 
 async fn persist_shared_task_list(
@@ -80,10 +105,13 @@ async fn persist_shared_task_list(
     session: &mut Session,
     shared_session_id: &str,
     session_id: &str,
-    task_list: &bamboo_domain::TaskList,
-) {
+) -> TaskPersistenceOutcome {
     let Some(ref persistence) = config.persistence else {
-        return;
+        return session
+            .task_list
+            .clone()
+            .map(TaskPersistenceOutcome::Publish)
+            .unwrap_or(TaskPersistenceOutcome::Suppress);
     };
 
     if let Err(error) = persistence.save_runtime_control_plane(session).await {
@@ -92,28 +120,44 @@ async fn persist_shared_task_list(
             session_id,
             error
         );
-    } else {
-        tracing::debug!(
-            "[{}] Session control-plane saved after Task update",
-            session_id
-        );
+        return TaskPersistenceOutcome::Suppress;
     }
+    tracing::debug!(
+        "[{}] Session control-plane saved after Task update",
+        session_id
+    );
 
     if shared_session_id == session.id {
-        return;
+        return session
+            .task_list
+            .clone()
+            .map(TaskPersistenceOutcome::Publish)
+            .unwrap_or(TaskPersistenceOutcome::Suppress);
     }
 
+    // The local save may have rebased a stale same-generation tool candidate
+    // onto a newer durable Task evaluation. Read both list and generation only
+    // after that save, from the same rewritten session snapshot, so a child can
+    // never overwrite its shared root with the candidate that just lost.
+    let Some(task_list) = session.task_list.clone() else {
+        tracing::warn!(
+            "[{}] Shared root Task update on {} has no authoritative task list",
+            session_id,
+            shared_session_id
+        );
+        return TaskPersistenceOutcome::Suppress;
+    };
     let Some(version) = session.task_list_version_meta() else {
         tracing::warn!(
             "[{}] Shared root Task update on {} has no task-list version",
             session_id,
             shared_session_id
         );
-        return;
+        return TaskPersistenceOutcome::Suppress;
     };
 
     match persistence
-        .update_task_list_control_plane(shared_session_id, task_list, &version)
+        .update_task_list_control_plane(shared_session_id, &task_list, &version)
         .await
     {
         Ok(true) => {
@@ -122,6 +166,7 @@ async fn persist_shared_task_list(
                 session_id,
                 shared_session_id
             );
+            TaskPersistenceOutcome::Publish(task_list)
         }
         Ok(false) => {
             // Save-only legacy/custom persisters leave the default load hook at
@@ -135,7 +180,7 @@ async fn persist_shared_task_list(
                     session_id,
                     shared_session_id
                 );
-                return;
+                return TaskPersistenceOutcome::Suppress;
             };
             let mut root_session = match storage.load_session(shared_session_id).await {
                 Ok(Some(root_session)) => root_session,
@@ -145,7 +190,7 @@ async fn persist_shared_task_list(
                         session_id,
                         shared_session_id
                     );
-                    return;
+                    return TaskPersistenceOutcome::Suppress;
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -154,7 +199,7 @@ async fn persist_shared_task_list(
                         shared_session_id,
                         error
                     );
-                    return;
+                    return TaskPersistenceOutcome::Suppress;
                 }
             };
             root_session.set_task_list(task_list.clone());
@@ -166,13 +211,25 @@ async fn persist_shared_task_list(
                     shared_session_id,
                     error
                 );
+                TaskPersistenceOutcome::Suppress
             } else {
                 tracing::debug!(
                     "[{}] Shared root Task full-save fallback completed on {}",
                     session_id,
                     shared_session_id
                 );
+                TaskPersistenceOutcome::Publish(task_list)
             }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            tracing::warn!(
+                "[{}] Shared root Task control-plane on {} changed concurrently: {}",
+                session_id,
+                shared_session_id,
+                error
+            );
+            reconcile_child_with_shared_root(persistence, session, shared_session_id, session_id)
+                .await
         }
         Err(error) => {
             tracing::warn!(
@@ -181,22 +238,106 @@ async fn persist_shared_task_list(
                 shared_session_id,
                 error
             );
+            TaskPersistenceOutcome::Suppress
         }
     }
+}
+
+async fn reconcile_child_with_shared_root(
+    persistence: &std::sync::Arc<dyn bamboo_domain::RuntimeSessionPersistence>,
+    session: &mut Session,
+    shared_session_id: &str,
+    session_id: &str,
+) -> TaskPersistenceOutcome {
+    let Some(child_task_list) = session.task_list.clone() else {
+        return TaskPersistenceOutcome::Suppress;
+    };
+    let Some(child_version) = session.task_list_version_meta() else {
+        return TaskPersistenceOutcome::Suppress;
+    };
+    let root = match persistence
+        .load_runtime_control_plane(shared_session_id)
+        .await
+    {
+        Ok(Some(root)) => root,
+        Ok(None) => return TaskPersistenceOutcome::Suppress,
+        Err(error) => {
+            tracing::warn!(
+                "[{}] Failed to load shared root {} for Task reconciliation: {}",
+                session_id,
+                shared_session_id,
+                error
+            );
+            return TaskPersistenceOutcome::Suppress;
+        }
+    };
+    let (Some(root_task_list), Some(root_version)) =
+        (root.task_list.clone(), root.task_list_version_meta())
+    else {
+        return TaskPersistenceOutcome::Suppress;
+    };
+
+    let reconciled = persistence
+        .update_task_list_control_plane_if_version(
+            &session.id,
+            &child_version,
+            &child_task_list,
+            &root_task_list,
+            &root_version,
+        )
+        .await;
+    if matches!(reconciled, Ok(true)) {
+        // Re-read the root after the child CAS. If it advanced again, suppress
+        // publication rather than claiming a cross-session snapshot that was
+        // never simultaneously authoritative.
+        let root_still_matches = persistence
+            .load_runtime_control_plane(shared_session_id)
+            .await
+            .ok()
+            .flatten()
+            .is_some_and(|latest| {
+                latest.task_list_version_meta().as_deref() == Some(root_version.as_str())
+                    && task_list_matches(latest.task_list.as_ref(), &root_task_list)
+            });
+        session.task_list = Some(root_task_list.clone());
+        session.set_task_list_version_meta(root_version);
+        if root_still_matches {
+            return TaskPersistenceOutcome::Publish(root_task_list);
+        }
+    } else if let Err(error) = reconciled {
+        tracing::warn!(
+            "[{}] Failed to reconcile child Task control-plane with root {}: {}",
+            session_id,
+            shared_session_id,
+            error
+        );
+    }
+
+    if let Ok(Some(durable_child)) = persistence.load_runtime_control_plane(&session.id).await {
+        let version = durable_child.task_list_version_meta();
+        if let (Some(task_list), Some(version)) = (durable_child.task_list, version) {
+            session.task_list = Some(task_list);
+            session.set_task_list_version_meta(version);
+        }
+    }
+    TaskPersistenceOutcome::Suppress
 }
 
 fn reinitialize_task_context(
     task_context: &mut Option<TaskLoopContext>,
     session: &Session,
     session_id: &str,
+    mark_dirty: bool,
 ) {
     // IMPORTANT: Re-initialize TaskLoopContext from session.
     *task_context = TaskLoopContext::from_session(session);
-    if let Some(ctx) = task_context.as_mut() {
-        // Mark the list dirty so the end-of-turn gate spawns exactly one
-        // evaluation for this Task-tool write. This is the only place the flag is
-        // set; it is cleared when the evaluation is spawned.
-        ctx.task_list_dirty = true;
-        tracing::debug!("[{}] TaskLoopContext re-initialized after Task", session_id);
+    if mark_dirty {
+        if let Some(ctx) = task_context.as_mut() {
+            // Mark the list dirty so the end-of-turn gate spawns exactly one
+            // evaluation for this Task-tool write. This is the only place the flag is
+            // set; it is cleared when the evaluation is spawned.
+            ctx.task_list_dirty = true;
+            tracing::debug!("[{}] TaskLoopContext re-initialized after Task", session_id);
+        }
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
@@ -73,6 +73,76 @@ impl RuntimeSessionPersistence for RecordingPersistence {
     }
 }
 
+struct RebasingTaskPersistence {
+    authoritative_task_list: bamboo_domain::TaskList,
+    local_saves: Mutex<Vec<(String, bamboo_domain::TaskList, String)>>,
+    root_patches: Mutex<Vec<(String, bamboo_domain::TaskList, String)>>,
+    full_saves: AtomicUsize,
+}
+
+impl RebasingTaskPersistence {
+    fn new(authoritative_task_list: bamboo_domain::TaskList) -> Self {
+        Self {
+            authoritative_task_list,
+            local_saves: Mutex::new(Vec::new()),
+            root_patches: Mutex::new(Vec::new()),
+            full_saves: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl RuntimeSessionPersistence for RebasingTaskPersistence {
+    async fn save_runtime_session(&self, _session: &mut Session) -> io::Result<()> {
+        self.full_saves.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn save_runtime_control_plane(&self, session: &mut Session) -> io::Result<()> {
+        let candidate = session.task_list.clone().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "candidate Task list is missing",
+            )
+        })?;
+        let candidate_version = session.task_list_version_meta().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "candidate Task version is missing",
+            )
+        })?;
+        self.local_saves
+            .lock()
+            .expect("local save recording lock")
+            .push((session.id.clone(), candidate, candidate_version));
+
+        // Model the real LockedSessionStore conflict-rebase contract: a
+        // competing evaluator already made E/v2 durable, so the local A/v1
+        // caller is rewritten to that authoritative snapshot before save
+        // returns successfully.
+        session.set_task_list(self.authoritative_task_list.clone());
+        session.set_task_list_version_meta("2");
+        Ok(())
+    }
+
+    async fn update_task_list_control_plane(
+        &self,
+        session_id: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+    ) -> io::Result<bool> {
+        self.root_patches
+            .lock()
+            .expect("root patch recording lock")
+            .push((
+                session_id.to_string(),
+                task_list.clone(),
+                version.to_string(),
+            ));
+        Ok(true)
+    }
+}
+
 struct SaveOnlyPersistence {
     full_saves: AtomicUsize,
     storage: Arc<dyn Storage>,
@@ -349,6 +419,99 @@ async fn child_taskwrite_saves_child_and_shared_root_control_planes_without_full
 }
 
 #[tokio::test]
+async fn child_taskwrite_publishes_snapshot_rebased_by_local_save_everywhere() {
+    let root_id = "rebased-task-root";
+    let child_id = "rebased-task-child";
+    let now = chrono::Utc::now();
+    let authoritative_task_list = bamboo_domain::TaskList {
+        session_id: root_id.to_string(),
+        title: "Evaluator authority".to_string(),
+        items: vec![bamboo_domain::TaskItem {
+            id: "evaluated-task".to_string(),
+            description: "Evaluator-owned task".to_string(),
+            status: TaskItemStatus::Completed,
+            ..bamboo_domain::TaskItem::default()
+        }],
+        created_at: now,
+        updated_at: now,
+    };
+    let persistence = Arc::new(RebasingTaskPersistence::new(
+        authoritative_task_list.clone(),
+    ));
+    let mut config = AgentLoopConfig::default();
+    config.persistence = Some(persistence.clone());
+    let mut child = Session::new_child(child_id, root_id, "model", "Child");
+    let mut task_context = None;
+    let (tx, mut rx) = mpsc::channel(4);
+    let (tool_call, result) = task_call_and_result();
+
+    maybe_handle_taskwrite(
+        &tool_call,
+        &result,
+        &mut child,
+        child_id,
+        &tx,
+        &config,
+        &mut task_context,
+    )
+    .await;
+
+    let local_saves = persistence
+        .local_saves
+        .lock()
+        .expect("local save recording lock")
+        .clone();
+    assert_eq!(local_saves.len(), 1);
+    let (saved_child_id, stale_candidate, stale_version) = &local_saves[0];
+    assert_eq!(saved_child_id, child_id);
+    assert_eq!(stale_version, "1");
+    assert_eq!(stale_candidate.items[0].description, "Refactor module");
+    assert_ne!(
+        serde_json::to_value(stale_candidate).expect("serialize stale candidate"),
+        serde_json::to_value(&authoritative_task_list).expect("serialize authority")
+    );
+
+    let root_patches = persistence
+        .root_patches
+        .lock()
+        .expect("root patch recording lock")
+        .clone();
+    assert_eq!(root_patches.len(), 1);
+    let (patched_root_id, patched_task_list, patched_version) = &root_patches[0];
+    assert_eq!(patched_root_id, root_id);
+    assert_eq!(patched_version, "2");
+    assert_eq!(
+        serde_json::to_value(patched_task_list).expect("serialize root patch"),
+        serde_json::to_value(&authoritative_task_list).expect("serialize authority")
+    );
+    assert_eq!(persistence.full_saves.load(Ordering::SeqCst), 0);
+
+    assert_eq!(child.task_list_version_meta().as_deref(), Some("2"));
+    assert_eq!(
+        serde_json::to_value(&child.task_list).expect("serialize live child Task list"),
+        serde_json::to_value(Some(&authoritative_task_list)).expect("serialize authority")
+    );
+    let context = task_context.expect("rebased Task context");
+    assert!(context.task_list_dirty);
+    assert_eq!(context.version, 2);
+    assert_eq!(
+        serde_json::to_value(
+            context.to_task_list_with_title(authoritative_task_list.title.clone())
+        )
+        .expect("serialize Task context"),
+        serde_json::to_value(&authoritative_task_list).expect("serialize authority")
+    );
+    let event_task_list = match rx.recv().await.expect("rebased Task event") {
+        AgentEvent::TaskListUpdated { task_list } => task_list,
+        other => panic!("unexpected event: {other:?}"),
+    };
+    assert_eq!(
+        serde_json::to_value(event_task_list).expect("serialize Task event"),
+        serde_json::to_value(authoritative_task_list).expect("serialize authority")
+    );
+}
+
+#[tokio::test]
 async fn child_taskwrite_custom_fallback_full_load_and_save_preserve_message_histories() {
     let directory = tempfile::tempdir().expect("tempdir");
     let store = Arc::new(
@@ -454,7 +617,7 @@ async fn child_taskwrite_root_cas_conflict_refreshes_repository_without_full_sav
     let mut config = AgentLoopConfig::default();
     config.storage = Some(storage);
     config.persistence = Some(repository.clone());
-    let (tx, _rx) = mpsc::channel(4);
+    let (tx, mut rx) = mpsc::channel(4);
     let (tool_call, result) = task_call_and_result();
     let taskwrite = tokio::spawn(async move {
         let mut task_context = None;
@@ -468,10 +631,19 @@ async fn child_taskwrite_root_cas_conflict_refreshes_repository_without_full_sav
             &mut task_context,
         )
         .await;
-        child
+        (child, task_context)
     });
 
     root_cas_reached.wait().await;
+    let stale_child_candidate = first_inner
+        .load_runtime_control_plane(child_id)
+        .await
+        .expect("load staged child candidate")
+        .expect("staged child candidate exists");
+    assert_eq!(
+        stale_child_candidate.task_list_version_meta().as_deref(),
+        Some("1")
+    );
     let original = second_inner
         .load_runtime_control_plane(root_id)
         .await
@@ -492,33 +664,91 @@ async fn child_taskwrite_root_cas_conflict_refreshes_repository_without_full_sav
         .await
         .expect("commit competing root Task"));
     release_root_cas.wait().await;
-    let child = taskwrite.await.expect("Taskwrite task");
+    let (child, task_context) = taskwrite.await.expect("Taskwrite task");
 
     assert_eq!(
         gated_storage.full_saves.load(Ordering::SeqCst),
         0,
         "an unconditional CAS conflict is an error, not the Ok(false) legacy fallback signal"
     );
-    let durable = first_inner
+    let durable_root = first_inner
         .load_session(root_id)
         .await
         .expect("load durable root")
         .expect("durable root exists");
-    let cached = repository.load(root_id).await.expect("cached root");
-    for (tier, session) in [("durable", &durable), ("cache", &cached)] {
+    let durable_child = first_inner
+        .load_session(child_id)
+        .await
+        .expect("load durable child")
+        .expect("durable child exists");
+    let cached_root = repository.load(root_id).await.expect("cached root");
+    let cached_child = repository.load(child_id).await.expect("cached child");
+    for (tier, session) in [
+        ("durable root", &durable_root),
+        ("durable child", &durable_child),
+        ("cache root", &cached_root),
+        ("cache child", &cached_child),
+        ("live child", &child),
+    ] {
         assert_eq!(session.task_list_version_meta().as_deref(), Some("1"));
         assert_eq!(
             session.task_list.as_ref().map(|list| list.title.as_str()),
             Some("concurrent winner"),
             "tier={tier}"
         );
-        assert_eq!(session.messages.len(), 1, "tier={tier}");
     }
-    assert_ne!(
-        task_list_value(&child),
-        task_list_value(&durable),
-        "the losing child candidate must not be published into the shared root"
+    assert_eq!(durable_root.messages.len(), 1);
+    let winner_task_list = durable_root.task_list.as_ref().expect("winner task list");
+    let context = task_context.expect("Task context follows authoritative winner");
+    assert!(context.task_list_dirty);
+    assert_eq!(
+        serde_json::to_value(context.to_task_list_with_title(winner_task_list.title.clone()))
+            .expect("serialize Task context"),
+        serde_json::to_value(winner_task_list).expect("serialize winner task list")
     );
+    let event_task_list = match rx.recv().await.expect("authoritative Task event") {
+        AgentEvent::TaskListUpdated { task_list } => task_list,
+        other => panic!("unexpected event: {other:?}"),
+    };
+    assert_eq!(
+        serde_json::to_value(event_task_list).expect("serialize event task list"),
+        serde_json::to_value(winner_task_list).expect("serialize winner task list")
+    );
+
+    // A real evaluator result produced from the losing A/v1 snapshot must not
+    // be allowed to overwrite the reconciled B/v1 pair merely because the
+    // numeric generation is unchanged.
+    let stale_task_list = stale_child_candidate
+        .task_list
+        .expect("staged child candidate task list");
+    let mut stale_evaluation = stale_task_list.clone();
+    stale_evaluation.title = "evaluation based on losing candidate".to_string();
+    stale_evaluation.updated_at = chrono::Utc::now();
+    assert!(
+        !RuntimeSessionPersistence::update_task_list_control_planes_if_version(
+            repository.as_ref(),
+            child_id,
+            root_id,
+            "1",
+            &stale_task_list,
+            &stale_evaluation,
+            "2",
+        )
+        .await
+        .expect("stale evaluator CAS returns a clean conflict")
+    );
+    for id in [child_id, root_id] {
+        let durable = first_inner
+            .load_session(id)
+            .await
+            .expect("reload after stale evaluator")
+            .expect("session remains");
+        assert_eq!(durable.task_list_version_meta().as_deref(), Some("1"));
+        assert_eq!(
+            durable.task_list.as_ref().map(|list| list.title.as_str()),
+            Some("concurrent winner")
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
@@ -78,6 +78,52 @@ struct SaveOnlyPersistence {
     storage: Arc<dyn Storage>,
 }
 
+struct RootCasPauseStorage {
+    inner: Arc<bamboo_storage::SessionStoreV2>,
+    root_id: String,
+    root_cas_reached: Arc<tokio::sync::Barrier>,
+    release_root_cas: Arc<tokio::sync::Barrier>,
+    full_saves: AtomicUsize,
+}
+
+#[async_trait]
+impl Storage for RootCasPauseStorage {
+    async fn save_session(&self, session: &Session) -> io::Result<()> {
+        self.full_saves.fetch_add(1, Ordering::SeqCst);
+        self.inner.save_session(session).await
+    }
+
+    async fn load_session(&self, session_id: &str) -> io::Result<Option<Session>> {
+        self.inner.load_session(session_id).await
+    }
+
+    async fn delete_session(&self, session_id: &str) -> io::Result<bool> {
+        self.inner.delete_session(session_id).await
+    }
+
+    async fn save_runtime_state(&self, session: &Session) -> io::Result<()> {
+        self.inner.save_runtime_state(session).await
+    }
+
+    async fn load_runtime_control_plane(&self, session_id: &str) -> io::Result<Option<Session>> {
+        self.inner.load_runtime_control_plane(session_id).await
+    }
+
+    async fn save_task_control_plane_if_matches(
+        &self,
+        original: &Session,
+        updated: &Session,
+    ) -> io::Result<bool> {
+        if original.id == self.root_id {
+            self.root_cas_reached.wait().await;
+            self.release_root_cas.wait().await;
+        }
+        self.inner
+            .save_task_control_plane_if_matches(original, updated)
+            .await
+    }
+}
+
 #[derive(Default)]
 struct FullSessionPersistence {
     full_saves: AtomicUsize,
@@ -362,6 +408,116 @@ async fn child_taskwrite_custom_fallback_full_load_and_save_preserve_message_his
     assert_eq!(
         saved_root.task_list_version_meta(),
         saved_child.task_list_version_meta()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn child_taskwrite_root_cas_conflict_refreshes_repository_without_full_save_fallback() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let home = directory.path().to_path_buf();
+    let first_inner = Arc::new(
+        bamboo_storage::SessionStoreV2::new(home.clone())
+            .await
+            .expect("first SessionStoreV2"),
+    );
+    let root_id = "taskwrite-cas-conflict-root";
+    let child_id = "taskwrite-cas-conflict-child";
+    let mut root = Session::new(root_id, "model");
+    root.add_message(Message::user("root transcript must survive"));
+    first_inner.save_session(&root).await.expect("seed root");
+    let second_inner = Arc::new(
+        bamboo_storage::SessionStoreV2::new(home)
+            .await
+            .expect("second SessionStoreV2"),
+    );
+
+    let root_cas_reached = Arc::new(tokio::sync::Barrier::new(2));
+    let release_root_cas = Arc::new(tokio::sync::Barrier::new(2));
+    let gated_storage = Arc::new(RootCasPauseStorage {
+        inner: first_inner.clone(),
+        root_id: root_id.to_string(),
+        root_cas_reached: root_cas_reached.clone(),
+        release_root_cas: release_root_cas.clone(),
+        full_saves: AtomicUsize::new(0),
+    });
+    let storage: Arc<dyn Storage> = gated_storage.clone();
+    let locked = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
+    let repository = Arc::new(crate::SessionRepository::new(
+        Default::default(),
+        storage.clone(),
+        locked,
+    ));
+    repository.load(root_id).await.expect("cache root");
+
+    let mut child = Session::new_child(child_id, root_id, "model", "Child");
+    child.add_message(Message::user("child transcript"));
+    let mut config = AgentLoopConfig::default();
+    config.storage = Some(storage);
+    config.persistence = Some(repository.clone());
+    let (tx, _rx) = mpsc::channel(4);
+    let (tool_call, result) = task_call_and_result();
+    let taskwrite = tokio::spawn(async move {
+        let mut task_context = None;
+        maybe_handle_taskwrite(
+            &tool_call,
+            &result,
+            &mut child,
+            child_id,
+            &tx,
+            &config,
+            &mut task_context,
+        )
+        .await;
+        child
+    });
+
+    root_cas_reached.wait().await;
+    let original = second_inner
+        .load_runtime_control_plane(root_id)
+        .await
+        .expect("load competing root")
+        .expect("competing root exists");
+    let now = chrono::Utc::now();
+    let mut winner = original.clone();
+    winner.task_list = Some(bamboo_domain::TaskList {
+        session_id: root_id.to_string(),
+        title: "concurrent winner".to_string(),
+        items: Vec::new(),
+        created_at: now,
+        updated_at: now,
+    });
+    winner.set_task_list_version_meta("1");
+    assert!(second_inner
+        .save_task_control_plane_if_matches(&original, &winner)
+        .await
+        .expect("commit competing root Task"));
+    release_root_cas.wait().await;
+    let child = taskwrite.await.expect("Taskwrite task");
+
+    assert_eq!(
+        gated_storage.full_saves.load(Ordering::SeqCst),
+        0,
+        "an unconditional CAS conflict is an error, not the Ok(false) legacy fallback signal"
+    );
+    let durable = first_inner
+        .load_session(root_id)
+        .await
+        .expect("load durable root")
+        .expect("durable root exists");
+    let cached = repository.load(root_id).await.expect("cached root");
+    for (tier, session) in [("durable", &durable), ("cache", &cached)] {
+        assert_eq!(session.task_list_version_meta().as_deref(), Some("1"));
+        assert_eq!(
+            session.task_list.as_ref().map(|list| list.title.as_str()),
+            Some("concurrent winner"),
+            "tier={tier}"
+        );
+        assert_eq!(session.messages.len(), 1, "tier={tier}");
+    }
+    assert_ne!(
+        task_list_value(&child),
+        task_list_value(&durable),
+        "the losing child candidate must not be published into the shared root"
     );
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -767,6 +767,13 @@ impl AgentRuntime {
             model_name: model,
             fast_model_name: fast_model.or_else(|| config.get_fast_model()),
             fast_model_provider,
+            auxiliary_evaluation_max_concurrency:
+                crate::runtime::config::normalize_auxiliary_evaluation_max_concurrency(
+                    config
+                        .extra
+                        .get("auxiliary_evaluation_max_concurrency")
+                        .and_then(serde_json::Value::as_u64),
+                ),
             background_model_name: background_model
                 .or_else(|| config.get_memory_background_model()),
             planning_model_name: config

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation.rs
@@ -34,6 +34,7 @@ pub struct TaskItemUpdate {
     pub criteria_met: Option<Vec<String>>,
 }
 
+pub(crate) use executor::evaluate_task_progress_with_dispatch;
 pub use executor::{evaluate_task_progress, TaskEvaluationFrame};
 pub use message_builder::build_task_evaluation_messages;
 pub use schema::get_task_evaluation_tools;

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
@@ -49,6 +49,26 @@ pub async fn evaluate_task_progress(
     llm: Arc<dyn LLMProvider>,
     frame: &TaskEvaluationFrame<'_>,
 ) -> Result<TaskEvaluationResult, AgentError> {
+    evaluate_task_progress_with_dispatch(ctx, session, llm, frame, std::future::ready(()), || {})
+        .await
+}
+
+/// Internal evaluator entry point that observes the exact provider-dispatch
+/// boundary. Queueing and prompt preparation must not inflate evaluator
+/// duration metrics, so the callback runs immediately before the provider
+/// future is first polled.
+pub(crate) async fn evaluate_task_progress_with_dispatch<G, Fut, F>(
+    ctx: &TaskLoopContext,
+    session: &Session,
+    llm: Arc<dyn LLMProvider>,
+    frame: &TaskEvaluationFrame<'_>,
+    acquire_dispatch_guard: Fut,
+    on_dispatch: F,
+) -> Result<TaskEvaluationResult, AgentError>
+where
+    Fut: std::future::Future<Output = G>,
+    F: FnOnce(),
+{
     use crate::runtime::stream::handler::{
         await_stream_bootstrap, consume_llm_stream_silent_with_context,
     };
@@ -113,6 +133,8 @@ pub async fn evaluate_task_progress(
         cache: None,
     };
     let cancel_token = tokio_util::sync::CancellationToken::new();
+    let _dispatch_guard = acquire_dispatch_guard.await;
+    on_dispatch();
     let stream = match await_stream_bootstrap(
         llm.chat_stream_with_options(&messages, &tools, Some(8192), model, Some(&request_options)),
         &cancel_token,
@@ -124,7 +146,7 @@ pub async fn evaluate_task_progress(
         Ok(stream) => stream,
         Err(error) => {
             tracing::warn!("[{}] Task evaluation failed: {}", session_id, error);
-            return Ok(skipped_evaluation(&format!("Evaluation failed: {}", error)));
+            return Ok(skipped_evaluation(&format!("Evaluation failed: {error}")));
         }
     };
     let stream_output =

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
@@ -77,7 +77,6 @@ where
     let session_id = frame.session_id;
     let model = frame.model;
     let reasoning_effort = frame.reasoning_effort;
-    let timeout_context = frame.timeout_context.clone().begin_request();
 
     let in_progress_count = ctx
         .items
@@ -134,6 +133,7 @@ where
     };
     let cancel_token = tokio_util::sync::CancellationToken::new();
     let _dispatch_guard = acquire_dispatch_guard.await;
+    let timeout_context = frame.timeout_context.clone().begin_request();
     on_dispatch();
     let stream = match await_stream_bootstrap(
         llm.chat_stream_with_options(&messages, &tools, Some(8192), model, Some(&request_options)),

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -475,6 +475,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         &self,
         session_id: &str,
         expected_version: &str,
+        expected_task_list: &bamboo_domain::TaskList,
         task_list: &bamboo_domain::TaskList,
         version: &str,
     ) -> std::io::Result<bool> {
@@ -482,6 +483,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
             .update_task_list_control_plane_if_version_and_publish(
                 session_id,
                 expected_version,
+                expected_task_list,
                 task_list,
                 version,
                 |_| {
@@ -500,6 +502,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         session_id: &str,
         shared_session_id: &str,
         expected_version: &str,
+        expected_task_list: &bamboo_domain::TaskList,
         task_list: &bamboo_domain::TaskList,
         version: &str,
     ) -> std::io::Result<bool> {
@@ -508,6 +511,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 session_id,
                 shared_session_id,
                 expected_version,
+                expected_task_list,
                 task_list,
                 version,
                 |_, _| {
@@ -718,12 +722,13 @@ mod tests {
         let repo = test_repo(storage.clone());
         let root_id = "paired-cache-root";
         let child_id = "paired-cache-child";
+        let expected_task_list = task_list(root_id, "old shared");
 
         let mut root = Session::new(root_id, "model");
         root.add_message(bamboo_agent_core::Message::user("root transcript"));
         root.metadata
             .insert("unrelated.root".to_string(), "keep".to_string());
-        root.set_task_list(task_list(root_id, "old root"));
+        root.set_task_list(expected_task_list.clone());
         root.set_task_list_version_meta("1");
         storage.save_session(&root).await.unwrap();
         cache_put(&repo, &root);
@@ -733,7 +738,7 @@ mod tests {
         child
             .metadata
             .insert("unrelated.child".to_string(), "keep".to_string());
-        child.set_task_list(task_list(root_id, "old child"));
+        child.set_task_list(expected_task_list.clone());
         child.set_task_list_version_meta("1");
         storage.save_session(&child).await.unwrap();
         cache_put(&repo, &child);
@@ -744,6 +749,7 @@ mod tests {
                 child_id,
                 root_id,
                 "1",
+                &expected_task_list,
                 &task_list(root_id, "evaluated"),
                 "2",
             )
@@ -778,12 +784,13 @@ mod tests {
         let repo = test_repo(storage.clone());
         let root_id = "paired-cache-failure-root";
         let child_id = "paired-cache-failure-child";
+        let expected_task_list = task_list(root_id, "old shared");
 
         let mut root = Session::new(root_id, "model");
         root.add_message(bamboo_agent_core::Message::user("root transcript"));
         root.metadata
             .insert("unrelated.root".to_string(), "keep".to_string());
-        root.set_task_list(task_list(root_id, "old root"));
+        root.set_task_list(expected_task_list.clone());
         root.set_task_list_version_meta("1");
         storage.save_session(&root).await.unwrap();
         cache_put(&repo, &root);
@@ -793,7 +800,7 @@ mod tests {
         child
             .metadata
             .insert("unrelated.child".to_string(), "keep".to_string());
-        child.set_task_list(task_list(root_id, "old child"));
+        child.set_task_list(expected_task_list.clone());
         child.set_task_list_version_meta("1");
         storage.save_session(&child).await.unwrap();
         cache_put(&repo, &child);
@@ -805,6 +812,7 @@ mod tests {
                 child_id,
                 root_id,
                 "1",
+                &expected_task_list,
                 &task_list(root_id, "must not publish"),
                 "2",
             )
@@ -813,8 +821,13 @@ mod tests {
         assert!(error.to_string().contains("injected paired"));
 
         for (id, expected_title, transcript, metadata_key) in [
-            (root_id, "old root", "root transcript", "unrelated.root"),
-            (child_id, "old child", "child transcript", "unrelated.child"),
+            (root_id, "old shared", "root transcript", "unrelated.root"),
+            (
+                child_id,
+                "old shared",
+                "child transcript",
+                "unrelated.child",
+            ),
         ] {
             let cached = read_cached_session(repo.cache(), id).expect("cached session remains");
             assert_eq!(cached.task_list_version_meta().as_deref(), Some("1"));

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -274,6 +274,42 @@ impl SessionRepository {
             tracing::warn!("[{}] Failed to save session: {}", session.id, error);
         }
     }
+
+    async fn refresh_cached_task_control_plane(&self, session_id: &str) {
+        match self.storage.load_runtime_control_plane(session_id).await {
+            Ok(Some(durable)) => {
+                if let Some(cached) = self.cache.get(session_id) {
+                    adopt_task_control_plane(&mut cached.write(), &durable);
+                }
+            }
+            Ok(None) => {}
+            Err(error) => tracing::warn!(
+                "[{}] Failed to refresh Task control-plane after write conflict: {}",
+                session_id,
+                error
+            ),
+        }
+    }
+}
+
+fn adopt_task_control_plane(target: &mut Session, durable: &Session) {
+    target.task_list = durable.task_list.clone();
+    target
+        .metadata
+        .remove(bamboo_domain::session::runtime_metadata::keys::TASK_LIST_VERSION);
+    if let Some(runtime_metadata) = target.runtime_metadata.as_mut() {
+        runtime_metadata.task_list_version = None;
+    }
+    if target
+        .runtime_metadata
+        .as_ref()
+        .is_some_and(bamboo_domain::session::SessionRuntimeMetadata::is_empty)
+    {
+        target.runtime_metadata = None;
+    }
+    if let Some(version) = durable.task_list_version_meta() {
+        target.set_task_list_version_meta(version);
+    }
 }
 
 fn should_prefer_storage(memory_session: &Session, storage_session: &Session) -> bool {
@@ -404,7 +440,8 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         task_list: &bamboo_domain::TaskList,
         version: &str,
     ) -> std::io::Result<bool> {
-        self.persistence
+        let result = self
+            .persistence
             .update_task_list_control_plane_and_publish(session_id, task_list, version, |_| {
                 #[cfg(test)]
                 self.run_post_durable_hook("task", version);
@@ -420,7 +457,18 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                     cached.set_task_list_version_meta(version.to_string());
                 }
             })
-            .await
+            .await;
+        if result
+            .as_ref()
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::WouldBlock)
+        {
+            // The storage final-CAS rejected this unconditional patch because
+            // an independent writer won. Refresh the winner into the cache but
+            // preserve the conflict result so Taskwrite never mistakes it for
+            // the Ok(false) legacy-persistence fallback signal.
+            self.refresh_cached_task_control_plane(session_id).await;
+        }
+        result
     }
 
     async fn update_task_list_control_plane_if_version(
@@ -538,12 +586,14 @@ mod tests {
     use bamboo_agent_core::storage::Storage;
     use chrono::Utc;
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Condvar, Mutex};
     use std::time::Duration;
 
     #[derive(Default)]
     struct MapStorage {
         sessions: Mutex<HashMap<String, Session>>,
+        fail_pair_commit: AtomicBool,
     }
 
     struct FailingSaveStorage {
@@ -564,6 +614,62 @@ mod tests {
         }
         async fn delete_session(&self, session_id: &str) -> std::io::Result<bool> {
             Ok(self.sessions.lock().unwrap().remove(session_id).is_some())
+        }
+
+        async fn save_task_control_plane_if_matches(
+            &self,
+            original: &Session,
+            updated: &Session,
+        ) -> std::io::Result<bool> {
+            let mut sessions = self.sessions.lock().unwrap();
+            let matches_original = sessions.get(&original.id).is_some_and(|current| {
+                current.task_list_version_meta() == original.task_list_version_meta()
+                    && serde_json::to_value(&current.task_list).ok()
+                        == serde_json::to_value(&original.task_list).ok()
+            });
+            if !matches_original {
+                return Ok(false);
+            }
+            let Some(current) = sessions.get(&original.id).cloned() else {
+                return Ok(false);
+            };
+            let mut committed = current;
+            committed.task_list = updated.task_list.clone();
+            if let Some(version) = updated.task_list_version_meta() {
+                committed.set_task_list_version_meta(version);
+            }
+            sessions.insert(committed.id.clone(), committed);
+            Ok(true)
+        }
+
+        async fn save_task_control_planes_atomically(
+            &self,
+            first_original: &Session,
+            first_updated: &Session,
+            second_original: &Session,
+            second_updated: &Session,
+        ) -> std::io::Result<bool> {
+            if self.fail_pair_commit.swap(false, Ordering::SeqCst) {
+                return Err(std::io::Error::other(
+                    "injected paired Task transaction failure",
+                ));
+            }
+            let mut sessions = self.sessions.lock().unwrap();
+            let matches_original = |current: Option<&Session>, original: &Session| {
+                current.is_some_and(|current| {
+                    current.task_list_version_meta() == original.task_list_version_meta()
+                        && serde_json::to_value(&current.task_list).ok()
+                            == serde_json::to_value(&original.task_list).ok()
+                })
+            };
+            if !matches_original(sessions.get(&first_original.id), first_original)
+                || !matches_original(sessions.get(&second_original.id), second_original)
+            {
+                return Ok(false);
+            }
+            sessions.insert(first_updated.id.clone(), first_updated.clone());
+            sessions.insert(second_updated.id.clone(), second_updated.clone());
+            Ok(true)
         }
     }
 
@@ -661,6 +767,72 @@ mod tests {
             assert_eq!(
                 session.metadata.get(metadata_key).map(String::as_str),
                 Some("keep")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_paired_task_transaction_does_not_publish_child_or_root_cache() {
+        let concrete = Arc::new(MapStorage::default());
+        let storage: Arc<dyn Storage> = concrete.clone();
+        let repo = test_repo(storage.clone());
+        let root_id = "paired-cache-failure-root";
+        let child_id = "paired-cache-failure-child";
+
+        let mut root = Session::new(root_id, "model");
+        root.add_message(bamboo_agent_core::Message::user("root transcript"));
+        root.metadata
+            .insert("unrelated.root".to_string(), "keep".to_string());
+        root.set_task_list(task_list(root_id, "old root"));
+        root.set_task_list_version_meta("1");
+        storage.save_session(&root).await.unwrap();
+        cache_put(&repo, &root);
+
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.add_message(bamboo_agent_core::Message::user("child transcript"));
+        child
+            .metadata
+            .insert("unrelated.child".to_string(), "keep".to_string());
+        child.set_task_list(task_list(root_id, "old child"));
+        child.set_task_list_version_meta("1");
+        storage.save_session(&child).await.unwrap();
+        cache_put(&repo, &child);
+
+        concrete.fail_pair_commit.store(true, Ordering::SeqCst);
+        let error =
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_planes_if_version(
+                &repo,
+                child_id,
+                root_id,
+                "1",
+                &task_list(root_id, "must not publish"),
+                "2",
+            )
+            .await
+            .expect_err("paired durable transaction fails");
+        assert!(error.to_string().contains("injected paired"));
+
+        for (id, expected_title, transcript, metadata_key) in [
+            (root_id, "old root", "root transcript", "unrelated.root"),
+            (child_id, "old child", "child transcript", "unrelated.child"),
+        ] {
+            let cached = read_cached_session(repo.cache(), id).expect("cached session remains");
+            assert_eq!(cached.task_list_version_meta().as_deref(), Some("1"));
+            assert_eq!(
+                cached.task_list.as_ref().map(|list| list.title.as_str()),
+                Some(expected_title)
+            );
+            assert_eq!(cached.messages[0].content, transcript);
+            assert_eq!(
+                cached.metadata.get(metadata_key).map(String::as_str),
+                Some("keep")
+            );
+
+            let durable = storage.load_session(id).await.unwrap().unwrap();
+            assert_eq!(durable.task_list_version_meta().as_deref(), Some("1"));
+            assert_eq!(
+                durable.task_list.as_ref().map(|list| list.title.as_str()),
+                Some(expected_title)
             );
         }
     }

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -423,6 +423,58 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
             .await
     }
 
+    async fn update_task_list_control_plane_if_version(
+        &self,
+        session_id: &str,
+        expected_version: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+    ) -> std::io::Result<bool> {
+        self.persistence
+            .update_task_list_control_plane_if_version_and_publish(
+                session_id,
+                expected_version,
+                task_list,
+                version,
+                |_| {
+                    if let Some(cached) = self.cache.get(session_id) {
+                        let mut cached = cached.write();
+                        cached.set_task_list(task_list.clone());
+                        cached.set_task_list_version_meta(version.to_string());
+                    }
+                },
+            )
+            .await
+    }
+
+    async fn update_task_list_control_planes_if_version(
+        &self,
+        session_id: &str,
+        shared_session_id: &str,
+        expected_version: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+    ) -> std::io::Result<bool> {
+        self.persistence
+            .update_task_list_control_planes_if_version_and_publish(
+                session_id,
+                shared_session_id,
+                expected_version,
+                task_list,
+                version,
+                |_, _| {
+                    for id in [session_id, shared_session_id] {
+                        if let Some(cached) = self.cache.get(id) {
+                            let mut cached = cached.write();
+                            cached.set_task_list(task_list.clone());
+                            cached.set_task_list_version_meta(version.to_string());
+                        }
+                    }
+                },
+            )
+            .await
+    }
+
     async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
         // The execute-boundary checkpoint uses LockedSessionStore's atomic
         // append-safe transcript merge, then publishes that reconciled snapshot
@@ -551,6 +603,65 @@ mod tests {
             items: Vec::new(),
             created_at: now,
             updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn paired_task_cas_narrowly_updates_child_and_root_cache() {
+        let storage: Arc<dyn Storage> = Arc::new(MapStorage::default());
+        let repo = test_repo(storage.clone());
+        let root_id = "paired-cache-root";
+        let child_id = "paired-cache-child";
+
+        let mut root = Session::new(root_id, "model");
+        root.add_message(bamboo_agent_core::Message::user("root transcript"));
+        root.metadata
+            .insert("unrelated.root".to_string(), "keep".to_string());
+        root.set_task_list(task_list(root_id, "old root"));
+        root.set_task_list_version_meta("1");
+        storage.save_session(&root).await.unwrap();
+        cache_put(&repo, &root);
+
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.add_message(bamboo_agent_core::Message::user("child transcript"));
+        child
+            .metadata
+            .insert("unrelated.child".to_string(), "keep".to_string());
+        child.set_task_list(task_list(root_id, "old child"));
+        child.set_task_list_version_meta("1");
+        storage.save_session(&child).await.unwrap();
+        cache_put(&repo, &child);
+
+        assert!(
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_planes_if_version(
+                &repo,
+                child_id,
+                root_id,
+                "1",
+                &task_list(root_id, "evaluated"),
+                "2",
+            )
+            .await
+            .expect("paired cache CAS succeeds")
+        );
+
+        let cached_root = read_cached_session(repo.cache(), root_id).expect("cached root");
+        let cached_child = read_cached_session(repo.cache(), child_id).expect("cached child");
+        for (session, transcript, metadata_key) in [
+            (&cached_root, "root transcript", "unrelated.root"),
+            (&cached_child, "child transcript", "unrelated.child"),
+        ] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("evaluated")
+            );
+            assert_eq!(session.messages.len(), 1);
+            assert_eq!(session.messages[0].content, transcript);
+            assert_eq!(
+                session.metadata.get(metadata_key).map(String::as_str),
+                Some("keep")
+            );
         }
     }
 

--- a/crates/infra/bamboo-storage/Cargo.toml
+++ b/crates/infra/bamboo-storage/Cargo.toml
@@ -23,5 +23,8 @@ sha2 = { workspace = true }
 rusqlite = { version = "0.40", features = ["bundled", "chrono"] }
 tracing = "0.1"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -72,6 +72,36 @@ fn adopt_durable_task_control_plane(session: &mut Session, durable: &Session) {
     }
 }
 
+fn task_list_snapshot_matches(
+    session: &Session,
+    expected_task_list: &bamboo_domain::TaskList,
+) -> std::io::Result<bool> {
+    Ok(serde_json::to_value(&session.task_list)
+        .map_err(|error| std::io::Error::other(error.to_string()))?
+        == serde_json::to_value(Some(expected_task_list))
+            .map_err(|error| std::io::Error::other(error.to_string()))?)
+}
+
+fn unconditional_task_patch_would_regress(
+    durable: &Session,
+    incoming_task_list: &bamboo_domain::TaskList,
+    incoming_version: &str,
+) -> std::io::Result<bool> {
+    let same_list = task_list_snapshot_matches(durable, incoming_task_list)?;
+    let Some(durable_version) = durable.task_list_version_meta() else {
+        return Ok(false);
+    };
+    match (
+        incoming_version.parse::<u64>(),
+        durable_version.parse::<u64>(),
+    ) {
+        (Ok(incoming), Ok(durable)) => {
+            Ok(incoming < durable || (incoming == durable && !same_list))
+        }
+        _ => Ok(incoming_version != durable_version || !same_list),
+    }
+}
+
 // ── LockedSessionStore ────────────────────────────────────────────────
 
 /// Wraps a [`Storage`] implementation with per-session write serialization.
@@ -320,6 +350,12 @@ impl LockedSessionStore {
         let Some(mut latest) = self.storage.load_runtime_control_plane(session_id).await? else {
             return Ok(false);
         };
+        if unconditional_task_patch_would_regress(&latest, task_list, version)? {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                format!("Task control-plane changed while patching session {session_id}"),
+            ));
+        }
         let original = latest.clone();
         latest.task_list = Some(task_list.clone());
         latest.set_task_list_version_meta(version.to_string());
@@ -344,6 +380,7 @@ impl LockedSessionStore {
         &self,
         session_id: &str,
         expected_version: &str,
+        expected_task_list: &bamboo_domain::TaskList,
         task_list: &bamboo_domain::TaskList,
         version: &str,
         publish: F,
@@ -355,7 +392,9 @@ impl LockedSessionStore {
         let Some(mut latest) = self.storage.load_runtime_control_plane(session_id).await? else {
             return Ok(false);
         };
-        if latest.task_list_version_meta().as_deref() != Some(expected_version) {
+        if latest.task_list_version_meta().as_deref() != Some(expected_version)
+            || !task_list_snapshot_matches(&latest, expected_task_list)?
+        {
             return Ok(false);
         }
         let original = latest.clone();
@@ -382,6 +421,7 @@ impl LockedSessionStore {
         session_id: &str,
         shared_session_id: &str,
         expected_version: &str,
+        expected_task_list: &bamboo_domain::TaskList,
         task_list: &bamboo_domain::TaskList,
         version: &str,
         publish: F,
@@ -394,6 +434,7 @@ impl LockedSessionStore {
                 .update_task_list_control_plane_if_version_and_publish(
                     session_id,
                     expected_version,
+                    expected_task_list,
                     task_list,
                     version,
                     |session| publish(session, session),
@@ -429,6 +470,8 @@ impl LockedSessionStore {
         };
         if local.task_list_version_meta().as_deref() != Some(expected_version)
             || shared.task_list_version_meta().as_deref() != Some(expected_version)
+            || !task_list_snapshot_matches(&local, expected_task_list)?
+            || !task_list_snapshot_matches(&shared, expected_task_list)?
         {
             return Ok(false);
         }
@@ -946,12 +989,14 @@ impl RuntimeSessionPersistence for LockedSessionStore {
         &self,
         session_id: &str,
         expected_version: &str,
+        expected_task_list: &bamboo_domain::TaskList,
         task_list: &bamboo_domain::TaskList,
         version: &str,
     ) -> std::io::Result<bool> {
         self.update_task_list_control_plane_if_version_and_publish(
             session_id,
             expected_version,
+            expected_task_list,
             task_list,
             version,
             |_| {},
@@ -964,6 +1009,7 @@ impl RuntimeSessionPersistence for LockedSessionStore {
         session_id: &str,
         shared_session_id: &str,
         expected_version: &str,
+        expected_task_list: &bamboo_domain::TaskList,
         task_list: &bamboo_domain::TaskList,
         version: &str,
     ) -> std::io::Result<bool> {
@@ -971,6 +1017,7 @@ impl RuntimeSessionPersistence for LockedSessionStore {
             session_id,
             shared_session_id,
             expected_version,
+            expected_task_list,
             task_list,
             version,
             |_, _| {},
@@ -2906,6 +2953,7 @@ mod tests {
             child_id,
             root_id,
             "1",
+            &task_list("current child"),
             &task_list("stale evaluator"),
             "3",
         )
@@ -2970,7 +3018,7 @@ mod tests {
         root.metadata
             .insert("unrelated.root".to_string(), "preserve".to_string());
         root.agent_runtime_state = Some(bamboo_domain::AgentRuntimeState::new("root-run"));
-        root.set_task_list(task_list("old root"));
+        root.set_task_list(task_list("old shared"));
         root.set_task_list_version_meta("1");
         inner.save_session(&root).await.expect("seed root");
 
@@ -2980,7 +3028,7 @@ mod tests {
             .metadata
             .insert("unrelated.child".to_string(), "preserve".to_string());
         child.agent_runtime_state = Some(bamboo_domain::AgentRuntimeState::new("child-run"));
-        child.set_task_list(task_list("old child"));
+        child.set_task_list(task_list("old shared"));
         child.set_task_list_version_meta("1");
         inner.save_session(&child).await.expect("seed child");
 
@@ -2998,6 +3046,7 @@ mod tests {
                 child_id,
                 root_id,
                 "1",
+                &task_list("old shared"),
                 &task_list("evaluated"),
                 "2",
             )
@@ -3175,6 +3224,106 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn single_task_cas_rejects_same_version_divergent_snapshot_without_callback() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "single-task-exact-snapshot";
+        let now = chrono::Utc::now();
+        let task_list = |title: &str| bamboo_domain::TaskList {
+            session_id: session_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+        let durable_winner = task_list("durable winner");
+        let stale_snapshot = task_list("stale same-version snapshot");
+        let mut session = fresh(session_id);
+        session.set_task_list(durable_winner.clone());
+        session.set_task_list_version_meta("1");
+        storage.save_session(&session).await.expect("seed session");
+
+        let published = Arc::new(AtomicBool::new(false));
+        let callback = published.clone();
+        assert!(!store
+            .update_task_list_control_plane_if_version_and_publish(
+                session_id,
+                "1",
+                &stale_snapshot,
+                &task_list("stale evaluation"),
+                "2",
+                move |_| callback.store(true, Ordering::SeqCst),
+            )
+            .await
+            .expect("same-version divergence is a clean stale result"));
+        assert!(!published.load(Ordering::SeqCst));
+        let durable = storage
+            .load_session(session_id)
+            .await
+            .unwrap()
+            .expect("session remains");
+        assert_eq!(durable.task_list_version_meta().as_deref(), Some("1"));
+        assert_eq!(
+            serde_json::to_value(&durable.task_list).expect("serialize durable Task list"),
+            serde_json::to_value(Some(&durable_winner)).expect("serialize expected Task list")
+        );
+    }
+
+    #[tokio::test]
+    async fn paired_task_cas_rejects_same_version_divergent_snapshot_without_callback() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let root_id = "paired-task-exact-snapshot-root";
+        let child_id = "paired-task-exact-snapshot-child";
+        let now = chrono::Utc::now();
+        let task_list = |title: &str| bamboo_domain::TaskList {
+            session_id: root_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+        let durable_winner = task_list("durable winner");
+        let stale_snapshot = task_list("stale same-version snapshot");
+        let mut root = fresh(root_id);
+        root.set_task_list(durable_winner.clone());
+        root.set_task_list_version_meta("1");
+        storage.save_session(&root).await.expect("seed root");
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.set_task_list(durable_winner.clone());
+        child.set_task_list_version_meta("1");
+        storage.save_session(&child).await.expect("seed child");
+
+        let published = Arc::new(AtomicBool::new(false));
+        let callback = published.clone();
+        assert!(!store
+            .update_task_list_control_planes_if_version_and_publish(
+                child_id,
+                root_id,
+                "1",
+                &stale_snapshot,
+                &task_list("stale evaluation"),
+                "2",
+                move |_, _| callback.store(true, Ordering::SeqCst),
+            )
+            .await
+            .expect("same-version divergence is a clean stale result"));
+        assert!(!published.load(Ordering::SeqCst));
+        for id in [child_id, root_id] {
+            let durable = storage
+                .load_session(id)
+                .await
+                .unwrap()
+                .expect("session remains");
+            assert_eq!(durable.task_list_version_meta().as_deref(), Some("1"));
+            assert_eq!(
+                serde_json::to_value(&durable.task_list).expect("serialize durable Task list"),
+                serde_json::to_value(Some(&durable_winner)).expect("serialize expected Task list")
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn unconditional_root_task_patch_reports_final_cas_conflict_without_publishing() {
         let temp = tempfile::tempdir().unwrap();
         let home = temp.path().to_path_buf();
@@ -3293,6 +3442,7 @@ mod tests {
         let second_published = Arc::new(AtomicBool::new(false));
         let first_callback = first_published.clone();
         let second_callback = second_published.clone();
+        let expected = task_list("original");
         let first_candidate = task_list("candidate one");
         let second_candidate = task_list("candidate two");
 
@@ -3301,6 +3451,7 @@ mod tests {
         let first = first_store.update_task_list_control_plane_if_version_and_publish(
             root_id,
             "1",
+            &expected,
             &first_candidate,
             "2",
             move |_| first_callback.store(true, Ordering::SeqCst),
@@ -3308,6 +3459,7 @@ mod tests {
         let second = second_store.update_task_list_control_plane_if_version_and_publish(
             root_id,
             "1",
+            &expected,
             &second_candidate,
             "2",
             move |_| second_callback.store(true, Ordering::SeqCst),
@@ -3356,11 +3508,11 @@ mod tests {
         };
 
         let mut root = fresh(root_id);
-        root.set_task_list(task_list("original root"));
+        root.set_task_list(task_list("original shared"));
         root.set_task_list_version_meta("1");
         first_inner.save_session(&root).await.expect("seed root");
         let mut child = Session::new_child(child_id, root_id, "model", "child");
-        child.set_task_list(task_list("original child"));
+        child.set_task_list(task_list("original shared"));
         child.set_task_list_version_meta("1");
         first_inner.save_session(&child).await.expect("seed child");
 
@@ -3384,6 +3536,7 @@ mod tests {
         let second_published = Arc::new(AtomicBool::new(false));
         let first_published_callback = first_published.clone();
         let second_published_callback = second_published.clone();
+        let expected = task_list("original shared");
         let first_candidate = task_list("candidate one");
         let second_candidate = task_list("candidate two");
 
@@ -3391,6 +3544,7 @@ mod tests {
             child_id,
             root_id,
             "1",
+            &expected,
             &first_candidate,
             "2",
             move |_, _| first_published_callback.store(true, Ordering::SeqCst),
@@ -3399,6 +3553,7 @@ mod tests {
             child_id,
             root_id,
             "1",
+            &expected,
             &second_candidate,
             "2",
             move |_, _| second_published_callback.store(true, Ordering::SeqCst),
@@ -3459,7 +3614,7 @@ mod tests {
         root.add_message(Message::user("root transcript"));
         root.metadata
             .insert("unrelated.root".to_string(), "preserve".to_string());
-        root.set_task_list(task_list("old root"));
+        root.set_task_list(task_list("old shared"));
         root.set_task_list_version_meta("1");
         inner.save_session(&root).await.expect("seed root");
 
@@ -3468,7 +3623,7 @@ mod tests {
         child
             .metadata
             .insert("unrelated.child".to_string(), "preserve".to_string());
-        child.set_task_list(task_list("old child"));
+        child.set_task_list(task_list("old shared"));
         child.set_task_list_version_meta("1");
         inner.save_session(&child).await.expect("seed child");
 
@@ -3483,6 +3638,7 @@ mod tests {
                 child_id,
                 root_id,
                 "1",
+                &task_list("old shared"),
                 &task_list("must roll back"),
                 "2",
                 move |_, _| published_for_callback.store(true, Ordering::SeqCst),
@@ -3500,13 +3656,13 @@ mod tests {
         for (session, title, transcript, metadata_key) in [
             (
                 &durable_root,
-                "old root",
+                "old shared",
                 "root transcript",
                 "unrelated.root",
             ),
             (
                 &durable_child,
-                "old child",
+                "old shared",
                 "child transcript",
                 "unrelated.child",
             ),

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -219,6 +219,95 @@ impl LockedSessionStore {
         Ok(true)
     }
 
+    /// Compare-and-patch variant used by asynchronous evaluators. The durable
+    /// generation check, narrow Task mutation, save, and cache publication all
+    /// occur under the same per-session lock.
+    pub async fn update_task_list_control_plane_if_version_and_publish<F>(
+        &self,
+        session_id: &str,
+        expected_version: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+        publish: F,
+    ) -> std::io::Result<bool>
+    where
+        F: FnOnce(&Session) + Send,
+    {
+        let _guard = self.acquire_lock(session_id).await;
+        let Some(mut latest) = self.storage.load_runtime_control_plane(session_id).await? else {
+            return Ok(false);
+        };
+        if latest.task_list_version_meta().as_deref() != Some(expected_version) {
+            return Ok(false);
+        }
+        latest.set_task_list(task_list.clone());
+        latest.set_task_list_version_meta(version.to_string());
+        self.storage.save_runtime_state(&latest).await?;
+        publish(&latest);
+        Ok(true)
+    }
+
+    /// Atomically validate and narrowly patch both the executing session and
+    /// its shared root. Locks are acquired in lexical id order to prevent two
+    /// child evaluators from deadlocking while sharing a root.
+    pub async fn update_task_list_control_planes_if_version_and_publish<F>(
+        &self,
+        session_id: &str,
+        shared_session_id: &str,
+        expected_version: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+        publish: F,
+    ) -> std::io::Result<bool>
+    where
+        F: FnOnce(&Session, &Session) + Send,
+    {
+        if session_id == shared_session_id {
+            return self
+                .update_task_list_control_plane_if_version_and_publish(
+                    session_id,
+                    expected_version,
+                    task_list,
+                    version,
+                    |session| publish(session, session),
+                )
+                .await;
+        }
+
+        let (first_id, second_id) = if session_id < shared_session_id {
+            (session_id, shared_session_id)
+        } else {
+            (shared_session_id, session_id)
+        };
+        let _first_guard = self.acquire_lock(first_id).await;
+        let _second_guard = self.acquire_lock(second_id).await;
+
+        let Some(mut local) = self.storage.load_runtime_control_plane(session_id).await? else {
+            return Ok(false);
+        };
+        let Some(mut shared) = self
+            .storage
+            .load_runtime_control_plane(shared_session_id)
+            .await?
+        else {
+            return Ok(false);
+        };
+        if local.task_list_version_meta().as_deref() != Some(expected_version)
+            || shared.task_list_version_meta().as_deref() != Some(expected_version)
+        {
+            return Ok(false);
+        }
+
+        local.set_task_list(task_list.clone());
+        local.set_task_list_version_meta(version.to_string());
+        shared.set_task_list(task_list.clone());
+        shared.set_task_list_version_meta(version.to_string());
+        self.storage.save_runtime_state(&local).await?;
+        self.storage.save_runtime_state(&shared).await?;
+        publish(&local, &shared);
+        Ok(true)
+    }
+
     /// Authoritative metadata commit.
     ///
     /// The caller must have already loaded the latest session, mutated the
@@ -692,6 +781,42 @@ impl RuntimeSessionPersistence for LockedSessionStore {
             .await
     }
 
+    async fn update_task_list_control_plane_if_version(
+        &self,
+        session_id: &str,
+        expected_version: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+    ) -> std::io::Result<bool> {
+        self.update_task_list_control_plane_if_version_and_publish(
+            session_id,
+            expected_version,
+            task_list,
+            version,
+            |_| {},
+        )
+        .await
+    }
+
+    async fn update_task_list_control_planes_if_version(
+        &self,
+        session_id: &str,
+        shared_session_id: &str,
+        expected_version: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+    ) -> std::io::Result<bool> {
+        self.update_task_list_control_planes_if_version_and_publish(
+            session_id,
+            shared_session_id,
+            expected_version,
+            task_list,
+            version,
+            |_, _| {},
+        )
+        .await
+    }
+
     async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
         LockedSessionStore::checkpoint_runtime_session(self, session).await
     }
@@ -900,11 +1025,14 @@ mod tests {
     struct CountingControlPlaneStorage {
         inner: Arc<SessionStoreV2>,
         control_plane_loads: AtomicUsize,
+        full_saves: AtomicUsize,
+        runtime_state_saves: AtomicUsize,
     }
 
     #[async_trait::async_trait]
     impl Storage for CountingControlPlaneStorage {
         async fn save_session(&self, session: &Session) -> std::io::Result<()> {
+            self.full_saves.fetch_add(1, Ordering::SeqCst);
             self.inner.save_session(session).await
         }
 
@@ -917,6 +1045,7 @@ mod tests {
         }
 
         async fn save_runtime_state(&self, session: &Session) -> std::io::Result<()> {
+            self.runtime_state_saves.fetch_add(1, Ordering::SeqCst);
             self.inner.save_runtime_state(session).await
         }
 
@@ -2316,6 +2445,8 @@ mod tests {
         let counted = Arc::new(CountingControlPlaneStorage {
             inner: inner.clone(),
             control_plane_loads: AtomicUsize::new(0),
+            full_saves: AtomicUsize::new(0),
+            runtime_state_saves: AtomicUsize::new(0),
         });
         let storage: Arc<dyn Storage> = counted.clone();
         let store = Arc::new(LockedSessionStore::new(storage));
@@ -2395,6 +2526,178 @@ mod tests {
             reloaded.task_list.as_ref().map(|list| list.title.as_str()),
             Some("Atomic Task patch")
         );
+    }
+
+    #[tokio::test]
+    async fn paired_task_cas_conflict_cannot_overwrite_newer_root_or_child_state() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let root_id = "task-cas-root";
+        let child_id = "task-cas-child";
+        let now = chrono::Utc::now();
+        let task_list = |title: &str| bamboo_domain::TaskList {
+            session_id: root_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let mut root = fresh(root_id);
+        root.set_task_list(task_list("newer root"));
+        root.set_task_list_version_meta("2");
+        storage.save_session(&root).await.expect("seed root");
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.set_task_list(task_list("current child"));
+        child.set_task_list_version_meta("1");
+        storage.save_session(&child).await.expect("seed child");
+
+        let updated = RuntimeSessionPersistence::update_task_list_control_planes_if_version(
+            &store,
+            child_id,
+            root_id,
+            "1",
+            &task_list("stale evaluator"),
+            "3",
+        )
+        .await
+        .expect("CAS returns clean conflict");
+        assert!(
+            !updated,
+            "mismatched root generation must reject both writes"
+        );
+
+        let durable_root = storage
+            .load_session(root_id)
+            .await
+            .expect("load root")
+            .expect("root exists");
+        let durable_child = storage
+            .load_session(child_id)
+            .await
+            .expect("load child")
+            .expect("child exists");
+        assert_eq!(durable_root.task_list_version_meta().as_deref(), Some("2"));
+        assert_eq!(
+            durable_root
+                .task_list
+                .as_ref()
+                .map(|list| list.title.as_str()),
+            Some("newer root")
+        );
+        assert_eq!(durable_child.task_list_version_meta().as_deref(), Some("1"));
+        assert_eq!(
+            durable_child
+                .task_list
+                .as_ref()
+                .map(|list| list.title.as_str()),
+            Some("current child")
+        );
+    }
+
+    #[tokio::test]
+    async fn paired_task_cas_success_uses_only_targeted_saves_and_preserves_both_transcripts() {
+        use bamboo_domain::session::types::Message;
+
+        let temp = tempfile::tempdir().unwrap();
+        let inner = Arc::new(
+            SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .expect("storage init"),
+        );
+        let root_id = "task-cas-success-root";
+        let child_id = "task-cas-success-child";
+        let now = chrono::Utc::now();
+        let task_list = |title: &str| bamboo_domain::TaskList {
+            session_id: root_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let mut root = fresh(root_id);
+        root.add_message(Message::user("root transcript"));
+        root.metadata
+            .insert("unrelated.root".to_string(), "preserve".to_string());
+        root.agent_runtime_state = Some(bamboo_domain::AgentRuntimeState::new("root-run"));
+        root.set_task_list(task_list("old root"));
+        root.set_task_list_version_meta("1");
+        inner.save_session(&root).await.expect("seed root");
+
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.add_message(Message::user("child transcript"));
+        child
+            .metadata
+            .insert("unrelated.child".to_string(), "preserve".to_string());
+        child.agent_runtime_state = Some(bamboo_domain::AgentRuntimeState::new("child-run"));
+        child.set_task_list(task_list("old child"));
+        child.set_task_list_version_meta("1");
+        inner.save_session(&child).await.expect("seed child");
+
+        let counted = Arc::new(CountingControlPlaneStorage {
+            inner: inner.clone(),
+            control_plane_loads: AtomicUsize::new(0),
+            full_saves: AtomicUsize::new(0),
+            runtime_state_saves: AtomicUsize::new(0),
+        });
+        let storage: Arc<dyn Storage> = counted.clone();
+        let store = LockedSessionStore::new(storage);
+        assert!(
+            RuntimeSessionPersistence::update_task_list_control_planes_if_version(
+                &store,
+                child_id,
+                root_id,
+                "1",
+                &task_list("evaluated"),
+                "2",
+            )
+            .await
+            .expect("paired CAS succeeds")
+        );
+        assert_eq!(counted.control_plane_loads.load(Ordering::SeqCst), 2);
+        assert_eq!(counted.runtime_state_saves.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            counted.full_saves.load(Ordering::SeqCst),
+            0,
+            "evaluation CAS must not call full save_session for child or root"
+        );
+
+        let durable_root = inner.load_session(root_id).await.unwrap().unwrap();
+        let durable_child = inner.load_session(child_id).await.unwrap().unwrap();
+        for (session, transcript, metadata_key, run_id) in [
+            (
+                &durable_root,
+                "root transcript",
+                "unrelated.root",
+                "root-run",
+            ),
+            (
+                &durable_child,
+                "child transcript",
+                "unrelated.child",
+                "child-run",
+            ),
+        ] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("evaluated")
+            );
+            assert_eq!(session.messages.len(), 1);
+            assert_eq!(session.messages[0].content, transcript);
+            assert_eq!(
+                session.metadata.get(metadata_key).map(String::as_str),
+                Some("preserve")
+            );
+            assert_eq!(
+                session
+                    .agent_runtime_state
+                    .as_ref()
+                    .map(|state| state.run_id.as_str()),
+                Some(run_id)
+            );
+        }
     }
 
     // ── LockedSessionStore tests ────────────────────────────────────

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -42,6 +42,35 @@ use dashmap::DashMap;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
 const AUTHORITATIVE_METADATA_KEYS: &[&str] = &["gold_config", "workflow.run_ids.v1"];
+const TASK_CONTROL_PLANE_CONFLICT_PREFIX: &str = "Task control-plane changed while saving session ";
+const MAX_TASK_CONTROL_PLANE_REBASE_RETRIES: usize = 3;
+
+fn is_task_control_plane_save_conflict(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::WouldBlock
+        && error
+            .to_string()
+            .starts_with(TASK_CONTROL_PLANE_CONFLICT_PREFIX)
+}
+
+fn adopt_durable_task_control_plane(session: &mut Session, durable: &Session) {
+    session.task_list = durable.task_list.clone();
+    session
+        .metadata
+        .remove(bamboo_domain::session::runtime_metadata::keys::TASK_LIST_VERSION);
+    if let Some(runtime_metadata) = session.runtime_metadata.as_mut() {
+        runtime_metadata.task_list_version = None;
+    }
+    if session
+        .runtime_metadata
+        .as_ref()
+        .is_some_and(bamboo_domain::session::SessionRuntimeMetadata::is_empty)
+    {
+        session.runtime_metadata = None;
+    }
+    if let Some(version) = durable.task_list_version_meta() {
+        session.set_task_list_version_meta(version);
+    }
+}
 
 // ── LockedSessionStore ────────────────────────────────────────────────
 
@@ -53,6 +82,10 @@ const AUTHORITATIVE_METADATA_KEYS: &[&str] = &["gold_config", "workflow.run_ids.
 pub struct LockedSessionStore {
     storage: Arc<dyn Storage>,
     locks: Arc<DashMap<String, Arc<Mutex<()>>>>,
+    /// Serializes recoverable child/root Task transactions. Per-session locks
+    /// still provide the data isolation; this gate ensures a retained recovery
+    /// journal is resolved before another pair attempts to commit.
+    task_pair_transaction_lock: Arc<Mutex<()>>,
 }
 
 /// Self-cleaning guard returned by [`LockedSessionStore::acquire_lock`].
@@ -100,6 +133,7 @@ impl LockedSessionStore {
         Self {
             storage,
             locks: Arc::new(DashMap::new()),
+            task_pair_transaction_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -135,6 +169,78 @@ impl LockedSessionStore {
             locks: self.locks.clone(),
             session_id: session_id.to_string(),
         }
+    }
+
+    /// Save a full snapshot while preserving Task generations advanced by an
+    /// independent store instance. V2 rejects such a stale write before any
+    /// mutation; reloading and adopting only Task-owned fields makes the retry,
+    /// caller snapshot, and subsequent cache publication agree exactly.
+    async fn save_session_rebasing_task_conflicts(
+        &self,
+        session: &mut Session,
+    ) -> std::io::Result<()> {
+        for attempt in 0..=MAX_TASK_CONTROL_PLANE_REBASE_RETRIES {
+            match self.storage.save_session(session).await {
+                Ok(()) => return Ok(()),
+                Err(error)
+                    if is_task_control_plane_save_conflict(&error)
+                        && attempt < MAX_TASK_CONTROL_PLANE_REBASE_RETRIES =>
+                {
+                    let Some(durable) =
+                        self.storage.load_runtime_control_plane(&session.id).await?
+                    else {
+                        return Err(error);
+                    };
+                    adopt_durable_task_control_plane(session, &durable);
+                }
+                Err(error) => {
+                    if is_task_control_plane_save_conflict(&error) {
+                        if let Some(durable) =
+                            self.storage.load_runtime_control_plane(&session.id).await?
+                        {
+                            adopt_durable_task_control_plane(session, &durable);
+                        }
+                    }
+                    return Err(error);
+                }
+            }
+        }
+        unreachable!("bounded Task conflict retry loop always returns")
+    }
+
+    /// Sidecar-only counterpart of
+    /// [`Self::save_session_rebasing_task_conflicts`].
+    async fn save_runtime_state_rebasing_task_conflicts(
+        &self,
+        session: &mut Session,
+    ) -> std::io::Result<()> {
+        for attempt in 0..=MAX_TASK_CONTROL_PLANE_REBASE_RETRIES {
+            match self.storage.save_runtime_state(session).await {
+                Ok(()) => return Ok(()),
+                Err(error)
+                    if is_task_control_plane_save_conflict(&error)
+                        && attempt < MAX_TASK_CONTROL_PLANE_REBASE_RETRIES =>
+                {
+                    let Some(durable) =
+                        self.storage.load_runtime_control_plane(&session.id).await?
+                    else {
+                        return Err(error);
+                    };
+                    adopt_durable_task_control_plane(session, &durable);
+                }
+                Err(error) => {
+                    if is_task_control_plane_save_conflict(&error) {
+                        if let Some(durable) =
+                            self.storage.load_runtime_control_plane(&session.id).await?
+                        {
+                            adopt_durable_task_control_plane(session, &durable);
+                        }
+                    }
+                    return Err(error);
+                }
+            }
+        }
+        unreachable!("bounded Task conflict retry loop always returns")
     }
 
     /// Runtime-only save: persist the control-plane (`agent_runtime_state`,
@@ -187,7 +293,9 @@ impl LockedSessionStore {
             // authoritative for the ledger and the published snapshot.
             adopt_durable_model_context_state(session, &latest);
         }
-        let result = self.storage.save_runtime_state(session).await;
+        let result = self
+            .save_runtime_state_rebasing_task_conflicts(session)
+            .await;
         publish(session);
         result
     }
@@ -212,9 +320,19 @@ impl LockedSessionStore {
         let Some(mut latest) = self.storage.load_runtime_control_plane(session_id).await? else {
             return Ok(false);
         };
-        latest.set_task_list(task_list.clone());
+        let original = latest.clone();
+        latest.task_list = Some(task_list.clone());
         latest.set_task_list_version_meta(version.to_string());
-        self.storage.save_runtime_state(&latest).await?;
+        if !self
+            .storage
+            .save_task_control_plane_if_matches(&original, &latest)
+            .await?
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                format!("Task control-plane changed while patching session {session_id}"),
+            ));
+        }
         publish(&latest);
         Ok(true)
     }
@@ -240,16 +358,25 @@ impl LockedSessionStore {
         if latest.task_list_version_meta().as_deref() != Some(expected_version) {
             return Ok(false);
         }
-        latest.set_task_list(task_list.clone());
+        let original = latest.clone();
+        latest.task_list = Some(task_list.clone());
         latest.set_task_list_version_meta(version.to_string());
-        self.storage.save_runtime_state(&latest).await?;
+        if !self
+            .storage
+            .save_task_control_plane_if_matches(&original, &latest)
+            .await?
+        {
+            return Ok(false);
+        }
         publish(&latest);
         Ok(true)
     }
 
-    /// Atomically validate and narrowly patch both the executing session and
+    /// Recoverably validate and narrowly patch both the executing session and
     /// its shared root. Locks are acquired in lexical id order to prevent two
-    /// child evaluators from deadlocking while sharing a root.
+    /// child evaluators from deadlocking while sharing a root. The underlying
+    /// storage transaction must either commit both Task generations or retain
+    /// an undo journal and fail closed until both originals are restored.
     pub async fn update_task_list_control_planes_if_version_and_publish<F>(
         &self,
         session_id: &str,
@@ -279,8 +406,16 @@ impl LockedSessionStore {
         } else {
             (shared_session_id, session_id)
         };
+        let _transaction_guard = self.task_pair_transaction_lock.lock().await;
         let _first_guard = self.acquire_lock(first_id).await;
         let _second_guard = self.acquire_lock(second_id).await;
+
+        // A prior rollback may have failed after one sidecar was published.
+        // Recover under the same lexical pair locks before observing either
+        // generation; an unresolved journal fails this access closed.
+        self.storage
+            .recover_task_control_plane_transaction(first_id, second_id)
+            .await?;
 
         let Some(mut local) = self.storage.load_runtime_control_plane(session_id).await? else {
             return Ok(false);
@@ -298,12 +433,33 @@ impl LockedSessionStore {
             return Ok(false);
         }
 
-        local.set_task_list(task_list.clone());
+        let local_original = local.clone();
+        let shared_original = shared.clone();
+        // The paired persistence port owns only Task list/generation. Keep the
+        // surrounding session snapshot byte-stable so its minimal undo journal
+        // never needs transcript or unrelated metadata.
+        local.task_list = Some(task_list.clone());
         local.set_task_list_version_meta(version.to_string());
-        shared.set_task_list(task_list.clone());
+        shared.task_list = Some(task_list.clone());
         shared.set_task_list_version_meta(version.to_string());
-        self.storage.save_runtime_state(&local).await?;
-        self.storage.save_runtime_state(&shared).await?;
+        let (first_original, first_updated, second_original, second_updated) =
+            if session_id < shared_session_id {
+                (&local_original, &local, &shared_original, &shared)
+            } else {
+                (&shared_original, &shared, &local_original, &local)
+            };
+        let committed = self
+            .storage
+            .save_task_control_planes_atomically(
+                first_original,
+                first_updated,
+                second_original,
+                second_updated,
+            )
+            .await?;
+        if !committed {
+            return Ok(false);
+        }
         publish(&local, &shared);
         Ok(true)
     }
@@ -323,7 +479,8 @@ impl LockedSessionStore {
         if let Some(latest) = self.storage.load_runtime_control_plane(&session.id).await? {
             adopt_durable_model_context_state(&mut committed, &latest);
         }
-        self.storage.save_session(&committed).await
+        self.save_session_rebasing_task_conflicts(&mut committed)
+            .await
     }
 
     /// Runtime / non-authoritative save with per-session lock.
@@ -413,7 +570,7 @@ impl LockedSessionStore {
             adopt_fresher_disk_permission_posture(session, latest);
         }
 
-        let result = self.storage.save_session(session).await;
+        let result = self.save_session_rebasing_task_conflicts(session).await;
         publish(session, result.is_ok());
         result
     }
@@ -499,7 +656,7 @@ impl LockedSessionStore {
             }
             adopt_fresher_durable_model_context_state(session, latest);
         }
-        let result = self.storage.save_session(session).await;
+        let result = self.save_session_rebasing_task_conflicts(session).await;
         publish(session, result.is_ok());
         result
     }
@@ -560,7 +717,7 @@ impl LockedSessionStore {
             .set_permission_mode(incoming_audit.resolution.requested);
         incoming_audit.write_to(&mut session.metadata);
 
-        let result = self.storage.save_session(session).await;
+        let result = self.save_session_rebasing_task_conflicts(session).await;
         publish(session, result.is_ok());
         result
     }
@@ -609,7 +766,8 @@ impl LockedSessionStore {
         if mode_changed {
             latest.metadata_version = latest.metadata_version.saturating_add(1);
         }
-        self.storage.save_session(&latest).await?;
+        self.save_session_rebasing_task_conflicts(&mut latest)
+            .await?;
         publish(&latest);
         Ok(Some(latest))
     }
@@ -656,7 +814,8 @@ impl LockedSessionStore {
         bamboo_domain::record_permission_audit(&mut latest.metadata, seed, None).map_err(
             |error| std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()),
         )?;
-        self.storage.save_session(&latest).await?;
+        self.save_session_rebasing_task_conflicts(&mut latest)
+            .await?;
         publish(&latest);
         Ok(Some(latest))
     }
@@ -701,7 +860,8 @@ impl LockedSessionStore {
             return Ok(None);
         };
         mutate(&mut session);
-        self.storage.save_session(&session).await?;
+        self.save_session_rebasing_task_conflicts(&mut session)
+            .await?;
         publish(&session);
         Ok(Some(session))
     }
@@ -725,7 +885,8 @@ impl LockedSessionStore {
             return Ok(false);
         }
         latest.clear_pending_injected_messages();
-        self.storage.save_runtime_state(&latest).await?;
+        self.save_runtime_state_rebasing_task_conflicts(&mut latest)
+            .await?;
         publish(&latest);
         Ok(true)
     }
@@ -1018,15 +1179,156 @@ pub async fn merge_save_session(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::v2::SessionStoreV2;
+    use crate::v2::{RuntimeTaskTransactionFault, SessionStoreV2};
     use bamboo_domain::{session::types::Session, PermissionMode};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     struct CountingControlPlaneStorage {
         inner: Arc<SessionStoreV2>,
         control_plane_loads: AtomicUsize,
         full_saves: AtomicUsize,
         runtime_state_saves: AtomicUsize,
+    }
+
+    struct PairCommitBarrierStorage {
+        inner: Arc<SessionStoreV2>,
+        before_commit: Arc<tokio::sync::Barrier>,
+    }
+
+    struct SingleCommitBarrierStorage {
+        inner: Arc<SessionStoreV2>,
+        before_commit: Arc<tokio::sync::Barrier>,
+    }
+
+    struct SingleCommitPauseStorage {
+        inner: Arc<SessionStoreV2>,
+        commit_reached: Arc<tokio::sync::Barrier>,
+        release_commit: Arc<tokio::sync::Barrier>,
+    }
+
+    #[async_trait::async_trait]
+    impl Storage for SingleCommitPauseStorage {
+        async fn save_session(&self, session: &Session) -> std::io::Result<()> {
+            self.inner.save_session(session).await
+        }
+
+        async fn load_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
+            self.inner.load_session(session_id).await
+        }
+
+        async fn delete_session(&self, session_id: &str) -> std::io::Result<bool> {
+            self.inner.delete_session(session_id).await
+        }
+
+        async fn load_runtime_control_plane(
+            &self,
+            session_id: &str,
+        ) -> std::io::Result<Option<Session>> {
+            self.inner.load_runtime_control_plane(session_id).await
+        }
+
+        async fn save_task_control_plane_if_matches(
+            &self,
+            original: &Session,
+            updated: &Session,
+        ) -> std::io::Result<bool> {
+            self.commit_reached.wait().await;
+            self.release_commit.wait().await;
+            self.inner
+                .save_task_control_plane_if_matches(original, updated)
+                .await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Storage for SingleCommitBarrierStorage {
+        async fn save_session(&self, session: &Session) -> std::io::Result<()> {
+            self.inner.save_session(session).await
+        }
+
+        async fn load_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
+            self.inner.load_session(session_id).await
+        }
+
+        async fn delete_session(&self, session_id: &str) -> std::io::Result<bool> {
+            self.inner.delete_session(session_id).await
+        }
+
+        async fn load_runtime_control_plane(
+            &self,
+            session_id: &str,
+        ) -> std::io::Result<Option<Session>> {
+            self.inner.load_runtime_control_plane(session_id).await
+        }
+
+        async fn save_task_control_plane_if_matches(
+            &self,
+            original: &Session,
+            updated: &Session,
+        ) -> std::io::Result<bool> {
+            self.before_commit.wait().await;
+            self.inner
+                .save_task_control_plane_if_matches(original, updated)
+                .await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Storage for PairCommitBarrierStorage {
+        async fn save_session(&self, session: &Session) -> std::io::Result<()> {
+            self.inner.save_session(session).await
+        }
+
+        async fn load_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
+            self.inner.load_session(session_id).await
+        }
+
+        async fn delete_session(&self, session_id: &str) -> std::io::Result<bool> {
+            self.inner.delete_session(session_id).await
+        }
+
+        async fn save_runtime_state(&self, session: &Session) -> std::io::Result<()> {
+            self.inner.save_runtime_state(session).await
+        }
+
+        async fn load_runtime_control_plane(
+            &self,
+            session_id: &str,
+        ) -> std::io::Result<Option<Session>> {
+            self.inner.load_runtime_control_plane(session_id).await
+        }
+
+        async fn recover_task_control_plane_transaction(
+            &self,
+            first_session_id: &str,
+            second_session_id: &str,
+        ) -> std::io::Result<()> {
+            self.inner
+                .recover_task_control_plane_transaction(first_session_id, second_session_id)
+                .await
+        }
+
+        async fn save_task_control_planes_atomically(
+            &self,
+            first_original: &Session,
+            first_updated: &Session,
+            second_original: &Session,
+            second_updated: &Session,
+        ) -> std::io::Result<bool> {
+            // Both independent LockedSessionStores have already recovered,
+            // loaded, and validated v1 when they meet here. Their per-instance
+            // lexical locks cannot serialize each other; the V2 commit-point
+            // revalidation must select exactly one winner.
+            self.before_commit.wait().await;
+            self.inner
+                .save_task_control_planes_atomically(
+                    first_original,
+                    first_updated,
+                    second_original,
+                    second_updated,
+                )
+                .await
+        }
     }
 
     #[async_trait::async_trait]
@@ -1055,6 +1357,53 @@ mod tests {
         ) -> std::io::Result<Option<Session>> {
             self.control_plane_loads.fetch_add(1, Ordering::SeqCst);
             self.inner.load_runtime_control_plane(session_id).await
+        }
+
+        async fn recover_task_control_plane_transaction(
+            &self,
+            first_session_id: &str,
+            second_session_id: &str,
+        ) -> std::io::Result<()> {
+            self.inner
+                .recover_task_control_plane_transaction(first_session_id, second_session_id)
+                .await
+        }
+
+        async fn save_task_control_plane_if_matches(
+            &self,
+            original: &Session,
+            updated: &Session,
+        ) -> std::io::Result<bool> {
+            let committed = self
+                .inner
+                .save_task_control_plane_if_matches(original, updated)
+                .await?;
+            if committed {
+                self.runtime_state_saves.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(committed)
+        }
+
+        async fn save_task_control_planes_atomically(
+            &self,
+            first_original: &Session,
+            first_updated: &Session,
+            second_original: &Session,
+            second_updated: &Session,
+        ) -> std::io::Result<bool> {
+            let committed = self
+                .inner
+                .save_task_control_planes_atomically(
+                    first_original,
+                    first_updated,
+                    second_original,
+                    second_updated,
+                )
+                .await?;
+            if committed {
+                self.runtime_state_saves.fetch_add(2, Ordering::SeqCst);
+            }
+            Ok(committed)
         }
     }
 
@@ -2696,6 +3045,481 @@ mod tests {
                     .as_ref()
                     .map(|state| state.run_id.as_str()),
                 Some(run_id)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn locked_runtime_and_full_saves_adopt_task_conflicts_before_publish() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().to_path_buf();
+        let first_storage = Arc::new(
+            SessionStoreV2::new(home.clone())
+                .await
+                .expect("first storage init"),
+        );
+        let second_storage = Arc::new(
+            SessionStoreV2::new(home)
+                .await
+                .expect("second storage init"),
+        );
+        let now = chrono::Utc::now();
+        let task_list = |session_id: &str, title: &str| bamboo_domain::TaskList {
+            session_id: session_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let runtime_id = "ordinary-task-retry-runtime";
+        let full_id = "ordinary-task-retry-full";
+        let mut runtime_initial = fresh(runtime_id);
+        runtime_initial.set_task_list(task_list(runtime_id, "runtime v1"));
+        runtime_initial.set_task_list_version_meta("1");
+        first_storage
+            .save_session(&runtime_initial)
+            .await
+            .expect("seed runtime session");
+        let mut full_initial = fresh(full_id);
+        full_initial.set_task_list(task_list(full_id, "full v1"));
+        full_initial.set_task_list_version_meta("1");
+        first_storage
+            .save_session(&full_initial)
+            .await
+            .expect("seed full session");
+
+        let mut runtime_advanced = runtime_initial.clone();
+        runtime_advanced.set_task_list(task_list(runtime_id, "runtime v2"));
+        runtime_advanced.set_task_list_version_meta("2");
+        second_storage
+            .save_runtime_state(&runtime_advanced)
+            .await
+            .expect("advance runtime Task generation");
+        let mut full_advanced = full_initial.clone();
+        full_advanced.set_task_list(task_list(full_id, "full v2"));
+        full_advanced.set_task_list_version_meta("2");
+        second_storage
+            .save_runtime_state(&full_advanced)
+            .await
+            .expect("advance full Task generation");
+
+        let storage: Arc<dyn Storage> = first_storage.clone();
+        let store = LockedSessionStore::new(storage);
+        let runtime_published = Arc::new(std::sync::Mutex::new(None));
+        let runtime_callback = runtime_published.clone();
+        let mut runtime_stale = runtime_initial;
+        runtime_stale
+            .metadata
+            .insert("runtime.non-task".to_string(), "preserved".to_string());
+        store
+            .save_runtime_only_and_publish(&mut runtime_stale, move |saved| {
+                *runtime_callback.lock().expect("runtime publish lock") = Some(saved.clone());
+            })
+            .await
+            .expect("locked runtime save rebases and retries");
+
+        let full_published = Arc::new(std::sync::Mutex::new(None));
+        let full_callback = full_published.clone();
+        let mut full_stale = full_initial;
+        full_stale
+            .metadata
+            .insert("full.non-task".to_string(), "preserved".to_string());
+        store
+            .merge_save_runtime_and_publish(&mut full_stale, move |saved, committed| {
+                assert!(committed);
+                *full_callback.lock().expect("full publish lock") = Some(saved.clone());
+            })
+            .await
+            .expect("locked full save rebases and retries");
+
+        let durable_runtime = first_storage
+            .load_session(runtime_id)
+            .await
+            .unwrap()
+            .expect("durable runtime session");
+        let durable_full = first_storage
+            .load_session(full_id)
+            .await
+            .unwrap()
+            .expect("durable full session");
+        let published_runtime = runtime_published
+            .lock()
+            .expect("runtime publish lock")
+            .clone()
+            .expect("runtime published snapshot");
+        let published_full = full_published
+            .lock()
+            .expect("full publish lock")
+            .clone()
+            .expect("full published snapshot");
+
+        for (session, expected_title, metadata_key) in [
+            (&runtime_stale, "runtime v2", "runtime.non-task"),
+            (&durable_runtime, "runtime v2", "runtime.non-task"),
+            (&published_runtime, "runtime v2", "runtime.non-task"),
+            (&full_stale, "full v2", "full.non-task"),
+            (&durable_full, "full v2", "full.non-task"),
+            (&published_full, "full v2", "full.non-task"),
+        ] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some(expected_title)
+            );
+            assert_eq!(
+                session.metadata.get(metadata_key).map(String::as_str),
+                Some("preserved")
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn unconditional_root_task_patch_reports_final_cas_conflict_without_publishing() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().to_path_buf();
+        let first_inner = Arc::new(
+            SessionStoreV2::new(home.clone())
+                .await
+                .expect("first storage init"),
+        );
+        let root_id = "single-task-unconditional-loser";
+        let now = chrono::Utc::now();
+        let task_list = |title: &str| bamboo_domain::TaskList {
+            session_id: root_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+        let mut root = fresh(root_id);
+        root.task_list = Some(task_list("original"));
+        root.set_task_list_version_meta("1");
+        first_inner.save_session(&root).await.expect("seed root");
+        let second_inner = Arc::new(
+            SessionStoreV2::new(home)
+                .await
+                .expect("second storage init"),
+        );
+        let commit_reached = Arc::new(tokio::sync::Barrier::new(2));
+        let release_commit = Arc::new(tokio::sync::Barrier::new(2));
+        let storage: Arc<dyn Storage> = Arc::new(SingleCommitPauseStorage {
+            inner: first_inner.clone(),
+            commit_reached: commit_reached.clone(),
+            release_commit: release_commit.clone(),
+        });
+        let store = LockedSessionStore::new(storage);
+        let published = Arc::new(AtomicBool::new(false));
+        let callback = published.clone();
+        let loser_candidate = task_list("loser");
+
+        let loser = store.update_task_list_control_plane_and_publish(
+            root_id,
+            &loser_candidate,
+            "2",
+            move |_| callback.store(true, Ordering::SeqCst),
+        );
+        let winner = async {
+            commit_reached.wait().await;
+            let original = second_inner
+                .load_runtime_control_plane(root_id)
+                .await
+                .expect("load winner original")
+                .expect("winner original exists");
+            let mut updated = original.clone();
+            updated.task_list = Some(task_list("winner"));
+            updated.set_task_list_version_meta("2");
+            assert!(second_inner
+                .save_task_control_plane_if_matches(&original, &updated)
+                .await
+                .expect("commit winner"));
+            release_commit.wait().await;
+        };
+        let (loser_result, ()) = tokio::join!(loser, winner);
+        let error = loser_result.expect_err("unconditional loser must be an explicit conflict");
+        assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+        assert!(!published.load(Ordering::SeqCst));
+        let durable = first_inner
+            .load_session(root_id)
+            .await
+            .unwrap()
+            .expect("durable root");
+        assert_eq!(durable.task_list_version_meta().as_deref(), Some("2"));
+        assert_eq!(
+            durable.task_list.as_ref().map(|list| list.title.as_str()),
+            Some("winner")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn independent_root_task_patches_have_one_final_cas_winner() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().to_path_buf();
+        let first_inner = Arc::new(
+            SessionStoreV2::new(home.clone())
+                .await
+                .expect("first storage init"),
+        );
+        let root_id = "single-task-cas-race-root";
+        let now = chrono::Utc::now();
+        let task_list = |title: &str| bamboo_domain::TaskList {
+            session_id: root_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+        let mut root = fresh(root_id);
+        root.set_task_list(task_list("original"));
+        root.set_task_list_version_meta("1");
+        first_inner.save_session(&root).await.expect("seed root");
+        let second_inner = Arc::new(
+            SessionStoreV2::new(home)
+                .await
+                .expect("second storage init"),
+        );
+        let before_commit = Arc::new(tokio::sync::Barrier::new(2));
+        let first_storage: Arc<dyn Storage> = Arc::new(SingleCommitBarrierStorage {
+            inner: first_inner.clone(),
+            before_commit: before_commit.clone(),
+        });
+        let second_storage: Arc<dyn Storage> = Arc::new(SingleCommitBarrierStorage {
+            inner: second_inner.clone(),
+            before_commit,
+        });
+        let first_store = LockedSessionStore::new(first_storage);
+        let second_store = LockedSessionStore::new(second_storage);
+        let first_published = Arc::new(AtomicBool::new(false));
+        let second_published = Arc::new(AtomicBool::new(false));
+        let first_callback = first_published.clone();
+        let second_callback = second_published.clone();
+        let first_candidate = task_list("candidate one");
+        let second_candidate = task_list("candidate two");
+
+        // Two expected-version patches stage from v1, but the storage final-CAS
+        // admits only one regardless of process-local lock ownership.
+        let first = first_store.update_task_list_control_plane_if_version_and_publish(
+            root_id,
+            "1",
+            &first_candidate,
+            "2",
+            move |_| first_callback.store(true, Ordering::SeqCst),
+        );
+        let second = second_store.update_task_list_control_plane_if_version_and_publish(
+            root_id,
+            "1",
+            &second_candidate,
+            "2",
+            move |_| second_callback.store(true, Ordering::SeqCst),
+        );
+        let (first_result, second_result) = tokio::join!(first, second);
+        let first_won = first_result.expect("first root result");
+        let second_won = second_result.expect("second root result");
+        assert_ne!(first_won, second_won, "exactly one root candidate wins");
+        assert_eq!(first_published.load(Ordering::SeqCst), first_won);
+        assert_eq!(second_published.load(Ordering::SeqCst), second_won);
+
+        let durable = first_inner
+            .load_session(root_id)
+            .await
+            .unwrap()
+            .expect("root");
+        assert_eq!(durable.task_list_version_meta().as_deref(), Some("2"));
+        assert_eq!(
+            durable.task_list.as_ref().map(|list| list.title.as_str()),
+            Some(if first_won {
+                "candidate one"
+            } else {
+                "candidate two"
+            })
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn independent_locked_stores_revalidate_pair_cas_at_storage_commit_point() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().to_path_buf();
+        let first_inner = Arc::new(
+            SessionStoreV2::new(home.clone())
+                .await
+                .expect("first storage init"),
+        );
+        let root_id = "task-cas-race-root";
+        let child_id = "task-cas-race-child";
+        let now = chrono::Utc::now();
+        let task_list = |title: &str| bamboo_domain::TaskList {
+            session_id: root_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let mut root = fresh(root_id);
+        root.set_task_list(task_list("original root"));
+        root.set_task_list_version_meta("1");
+        first_inner.save_session(&root).await.expect("seed root");
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.set_task_list(task_list("original child"));
+        child.set_task_list_version_meta("1");
+        first_inner.save_session(&child).await.expect("seed child");
+
+        let second_inner = Arc::new(
+            SessionStoreV2::new(home)
+                .await
+                .expect("second storage init"),
+        );
+        let before_commit = Arc::new(tokio::sync::Barrier::new(2));
+        let first_storage: Arc<dyn Storage> = Arc::new(PairCommitBarrierStorage {
+            inner: first_inner.clone(),
+            before_commit: before_commit.clone(),
+        });
+        let second_storage: Arc<dyn Storage> = Arc::new(PairCommitBarrierStorage {
+            inner: second_inner.clone(),
+            before_commit,
+        });
+        let first_store = LockedSessionStore::new(first_storage);
+        let second_store = LockedSessionStore::new(second_storage);
+        let first_published = Arc::new(AtomicBool::new(false));
+        let second_published = Arc::new(AtomicBool::new(false));
+        let first_published_callback = first_published.clone();
+        let second_published_callback = second_published.clone();
+        let first_candidate = task_list("candidate one");
+        let second_candidate = task_list("candidate two");
+
+        let first = first_store.update_task_list_control_planes_if_version_and_publish(
+            child_id,
+            root_id,
+            "1",
+            &first_candidate,
+            "2",
+            move |_, _| first_published_callback.store(true, Ordering::SeqCst),
+        );
+        let second = second_store.update_task_list_control_planes_if_version_and_publish(
+            child_id,
+            root_id,
+            "1",
+            &second_candidate,
+            "2",
+            move |_, _| second_published_callback.store(true, Ordering::SeqCst),
+        );
+        let (first_result, second_result) = tokio::join!(first, second);
+        let first_won = first_result.expect("first CAS result");
+        let second_won = second_result.expect("second CAS result");
+        assert_ne!(first_won, second_won, "exactly one staged v1 CAS may win");
+        assert_eq!(first_published.load(Ordering::SeqCst), first_won);
+        assert_eq!(second_published.load(Ordering::SeqCst), second_won);
+
+        let expected_title = if first_won {
+            "candidate one"
+        } else {
+            "candidate two"
+        };
+        let durable_child = first_inner
+            .load_session(child_id)
+            .await
+            .unwrap()
+            .expect("child");
+        let durable_root = second_inner
+            .load_session(root_id)
+            .await
+            .unwrap()
+            .expect("root");
+        for session in [&durable_child, &durable_root] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some(expected_title)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn paired_task_second_write_failure_rolls_back_and_skips_publish_callback() {
+        use bamboo_domain::session::types::Message;
+
+        let temp = tempfile::tempdir().unwrap();
+        let inner = Arc::new(
+            SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .expect("storage init"),
+        );
+        let root_id = "task-cas-failure-root";
+        let child_id = "task-cas-failure-child";
+        let now = chrono::Utc::now();
+        let task_list = |title: &str| bamboo_domain::TaskList {
+            session_id: root_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let mut root = fresh(root_id);
+        root.add_message(Message::user("root transcript"));
+        root.metadata
+            .insert("unrelated.root".to_string(), "preserve".to_string());
+        root.set_task_list(task_list("old root"));
+        root.set_task_list_version_meta("1");
+        inner.save_session(&root).await.expect("seed root");
+
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.add_message(Message::user("child transcript"));
+        child
+            .metadata
+            .insert("unrelated.child".to_string(), "preserve".to_string());
+        child.set_task_list(task_list("old child"));
+        child.set_task_list_version_meta("1");
+        inner.save_session(&child).await.expect("seed child");
+
+        inner
+            .inject_runtime_task_transaction_fault(RuntimeTaskTransactionFault::SecondUpdatedWrite);
+        let storage: Arc<dyn Storage> = inner.clone();
+        let store = LockedSessionStore::new(storage);
+        let published = Arc::new(AtomicBool::new(false));
+        let published_for_callback = published.clone();
+        let error = store
+            .update_task_list_control_planes_if_version_and_publish(
+                child_id,
+                root_id,
+                "1",
+                &task_list("must roll back"),
+                "2",
+                move |_, _| published_for_callback.store(true, Ordering::SeqCst),
+            )
+            .await
+            .expect_err("injected second write fails");
+        assert!(error.to_string().contains("rolled back"), "{error}");
+        assert!(
+            !published.load(Ordering::SeqCst),
+            "durable failure must not publish either cache snapshot"
+        );
+
+        let durable_root = inner.load_session(root_id).await.unwrap().unwrap();
+        let durable_child = inner.load_session(child_id).await.unwrap().unwrap();
+        for (session, title, transcript, metadata_key) in [
+            (
+                &durable_root,
+                "old root",
+                "root transcript",
+                "unrelated.root",
+            ),
+            (
+                &durable_child,
+                "old child",
+                "child transcript",
+                "unrelated.child",
+            ),
+        ] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("1"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some(title)
+            );
+            assert_eq!(session.messages[0].content, transcript);
+            assert_eq!(
+                session.metadata.get(metadata_key).map(String::as_str),
+                Some("preserve")
             );
         }
     }

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -20,6 +20,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use base64::Engine;
 use chrono::{DateTime, Utc};
@@ -31,7 +32,7 @@ use uuid::Uuid;
 
 use bamboo_domain::ProviderModelRef;
 use bamboo_domain::ReasoningEffort;
-use bamboo_domain::{ProjectId, Role, Session, SessionKind, TokenBudgetUsage};
+use bamboo_domain::{ProjectId, Role, Session, SessionKind, TaskList, TokenBudgetUsage};
 
 use crate::search_index::{should_index_session, SessionSearchIndex};
 use bamboo_domain::AttachmentReader;
@@ -44,6 +45,11 @@ pub(crate) fn other_io_error(message: impl Into<String>) -> io::Error {
 /// Filename of the runtime control-plane sidecar, stored alongside
 /// `session.json` in each session directory.
 const RUNTIME_SIDECAR_FILE: &str = "runtime.json";
+/// Private undo journals for recoverable two-session Task sidecar commits.
+/// Filenames are random UUIDs; untrusted session ids are never used as paths.
+const RUNTIME_TASK_TRANSACTION_DIR: &str = ".runtime-task-transactions";
+const RUNTIME_TASK_TRANSACTION_LOCK_FILE: &str = ".runtime-task-transactions.lock";
+const RUNTIME_TASK_TRANSACTION_VERSION: u32 = 1;
 const SESSIONS_INDEX_VERSION: u32 = 4;
 
 /// Filename of the append-only per-LLM-call token-usage log, stored alongside
@@ -58,6 +64,59 @@ const SESSION_INDEX_LOCK_FILE: &str = ".sessions-index.lock";
 
 struct SessionIndexFileGuard {
     file: std::fs::File,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TaskControlPlaneUndo {
+    session_id: String,
+    task_list: Option<TaskList>,
+    task_list_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RuntimeTaskTransactionJournal {
+    version: u32,
+    transaction_id: String,
+    first: TaskControlPlaneUndo,
+    second: TaskControlPlaneUndo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeTaskTransactionFault {
+    FirstUpdatedWrite,
+    SecondUpdatedWrite,
+    JournalRemove,
+    FirstRollbackWrite,
+    SecondRollbackWrite,
+}
+
+struct RuntimeTaskTransactionReadGuard {
+    _process: OwnedRwLockReadGuard<()>,
+    file: std::fs::File,
+}
+
+impl Drop for RuntimeTaskTransactionReadGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+struct RuntimeTaskTransactionWriteGuard {
+    _process: OwnedRwLockWriteGuard<()>,
+    file: std::fs::File,
+}
+
+impl Drop for RuntimeTaskTransactionWriteGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone)]
+struct RuntimeTaskFirstWritePause {
+    reached: std::sync::Arc<tokio::sync::Barrier>,
+    release: std::sync::Arc<tokio::sync::Barrier>,
 }
 
 impl Drop for SessionIndexFileGuard {
@@ -340,6 +399,18 @@ pub struct SessionStoreV2 {
     /// operations. The Tokio lock covers one runtime; the file lock covers
     /// independent Bamboo processes sharing the same data directory.
     session_lifecycle_lock: std::sync::Arc<RwLock<()>>,
+    /// Coordinates every runtime-sidecar read/write with paired Task commits
+    /// and orphan recovery. The Tokio gate prevents same-instance re-entry;
+    /// the dedicated fs2 file lock covers independent store instances and
+    /// processes sharing this Bamboo home.
+    runtime_task_transaction_gate: std::sync::Arc<RwLock<()>>,
+    /// When true, ordinary control-plane access fails closed until the retained
+    /// undo journal has restored both sides of an interrupted transaction.
+    runtime_task_recovery_required: AtomicBool,
+    #[cfg(test)]
+    runtime_task_faults: std::sync::Mutex<Vec<RuntimeTaskTransactionFault>>,
+    #[cfg(test)]
+    runtime_task_first_write_pause: std::sync::Mutex<Option<RuntimeTaskFirstWritePause>>,
 }
 
 impl SessionStoreV2 {
@@ -455,7 +526,23 @@ impl SessionStoreV2 {
             index: RwLock::new(index),
             write_lock: Mutex::new(()),
             session_lifecycle_lock: std::sync::Arc::new(RwLock::new(())),
+            runtime_task_transaction_gate: std::sync::Arc::new(RwLock::new(())),
+            runtime_task_recovery_required: AtomicBool::new(false),
+            #[cfg(test)]
+            runtime_task_faults: std::sync::Mutex::new(Vec::new()),
+            #[cfg(test)]
+            runtime_task_first_write_pause: std::sync::Mutex::new(None),
         };
+
+        // Create and permission the private journal directory once at store
+        // initialization. Clean hot-path reads only probe it and never repeat
+        // mkdir/chmod work; journal creation also revalidates it before write.
+        storage.ensure_runtime_task_transaction_dir().await?;
+
+        // Constructor recovery takes the same cross-process exclusive gate as
+        // a live commit. A second store can therefore recover an orphan, but
+        // can never mistake another process's in-flight journal for one.
+        storage.recover_all_runtime_task_transactions().await?;
 
         if needs_rebuild {
             storage.rebuild_index_from_disk().await?;
@@ -616,6 +703,7 @@ impl SessionStoreV2 {
         rel_path: String,
     ) -> io::Result<bool> {
         let _lifecycle = self.lock_session_lifecycle_shared().await?;
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
         let Some(session) = Self::load_session_from_dir(abs_dir, session_id).await else {
             return Ok(false);
         };
@@ -690,6 +778,31 @@ impl SessionStoreV2 {
         .map_err(|error| other_io_error(format!("join session lifecycle lock task: {error}")))?
     }
 
+    async fn open_runtime_task_transaction_file(
+        &self,
+        exclusive: bool,
+    ) -> io::Result<std::fs::File> {
+        let path = self
+            .bamboo_home_dir
+            .join(RUNTIME_TASK_TRANSACTION_LOCK_FILE);
+        tokio::task::spawn_blocking(move || {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&path)?;
+            if exclusive {
+                FileExt::lock_exclusive(&file)?;
+            } else {
+                FileExt::lock_shared(&file)?;
+            }
+            Ok(file)
+        })
+        .await
+        .map_err(|error| other_io_error(format!("join runtime Task lock task: {error}")))?
+    }
+
     async fn lock_index_file_exclusive(&self) -> io::Result<SessionIndexFileGuard> {
         lock_index_file_exclusive_at(&self.bamboo_home_dir).await
     }
@@ -709,6 +822,36 @@ impl SessionStoreV2 {
         let process = self.session_lifecycle_lock.clone().write_owned().await;
         let file = self.open_session_lifecycle_file(true).await?;
         Ok(SessionLifecycleWriteGuard {
+            _process: process,
+            file,
+        })
+    }
+
+    async fn lock_runtime_task_transaction_shared(
+        &self,
+    ) -> io::Result<RuntimeTaskTransactionReadGuard> {
+        let process = self
+            .runtime_task_transaction_gate
+            .clone()
+            .read_owned()
+            .await;
+        let file = self.open_runtime_task_transaction_file(false).await?;
+        Ok(RuntimeTaskTransactionReadGuard {
+            _process: process,
+            file,
+        })
+    }
+
+    async fn lock_runtime_task_transaction_exclusive(
+        &self,
+    ) -> io::Result<RuntimeTaskTransactionWriteGuard> {
+        let process = self
+            .runtime_task_transaction_gate
+            .clone()
+            .write_owned()
+            .await;
+        let file = self.open_runtime_task_transaction_file(true).await?;
+        Ok(RuntimeTaskTransactionWriteGuard {
             _process: process,
             file,
         })
@@ -825,6 +968,7 @@ impl SessionStoreV2 {
     ) -> io::Result<Option<Session>> {
         validate_session_id(session_id)?;
         let _lifecycle = self.lock_session_lifecycle_shared().await?;
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
         let Some(session) = self.load_authoritative_root_session(session_id).await? else {
             return Ok(None);
         };
@@ -843,6 +987,7 @@ impl SessionStoreV2 {
     ) -> io::Result<Option<Session>> {
         validate_session_id(session_id)?;
         let _lifecycle = self.lock_session_lifecycle_shared().await?;
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
         self.load_authoritative_root_session(session_id).await
     }
 
@@ -928,6 +1073,729 @@ impl SessionStoreV2 {
         }
     }
 
+    fn runtime_task_transaction_dir(&self) -> PathBuf {
+        self.bamboo_home_dir.join(RUNTIME_TASK_TRANSACTION_DIR)
+    }
+
+    async fn ensure_runtime_task_transaction_dir(&self) -> io::Result<PathBuf> {
+        let path = self.runtime_task_transaction_dir();
+        fs::create_dir_all(&path).await?;
+        // Journals contain only Task lists/generations (never transcripts or
+        // arbitrary metadata), but Task descriptions may still be private user
+        // data. Restrict the directory even when the process umask is loose.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).await?;
+        }
+        Ok(path)
+    }
+
+    fn runtime_task_recovery_error() -> io::Error {
+        other_io_error("runtime Task transaction recovery is required before control-plane access")
+    }
+
+    async fn ensure_no_runtime_task_journal_locked(&self) -> io::Result<()> {
+        match self.runtime_task_journal_paths().await {
+            Ok(paths) if paths.is_empty() => {
+                self.runtime_task_recovery_required
+                    .store(false, Ordering::Release);
+                Ok(())
+            }
+            Ok(_) => {
+                self.runtime_task_recovery_required
+                    .store(true, Ordering::Release);
+                Err(Self::runtime_task_recovery_error())
+            }
+            Err(error) => {
+                self.runtime_task_recovery_required
+                    .store(true, Ordering::Release);
+                Err(error)
+            }
+        }
+    }
+
+    /// Acquire the ordinary shared sidecar boundary, then consult the durable
+    /// journal directory rather than this instance's in-memory flag. Once the
+    /// shared file lock is held no live commit can create/remove a journal, so
+    /// an existing entry is necessarily recovery-required and access fails
+    /// closed even in a freshly constructed independent store.
+    async fn lock_runtime_task_sidecar_shared(
+        &self,
+    ) -> io::Result<RuntimeTaskTransactionReadGuard> {
+        let guard = self.lock_runtime_task_transaction_shared().await?;
+        self.ensure_no_runtime_task_journal_locked().await?;
+        Ok(guard)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_runtime_task_transaction_fault(&self, fault: RuntimeTaskTransactionFault) {
+        self.runtime_task_faults
+            .lock()
+            .expect("runtime task fault lock")
+            .push(fault);
+    }
+
+    #[cfg(test)]
+    fn pause_runtime_task_transaction_after_first_write(
+        &self,
+    ) -> (
+        std::sync::Arc<tokio::sync::Barrier>,
+        std::sync::Arc<tokio::sync::Barrier>,
+    ) {
+        let pause = RuntimeTaskFirstWritePause {
+            reached: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+            release: std::sync::Arc::new(tokio::sync::Barrier::new(2)),
+        };
+        *self
+            .runtime_task_first_write_pause
+            .lock()
+            .expect("runtime task pause lock") = Some(pause.clone());
+        (pause.reached, pause.release)
+    }
+
+    #[cfg(test)]
+    async fn maybe_pause_runtime_task_transaction_after_first_write(&self) {
+        let pause = self
+            .runtime_task_first_write_pause
+            .lock()
+            .expect("runtime task pause lock")
+            .take();
+        if let Some(pause) = pause {
+            pause.reached.wait().await;
+            pause.release.wait().await;
+        }
+    }
+
+    fn maybe_fail_runtime_task_transaction(
+        &self,
+        fault: RuntimeTaskTransactionFault,
+    ) -> io::Result<()> {
+        #[cfg(test)]
+        {
+            let mut faults = self
+                .runtime_task_faults
+                .lock()
+                .expect("runtime task fault lock");
+            if let Some(index) = faults.iter().position(|candidate| *candidate == fault) {
+                faults.remove(index);
+                return Err(other_io_error(format!(
+                    "injected runtime Task transaction fault: {fault:?}"
+                )));
+            }
+        }
+        #[cfg(not(test))]
+        let _ = fault;
+        Ok(())
+    }
+
+    async fn load_runtime_control_plane_unchecked(
+        &self,
+        session_id: &str,
+    ) -> io::Result<Option<Session>> {
+        validate_session_id(session_id)?;
+        if let Some(side) = self.read_runtime_sidecar(session_id).await? {
+            return Ok(Some(side));
+        }
+        let Some(path) = self.session_json_path(session_id).await? else {
+            return Ok(None);
+        };
+        let raw = match fs::read_to_string(path).await {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let mut session: Session = serde_json::from_str(&raw)
+            .map_err(|error| other_io_error(format!("invalid session.json: {error}")))?;
+        session.messages.clear();
+        session.clear_stale_root_token_budget();
+        Ok(Some(session))
+    }
+
+    async fn write_existing_runtime_sidecar_unchecked(&self, session: &Session) -> io::Result<()> {
+        validate_session_id(&session.id)?;
+        let Some(rel) = self.resolve_rel_path(&session.id).await else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("session {} has no persisted runtime target", session.id),
+            ));
+        };
+        self.write_runtime_sidecar(&self.abs_path_from_rel(&rel), session)
+            .await
+    }
+
+    async fn runtime_task_journal_paths(&self) -> io::Result<Vec<PathBuf>> {
+        let dir = self.runtime_task_transaction_dir();
+        let mut entries = match fs::read_dir(dir).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error),
+        };
+        let mut paths = Vec::new();
+        while let Some(entry) = entries.next_entry().await? {
+            if entry
+                .file_type()
+                .await
+                .map(|kind| kind.is_file())
+                .unwrap_or(false)
+                && entry.path().extension().and_then(|value| value.to_str()) == Some("json")
+            {
+                paths.push(entry.path());
+            }
+        }
+        paths.sort();
+        Ok(paths)
+    }
+
+    fn validate_runtime_task_journal(
+        path: &Path,
+        journal: &RuntimeTaskTransactionJournal,
+    ) -> io::Result<()> {
+        if journal.version != RUNTIME_TASK_TRANSACTION_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported runtime Task transaction journal version {}",
+                    journal.version
+                ),
+            ));
+        }
+        let file_id = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid journal name"))?;
+        Uuid::parse_str(file_id).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid runtime Task transaction journal UUID: {error}"),
+            )
+        })?;
+        if journal.transaction_id != file_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "runtime Task transaction journal id does not match its filename",
+            ));
+        }
+        validate_session_id(&journal.first.session_id)?;
+        validate_session_id(&journal.second.session_id)?;
+        if journal.first.session_id >= journal.second.session_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "runtime Task transaction journal pair is not lexically ordered",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn read_runtime_task_journal(
+        &self,
+        path: &Path,
+    ) -> io::Result<RuntimeTaskTransactionJournal> {
+        let raw = fs::read_to_string(path).await?;
+        let journal: RuntimeTaskTransactionJournal =
+            serde_json::from_str(&raw).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid runtime Task transaction journal: {error}"),
+                )
+            })?;
+        Self::validate_runtime_task_journal(path, &journal)?;
+        Ok(journal)
+    }
+
+    async fn write_runtime_task_journal(
+        &self,
+        journal: &RuntimeTaskTransactionJournal,
+    ) -> io::Result<PathBuf> {
+        let dir = self.ensure_runtime_task_transaction_dir().await?;
+        let path = dir.join(format!("{}.json", journal.transaction_id));
+        let bytes = serde_json::to_vec(journal)
+            .map_err(|error| other_io_error(format!("serialize Task undo journal: {error}")))?;
+        atomic_write(&path, &bytes).await?;
+        Ok(path)
+    }
+
+    async fn remove_runtime_task_journal(&self, path: &Path) -> io::Result<()> {
+        self.maybe_fail_runtime_task_transaction(RuntimeTaskTransactionFault::JournalRemove)?;
+        fs::remove_file(path).await
+    }
+
+    async fn restore_runtime_task_undo(
+        &self,
+        undo: &TaskControlPlaneUndo,
+        fault: RuntimeTaskTransactionFault,
+    ) -> io::Result<()> {
+        self.maybe_fail_runtime_task_transaction(fault)?;
+        let Some(mut current) = self
+            .load_runtime_control_plane_unchecked(&undo.session_id)
+            .await?
+        else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("cannot recover missing session {}", undo.session_id),
+            ));
+        };
+        current.task_list = undo.task_list.clone();
+        current.set_task_list_version_meta(undo.task_list_version.clone());
+        self.write_existing_runtime_sidecar_unchecked(&current)
+            .await
+    }
+
+    async fn rollback_runtime_task_journal(
+        &self,
+        journal: &RuntimeTaskTransactionJournal,
+    ) -> io::Result<()> {
+        let mut errors = Vec::new();
+        if let Err(error) = self
+            .restore_runtime_task_undo(
+                &journal.first,
+                RuntimeTaskTransactionFault::FirstRollbackWrite,
+            )
+            .await
+        {
+            errors.push(format!("{}: {error}", journal.first.session_id));
+        }
+        if let Err(error) = self
+            .restore_runtime_task_undo(
+                &journal.second,
+                RuntimeTaskTransactionFault::SecondRollbackWrite,
+            )
+            .await
+        {
+            errors.push(format!("{}: {error}", journal.second.session_id));
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(other_io_error(format!(
+                "runtime Task transaction rollback failed for {}",
+                errors.join(", ")
+            )))
+        }
+    }
+
+    async fn recover_runtime_task_journal(
+        &self,
+        path: &Path,
+        journal: &RuntimeTaskTransactionJournal,
+    ) -> io::Result<()> {
+        self.rollback_runtime_task_journal(journal).await?;
+        self.remove_runtime_task_journal(path).await
+    }
+
+    async fn recover_all_runtime_task_transactions_locked(&self) -> io::Result<()> {
+        let paths = self.runtime_task_journal_paths().await?;
+        for path in paths {
+            let journal = match self.read_runtime_task_journal(&path).await {
+                Ok(journal) => journal,
+                Err(error) => {
+                    self.runtime_task_recovery_required
+                        .store(true, Ordering::Release);
+                    return Err(error);
+                }
+            };
+            if let Err(error) = self.recover_runtime_task_journal(&path, &journal).await {
+                self.runtime_task_recovery_required
+                    .store(true, Ordering::Release);
+                return Err(error);
+            }
+        }
+        self.runtime_task_recovery_required
+            .store(false, Ordering::Release);
+        Ok(())
+    }
+
+    async fn recover_all_runtime_task_transactions(&self) -> io::Result<()> {
+        let _guard = self.lock_runtime_task_transaction_exclusive().await?;
+        self.recover_all_runtime_task_transactions_locked().await
+    }
+
+    async fn recover_runtime_task_transaction_for_pair_locked(
+        &self,
+        first_session_id: &str,
+        second_session_id: &str,
+    ) -> io::Result<()> {
+        validate_session_id(first_session_id)?;
+        validate_session_id(second_session_id)?;
+        if first_session_id >= second_session_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "runtime Task recovery pair must be lexically ordered",
+            ));
+        }
+
+        let paths = self.runtime_task_journal_paths().await?;
+        for path in paths {
+            let journal = self.read_runtime_task_journal(&path).await?;
+            if journal.first.session_id != first_session_id
+                || journal.second.session_id != second_session_id
+            {
+                self.runtime_task_recovery_required
+                    .store(true, Ordering::Release);
+                return Err(other_io_error(format!(
+                    "pending runtime Task transaction for {}/{} must be recovered before accessing {}/{}",
+                    journal.first.session_id,
+                    journal.second.session_id,
+                    first_session_id,
+                    second_session_id
+                )));
+            }
+            if let Err(error) = self.recover_runtime_task_journal(&path, &journal).await {
+                self.runtime_task_recovery_required
+                    .store(true, Ordering::Release);
+                return Err(error);
+            }
+        }
+        self.runtime_task_recovery_required
+            .store(false, Ordering::Release);
+        Ok(())
+    }
+
+    async fn fail_runtime_task_transaction_with_rollback(
+        &self,
+        path: &Path,
+        journal: &RuntimeTaskTransactionJournal,
+        primary: io::Error,
+    ) -> io::Result<()> {
+        let primary_kind = primary.kind();
+        let primary_message = primary.to_string();
+        match self.rollback_runtime_task_journal(journal).await {
+            Ok(()) => match self.remove_runtime_task_journal(path).await {
+                Ok(()) => {
+                    self.runtime_task_recovery_required
+                        .store(false, Ordering::Release);
+                    Err(io::Error::new(
+                        primary_kind,
+                        format!(
+                            "runtime Task transaction failed and was rolled back: {primary_message}"
+                        ),
+                    ))
+                }
+                Err(cleanup_error) => {
+                    self.runtime_task_recovery_required
+                        .store(true, Ordering::Release);
+                    Err(other_io_error(format!(
+                        "runtime Task transaction failed ({primary_message}); rollback succeeded but journal cleanup failed ({cleanup_error}); recovery required"
+                    )))
+                }
+            },
+            Err(rollback_error) => {
+                self.runtime_task_recovery_required
+                    .store(true, Ordering::Release);
+                Err(other_io_error(format!(
+                    "runtime Task transaction failed ({primary_message}); {rollback_error}; recovery required"
+                )))
+            }
+        }
+    }
+
+    async fn save_runtime_task_control_plane_if_matches(
+        &self,
+        original: &Session,
+        updated: &Session,
+    ) -> io::Result<bool> {
+        validate_session_id(&original.id)?;
+        validate_session_id(&updated.id)?;
+        if original.id != updated.id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "single Task snapshots must preserve the session id",
+            ));
+        }
+        if Self::runtime_task_non_task_snapshot(original)?
+            != Self::runtime_task_non_task_snapshot(updated)?
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "single Task update modifies fields outside Task list/generation",
+            ));
+        }
+        if updated.task_list.is_none() || updated.task_list_version_meta().is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "single Task update requires a list and generation",
+            ));
+        }
+        let Some(current) = self
+            .load_runtime_control_plane_unchecked(&original.id)
+            .await?
+        else {
+            return Ok(false);
+        };
+        if !Self::runtime_task_owned_snapshot_matches(&current, original)? {
+            return Ok(false);
+        }
+        let mut committed = current;
+        committed.task_list = updated.task_list.clone();
+        committed.set_task_list_version_meta(
+            updated
+                .task_list_version_meta()
+                .expect("validated updated Task generation"),
+        );
+        self.write_existing_runtime_sidecar_unchecked(&committed)
+            .await?;
+        Ok(true)
+    }
+
+    async fn save_runtime_task_pair_transaction(
+        &self,
+        first_original: &Session,
+        first_updated: &Session,
+        second_original: &Session,
+        second_updated: &Session,
+    ) -> io::Result<bool> {
+        for session in [
+            first_original,
+            first_updated,
+            second_original,
+            second_updated,
+        ] {
+            validate_session_id(&session.id)?;
+        }
+        if first_original.id != first_updated.id
+            || second_original.id != second_updated.id
+            || first_original.id >= second_original.id
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "paired Task snapshots must preserve ids and be lexically ordered",
+            ));
+        }
+        for (label, original, updated) in [
+            ("first", first_original, first_updated),
+            ("second", second_original, second_updated),
+        ] {
+            if Self::runtime_task_non_task_snapshot(original)?
+                != Self::runtime_task_non_task_snapshot(updated)?
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "{label} paired Task update modifies fields outside Task list/generation"
+                    ),
+                ));
+            }
+        }
+        if first_updated.task_list.is_none()
+            || first_updated.task_list_version_meta().is_none()
+            || first_updated.task_list_version_meta() != second_updated.task_list_version_meta()
+            || serde_json::to_value(&first_updated.task_list)
+                .map_err(|error| other_io_error(error.to_string()))?
+                != serde_json::to_value(&second_updated.task_list)
+                    .map_err(|error| other_io_error(error.to_string()))?
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "paired Task updates must publish identical Task lists/generations",
+            ));
+        }
+        // This is the final CAS boundary. Different LockedSessionStore
+        // instances have independent lexical mutexes, so both may stage from
+        // the same generation before either reaches this storage transaction.
+        // Re-read both Task-owned snapshots while the cross-process exclusive
+        // lock is held; a loser returns a typed stale result without creating a
+        // journal or touching either sidecar.
+        let Some(current_first) = self
+            .load_runtime_control_plane_unchecked(&first_original.id)
+            .await?
+        else {
+            return Ok(false);
+        };
+        let Some(current_second) = self
+            .load_runtime_control_plane_unchecked(&second_original.id)
+            .await?
+        else {
+            return Ok(false);
+        };
+        if !Self::runtime_task_owned_snapshot_matches(&current_first, first_original)?
+            || !Self::runtime_task_owned_snapshot_matches(&current_second, second_original)?
+        {
+            return Ok(false);
+        }
+
+        let first_version = current_first.task_list_version_meta().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "first current Task snapshot has no generation",
+            )
+        })?;
+        let second_version = current_second.task_list_version_meta().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "second current Task snapshot has no generation",
+            )
+        })?;
+        // The staging snapshots may predate unrelated status/round/inbox or
+        // metadata writes from another store. Build the physical writes from
+        // the just-revalidated durable snapshots and patch only Task-owned
+        // fields, so the transaction remains narrowly targeted.
+        let mut first_commit = current_first.clone();
+        first_commit.task_list = first_updated.task_list.clone();
+        first_commit.set_task_list_version_meta(
+            first_updated
+                .task_list_version_meta()
+                .expect("validated updated Task generation"),
+        );
+        let mut second_commit = current_second.clone();
+        second_commit.task_list = second_updated.task_list.clone();
+        second_commit.set_task_list_version_meta(
+            second_updated
+                .task_list_version_meta()
+                .expect("validated updated Task generation"),
+        );
+
+        let transaction_id = Uuid::new_v4().to_string();
+        let journal = RuntimeTaskTransactionJournal {
+            version: RUNTIME_TASK_TRANSACTION_VERSION,
+            transaction_id,
+            first: TaskControlPlaneUndo {
+                session_id: current_first.id.clone(),
+                task_list: current_first.task_list.clone(),
+                task_list_version: first_version,
+            },
+            second: TaskControlPlaneUndo {
+                session_id: current_second.id.clone(),
+                task_list: current_second.task_list.clone(),
+                task_list_version: second_version,
+            },
+        };
+        let journal_path = self.write_runtime_task_journal(&journal).await?;
+        self.runtime_task_recovery_required
+            .store(true, Ordering::Release);
+
+        if let Err(error) =
+            self.maybe_fail_runtime_task_transaction(RuntimeTaskTransactionFault::FirstUpdatedWrite)
+        {
+            return self
+                .fail_runtime_task_transaction_with_rollback(&journal_path, &journal, error)
+                .await
+                .map(|()| true);
+        }
+        if let Err(error) = self
+            .write_existing_runtime_sidecar_unchecked(&first_commit)
+            .await
+        {
+            return self
+                .fail_runtime_task_transaction_with_rollback(&journal_path, &journal, error)
+                .await
+                .map(|()| true);
+        }
+
+        #[cfg(test)]
+        self.maybe_pause_runtime_task_transaction_after_first_write()
+            .await;
+
+        if let Err(error) = self
+            .maybe_fail_runtime_task_transaction(RuntimeTaskTransactionFault::SecondUpdatedWrite)
+        {
+            return self
+                .fail_runtime_task_transaction_with_rollback(&journal_path, &journal, error)
+                .await
+                .map(|()| true);
+        }
+        if let Err(error) = self
+            .write_existing_runtime_sidecar_unchecked(&second_commit)
+            .await
+        {
+            return self
+                .fail_runtime_task_transaction_with_rollback(&journal_path, &journal, error)
+                .await
+                .map(|()| true);
+        }
+
+        if let Err(error) = self.remove_runtime_task_journal(&journal_path).await {
+            return self
+                .fail_runtime_task_transaction_with_rollback(&journal_path, &journal, error)
+                .await
+                .map(|()| true);
+        }
+        self.runtime_task_recovery_required
+            .store(false, Ordering::Release);
+        Ok(true)
+    }
+
+    fn runtime_task_owned_snapshot_matches(
+        current: &Session,
+        expected: &Session,
+    ) -> io::Result<bool> {
+        Ok(
+            current.task_list_version_meta() == expected.task_list_version_meta()
+                && serde_json::to_value(&current.task_list)
+                    .map_err(|error| other_io_error(error.to_string()))?
+                    == serde_json::to_value(&expected.task_list)
+                        .map_err(|error| other_io_error(error.to_string()))?,
+        )
+    }
+
+    fn ordinary_task_write_would_regress(
+        incoming: &Session,
+        durable: &Session,
+    ) -> io::Result<bool> {
+        if Self::runtime_task_owned_snapshot_matches(incoming, durable)? {
+            return Ok(false);
+        }
+        let incoming_version = incoming.task_list_version_meta();
+        let durable_version = durable.task_list_version_meta();
+        match (incoming_version.as_deref(), durable_version.as_deref()) {
+            (_, None) => Ok(false),
+            (None, Some(_)) => Ok(true),
+            (Some(incoming), Some(durable)) => {
+                match (incoming.parse::<u64>(), durable.parse::<u64>()) {
+                    (Ok(incoming), Ok(durable)) => Ok(incoming <= durable),
+                    // Production Task generations are monotonic integers. An
+                    // incomparable legacy/custom generation cannot prove it is
+                    // newer, so preserve the durable Task snapshot fail-closed.
+                    _ => Ok(true),
+                }
+            }
+        }
+    }
+
+    /// Ordinary full/runtime saves may have queued on the shared file lock
+    /// while a paired transaction advanced the durable generation. They must
+    /// not silently report success after substituting a different Task
+    /// snapshot: upper layers would then publish the caller's stale value into
+    /// their cache. Fail before any write so the locked persistence boundary
+    /// can adopt the durable Task fields and retry with one coherent snapshot.
+    async fn reject_regressing_runtime_task(&self, incoming: &Session) -> io::Result<()> {
+        if let Some(durable) = self
+            .load_runtime_control_plane_unchecked(&incoming.id)
+            .await?
+        {
+            if Self::ordinary_task_write_would_regress(incoming, &durable)? {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    format!(
+                        "Task control-plane changed while saving session {}",
+                        incoming.id
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn runtime_task_non_task_snapshot(session: &Session) -> io::Result<serde_json::Value> {
+        let mut snapshot = session.clone();
+        snapshot.task_list = None;
+        snapshot
+            .metadata
+            .remove(bamboo_domain::session::runtime_metadata::keys::TASK_LIST_VERSION);
+        if let Some(runtime_metadata) = snapshot.runtime_metadata.as_mut() {
+            runtime_metadata.task_list_version = None;
+        }
+        if snapshot
+            .runtime_metadata
+            .as_ref()
+            .is_some_and(bamboo_domain::session::SessionRuntimeMetadata::is_empty)
+        {
+            snapshot.runtime_metadata = None;
+        }
+        serde_json::to_value(snapshot).map_err(|error| {
+            other_io_error(format!("serialize Task transaction snapshot: {error}"))
+        })
+    }
+
     /// Write the runtime control-plane sidecar: a full session snapshot with the
     /// (potentially huge) `messages` history cleared. This is what makes
     /// runtime-only saves O(1) in conversation length.
@@ -955,6 +1823,7 @@ impl SessionStoreV2 {
     /// session that already has a sidecar is skipped. Returns the number of
     /// sidecars created.
     pub async fn migrate_runtime_sidecars(&self) -> io::Result<usize> {
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
         let marker = self.bamboo_home_dir.join(RUNTIME_SIDECAR_MIGRATION_MARKER);
         if fs::try_exists(&marker).await.unwrap_or(false) {
             return Ok(0);
@@ -1416,6 +2285,7 @@ impl SessionStoreV2 {
     /// - `bamboo_home_dir/sessions.json` (rewritten to empty index)
     pub async fn dev_reset(&self) -> io::Result<()> {
         let _lifecycle = self.lock_session_lifecycle_exclusive().await?;
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
 
         // Remove the sessions directory entirely.
         let _ = fs::remove_dir_all(&self.sessions_dir).await;
@@ -1440,6 +2310,7 @@ impl SessionStoreV2 {
         force: bool,
     ) -> io::Result<bool> {
         let _lifecycle = self.lock_session_lifecycle_exclusive().await?;
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
         self.delete_session_recursive_locked(session_id, force)
             .await
     }
@@ -1618,6 +2489,8 @@ fn extension_to_mime(ext: &str) -> Option<&'static str> {
 #[async_trait::async_trait]
 impl Storage for SessionStoreV2 {
     async fn save_session(&self, session: &Session) -> io::Result<()> {
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
+        self.reject_regressing_runtime_task(session).await?;
         let rel_path = self.ensure_session_dirs(session).await?;
         let abs_dir = self.abs_path_from_rel(&rel_path);
         let path = abs_dir.join("session.json");
@@ -1648,6 +2521,7 @@ impl Storage for SessionStoreV2 {
     }
 
     async fn load_session(&self, session_id: &str) -> io::Result<Option<Session>> {
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
         validate_session_id(session_id)?;
         let Some(path) = self.session_json_path(session_id).await? else {
             return Ok(None);
@@ -1676,9 +2550,13 @@ impl Storage for SessionStoreV2 {
         // This is O(1) in conversation length, unlike `save_session`.
         let Some(rel) = self.resolve_rel_path(&session.id).await else {
             // Session was never fully persisted yet — fall back to a full save so
-            // session.json and the index get created.
+            // session.json and the index get created. Deliberately acquire no
+            // shared Task guard before this call: `save_session` owns that
+            // boundary, avoiding a same-instance shared-lock re-entry.
             return self.save_session(session).await;
         };
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
+        self.reject_regressing_runtime_task(session).await?;
         let abs_dir = self.abs_path_from_rel(&rel);
         self.write_runtime_sidecar(&abs_dir, session).await?;
 
@@ -1711,13 +2589,51 @@ impl Storage for SessionStoreV2 {
     }
 
     async fn load_runtime_control_plane(&self, session_id: &str) -> io::Result<Option<Session>> {
-        validate_session_id(session_id)?;
-        // Prefer the sidecar (cheap: no messages). Fall back to a full load for
-        // sessions that predate the sidecar (not yet migrated).
-        if let Some(side) = self.read_runtime_sidecar(session_id).await? {
-            return Ok(Some(side));
-        }
-        self.load_session(session_id).await
+        let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
+        self.load_runtime_control_plane_unchecked(session_id).await
+    }
+
+    async fn recover_task_control_plane_transaction(
+        &self,
+        first_session_id: &str,
+        second_session_id: &str,
+    ) -> io::Result<()> {
+        let _guard = self.lock_runtime_task_transaction_exclusive().await?;
+        self.recover_runtime_task_transaction_for_pair_locked(first_session_id, second_session_id)
+            .await
+    }
+
+    async fn save_task_control_plane_if_matches(
+        &self,
+        original: &Session,
+        updated: &Session,
+    ) -> io::Result<bool> {
+        let _guard = self.lock_runtime_task_transaction_exclusive().await?;
+        self.recover_all_runtime_task_transactions_locked().await?;
+        self.save_runtime_task_control_plane_if_matches(original, updated)
+            .await
+    }
+
+    async fn save_task_control_planes_atomically(
+        &self,
+        first_original: &Session,
+        first_updated: &Session,
+        second_original: &Session,
+        second_updated: &Session,
+    ) -> io::Result<bool> {
+        let _guard = self.lock_runtime_task_transaction_exclusive().await?;
+        self.recover_runtime_task_transaction_for_pair_locked(
+            &first_original.id,
+            &second_original.id,
+        )
+        .await?;
+        self.save_runtime_task_pair_transaction(
+            first_original,
+            first_updated,
+            second_original,
+            second_updated,
+        )
+        .await
     }
 
     async fn list_child_run_statuses(
@@ -1803,7 +2719,10 @@ impl AttachmentReader for SessionStoreV2 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bamboo_domain::{SessionInboxError, SessionInboxPort, SessionMessageEnvelope};
+    use bamboo_domain::{
+        Message, SessionInboxError, SessionInboxPort, SessionMessageEnvelope, TaskItem,
+        TaskItemStatus,
+    };
     use std::io;
     use std::sync::Arc;
     use tempfile::TempDir;
@@ -1813,6 +2732,561 @@ mod tests {
         let bamboo_home = temp_dir.path().to_path_buf();
         let storage = SessionStoreV2::new(bamboo_home).await?;
         Ok((storage, temp_dir))
+    }
+
+    fn transaction_task_list(root_id: &str, title: &str) -> TaskList {
+        let now = Utc::now();
+        TaskList {
+            session_id: root_id.to_string(),
+            title: title.to_string(),
+            items: vec![TaskItem {
+                id: "task-1".to_string(),
+                description: format!("{title} work"),
+                status: TaskItemStatus::InProgress,
+                ..TaskItem::default()
+            }],
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    async fn seed_runtime_task_transaction_pair(
+        storage: &SessionStoreV2,
+    ) -> io::Result<(Session, Session, Session, Session)> {
+        let root_id = "tx-root";
+        let child_id = "tx-child";
+
+        let mut root = Session::new(root_id, "model");
+        root.add_message(Message::user("root transcript secret"));
+        root.metadata.insert(
+            "unrelated.root".to_string(),
+            "root metadata secret".to_string(),
+        );
+        root.set_task_list(transaction_task_list(root_id, "original root"));
+        root.set_task_list_version_meta("1");
+        storage.save_session(&root).await?;
+
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.add_message(Message::user("child transcript secret"));
+        child.metadata.insert(
+            "unrelated.child".to_string(),
+            "child metadata secret".to_string(),
+        );
+        child.set_task_list(transaction_task_list(root_id, "original child"));
+        child.set_task_list_version_meta("1");
+        storage.save_session(&child).await?;
+
+        let child_original = storage
+            .load_runtime_control_plane(child_id)
+            .await?
+            .expect("child control plane");
+        let root_original = storage
+            .load_runtime_control_plane(root_id)
+            .await?
+            .expect("root control plane");
+        let evaluated = transaction_task_list(root_id, "evaluated");
+        let mut child_updated = child_original.clone();
+        child_updated.task_list = Some(evaluated.clone());
+        child_updated.set_task_list_version_meta("2");
+        let mut root_updated = root_original.clone();
+        root_updated.task_list = Some(evaluated);
+        root_updated.set_task_list_version_meta("2");
+
+        // child < root lexically, matching the Storage transaction contract.
+        Ok((child_original, child_updated, root_original, root_updated))
+    }
+
+    async fn assert_original_runtime_task_pair(storage: &SessionStoreV2) -> io::Result<()> {
+        let child = storage
+            .load_session("tx-child")
+            .await?
+            .expect("child remains");
+        let root = storage
+            .load_session("tx-root")
+            .await?
+            .expect("root remains");
+        for (session, title, transcript, metadata_key, metadata_value) in [
+            (
+                &child,
+                "original child",
+                "child transcript secret",
+                "unrelated.child",
+                "child metadata secret",
+            ),
+            (
+                &root,
+                "original root",
+                "root transcript secret",
+                "unrelated.root",
+                "root metadata secret",
+            ),
+        ] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("1"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some(title)
+            );
+            assert_eq!(session.messages.len(), 1);
+            assert_eq!(session.messages[0].content, transcript);
+            assert_eq!(
+                session.metadata.get(metadata_key).map(String::as_str),
+                Some(metadata_value)
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn paired_task_second_write_failure_rolls_back_both_originals() -> io::Result<()> {
+        let (storage, _temp) = create_temp_storage().await?;
+        let (child_original, child_updated, root_original, root_updated) =
+            seed_runtime_task_transaction_pair(&storage).await?;
+        storage
+            .inject_runtime_task_transaction_fault(RuntimeTaskTransactionFault::SecondUpdatedWrite);
+
+        let error = storage
+            .save_task_control_planes_atomically(
+                &child_original,
+                &child_updated,
+                &root_original,
+                &root_updated,
+            )
+            .await
+            .expect_err("second write must fail");
+        assert!(error.to_string().contains("rolled back"), "{error}");
+        assert_original_runtime_task_pair(&storage).await?;
+        assert!(storage.runtime_task_journal_paths().await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn paired_task_commit_marker_removal_failure_rolls_back_before_error() -> io::Result<()> {
+        let (storage, _temp) = create_temp_storage().await?;
+        let (child_original, child_updated, root_original, root_updated) =
+            seed_runtime_task_transaction_pair(&storage).await?;
+        storage.inject_runtime_task_transaction_fault(RuntimeTaskTransactionFault::JournalRemove);
+
+        let error = storage
+            .save_task_control_planes_atomically(
+                &child_original,
+                &child_updated,
+                &root_original,
+                &root_updated,
+            )
+            .await
+            .expect_err("journal removal failure cannot publish success");
+        assert!(error.to_string().contains("rolled back"), "{error}");
+        assert_original_runtime_task_pair(&storage).await?;
+        assert!(storage.runtime_task_journal_paths().await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn paired_task_rollback_failure_retains_journal_and_fails_closed_until_recovery(
+    ) -> io::Result<()> {
+        let (storage, _temp) = create_temp_storage().await?;
+        let (child_original, child_updated, root_original, root_updated) =
+            seed_runtime_task_transaction_pair(&storage).await?;
+        storage
+            .inject_runtime_task_transaction_fault(RuntimeTaskTransactionFault::SecondUpdatedWrite);
+        storage
+            .inject_runtime_task_transaction_fault(RuntimeTaskTransactionFault::FirstRollbackWrite);
+
+        let error = storage
+            .save_task_control_planes_atomically(
+                &child_original,
+                &child_updated,
+                &root_original,
+                &root_updated,
+            )
+            .await
+            .expect_err("rollback failure must surface");
+        assert!(error.to_string().contains("recovery required"), "{error}");
+        assert_eq!(storage.runtime_task_journal_paths().await?.len(), 1);
+        assert!(
+            storage.load_session("tx-child").await.is_err(),
+            "ordinary access must fail closed while an undo journal remains"
+        );
+
+        storage
+            .recover_task_control_plane_transaction("tx-child", "tx-root")
+            .await?;
+        assert_original_runtime_task_pair(&storage).await?;
+        assert!(storage.runtime_task_journal_paths().await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn independent_store_sidecar_access_and_constructor_wait_for_live_pair_commit(
+    ) -> io::Result<()> {
+        let temp = TempDir::new().map_err(io::Error::other)?;
+        let home = temp.path().to_path_buf();
+        let first_store = Arc::new(SessionStoreV2::new(home.clone()).await?);
+        let (child_original, child_updated, root_original, root_updated) =
+            seed_runtime_task_transaction_pair(&first_store).await?;
+        // This store starts with its own recovery flag clear. Correctness must
+        // therefore come from the shared file lock + durable journal check.
+        let second_store = Arc::new(SessionStoreV2::new(home.clone()).await?);
+
+        let (first_write_reached, release_first_write) =
+            first_store.pause_runtime_task_transaction_after_first_write();
+        let commit_store = first_store.clone();
+        let commit_child_original = child_original.clone();
+        let commit_child_updated = child_updated.clone();
+        let commit_root_original = root_original.clone();
+        let commit_root_updated = root_updated.clone();
+        let commit = tokio::spawn(async move {
+            commit_store
+                .save_task_control_planes_atomically(
+                    &commit_child_original,
+                    &commit_child_updated,
+                    &commit_root_original,
+                    &commit_root_updated,
+                )
+                .await
+        });
+        first_write_reached.wait().await;
+        assert_eq!(first_store.runtime_task_journal_paths().await?.len(), 1);
+
+        let load_store = second_store.clone();
+        let mut full_load = tokio::spawn(async move { load_store.load_session("tx-child").await });
+        let control_store = second_store.clone();
+        let mut control_load =
+            tokio::spawn(async move { control_store.load_runtime_control_plane("tx-root").await });
+        let save_store = second_store.clone();
+        // Queue an actually stale v1 writer. Once the shared lock is granted it
+        // must fail before writing rather than silently substitute the durable
+        // v2 Task fields while reporting the caller's v1 snapshot as saved.
+        let mut save_snapshot = child_original.clone();
+        save_snapshot
+            .metadata
+            .insert("independent.writer".to_string(), "preserved".to_string());
+        let mut runtime_save =
+            tokio::spawn(async move { save_store.save_runtime_state(&save_snapshot).await });
+        let full_save_store = second_store.clone();
+        let mut full_save_snapshot = root_original.clone();
+        full_save_snapshot.metadata.insert(
+            "independent.full-writer".to_string(),
+            "preserved".to_string(),
+        );
+        let mut full_save =
+            tokio::spawn(async move { full_save_store.save_session(&full_save_snapshot).await });
+        let constructor_home = home.clone();
+        let mut constructor =
+            tokio::spawn(async move { SessionStoreV2::new(constructor_home).await });
+
+        let blocked_for = std::time::Duration::from_millis(100);
+        assert!(
+            tokio::time::timeout(blocked_for, &mut full_load)
+                .await
+                .is_err(),
+            "full load must not observe the first published sidecar"
+        );
+        assert!(
+            tokio::time::timeout(blocked_for, &mut control_load)
+                .await
+                .is_err(),
+            "control-plane load must not observe the first published sidecar"
+        );
+        assert!(
+            tokio::time::timeout(blocked_for, &mut runtime_save)
+                .await
+                .is_err(),
+            "runtime save must not overwrite a half-published transaction"
+        );
+        assert!(
+            tokio::time::timeout(blocked_for, &mut full_save)
+                .await
+                .is_err(),
+            "full save must not overwrite a half-published transaction"
+        );
+        assert!(
+            tokio::time::timeout(blocked_for, &mut constructor)
+                .await
+                .is_err(),
+            "a second constructor must not recover another store's live journal"
+        );
+
+        release_first_write.wait().await;
+        assert!(commit.await.map_err(io::Error::other)??);
+
+        let full = full_load
+            .await
+            .map_err(io::Error::other)??
+            .expect("child remains");
+        let control = control_load
+            .await
+            .map_err(io::Error::other)??
+            .expect("root remains");
+        let runtime_error = runtime_save
+            .await
+            .map_err(io::Error::other)?
+            .expect_err("stale runtime save must report a Task conflict");
+        assert_eq!(runtime_error.kind(), io::ErrorKind::WouldBlock);
+        let full_save_error = full_save
+            .await
+            .map_err(io::Error::other)?
+            .expect_err("stale full save must report a Task conflict");
+        assert_eq!(full_save_error.kind(), io::ErrorKind::WouldBlock);
+        let constructed = constructor.await.map_err(io::Error::other)??;
+        for session in [&full, &control] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("evaluated")
+            );
+        }
+        for storage in [second_store.as_ref(), &constructed] {
+            let child = storage.load_session("tx-child").await?.expect("child");
+            let root = storage.load_session("tx-root").await?.expect("root");
+            for session in [&child, &root] {
+                assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+                assert_eq!(
+                    session.task_list.as_ref().map(|list| list.title.as_str()),
+                    Some("evaluated")
+                );
+            }
+            assert!(!child.metadata.contains_key("independent.writer"));
+            assert!(!root.metadata.contains_key("independent.full-writer"));
+        }
+        assert!(first_store.runtime_task_journal_paths().await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn paired_task_commit_rebases_on_current_non_task_control_plane() -> io::Result<()> {
+        let temp = TempDir::new().map_err(io::Error::other)?;
+        let home = temp.path().to_path_buf();
+        let first_store = SessionStoreV2::new(home.clone()).await?;
+        let (child_original, child_updated, root_original, root_updated) =
+            seed_runtime_task_transaction_pair(&first_store).await?;
+        let second_store = SessionStoreV2::new(home).await?;
+
+        let mut current_child = second_store
+            .load_runtime_control_plane("tx-child")
+            .await?
+            .expect("child");
+        current_child.metadata.insert(
+            "concurrent.child.status".to_string(),
+            "must survive".to_string(),
+        );
+        second_store.save_runtime_state(&current_child).await?;
+        let mut current_root = second_store
+            .load_runtime_control_plane("tx-root")
+            .await?
+            .expect("root");
+        current_root.metadata.insert(
+            "concurrent.root.round".to_string(),
+            "must survive".to_string(),
+        );
+        second_store.save_runtime_state(&current_root).await?;
+
+        assert!(
+            first_store
+                .save_task_control_planes_atomically(
+                    &child_original,
+                    &child_updated,
+                    &root_original,
+                    &root_updated,
+                )
+                .await?,
+            "Task-owned originals still match, so the narrow CAS should commit"
+        );
+        let child = first_store.load_session("tx-child").await?.expect("child");
+        let root = first_store.load_session("tx-root").await?.expect("root");
+        for session in [&child, &root] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("evaluated")
+            );
+        }
+        assert_eq!(
+            child
+                .metadata
+                .get("concurrent.child.status")
+                .map(String::as_str),
+            Some("must survive")
+        );
+        assert_eq!(
+            root.metadata
+                .get("concurrent.root.round")
+                .map(String::as_str),
+            Some("must survive")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn paired_task_cas_accepts_legacy_only_generation_metadata() -> io::Result<()> {
+        let (storage, _temp) = create_temp_storage().await?;
+        let root_id = "legacy-task-root";
+        let child_id = "legacy-task-child";
+        let generation_key =
+            bamboo_domain::session::runtime_metadata::keys::TASK_LIST_VERSION.to_string();
+        let mut root = Session::new(root_id, "model");
+        root.task_list = Some(transaction_task_list(root_id, "legacy root"));
+        root.metadata
+            .insert(generation_key.clone(), "1".to_string());
+        assert!(root.runtime_metadata.is_none());
+        storage.save_session(&root).await?;
+        let mut child = Session::new_child(child_id, root_id, "model", "child");
+        child.task_list = Some(transaction_task_list(root_id, "legacy child"));
+        child.metadata.insert(generation_key, "1".to_string());
+        assert!(child.runtime_metadata.is_none());
+        storage.save_session(&child).await?;
+
+        let child_original = storage
+            .load_runtime_control_plane(child_id)
+            .await?
+            .expect("child");
+        let root_original = storage
+            .load_runtime_control_plane(root_id)
+            .await?
+            .expect("root");
+        assert!(child_original.runtime_metadata.is_none());
+        assert!(root_original.runtime_metadata.is_none());
+        let evaluated = transaction_task_list(root_id, "legacy evaluated");
+        let mut child_updated = child_original.clone();
+        child_updated.task_list = Some(evaluated.clone());
+        child_updated.set_task_list_version_meta("2");
+        let mut root_updated = root_original.clone();
+        root_updated.task_list = Some(evaluated);
+        root_updated.set_task_list_version_meta("2");
+
+        assert!(
+            storage
+                .save_task_control_planes_atomically(
+                    &child_original,
+                    &child_updated,
+                    &root_original,
+                    &root_updated,
+                )
+                .await?,
+            "typed setter normalization must not look like a non-Task mutation"
+        );
+        for id in [child_id, root_id] {
+            let session = storage.load_session(id).await?.expect("session");
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("legacy evaluated")
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ordinary_task_save_accepts_newer_generation_and_rejects_same_generation_divergence(
+    ) -> io::Result<()> {
+        let (storage, _temp) = create_temp_storage().await?;
+        let mut initial = Session::new("ordinary-task-rebase", "model");
+        initial.set_task_list(transaction_task_list(&initial.id, "generation one"));
+        initial.set_task_list_version_meta("1");
+        storage.save_session(&initial).await?;
+
+        let mut newer = initial.clone();
+        newer.set_task_list(transaction_task_list(&newer.id, "generation two"));
+        newer.set_task_list_version_meta("2");
+        storage.save_runtime_state(&newer).await?;
+        let durable_newer = storage
+            .load_session(&newer.id)
+            .await?
+            .expect("newer session");
+        assert_eq!(
+            durable_newer
+                .task_list
+                .as_ref()
+                .map(|list| list.title.as_str()),
+            Some("generation two"),
+            "a legitimate monotonic Taskwrite must not be rebased away"
+        );
+
+        let mut divergent = durable_newer.clone();
+        divergent.set_task_list(transaction_task_list(
+            &divergent.id,
+            "same generation divergent",
+        ));
+        divergent.set_task_list_version_meta("2");
+        divergent
+            .metadata
+            .insert("ordinary.non-task".to_string(), "must persist".to_string());
+        let conflict = storage
+            .save_runtime_state(&divergent)
+            .await
+            .expect_err("same-generation divergence must fail before writing");
+        assert_eq!(conflict.kind(), io::ErrorKind::WouldBlock);
+        assert_eq!(
+            divergent.task_list.as_ref().map(|list| list.title.as_str()),
+            Some("same generation divergent"),
+            "save must not mutate the caller-owned snapshot"
+        );
+        let durable = storage
+            .load_session(&divergent.id)
+            .await?
+            .expect("durable session");
+        assert_eq!(durable.task_list_version_meta().as_deref(), Some("2"));
+        assert_eq!(
+            durable.task_list.as_ref().map(|list| list.title.as_str()),
+            Some("generation two"),
+            "same-generation divergent content must preserve durable truth"
+        );
+        assert!(!durable.metadata.contains_key("ordinary.non-task"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reopening_store_recovers_orphan_task_journal_without_transcript_or_metadata_copy(
+    ) -> io::Result<()> {
+        let (storage, temp) = create_temp_storage().await?;
+        let (child_original, child_updated, root_original, _root_updated) =
+            seed_runtime_task_transaction_pair(&storage).await?;
+        let transaction_id = Uuid::new_v4().to_string();
+        let journal = RuntimeTaskTransactionJournal {
+            version: RUNTIME_TASK_TRANSACTION_VERSION,
+            transaction_id,
+            first: TaskControlPlaneUndo {
+                session_id: child_original.id.clone(),
+                task_list: child_original.task_list.clone(),
+                task_list_version: child_original
+                    .task_list_version_meta()
+                    .expect("child generation"),
+            },
+            second: TaskControlPlaneUndo {
+                session_id: root_original.id.clone(),
+                task_list: root_original.task_list.clone(),
+                task_list_version: root_original
+                    .task_list_version_meta()
+                    .expect("root generation"),
+            },
+        };
+        let journal_path = storage.write_runtime_task_journal(&journal).await?;
+        let journal_json = fs::read_to_string(&journal_path).await?;
+        assert!(!journal_json.contains("transcript secret"));
+        assert!(!journal_json.contains("metadata secret"));
+        assert!(!journal_json.contains("unrelated.child"));
+        assert!(!journal_json.contains("unrelated.root"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(storage.runtime_task_transaction_dir())
+                .await?
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o077, 0, "journal directory must be private");
+        }
+
+        // Simulate process death after the first rename: leave the durable undo
+        // journal and only the lexically first target at generation 2.
+        storage
+            .write_existing_runtime_sidecar_unchecked(&child_updated)
+            .await?;
+        drop(storage);
+
+        let reopened = SessionStoreV2::new(temp.path().to_path_buf()).await?;
+        assert_original_runtime_task_pair(&reopened).await?;
+        assert!(reopened.runtime_task_journal_paths().await?.is_empty());
+        Ok(())
     }
 
     #[tokio::test]
@@ -1825,6 +3299,39 @@ mod tests {
         let _storage = SessionStoreV2::new(bamboo_home).await?;
         assert!(sessions_dir.exists());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn clean_sidecar_reads_do_not_create_or_rechmod_journal_directory() -> io::Result<()> {
+        let (storage, _temp) = create_temp_storage().await?;
+        let session = Session::new("clean-journal-probe", "model");
+        storage.save_session(&session).await?;
+        let journal_dir = storage.runtime_task_transaction_dir();
+        fs::remove_dir(&journal_dir).await?;
+
+        assert!(storage.load_session(&session.id).await?.is_some());
+        assert!(
+            !journal_dir.exists(),
+            "ordinary clean reads must treat a missing journal directory as empty"
+        );
+
+        fs::create_dir(&journal_dir).await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&journal_dir, std::fs::Permissions::from_mode(0o750)).await?;
+            assert!(storage
+                .load_runtime_control_plane(&session.id)
+                .await?
+                .is_some());
+            let mode = fs::metadata(&journal_dir).await?.permissions().mode();
+            assert_eq!(
+                mode & 0o777,
+                0o750,
+                "ordinary clean reads must not repeat constructor/write chmod"
+            );
+        }
         Ok(())
     }
 
@@ -1895,7 +3402,6 @@ mod tests {
 
     // ── Runtime sidecar (③) ───────────────────────────────────────────────
 
-    use bamboo_domain::session::types::Message;
     use bamboo_domain::AgentRuntimeState;
 
     fn session_with_history(id: &str, messages: usize, run_id: &str) -> Session {

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -82,12 +82,46 @@ struct RuntimeTaskTransactionJournal {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeTaskJournalMarkerState {
+    Prepared,
+    Committing,
+    Committed,
+}
+
+impl RuntimeTaskJournalMarkerState {
+    fn from_path(path: &Path) -> Option<Self> {
+        match path.extension().and_then(|value| value.to_str()) {
+            Some("json") => Some(Self::Prepared),
+            Some("committing") => Some(Self::Committing),
+            Some("committed") => Some(Self::Committed),
+            _ => None,
+        }
+    }
+}
+
+enum RuntimeTaskJournalFinalizeError {
+    Rollback(io::Error),
+    RecoveryRequired(io::Error),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RuntimeTaskTransactionFault {
     FirstUpdatedWrite,
     SecondUpdatedWrite,
     JournalRemove,
     FirstRollbackWrite,
     SecondRollbackWrite,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeTaskDurabilityEvent {
+    JournalPublished,
+    SingleUpdatedSidecarPublished,
+    FirstUpdatedSidecarPublished,
+    SecondUpdatedSidecarPublished,
+    FirstRollbackSidecarPublished,
+    SecondRollbackSidecarPublished,
+    JournalDeactivated,
 }
 
 struct RuntimeTaskTransactionReadGuard {
@@ -411,6 +445,8 @@ pub struct SessionStoreV2 {
     runtime_task_faults: std::sync::Mutex<Vec<RuntimeTaskTransactionFault>>,
     #[cfg(test)]
     runtime_task_first_write_pause: std::sync::Mutex<Option<RuntimeTaskFirstWritePause>>,
+    #[cfg(test)]
+    runtime_task_durability_events: std::sync::Mutex<Vec<RuntimeTaskDurabilityEvent>>,
 }
 
 impl SessionStoreV2 {
@@ -532,6 +568,8 @@ impl SessionStoreV2 {
             runtime_task_faults: std::sync::Mutex::new(Vec::new()),
             #[cfg(test)]
             runtime_task_first_write_pause: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            runtime_task_durability_events: std::sync::Mutex::new(Vec::new()),
         };
 
         // Create and permission the private journal directory once at store
@@ -785,22 +823,36 @@ impl SessionStoreV2 {
         let path = self
             .bamboo_home_dir
             .join(RUNTIME_TASK_TRANSACTION_LOCK_FILE);
-        tokio::task::spawn_blocking(move || {
-            let file = std::fs::OpenOptions::new()
-                .create(true)
-                .truncate(false)
-                .read(true)
-                .write(true)
-                .open(&path)?;
-            if exclusive {
-                FileExt::lock_exclusive(&file)?;
-            } else {
-                FileExt::lock_shared(&file)?;
+        let open = |path: PathBuf| async move {
+            tokio::task::spawn_blocking(move || {
+                let file = std::fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(false)
+                    .read(true)
+                    .write(true)
+                    .open(&path)?;
+                if exclusive {
+                    FileExt::lock_exclusive(&file)?;
+                } else {
+                    FileExt::lock_shared(&file)?;
+                }
+                Ok::<_, io::Error>(file)
+            })
+            .await
+            .map_err(|error| other_io_error(format!("join runtime Task lock task: {error}")))?
+        };
+
+        match open(path.clone()).await {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                // Keep the existing save-session recovery contract when an
+                // embedding removes an otherwise idle Bamboo home between
+                // construction and first use. The normal hot path performs no
+                // mkdir; only a missing lock-file parent takes this retry.
+                fs::create_dir_all(&self.bamboo_home_dir).await?;
+                open(path).await
             }
-            Ok(file)
-        })
-        .await
-        .map_err(|error| other_io_error(format!("join runtime Task lock task: {error}")))?
+            result => result,
+        }
     }
 
     async fn lock_index_file_exclusive(&self) -> io::Result<SessionIndexFileGuard> {
@@ -1079,6 +1131,12 @@ impl SessionStoreV2 {
 
     async fn ensure_runtime_task_transaction_dir(&self) -> io::Result<PathBuf> {
         let path = self.runtime_task_transaction_dir();
+        let home_existed = fs::try_exists(&self.bamboo_home_dir).await?;
+        fs::create_dir_all(&self.bamboo_home_dir).await?;
+        if !home_existed {
+            sync_parent_directory_entry(&self.bamboo_home_dir).await?;
+        }
+        let path_existed = fs::try_exists(&path).await?;
         fs::create_dir_all(&path).await?;
         // Journals contain only Task lists/generations (never transcripts or
         // arbitrary metadata), but Task descriptions may still be private user
@@ -1087,6 +1145,11 @@ impl SessionStoreV2 {
         {
             use std::os::unix::fs::PermissionsExt;
             fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).await?;
+        }
+        if !path_existed {
+            // The journal file cannot be durable if the directory containing it
+            // can itself disappear after a power loss.
+            sync_parent_directory_entry(&path).await?;
         }
         Ok(path)
     }
@@ -1134,6 +1197,26 @@ impl SessionStoreV2 {
             .lock()
             .expect("runtime task fault lock")
             .push(fault);
+    }
+
+    fn record_runtime_task_durability_event(&self, event: RuntimeTaskDurabilityEvent) {
+        #[cfg(test)]
+        self.runtime_task_durability_events
+            .lock()
+            .expect("runtime task durability event lock")
+            .push(event);
+        #[cfg(not(test))]
+        let _ = event;
+    }
+
+    #[cfg(test)]
+    fn take_runtime_task_durability_events(&self) -> Vec<RuntimeTaskDurabilityEvent> {
+        std::mem::take(
+            &mut *self
+                .runtime_task_durability_events
+                .lock()
+                .expect("runtime task durability event lock"),
+        )
     }
 
     #[cfg(test)]
@@ -1212,7 +1295,11 @@ impl SessionStoreV2 {
         Ok(Some(session))
     }
 
-    async fn write_existing_runtime_sidecar_unchecked(&self, session: &Session) -> io::Result<()> {
+    async fn write_existing_runtime_sidecar_durable_unchecked(
+        &self,
+        session: &Session,
+        event: RuntimeTaskDurabilityEvent,
+    ) -> io::Result<()> {
         validate_session_id(&session.id)?;
         let Some(rel) = self.resolve_rel_path(&session.id).await else {
             return Err(io::Error::new(
@@ -1220,8 +1307,10 @@ impl SessionStoreV2 {
                 format!("session {} has no persisted runtime target", session.id),
             ));
         };
-        self.write_runtime_sidecar(&self.abs_path_from_rel(&rel), session)
-            .await
+        self.write_runtime_sidecar_durable(&self.abs_path_from_rel(&rel), session)
+            .await?;
+        self.record_runtime_task_durability_event(event);
+        Ok(())
     }
 
     async fn runtime_task_journal_paths(&self) -> io::Result<Vec<PathBuf>> {
@@ -1233,14 +1322,15 @@ impl SessionStoreV2 {
         };
         let mut paths = Vec::new();
         while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
             if entry
                 .file_type()
                 .await
                 .map(|kind| kind.is_file())
                 .unwrap_or(false)
-                && entry.path().extension().and_then(|value| value.to_str()) == Some("json")
+                && RuntimeTaskJournalMarkerState::from_path(&path).is_some()
             {
-                paths.push(entry.path());
+                paths.push(path);
             }
         }
         paths.sort();
@@ -1311,13 +1401,63 @@ impl SessionStoreV2 {
         let path = dir.join(format!("{}.json", journal.transaction_id));
         let bytes = serde_json::to_vec(journal)
             .map_err(|error| other_io_error(format!("serialize Task undo journal: {error}")))?;
-        atomic_write(&path, &bytes).await?;
+        durable_atomic_write(&path, &bytes).await?;
+        self.record_runtime_task_durability_event(RuntimeTaskDurabilityEvent::JournalPublished);
         Ok(path)
     }
 
     async fn remove_runtime_task_journal(&self, path: &Path) -> io::Result<()> {
-        self.maybe_fail_runtime_task_transaction(RuntimeTaskTransactionFault::JournalRemove)?;
-        fs::remove_file(path).await
+        durable_deactivate_recovery_marker(path).await?;
+        self.record_runtime_task_durability_event(RuntimeTaskDurabilityEvent::JournalDeactivated);
+        Ok(())
+    }
+
+    async fn remove_runtime_task_journal_family(
+        &self,
+        journal: &RuntimeTaskTransactionJournal,
+    ) -> io::Result<()> {
+        let dir = self.runtime_task_transaction_dir();
+        for extension in ["json", "committing", "committed"] {
+            let path = dir.join(format!("{}.{}", journal.transaction_id, extension));
+            match fs::try_exists(&path).await {
+                Ok(true) => self.remove_runtime_task_journal(&path).await?,
+                Ok(false) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    }
+
+    /// Transition a prepared undo journal through a fail-closed intermediate
+    /// name to a committed marker, then durably deactivate it. Recovery rolls
+    /// back `.json`/`.committing`, but never rolls back `.committed`; a failure
+    /// after the committed rename therefore cannot turn two durable sidecars
+    /// into a later undo.
+    async fn finalize_runtime_task_journal(
+        &self,
+        path: &Path,
+    ) -> Result<(), RuntimeTaskJournalFinalizeError> {
+        self.maybe_fail_runtime_task_transaction(RuntimeTaskTransactionFault::JournalRemove)
+            .map_err(RuntimeTaskJournalFinalizeError::Rollback)?;
+
+        let committing = path.with_extension("committing");
+        atomic_rename(path, &committing)
+            .await
+            .map_err(RuntimeTaskJournalFinalizeError::Rollback)?;
+        sync_parent_directory_entry(&committing)
+            .await
+            .map_err(RuntimeTaskJournalFinalizeError::Rollback)?;
+
+        let committed = path.with_extension("committed");
+        atomic_rename(&committing, &committed)
+            .await
+            .map_err(RuntimeTaskJournalFinalizeError::Rollback)?;
+        sync_parent_directory_entry(&committed)
+            .await
+            .map_err(RuntimeTaskJournalFinalizeError::RecoveryRequired)?;
+        self.remove_runtime_task_journal(&committed)
+            .await
+            .map_err(RuntimeTaskJournalFinalizeError::RecoveryRequired)
     }
 
     async fn restore_runtime_task_undo(
@@ -1337,7 +1477,16 @@ impl SessionStoreV2 {
         };
         current.task_list = undo.task_list.clone();
         current.set_task_list_version_meta(undo.task_list_version.clone());
-        self.write_existing_runtime_sidecar_unchecked(&current)
+        let event = match fault {
+            RuntimeTaskTransactionFault::FirstRollbackWrite => {
+                RuntimeTaskDurabilityEvent::FirstRollbackSidecarPublished
+            }
+            RuntimeTaskTransactionFault::SecondRollbackWrite => {
+                RuntimeTaskDurabilityEvent::SecondRollbackSidecarPublished
+            }
+            _ => unreachable!("rollback helper only accepts rollback write faults"),
+        };
+        self.write_existing_runtime_sidecar_durable_unchecked(&current, event)
             .await
     }
 
@@ -1379,7 +1528,15 @@ impl SessionStoreV2 {
         path: &Path,
         journal: &RuntimeTaskTransactionJournal,
     ) -> io::Result<()> {
-        self.rollback_runtime_task_journal(journal).await?;
+        let state = RuntimeTaskJournalMarkerState::from_path(path).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid runtime Task journal marker extension",
+            )
+        })?;
+        if state != RuntimeTaskJournalMarkerState::Committed {
+            self.rollback_runtime_task_journal(journal).await?;
+        }
         self.remove_runtime_task_journal(path).await
     }
 
@@ -1427,6 +1584,12 @@ impl SessionStoreV2 {
         let paths = self.runtime_task_journal_paths().await?;
         for path in paths {
             let journal = self.read_runtime_task_journal(&path).await?;
+            if RuntimeTaskJournalMarkerState::from_path(&path)
+                == Some(RuntimeTaskJournalMarkerState::Committed)
+            {
+                self.recover_runtime_task_journal(&path, &journal).await?;
+                continue;
+            }
             if journal.first.session_id != first_session_id
                 || journal.second.session_id != second_session_id
             {
@@ -1453,14 +1616,14 @@ impl SessionStoreV2 {
 
     async fn fail_runtime_task_transaction_with_rollback(
         &self,
-        path: &Path,
+        _path: &Path,
         journal: &RuntimeTaskTransactionJournal,
         primary: io::Error,
     ) -> io::Result<()> {
         let primary_kind = primary.kind();
         let primary_message = primary.to_string();
         match self.rollback_runtime_task_journal(journal).await {
-            Ok(()) => match self.remove_runtime_task_journal(path).await {
+            Ok(()) => match self.remove_runtime_task_journal_family(journal).await {
                 Ok(()) => {
                     self.runtime_task_recovery_required
                         .store(false, Ordering::Release);
@@ -1532,8 +1695,11 @@ impl SessionStoreV2 {
                 .task_list_version_meta()
                 .expect("validated updated Task generation"),
         );
-        self.write_existing_runtime_sidecar_unchecked(&committed)
-            .await?;
+        self.write_existing_runtime_sidecar_durable_unchecked(
+            &committed,
+            RuntimeTaskDurabilityEvent::SingleUpdatedSidecarPublished,
+        )
+        .await?;
         Ok(true)
     }
 
@@ -1672,7 +1838,10 @@ impl SessionStoreV2 {
                 .map(|()| true);
         }
         if let Err(error) = self
-            .write_existing_runtime_sidecar_unchecked(&first_commit)
+            .write_existing_runtime_sidecar_durable_unchecked(
+                &first_commit,
+                RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
+            )
             .await
         {
             return self
@@ -1694,7 +1863,10 @@ impl SessionStoreV2 {
                 .map(|()| true);
         }
         if let Err(error) = self
-            .write_existing_runtime_sidecar_unchecked(&second_commit)
+            .write_existing_runtime_sidecar_durable_unchecked(
+                &second_commit,
+                RuntimeTaskDurabilityEvent::SecondUpdatedSidecarPublished,
+            )
             .await
         {
             return self
@@ -1703,11 +1875,25 @@ impl SessionStoreV2 {
                 .map(|()| true);
         }
 
-        if let Err(error) = self.remove_runtime_task_journal(&journal_path).await {
-            return self
-                .fail_runtime_task_transaction_with_rollback(&journal_path, &journal, error)
-                .await
-                .map(|()| true);
+        match self.finalize_runtime_task_journal(&journal_path).await {
+            Ok(()) => {}
+            Err(RuntimeTaskJournalFinalizeError::Rollback(error)) => {
+                return self
+                    .fail_runtime_task_transaction_with_rollback(&journal_path, &journal, error)
+                    .await
+                    .map(|()| true);
+            }
+            Err(RuntimeTaskJournalFinalizeError::RecoveryRequired(error)) => {
+                // Both sidecars were synchronized before the committed marker
+                // transition began. Never roll them back after a committed
+                // marker may be visible: exclusive recovery will retain the
+                // committed pair and durably deactivate that marker.
+                self.runtime_task_recovery_required
+                    .store(true, Ordering::Release);
+                return Err(other_io_error(format!(
+                    "runtime Task transaction committed durably but marker cleanup requires recovery: {error}"
+                )));
+            }
         }
         self.runtime_task_recovery_required
             .store(false, Ordering::Release);
@@ -1808,6 +1994,21 @@ impl SessionStoreV2 {
         fs::write(&tmp, bytes).await?;
         atomic_rename(&tmp, &path).await?;
         Ok(())
+    }
+
+    /// Task CAS/transaction replacement with a file+directory durability
+    /// boundary. Ordinary runtime saves intentionally keep the cheaper helper
+    /// above; only authoritative Task commits and recovery pay these fsyncs.
+    async fn write_runtime_sidecar_durable(
+        &self,
+        abs_dir: &Path,
+        session: &Session,
+    ) -> io::Result<()> {
+        let path = abs_dir.join(RUNTIME_SIDECAR_FILE);
+        let snapshot = runtime_sidecar_snapshot(session);
+        let bytes = serde_json::to_vec_pretty(&snapshot)
+            .map_err(|error| other_io_error(error.to_string()))?;
+        durable_atomic_write(&path, &bytes).await
     }
 
     /// One-shot migration: create the runtime sidecar (`runtime.json`) for every
@@ -2410,9 +2611,11 @@ pub struct CleanupResult {
 ///
 /// Residuals (tracked in #166): the rename + parent directory are not fsync'd, so
 /// after a power loss the file may revert to the OLD complete content (still never
-/// torn); a crash BETWEEN temp-create and rename leaks an orphan `*.tmp.*` (disk
-/// litter, not corruption — no sweep yet); and [`atomic_rename`] is
-/// remove-then-rename on Windows, where a crash in that window can lose the target.
+/// torn), and a crash BETWEEN temp-create and rename leaks an orphan `*.tmp.*`
+/// (disk litter, not corruption — no sweep yet). Windows replacement is a true
+/// `MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH)`, so it has no remove-first gap.
+/// Task CAS/transaction paths use [`durable_atomic_write`] below, which also
+/// synchronizes the published directory entry.
 pub(crate) async fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     use tokio::io::AsyncWriteExt;
 
@@ -2432,21 +2635,104 @@ pub(crate) async fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
 }
 
 async fn atomic_rename(from: &Path, to: &Path) -> io::Result<()> {
-    // Best-effort atomic on Unix. On Windows, rename cannot overwrite.
-    match fs::rename(from, to).await {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            if to.exists() {
-                let _ = fs::remove_file(to).await;
-            }
-            fs::rename(from, to).await.map_err(|e| {
-                other_io_error(format!(
-                    "failed to rename {:?} -> {:?}: {} (original: {})",
-                    from, to, e, err
-                ))
-            })
+    #[cfg(not(windows))]
+    {
+        fs::rename(from, to).await
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
+
+        let source: Vec<u16> = from.as_os_str().encode_wide().chain(Some(0)).collect();
+        let destination: Vec<u16> = to.as_os_str().encode_wide().chain(Some(0)).collect();
+        let result = unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
         }
     }
+}
+
+/// Flush the directory entry containing `path` after a create/rename/remove.
+/// Unix exposes directory handles through `std`; Windows does not, so Windows
+/// transaction renames use `MoveFileExW(..., MOVEFILE_WRITE_THROUGH)` above as
+/// the strongest portable completion boundary available here.
+async fn sync_parent_directory_entry(path: &Path) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
+    #[cfg(unix)]
+    {
+        let parent = parent.to_path_buf();
+        tokio::task::spawn_blocking(move || std::fs::File::open(parent)?.sync_all())
+            .await
+            .map_err(|error| other_io_error(format!("join directory sync task: {error}")))?
+    }
+    #[cfg(windows)]
+    {
+        let _ = parent;
+        Ok(())
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = parent;
+        Ok(())
+    }
+}
+
+/// Transaction-only durable replacement. Unlike ordinary sidecar writes, the
+/// temp contents and the published directory entry are both synchronized
+/// before this returns. Windows uses a true replace-existing primitive, never
+/// the target-loss-prone remove-then-rename fallback.
+async fn durable_atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let tmp = path.with_extension(format!("durable.tmp.{}", Uuid::new_v4()));
+    let write_result = async {
+        let mut file = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&tmp)
+            .await?;
+        file.write_all(bytes).await?;
+        file.sync_all().await
+    }
+    .await;
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(error);
+    }
+    if let Err(error) = atomic_rename(&tmp, path).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(error);
+    }
+    sync_parent_directory_entry(path).await
+}
+
+/// Durably remove an active recovery marker without relying on directory
+/// unlink persistence. The marker is first renamed to an extension the scanner
+/// never treats as active; a resurrected cleanup tombstone is therefore inert.
+async fn durable_deactivate_recovery_marker(path: &Path) -> io::Result<()> {
+    let tombstone = path.with_extension(format!("removed.{}", Uuid::new_v4()));
+    atomic_rename(path, &tombstone).await?;
+    sync_parent_directory_entry(&tombstone).await?;
+
+    // Once the rename above is durable, cleanup cannot affect recovery
+    // correctness. A power-loss-resurrected tombstone remains non-scannable.
+    if fs::remove_file(&tombstone).await.is_ok() {
+        let _ = sync_parent_directory_entry(&tombstone).await;
+    }
+    Ok(())
 }
 
 fn parse_data_url_base64(url: &str) -> Option<(String, String)> {
@@ -2837,10 +3123,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn paired_task_success_records_durable_publish_order() -> io::Result<()> {
+        let (storage, _temp) = create_temp_storage().await?;
+        let (child_original, child_updated, root_original, root_updated) =
+            seed_runtime_task_transaction_pair(&storage).await?;
+        assert!(storage.take_runtime_task_durability_events().is_empty());
+
+        assert!(
+            storage
+                .save_task_control_planes_atomically(
+                    &child_original,
+                    &child_updated,
+                    &root_original,
+                    &root_updated,
+                )
+                .await?
+        );
+        assert_eq!(
+            storage.take_runtime_task_durability_events(),
+            vec![
+                RuntimeTaskDurabilityEvent::JournalPublished,
+                RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
+                RuntimeTaskDurabilityEvent::SecondUpdatedSidecarPublished,
+                RuntimeTaskDurabilityEvent::JournalDeactivated,
+            ]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn paired_task_second_write_failure_rolls_back_both_originals() -> io::Result<()> {
         let (storage, _temp) = create_temp_storage().await?;
         let (child_original, child_updated, root_original, root_updated) =
             seed_runtime_task_transaction_pair(&storage).await?;
+        assert!(storage.take_runtime_task_durability_events().is_empty());
         storage
             .inject_runtime_task_transaction_fault(RuntimeTaskTransactionFault::SecondUpdatedWrite);
 
@@ -2856,6 +3172,16 @@ mod tests {
         assert!(error.to_string().contains("rolled back"), "{error}");
         assert_original_runtime_task_pair(&storage).await?;
         assert!(storage.runtime_task_journal_paths().await?.is_empty());
+        assert_eq!(
+            storage.take_runtime_task_durability_events(),
+            vec![
+                RuntimeTaskDurabilityEvent::JournalPublished,
+                RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
+                RuntimeTaskDurabilityEvent::FirstRollbackSidecarPublished,
+                RuntimeTaskDurabilityEvent::SecondRollbackSidecarPublished,
+                RuntimeTaskDurabilityEvent::JournalDeactivated,
+            ]
+        );
         Ok(())
     }
 
@@ -3279,13 +3605,103 @@ mod tests {
         // Simulate process death after the first rename: leave the durable undo
         // journal and only the lexically first target at generation 2.
         storage
-            .write_existing_runtime_sidecar_unchecked(&child_updated)
+            .write_existing_runtime_sidecar_durable_unchecked(
+                &child_updated,
+                RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
+            )
             .await?;
         drop(storage);
 
         let reopened = SessionStoreV2::new(temp.path().to_path_buf()).await?;
         assert_original_runtime_task_pair(&reopened).await?;
         assert!(reopened.runtime_task_journal_paths().await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reopening_store_keeps_durable_pair_when_committed_marker_survives() -> io::Result<()> {
+        let (storage, temp) = create_temp_storage().await?;
+        let (child_original, child_updated, root_original, root_updated) =
+            seed_runtime_task_transaction_pair(&storage).await?;
+        let journal = RuntimeTaskTransactionJournal {
+            version: RUNTIME_TASK_TRANSACTION_VERSION,
+            transaction_id: Uuid::new_v4().to_string(),
+            first: TaskControlPlaneUndo {
+                session_id: child_original.id.clone(),
+                task_list: child_original.task_list.clone(),
+                task_list_version: child_original
+                    .task_list_version_meta()
+                    .expect("child generation"),
+            },
+            second: TaskControlPlaneUndo {
+                session_id: root_original.id.clone(),
+                task_list: root_original.task_list.clone(),
+                task_list_version: root_original
+                    .task_list_version_meta()
+                    .expect("root generation"),
+            },
+        };
+        let prepared = storage.write_runtime_task_journal(&journal).await?;
+        storage
+            .write_existing_runtime_sidecar_durable_unchecked(
+                &child_updated,
+                RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
+            )
+            .await?;
+        storage
+            .write_existing_runtime_sidecar_durable_unchecked(
+                &root_updated,
+                RuntimeTaskDurabilityEvent::SecondUpdatedSidecarPublished,
+            )
+            .await?;
+        let committing = prepared.with_extension("committing");
+        atomic_rename(&prepared, &committing).await?;
+        sync_parent_directory_entry(&committing).await?;
+        let committed = prepared.with_extension("committed");
+        atomic_rename(&committing, &committed).await?;
+        sync_parent_directory_entry(&committed).await?;
+        drop(storage);
+
+        let reopened = SessionStoreV2::new(temp.path().to_path_buf()).await?;
+        assert_eq!(
+            reopened.take_runtime_task_durability_events(),
+            vec![RuntimeTaskDurabilityEvent::JournalDeactivated],
+            "committed recovery must clean the marker without publishing either undo"
+        );
+        assert!(reopened.runtime_task_journal_paths().await?.is_empty());
+        let child = reopened
+            .load_session("tx-child")
+            .await?
+            .expect("child remains");
+        let root = reopened
+            .load_session("tx-root")
+            .await?
+            .expect("root remains");
+        for (session, transcript, metadata_key, metadata_value) in [
+            (
+                &child,
+                "child transcript secret",
+                "unrelated.child",
+                "child metadata secret",
+            ),
+            (
+                &root,
+                "root transcript secret",
+                "unrelated.root",
+                "root metadata secret",
+            ),
+        ] {
+            assert_eq!(session.task_list_version_meta().as_deref(), Some("2"));
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("evaluated")
+            );
+            assert_eq!(session.messages[0].content, transcript);
+            assert_eq!(
+                session.metadata.get(metadata_key).map(String::as_str),
+                Some(metadata_value)
+            );
+        }
         Ok(())
     }
 
@@ -3299,6 +3715,26 @@ mod tests {
         let _storage = SessionStoreV2::new(bamboo_home).await?;
         assert!(sessions_dir.exists());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn first_save_recreates_removed_home_before_opening_task_lock() -> io::Result<()> {
+        let temp_dir = TempDir::new().map_err(io::Error::other)?;
+        let bamboo_home = temp_dir.path().join("removed-bamboo-home");
+        let storage = SessionStoreV2::new(bamboo_home.clone()).await?;
+        fs::remove_dir_all(&bamboo_home).await?;
+
+        let session = Session::new("first-save-after-home-removal", "model");
+        storage.save_session(&session).await?;
+
+        assert!(
+            bamboo_home
+                .join(RUNTIME_TASK_TRANSACTION_LOCK_FILE)
+                .exists(),
+            "the Task transaction lock parent must be recreated on first use"
+        );
+        assert!(storage.load_session(&session.id).await?.is_some());
         Ok(())
     }
 

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -713,21 +713,34 @@ impl SessionStoreV2 {
             }
         }
 
-        // Re-materialize sessions.json even when nothing was recovered (we may
-        // have renamed the only copy to sessions.json.bak), so the "index file
-        // always exists after boot" invariant holds.
-        self.update_index(|index| {
-            // Publishing the current version is the commit point for a complete rebuild.
-            // `persist_index_locked` writes a temp file and atomically renames it.
-            index.version = SESSIONS_INDEX_VERSION;
-            index.rebuild_in_progress = false;
-            Ok(())
-        })
-        .await?;
+        // The per-entry lifecycle -> shared-Task probes above must not be held
+        // across this final phase: deletion owns lifecycle -> shared-Task, so
+        // taking Task first and then attempting another lifecycle probe would
+        // invert that order. A single shared Task guard here instead seals the
+        // scan result against a new paired transaction and rejects any durable
+        // journal left by a transaction that crashed between entry probes. In
+        // that case the old rebuild marker remains retryable for the next boot.
+        {
+            let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
+
+            // Re-materialize sessions.json even when nothing was recovered (we
+            // may have renamed the only copy to sessions.json.bak), so the
+            // "index file always exists after boot" invariant holds.
+            self.update_index(|index| {
+                // Publishing the current version is the commit point for a complete rebuild.
+                // `persist_index_locked` writes a temp file and atomically renames it.
+                index.version = SESSIONS_INDEX_VERSION;
+                index.rebuild_in_progress = false;
+                Ok(())
+            })
+            .await?;
+        }
 
         tracing::info!("index rebuild from disk complete: recovered {recovered} session(s)");
 
-        // Rebuild the FTS index from the freshly recovered sessions.
+        // Pair transactions only modify Task list/generation, neither of which
+        // is indexed by FTS. Keep this best-effort pass outside the final guard
+        // so the server's background rebuild retains per-session lock scope.
         if let Err(error) = self.rebuild_search_index().await {
             tracing::warn!("index rebuild: failed to rebuild search index: {error}");
         }
@@ -1398,6 +1411,12 @@ impl SessionStoreV2 {
         session_id: &str,
     ) -> io::Result<Option<(PathBuf, Session)>> {
         validate_session_id(session_id)?;
+        if !Self::runtime_task_recovery_real_directory(&self.sessions_dir).await? {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "runtime Task recovery sessions directory is missing",
+            ));
+        }
         let mut candidates = Vec::new();
 
         let root_dir = self.sessions_dir.join(session_id);
@@ -1486,6 +1505,12 @@ impl SessionStoreV2 {
         abs_dir: &Path,
         current: &Session,
     ) -> io::Result<()> {
+        if !Self::runtime_task_recovery_real_directory(&self.sessions_dir).await? {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "runtime Task recovery sessions directory is missing",
+            ));
+        }
         let expected_dir = match current.kind {
             SessionKind::Root => self.sessions_dir.join(&current.id),
             SessionKind::Child => self
@@ -3995,6 +4020,108 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn rebuild_keeps_retry_marker_when_pair_transaction_crashes_mid_scan() -> io::Result<()> {
+        let temp = TempDir::new().map_err(io::Error::other)?;
+        let home = temp.path().to_path_buf();
+        let rebuild_store = Arc::new(SessionStoreV2::new(home.clone()).await?);
+        let (child_original, child_updated, root_original, root_updated) =
+            seed_runtime_task_transaction_pair(&rebuild_store).await?;
+        // Independent in-memory locks model the second Bamboo process that can
+        // start a Task pair commit after constructor recovery releases its
+        // exclusive cross-process guard.
+        let commit_store = Arc::new(SessionStoreV2::new(home.clone()).await?);
+
+        rebuild_store
+            .update_index(|index| {
+                *index = SessionsIndex::empty();
+                index.version = 0;
+                index.rebuild_in_progress = true;
+                Ok(())
+            })
+            .await?;
+
+        // Freeze the first per-entry lifecycle probe. Pair commits do not own
+        // lifecycle, so the independent store can publish its journal and
+        // first sidecar while rebuild is demonstrably mid-scan.
+        let lifecycle = rebuild_store.lock_session_lifecycle_exclusive().await?;
+        let rebuilding = Arc::clone(&rebuild_store);
+        let rebuild = tokio::spawn(async move { rebuilding.rebuild_index_from_disk().await });
+        tokio::task::yield_now().await;
+
+        let (first_write_reached, _release_first_write) =
+            commit_store.pause_runtime_task_transaction_after_first_write();
+        let committing = Arc::clone(&commit_store);
+        let commit = tokio::spawn(async move {
+            committing
+                .save_task_control_planes_atomically(
+                    &child_original,
+                    &child_updated,
+                    &root_original,
+                    &root_updated,
+                )
+                .await
+        });
+        first_write_reached.wait().await;
+        assert_eq!(commit_store.runtime_task_journal_paths().await?.len(), 1);
+        assert_eq!(
+            commit_store.take_runtime_task_durability_events(),
+            vec![
+                RuntimeTaskDurabilityEvent::JournalPublished,
+                RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
+            ]
+        );
+
+        // Cancellation models process death: the exclusive file guard drops,
+        // while the prepared undo journal and first durable sidecar remain.
+        commit.abort();
+        assert!(
+            commit
+                .await
+                .expect_err("commit task must be cancelled")
+                .is_cancelled(),
+            "cancelled commit must release the cross-process Task guard"
+        );
+        drop(lifecycle);
+
+        let rebuild_error = rebuild
+            .await
+            .map_err(io::Error::other)?
+            .expect_err("a pending journal must prevent rebuild finalization");
+        assert!(
+            rebuild_error.to_string().contains("recovery is required"),
+            "{rebuild_error}"
+        );
+        let retryable: SessionsIndex =
+            serde_json::from_slice(&fs::read(&home.join("sessions.json")).await?)
+                .map_err(io::Error::other)?;
+        assert_eq!(retryable.version, 0);
+        assert!(retryable.rebuild_in_progress);
+        assert!(retryable.sessions.is_empty());
+        assert_eq!(commit_store.runtime_task_journal_paths().await?.len(), 1);
+
+        drop(commit_store);
+        drop(rebuild_store);
+        let reopened = SessionStoreV2::new(home).await?;
+        assert_eq!(
+            reopened.take_runtime_task_durability_events(),
+            vec![
+                RuntimeTaskDurabilityEvent::FirstRollbackSidecarPublished,
+                RuntimeTaskDurabilityEvent::SecondRollbackSidecarPublished,
+                RuntimeTaskDurabilityEvent::JournalDeactivated,
+            ]
+        );
+        assert_original_runtime_task_pair(&reopened).await?;
+        assert!(reopened.runtime_task_journal_paths().await?.is_empty());
+        let rebuilt: SessionsIndex =
+            serde_json::from_slice(&fs::read(reopened.index_path()).await?)
+                .map_err(io::Error::other)?;
+        assert_eq!(rebuilt.version, SESSIONS_INDEX_VERSION);
+        assert!(!rebuilt.rebuild_in_progress);
+        assert_eq!(rebuilt.sessions.len(), 2);
+        Ok(())
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn orphan_recovery_rejects_symlinked_child_without_writing_outside_sessions(
@@ -4052,6 +4179,71 @@ mod tests {
             "recovery must not rewrite runtime.json outside sessions/"
         );
         assert!(fs::symlink_metadata(&child_dir)
+            .await?
+            .file_type()
+            .is_symlink());
+        assert!(journal_path.exists(), "failed recovery must retain undo");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn orphan_recovery_rejects_symlinked_sessions_root_without_writing_outside_home(
+    ) -> io::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let (storage, temp) = create_temp_storage().await?;
+        let (child_original, child_updated, root_original, _root_updated) =
+            seed_runtime_task_transaction_pair(&storage).await?;
+        let journal = RuntimeTaskTransactionJournal {
+            version: RUNTIME_TASK_TRANSACTION_VERSION,
+            transaction_id: Uuid::new_v4().to_string(),
+            first: TaskControlPlaneUndo {
+                session_id: child_original.id.clone(),
+                task_list: child_original.task_list.clone(),
+                task_list_version: child_original
+                    .task_list_version_meta()
+                    .expect("child generation"),
+            },
+            second: TaskControlPlaneUndo {
+                session_id: root_original.id.clone(),
+                task_list: root_original.task_list.clone(),
+                task_list_version: root_original
+                    .task_list_version_meta()
+                    .expect("root generation"),
+            },
+        };
+        let journal_path = storage.write_runtime_task_journal(&journal).await?;
+        storage
+            .write_existing_runtime_sidecar_durable_unchecked(
+                &child_updated,
+                RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
+            )
+            .await?;
+
+        let sessions_dir = temp.path().join("sessions");
+        let outside_home = TempDir::new().map_err(io::Error::other)?;
+        let outside_dir = outside_home.path().join("sessions");
+        fs::rename(&sessions_dir, &outside_dir).await?;
+        symlink(&outside_dir, &sessions_dir).map_err(io::Error::other)?;
+        let outside_runtime = outside_dir.join("tx-root/children/tx-child/runtime.json");
+        let outside_before = fs::read(&outside_runtime).await?;
+        fs::write(storage.index_path(), b"{ corrupt sessions index").await?;
+        drop(storage);
+
+        let error = SessionStoreV2::new(temp.path().to_path_buf())
+            .await
+            .expect_err("symlinked sessions root must fail closed");
+        assert!(
+            error.to_string().contains("not a real directory"),
+            "{error}"
+        );
+        assert_eq!(
+            fs::read(&outside_runtime).await?,
+            outside_before,
+            "recovery must not rewrite runtime.json outside Bamboo home"
+        );
+        assert!(fs::symlink_metadata(&sessions_dir)
             .await?
             .file_type()
             .is_symlink());

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -1295,6 +1295,311 @@ impl SessionStoreV2 {
         Ok(Some(session))
     }
 
+    fn validate_runtime_task_recovery_identity(
+        session: &Session,
+        session_id: &str,
+        expected_kind: SessionKind,
+        expected_root_id: &str,
+    ) -> io::Result<()> {
+        if session.id != session_id
+            || session.kind != expected_kind
+            || session.root_session_id != expected_root_id
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "runtime Task recovery identity mismatch for {session_id}: found id={}, kind={:?}, root={}",
+                    session.id, session.kind, session.root_session_id
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn runtime_task_recovery_real_directory(path: &Path) -> io::Result<bool> {
+        let metadata = match fs::symlink_metadata(path).await {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "runtime Task recovery candidate is not a real directory: {}",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(true)
+    }
+
+    async fn runtime_task_recovery_real_file(path: &Path) -> io::Result<bool> {
+        let metadata = match fs::symlink_metadata(path).await {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "runtime Task recovery candidate is not a real file: {}",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(true)
+    }
+
+    async fn read_runtime_task_recovery_main_at(
+        abs_dir: &Path,
+        session_id: &str,
+        expected_kind: SessionKind,
+        expected_root_id: &str,
+    ) -> io::Result<Option<Session>> {
+        if !Self::runtime_task_recovery_real_directory(abs_dir).await? {
+            return Ok(None);
+        }
+        let path = abs_dir.join("session.json");
+        if !Self::runtime_task_recovery_real_file(&path).await? {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&path).await?;
+        let session: Session = serde_json::from_str(&raw).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "invalid authoritative session.json for runtime Task recovery at {}: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        Self::validate_runtime_task_recovery_identity(
+            &session,
+            session_id,
+            expected_kind,
+            expected_root_id,
+        )?;
+        Ok(Some(session))
+    }
+
+    /// Resolve one journal target without consulting the rebuildable index.
+    ///
+    /// Constructor recovery deliberately runs before corrupt-index rebuild so
+    /// no half-published Task sidecar can be folded into index/FTS state. The
+    /// caller holds the cross-process runtime-Task lock exclusively: session
+    /// deletion therefore cannot mutate the tree while this strict scan finds
+    /// either `sessions/<id>` or the unique
+    /// `sessions/*/children/<id>`. Corrupt identity or duplicate candidates
+    /// fail closed instead of selecting an arbitrary sidecar.
+    async fn load_runtime_task_recovery_target(
+        &self,
+        session_id: &str,
+    ) -> io::Result<Option<(PathBuf, Session)>> {
+        validate_session_id(session_id)?;
+        let mut candidates = Vec::new();
+
+        let root_dir = self.sessions_dir.join(session_id);
+        if let Some(session) = Self::read_runtime_task_recovery_main_at(
+            &root_dir,
+            session_id,
+            SessionKind::Root,
+            session_id,
+        )
+        .await?
+        {
+            candidates.push((root_dir, session));
+        }
+
+        let mut root_dirs = match fs::read_dir(&self.sessions_dir).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(candidates.pop()),
+            Err(error) => return Err(error),
+        };
+        while let Some(root_entry) = root_dirs.next_entry().await? {
+            if !root_entry.file_type().await?.is_dir() {
+                continue;
+            }
+            let Ok(root_id) = root_entry.file_name().into_string() else {
+                continue;
+            };
+            if validate_session_id(&root_id).is_err() {
+                continue;
+            }
+            let children_dir = root_entry.path().join("children");
+            let children_metadata = match fs::symlink_metadata(&children_dir).await {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            // This is an intermediate container rather than an exact journal
+            // target. Match rebuild semantics by ignoring malformed/symlinked
+            // children trees; the exact target will then remain missing and
+            // recovery fails closed without following it outside sessions/.
+            if children_metadata.file_type().is_symlink() || !children_metadata.is_dir() {
+                continue;
+            }
+            let child_dir = children_dir.join(session_id);
+            if let Some(session) = Self::read_runtime_task_recovery_main_at(
+                &child_dir,
+                session_id,
+                SessionKind::Child,
+                &root_id,
+            )
+            .await?
+            {
+                if Self::read_runtime_task_recovery_main_at(
+                    &root_entry.path(),
+                    &root_id,
+                    SessionKind::Root,
+                    &root_id,
+                )
+                .await?
+                .is_none()
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "runtime Task recovery child {session_id} has no authoritative root {root_id}"
+                        ),
+                    ));
+                }
+                candidates.push((child_dir, session));
+            }
+        }
+
+        match candidates.len() {
+            0 => Ok(None),
+            1 => Ok(candidates.pop()),
+            count => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "runtime Task recovery target {session_id} is ambiguous across {count} authoritative directories"
+                ),
+            )),
+        }
+    }
+
+    async fn validate_runtime_task_recovery_write_target(
+        &self,
+        abs_dir: &Path,
+        current: &Session,
+    ) -> io::Result<()> {
+        let expected_dir = match current.kind {
+            SessionKind::Root => self.sessions_dir.join(&current.id),
+            SessionKind::Child => self
+                .sessions_dir
+                .join(&current.root_session_id)
+                .join("children")
+                .join(&current.id),
+        };
+        if abs_dir != expected_dir {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "runtime Task recovery path mismatch for {}: {}",
+                    current.id,
+                    abs_dir.display()
+                ),
+            ));
+        }
+
+        if current.kind == SessionKind::Child {
+            let root_dir = self.sessions_dir.join(&current.root_session_id);
+            if Self::read_runtime_task_recovery_main_at(
+                &root_dir,
+                &current.root_session_id,
+                SessionKind::Root,
+                &current.root_session_id,
+            )
+            .await?
+            .is_none()
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "runtime Task recovery child {} lost authoritative root {}",
+                        current.id, current.root_session_id
+                    ),
+                ));
+            }
+            let children_dir = root_dir.join("children");
+            if !Self::runtime_task_recovery_real_directory(&children_dir).await? {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!(
+                        "runtime Task recovery children directory disappeared for {}",
+                        current.id
+                    ),
+                ));
+            }
+        }
+        let Some(main) = Self::read_runtime_task_recovery_main_at(
+            abs_dir,
+            &current.id,
+            current.kind,
+            &current.root_session_id,
+        )
+        .await?
+        else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "runtime Task recovery target disappeared for {}",
+                    current.id
+                ),
+            ));
+        };
+        if main.parent_session_id != current.parent_session_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "runtime Task recovery parent identity changed for {}",
+                    current.id
+                ),
+            ));
+        }
+
+        let runtime_path = abs_dir.join(RUNTIME_SIDECAR_FILE);
+        let _ = Self::runtime_task_recovery_real_file(&runtime_path).await?;
+        Ok(())
+    }
+
+    async fn load_runtime_task_recovery_control_plane(
+        &self,
+        session_id: &str,
+    ) -> io::Result<Option<(PathBuf, Session)>> {
+        let Some((abs_dir, main)) = self.load_runtime_task_recovery_target(session_id).await?
+        else {
+            return Ok(None);
+        };
+        let runtime_path = abs_dir.join(RUNTIME_SIDECAR_FILE);
+        let sidecar = if Self::runtime_task_recovery_real_file(&runtime_path).await? {
+            Self::read_runtime_sidecar_at(&runtime_path, session_id).await?
+        } else {
+            None
+        };
+        if let Some(sidecar) = sidecar.as_ref() {
+            Self::validate_runtime_task_recovery_identity(
+                sidecar,
+                session_id,
+                main.kind,
+                &main.root_session_id,
+            )?;
+            if sidecar.parent_session_id != main.parent_session_id {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("runtime Task recovery parent identity mismatch for {session_id}"),
+                ));
+            }
+        }
+        let mut session = overlay_runtime_sidecar(main, sidecar);
+        session.messages.clear();
+        session.clear_stale_root_token_budget();
+        Ok(Some((abs_dir, session)))
+    }
+
     async fn write_existing_runtime_sidecar_durable_unchecked(
         &self,
         session: &Session,
@@ -1466,8 +1771,8 @@ impl SessionStoreV2 {
         fault: RuntimeTaskTransactionFault,
     ) -> io::Result<()> {
         self.maybe_fail_runtime_task_transaction(fault)?;
-        let Some(mut current) = self
-            .load_runtime_control_plane_unchecked(&undo.session_id)
+        let Some((abs_dir, mut current)) = self
+            .load_runtime_task_recovery_control_plane(&undo.session_id)
             .await?
         else {
             return Err(io::Error::new(
@@ -1486,8 +1791,12 @@ impl SessionStoreV2 {
             }
             _ => unreachable!("rollback helper only accepts rollback write faults"),
         };
-        self.write_existing_runtime_sidecar_durable_unchecked(&current, event)
-            .await
+        self.validate_runtime_task_recovery_write_target(&abs_dir, &current)
+            .await?;
+        self.write_runtime_sidecar_durable(&abs_dir, &current)
+            .await?;
+        self.record_runtime_task_durability_event(event);
+        Ok(())
     }
 
     async fn rollback_runtime_task_journal(
@@ -3561,9 +3870,13 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn reopening_store_recovers_orphan_task_journal_without_transcript_or_metadata_copy(
+    async fn assert_corrupt_index_orphan_task_journal_recovers(
+        marker_state: RuntimeTaskJournalMarkerState,
     ) -> io::Result<()> {
+        assert!(matches!(
+            marker_state,
+            RuntimeTaskJournalMarkerState::Prepared | RuntimeTaskJournalMarkerState::Committing
+        ));
         let (storage, temp) = create_temp_storage().await?;
         let (child_original, child_updated, root_original, _root_updated) =
             seed_runtime_task_transaction_pair(&storage).await?;
@@ -3586,7 +3899,7 @@ mod tests {
                     .expect("root generation"),
             },
         };
-        let journal_path = storage.write_runtime_task_journal(&journal).await?;
+        let mut journal_path = storage.write_runtime_task_journal(&journal).await?;
         let journal_json = fs::read_to_string(&journal_path).await?;
         assert!(!journal_json.contains("transcript secret"));
         assert!(!journal_json.contains("metadata secret"));
@@ -3610,11 +3923,139 @@ mod tests {
                 RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
             )
             .await?;
+        if marker_state == RuntimeTaskJournalMarkerState::Committing {
+            let committing = journal_path.with_extension("committing");
+            atomic_rename(&journal_path, &committing).await?;
+            sync_parent_directory_entry(&committing).await?;
+            journal_path = committing;
+        }
+        assert!(journal_path.exists());
+        let child_sidecar = storage
+            .runtime_json_path("tx-child")
+            .await?
+            .expect("child runtime sidecar path");
+        let root_sidecar = storage
+            .runtime_json_path("tx-root")
+            .await?
+            .expect("root runtime sidecar path");
+        assert!(child_sidecar.exists());
+        assert!(root_sidecar.exists());
+
+        // Exercise the constructor ordering hazard: corrupt-index handling
+        // publishes an empty rebuild marker before orphan Task recovery. Undo
+        // must therefore locate these intact authoritative session directories
+        // without consulting that temporarily empty index.
+        fs::write(storage.index_path(), b"{ corrupt sessions index").await?;
         drop(storage);
 
         let reopened = SessionStoreV2::new(temp.path().to_path_buf()).await?;
+        assert_eq!(
+            reopened.take_runtime_task_durability_events(),
+            vec![
+                RuntimeTaskDurabilityEvent::FirstRollbackSidecarPublished,
+                RuntimeTaskDurabilityEvent::SecondRollbackSidecarPublished,
+                RuntimeTaskDurabilityEvent::JournalDeactivated,
+            ]
+        );
         assert_original_runtime_task_pair(&reopened).await?;
         assert!(reopened.runtime_task_journal_paths().await?.is_empty());
+        assert!(temp.path().join("sessions.json.bak").exists());
+        let rebuilt_raw = fs::read_to_string(reopened.index_path()).await?;
+        let rebuilt: SessionsIndex = serde_json::from_str(&rebuilt_raw)
+            .map_err(|error| other_io_error(format!("parse rebuilt sessions index: {error}")))?;
+        assert_eq!(rebuilt.version, SESSIONS_INDEX_VERSION);
+        assert!(!rebuilt.rebuild_in_progress);
+        assert_eq!(rebuilt.sessions.len(), 2);
+        assert_eq!(
+            rebuilt
+                .sessions
+                .get("tx-root")
+                .map(|entry| entry.rel_path.as_str()),
+            Some("sessions/tx-root")
+        );
+        assert_eq!(
+            rebuilt
+                .sessions
+                .get("tx-child")
+                .map(|entry| entry.rel_path.as_str()),
+            Some("sessions/tx-root/children/tx-child")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reopening_store_recovers_orphan_task_journal_without_transcript_or_metadata_copy(
+    ) -> io::Result<()> {
+        for marker_state in [
+            RuntimeTaskJournalMarkerState::Prepared,
+            RuntimeTaskJournalMarkerState::Committing,
+        ] {
+            assert_corrupt_index_orphan_task_journal_recovers(marker_state).await?;
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn orphan_recovery_rejects_symlinked_child_without_writing_outside_sessions(
+    ) -> io::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let (storage, temp) = create_temp_storage().await?;
+        let (child_original, child_updated, root_original, _root_updated) =
+            seed_runtime_task_transaction_pair(&storage).await?;
+        let journal = RuntimeTaskTransactionJournal {
+            version: RUNTIME_TASK_TRANSACTION_VERSION,
+            transaction_id: Uuid::new_v4().to_string(),
+            first: TaskControlPlaneUndo {
+                session_id: child_original.id.clone(),
+                task_list: child_original.task_list.clone(),
+                task_list_version: child_original
+                    .task_list_version_meta()
+                    .expect("child generation"),
+            },
+            second: TaskControlPlaneUndo {
+                session_id: root_original.id.clone(),
+                task_list: root_original.task_list.clone(),
+                task_list_version: root_original
+                    .task_list_version_meta()
+                    .expect("root generation"),
+            },
+        };
+        let journal_path = storage.write_runtime_task_journal(&journal).await?;
+        storage
+            .write_existing_runtime_sidecar_durable_unchecked(
+                &child_updated,
+                RuntimeTaskDurabilityEvent::FirstUpdatedSidecarPublished,
+            )
+            .await?;
+
+        let child_dir = temp.path().join("sessions/tx-root/children/tx-child");
+        let outside_dir = temp.path().join("outside-session-tree");
+        fs::rename(&child_dir, &outside_dir).await?;
+        symlink(&outside_dir, &child_dir).map_err(io::Error::other)?;
+        let outside_runtime = outside_dir.join(RUNTIME_SIDECAR_FILE);
+        let outside_before = fs::read(&outside_runtime).await?;
+        fs::write(storage.index_path(), b"{ corrupt sessions index").await?;
+        drop(storage);
+
+        let error = SessionStoreV2::new(temp.path().to_path_buf())
+            .await
+            .expect_err("symlinked journal target must fail closed");
+        assert!(
+            error.to_string().contains("not a real directory"),
+            "{error}"
+        );
+        assert_eq!(
+            fs::read(&outside_runtime).await?,
+            outside_before,
+            "recovery must not rewrite runtime.json outside sessions/"
+        );
+        assert!(fs::symlink_metadata(&child_dir)
+            .await?
+            .file_type()
+            .is_symlink());
+        assert!(journal_path.exists(), "failed recovery must retain undo");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- give every Task evaluation a unique execution/metrics identity and record metrics at the actual provider-dispatch and terminal boundaries
- share a process-wide provider/model-keyed auxiliary budget across Task, Gold, and Gold auto-answer evaluations without affecting foreground requests
- make pipeline cleanup abort active evaluators, harvest already-finished Task/Gold results accurately, and clear queued snapshots on every exit path
- apply evaluator results through narrow, versioned child/root Task-list CAS bound to the exact evaluated snapshot, so same-version divergent state is rejected
- reconcile child/root Taskwrite conflicts to one authoritative durable/cache/live/event snapshot and publish the post-save rebased state
- make paired child/root persistence crash-safe with a private fsynced journal, phase markers, rollback/committed recovery, cross-instance locking, final-CAS revalidation, and atomic Windows replacement
- recover prepared/committing Task journals even while a corrupt session index is temporarily empty, using strict index-independent authoritative path discovery that rejects ambiguous, corrupt, or symlinked targets
- seal corrupt-index rebuild finalization against a newly crashed Task transaction, retaining the retry marker instead of committing an incomplete index
- prevent stale ordinary saves and the Taskwrite legacy fallback from replacing a newer Task control plane

## Root Cause

Task evaluation was bounded only within a single run. Across sessions, auxiliary evaluator calls could fan out against the same provider/model; Gold auto-answer bypassed the shared budget; several early-return paths detached their Tokio tasks; cleanup could relabel a finished evaluator as cancelled; evaluation persistence reused the full-session path; paired child/root writes could half-commit; and synthetic metrics reused a session/round-derived ID while writing start and finish together during result application.

The repair also exposed deeper conflict and recovery hazards: numeric Task versions alone could not distinguish divergent snapshots; a successful local save may rebase the caller onto newer authoritative Task state before the shared-root patch; and orphan journal recovery originally depended on an index that corrupt-index boot recovery had intentionally emptied before rebuilding. These paths now carry/publish the exact authoritative snapshot and recover journal targets independently of the rebuildable index.

## Impact

The change caps all low-priority evaluator concurrency, prevents detached work after loop exit, preserves actual finish/error/cancellation outcomes, prevents half-committed or stale Task state across independent stores, avoids evaluator-triggered full session rewrites, and produces independently accurate metrics rows across activations. Foreground requests remain outside the auxiliary budget, and permit queue time no longer consumes the stream request timeout.

Crash recovery now preserves the intended recovery-before-rebuild ordering, restores prepared/committing pairs from intact authoritative sidecars even with a corrupt index, and fails closed without following persistent symlinks outside the session tree.

## Test Plan

- `cargo test --all-features --lib --tests` — passed on the prior production-complete head; the current review fix is isolated to bamboo-storage and is covered below plus the new exact-head CI run
- `cargo test --tests` — passed on the prior production-complete head (including bamboo-engine 1345 passed and bamboo-server 1797 passed / 1 ignored)
- `cargo test -p bamboo-storage` — 142 passed on the current head
- `cargo build --examples` — passed
- `cargo check --locked --workspace --all-targets --all-features` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code` — passed
- `git diff --check` — passed
- focused coverage proves shared Task/Gold/auto-answer budgeting, post-permit timeouts, finished-but-unharvested cleanup, exact-snapshot stale evaluator rejection, root-conflict convergence, post-save E/v2 rebase publication, paired rollback/recovery, prepared and committing recovery with a corrupt index, exact-child and ancestor-symlink fail-closed/no external write, mid-scan pair-crash retry-marker retention, directory recreation, and no full-session fallback

## Screenshots

Not applicable (backend-only).

Fixes #695