### PR TITLE
feat(tui): preserve typed clarification semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bamboo-client-core",
+ "base64 0.23.0",
  "chrono",
  "clap",
  "crossterm 0.29.0",
@@ -1615,6 +1616,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tui-textarea-2",
+ "unicode-width",
 ]
 
 [[package]]

--- a/crates/app/bamboo-client-core/src/lib.rs
+++ b/crates/app/bamboo-client-core/src/lib.rs
@@ -9,6 +9,10 @@
 
 use serde::{Deserialize, Serialize};
 
+fn default_allow_custom() -> bool {
+    true
+}
+
 // ── Chat ──
 
 #[derive(Serialize, Clone, Debug)]
@@ -74,6 +78,11 @@ pub struct ExecuteResponse {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentEvent {
+    ExecutionStarted {
+        run_id: String,
+        session_id: String,
+        started_at: String,
+    },
     Token {
         content: String,
     },
@@ -100,6 +109,14 @@ pub enum AgentEvent {
     NeedClarification {
         question: String,
         options: Option<Vec<String>>,
+        #[serde(default)]
+        tool_call_id: Option<String>,
+        #[serde(default)]
+        tool_name: Option<String>,
+        #[serde(default = "default_allow_custom")]
+        allow_custom: bool,
+        #[serde(default)]
+        source: Option<String>,
     },
     ToolLifecycle {
         tool_call_id: String,
@@ -193,4 +210,60 @@ pub struct TokenUsage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+}
+
+#[cfg(test)]
+mod clarification_event_tests {
+    use super::AgentEvent;
+
+    #[test]
+    fn typed_clarification_preserves_all_contract_fields() {
+        let event: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "need_clarification",
+            "question": "Choose",
+            "options": ["same", "same"],
+            "tool_call_id": "call-1",
+            "tool_name": "ConclusionWithOptions",
+            "allow_custom": false,
+            "source": "pause_tool"
+        }))
+        .unwrap();
+
+        assert!(matches!(
+            event,
+            AgentEvent::NeedClarification {
+                question,
+                options: Some(options),
+                tool_call_id: Some(tool_call_id),
+                tool_name: Some(tool_name),
+                allow_custom: false,
+                source: Some(source),
+            } if question == "Choose"
+                && options == ["same", "same"]
+                && tool_call_id == "call-1"
+                && tool_name == "ConclusionWithOptions"
+                && source == "pause_tool"
+        ));
+    }
+
+    #[test]
+    fn legacy_clarification_defaults_to_open_custom_mode() {
+        let event: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "need_clarification",
+            "question": "Explain",
+            "options": null
+        }))
+        .unwrap();
+
+        assert!(matches!(
+            event,
+            AgentEvent::NeedClarification {
+                allow_custom: true,
+                tool_call_id: None,
+                tool_name: None,
+                source: None,
+                ..
+            }
+        ));
+    }
 }

--- a/crates/app/bamboo-sdk/src/agent/error.rs
+++ b/crates/app/bamboo-sdk/src/agent/error.rs
@@ -100,6 +100,10 @@ pub enum SdkError {
     #[error("no pending question waiting for response")]
     NoPendingQuestion,
 
+    /// The pending tool call changed after a typed client displayed it.
+    #[error("pending question changed (expected tool call {expected}, actual {actual})")]
+    PendingQuestionChanged { expected: String, actual: String },
+
     /// The response passed to [`Agent::answer`](super::Agent::answer) did not
     /// match one of the pending question's fixed options (and it does not
     /// allow a custom response).
@@ -141,6 +145,9 @@ impl From<RespondError> for SdkError {
             RespondError::LoadFailed(inner) => inner.into(),
             RespondError::SaveFailed(inner) => inner.into(),
             RespondError::NoPendingQuestion => SdkError::NoPendingQuestion,
+            RespondError::PendingQuestionMismatch { expected, actual } => {
+                SdkError::PendingQuestionChanged { expected, actual }
+            }
             RespondError::InvalidResponse(message) => SdkError::InvalidResponse(message),
         }
     }

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -16,6 +16,7 @@ use bamboo_engine::model_config_helper::{
 use bamboo_engine::session_app::approval_replay::{
     refresh_approval_replay_posture, ApprovalReplayDecision,
 };
+use bamboo_engine::session_app::execute::consume_pending_clarification_resume;
 use bamboo_engine::session_app::provider_model::session_effective_model_ref;
 use bamboo_engine::session_app::respond::PERMISSION_REEXECUTE_METADATA_KEY;
 use bamboo_engine::session_app::resume::{ResumeExecutionPort, ResumeSpawnRequest};
@@ -62,10 +63,21 @@ impl ResumeExecutionPort for AppStateResumeRef {
         get_or_create_event_sender(&self.0.session_event_senders, session_id).await
     }
 
+    fn dispatch_resume_execution(
+        &self,
+        request: ResumeSpawnRequest,
+    ) -> Result<(), ResumeSpawnRequest> {
+        let owner = AppStateResumeRef(self.0.clone());
+        tokio::spawn(async move {
+            ResumeExecutionPort::spawn_resume_execution(&owner, request).await;
+        });
+        Ok(())
+    }
+
     async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) {
         let ResumeSpawnRequest {
             session_id,
-            session,
+            mut session,
             mut execution_reservation,
             event_sender,
             config,
@@ -141,6 +153,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
         spawn_event_forwarder(
             state.clone(),
             session_id.clone(),
+            execution_reservation.run_id().to_string(),
             mpsc_rx,
             event_sender,
             gold_config.clone(),
@@ -175,6 +188,11 @@ impl ResumeExecutionPort for AppStateResumeRef {
             .cloned();
         let reexecute_tool_call_id = match reexecute_tool_call_id {
             None => {
+                // Keep the durable startup marker armed across every async
+                // preparation step. Clear it only in the in-memory snapshot at
+                // the synchronous handoff to the spawned runner; the runner's
+                // first checkpoint durably acknowledges takeover.
+                consume_pending_clarification_resume(&mut session);
                 spawn_agent_execution(SpawnAgentExecution {
                     state: state.clone(),
                     session_id,
@@ -326,6 +344,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                 );
             }
 
+            consume_pending_clarification_resume(&mut session);
             spawn_agent_execution(SpawnAgentExecution {
                 state: state.clone(),
                 session_id,

--- a/crates/app/bamboo-server/src/app_state/session_events.rs
+++ b/crates/app/bamboo-server/src/app_state/session_events.rs
@@ -206,6 +206,7 @@ mod tests {
             tool_call_id: Some("tc-1".to_string()),
             tool_name: None,
             allow_custom: true,
+            source: None,
         })
         .unwrap();
 

--- a/crates/app/bamboo-server/src/app_state/session_loader.rs
+++ b/crates/app/bamboo-server/src/app_state/session_loader.rs
@@ -13,7 +13,7 @@
 use super::*;
 
 use bamboo_agent_core::Session;
-use bamboo_engine::session_app::errors::{SessionLoadError, SessionSaveError};
+use bamboo_engine::session_app::errors::{RespondError, SessionLoadError, SessionSaveError};
 use bamboo_engine::session_app::repository::SessionAccess;
 
 // `SessionAccess` for `AppState` is a pure forward to the framework-owned
@@ -40,6 +40,22 @@ impl SessionAccess for AppState {
 
     async fn save_and_cache(&self, session: &mut Session) -> Result<(), SessionSaveError> {
         SessionAccess::save_and_cache(&self.session_repo, session).await
+    }
+
+    async fn inspect_for_response(&self, id: &str) -> Result<Option<Session>, SessionLoadError> {
+        SessionAccess::inspect_for_response(&self.session_repo, id).await
+    }
+
+    async fn mutate_for_response(
+        &self,
+        id: &str,
+        mutate: Box<
+            dyn for<'session> FnOnce(&'session mut Session) -> Result<(), RespondError>
+                + Send
+                + 'static,
+        >,
+    ) -> Result<Option<Session>, RespondError> {
+        SessionAccess::mutate_for_response(&self.session_repo, id, mutate).await
     }
 }
 

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -33,13 +33,14 @@ use bamboo_engine::runtime::execution::agent_spawn::{
 use bamboo_engine::session_app::approval_replay::{
     refresh_approval_replay_posture, ApprovalReplayDecision,
 };
+use bamboo_engine::session_app::execute::consume_pending_clarification_resume;
 use bamboo_engine::session_app::resolution::resolve_resume_config_snapshot;
 use bamboo_engine::session_app::respond::{
-    submit_pending_response, PERMISSION_REEXECUTE_METADATA_KEY,
+    acquire_pending_response_guard, inspect_pending_response_guarded,
+    submit_pending_response_checked_guarded, validate_pending_response,
+    PERMISSION_REEXECUTE_METADATA_KEY,
 };
-use bamboo_engine::session_app::resume::{
-    resume_session_execution, ResumeExecutionPort, ResumeSpawnRequest,
-};
+use bamboo_engine::session_app::resume::{ResumeExecutionPort, ResumeSpawnRequest};
 use bamboo_engine::session_app::types::RespondInput;
 use bamboo_engine::{ModelRoster, RoleModel};
 
@@ -66,6 +67,10 @@ pub struct ParkedAsk {
     /// forged/stale data is ignored.
     pub nonce: String,
     pub session_id: String,
+    /// Exact durable identity used as the response CAS guard. Legacy live
+    /// events are reconciled against session persistence before a `ParkedAsk`
+    /// can be constructed, so a new Connect client never submits an
+    /// unguarded clarification answer.
     pub tool_call_id: String,
     pub tool_name: String,
     pub question: String,
@@ -74,16 +79,16 @@ pub struct ParkedAsk {
 }
 
 impl ParkedAsk {
-    pub fn new(nonce: String, session_id: String, ask: &PendingAsk) -> Self {
-        Self {
+    pub fn new(nonce: String, session_id: String, ask: &PendingAsk) -> Option<Self> {
+        Some(Self {
             nonce,
             session_id,
-            tool_call_id: ask.tool_call_id.clone(),
+            tool_call_id: ask.tool_call_id.clone()?,
             tool_name: ask.tool_name.clone(),
             question: ask.question.clone(),
             options: ask.options.clone(),
             allow_custom: ask.allow_custom,
-        }
+        })
     }
 }
 
@@ -155,6 +160,32 @@ pub async fn render_ask(
         OutboundMessage::text(text)
     };
     platform.reply(reply_ctx, outbound).await.map(|_| ())
+}
+
+/// Render a legacy/external clarification that cannot be matched to a durable
+/// pending tool call. It remains fully inspectable, but deliberately has no
+/// buttons or reply instructions and is never registered as answerable chat
+/// state.
+pub async fn render_read_only_ask(
+    platform: &Arc<dyn Platform>,
+    reply_ctx: &ReplyCtx,
+    ask: &PendingAsk,
+    reason: &str,
+) -> PlatformResult<()> {
+    let mut text = ask.question.clone();
+    if !ask.options.is_empty() {
+        text.push_str("\n\n");
+        for (index, option) in ask.options.iter().enumerate() {
+            text.push_str(&format!("{}. {}\n", index + 1, option));
+        }
+    }
+    text.push_str("\n(Response unavailable: ");
+    text.push_str(reason);
+    text.push(')');
+    platform
+        .reply(reply_ctx, OutboundMessage::text(text))
+        .await
+        .map(|_| ())
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +322,8 @@ pub enum ResponderError {
     NotFound,
     #[error("no pending question waiting for a response")]
     NoPendingQuestion,
+    #[error("the pending question changed; this action has expired")]
+    PendingQuestionChanged,
     #[error("invalid response: {0}")]
     InvalidResponse(String),
     #[error("{0}")]
@@ -308,6 +341,7 @@ pub trait Responder: Send + Sync {
     async fn respond_and_resume(
         &self,
         session_id: &str,
+        expected_tool_call_id: Option<&str>,
         answer: String,
     ) -> Result<RespondAndResumeOutcome, ResponderError>;
 }
@@ -317,6 +351,7 @@ fn map_respond_error(error: bamboo_engine::session_app::errors::RespondError) ->
     match error {
         RespondError::NotFound(_) => ResponderError::NotFound,
         RespondError::NoPendingQuestion => ResponderError::NoPendingQuestion,
+        RespondError::PendingQuestionMismatch { .. } => ResponderError::PendingQuestionChanged,
         RespondError::InvalidResponse(message) => ResponderError::InvalidResponse(message),
         other => ResponderError::Other(other.to_string()),
     }
@@ -346,8 +381,45 @@ impl Responder for EngineResponder {
     async fn respond_and_resume(
         &self,
         session_id: &str,
+        expected_tool_call_id: Option<&str>,
         answer: String,
     ) -> Result<RespondAndResumeOutcome, ResponderError> {
+        let response_guard = acquire_pending_response_guard(session_id).await;
+        let current =
+            inspect_pending_response_guarded(&self.ctx.session_repo, session_id, &response_guard)
+                .await
+                .map_err(map_respond_error)?
+                .ok_or(ResponderError::NotFound)?;
+        let pending = current
+            .pending_question
+            .as_ref()
+            .ok_or(ResponderError::NoPendingQuestion)?;
+        if expected_tool_call_id.is_some_and(|expected| expected != pending.tool_call_id) {
+            return Err(ResponderError::PendingQuestionChanged);
+        }
+        validate_pending_response(pending, &answer).map_err(ResponderError::InvalidResponse)?;
+
+        let port = ConnectResumePort {
+            ctx: self.ctx.clone(),
+        };
+        let handoff = bamboo_engine::session_app::resume::reserve_response_resume_handoff(
+            &port,
+            session_id,
+            std::time::Duration::from_secs(15),
+        )
+        .await
+        .map_err(|_| {
+            ResponderError::Other(
+                "the suspending run is still finalizing; answer not consumed".to_string(),
+            )
+        })?;
+        // Subscribe and resolve async configuration before the response CAS.
+        // This intentionally gives one response a stable config snapshot;
+        // concurrent config changes apply to later requests/runs. After the
+        // answer commits, the reserved successor is transferred to a detached
+        // owner synchronously, so callback cancellation cannot strand it.
+        let receiver = handoff.subscribe();
+        let config_snapshot = self.ctx.config.read().await.clone();
         let input = RespondInput {
             session_id: session_id.to_string(),
             user_response: answer,
@@ -357,10 +429,21 @@ impl Responder for EngineResponder {
             reasoning_effort: None,
         };
 
-        let (session, _submitted_answer, plan_mode_transition, permission_grants) =
-            submit_pending_response(&self.ctx.session_repo, input)
-                .await
-                .map_err(map_respond_error)?;
+        let submission = submit_pending_response_checked_guarded(
+            &self.ctx.session_repo,
+            input,
+            expected_tool_call_id.map(str::to_string),
+            &response_guard,
+        )
+        .await;
+        let (session, _submitted_answer, plan_mode_transition, permission_grants) = match submission
+        {
+            Ok(submission) => submission,
+            Err(error) => {
+                handoff.abandon().await;
+                return Err(map_respond_error(error));
+            }
+        };
 
         // Mirrors `handlers::agent::respond::handlers::submit`: record any
         // permission grant so the resumed re-execution of the gated tool
@@ -376,18 +459,10 @@ impl Responder for EngineResponder {
             }
         }
 
-        // Subscribe BEFORE triggering resume so the `ExecutionStarted` event
-        // (and everything after) is never missed — same ordering
-        // `bridge::ConnectBridge::run_prompt` uses for a fresh prompt.
-        let session_tx =
-            get_or_create_event_sender(&self.ctx.session_event_senders, session_id).await;
-        let receiver = session_tx.subscribe();
-
         if let Some(event) = plan_mode_transition_event(session_id, plan_mode_transition.as_ref()) {
-            let _ = session_tx.send(event);
+            handoff.publish_event(event);
         }
 
-        let config_snapshot = self.ctx.config.read().await.clone();
         let resume_config = resolve_resume_config_snapshot(
             &config_snapshot,
             &self.ctx.provider_registry,
@@ -395,10 +470,15 @@ impl Responder for EngineResponder {
             None,
         );
 
-        let port = ConnectResumePort {
-            ctx: self.ctx.clone(),
-        };
-        let outcome = resume_session_execution(&port, session_id, resume_config).await;
+        let outcome = bamboo_engine::session_app::resume::resume_session_execution_with_handoff(
+            &port,
+            session_id,
+            session,
+            resume_config,
+            handoff,
+        )
+        .await;
+        drop(response_guard);
 
         match outcome {
             bamboo_engine::session_app::types::ResumeOutcome::Started { .. } => {
@@ -496,10 +576,23 @@ impl ResumeExecutionPort for ConnectResumePort {
         get_or_create_event_sender(&self.ctx.session_event_senders, session_id).await
     }
 
+    fn dispatch_resume_execution(
+        &self,
+        request: ResumeSpawnRequest,
+    ) -> Result<(), ResumeSpawnRequest> {
+        let owner = ConnectResumePort {
+            ctx: self.ctx.clone(),
+        };
+        tokio::spawn(async move {
+            ResumeExecutionPort::spawn_resume_execution(&owner, request).await;
+        });
+        Ok(())
+    }
+
     async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) {
         let ResumeSpawnRequest {
             session_id,
-            session,
+            mut session,
             mut execution_reservation,
             event_sender,
             config,
@@ -533,6 +626,7 @@ impl ResumeExecutionPort for ConnectResumePort {
 
         let (mpsc_tx, _forwarder_handle) = create_event_forwarder(
             session_id.clone(),
+            execution_reservation.run_id().to_string(),
             event_sender,
             self.ctx.agent_runners.clone(),
             self.ctx.account_feed_inbox.clone(),
@@ -551,6 +645,7 @@ impl ResumeExecutionPort for ConnectResumePort {
             .cloned();
 
         let Some(reexecute_tool_call_id) = reexecute_tool_call_id else {
+            consume_pending_clarification_resume(&mut session);
             spawn_session_execution(SessionExecutionArgs {
                 agent: self.ctx.agent.clone(),
                 session_id,
@@ -710,6 +805,7 @@ impl ResumeExecutionPort for ConnectResumePort {
                 );
             }
 
+            consume_pending_clarification_resume(&mut session);
             spawn_session_execution(SessionExecutionArgs {
                 agent: ctx.agent.clone(),
                 session_id,

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -26,7 +26,7 @@ use bamboo_llm::{Config, ProviderRegistry};
 
 use crate::permission_audit::record_bamboo_runtime_permission_metadata;
 
-use super::approvals::{self, ParkedAsk, RespondAndResumeOutcome, Responder};
+use super::approvals::{self, ParkedAsk, RespondAndResumeOutcome, Responder, ResponderError};
 use super::platform::{CallbackQuery, InboundMessage, OutboundMessage, Platform, ReplyCtx};
 use super::render;
 
@@ -153,8 +153,11 @@ struct ChatState {
 #[derive(Debug, Clone)]
 enum AskResolution {
     /// A button press or text reply matched the parked ask; submit this as
-    /// the answer.
-    Answer(String),
+    /// the answer only if that exact tool call is still pending.
+    Answer {
+        answer: String,
+        expected_tool_call_id: String,
+    },
     /// `/new`, session rotation, or an explicit clear invalidated the ask
     /// before it was answered — the waiting render task must stop rendering
     /// this (now-abandoned) run rather than hang forever.
@@ -370,14 +373,15 @@ impl ConnectBridge {
         &self,
         key: &str,
         resolve: impl FnOnce(&ParkedAsk) -> Option<String>,
-    ) -> Option<(String, mpsc::Sender<AskResolution>)> {
+    ) -> Option<(String, String, mpsc::Sender<AskResolution>)> {
         let mut guard = self.chat_state.lock().await;
         let state = guard.get_mut(key)?;
         let ask_ref = state.pending_ask.as_ref()?;
         let answer = resolve(ask_ref)?;
+        let expected_tool_call_id = ask_ref.tool_call_id.clone();
         let sender = state.ask_resolution.take()?;
         state.pending_ask = None;
-        Some((answer, sender))
+        Some((answer, expected_tool_call_id, sender))
     }
 
     /// Clears `key`'s parked ask (if any) and wakes its waiting render task
@@ -510,11 +514,16 @@ impl ConnectBridge {
         // reply, so it must never sit behind the FIFO queue. A non-matching
         // reply on a CLOSED ask (no free text allowed) falls through to the
         // normal busy/queue handling below, exactly like any other message.
-        if let Some((answer, sender)) = self
+        if let Some((answer, expected_tool_call_id, sender)) = self
             .try_resolve_pending_ask(&key, |ask| approvals::match_text_answer(ask, &msg.text))
             .await
         {
-            let _ = sender.send(AskResolution::Answer(answer)).await;
+            let _ = sender
+                .send(AskResolution::Answer {
+                    answer,
+                    expected_tool_call_id,
+                })
+                .await;
             return;
         }
 
@@ -622,11 +631,16 @@ impl ConnectBridge {
             .await;
 
         match resolved {
-            Some((answer, sender)) => {
+            Some((answer, expected_tool_call_id, sender)) => {
                 let _ = platform
                     .answer_callback(&callback.callback_query_id, None)
                     .await;
-                let _ = sender.send(AskResolution::Answer(answer)).await;
+                let _ = sender
+                    .send(AskResolution::Answer {
+                        answer,
+                        expected_tool_call_id,
+                    })
+                    .await;
             }
             None => {
                 tracing::debug!(
@@ -895,6 +909,7 @@ impl ConnectBridge {
 
         let (mpsc_tx, _forwarder_handle) = create_event_forwarder(
             session_id.clone(),
+            execution_reservation.run_id().to_string(),
             session_tx.clone(),
             self.ctx.agent_runners.clone(),
             self.ctx.account_feed_inbox.clone(),
@@ -987,7 +1002,7 @@ impl ConnectBridge {
         mut rx: broadcast::Receiver<AgentEvent>,
     ) {
         let mut stream_state: Option<Box<render::StreamState>> = None;
-        loop {
+        'stream: loop {
             match render::stream_execution(
                 platform.clone(),
                 reply_ctx.clone(),
@@ -998,38 +1013,162 @@ impl ConnectBridge {
             {
                 render::RunOutcome::Terminal => return,
                 render::RunOutcome::Paused {
-                    ask,
+                    mut ask,
                     stream_state: paused_state,
                 } => {
                     stream_state = paused_state;
-                    let caps = platform.capabilities();
-                    let parked =
-                        ParkedAsk::new(approvals::new_nonce(), session_id.to_string(), &ask);
+                    'ask: loop {
+                        if ask.tool_call_id.is_none() {
+                            match self.authoritative_pending_ask(session_id).await {
+                                Ok(Some(current)) if ask.same_visible_contract(&current) => {
+                                    ask = current;
+                                }
+                                Ok(Some(_)) => {
+                                    let _ = approvals::render_read_only_ask(
+                                        &platform,
+                                        &reply_ctx,
+                                        &ask,
+                                        "the durable pending question changed",
+                                    )
+                                    .await;
+                                    return;
+                                }
+                                Ok(None) => {
+                                    let _ = approvals::render_read_only_ask(
+                                        &platform,
+                                        &reply_ctx,
+                                        &ask,
+                                        "the server did not expose an exact response identity",
+                                    )
+                                    .await;
+                                    return;
+                                }
+                                Err(error) => {
+                                    let _ = approvals::render_read_only_ask(
+                                        &platform,
+                                        &reply_ctx,
+                                        &ask,
+                                        &format!("identity reconciliation failed: {error}"),
+                                    )
+                                    .await;
+                                    return;
+                                }
+                            }
+                        }
 
-                    if let Err(error) =
-                        approvals::render_ask(&platform, &reply_ctx, &parked, caps.buttons).await
-                    {
-                        tracing::warn!("connect: failed to render pending ask: {error}");
-                    }
+                        let caps = platform.capabilities();
+                        let Some(parked) =
+                            ParkedAsk::new(approvals::new_nonce(), session_id.to_string(), &ask)
+                        else {
+                            // The branch above makes this unreachable, but
+                            // retain the constructor's invariant at the type
+                            // boundary instead of ever parking an unguarded
+                            // ask if future control flow changes.
+                            return;
+                        };
 
-                    let (ask_tx, mut ask_rx) = mpsc::channel(1);
-                    {
-                        let mut guard = self.chat_state.lock().await;
-                        let state = guard.entry(key.to_string()).or_default();
-                        state.pending_ask = Some(parked);
-                        state.ask_resolution = Some(ask_tx);
-                    }
+                        if let Err(error) =
+                            approvals::render_ask(&platform, &reply_ctx, &parked, caps.buttons)
+                                .await
+                        {
+                            tracing::warn!("connect: failed to render pending ask: {error}");
+                        }
 
-                    match ask_rx.recv().await {
-                        Some(AskResolution::Answer(answer)) => {
-                            match self.responder.respond_and_resume(session_id, answer).await {
+                        let (ask_tx, mut ask_rx) = mpsc::channel(1);
+                        {
+                            let mut guard = self.chat_state.lock().await;
+                            let state = guard.entry(key.to_string()).or_default();
+                            state.pending_ask = Some(parked);
+                            state.ask_resolution = Some(ask_tx);
+                        }
+
+                        match ask_rx.recv().await {
+                            Some(AskResolution::Answer {
+                                answer,
+                                expected_tool_call_id,
+                            }) => match self
+                                .responder
+                                .respond_and_resume(
+                                    session_id,
+                                    Some(expected_tool_call_id.as_str()),
+                                    answer,
+                                )
+                                .await
+                            {
                                 Ok(RespondAndResumeOutcome::Resumed(new_rx)) => {
                                     rx = new_rx;
-                                    continue;
+                                    continue 'stream;
                                 }
                                 Ok(RespondAndResumeOutcome::NotResumed(reason)) => {
                                     reply_text(&platform, &reply_ctx, format!("({reason})")).await;
                                     return;
+                                }
+                                Err(
+                                    error @ (ResponderError::PendingQuestionChanged
+                                    | ResponderError::NoPendingQuestion),
+                                ) => {
+                                    reply_text(
+                                        &platform,
+                                        &reply_ctx,
+                                        format!("Your previous action expired: {error}"),
+                                    )
+                                    .await;
+                                    match self.authoritative_pending_ask(session_id).await {
+                                        Ok(Some(current)) => {
+                                            ask = current;
+                                            continue 'ask;
+                                        }
+                                        Ok(None) => {}
+                                        Err(load_error) => {
+                                            reply_text(
+                                                &platform,
+                                                &reply_ctx,
+                                                format!(
+                                                    "Could not refresh the current question: {load_error}"
+                                                ),
+                                            )
+                                            .await;
+                                        }
+                                    }
+                                    return;
+                                }
+                                Err(
+                                    error @ (ResponderError::InvalidResponse(_)
+                                    | ResponderError::Other(_)),
+                                ) => {
+                                    reply_text(
+                                        &platform,
+                                        &reply_ctx,
+                                        format!("Failed to record your answer: {error}"),
+                                    )
+                                    .await;
+                                    // The inbound fast path atomically removed
+                                    // the parked ask before waking this task.
+                                    // Validation, storage, or handoff failures
+                                    // do not necessarily consume the durable
+                                    // question, so reload it and park a fresh
+                                    // nonce instead of leaving the chat able to
+                                    // route subsequent replies as new prompts.
+                                    match self.authoritative_pending_ask(session_id).await {
+                                        Ok(Some(current)) => ask = current,
+                                        Ok(None) => return,
+                                        Err(load_error) => {
+                                            // Keep the exact original ask and
+                                            // mint a new nonce. Its tool id is
+                                            // still a safe CAS guard if another
+                                            // client consumed it while storage
+                                            // was unavailable.
+                                            reply_text(
+                                                &platform,
+                                                &reply_ctx,
+                                                format!(
+                                                    "Could not reload the question ({load_error}); the original question is still available to retry."
+                                                ),
+                                            )
+                                            .await;
+                                        }
+                                    }
+                                    continue 'ask;
                                 }
                                 Err(error) => {
                                     reply_text(
@@ -1040,21 +1179,39 @@ impl ConnectBridge {
                                     .await;
                                     return;
                                 }
+                            },
+                            Some(AskResolution::Invalidated) | None => {
+                                // Already cleared by the invalidator in the
+                                // common case; clear defensively so a stale entry
+                                // never lingers if the sender was dropped instead.
+                                self.clear_pending_ask(key).await;
+                                return;
                             }
-                        }
-                        Some(AskResolution::Invalidated) | None => {
-                            // Already cleared by the invalidator in the
-                            // common case; clear defensively so a stale entry
-                            // never lingers if the sender was dropped instead
-                            // (e.g. a bug elsewhere) rather than sending
-                            // `Invalidated` explicitly.
-                            self.clear_pending_ask(key).await;
-                            return;
                         }
                     }
                 }
             }
         }
+    }
+
+    async fn authoritative_pending_ask(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<render::PendingAsk>, String> {
+        let pending = self
+            .ctx
+            .session_repo
+            .load_merged_checked(session_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .and_then(|session| session.pending_question);
+        Ok(pending.map(|pending| render::PendingAsk {
+            tool_call_id: Some(pending.tool_call_id),
+            tool_name: pending.tool_name,
+            question: pending.question,
+            options: pending.options,
+            allow_custom: pending.allow_custom,
+        }))
     }
 }
 
@@ -1086,6 +1243,10 @@ mod tests {
     use super::*;
     use crate::app_state::AppState;
     use crate::tools::ToolSurface;
+    use bamboo_agent_core::storage::Storage;
+    use bamboo_agent_core::{PendingQuestion, PendingQuestionSource, Session};
+    use bamboo_storage::LockedSessionStore;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::Duration;
     use tokio::sync::Mutex as TokioMutex;
 
@@ -1179,9 +1340,11 @@ mod tests {
     /// broadcast receiver subscribed to a test-controlled sender, so a test
     /// can drive the "resumed run" by sending events directly.
     struct FakeResponder {
-        calls: TokioMutex<Vec<(String, String)>>,
+        calls: TokioMutex<Vec<(String, Option<String>, String)>>,
         resume_sender: broadcast::Sender<AgentEvent>,
         fail_with: Option<String>,
+        failures_remaining: AtomicUsize,
+        current_tool_call_id: Option<String>,
     }
 
     impl FakeResponder {
@@ -1190,6 +1353,8 @@ mod tests {
                 calls: TokioMutex::new(Vec::new()),
                 resume_sender,
                 fail_with: None,
+                failures_remaining: AtomicUsize::new(0),
+                current_tool_call_id: None,
             })
         }
 
@@ -1198,6 +1363,31 @@ mod tests {
                 calls: TokioMutex::new(Vec::new()),
                 resume_sender,
                 fail_with: Some(reason.to_string()),
+                failures_remaining: AtomicUsize::new(usize::MAX),
+                current_tool_call_id: None,
+            })
+        }
+
+        fn failing_once(resume_sender: broadcast::Sender<AgentEvent>, reason: &str) -> Arc<Self> {
+            Arc::new(Self {
+                calls: TokioMutex::new(Vec::new()),
+                resume_sender,
+                fail_with: Some(reason.to_string()),
+                failures_remaining: AtomicUsize::new(1),
+                current_tool_call_id: None,
+            })
+        }
+
+        fn guarding_current(
+            resume_sender: broadcast::Sender<AgentEvent>,
+            current_tool_call_id: &str,
+        ) -> Arc<Self> {
+            Arc::new(Self {
+                calls: TokioMutex::new(Vec::new()),
+                resume_sender,
+                fail_with: None,
+                failures_remaining: AtomicUsize::new(0),
+                current_tool_call_id: Some(current_tool_call_id.to_string()),
             })
         }
     }
@@ -1207,20 +1397,57 @@ mod tests {
         async fn respond_and_resume(
             &self,
             session_id: &str,
+            expected_tool_call_id: Option<&str>,
             answer: String,
         ) -> Result<RespondAndResumeOutcome, super::super::approvals::ResponderError> {
-            self.calls
-                .lock()
-                .await
-                .push((session_id.to_string(), answer));
-            if let Some(reason) = &self.fail_with {
+            self.calls.lock().await.push((
+                session_id.to_string(),
+                expected_tool_call_id.map(str::to_string),
+                answer,
+            ));
+            if self
+                .current_tool_call_id
+                .as_deref()
+                .is_some_and(|current| Some(current) != expected_tool_call_id)
+            {
+                return Err(super::super::approvals::ResponderError::PendingQuestionChanged);
+            }
+            let remaining = self.failures_remaining.load(Ordering::SeqCst);
+            if remaining > 0 {
+                if remaining != usize::MAX {
+                    self.failures_remaining.fetch_sub(1, Ordering::SeqCst);
+                }
+                let reason = self.fail_with.as_deref().unwrap_or("injected failure");
                 return Err(super::super::approvals::ResponderError::Other(
-                    reason.clone(),
+                    reason.to_string(),
                 ));
             }
             Ok(RespondAndResumeOutcome::Resumed(
                 self.resume_sender.subscribe(),
             ))
+        }
+    }
+
+    struct ToggleLoadStorage {
+        inner: Arc<dyn Storage>,
+        fail_load: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl Storage for ToggleLoadStorage {
+        async fn save_session(&self, session: &Session) -> std::io::Result<()> {
+            self.inner.save_session(session).await
+        }
+
+        async fn load_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
+            if self.fail_load.load(Ordering::SeqCst) {
+                return Err(std::io::Error::other("injected connect reload failure"));
+            }
+            self.inner.load_session(session_id).await
+        }
+
+        async fn delete_session(&self, session_id: &str) -> std::io::Result<bool> {
+            self.inner.delete_session(session_id).await
         }
     }
 
@@ -1818,6 +2045,7 @@ mod tests {
             tool_call_id: Some("call-1".to_string()),
             tool_name: Some("request_permissions".to_string()),
             allow_custom,
+            source: Some(bamboo_agent_core::PendingQuestionSource::PauseTool),
         }
     }
 
@@ -1908,13 +2136,338 @@ mod tests {
 
         assert_eq!(
             responder.calls.lock().await.as_slice(),
-            &[("sess-1".to_string(), "Approve".to_string())]
+            &[(
+                "sess-1".to_string(),
+                Some("call-1".to_string()),
+                "Approve".to_string()
+            )]
         );
         assert_eq!(
             platform.answered_callbacks.lock().await.as_slice(),
             &[("cbq-1".to_string(), None)]
         );
         assert!(!bridge.has_pending_ask(&key).await);
+    }
+
+    #[tokio::test]
+    async fn legacy_clarification_hydrates_exact_identity_before_submission() {
+        let (ctx, _dir) = test_context().await;
+        let mut session = Session::new("sess-legacy", "model");
+        session.pending_question = Some(PendingQuestion {
+            tool_call_id: "call-legacy-exact".to_string(),
+            tool_name: "conclusion_with_options".to_string(),
+            question: "Legacy approval?".to_string(),
+            options: vec!["Approve".to_string(), "Deny".to_string()],
+            allow_custom: false,
+            source: PendingQuestionSource::PauseTool,
+        });
+        ctx.session_repo.save_and_cache(&mut session).await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("legacy-chat", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "legacy-chat" }));
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(AgentEvent::NeedClarification {
+            question: "Legacy approval?".to_string(),
+            options: Some(vec!["Approve".to_string(), "Deny".to_string()]),
+            tool_call_id: None,
+            tool_name: None,
+            allow_custom: false,
+            source: None,
+        })
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-legacy", rx)
+                    .await;
+            })
+        };
+        let parked = wait_for_parked_ask(&bridge, &key).await;
+        assert_eq!(parked.tool_call_id, "call-legacy-exact");
+        ConnectBridge::handle_callback(
+            bridge,
+            platform,
+            vec!["u1".to_string()],
+            CallbackQuery {
+                platform: "fake".to_string(),
+                chat_id: "legacy-chat".to_string(),
+                user_id: "u1".to_string(),
+                callback_query_id: "legacy-callback".to_string(),
+                data: format!("{}:0", parked.nonce),
+                reply_ctx,
+            },
+        )
+        .await;
+        wait_for_responder_calls(&responder, 1).await;
+        resume_tx
+            .send(AgentEvent::ExecutionStarted {
+                run_id: "run-legacy-successor".to_string(),
+                session_id: "sess-legacy".to_string(),
+                started_at: "2026-08-10T00:00:00Z".to_string(),
+            })
+            .unwrap();
+        resume_tx
+            .send(AgentEvent::Complete {
+                usage: bamboo_agent_core::TokenUsage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                },
+            })
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            responder.calls.lock().await.as_slice(),
+            &[(
+                "sess-legacy".to_string(),
+                Some("call-legacy-exact".to_string()),
+                "Approve".to_string()
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_clarification_without_durable_identity_is_read_only() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx);
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("legacy-read-only", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "legacy-read-only" }));
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(AgentEvent::NeedClarification {
+            question: "External legacy question?".to_string(),
+            options: Some(vec!["One".to_string(), "Two".to_string()]),
+            tool_call_id: None,
+            tool_name: None,
+            allow_custom: true,
+            source: Some(PendingQuestionSource::ExternalAgent),
+        })
+        .unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            bridge.render_until_settled(&key, platform.clone(), reply_ctx, "sess-external", rx),
+        )
+        .await
+        .expect("read-only legacy ask must not wait for an answer");
+
+        assert!(!bridge.has_pending_ask(&key).await);
+        assert!(responder.calls.lock().await.is_empty());
+        let sent = platform.sent_texts().await;
+        assert!(sent.iter().any(|message| {
+            message.contains("External legacy question?")
+                && message.contains("1. One")
+                && message.contains("2. Two")
+                && message.contains("Response unavailable")
+        }));
+    }
+
+    #[tokio::test]
+    async fn reload_failure_reparks_exact_ask_until_storage_recovers() {
+        let (mut ctx, _dir) = test_context().await;
+        let mut session = Session::new("sess-retry", "model");
+        session.pending_question = Some(PendingQuestion {
+            tool_call_id: "call-1".to_string(),
+            tool_name: "request_permissions".to_string(),
+            question: "Retry approval?".to_string(),
+            options: vec!["Approve".to_string(), "Deny".to_string()],
+            allow_custom: false,
+            source: PendingQuestionSource::PauseTool,
+        });
+        ctx.session_repo.save_and_cache(&mut session).await;
+
+        let toggle = Arc::new(ToggleLoadStorage {
+            inner: ctx.session_repo.storage().clone(),
+            fail_load: AtomicBool::new(false),
+        });
+        let storage: Arc<dyn Storage> = toggle.clone();
+        ctx.session_repo = SessionRepository::new(
+            ctx.session_repo.cache().clone(),
+            storage.clone(),
+            Arc::new(LockedSessionStore::new(storage)),
+        );
+
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::failing_once(resume_tx.clone(), "temporary write failure");
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("retry-chat", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "retry-chat" }));
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Retry approval?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-retry", rx)
+                    .await;
+            })
+        };
+
+        let first = wait_for_parked_ask(&bridge, &key).await;
+        toggle.fail_load.store(true, Ordering::SeqCst);
+        ConnectBridge::handle_callback(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            CallbackQuery {
+                platform: "fake".to_string(),
+                chat_id: "retry-chat".to_string(),
+                user_id: "u1".to_string(),
+                callback_query_id: "retry-1".to_string(),
+                data: format!("{}:0", first.nonce),
+                reply_ctx: reply_ctx.clone(),
+            },
+        )
+        .await;
+        wait_for_responder_calls(&responder, 1).await;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let second = loop {
+            if let Some(parked) = bridge
+                .chat_state
+                .lock()
+                .await
+                .get(&key)
+                .and_then(|state| state.pending_ask.clone())
+                .filter(|parked| parked.nonce != first.nonce)
+            {
+                break parked;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "ask was not reparked"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(second.tool_call_id, "call-1");
+        assert!(platform
+            .sent_texts()
+            .await
+            .iter()
+            .any(|message| message.contains("original question is still available")));
+
+        toggle.fail_load.store(false, Ordering::SeqCst);
+        ConnectBridge::handle_callback(
+            bridge.clone(),
+            platform,
+            vec!["u1".to_string()],
+            CallbackQuery {
+                platform: "fake".to_string(),
+                chat_id: "retry-chat".to_string(),
+                user_id: "u1".to_string(),
+                callback_query_id: "retry-2".to_string(),
+                data: format!("{}:0", second.nonce),
+                reply_ctx,
+            },
+        )
+        .await;
+        wait_for_responder_calls(&responder, 2).await;
+        tokio::task::yield_now().await;
+        resume_tx
+            .send(AgentEvent::ExecutionStarted {
+                run_id: "run-retry-successor".to_string(),
+                session_id: "sess-retry".to_string(),
+                started_at: "2026-08-10T00:00:00Z".to_string(),
+            })
+            .unwrap();
+        resume_tx
+            .send(AgentEvent::Complete {
+                usage: Default::default(),
+            })
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("retry should resume and finish")
+            .unwrap();
+        assert!(!bridge.has_pending_ask(&key).await);
+        assert_eq!(responder.calls.lock().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn old_parked_ask_cannot_answer_a_newer_pending_tool_call() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        // Simulate another client consuming call-1 and advancing the same
+        // session to call-2 while Connect still displays call-1.
+        let responder = FakeResponder::guarding_current(resume_tx, "call-2");
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Old approval?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        let parked = wait_for_parked_ask(&bridge, &key).await;
+        ConnectBridge::handle_callback(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            CallbackQuery {
+                platform: "fake".to_string(),
+                chat_id: "chat1".to_string(),
+                user_id: "u1".to_string(),
+                callback_query_id: "cbq-old".to_string(),
+                data: format!("{}:0", parked.nonce),
+                reply_ctx,
+            },
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("stale answer rejection should settle the render task")
+            .unwrap();
+        assert_eq!(
+            responder.calls.lock().await.as_slice(),
+            &[(
+                "sess-1".to_string(),
+                Some("call-1".to_string()),
+                "Approve".to_string()
+            )]
+        );
+        assert!(platform.sent_texts().await.iter().any(|message| {
+            message.contains("pending question changed") || message.contains("expired")
+        }));
     }
 
     #[tokio::test]
@@ -2045,7 +2598,11 @@ mod tests {
 
         assert_eq!(
             responder.calls.lock().await.as_slice(),
-            &[("sess-1".to_string(), "please also add tests".to_string())]
+            &[(
+                "sess-1".to_string(),
+                Some("call-1".to_string()),
+                "please also add tests".to_string()
+            )]
         );
     }
 
@@ -2114,7 +2671,11 @@ mod tests {
 
         assert_eq!(
             responder.calls.lock().await.as_slice(),
-            &[("sess-1".to_string(), "Approve".to_string())]
+            &[(
+                "sess-1".to_string(),
+                Some("call-1".to_string()),
+                "Approve".to_string()
+            )]
         );
     }
 

--- a/crates/app/bamboo-server/src/connect/render.rs
+++ b/crates/app/bamboo-server/src/connect/render.rs
@@ -60,9 +60,10 @@ pub enum RunOutcome {
         /// pause/answer/resume loop can pass it into the NEXT
         /// [`stream_execution`] call — the resumed run keeps EDITING the same
         /// status message instead of opening a fresh "⏳ Working…" bubble per
-        /// resume. `None` in legacy (non-`edit_message`) mode, which has no
-        /// cross-run state. Boxed to keep the enum's variants close in size
-        /// (clippy `large_enum_variant`).
+        /// resume. Legacy mode carries only accumulated assistant text; the
+        /// edit-in-place mode also carries its status-message bookkeeping.
+        /// Boxed to keep the enum's variants close in size (clippy
+        /// `large_enum_variant`).
         stream_state: Option<Box<StreamState>>,
     },
 }
@@ -84,11 +85,23 @@ pub struct StreamState {
 /// match on `AgentEvent` itself.
 #[derive(Debug, Clone)]
 pub struct PendingAsk {
-    pub tool_call_id: String,
+    pub tool_call_id: Option<String>,
     pub tool_name: String,
     pub question: String,
     pub options: Vec<String>,
     pub allow_custom: bool,
+}
+
+impl PendingAsk {
+    /// Whether two asks expose the same answer contract to the operator.
+    /// Legacy events may omit `tool_call_id`/`tool_name`; those transport
+    /// fields are intentionally excluded so a checked durable snapshot can
+    /// hydrate identity without mapping input onto a different question.
+    pub(super) fn same_visible_contract(&self, other: &Self) -> bool {
+        self.question == other.question
+            && self.options == other.options
+            && self.allow_custom == other.allow_custom
+    }
 }
 
 /// Split `text` into chunks of at most `limit` **characters** (not bytes), so
@@ -166,7 +179,7 @@ fn pending_ask_from_event(
     allow_custom: bool,
 ) -> PendingAsk {
     PendingAsk {
-        tool_call_id: tool_call_id.unwrap_or_default(),
+        tool_call_id,
         tool_name: tool_name.unwrap_or_default(),
         question,
         options: options.unwrap_or_default(),
@@ -193,7 +206,7 @@ pub async fn stream_execution(
     if platform.capabilities().edit_message {
         stream_execution_streaming(platform, reply_ctx, rx, prior).await
     } else {
-        stream_execution_legacy(platform, reply_ctx, rx).await
+        stream_execution_legacy(platform, reply_ctx, rx, prior).await
     }
 }
 
@@ -205,8 +218,13 @@ async fn stream_execution_legacy(
     platform: Arc<dyn Platform>,
     reply_ctx: ReplyCtx,
     mut rx: broadcast::Receiver<AgentEvent>,
+    prior: Option<Box<StreamState>>,
 ) -> RunOutcome {
-    let mut final_text = String::new();
+    let prior = prior.map(|state| *state);
+    let mut final_text = prior
+        .as_ref()
+        .map(|state| state.assistant_text.clone())
+        .unwrap_or_default();
     let mut terminal_note: Option<String> = None;
 
     loop {
@@ -220,12 +238,14 @@ async fn stream_execution_legacy(
                 send_chunks(&platform, &reply_ctx, &line).await;
             }
             Ok(AgentEvent::Token { content }) => final_text.push_str(&content),
+            Ok(AgentEvent::ExecutionStarted { .. }) => {}
             Ok(AgentEvent::NeedClarification {
                 question,
                 options,
                 tool_call_id,
                 tool_name,
                 allow_custom,
+                ..
             }) => {
                 return RunOutcome::Paused {
                     ask: pending_ask_from_event(
@@ -235,7 +255,13 @@ async fn stream_execution_legacy(
                         tool_name,
                         allow_custom,
                     ),
-                    stream_state: None,
+                    stream_state: Some(Box::new(StreamState {
+                        tool_lines: Vec::new(),
+                        assistant_text: final_text,
+                        status_ref: None,
+                        last_edit_at: None,
+                        chars_since_edit: 0,
+                    })),
                 };
             }
             Ok(AgentEvent::Complete { .. }) => break,
@@ -485,12 +511,14 @@ async fn stream_execution_streaming(
                 renderer.assistant_text.push_str(&content);
                 renderer.note_growth(added).await;
             }
+            Ok(AgentEvent::ExecutionStarted { .. }) => {}
             Ok(AgentEvent::NeedClarification {
                 question,
                 options,
                 tool_call_id,
                 tool_name,
                 allow_custom,
+                ..
             }) => {
                 renderer.finalize_paused().await;
                 return RunOutcome::Paused {
@@ -668,6 +696,7 @@ mod tests {
             tool_call_id: Some("call-1".to_string()),
             tool_name: Some("conclusion_with_options".to_string()),
             allow_custom,
+            source: Some(bamboo_agent_core::PendingQuestionSource::PauseTool),
         }
     }
 
@@ -765,10 +794,11 @@ mod tests {
             RunOutcome::Paused { ask, stream_state } => {
                 assert_eq!(ask.question, "Pick one");
                 assert_eq!(ask.options, vec!["A".to_string(), "B".to_string()]);
-                assert_eq!(ask.tool_call_id, "call-1");
+                assert_eq!(ask.tool_call_id.as_deref(), Some("call-1"));
                 assert!(!ask.allow_custom);
-                // Legacy mode carries no streaming state.
-                assert!(stream_state.is_none());
+                // Legacy mode also carries accumulated assistant text across
+                // the pause so pre-question output is not lost on resume.
+                assert!(stream_state.is_some());
             }
             RunOutcome::Terminal => panic!("expected Paused"),
         }

--- a/crates/app/bamboo-server/src/handlers/agent/events/stream.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/stream.rs
@@ -45,6 +45,51 @@ pub(crate) fn coalesce_key(event: &AgentEvent) -> Option<CoalesceKey> {
 /// burst yet small enough to bound the allocation.
 pub(crate) const MAX_PENDING_CONTENT_BYTES: usize = 64 * 1024;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamEventDisposition {
+    Forward,
+    ForwardAndClose,
+    SuppressPauseComplete,
+}
+
+/// Tracks one clarification suspension across runner generations sharing the
+/// same long-lived session broadcaster. The suspending runner emits Complete,
+/// but that is an activation boundary rather than terminal user work. A fresh
+/// subscriber installed for the answer must remain attached until the
+/// successor announces ExecutionStarted and later emits its own terminal.
+#[derive(Debug, Default)]
+struct ClarificationBoundary {
+    open: bool,
+}
+
+impl ClarificationBoundary {
+    fn from_replay(events: &[AgentEvent]) -> Self {
+        Self {
+            open: events
+                .iter()
+                .any(|event| matches!(event, AgentEvent::NeedClarification { .. })),
+        }
+    }
+
+    fn classify(&mut self, event: &AgentEvent) -> StreamEventDisposition {
+        match event {
+            AgentEvent::NeedClarification { .. } => {
+                self.open = true;
+                StreamEventDisposition::Forward
+            }
+            AgentEvent::ExecutionStarted { .. } => {
+                self.open = false;
+                StreamEventDisposition::Forward
+            }
+            AgentEvent::Complete { .. } if self.open => {
+                StreamEventDisposition::SuppressPauseComplete
+            }
+            event if is_terminal_event(event) => StreamEventDisposition::ForwardAndClose,
+            _ => StreamEventDisposition::Forward,
+        }
+    }
+}
+
 /// Returns the byte length of a coalescible event's `content`, or 0 for
 /// non-token events (which are never buffered).
 pub(crate) fn pending_content_len(event: &AgentEvent) -> usize {
@@ -203,6 +248,8 @@ pub(super) fn live_stream_response(
             // decrementing the session's live-watcher count. Never read —
             // only its RAII drop matters.
             let _watcher_guard = watcher_guard;
+            let mut clarification_boundary =
+                ClarificationBoundary::from_replay(&critical_events_to_replay);
             // Replay cached critical state events first (task list, sub-sessions, …).
             for event in &critical_events_to_replay {
                 if let Some(sse_data) = as_sse_data(Some(event)) {
@@ -275,7 +322,15 @@ pub(super) fn live_stream_response(
                         recv = receiver.recv() => {
                             match recv {
                                 Ok(event) => {
-                                    let is_terminal = is_terminal_event(&event);
+                                    let disposition = clarification_boundary.classify(&event);
+                                    if disposition == StreamEventDisposition::SuppressPauseComplete {
+                                        // Do not forward a pause activation's Complete: clients
+                                        // classify Complete as transport-terminal and would drop
+                                        // the fresh answer subscriber before the successor starts.
+                                        continue;
+                                    }
+                                    let is_terminal =
+                                        disposition == StreamEventDisposition::ForwardAndClose;
                                     let is_child_completed =
                                         matches!(event, AgentEvent::SubAgentCompleted { .. });
                                     let Ok(event_json) = serde_json::to_string(&event) else {
@@ -304,8 +359,10 @@ pub(super) fn live_stream_response(
                                     }
                                 }
                                 Err(broadcast::error::RecvError::Lagged(_skipped)) => {
-                                    // Best-effort stream; late subscribers can open history.
-                                    continue;
+                                    // A lag gap may include a one-shot modal gate such as
+                                    // NeedClarification. Close this response so clients
+                                    // reconnect and reconcile authoritative pending state.
+                                    break;
                                 }
                                 Err(broadcast::error::RecvError::Closed) => {
                                     // Should not happen for long-lived session senders, but exit cleanly.
@@ -377,7 +434,21 @@ pub(super) fn live_stream_response(
                         recv = receiver.recv() => {
                             match recv {
                                 Ok(event) => {
-                                    let is_terminal = is_terminal_event(&event);
+                                    let disposition = clarification_boundary.classify(&event);
+                                    if disposition == StreamEventDisposition::SuppressPauseComplete {
+                                        // Preserve any token buffered before the pause boundary,
+                                        // but keep the connection open and omit the boundary
+                                        // Complete itself.
+                                        if let Some(pending) = coalescer.take_pending() {
+                                            if let Some(sse_data) = event_sse_data(&pending) {
+                                                yield Ok::<_, actix_web::Error>(web::Bytes::from(sse_data));
+                                            }
+                                        }
+                                        flush_deadline = None;
+                                        continue;
+                                    }
+                                    let is_terminal =
+                                        disposition == StreamEventDisposition::ForwardAndClose;
                                     let is_child_completed =
                                         matches!(event, AgentEvent::SubAgentCompleted { .. });
 
@@ -433,9 +504,10 @@ pub(super) fn live_stream_response(
                                         if let Some(sse_data) = event_sse_data(&pending) {
                                             yield Ok::<_, actix_web::Error>(web::Bytes::from(sse_data));
                                         }
-                                        flush_deadline = None;
                                     }
-                                    continue;
+                                    // Do not keep a healthy-looking stream after an
+                                    // unknown event gap: closing forces client resync.
+                                    break;
                                 }
                                 Err(broadcast::error::RecvError::Closed) => {
                                     // Flush any buffered tokens before closing so
@@ -507,6 +579,168 @@ mod coalesce_tests {
             tool_name: "Bash".to_string(),
             arguments: serde_json::json!({}),
         }
+    }
+
+    #[test]
+    fn fresh_answer_stream_ignores_old_pause_complete_until_successor_generation() {
+        let clarification = AgentEvent::NeedClarification {
+            question: "Choose".to_string(),
+            options: Some(vec!["A".to_string()]),
+            tool_call_id: Some("call-1".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some(bamboo_agent_core::PendingQuestionSource::PauseTool),
+        };
+        // A fresh SSE handshake replays the still-pending clarification before
+        // the respond request begins.
+        let mut boundary = ClarificationBoundary::from_replay(&[clarification]);
+        // The old suspending runner finalizes after POST starts. Its Complete
+        // must neither be forwarded nor close this fresh transport.
+        assert_eq!(
+            boundary.classify(&AgentEvent::Complete {
+                usage: TokenUsage::default(),
+            }),
+            StreamEventDisposition::SuppressPauseComplete
+        );
+        assert_eq!(
+            boundary.classify(&AgentEvent::ExecutionStarted {
+                run_id: "run-successor".to_string(),
+                session_id: "s1".to_string(),
+                started_at: "2026-08-10T00:00:00Z".to_string(),
+            }),
+            StreamEventDisposition::Forward
+        );
+        assert_eq!(
+            boundary.classify(&AgentEvent::Token {
+                content: "successor🙂".to_string(),
+            }),
+            StreamEventDisposition::Forward
+        );
+        assert_eq!(
+            boundary.classify(&AgentEvent::Complete {
+                usage: TokenUsage::default(),
+            }),
+            StreamEventDisposition::ForwardAndClose
+        );
+    }
+
+    #[tokio::test]
+    async fn generic_forwarder_replay_bridges_pause_to_successor_generation() {
+        use std::{collections::HashMap, sync::Arc};
+
+        use bamboo_engine::{execution::create_event_forwarder, AgentRunner, AgentStatus};
+        use tokio::sync::RwLock;
+
+        let session_id = "generic-pause";
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel(32);
+        let mut old_runner = AgentRunner::new();
+        old_runner.run_id = "run-old".to_string();
+        old_runner.status = AgentStatus::Running;
+        old_runner.event_sender = broadcast_tx.clone();
+        let runners = Arc::new(RwLock::new(HashMap::from([(
+            session_id.to_string(),
+            old_runner,
+        )])));
+
+        let (old_tx, old_forwarder) = create_event_forwarder(
+            session_id.to_string(),
+            "run-old".to_string(),
+            broadcast_tx.clone(),
+            runners.clone(),
+            None,
+        );
+        assert!(matches!(
+            broadcast_rx.recv().await.unwrap(),
+            AgentEvent::ExecutionStarted { ref run_id, .. } if run_id == "run-old"
+        ));
+
+        let clarification = AgentEvent::NeedClarification {
+            question: "Choose".to_string(),
+            options: Some(vec!["A".to_string()]),
+            tool_call_id: Some("call-1".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some(bamboo_agent_core::PendingQuestionSource::PauseTool),
+        };
+        old_tx.send(clarification.clone()).await.unwrap();
+        assert!(matches!(
+            broadcast_rx.recv().await.unwrap(),
+            AgentEvent::NeedClarification { .. }
+        ));
+
+        // A fresh HTTP/SSE subscriber snapshots the generic runner after the
+        // live Need frame. The clarification must already be replayable, so
+        // its boundary is open before the old activation terminal arrives.
+        let replay = runners
+            .read()
+            .await
+            .get(session_id)
+            .unwrap()
+            .last_critical_events
+            .clone();
+        assert_eq!(replay.len(), 1);
+        assert!(matches!(
+            &replay[0],
+            AgentEvent::NeedClarification {
+                tool_call_id: Some(tool_call_id),
+                ..
+            } if tool_call_id == "call-1"
+        ));
+        let mut boundary = ClarificationBoundary::from_replay(&replay);
+
+        old_tx
+            .send(AgentEvent::Complete {
+                usage: TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        let old_complete = broadcast_rx.recv().await.unwrap();
+        assert_eq!(
+            boundary.classify(&old_complete),
+            StreamEventDisposition::SuppressPauseComplete
+        );
+        drop(old_tx);
+        old_forwarder.await.unwrap();
+
+        let mut successor = AgentRunner::new();
+        successor.run_id = "run-successor".to_string();
+        successor.status = AgentStatus::Running;
+        successor.event_sender = broadcast_tx.clone();
+        runners
+            .write()
+            .await
+            .insert(session_id.to_string(), successor);
+        let (successor_tx, successor_forwarder) = create_event_forwarder(
+            session_id.to_string(),
+            "run-successor".to_string(),
+            broadcast_tx,
+            runners,
+            None,
+        );
+        let started = broadcast_rx.recv().await.unwrap();
+        assert_eq!(boundary.classify(&started), StreamEventDisposition::Forward);
+        successor_tx
+            .send(AgentEvent::Token {
+                content: "successor output".to_string(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            boundary.classify(&broadcast_rx.recv().await.unwrap()),
+            StreamEventDisposition::Forward
+        );
+        successor_tx
+            .send(AgentEvent::Complete {
+                usage: TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            boundary.classify(&broadcast_rx.recv().await.unwrap()),
+            StreamEventDisposition::ForwardAndClose
+        );
+        drop(successor_tx);
+        successor_forwarder.await.unwrap();
     }
 
     fn complete() -> AgentEvent {

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -177,6 +177,7 @@ pub(super) async fn handle_execute_ready(context: ExecuteReadyContext<'_>) -> Ht
     spawn_event_forwarder(
         state.clone(),
         session_id.to_string(),
+        run_id.clone(),
         mpsc_rx,
         session_tx.clone(),
         gold_config.clone(),

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
@@ -12,28 +12,13 @@ use bamboo_engine::gold_auto_answer::{maybe_auto_answer_pending_question, GoldAu
 /// These are cached on the runner and replayed when an SSE client connects
 /// after the live stream has already started.
 fn is_critical_event(event: &AgentEvent) -> bool {
-    matches!(
-        event,
-        AgentEvent::TaskListUpdated { .. }
-            | AgentEvent::TaskListCompleted { .. }
-            | AgentEvent::SubAgentStarted { .. }
-            | AgentEvent::SubAgentCompleted { .. }
-            | AgentEvent::ChildApprovalRequested { .. }
-            | AgentEvent::ChildApprovalChanged { .. }
-            | AgentEvent::BashCompleted { .. }
-            | AgentEvent::SessionTitleUpdated { .. }
-            | AgentEvent::SessionPinnedUpdated { .. }
-            | AgentEvent::PlanModeEntered { .. }
-            | AgentEvent::PlanModeExited { .. }
-            | AgentEvent::BudgetExceeded { .. }
-            | AgentEvent::WorkflowActivated { .. }
-            | AgentEvent::WorkflowDeactivated { .. }
-    )
+    event.is_replayable_session_state()
 }
 
 pub(crate) fn spawn_event_forwarder(
     state: actix_web::web::Data<AppState>,
     session_id: String,
+    run_id: String,
     mut mpsc_rx: mpsc::Receiver<AgentEvent>,
     session_tx: tokio::sync::broadcast::Sender<AgentEvent>,
     gold_config: Option<GoldConfig>,
@@ -56,6 +41,26 @@ pub(crate) fn spawn_event_forwarder(
 
     tokio::spawn(
         async move {
+            // Capture the reservation generation at the call site. This task
+            // may start only after a clarification answer has replaced the
+            // shared runner entry; reading that mutable registry here would
+            // tag the old activation's terminal with the successor run id.
+            let started_event = AgentEvent::ExecutionStarted {
+                run_id: run_id.clone(),
+                session_id: session_id.clone(),
+                started_at: chrono::Utc::now().to_rfc3339(),
+            };
+            {
+                let runners = state.agent_runners.read().await;
+                if runners
+                    .get(&session_id)
+                    .is_none_or(|runner| runner.run_id != run_id)
+                {
+                    return;
+                }
+                state.account_sink.record(Some(&session_id), &started_event);
+                let _ = session_tx.send(started_event);
+            }
             let mut forwarded_lifecycle_ids = HashSet::new();
             while let Some(event) = mpsc_rx.recv().await {
                 let lifecycle_id = match &event {
@@ -72,22 +77,24 @@ pub(crate) fn spawn_event_forwarder(
                     );
                     continue;
                 }
-                // Cache critical events for late-subscriber replay.
-                if is_critical_event(&event) {
+                let needs_runner_update = is_critical_event(&event)
+                    || matches!(&event, AgentEvent::TokenBudgetUpdated { .. });
+                if needs_runner_update {
                     let mut runners = state.agent_runners.write().await;
-                    if let Some(runner) = runners.get_mut(&session_id) {
+                    let Some(runner) = runners
+                        .get_mut(&session_id)
+                        .filter(|runner| runner.run_id == run_id)
+                    else {
+                        return;
+                    };
+                    if is_critical_event(&event) {
                         runner.push_critical_event(event.clone());
                         tracing::trace!(
                             "[{}] Cached critical event for late subscribers",
                             session_id
                         );
                     }
-                }
-
-                // Store budget events for late subscribers.
-                if matches!(&event, AgentEvent::TokenBudgetUpdated { .. }) {
-                    let mut runners = state.agent_runners.write().await;
-                    if let Some(runner) = runners.get_mut(&session_id) {
+                    if matches!(&event, AgentEvent::TokenBudgetUpdated { .. }) {
                         runner.last_budget_event = Some(event.clone());
                         // Fires once per agent round — far too hot for debug.
                         tracing::trace!(
@@ -95,27 +102,28 @@ pub(crate) fn spawn_event_forwarder(
                             session_id
                         );
                     }
+                    // Hold exact generation ownership through the synchronous
+                    // account/broadcast publication. A successor reservation
+                    // needs this write lock and therefore cannot interleave a
+                    // new Started before this old frame.
+                    let route_session_id = event.session_id().unwrap_or(&session_id);
+                    state.account_sink.record(Some(route_session_id), &event);
+                    let _ = session_tx.send(event);
+                } else {
+                    let runners = state.agent_runners.read().await;
+                    if runners
+                        .get(&session_id)
+                        .is_none_or(|runner| runner.run_id != run_id)
+                    {
+                        return;
+                    }
+                    // The read guard remains held through both synchronous
+                    // sends, closing the check-then-publish replacement race
+                    // without taking a write lock for token-hot paths.
+                    let route_session_id = event.session_id().unwrap_or(&session_id);
+                    state.account_sink.record(Some(route_session_id), &event);
+                    let _ = session_tx.send(event);
                 }
-
-                // Mirror durable change events onto the account-wide feed
-                // (sequenced + journaled) for resumable multi-client sync. The
-                // sink filters ephemeral events (tokens, etc.) internally, so
-                // this is near-free for the hot path. `session_id` is passed
-                // explicitly so terminal events (which carry no id) still route.
-                // Parent-scoped child lifecycle/approval events carry their
-                // canonical routing id. Prefer it over the forwarder's source
-                // session so a child stream journals the delta under the parent
-                // account-feed envelope and reconnecting parent UIs see it.
-                let route_session_id = event.session_id().unwrap_or(&session_id);
-                state.account_sink.record(Some(route_session_id), &event);
-
-                // Always forward to the broadcast channel regardless of subscriber count.
-                // The broadcast channel's internal capacity (1000 slots) buffers events so
-                // that late or temporarily-disconnected subscribers can catch up when they
-                // resubscribe.  Critical events are *also* cached on the runner above, so
-                // even if the broadcast ring wraps, a fresh subscriber will still receive
-                // the latest state via the replay path.
-                let _ = session_tx.send(event);
             }
 
             // Gold auto-answer responds to a pending clarification that genuinely
@@ -124,14 +132,27 @@ pub(crate) fn spawn_event_forwarder(
             // now happens INSIDE the runner loop's terminal gate (see
             // bamboo-engine `evaluate_gold_terminal`) so the run emits a single
             // terminal `Complete` and the frontend never gets stuck mid-settle.
-            let resume_port = crate::app_state::resume_adapter::AppStateResumeRef(state.clone());
-            let auto_answer_outcome = maybe_auto_answer_pending_question(
-                state.get_ref(),
-                &resume_port,
-                &session_id,
-                gold_config.clone(),
-            )
-            .await;
+            let superseded = state
+                .agent_runners
+                .read()
+                .await
+                .get(&session_id)
+                .is_some_and(|runner| runner.run_id != run_id);
+            let auto_answer_outcome = if superseded {
+                GoldAutoAnswerOutcome::Skipped {
+                    reason: format!("run {run_id} was superseded before post-stop auto-answer"),
+                }
+            } else {
+                let resume_port =
+                    crate::app_state::resume_adapter::AppStateResumeRef(state.clone());
+                maybe_auto_answer_pending_question(
+                    state.get_ref(),
+                    &resume_port,
+                    &session_id,
+                    gold_config.clone(),
+                )
+                .await
+            };
             match auto_answer_outcome {
                 GoldAutoAnswerOutcome::Skipped { reason } => {
                     tracing::debug!(
@@ -207,6 +228,10 @@ mod tests {
             child_session_id: "child-1".into(),
             title: Some("child work".into()),
         }
+    }
+
+    async fn current_run_id(state: &actix_web::web::Data<AppState>, session_id: &str) -> String {
+        state.agent_runners.read().await[session_id].run_id.clone()
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -530,6 +555,18 @@ mod tests {
         }));
     }
 
+    #[test]
+    fn clarification_is_replayed_to_late_subscribers() {
+        assert!(is_critical_event(&AgentEvent::NeedClarification {
+            question: "Choose".to_string(),
+            options: Some(vec!["A".to_string()]),
+            tool_call_id: Some("call-1".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some(bamboo_agent_core::PendingQuestionSource::PauseTool),
+        }));
+    }
+
     // ── Event forwarder integration ────────────────────────────────────
 
     #[tokio::test]
@@ -561,6 +598,7 @@ mod tests {
         spawn_event_forwarder(
             state.clone(),
             session_id.to_string(),
+            current_run_id(&state, session_id).await,
             mpsc_rx,
             session_tx.clone(),
             None,
@@ -600,6 +638,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delayed_server_forwarder_cannot_publish_after_successor_reservation() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let state = actix_web::web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let session_id = "server-generation-race";
+        let (session_tx, mut session_rx) = tokio::sync::broadcast::channel(16);
+        let mut successor = bamboo_engine::runtime::execution::runner_state::AgentRunner::new();
+        successor.run_id = "run-new".to_string();
+        successor.status = bamboo_engine::runtime::execution::runner_state::AgentStatus::Running;
+        successor.event_sender = session_tx.clone();
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), successor);
+
+        session_tx
+            .send(AgentEvent::ExecutionStarted {
+                run_id: "run-new".to_string(),
+                session_id: session_id.to_string(),
+                started_at: Utc::now().to_rfc3339(),
+            })
+            .unwrap();
+        let (old_tx, old_rx) = mpsc::channel(4);
+        spawn_event_forwarder(
+            state,
+            session_id.to_string(),
+            "run-old".to_string(),
+            old_rx,
+            session_tx,
+            None,
+        );
+        let _ = old_tx.send(task_list_updated()).await;
+        drop(old_tx);
+
+        assert!(matches!(
+            session_rx.recv().await.unwrap(),
+            AgentEvent::ExecutionStarted { ref run_id, .. } if run_id == "run-new"
+        ));
+        assert!(
+            timeout(Duration::from_millis(100), session_rx.recv())
+                .await
+                .is_err(),
+            "superseded server forwarder must not publish Started or stale state"
+        );
+    }
+
+    #[tokio::test]
     async fn event_forwarder_mirrors_durable_events_to_account_feed() {
         let temp_dir = tempfile::tempdir().unwrap();
         let state = AppState::new(temp_dir.path().to_path_buf())
@@ -624,6 +713,7 @@ mod tests {
         spawn_event_forwarder(
             state.clone(),
             session_id.to_string(),
+            current_run_id(&state, session_id).await,
             mpsc_rx,
             session_tx,
             None,
@@ -668,23 +758,28 @@ mod tests {
 
         let journaled =
             bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
-        assert_eq!(journaled.len(), 3, "ephemeral Token must be excluded");
+        assert_eq!(journaled.len(), 4, "ephemeral Token must be excluded");
         assert!(matches!(
             journaled[0].event,
+            AgentEvent::ExecutionStarted { .. }
+        ));
+        assert!(matches!(
+            journaled[1].event,
             AgentEvent::TaskListUpdated { .. }
         ));
-        assert!(matches!(journaled[1].event, AgentEvent::Complete { .. }));
+        assert!(matches!(journaled[2].event, AgentEvent::Complete { .. }));
         // The terminal event routed to the right session via caller context.
-        assert_eq!(journaled[1].session_id.as_deref(), Some(session_id));
-        assert_eq!(journaled[2].session_id.as_deref(), Some("parent-session"));
+        assert_eq!(journaled[2].session_id.as_deref(), Some(session_id));
+        assert_eq!(journaled[3].session_id.as_deref(), Some("parent-session"));
         assert!(matches!(
-            journaled[2].event,
+            journaled[3].event,
             AgentEvent::ChildApprovalChanged { .. }
         ));
         // Sequence numbers are monotonic and 1-based.
         assert_eq!(journaled[0].seq, 1);
         assert_eq!(journaled[1].seq, 2);
         assert_eq!(journaled[2].seq, 3);
+        assert_eq!(journaled[3].seq, 4);
     }
 
     #[tokio::test]
@@ -710,6 +805,7 @@ mod tests {
         spawn_event_forwarder(
             state.clone(),
             session_id.to_string(),
+            current_run_id(&state, session_id).await,
             mpsc_rx,
             session_tx,
             None,
@@ -725,9 +821,14 @@ mod tests {
         mpsc_tx.send(event).await.unwrap();
         drop(mpsc_tx);
 
+        let started = timeout(Duration::from_secs(1), session_rx.recv())
+            .await
+            .expect("session start event")
+            .expect("broadcast");
+        assert!(matches!(started, AgentEvent::ExecutionStarted { .. }));
         let session_event = timeout(Duration::from_secs(1), session_rx.recv())
             .await
-            .expect("session event")
+            .expect("session lifecycle event")
             .expect("broadcast");
         assert!(matches!(
             session_event,
@@ -741,9 +842,17 @@ mod tests {
             }
         }
         assert_eq!(session_lifecycle_count, 1);
+        let account_started = timeout(Duration::from_secs(1), account_rx.recv())
+            .await
+            .expect("account start event")
+            .expect("account broadcast");
+        assert!(matches!(
+            account_started.event,
+            AgentEvent::ExecutionStarted { .. }
+        ));
         let account_event = timeout(Duration::from_secs(1), account_rx.recv())
             .await
-            .expect("account event")
+            .expect("account lifecycle event")
             .expect("account broadcast");
         assert!(matches!(
             account_event.event,
@@ -788,6 +897,7 @@ mod tests {
         spawn_event_forwarder(
             state.clone(),
             session_id.to_string(),
+            current_run_id(&state, session_id).await,
             mpsc_rx,
             session_tx,
             None,
@@ -850,6 +960,7 @@ mod tests {
         spawn_event_forwarder(
             state.clone(),
             session_id.to_string(),
+            current_run_id(&state, session_id).await,
             mpsc_rx,
             session_tx.clone(),
             None,
@@ -927,10 +1038,20 @@ mod tests {
 
         let (mpsc_tx, mpsc_rx) = mpsc::channel::<AgentEvent>(64);
         let (session_tx, _session_rx) = tokio::sync::broadcast::channel::<AgentEvent>(1000);
+        let mut runner = bamboo_engine::runtime::execution::runner_state::AgentRunner::new();
+        runner.run_id = "gold-run".to_string();
+        runner.status = AgentStatus::Running;
+        runner.event_sender = session_tx.clone();
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), runner);
 
         spawn_event_forwarder(
             state.clone(),
             session_id.to_string(),
+            "gold-run".to_string(),
             mpsc_rx,
             session_tx,
             Some(test_gold_config()),
@@ -942,6 +1063,13 @@ mod tests {
             })
             .await
             .expect("should send token before close");
+        state
+            .agent_runners
+            .write()
+            .await
+            .get_mut(session_id)
+            .unwrap()
+            .status = AgentStatus::Completed;
         drop(mpsc_tx);
 
         let resumed_status = wait_for_resume_activity(state.as_ref(), session_id).await;
@@ -1041,6 +1169,15 @@ mod tests {
 
         let (mpsc_tx, mpsc_rx) = mpsc::channel::<AgentEvent>(64);
         let (session_tx, _session_rx) = tokio::sync::broadcast::channel::<AgentEvent>(1000);
+        let mut runner = bamboo_engine::runtime::execution::runner_state::AgentRunner::new();
+        runner.run_id = "gold-run".to_string();
+        runner.status = AgentStatus::Running;
+        runner.event_sender = session_tx.clone();
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), runner);
 
         let mut gold_config = test_gold_config();
         gold_config.auto_answer_enabled = true;
@@ -1050,6 +1187,7 @@ mod tests {
         spawn_event_forwarder(
             state.clone(),
             session_id.to_string(),
+            "gold-run".to_string(),
             mpsc_rx,
             session_tx,
             Some(gold_config),
@@ -1061,6 +1199,13 @@ mod tests {
             })
             .await
             .expect("should send token before close");
+        state
+            .agent_runners
+            .write()
+            .await
+            .get_mut(session_id)
+            .unwrap()
+            .status = AgentStatus::Completed;
         drop(mpsc_tx);
 
         let resumed_status = wait_for_resume_activity(state.as_ref(), session_id).await;

--- a/crates/app/bamboo-server/src/handlers/agent/respond/handlers/decision.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/respond/handlers/decision.rs
@@ -58,6 +58,7 @@ pub async fn submit_permission_decision(
 ) -> Result<HttpResponse, AppError> {
     let session_id = session_id.into_inner();
     let decision = payload.into_inner();
+    let expected_tool_call_id = decision.request_id.clone();
     let Some(config) = state.permission_checker.permission_config() else {
         return Err(AppError::InternalError(anyhow::anyhow!(
             "permission checker does not expose typed decisions"
@@ -220,6 +221,10 @@ pub async fn submit_permission_decision(
         web::Path::from(session_id),
         web::Json(RespondRequest {
             response: legacy_response.to_string(),
+            // Permission request identity is the originating tool-call id.
+            // Keep that exact CAS on replay so receipt A can never answer a
+            // newer pending permission B.
+            expected_tool_call_id: Some(expected_tool_call_id),
             model: None,
             provider: None,
             model_ref: None,
@@ -238,4 +243,124 @@ pub async fn submit_permission_decision(
         receipt,
         resume: Some(serde_json::json!({ "accepted": true })),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_agent_core::{PendingQuestionSource, Session};
+    use bamboo_engine::execution::{AgentRunner, AgentStatus};
+
+    #[actix_web::test]
+    async fn replayed_decision_returns_immediately_while_successor_is_running() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let state = web::Data::new(
+            AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let session_id = "permission-replay-running-successor";
+        state
+            .storage
+            .save_session(&Session::new(session_id, "test-model"))
+            .await
+            .expect("save completed session");
+
+        let decision = PermissionDecision {
+            request_id: "request-1".to_string(),
+            decision: PermissionDecisionKind::AllowOnce,
+            matcher_id: None,
+            expected_policy_revision: None,
+            confirm_global: false,
+        };
+        state
+            .permission_checker
+            .permission_config()
+            .expect("typed permission config")
+            .record_decision(session_id, decision.clone())
+            .expect("record original decision");
+
+        let mut successor = AgentRunner::new();
+        successor.status = AgentStatus::Running;
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), successor);
+
+        let response = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            submit_permission_decision(
+                state,
+                web::Path::from(session_id.to_string()),
+                web::Json(decision),
+            ),
+        )
+        .await
+        .expect("idempotent replay must not wait for the running successor")
+        .expect("response");
+
+        assert_eq!(response.status(), actix_web::http::StatusCode::OK);
+    }
+
+    #[actix_web::test]
+    async fn replayed_old_decision_cannot_consume_a_newer_permission_question() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let state = web::Data::new(
+            AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let session_id = "permission-replay-newer-question";
+        let old_decision = PermissionDecision {
+            request_id: "request-a".to_string(),
+            decision: PermissionDecisionKind::AllowOnce,
+            matcher_id: None,
+            expected_policy_revision: None,
+            confirm_global: false,
+        };
+        state
+            .permission_checker
+            .permission_config()
+            .expect("typed permission config")
+            .record_decision(session_id, old_decision.clone())
+            .expect("record old receipt");
+
+        let mut session = Session::new(session_id, "test-model");
+        session.set_pending_question_with_source(
+            "request-b".to_string(),
+            "Bash".to_string(),
+            "Allow the newer command?".to_string(),
+            vec!["Approve".to_string(), "Deny".to_string()],
+            false,
+            PendingQuestionSource::PauseTool,
+        );
+        state.save_and_cache_session(&mut session).await;
+        let baseline_runners = state.agent_runners.read().await.len();
+        let baseline_senders = state.session_event_senders.read().await.len();
+
+        let response = submit_permission_decision(
+            state.clone(),
+            web::Path::from(session_id.to_string()),
+            web::Json(old_decision),
+        )
+        .await
+        .expect("replay response");
+        assert_eq!(response.status(), actix_web::http::StatusCode::CONFLICT);
+
+        let durable = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("durable load")
+            .expect("durable session");
+        let pending = durable.pending_question.expect("newer question remains");
+        assert_eq!(pending.tool_call_id, "request-b");
+        assert_eq!(pending.question, "Allow the newer command?");
+        assert_eq!(state.agent_runners.read().await.len(), baseline_runners);
+        assert_eq!(
+            state.session_event_senders.read().await.len(),
+            baseline_senders
+        );
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/respond/handlers/submit.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/respond/handlers/submit.rs
@@ -25,6 +25,77 @@ pub async fn submit_response(
 
     tracing::info!("[{}] Received user response: {}", session_id, user_response);
 
+    // One guard spans authoritative preflight, successor reservation, durable
+    // compare-and-consume, and detached dispatch for every response source.
+    // A duplicate waits here, then observes the consumed question without
+    // allocating or replacing runner state.
+    let response_guard =
+        bamboo_engine::session_app::respond::acquire_pending_response_guard(&session_id).await;
+
+    // Reload using the same durable-consumption rules as the response CAS
+    // before creating a long-lived sender or reserving a successor runner.
+    let preflight = match bamboo_engine::session_app::respond::inspect_pending_response_guarded(
+        state.as_ref(),
+        &session_id,
+        &response_guard,
+    )
+    .await
+    {
+        Ok(Some(session)) => session,
+        Ok(None) => {
+            return Ok(HttpResponse::NotFound().json(serde_json::json!({
+                "error": crate::error::error_value("Session not found")
+            })));
+        }
+        Err(error) => {
+            return Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": crate::error::error_value(format!(
+                    "Failed to load session before response: {error}"
+                ))
+            })));
+        }
+    };
+    let Some(pending) = preflight.pending_question.as_ref() else {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": crate::error::error_value("No pending question waiting for response")
+        })));
+    };
+    if let Some(expected) = req.expected_tool_call_id.as_deref() {
+        if expected != pending.tool_call_id {
+            return Ok(HttpResponse::Conflict().json(serde_json::json!({
+                "error": crate::error::error_value("Pending question changed"),
+                "expected_tool_call_id": expected,
+                "actual_tool_call_id": pending.tool_call_id,
+            })));
+        }
+    }
+    if let Err(message) =
+        bamboo_engine::session_app::respond::validate_pending_response(pending, &user_response)
+    {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": crate::error::error_value("Invalid response"),
+            "message": message,
+        })));
+    }
+
+    let resume_port = crate::app_state::resume_adapter::AppStateResumeRef(state.clone());
+    let handoff = match bamboo_engine::session_app::resume::reserve_response_resume_handoff(
+        &resume_port,
+        &session_id,
+        std::time::Duration::from_secs(15),
+    )
+    .await
+    {
+        Ok(handoff) => handoff,
+        Err(_) => {
+            return Ok(HttpResponse::ServiceUnavailable().json(serde_json::json!({
+                "error": crate::error::error_value(
+                    "The suspending run is still finalizing; the answer was not consumed"
+                )
+            })));
+        }
+    };
+
     let input = bamboo_engine::session_app::types::RespondInput {
         session_id: session_id.clone(),
         user_response: user_response.clone(),
@@ -34,39 +105,58 @@ pub async fn submit_response(
         reasoning_effort: req.reasoning_effort,
     };
 
-    let (session, user_response, plan_mode_transition, permission_grants) =
-        match bamboo_engine::session_app::respond::submit_pending_response(state.as_ref(), input)
-            .await
-        {
-            Ok(result) => result,
-            Err(error) => {
-                return match error {
-                    bamboo_engine::session_app::errors::RespondError::NotFound(_) => {
-                        Ok(HttpResponse::NotFound().json(serde_json::json!({
-                            "error": crate::error::error_value("Session not found")
-                        })))
-                    }
-                    bamboo_engine::session_app::errors::RespondError::NoPendingQuestion => {
-                        Ok(HttpResponse::BadRequest().json(serde_json::json!({
-                            "error": crate::error::error_value(
-                                "No pending question waiting for response"
-                            )
-                        })))
-                    }
-                    bamboo_engine::session_app::errors::RespondError::InvalidResponse(msg) => {
-                        Ok(HttpResponse::BadRequest().json(serde_json::json!({
-                            "error": crate::error::error_value("Invalid response"),
-                            "message": msg,
-                        })))
-                    }
-                    _ => Ok(HttpResponse::InternalServerError().json(serde_json::json!({
-                        "error": crate::error::error_value(format!(
-                            "Response submission failed: {error}"
-                        ))
-                    }))),
-                };
-            }
-        };
+    // Resolve the only async resume input before the durable response CAS. This
+    // intentionally gives one response a stable config snapshot; concurrent
+    // config changes apply to later requests/runs. Once that CAS succeeds, the
+    // exact handoff must reach its detached owner without a cancellation point.
+    let config_snapshot = state.config.read().await.clone();
+
+    let submission = bamboo_engine::session_app::respond::submit_pending_response_checked_guarded(
+        state.as_ref(),
+        input,
+        req.expected_tool_call_id.clone(),
+        &response_guard,
+    )
+    .await;
+    let (session, user_response, plan_mode_transition, permission_grants) = match submission {
+        Ok(result) => result,
+        Err(error) => {
+            handoff.abandon().await;
+            return match error {
+                bamboo_engine::session_app::errors::RespondError::NotFound(_) => {
+                    Ok(HttpResponse::NotFound().json(serde_json::json!({
+                        "error": crate::error::error_value("Session not found")
+                    })))
+                }
+                bamboo_engine::session_app::errors::RespondError::NoPendingQuestion => {
+                    Ok(HttpResponse::BadRequest().json(serde_json::json!({
+                        "error": crate::error::error_value(
+                            "No pending question waiting for response"
+                        )
+                    })))
+                }
+                bamboo_engine::session_app::errors::RespondError::PendingQuestionMismatch {
+                    expected,
+                    actual,
+                } => Ok(HttpResponse::Conflict().json(serde_json::json!({
+                    "error": crate::error::error_value("Pending question changed"),
+                    "expected_tool_call_id": expected,
+                    "actual_tool_call_id": actual,
+                }))),
+                bamboo_engine::session_app::errors::RespondError::InvalidResponse(msg) => {
+                    Ok(HttpResponse::BadRequest().json(serde_json::json!({
+                        "error": crate::error::error_value("Invalid response"),
+                        "message": msg,
+                    })))
+                }
+                _ => Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+                    "error": crate::error::error_value(format!(
+                        "Response submission failed: {error}"
+                    ))
+                }))),
+            };
+        }
+    };
 
     // Record session grants for any permission prompt the user approved, so the
     // resumed run's re-attempt of the gated operation passes the checker without
@@ -121,8 +211,7 @@ pub async fn submit_response(
             },
         })
     {
-        let tx = state.get_session_event_sender(&session_id).await;
-        let _ = tx.send(event);
+        handoff.publish_event(event);
     }
 
     tracing::info!(
@@ -132,7 +221,6 @@ pub async fn submit_response(
 
     // Build resume config snapshot from server config via the single-source-of-
     // truth resolver (provider-name derivation + global auxiliary models + gold).
-    let config_snapshot = state.config.read().await.clone();
     let resume_config = bamboo_engine::session_app::resolution::resolve_resume_config_snapshot(
         &config_snapshot,
         &state.provider_registry,
@@ -140,12 +228,16 @@ pub async fn submit_response(
         None,
     );
 
-    let auto_resume_outcome = bamboo_engine::session_app::resume::resume_session_execution(
-        &crate::app_state::resume_adapter::AppStateResumeRef(state),
-        &session_id,
-        resume_config,
-    )
-    .await;
+    let auto_resume_outcome =
+        bamboo_engine::session_app::resume::resume_session_execution_with_handoff(
+            &resume_port,
+            &session_id,
+            session,
+            resume_config,
+            handoff,
+        )
+        .await;
+    drop(response_guard);
 
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "success": true,
@@ -154,4 +246,166 @@ pub async fn submit_response(
         "auto_resume_status": auto_resume_outcome.status_str(),
         "run_id": auto_resume_outcome.run_id()
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_agent_core::{PendingQuestionSource, Session};
+    use bamboo_engine::execution::{AgentRunner, AgentStatus};
+
+    #[actix_web::test]
+    async fn nonexistent_response_ids_do_not_allocate_runner_or_sender_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(
+            AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let baseline_runners = state.agent_runners.read().await.len();
+        let baseline_senders = state.session_event_senders.read().await.len();
+
+        for index in 0..16 {
+            let response = submit_response(
+                state.clone(),
+                web::Path::from(format!("missing-{index}")),
+                web::Json(RespondRequest {
+                    response: "Approve".to_string(),
+                    expected_tool_call_id: Some("random-tool".to_string()),
+                    model: None,
+                    provider: None,
+                    model_ref: None,
+                    reasoning_effort: None,
+                }),
+            )
+            .await
+            .unwrap();
+            assert_eq!(response.status(), actix_web::http::StatusCode::NOT_FOUND);
+        }
+
+        assert_eq!(state.agent_runners.read().await.len(), baseline_runners);
+        assert_eq!(
+            state.session_event_senders.read().await.len(),
+            baseline_senders
+        );
+    }
+
+    #[actix_web::test]
+    async fn queued_duplicate_cannot_replace_a_fast_completed_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(
+            AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let session_id = "duplicate-after-fast-successor";
+        let tool_call_id = "call-fast-successor";
+        let mut session = Session::new(session_id, "test-model");
+        session.set_pending_question_with_source(
+            tool_call_id.to_string(),
+            "conclusion_with_options".to_string(),
+            "Continue?".to_string(),
+            vec!["Yes".to_string(), "No".to_string()],
+            false,
+            PendingQuestionSource::PauseTool,
+        );
+        state.save_and_cache_session(&mut session).await;
+
+        // Model the winning response while retaining the shared outer gate.
+        // Its successor finishes before the queued duplicate is allowed to
+        // revalidate, which is the race that previously installed a phantom
+        // reservation and finalized it as Cancelled.
+        let guard =
+            bamboo_engine::session_app::respond::acquire_pending_response_guard(session_id).await;
+        let baseline_senders = state.session_event_senders.read().await.len();
+        let duplicate_state = state.clone();
+        let duplicate = tokio::spawn(async move {
+            submit_response(
+                duplicate_state,
+                web::Path::from(session_id.to_string()),
+                web::Json(RespondRequest {
+                    response: "Yes".to_string(),
+                    expected_tool_call_id: Some(tool_call_id.to_string()),
+                    model: None,
+                    provider: None,
+                    model_ref: None,
+                    reasoning_effort: None,
+                }),
+            )
+            .await
+            .expect("duplicate response handler")
+            .status()
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while bamboo_engine::session_app::respond::pending_response_waiter_count(session_id)
+                != 1
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("duplicate must reach the shared response gate");
+
+        let input = bamboo_engine::session_app::types::RespondInput {
+            session_id: session_id.to_string(),
+            user_response: "Yes".to_string(),
+            model: None,
+            model_ref: None,
+            provider: None,
+            reasoning_effort: None,
+        };
+        let (mut completed, ..) =
+            bamboo_engine::session_app::respond::submit_pending_response_checked_guarded(
+                state.as_ref(),
+                input,
+                Some(tool_call_id.to_string()),
+                &guard,
+            )
+            .await
+            .expect("winning response");
+        bamboo_engine::session_app::execute::consume_pending_clarification_resume(&mut completed);
+        bamboo_engine::session_app::execute::clear_startup_handoff(&mut completed);
+        completed.set_last_run_status("completed");
+        completed.clear_last_run_error();
+        state.save_and_cache_session(&mut completed).await;
+
+        let mut winner = AgentRunner::new();
+        winner.run_id = "winner-run".to_string();
+        winner.status = AgentStatus::Completed;
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), winner);
+        assert!(
+            !duplicate.is_finished(),
+            "duplicate must wait behind the winner's response transaction"
+        );
+
+        drop(guard);
+        let status = tokio::time::timeout(std::time::Duration::from_secs(1), duplicate)
+            .await
+            .expect("duplicate should finish after the gate opens")
+            .expect("duplicate task");
+        assert_eq!(status, actix_web::http::StatusCode::BAD_REQUEST);
+
+        let runners = state.agent_runners.read().await;
+        let runner = runners.get(session_id).expect("winner runner remains");
+        assert_eq!(runner.run_id, "winner-run");
+        assert!(matches!(runner.status, AgentStatus::Completed));
+        drop(runners);
+        assert_eq!(
+            state.session_event_senders.read().await.len(),
+            baseline_senders,
+            "stale duplicate must not allocate a sender before rejecting"
+        );
+        let durable = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("durable load")
+            .expect("durable session");
+        assert!(durable.pending_question.is_none());
+        assert_eq!(durable.last_run_status().as_deref(), Some("completed"));
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/respond/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/respond/types.rs
@@ -11,6 +11,10 @@ use serde::Deserialize;
 pub struct RespondRequest {
     /// The user's response - either one of the options or custom input
     pub response: String,
+    /// Optional optimistic identity guard for the pending tool call. Older
+    /// clients may omit it; clients that display a typed question should send it.
+    #[serde(default)]
+    pub expected_tool_call_id: Option<String>,
     /// Optional model to auto-resume execution after recording response.
     pub model: Option<String>,
     /// Optional provider name for model resolution.
@@ -34,7 +38,15 @@ mod tests {
         let json = r#"{"response":"yes"}"#;
         let req: RespondRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.response, "yes");
+        assert_eq!(req.expected_tool_call_id, None);
         assert_eq!(req.model, None);
+    }
+
+    #[test]
+    fn test_respond_request_with_expected_tool_call_id() {
+        let json = r#"{"response":"yes","expected_tool_call_id":"call-42"}"#;
+        let req: RespondRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.expected_tool_call_id.as_deref(), Some("call-42"));
     }
 
     #[test]
@@ -64,6 +76,7 @@ mod tests {
     fn test_respond_request_debug() {
         let req = RespondRequest {
             response: "test response".to_string(),
+            expected_tool_call_id: None,
             model: None,
             provider: None,
             model_ref: None,

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -542,6 +542,7 @@ async fn run_schedule_job(
 
     let (mpsc_tx, _forwarder_handle) = create_event_forwarder(
         session_id.clone(),
+        execution_reservation.run_id().to_string(),
         session_tx.clone(),
         ctx.agent_runners.clone(),
         ctx.account_feed_inbox.clone(),

--- a/crates/app/bamboo-tui/Cargo.toml
+++ b/crates/app/bamboo-tui/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 
 # TUI
-ratatui = "0.30"
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 tui-textarea-2 = "0.12"
 
@@ -35,3 +35,5 @@ serde_json = "1"
 # Utilities
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+base64 = "0.23"
+unicode-width = "0.2"

--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -6,6 +6,86 @@ use reqwest::Client;
 
 use types::*;
 
+#[derive(Debug, Clone)]
+pub struct RespondFailure {
+    refresh_question: bool,
+    message: String,
+}
+
+impl RespondFailure {
+    fn transport(error: reqwest::Error) -> Self {
+        Self {
+            // Once the POST has been sent, a transport failure leaves its
+            // outcome unknown: the server may have consumed the question and
+            // resumed before the response was lost. Reconcile authoritative
+            // state instead of enabling a blind duplicate submission.
+            refresh_question: true,
+            message: format!("answer response transport failed: {error}"),
+        }
+    }
+
+    fn protocol(message: impl Into<String>) -> Self {
+        Self {
+            // A successful status with an unreadable/invalid body is the same
+            // unknown-outcome class as a lost response body.
+            refresh_question: true,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn rejected(status: reqwest::StatusCode, body: String) -> Self {
+        let refresh_question = status == reqwest::StatusCode::CONFLICT
+            || (status == reqwest::StatusCode::BAD_REQUEST && body.contains("No pending question"));
+        Self {
+            refresh_question,
+            message: format!("server rejected the answer ({status}): {}", body.trim()),
+        }
+    }
+
+    /// A conflict means the tool identity changed; a bad request can mean the
+    /// pending question was already consumed. In both cases the modal must be
+    /// reconciled with the server instead of blindly retrying stale state.
+    pub fn should_refresh_question(&self) -> bool {
+        self.refresh_question
+    }
+
+    pub(crate) fn unavailable(message: impl Into<String>) -> Self {
+        Self {
+            refresh_question: false,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for RespondFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RespondFailure {}
+
+fn parse_auto_resume_status(body: &str) -> std::result::Result<String, RespondFailure> {
+    let value: serde_json::Value = serde_json::from_str(body).map_err(|error| {
+        RespondFailure::protocol(format!("invalid answer response JSON: {error}"))
+    })?;
+    let status = value
+        .get("auto_resume_status")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            RespondFailure::protocol("answer response is missing string field 'auto_resume_status'")
+        })?;
+
+    match status {
+        "started" | "already_running" | "completed" | "error: session not found" => {
+            Ok(status.to_string())
+        }
+        other => Err(RespondFailure::protocol(format!(
+            "answer response returned unsupported auto_resume_status '{other}'"
+        ))),
+    }
+}
+
 #[derive(Clone)]
 pub struct BambooClient {
     pub base_url: String,
@@ -83,34 +163,35 @@ impl BambooClient {
     /// Submit an answer to a pending question. Returns the server's
     /// `auto_resume_status` (`started` / `already_running` / `completed` /
     /// `error: …`) so the caller knows whether a run is actually resuming.
-    pub async fn respond(&self, session_id: &str, response: &str) -> Result<String> {
+    pub async fn respond(
+        &self,
+        session_id: &str,
+        response: &str,
+        expected_tool_call_id: Option<&str>,
+    ) -> std::result::Result<String, RespondFailure> {
         let resp = self
             .client
             .post(self.url(&format!("/api/v1/respond/{}", session_id)))
             .json(&RespondRequest {
                 response: response.to_string(),
+                expected_tool_call_id: expected_tool_call_id.map(str::to_string),
             })
             .send()
-            .await?;
+            .await
+            .map_err(RespondFailure::transport)?;
         // The respond validator rejects an answer that doesn't match an option
         // (when custom input is not allowed) with a non-2xx status. Surface that
         // so the UI can keep the question open instead of silently swallowing it.
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = resp.text().await.map_err(|error| {
+            RespondFailure::protocol(format!("failed to read answer response body: {error}"))
+        })?;
         if !status.is_success() {
-            anyhow::bail!("server rejected the answer ({status}): {}", body.trim());
+            return Err(RespondFailure::rejected(status, body));
         }
-        // Extract auto_resume_status; the run only actually resumes for
-        // `started` / `already_running`.
-        let auto_resume = serde_json::from_str::<serde_json::Value>(&body)
-            .ok()
-            .and_then(|v| {
-                v.get("auto_resume_status")
-                    .and_then(|s| s.as_str())
-                    .map(String::from)
-            })
-            .unwrap_or_default();
-        Ok(auto_resume)
+        // Do not turn an unknown successful response into an empty status:
+        // that would clear the modal and detach the fresh successor stream.
+        parse_auto_resume_status(&body)
     }
 
     // ── Session resume ──
@@ -447,5 +528,36 @@ impl BambooClient {
     pub async fn health(&self) -> Result<bool> {
         let resp = self.client.get(self.url("/api/v1/health")).send().await?;
         Ok(resp.status().is_success())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_auto_resume_status;
+
+    #[test]
+    fn auto_resume_status_accepts_only_server_contract_values() {
+        for status in [
+            "started",
+            "already_running",
+            "completed",
+            "error: session not found",
+        ] {
+            let body = format!(r#"{{"auto_resume_status":"{status}"}}"#);
+            assert_eq!(parse_auto_resume_status(&body).unwrap(), status);
+        }
+    }
+
+    #[test]
+    fn malformed_missing_and_unknown_resume_status_require_reconciliation() {
+        for body in [
+            "not-json",
+            r#"{"success":true}"#,
+            r#"{"auto_resume_status":7}"#,
+            r#"{"auto_resume_status":"future_status"}"#,
+        ] {
+            let error = parse_auto_resume_status(body).unwrap_err();
+            assert!(error.should_refresh_question(), "body: {body}");
+        }
     }
 }

--- a/crates/app/bamboo-tui/src/api/sse.rs
+++ b/crates/app/bamboo-tui/src/api/sse.rs
@@ -1,10 +1,34 @@
 use anyhow::Result;
 use futures::StreamExt;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 use super::types::AgentEvent;
 
 pub struct SseStream;
+
+#[derive(Debug)]
+pub enum SessionSseEvent {
+    Event {
+        session_id: String,
+        stream_epoch: u64,
+        event: AgentEvent,
+    },
+    /// An initial connection or retry reached a successful SSE response. A
+    /// question may have been persisted before the server subscribed this
+    /// connection, so every handshake reconciles authoritative pending state.
+    Connected {
+        session_id: String,
+        stream_epoch: u64,
+        reconnecting: bool,
+    },
+    /// The stream cannot continue (non-retryable HTTP error or retry budget
+    /// exhausted). This is transport state, not an agent terminal event.
+    TransportFailed {
+        session_id: String,
+        stream_epoch: u64,
+        message: String,
+    },
+}
 
 impl SseStream {
     /// Max reconnect attempts after an unexpected drop (before a terminal event).
@@ -17,30 +41,45 @@ impl SseStream {
     pub fn start(
         base_url: &str,
         session_id: &str,
-        tx: mpsc::UnboundedSender<AgentEvent>,
-    ) -> Result<()> {
+        stream_epoch: u64,
+        tx: mpsc::UnboundedSender<SessionSseEvent>,
+    ) -> Result<(tokio::task::JoinHandle<()>, watch::Receiver<bool>)> {
         let url = format!("{}/api/v1/events/{}", base_url, session_id);
+        let session_id = session_id.to_string();
         let client = reqwest::Client::new();
+        let (ready_tx, ready_rx) = watch::channel(false);
 
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             // Reconnect with capped exponential backoff on an unexpected drop
-            // (network blip, EOF before a terminal event). The server's
-            // per-session feed re-sends only cached critical events on reconnect
-            // and then live-tails, so this does NOT replay the whole token
-            // history — at worst a few tokens emitted during the gap are missed.
+            // (network blip, EOF before a terminal event). Critical-event replay
+            // does not include every stateful event, and the initial subscribe
+            // can race execution startup, so every successful handshake tells
+            // the app to reconcile the pending-question endpoint.
             let mut attempt: u32 = 0;
             loop {
-                let terminal_seen = Self::consume_once(&client, &url, &tx).await;
+                let terminal_seen = Self::consume_once(
+                    &client,
+                    &url,
+                    &session_id,
+                    stream_epoch,
+                    attempt > 0,
+                    &tx,
+                    &ready_tx,
+                )
+                .await;
                 if terminal_seen {
                     return; // run completed / cancelled / hard error — done.
                 }
+                ready_tx.send(false).ok();
                 // The UI dropped the receiver ⇒ nothing to reconnect for.
                 if tx.is_closed() {
                     return;
                 }
                 attempt += 1;
                 if attempt > Self::MAX_RETRIES {
-                    tx.send(AgentEvent::Error {
+                    tx.send(SessionSseEvent::TransportFailed {
+                        session_id: session_id.clone(),
+                        stream_epoch,
                         message: "SSE stream lost and reconnect gave up after retries".to_string(),
                     })
                     .ok();
@@ -51,7 +90,7 @@ impl SseStream {
             }
         });
 
-        Ok(())
+        Ok((task, ready_rx))
     }
 
     /// One connect + consume cycle. Returns `true` when a terminal event (or a
@@ -61,7 +100,11 @@ impl SseStream {
     async fn consume_once(
         client: &reqwest::Client,
         url: &str,
-        tx: &mpsc::UnboundedSender<AgentEvent>,
+        session_id: &str,
+        stream_epoch: u64,
+        reconnecting: bool,
+        tx: &mpsc::UnboundedSender<SessionSseEvent>,
+        ready_tx: &watch::Sender<bool>,
     ) -> bool {
         let resp = match client.get(url).send().await {
             Ok(resp) => resp,
@@ -74,7 +117,9 @@ impl SseStream {
             // report and stop. A 5xx is transient → retry.
             if status.is_client_error() {
                 let body = resp.text().await.unwrap_or_default();
-                tx.send(AgentEvent::Error {
+                tx.send(SessionSseEvent::TransportFailed {
+                    session_id: session_id.to_string(),
+                    stream_epoch,
                     message: format!("SSE connection failed: {} - {}", status, body),
                 })
                 .ok();
@@ -83,19 +128,47 @@ impl SseStream {
             return false;
         }
 
+        // A successful HTTP response means the server has installed this SSE
+        // subscription. Answer submission waits on this signal so a resumed
+        // run cannot emit its first token before the TUI is listening.
+        ready_tx.send(true).ok();
+        if tx
+            .send(SessionSseEvent::Connected {
+                session_id: session_id.to_string(),
+                stream_epoch,
+                reconnecting,
+            })
+            .is_err()
+        {
+            return true;
+        }
+
         let mut stream = resp.bytes_stream();
-        let mut buffer = String::new();
+        let mut buffer = Vec::new();
         while let Some(chunk) = stream.next().await {
+            if tx.is_closed() {
+                return true;
+            }
             let chunk = match chunk {
                 Ok(c) => c,
                 Err(_) => return false, // mid-stream error → reconnect
             };
-            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            // Preserve raw bytes across transport chunks. A UTF-8 scalar may
+            // be split between chunks; lossy-decoding each chunk separately
+            // would silently replace it with U+FFFD.
+            buffer.extend_from_slice(&chunk);
             // SSE events are separated by blank lines.
-            while let Some(sep_pos) = buffer.find("\n\n") {
-                let event_text = buffer[..sep_pos].to_string();
-                buffer = buffer[sep_pos + 2..].to_string();
-                if Self::parse_sse_block(&event_text, tx) {
+            while let Some((sep_pos, sep_len)) = Self::find_event_separator(&buffer) {
+                let remainder = buffer.split_off(sep_pos + sep_len);
+                let mut event_bytes = std::mem::replace(&mut buffer, remainder);
+                event_bytes.truncate(sep_pos);
+                let Ok(event_text) = std::str::from_utf8(&event_bytes) else {
+                    // SSE is UTF-8 by contract. Skip a malformed complete
+                    // frame, but never corrupt a valid scalar split across
+                    // network chunks.
+                    continue;
+                };
+                if Self::parse_sse_block(event_text, session_id, stream_epoch, tx) {
                     return true; // terminal event delivered
                 }
             }
@@ -106,7 +179,12 @@ impl SseStream {
 
     /// Parse one SSE block and forward its events. Returns `true` if a terminal
     /// event (Complete / Cancelled / Error) or a closed receiver was seen.
-    fn parse_sse_block(block: &str, tx: &mpsc::UnboundedSender<AgentEvent>) -> bool {
+    fn parse_sse_block(
+        block: &str,
+        session_id: &str,
+        stream_epoch: u64,
+        tx: &mpsc::UnboundedSender<SessionSseEvent>,
+    ) -> bool {
         for line in block.lines() {
             // Skip comments (heartbeat, etc.)
             if line.starts_with(':') {
@@ -123,7 +201,14 @@ impl SseStream {
                             | AgentEvent::Cancelled { .. }
                             | AgentEvent::Error { .. }
                     );
-                    if tx.send(event).is_err() {
+                    if tx
+                        .send(SessionSseEvent::Event {
+                            session_id: session_id.to_string(),
+                            stream_epoch,
+                            event,
+                        })
+                        .is_err()
+                    {
                         return true; // receiver gone — stop
                     }
                     if is_terminal {
@@ -134,29 +219,59 @@ impl SseStream {
         }
         false
     }
+
+    fn find_event_separator(buffer: &[u8]) -> Option<(usize, usize)> {
+        buffer
+            .windows(2)
+            .position(|window| window == b"\n\n")
+            .map(|position| (position, 2))
+            .or_else(|| {
+                buffer
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .map(|position| (position, 4))
+            })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
     fn parse_block_flags_terminal_events_only() {
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         // A token is not terminal.
-        let terminal = SseStream::parse_sse_block(r#"data: {"type":"token","content":"hi"}"#, &tx);
+        let terminal =
+            SseStream::parse_sse_block(r#"data: {"type":"token","content":"hi"}"#, "s1", 7, &tx);
         assert!(!terminal);
-        assert!(rx.try_recv().is_ok());
+        let event = rx.try_recv().unwrap();
+        assert!(matches!(
+            event,
+            SessionSseEvent::Event {
+                session_id,
+                stream_epoch: 7,
+                event: AgentEvent::Token { .. }
+            } if session_id == "s1"
+        ));
 
         // A heartbeat comment / keepalive is skipped, not terminal.
-        assert!(!SseStream::parse_sse_block(": heartbeat", &tx));
-        assert!(!SseStream::parse_sse_block("data: [KEEPALIVE]", &tx));
+        assert!(!SseStream::parse_sse_block(": heartbeat", "s1", 7, &tx));
+        assert!(!SseStream::parse_sse_block(
+            "data: [KEEPALIVE]",
+            "s1",
+            7,
+            &tx
+        ));
         assert!(rx.try_recv().is_err());
 
         // Complete is terminal.
         let terminal = SseStream::parse_sse_block(
             r#"data: {"type":"complete","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#,
+            "s1",
+            7,
             &tx,
         );
         assert!(terminal);
@@ -164,12 +279,83 @@ mod tests {
 
     #[test]
     fn closed_receiver_is_reported_terminal() {
-        let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
+        let (tx, rx) = mpsc::unbounded_channel::<SessionSseEvent>();
         drop(rx);
         // With no receiver, sending fails and the block reports "stop".
         assert!(SseStream::parse_sse_block(
             r#"data: {"type":"token","content":"x"}"#,
+            "s1",
+            1,
             &tx
         ));
+    }
+
+    #[tokio::test]
+    async fn split_utf8_scalar_across_http_chunks_is_lossless() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut byte = [0u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                socket.read_exact(&mut byte).await.unwrap();
+                request.push(byte[0]);
+            }
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+
+            let frame = "data: {\"type\":\"token\",\"content\":\"你好🙂\"}\n\n";
+            let emoji = frame.find('🙂').unwrap();
+            // Split halfway through the four-byte emoji scalar. Per-chunk
+            // lossy decoding would produce replacement characters here.
+            let parts = [
+                &frame.as_bytes()[..emoji + 2],
+                &frame.as_bytes()[emoji + 2..],
+            ];
+            for part in parts {
+                socket
+                    .write_all(format!("{:X}\r\n", part.len()).as_bytes())
+                    .await
+                    .unwrap();
+                socket.write_all(part).await.unwrap();
+                socket.write_all(b"\r\n").await.unwrap();
+                socket.flush().await.unwrap();
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            std::future::pending::<()>().await;
+        });
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (task, _ready) = SseStream::start(&base_url, "unicode", 42, tx).unwrap();
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            SessionSseEvent::Connected {
+                stream_epoch: 42,
+                ..
+            }
+        ));
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            event,
+            SessionSseEvent::Event {
+                stream_epoch: 42,
+                event: AgentEvent::Token { content },
+                ..
+            } if content == "你好🙂"
+        ));
+
+        task.abort();
+        server.abort();
     }
 }

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -10,6 +10,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+fn default_allow_custom() -> bool {
+    true
+}
+
 fn default_title_generated() -> bool {
     true
 }
@@ -76,6 +80,8 @@ pub struct ListSessionsEnvelope {
 #[derive(Serialize)]
 pub struct RespondRequest {
     pub response: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_tool_call_id: Option<String>,
 }
 
 /// Wire shape of `GET /api/v1/sessions/{session_id}` — the server wraps the
@@ -163,7 +169,7 @@ pub struct PendingQuestion {
     pub question: String,
     #[serde(default)]
     pub options: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default = "default_allow_custom")]
     pub allow_custom: bool,
     #[serde(default)]
     pub tool_call_id: Option<String>,
@@ -587,6 +593,31 @@ mod tests {
             Some(&["Yes".to_string(), "No".to_string()][..])
         );
         assert!(some.allow_custom);
+
+        let legacy: PendingQuestion =
+            serde_json::from_str(r#"{"has_pending_question":true,"question":"Legacy question"}"#)
+                .unwrap();
+        assert!(
+            legacy.allow_custom,
+            "missing legacy field preserves free-text compatibility"
+        );
+    }
+
+    #[test]
+    fn respond_request_serializes_optional_question_identity() {
+        let guarded = serde_json::to_value(RespondRequest {
+            response: "Yes".to_string(),
+            expected_tool_call_id: Some("t1".to_string()),
+        })
+        .unwrap();
+        assert_eq!(guarded["expected_tool_call_id"], "t1");
+
+        let legacy = serde_json::to_value(RespondRequest {
+            response: "Yes".to_string(),
+            expected_tool_call_id: None,
+        })
+        .unwrap();
+        assert!(legacy.get("expected_tool_call_id").is_none());
     }
 
     /// `GET /api/v1/sessions/{id}` wraps the summary in a `{ "session": ... }`

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -1,19 +1,22 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, VecDeque};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use base64::prelude::{Engine as _, BASE64_STANDARD};
 use chrono::{DateTime, Utc};
 use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers};
 use futures::StreamExt;
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use tokio::process::{Child, Command};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tui_textarea::TextArea;
 
-use crate::api::sse::SseStream;
+use crate::api::sse::{SessionSseEvent, SseStream};
 use crate::api::types::*;
-use crate::api::BambooClient;
+use crate::api::{BambooClient, RespondFailure};
 use crate::event::AppEvent;
 use crate::history::map_history;
 use crate::ui;
@@ -322,15 +325,111 @@ pub struct Notification {
 // ── Interactive question (permission gate / clarification) ──
 
 /// An agent question awaiting the operator's answer, driven by the modal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QuestionIdentity {
+    pub session_id: String,
+    pub tool_call_id: Option<String>,
+    /// Fallback discriminator for older/external events that do not carry a
+    /// tool-call id. The server-side optimistic guard is available whenever
+    /// `tool_call_id` is present; this keeps local replay/draft state separate
+    /// even for legacy events.
+    pub question: String,
+}
+
+impl QuestionIdentity {
+    fn new(session_id: String, tool_call_id: Option<String>, question: String) -> Self {
+        let fallback_question = if tool_call_id.is_none() {
+            question
+        } else {
+            String::new()
+        };
+        Self {
+            session_id,
+            tool_call_id,
+            question: fallback_question,
+        }
+    }
+}
+
+const MAX_QUESTION_DRAFTS: usize = 64;
+
+/// Draft cache key. Typed questions are keyed by their durable tool-call id;
+/// legacy questions additionally retain the visible contract so a later
+/// `/pending` hydration cannot carry text onto a different prompt that happens
+/// to reuse the same question label.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct QuestionDraftKey {
+    identity: QuestionIdentity,
+    fallback_options: Vec<String>,
+    fallback_allow_custom: bool,
+}
+
+impl QuestionDraftKey {
+    fn new(
+        session_id: String,
+        tool_call_id: Option<String>,
+        question: String,
+        options: Vec<String>,
+        allow_custom: bool,
+    ) -> Self {
+        let legacy = tool_call_id.is_none();
+        Self {
+            identity: QuestionIdentity::new(session_id, tool_call_id, question),
+            fallback_options: if legacy { options } else { Vec::new() },
+            fallback_allow_custom: legacy && allow_custom,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct QuestionOptionHitbox {
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub index: usize,
+}
+
+impl QuestionOptionHitbox {
+    fn contains(self, column: u16, row: u16) -> bool {
+        row == self.y && column >= self.x && column < self.x.saturating_add(self.width)
+    }
+}
+
+/// An agent question awaiting the operator's answer, driven by the modal.
 pub struct ActiveQuestion {
+    pub session_id: String,
+    pub tool_call_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub source: Option<String>,
     pub question: String,
     /// Preset choices; empty means free-text only.
     pub options: Vec<String>,
     /// Highlighted option index (option-select mode).
     pub selected: usize,
+    pub allow_custom: bool,
     /// `Some(buf)` = free-text entry mode (typing into `buf`); `None` =
     /// option-select mode. Starts `Some("")` when there are no options.
     pub custom: Option<String>,
+    /// Draft retained while focus returns to the option list. The currently
+    /// edited value lives in `custom`; `custom_draft` keeps it when custom mode
+    /// is temporarily closed.
+    pub custom_draft: String,
+    /// Numeric jump entry (`g`, digits, Enter) reaches options beyond 1-9
+    /// without submitting an ambiguous/truncated display label.
+    pub number_entry: Option<String>,
+    /// Full-text inspector for long questions and selected option values.
+    pub inspecting: bool,
+    /// `false` inspects/copies the question; `true` the selected exact option.
+    pub inspect_option: bool,
+    pub inspect_scroll: u16,
+    /// Last maximum scroll measured by the renderer. Input handling clamps to
+    /// this value so a terminal resize cannot leave an unreachable raw offset.
+    pub inspect_max_scroll: Cell<u16>,
+    /// Last submission error, rendered in the modal until the next retry.
+    pub error: Option<String>,
+    /// Option rows recorded by the renderer for click hit-testing.
+    pub option_hitboxes: RefCell<Vec<QuestionOptionHitbox>>,
+    pub mouse_pressed_option: Option<usize>,
     /// An answer POST is in flight for this question: the modal renders a
     /// "Submitting answer…" state and `handle_question_key` swallows every
     /// key (preventing a double-submit on repeated Enter, and preventing the
@@ -338,26 +437,110 @@ pub struct ActiveQuestion {
     /// `AppEvent::AnswerSubmitted` lands. Cleared on failure so the operator
     /// can retry; on success the whole question is dropped.
     pub submitting: bool,
+    /// A legacy/external event omitted its durable tool-call identity. The
+    /// modal remains inspectable but cannot submit until `/pending` supplies
+    /// the exact CAS guard.
+    pub identity_syncing: bool,
 }
 
 impl ActiveQuestion {
     /// Build the modal state from a `GET .../pending` response. Mirrors the
     /// SSE `NeedClarification` handler: no preset options opens straight into
     /// free-text entry instead of an empty option list.
-    fn from_pending(pending: &PendingQuestion) -> Self {
+    fn from_pending(session_id: String, pending: &PendingQuestion, draft: String) -> Self {
         let options = pending.options.clone().unwrap_or_default();
-        let custom = if options.is_empty() {
-            Some(String::new())
+        let custom = if options.is_empty() && pending.allow_custom {
+            Some(draft.clone())
         } else {
             None
         };
         Self {
+            session_id,
+            tool_call_id: pending.tool_call_id.clone(),
+            tool_name: pending.tool_name.clone(),
+            source: pending.source.clone(),
             question: pending.question.clone(),
             options,
             selected: 0,
+            allow_custom: pending.allow_custom,
             custom,
+            custom_draft: draft,
+            number_entry: None,
+            inspecting: false,
+            inspect_option: false,
+            inspect_scroll: 0,
+            inspect_max_scroll: Cell::new(0),
+            error: None,
+            option_hitboxes: RefCell::new(Vec::new()),
+            mouse_pressed_option: None,
             submitting: false,
+            identity_syncing: pending.tool_call_id.is_none(),
         }
+    }
+
+    fn identity(&self) -> QuestionIdentity {
+        QuestionIdentity::new(
+            self.session_id.clone(),
+            self.tool_call_id.clone(),
+            self.question.clone(),
+        )
+    }
+
+    fn draft_key(&self) -> QuestionDraftKey {
+        QuestionDraftKey::new(
+            self.session_id.clone(),
+            self.tool_call_id.clone(),
+            self.question.clone(),
+            self.options.clone(),
+            self.allow_custom,
+        )
+    }
+
+    /// A legacy live event can omit the durable tool-call id while exposing
+    /// the rest of the exact question contract.  Let the authoritative
+    /// `/pending` snapshot fill in that one missing identity component in
+    /// place so an operator's custom draft survives the handshake.  Contract
+    /// mismatches still replace the modal instead of carrying input onto a
+    /// different question.
+    fn can_hydrate_identity_from(&self, incoming: &Self) -> bool {
+        self.tool_call_id.is_none()
+            && incoming.tool_call_id.is_some()
+            && self.session_id == incoming.session_id
+            && self.question == incoming.question
+            && self.options == incoming.options
+            && self.allow_custom == incoming.allow_custom
+    }
+
+    fn refresh_contract(&mut self, incoming: Self) {
+        let was_identity_syncing = self.identity_syncing;
+        self.tool_call_id = incoming.tool_call_id;
+        self.tool_name = incoming.tool_name;
+        self.source = incoming.source;
+        self.question = incoming.question;
+        self.options = incoming.options;
+        self.option_hitboxes.borrow_mut().clear();
+        self.mouse_pressed_option = None;
+        self.allow_custom = incoming.allow_custom;
+        self.identity_syncing = incoming.identity_syncing;
+        if was_identity_syncing && !self.identity_syncing {
+            self.error = None;
+        }
+        self.selected = self.selected.min(self.options.len().saturating_sub(1));
+        if self.options.is_empty() && self.inspect_option {
+            self.inspect_option = false;
+            self.inspect_scroll = 0;
+        }
+        if !self.allow_custom {
+            if let Some(draft) = self.custom.take() {
+                self.custom_draft = draft;
+            }
+        } else if self.options.is_empty() && self.custom.is_none() {
+            self.custom = Some(std::mem::take(&mut self.custom_draft));
+        }
+    }
+
+    fn draft(&self) -> &str {
+        self.custom.as_deref().unwrap_or(&self.custom_draft)
     }
 }
 
@@ -600,11 +783,48 @@ pub struct App {
     /// underneath it, so a late response for a superseded question is
     /// discarded instead of applied to the wrong question/session.
     answer_epoch: u64,
+    /// Tracked answer task so stopping, switching sessions, or superseding a
+    /// question cancels the network operation itself.  Ignoring only the late
+    /// result is insufficient: a task waiting for SSE readiness could still
+    /// POST after the UI already reported the run stopped.
+    answer_task: Option<tokio::task::JoinHandle<()>>,
+    /// Free-text drafts survive dismissal, session switches, and SSE replay,
+    /// keyed by the typed question identity rather than the active tab.
+    question_drafts: HashMap<QuestionDraftKey, String>,
+    /// Insertion/LRU order for the bounded draft cache. Drafts are useful
+    /// across session switches, but must not accumulate for the lifetime of a
+    /// long-running TUI process.
+    question_draft_order: VecDeque<QuestionDraftKey>,
+    /// Latest session whose async resume result is authoritative. An older
+    /// request finishing later must not switch the operator back.
+    opening_session_id: Option<String>,
     /// Sender into the main event loop, used to post results of background API
     /// calls (so those calls never block the UI thread). Set in [`run`].
     event_tx: Option<mpsc::UnboundedSender<AppEvent>>,
-    sse_tx: Option<mpsc::UnboundedSender<AgentEvent>>,
-    sse_rx: Option<mpsc::UnboundedReceiver<AgentEvent>>,
+    sse_tx: Option<mpsc::UnboundedSender<SessionSseEvent>>,
+    sse_rx: Option<mpsc::UnboundedReceiver<SessionSseEvent>>,
+    sse_task: Option<tokio::task::JoinHandle<()>>,
+    /// Monotonic identity for an attached SSE task. Control/data events from a
+    /// detached generation are ignored even if they were already queued when
+    /// a replacement stream was installed.
+    sse_epoch: u64,
+    /// Monotonic identity for pending-question reconciliation requests. One
+    /// SSE generation can reconnect more than once; a slower earlier GET must
+    /// never overwrite a newer authoritative snapshot for the same session
+    /// and answer epoch.
+    pending_reconcile_epoch: u64,
+    /// Handshake state for the current SSE generation. Pending answers wait
+    /// until this is true before POSTing because the server may resume the run
+    /// before the respond HTTP request returns.
+    sse_ready: Option<watch::Receiver<bool>>,
+    /// The agent may still be running but its event transport is unavailable.
+    /// Kept separate from `chat.streaming` so input stays blocked and partial
+    /// output remains intact while the operator can still request Stop.
+    pub stream_disconnected: bool,
+    /// A new execution generation was observed after the currently-submitting
+    /// clarification answer. Its Complete is a real terminal event even if the
+    /// respond HTTP result has not yet arrived to clear the local modal.
+    pending_answer_run_started: bool,
 }
 
 /// Move a list selection by `delta` (positive = down, negative = up),
@@ -616,6 +836,28 @@ fn scroll_selection(selected: usize, len: usize, delta: i32) -> usize {
     }
     let next = selected as i64 + delta as i64;
     next.clamp(0, (len - 1) as i64) as usize
+}
+
+fn question_option_at(question: &ActiveQuestion, column: u16, row: u16) -> Option<usize> {
+    if question.inspecting || question.custom.is_some() || question.number_entry.is_some() {
+        return None;
+    }
+    question
+        .option_hitboxes
+        .borrow()
+        .iter()
+        .find(|hitbox| hitbox.contains(column, row))
+        .map(|hitbox| hitbox.index)
+}
+
+/// Copy text through the terminal-standard OSC 52 clipboard sequence. The
+/// payload is base64 encoded, so arbitrary Unicode and line breaks remain
+/// exact and never terminate the control sequence early.
+fn copy_via_osc52(value: &str) -> std::io::Result<()> {
+    let encoded = BASE64_STANDARD.encode(value.as_bytes());
+    let mut stdout = std::io::stdout().lock();
+    write!(stdout, "\x1b]52;c;{encoded}\x07")?;
+    stdout.flush()
 }
 
 impl App {
@@ -646,9 +888,19 @@ impl App {
             notifications_visible: false,
             unseen_alerts: 0,
             answer_epoch: 0,
+            answer_task: None,
+            question_drafts: HashMap::new(),
+            question_draft_order: VecDeque::new(),
+            opening_session_id: None,
             event_tx: None,
             sse_tx: None,
             sse_rx: None,
+            sse_task: None,
+            sse_epoch: 0,
+            pending_reconcile_epoch: 0,
+            sse_ready: None,
+            stream_disconnected: false,
+            pending_answer_run_started: false,
         }
     }
 
@@ -747,7 +999,7 @@ impl App {
                     }
                 } => {
                     if let Some(event) = sse_event {
-                        if let Err(e) = self.handle_sse_event(event) {
+                        if let Err(e) = self.handle_session_sse_event(event) {
                             self.notify(NoticeLevel::Error, format!("SSE error: {e}"));
                         }
                     }
@@ -762,20 +1014,20 @@ impl App {
     }
 
     fn poll_sse(&mut self) {
-        let events: Vec<AgentEvent> = if let Some(rx) = &mut self.sse_rx {
+        let events: Vec<SessionSseEvent> = if let Some(rx) = &mut self.sse_rx {
             std::iter::from_fn(|| rx.try_recv().ok()).collect()
         } else {
             Vec::new()
         };
         for event in events {
-            if let Err(e) = self.handle_sse_event(event) {
+            if let Err(e) = self.handle_session_sse_event(event) {
                 self.notify(NoticeLevel::Error, format!("SSE error: {e}"));
             }
         }
     }
 
     async fn handle_event(&mut self, event: AppEvent) -> Result<()> {
-        if self.help_visible {
+        if self.help_visible && !self.any_modal_open() {
             if let AppEvent::Key(_) = &event {
                 self.help_visible = false;
                 return Ok(());
@@ -783,7 +1035,7 @@ impl App {
         }
 
         // The notification-log overlay is dismissed by any key.
-        if self.notifications_visible {
+        if self.notifications_visible && !self.any_modal_open() {
             if let AppEvent::Key(_) = &event {
                 self.notifications_visible = false;
                 return Ok(());
@@ -916,76 +1168,235 @@ impl App {
                 }
                 Err(e) => self.skills.error = Some(e),
             },
-            AppEvent::SessionOpened { session_id, result } => match result {
-                Ok(opened) => {
-                    // Reset every per-run scratch field `finalize_streaming`
-                    // would otherwise leave behind from whatever was open
-                    // before — a resumed session must not inherit stale
-                    // in-flight-turn state from a prior chat.
-                    self.chat.session_id = Some(session_id.clone());
-                    self.chat.model = opened.model;
-                    self.chat.project_id = opened.project_id;
-                    self.chat.current_response.clear();
-                    self.chat.current_tool_calls.clear();
-                    self.chat.current_reasoning.clear();
-                    self.chat.sub_agents.clear();
-                    self.chat.token_usage = None;
-                    self.chat.scroll_offset = 0;
-                    self.chat.streaming = false;
-                    self.supersede_pending_answer();
-                    self.pending_question = None;
-                    self.dismissed_question = None;
+            AppEvent::SessionOpened { session_id, result } => {
+                if self.opening_session_id.as_deref() != Some(session_id.as_str()) {
+                    return Ok(());
+                }
+                self.opening_session_id = None;
+                match result {
+                    Ok(opened) => {
+                        // Reset every per-run scratch field `finalize_streaming`
+                        // would otherwise leave behind from whatever was open
+                        // before — a resumed session must not inherit stale
+                        // in-flight-turn state from a prior chat.
+                        self.detach_stream();
+                        self.chat.session_id = Some(session_id.clone());
+                        self.chat.model = opened.model;
+                        self.chat.project_id = opened.project_id;
+                        self.chat.current_response.clear();
+                        self.chat.current_tool_calls.clear();
+                        self.chat.current_reasoning.clear();
+                        self.chat.sub_agents.clear();
+                        self.chat.token_usage = None;
+                        self.chat.scroll_offset = 0;
+                        self.chat.streaming = false;
+                        self.stream_disconnected = false;
+                        self.pending_answer_run_started = false;
+                        self.stash_question_drafts();
+                        self.supersede_pending_answer();
+                        self.pending_question = None;
+                        self.dismissed_question = None;
 
-                    let shown = opened.messages.len();
-                    self.chat.messages = opened.messages;
-                    self.chat.auto_scroll = true;
-                    self.tab = Tab::Chat;
-                    self.status_message = "Session resumed".to_string();
+                        let shown = opened.messages.len();
+                        self.chat.messages = opened.messages;
+                        self.chat.auto_scroll = true;
+                        self.tab = Tab::Chat;
+                        self.status_message = "Session resumed".to_string();
 
-                    if opened.truncated {
-                        self.notify(
-                            NoticeLevel::Info,
-                            format!(
-                                "Showing last {shown} of {} messages",
-                                opened.total_message_count
-                            ),
-                        );
+                        if opened.truncated {
+                            self.notify(
+                                NoticeLevel::Info,
+                                format!(
+                                    "Showing last {shown} of {} messages",
+                                    opened.total_message_count
+                                ),
+                            );
+                        }
+
+                        // A persisted question is an idle pause, but answering
+                        // it resumes execution inside the respond handler
+                        // before that HTTP response returns. Subscribe now so
+                        // even an immediate resumed Token/Complete is observed.
+                        if opened.is_running || opened.pending.is_some() {
+                            self.attach_stream(session_id.clone());
+                            self.chat.streaming = true;
+                            self.status_message = if opened.is_running {
+                                "Reattached — streaming".to_string()
+                            } else {
+                                "Reattached — waiting for answer".to_string()
+                            };
+                        }
+
+                        if let Some(pending) = &opened.pending {
+                            self.status_message =
+                                format!("Question: {} (answer in the dialog)", pending.question);
+                            let question = self.question_from_pending(session_id, pending);
+                            self.pending_question = Some(question);
+                        }
                     }
-
-                    if opened.is_running {
+                    Err(e) => {
+                        self.notify(NoticeLevel::Error, format!("Failed to open session: {e}"));
+                    }
+                }
+            }
+            AppEvent::PendingQuestionChecked {
+                session_id,
+                epoch,
+                result,
+            } => {
+                if epoch != self.answer_epoch
+                    || self.chat.session_id.as_deref() != Some(session_id.as_str())
+                {
+                    return Ok(());
+                }
+                match result {
+                    Ok(pending) if pending.has_pending_question => {
+                        self.stash_question_drafts();
+                        self.supersede_pending_answer();
+                        let question = self.question_from_pending(session_id.clone(), &pending);
+                        self.pending_question = Some(question);
+                        // Ctrl+Q may recover a server-side pause after the old
+                        // event stream was detached. Treat it as an active run
+                        // again so Ctrl+C routes to STOP (instead of quitting
+                        // the TUI), and subscribe before any answer can resume.
                         self.attach_stream(session_id);
                         self.chat.streaming = true;
-                        self.status_message = "Reattached — streaming".to_string();
+                        self.status_message = "Question reopened".to_string();
                     }
+                    Ok(_) => {
+                        self.notify(NoticeLevel::Info, "No pending question on the server");
+                    }
+                    Err(e) => {
+                        self.notify(
+                            NoticeLevel::Error,
+                            format!("Failed to check pending question: {e}"),
+                        );
+                    }
+                }
+            }
+            AppEvent::PendingQuestionReconciled {
+                session_id,
+                epoch,
+                reconcile_epoch,
+                result,
+            } => {
+                if epoch != self.answer_epoch
+                    || reconcile_epoch != self.pending_reconcile_epoch
+                    || self.chat.session_id.as_deref() != Some(session_id.as_str())
+                    || self
+                        .pending_question
+                        .as_ref()
+                        .is_some_and(|question| question.submitting)
+                {
+                    return Ok(());
+                }
+                match result {
+                    Ok(pending) if pending.has_pending_question => {
+                        let incoming = self.question_from_pending(session_id, &pending);
+                        if let Some(existing) = self.pending_question.as_mut() {
+                            if existing.identity() == incoming.identity()
+                                || existing.can_hydrate_identity_from(&incoming)
+                            {
+                                existing.refresh_contract(incoming);
+                                return Ok(());
+                            }
+                        } else if let Some(dismissed) = self.dismissed_question.as_mut() {
+                            if dismissed.identity() == incoming.identity()
+                                || dismissed.can_hydrate_identity_from(&incoming)
+                            {
+                                dismissed.refresh_contract(incoming);
+                                return Ok(());
+                            }
+                        }
 
-                    if let Some(pending) = &opened.pending {
+                        self.stash_question_drafts();
+                        self.supersede_pending_answer();
+                        self.dismissed_question = None;
+                        self.status_message = format!(
+                            "Question recovered after stream sync: {}",
+                            incoming.question
+                        );
+                        self.pending_question = Some(incoming);
+                    }
+                    Ok(_) => {
+                        if let Some(question) = self.pending_question.as_mut() {
+                            if question.identity_syncing {
+                                question.identity_syncing = false;
+                                question.error = Some(
+                                    "The server did not expose an exact response identity; this question cannot be answered from the TUI yet"
+                                        .to_string(),
+                                );
+                                self.status_message =
+                                    "Question identity unavailable — answer not sent".to_string();
+                                return Ok(());
+                            }
+                        }
+                        if self.pending_question.is_some() || self.dismissed_question.is_some() {
+                            self.stash_question_drafts();
+                            self.supersede_pending_answer();
+                            self.pending_question = None;
+                            self.dismissed_question = None;
+                            self.status_message =
+                                "Pending question cleared after stream sync".to_string();
+                        }
+                    }
+                    Err(error) => self.notify(
+                        NoticeLevel::Error,
+                        format!("Failed to reconcile question after SSE connect: {error}"),
+                    ),
+                }
+            }
+            AppEvent::PendingQuestionRefreshed {
+                session_id,
+                epoch,
+                identity,
+                result,
+            } => {
+                if epoch != self.answer_epoch
+                    || self.chat.session_id.as_deref() != Some(session_id.as_str())
+                    || self
+                        .pending_question
+                        .as_ref()
+                        .is_none_or(|question| question.identity() != identity)
+                {
+                    return Ok(());
+                }
+                match result {
+                    Ok(pending) if pending.has_pending_question => {
+                        self.stash_question_drafts();
+                        self.supersede_pending_answer();
+                        let question = self.question_from_pending(session_id, &pending);
+                        self.pending_question = Some(question);
                         self.status_message =
-                            format!("Question: {} (answer in the dialog)", pending.question);
-                        self.pending_question = Some(ActiveQuestion::from_pending(pending));
+                            "Question refreshed after rejected answer".to_string();
+                    }
+                    Ok(_) => {
+                        self.remove_question_drafts_for_identity(&identity);
+                        self.supersede_pending_answer();
+                        self.pending_question = None;
+                        self.dismissed_question = None;
+                        self.status_message = "Question was already answered".to_string();
+                        self.notify(
+                            NoticeLevel::Info,
+                            "The pending question no longer exists on the server",
+                        );
+                    }
+                    Err(error) => {
+                        if let Some(question) = self.pending_question.as_mut() {
+                            question.submitting = false;
+                            question.error =
+                                Some(format!("Could not refresh after rejection: {error}"));
+                        }
+                        self.notify(
+                            NoticeLevel::Error,
+                            format!("Failed to refresh pending question: {error}"),
+                        );
                     }
                 }
-                Err(e) => {
-                    self.notify(NoticeLevel::Error, format!("Failed to open session: {e}"));
-                }
-            },
-            AppEvent::PendingQuestionChecked(r) => match r {
-                Ok(pending) if pending.has_pending_question => {
-                    self.supersede_pending_answer();
-                    self.pending_question = Some(ActiveQuestion::from_pending(&pending));
-                    self.status_message = "Question reopened".to_string();
-                }
-                Ok(_) => {
-                    self.notify(NoticeLevel::Info, "No pending question on the server");
-                }
-                Err(e) => {
-                    self.notify(
-                        NoticeLevel::Error,
-                        format!("Failed to check pending question: {e}"),
-                    );
-                }
-            },
+            }
             AppEvent::AnswerSubmitted {
                 epoch,
+                identity,
                 answer,
                 result,
             } => {
@@ -996,34 +1407,64 @@ impl App {
                 // discarded outright: applying it would clear or resume state
                 // that belongs to a different question than the one this
                 // answer was for.
-                if epoch != self.answer_epoch {
+                if epoch != self.answer_epoch
+                    || self
+                        .pending_question
+                        .as_ref()
+                        .is_none_or(|question| question.identity() != identity)
+                {
                     return Ok(());
                 }
+                self.answer_task.take();
                 match result {
                     Ok(status) => {
+                        self.remove_question_drafts_for_identity(&identity);
                         self.pending_question = None;
+                        if self
+                            .dismissed_question
+                            .as_ref()
+                            .is_some_and(|question| question.identity() == identity)
+                        {
+                            self.dismissed_question = None;
+                        }
                         // Only keep the spinner on if a run is actually
                         // running: the server returns 200 even when it did
                         // NOT resume (e.g. the session already `completed`),
-                        // so a blind `streaming = true` would spin forever
-                        // with no events behind it. No SSE reattach here —
-                        // the stream opened for the run stays attached across
-                        // the question, exactly as before.
+                        // so a blind `streaming = true` would spin forever.
+                        // Normally the original stream stays attached across
+                        // the question. If transport retries gave up while it
+                        // was open, a successful POST proves the server is
+                        // reachable again, so reattach before waiting for the
+                        // resumed run's events.
                         if matches!(status.as_str(), "started" | "already_running") {
+                            if !self.stream_is_ready() {
+                                self.attach_stream(identity.session_id.clone());
+                            }
                             self.status_message = format!("Answered: {answer} — resuming");
                             self.chat.streaming = true;
                         } else {
-                            self.status_message = format!("Answered: {answer} ({status})");
                             self.finalize_streaming();
+                            self.status_message = format!("Answered: {answer} ({status})");
                         }
                     }
-                    Err(e) => {
-                        // Keep the modal open — with input re-enabled — so
-                        // the operator can pick a valid option or retry.
+                    Err(error) if error.should_refresh_question() => {
+                        let message = error.to_string();
+                        self.notify(
+                            NoticeLevel::Warn,
+                            format!("Answer rejected; refreshing question state: {message}"),
+                        );
+                        self.refresh_question_after_rejection(identity, message);
+                    }
+                    Err(error) => {
+                        let message = error.to_string();
+                        // Transport/server failures do not prove the question
+                        // changed. Keep the modal open with input enabled so
+                        // the operator can retry the exact submission.
                         if let Some(q) = self.pending_question.as_mut() {
                             q.submitting = false;
+                            q.error = Some(message.clone());
                         }
-                        self.notify(NoticeLevel::Error, format!("Answer rejected: {e}"));
+                        self.notify(NoticeLevel::Error, format!("Answer rejected: {message}"));
                     }
                 }
             }
@@ -1090,7 +1531,66 @@ impl App {
     /// selection instead (3 rows per notch, clamped) rather than being a
     /// dead input.
     fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
-        use crossterm::event::MouseEventKind;
+        use crossterm::event::{MouseButton, MouseEventKind};
+        if self.pending_question.is_some() {
+            let mut submit = None;
+            {
+                let question = self.pending_question.as_mut().unwrap();
+                if question.submitting {
+                    return;
+                }
+                match mouse.kind {
+                    MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+                        let delta: i32 = if matches!(mouse.kind, MouseEventKind::ScrollUp) {
+                            -3
+                        } else {
+                            3
+                        };
+                        if question.inspecting {
+                            let max_scroll = question.inspect_max_scroll.get();
+                            let current = question.inspect_scroll.min(max_scroll);
+                            if delta < 0 {
+                                question.inspect_scroll =
+                                    current.saturating_sub(delta.unsigned_abs() as u16);
+                            } else {
+                                question.inspect_scroll =
+                                    current.saturating_add(delta as u16).min(max_scroll);
+                            }
+                        } else if question.custom.is_none() && !question.options.is_empty() {
+                            question.selected =
+                                scroll_selection(question.selected, question.options.len(), delta);
+                            question.error = None;
+                        }
+                    }
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        question.mouse_pressed_option =
+                            question_option_at(question, mouse.column, mouse.row);
+                    }
+                    MouseEventKind::Up(MouseButton::Left) => {
+                        let pressed = question.mouse_pressed_option.take();
+                        if let Some(index) = question_option_at(question, mouse.column, mouse.row)
+                            .filter(|index| Some(*index) == pressed)
+                        {
+                            // Commit the selection only on release. Updating it
+                            // on mouse-down recenters a long option window on
+                            // the next redraw and moves the hitboxes before the
+                            // matching mouse-up arrives.
+                            question.selected = index;
+                            question.error = None;
+                            submit = question.options.get(index).cloned();
+                        }
+                    }
+                    _ => {
+                        question.mouse_pressed_option = None;
+                    }
+                }
+            }
+            if let Some(answer) = submit {
+                self.submit_answer(answer);
+            }
+            return;
+        }
+
         let delta: i32 = match mouse.kind {
             MouseEventKind::ScrollUp => -3,
             MouseEventKind::ScrollDown => 3,
@@ -1192,8 +1692,8 @@ impl App {
 
     /// Route one key event.
     ///
-    /// Modal precedence (checked top to bottom, each returning early — so at
-    /// most one modal ever owns the keyboard, and every one of them runs
+    /// Modal precedence (checked top to bottom, each returning early — so
+    /// exactly one visible modal owns the keyboard, and every one of them runs
     /// before the global bindings further down: Ctrl+N/Ctrl+O/Ctrl+Q, `?`,
     /// digit tab-switching, Tab/Shift+Tab):
     ///   0. `serve_offer`      — startup-only "start a local server?" offer
@@ -1202,6 +1702,10 @@ impl App {
     ///   3. `model_picker`     — Ctrl+O provider-catalog picker
     ///   4. `schedule_form`    — new-schedule authoring form
     ///   5. `config_editor`    — raw config JSON editor
+    ///
+    /// Runtime modals can coexist in state because a clarification arrives
+    /// asynchronously. The renderer layers them in the reverse order below,
+    /// keeping this keyboard owner visible without discarding editor drafts.
     ///
     /// `serve_offer` can never actually coexist with 1-5 in practice — `run`
     /// sets it (if at all) before the main loop starts driving any of the
@@ -1506,7 +2010,9 @@ impl App {
         enum QAction {
             None,
             Dismiss,
+            CloseCustom,
             Submit(String),
+            Copy(String),
         }
 
         let action = {
@@ -1520,15 +2026,101 @@ impl App {
                 // request (Ctrl+C at the top of `handle_key` still preempts).
                 return Ok(());
             }
-            if let Some(buf) = q.custom.as_mut() {
+
+            if q.inspecting {
+                match key.code {
+                    KeyCode::Char('v') | KeyCode::Esc => {
+                        q.inspecting = false;
+                        q.inspect_scroll = 0;
+                        QAction::None
+                    }
+                    KeyCode::Tab if !q.options.is_empty() => {
+                        q.inspect_option = !q.inspect_option;
+                        q.inspect_scroll = 0;
+                        QAction::None
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        q.inspect_scroll = q
+                            .inspect_scroll
+                            .min(q.inspect_max_scroll.get())
+                            .saturating_sub(1);
+                        QAction::None
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        q.inspect_scroll = q
+                            .inspect_scroll
+                            .min(q.inspect_max_scroll.get())
+                            .saturating_add(1)
+                            .min(q.inspect_max_scroll.get());
+                        QAction::None
+                    }
+                    KeyCode::PageUp => {
+                        q.inspect_scroll = q
+                            .inspect_scroll
+                            .min(q.inspect_max_scroll.get())
+                            .saturating_sub(5);
+                        QAction::None
+                    }
+                    KeyCode::PageDown => {
+                        q.inspect_scroll = q
+                            .inspect_scroll
+                            .min(q.inspect_max_scroll.get())
+                            .saturating_add(5)
+                            .min(q.inspect_max_scroll.get());
+                        QAction::None
+                    }
+                    KeyCode::Home => {
+                        q.inspect_scroll = 0;
+                        QAction::None
+                    }
+                    KeyCode::Char('y') => {
+                        let value = if q.inspect_option {
+                            q.options.get(q.selected).cloned().unwrap_or_default()
+                        } else {
+                            q.question.clone()
+                        };
+                        QAction::Copy(value)
+                    }
+                    _ => QAction::None,
+                }
+            } else if let Some(entry) = q.number_entry.as_mut() {
+                match key.code {
+                    KeyCode::Char(d) if d.is_ascii_digit() => {
+                        entry.push(d);
+                        QAction::None
+                    }
+                    KeyCode::Backspace => {
+                        entry.pop();
+                        QAction::None
+                    }
+                    KeyCode::Esc => {
+                        q.number_entry = None;
+                        QAction::None
+                    }
+                    KeyCode::Enter => {
+                        let requested = entry.parse::<usize>().ok();
+                        q.number_entry = None;
+                        match requested.and_then(|number| number.checked_sub(1)) {
+                            Some(index) if index < q.options.len() => {
+                                q.selected = index;
+                                q.error = None;
+                            }
+                            _ => {
+                                q.error = Some("That option number does not exist".to_string());
+                            }
+                        }
+                        QAction::None
+                    }
+                    _ => QAction::None,
+                }
+            } else if let Some(buf) = q.custom.as_mut() {
                 // Free-text entry mode.
                 match key.code {
                     KeyCode::Enter => {
-                        let answer = buf.trim().to_string();
-                        if answer.is_empty() {
+                        if buf.trim().is_empty() {
                             QAction::None
                         } else {
-                            QAction::Submit(answer)
+                            QAction::Submit(buf.clone())
                         }
                     }
                     KeyCode::Esc => {
@@ -1536,16 +2128,23 @@ impl App {
                         if q.options.is_empty() {
                             QAction::Dismiss
                         } else {
-                            q.custom = None;
-                            QAction::None
+                            QAction::CloseCustom
                         }
                     }
                     KeyCode::Backspace => {
                         buf.pop();
+                        q.error = None;
+                        QAction::None
+                    }
+                    KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        q.inspecting = true;
+                        q.inspect_option = false;
+                        q.inspect_scroll = 0;
                         QAction::None
                     }
                     KeyCode::Char(c) => {
                         buf.push(c);
+                        q.error = None;
                         QAction::None
                     }
                     _ => QAction::None,
@@ -1555,18 +2154,64 @@ impl App {
                 match key.code {
                     KeyCode::Up | KeyCode::Char('k') => {
                         q.selected = q.selected.saturating_sub(1);
+                        q.error = None;
                         QAction::None
                     }
                     KeyCode::Down | KeyCode::Char('j') => {
                         if q.selected + 1 < q.options.len() {
                             q.selected += 1;
                         }
+                        q.error = None;
                         QAction::None
                     }
-                    KeyCode::Char('c') => {
-                        // Switch to free-text entry (for allow-custom questions).
-                        q.custom = Some(String::new());
+                    KeyCode::PageUp => {
+                        q.selected = q.selected.saturating_sub(5);
+                        q.error = None;
                         QAction::None
+                    }
+                    KeyCode::PageDown => {
+                        q.selected = q
+                            .selected
+                            .saturating_add(5)
+                            .min(q.options.len().saturating_sub(1));
+                        q.error = None;
+                        QAction::None
+                    }
+                    KeyCode::Home => {
+                        q.selected = 0;
+                        q.error = None;
+                        QAction::None
+                    }
+                    KeyCode::End => {
+                        q.selected = q.options.len().saturating_sub(1);
+                        q.error = None;
+                        QAction::None
+                    }
+                    KeyCode::Char('c') if q.allow_custom => {
+                        // Switch to free-text entry without discarding a draft
+                        // entered before dismissal/session switching.
+                        q.custom = Some(std::mem::take(&mut q.custom_draft));
+                        q.error = None;
+                        QAction::None
+                    }
+                    KeyCode::Char('g') if !q.options.is_empty() => {
+                        q.number_entry = Some(String::new());
+                        q.error = None;
+                        QAction::None
+                    }
+                    KeyCode::Char('v') => {
+                        q.inspecting = true;
+                        q.inspect_option = false;
+                        q.inspect_scroll = 0;
+                        QAction::None
+                    }
+                    KeyCode::Char('y') => {
+                        let value = q
+                            .options
+                            .get(q.selected)
+                            .cloned()
+                            .unwrap_or_else(|| q.question.clone());
+                        QAction::Copy(value)
                     }
                     KeyCode::Enter => q
                         .options
@@ -1590,6 +2235,17 @@ impl App {
 
         match action {
             QAction::Submit(answer) => self.submit_answer(answer),
+            QAction::CloseCustom => {
+                if let Some(question) = self.pending_question.as_mut() {
+                    question.custom_draft = question.custom.take().unwrap_or_default();
+                }
+            }
+            QAction::Copy(value) => match copy_via_osc52(&value) {
+                Ok(()) => self.status_message = "Copied exact text".to_string(),
+                Err(error) => {
+                    self.notify(NoticeLevel::Error, format!("Failed to copy text: {error}"))
+                }
+            },
             QAction::Dismiss => {
                 // Keep it, not just drop it: dismissing does NOT tell the
                 // server to stop waiting, so the run is still blocked on an
@@ -1605,6 +2261,84 @@ impl App {
         Ok(())
     }
 
+    fn stash_question_drafts(&mut self) {
+        let drafts = [
+            self.pending_question.as_ref(),
+            self.dismissed_question.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|question| question.allow_custom)
+        .map(|question| (question.draft_key(), question.draft().to_string()))
+        .collect::<Vec<_>>();
+        for (key, draft) in drafts {
+            self.store_question_draft(key, draft);
+        }
+    }
+
+    fn store_question_draft(&mut self, key: QuestionDraftKey, draft: String) {
+        self.question_draft_order
+            .retain(|existing| existing != &key);
+        if draft.is_empty() {
+            self.question_drafts.remove(&key);
+            return;
+        }
+
+        self.question_drafts.insert(key.clone(), draft);
+        self.question_draft_order.push_back(key);
+        while self.question_draft_order.len() > MAX_QUESTION_DRAFTS {
+            if let Some(oldest) = self.question_draft_order.pop_front() {
+                self.question_drafts.remove(&oldest);
+            }
+        }
+    }
+
+    fn take_question_draft(&mut self, key: &QuestionDraftKey) -> Option<String> {
+        let draft = self.question_drafts.remove(key);
+        if draft.is_some() {
+            self.question_draft_order.retain(|existing| existing != key);
+        }
+        draft
+    }
+
+    fn remove_question_drafts_for_identity(&mut self, identity: &QuestionIdentity) {
+        self.question_drafts
+            .retain(|key, _| &key.identity != identity);
+        self.question_draft_order
+            .retain(|key| &key.identity != identity);
+    }
+
+    fn question_from_pending(
+        &mut self,
+        session_id: String,
+        pending: &PendingQuestion,
+    ) -> ActiveQuestion {
+        let exact_key = QuestionDraftKey::new(
+            session_id.clone(),
+            pending.tool_call_id.clone(),
+            pending.question.clone(),
+            pending.options.clone().unwrap_or_default(),
+            pending.allow_custom,
+        );
+        let draft = if pending.allow_custom {
+            self.take_question_draft(&exact_key).or_else(|| {
+                pending.tool_call_id.as_ref()?;
+                let legacy_key = QuestionDraftKey::new(
+                    session_id.clone(),
+                    None,
+                    pending.question.clone(),
+                    pending.options.clone().unwrap_or_default(),
+                    pending.allow_custom,
+                );
+                self.take_question_draft(&legacy_key)
+            })
+        } else {
+            None
+        }
+        .unwrap_or_default();
+        ActiveQuestion::from_pending(session_id, pending, draft)
+    }
+
     /// Invalidate any in-flight answer POST by bumping `answer_epoch`. Called
     /// from every site that changes the pending-question context (a new
     /// question arriving, a session switch/resume, the run finalizing, the
@@ -1612,7 +2346,11 @@ impl App {
     /// `AppEvent::AnswerSubmitted` carrying an older epoch is discarded in
     /// `handle_event` instead of applied to a question it doesn't belong to.
     fn supersede_pending_answer(&mut self) {
+        if let Some(task) = self.answer_task.take() {
+            task.abort();
+        }
         self.answer_epoch = self.answer_epoch.wrapping_add(1);
+        self.pending_answer_run_started = false;
     }
 
     /// Submit an answer to the agent's pending question WITHOUT blocking the
@@ -1622,10 +2360,44 @@ impl App {
     /// `AppEvent::AnswerSubmitted`. Until then the modal stays open in a
     /// "Submitting answer…" state with input disabled.
     fn submit_answer(&mut self, answer: String) {
-        let Some(session_id) = self.chat.session_id.clone() else {
-            self.notify(NoticeLevel::Warn, "No active chat session to answer");
-            self.supersede_pending_answer();
-            self.pending_question = None;
+        let Some(identity) = self.pending_question.as_ref().map(ActiveQuestion::identity) else {
+            return;
+        };
+        if self.chat.session_id.as_deref() != Some(identity.session_id.as_str()) {
+            self.notify(
+                NoticeLevel::Warn,
+                "Question belongs to a different session; reopen that session before answering",
+            );
+            return;
+        }
+        if identity.tool_call_id.is_none() {
+            if let Some(question) = self.pending_question.as_mut() {
+                question.identity_syncing = true;
+                question.error = Some(
+                    "Waiting for the server's exact question identity; answer not sent".to_string(),
+                );
+            }
+            self.status_message = "Synchronizing question identity...".to_string();
+            self.reconcile_pending_question_after_stream_connect(identity.session_id);
+            return;
+        }
+        // The old pause activation can have queued its terminal Complete while
+        // its SSE task/readiness flag still looks live. Reusing that generation
+        // creates a gap: the server closes it at Complete and a fast successor
+        // run can finish before the UI processes Complete and reconnects.
+        // Always install and await a fresh subscriber generation before POSTing
+        // the answer; attaching also discards any queued terminal from the old
+        // pause stream.
+        if !self.attach_stream(identity.session_id.clone()) {
+            if let Some(question) = self.pending_question.as_mut() {
+                question.error = Some("Could not attach the event stream; answer not sent".into());
+            }
+            return;
+        }
+        let Some(mut sse_ready) = self.sse_ready.clone() else {
+            if let Some(question) = self.pending_question.as_mut() {
+                question.error = Some("Event stream is unavailable; answer not sent".into());
+            }
             return;
         };
         let Some(tx) = self.event_tx.clone() else {
@@ -1640,6 +2412,8 @@ impl App {
             return;
         }
         q.submitting = true;
+        q.error = None;
+        self.pending_answer_run_started = false;
 
         // Claim a fresh epoch for this submission; the spawned task carries a
         // copy so the handler can tell whether the response still belongs to
@@ -1649,14 +2423,71 @@ impl App {
         self.status_message = format!("Submitting answer: {answer}…");
 
         let client = self.client.clone();
-        tokio::spawn(async move {
-            let result = client
-                .respond(&session_id, &answer)
+        let session_id = identity.session_id.clone();
+        let expected_tool_call_id = identity.tool_call_id.clone();
+        let submitted_identity = identity.clone();
+        self.answer_task = Some(tokio::spawn(async move {
+            let stream_ready = if *sse_ready.borrow() {
+                Ok(())
+            } else {
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(15),
+                    sse_ready.wait_for(|ready| *ready),
+                )
                 .await
-                .map_err(|e| e.to_string());
+                .map_err(|_| "timed out waiting for the event stream".to_string())
+                .and_then(|result| {
+                    result
+                        .map(|_| ())
+                        .map_err(|_| "event stream closed before subscribing".to_string())
+                })
+            };
+            let result = match stream_ready {
+                Ok(()) => {
+                    client
+                        .respond(&session_id, &answer, expected_tool_call_id.as_deref())
+                        .await
+                }
+                Err(message) => Err(RespondFailure::unavailable(format!(
+                    "Answer not sent: {message}"
+                ))),
+            };
             let _ = tx.send(AppEvent::AnswerSubmitted {
                 epoch,
+                identity: submitted_identity,
                 answer,
+                result,
+            });
+        }));
+    }
+
+    fn refresh_question_after_rejection(&mut self, identity: QuestionIdentity, error: String) {
+        let Some(tx) = self.event_tx.clone() else {
+            if let Some(question) = self.pending_question.as_mut() {
+                question.submitting = false;
+                question.error = Some(error);
+            }
+            return;
+        };
+        if let Some(question) = self.pending_question.as_mut() {
+            // Keep input disabled until the authoritative pending state is
+            // known; retrying during reconciliation could repeat the same
+            // stale submission.
+            question.error = Some(format!("{error}; refreshing from server..."));
+        }
+        self.supersede_pending_answer();
+        let epoch = self.answer_epoch;
+        let session_id = identity.session_id.clone();
+        let client = self.client.clone();
+        tokio::spawn(async move {
+            let result = client
+                .get_pending_question(&session_id)
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::PendingQuestionRefreshed {
+                session_id,
+                epoch,
+                identity,
                 result,
             });
         });
@@ -1870,20 +2701,49 @@ impl App {
     /// `poll_sse`/`run`'s select loop starts receiving events. Shared by a
     /// freshly-started run (`start_stream_and_execute`, before `execute` so no
     /// early event is missed) and reattaching to an already-running session on
-    /// resume (`AppEvent::SessionOpened` with `is_running: true`) — in both
-    /// cases the server replays cached critical events then live-tails, so
-    /// connecting mid-flight doesn't lose anything. Returns whether the
-    /// connection was opened; on failure it has already `notify`'d.
+    /// resume (`AppEvent::SessionOpened` with `is_running: true`). Successful
+    /// retries also trigger an authoritative pending-question reconciliation,
+    /// because that state is not part of the server's critical-event replay.
+    /// Returns whether the connection was opened; on failure it has already
+    /// `notify`'d.
     fn attach_stream(&mut self, session_id: String) -> bool {
+        self.detach_stream();
+        let stream_epoch = self.sse_epoch;
         let (sse_tx, sse_rx) = mpsc::unbounded_channel();
         self.sse_tx = Some(sse_tx.clone());
         self.sse_rx = Some(sse_rx);
+        self.stream_disconnected = true;
         let base_url = self.client.base_url.clone();
-        if let Err(e) = SseStream::start(&base_url, &session_id, sse_tx) {
-            self.notify(NoticeLevel::Error, format!("SSE start failed: {e}"));
-            return false;
+        match SseStream::start(&base_url, &session_id, stream_epoch, sse_tx) {
+            Ok((task, ready)) => {
+                self.sse_task = Some(task);
+                self.sse_ready = Some(ready);
+            }
+            Err(error) => {
+                self.detach_stream();
+                self.notify(NoticeLevel::Error, format!("SSE start failed: {error}"));
+                return false;
+            }
         }
         true
+    }
+
+    fn stream_is_ready(&self) -> bool {
+        self.sse_task
+            .as_ref()
+            .is_some_and(|task| !task.is_finished())
+            && self.sse_ready.as_ref().is_some_and(|ready| *ready.borrow())
+    }
+
+    fn detach_stream(&mut self) {
+        self.sse_epoch = self.sse_epoch.wrapping_add(1);
+        self.pending_reconcile_epoch = self.pending_reconcile_epoch.wrapping_add(1);
+        if let Some(task) = self.sse_task.take() {
+            task.abort();
+        }
+        self.sse_ready = None;
+        self.sse_tx = None;
+        self.sse_rx = None;
     }
 
     /// After `chat` returns a session id, open the SSE stream (before execute, so
@@ -1892,6 +2752,13 @@ impl App {
         if !self.attach_stream(session_id.clone()) {
             return;
         }
+        let Some(mut sse_ready) = self.sse_ready.clone() else {
+            self.notify(
+                NoticeLevel::Error,
+                "SSE readiness channel unavailable; run was not started",
+            );
+            return;
+        };
         let Some(tx) = self.event_tx.clone() else {
             return;
         };
@@ -1899,6 +2766,27 @@ impl App {
         let model = self.chat.model.clone();
         tokio::spawn(async move {
             let model = if model.is_empty() { None } else { Some(model) };
+            let ready = if *sse_ready.borrow() {
+                Ok(())
+            } else {
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(15),
+                    sse_ready.wait_for(|ready| *ready),
+                )
+                .await
+                .map_err(|_| "timed out waiting for the event stream".to_string())
+                .and_then(|result| {
+                    result
+                        .map(|_| ())
+                        .map_err(|_| "event stream closed before subscribing".to_string())
+                })
+            };
+            if let Err(error) = ready {
+                let _ = tx.send(AppEvent::ExecuteFailed(format!(
+                    "execute not started: {error}"
+                )));
+                return;
+            }
             // If this POST fails (server down, 4xx/5xx), no SSE terminal event
             // will ever arrive for a run that never started — report it back so
             // the handler can finalize `chat.streaming` instead of spinning
@@ -1918,6 +2806,7 @@ impl App {
         let Some(tx) = self.event_tx.clone() else {
             return;
         };
+        self.opening_session_id = Some(session_id.clone());
         let client = self.client.clone();
         self.status_message = "Resuming session...".to_string();
         tokio::spawn(async move {
@@ -1942,15 +2831,23 @@ impl App {
                 }
             };
             // Only fetch the pending question when the summary says there is
-            // one — saves a round-trip for the common case, and a failure
-            // here is non-fatal: the session still opens, just without the
-            // modal pre-populated (Ctrl+Q can fetch it again).
+            // one. A detail-fetch failure is fatal to this open attempt: the
+            // summary is authoritative that input must remain blocked, so
+            // opening without the modal would silently expose an unusable
+            // chat composer and lose the discoverable retry path.
             let pending = if summary.has_pending_question {
-                client
-                    .get_pending_question(&session_id)
-                    .await
-                    .ok()
-                    .filter(|p| p.has_pending_question)
+                match client.get_pending_question(&session_id).await {
+                    Ok(pending) => pending.has_pending_question.then_some(pending),
+                    Err(error) => {
+                        let _ = tx.send(AppEvent::SessionOpened {
+                            session_id,
+                            result: Err(format!(
+                                "session has a pending question, but its details could not be loaded: {error}"
+                            )),
+                        });
+                        return;
+                    }
+                }
             } else {
                 None
             };
@@ -1974,6 +2871,9 @@ impl App {
     /// membership (the operator picked both deliberately) while dropping
     /// per-session conversation state.
     fn new_session(&mut self) {
+        self.stash_question_drafts();
+        self.detach_stream();
+        self.opening_session_id = None;
         self.chat.session_id = None;
         self.chat.messages.clear();
         self.chat.current_response.clear();
@@ -2010,6 +2910,8 @@ impl App {
         let Some(tx) = self.event_tx.clone() else {
             return;
         };
+        self.supersede_pending_answer();
+        let epoch = self.answer_epoch;
         let client = self.client.clone();
         self.status_message = "Checking for a pending question...".to_string();
         tokio::spawn(async move {
@@ -2017,7 +2919,36 @@ impl App {
                 .get_pending_question(&session_id)
                 .await
                 .map_err(|e| e.to_string());
-            let _ = tx.send(AppEvent::PendingQuestionChecked(r));
+            let _ = tx.send(AppEvent::PendingQuestionChecked {
+                session_id,
+                epoch,
+                result: r,
+            });
+        });
+    }
+
+    fn reconcile_pending_question_after_stream_connect(&mut self, session_id: String) {
+        if self.chat.session_id.as_deref() != Some(session_id.as_str()) {
+            return;
+        }
+        let Some(tx) = self.event_tx.clone() else {
+            return;
+        };
+        let epoch = self.answer_epoch;
+        self.pending_reconcile_epoch = self.pending_reconcile_epoch.wrapping_add(1);
+        let reconcile_epoch = self.pending_reconcile_epoch;
+        let client = self.client.clone();
+        tokio::spawn(async move {
+            let result = client
+                .get_pending_question(&session_id)
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::PendingQuestionReconciled {
+                session_id,
+                epoch,
+                reconcile_epoch,
+                result,
+            });
         });
     }
 
@@ -2033,6 +2964,74 @@ impl App {
             .find(|t| t.id == tool_call_id)
     }
 
+    fn handle_session_sse_event(&mut self, message: SessionSseEvent) -> Result<()> {
+        match message {
+            SessionSseEvent::Event {
+                session_id,
+                stream_epoch,
+                event,
+            } => {
+                if self.chat.session_id.as_deref() != Some(session_id.as_str())
+                    || self.sse_epoch != stream_epoch
+                {
+                    return Ok(());
+                }
+                self.handle_sse_event(event)
+            }
+            SessionSseEvent::Connected {
+                session_id,
+                stream_epoch,
+                reconnecting,
+            } => {
+                if self.chat.session_id.as_deref() != Some(session_id.as_str())
+                    || self.sse_epoch != stream_epoch
+                {
+                    return Ok(());
+                }
+                self.connected = true;
+                self.stream_disconnected = false;
+                if reconnecting {
+                    self.status_message = "SSE reconnected — synchronizing".to_string();
+                }
+                // Answer submission deliberately attaches a fresh stream
+                // before POST. Its watch readiness can wake the POST task
+                // before this Connected control message reaches the UI loop;
+                // a pending GET issued here could then observe the consumed
+                // question as `none` and invalidate the still-pending
+                // AnswerSubmitted result. The answer outcome owns
+                // reconciliation while the modal is submitting.
+                if self
+                    .pending_question
+                    .as_ref()
+                    .is_none_or(|question| !question.submitting)
+                {
+                    self.reconcile_pending_question_after_stream_connect(session_id);
+                }
+                Ok(())
+            }
+            SessionSseEvent::TransportFailed {
+                session_id,
+                stream_epoch,
+                message,
+            } => {
+                if self.chat.session_id.as_deref() != Some(session_id.as_str())
+                    || self.sse_epoch != stream_epoch
+                {
+                    return Ok(());
+                }
+                // Transport failure is not an AgentEvent::Error: the server
+                // may still be waiting on the visible question. Detach the
+                // exhausted stream but preserve modal/dismissed state, draft,
+                // identity, and answer epoch for a safe retry.
+                self.detach_stream();
+                self.connected = false;
+                self.stream_disconnected = true;
+                self.notify(NoticeLevel::Error, format!("SSE disconnected: {message}"));
+                Ok(())
+            }
+        }
+    }
+
     fn handle_sse_event(&mut self, event: AgentEvent) -> Result<()> {
         if self.chat.auto_scroll {
             // Any incoming event means new content; auto_scroll will reposition.
@@ -2041,6 +3040,16 @@ impl App {
             AgentEvent::Token { content } => {
                 self.chat.current_response.push_str(&content);
                 self.chat.auto_scroll = true;
+            }
+            AgentEvent::ExecutionStarted { .. } => {
+                if self
+                    .pending_question
+                    .as_ref()
+                    .is_some_and(|question| question.submitting)
+                {
+                    self.pending_answer_run_started = true;
+                }
+                self.stream_disconnected = false;
             }
             AgentEvent::ReasoningToken { content } => {
                 self.chat.current_reasoning.push_str(&content);
@@ -2128,31 +3137,83 @@ impl App {
                 // Complete/Error's definitive terminal result).
             }
             AgentEvent::NeedClarification {
-                question, options, ..
+                question,
+                options,
+                tool_call_id,
+                tool_name,
+                allow_custom,
+                source,
             } => {
-                let options = options.unwrap_or_default();
-                // No preset options ⇒ open straight into free-text entry.
-                let custom = if options.is_empty() {
-                    Some(String::new())
-                } else {
-                    None
+                let Some(session_id) = self.chat.session_id.clone() else {
+                    self.notify(
+                        NoticeLevel::Warn,
+                        "Ignored clarification without an active session",
+                    );
+                    return Ok(());
                 };
-                self.status_message = format!("Question: {} (answer in the dialog)", question);
-                // A new question supersedes any answer still in flight for a
-                // previous one — a late response must not clear this modal.
-                self.supersede_pending_answer();
-                self.pending_question = Some(ActiveQuestion {
+                let pending = PendingQuestion {
+                    has_pending_question: true,
                     question,
                     options,
-                    selected: 0,
-                    custom,
-                    submitting: false,
-                });
+                    allow_custom,
+                    tool_call_id,
+                    tool_name,
+                    source,
+                };
+                let incoming = self.question_from_pending(session_id, &pending);
+                let needs_identity_sync = incoming.tool_call_id.is_none();
+                if let Some(existing) = self.pending_question.as_mut() {
+                    if existing.identity() == incoming.identity() {
+                        // Critical-event replay/reconnect may deliver the same
+                        // question again. Refresh its contract without resetting
+                        // selection, draft, inspector, error, or in-flight state.
+                        existing.refresh_contract(incoming);
+                        if needs_identity_sync {
+                            self.status_message = "Synchronizing question identity...".to_string();
+                            if let Some(session_id) = self.chat.session_id.clone() {
+                                self.reconcile_pending_question_after_stream_connect(session_id);
+                            }
+                        }
+                        return Ok(());
+                    }
+                }
+                if self.pending_question.is_none() {
+                    if let Some(dismissed) = self.dismissed_question.as_mut() {
+                        if dismissed.identity() == incoming.identity() {
+                            // Replayed critical events must not undo an explicit
+                            // Esc dismissal. Refresh the typed contract/draft in
+                            // place and keep the question cached for Ctrl+Q.
+                            dismissed.refresh_contract(incoming);
+                            self.status_message =
+                                "Question remains dismissed (Ctrl+Q to reopen)".to_string();
+                            if needs_identity_sync {
+                                if let Some(session_id) = self.chat.session_id.clone() {
+                                    self.reconcile_pending_question_after_stream_connect(
+                                        session_id,
+                                    );
+                                }
+                            }
+                            return Ok(());
+                        }
+                    }
+                }
+                // A new question supersedes any answer still in flight for a
+                // previous one — a late response must not clear this modal.
+                self.stash_question_drafts();
+                self.supersede_pending_answer();
+                self.pending_answer_run_started = false;
+                self.dismissed_question = None;
+                self.status_message =
+                    format!("Question: {} (answer in the dialog)", incoming.question);
+                self.pending_question = Some(incoming);
+                if needs_identity_sync {
+                    self.status_message = "Synchronizing question identity...".to_string();
+                    if let Some(session_id) = self.chat.session_id.clone() {
+                        self.reconcile_pending_question_after_stream_connect(session_id);
+                    }
+                }
             }
-            AgentEvent::Complete { usage } => {
-                self.finalize_streaming();
-                self.chat.token_usage = Some(usage);
-            }
+            AgentEvent::Complete { usage } => self.handle_complete(usage),
             AgentEvent::Cancelled { message } => {
                 self.status_message = message.unwrap_or_else(|| "Cancelled".to_string());
                 self.finalize_streaming();
@@ -2245,6 +3306,49 @@ impl App {
 
     fn finalize_streaming(&mut self) {
         self.chat.streaming = false;
+        self.flush_streaming_output();
+        self.status_message = "Ready".to_string();
+        self.detach_stream();
+        self.stream_disconnected = false;
+        self.pending_answer_run_started = false;
+        self.chat.sub_agents.clear();
+        // A run that ended (completed / cancelled / stopped) can no longer accept
+        // an answer, so drop any open (or dismissed-but-cached) question modal
+        // to avoid answering a dead session — and invalidate any answer POST
+        // still in flight for it.
+        self.supersede_pending_answer();
+        self.pending_question = None;
+        self.dismissed_question = None;
+    }
+
+    fn handle_complete(&mut self, usage: TokenUsage) {
+        let answer_in_flight = self
+            .pending_question
+            .as_ref()
+            .is_some_and(|question| question.submitting);
+        if (self.pending_question.is_some() || self.dismissed_question.is_some())
+            && !self.pending_answer_run_started
+            && !answer_in_flight
+        {
+            // Legacy servers may still expose the Complete emitted by the
+            // activation that suspended at NeedClarification. That boundary is
+            // not terminal user work: preserve the exact modal/draft and keep
+            // the session input-blocked.
+            self.flush_streaming_output();
+            self.chat.token_usage = Some(usage);
+            self.chat.streaming = true;
+            self.chat.sub_agents.clear();
+            self.status_message = "Paused — waiting for your answer".to_string();
+            if let Some(session_id) = self.chat.session_id.clone() {
+                self.attach_stream(session_id);
+            }
+            return;
+        }
+        self.finalize_streaming();
+        self.chat.token_usage = Some(usage);
+    }
+
+    fn flush_streaming_output(&mut self) {
         if !self.chat.current_response.is_empty() || !self.chat.current_tool_calls.is_empty() {
             self.chat.messages.push(ChatMessage {
                 role: MessageRole::Assistant,
@@ -2257,17 +3361,6 @@ impl App {
                 },
             });
         }
-        self.status_message = "Ready".to_string();
-        self.sse_tx = None;
-        self.sse_rx = None;
-        self.chat.sub_agents.clear();
-        // A run that ended (completed / cancelled / stopped) can no longer accept
-        // an answer, so drop any open (or dismissed-but-cached) question modal
-        // to avoid answering a dead session — and invalidate any answer POST
-        // still in flight for it.
-        self.supersede_pending_answer();
-        self.pending_question = None;
-        self.dismissed_question = None;
     }
 
     /// Stop the current run WITHOUT blocking the event loop: the `stop` POST
@@ -2278,6 +3371,11 @@ impl App {
     /// possible moment (pressing Ctrl+C to stop a run) tore down the whole
     /// TUI instead of just failing the stop.
     fn stop_streaming(&mut self) {
+        // Cancel a clarification answer before launching the stop request.
+        // In particular this prevents a task blocked on SSE readiness from
+        // waking later and POSTing into a session the operator already
+        // stopped.
+        self.supersede_pending_answer();
         let Some(sid) = self.chat.session_id.clone() else {
             // Nothing to stop server-side; still clear local streaming state.
             self.finalize_streaming();
@@ -2744,21 +3842,139 @@ mod question_tests {
         KeyEvent::new(code, KeyModifiers::empty())
     }
 
+    async fn read_test_http_request(stream: &mut tokio::net::TcpStream) -> String {
+        use tokio::io::AsyncReadExt;
+
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            if let Some(index) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                break index + 4;
+            }
+            let read = stream.read(&mut chunk).await.unwrap();
+            if read == 0 {
+                break request.len();
+            }
+            request.extend_from_slice(&chunk[..read]);
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        while request.len() < header_end + content_length {
+            let read = stream.read(&mut chunk).await.unwrap();
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&chunk[..read]);
+        }
+        String::from_utf8_lossy(&request).into_owned()
+    }
+
+    async fn read_test_http_path(stream: &mut tokio::net::TcpStream) -> String {
+        read_test_http_request(stream)
+            .await
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    async fn respond_test_http(stream: &mut tokio::net::TcpStream, content_type: &str, body: &str) {
+        use tokio::io::AsyncWriteExt;
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+    }
+
+    async fn spawn_answer_test_server(
+        session_id: &str,
+    ) -> (BambooClient, tokio::task::JoinHandle<()>) {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let expected_events_path = format!("/api/v1/events/{session_id}");
+        let expected_respond_path = format!("/api/v1/respond/{session_id}");
+        let server = tokio::spawn(async move {
+            let (mut sse_socket, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut sse_socket).await,
+                expected_events_path
+            );
+            sse_socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            sse_socket.flush().await.unwrap();
+
+            let (mut respond_socket, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut respond_socket).await,
+                expected_respond_path
+            );
+            respond_test_http(
+                &mut respond_socket,
+                "application/json",
+                r#"{"auto_resume_status":"completed"}"#,
+            )
+            .await;
+        });
+        (BambooClient::new(&base_url), server)
+    }
+
+    fn question_identity(app: &App) -> QuestionIdentity {
+        app.pending_question
+            .as_ref()
+            .expect("pending question")
+            .identity()
+    }
+
+    fn active_question(
+        session_id: &str,
+        question: String,
+        options: Option<Vec<String>>,
+        tool_call_id: &str,
+        allow_custom: bool,
+        draft: &str,
+    ) -> ActiveQuestion {
+        let pending = PendingQuestion {
+            has_pending_question: true,
+            question,
+            options,
+            allow_custom,
+            tool_call_id: Some(tool_call_id.to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            source: Some("pause_tool".to_string()),
+        };
+        ActiveQuestion::from_pending(session_id.to_string(), &pending, draft.to_string())
+    }
+
     fn app_with_question(options: Vec<&str>) -> App {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("sess-1".to_string());
         let options: Vec<String> = options.into_iter().map(String::from).collect();
-        let custom = if options.is_empty() {
-            Some(String::new())
-        } else {
-            None
-        };
-        app.pending_question = Some(ActiveQuestion {
-            question: "Run this command?".to_string(),
-            options,
-            selected: 0,
-            custom,
-            submitting: false,
-        });
+        app.pending_question = Some(active_question(
+            "sess-1",
+            "Run this command?".to_string(),
+            Some(options),
+            "tool-1",
+            true,
+            "",
+        ));
         app
     }
 
@@ -2808,18 +4024,600 @@ mod question_tests {
     }
 
     #[tokio::test]
-    async fn submitting_without_a_session_clears_the_question() {
-        // No chat session ⇒ submit short-circuits (no network) and clears the modal.
+    async fn submitting_without_matching_session_keeps_the_question() {
+        // The modal is bound to sess-1. If the active chat no longer matches,
+        // keep the draft/question and refuse to send it anywhere.
         let mut app = app_with_question(vec!["Approve", "Deny"]);
+        app.chat.session_id = None;
         assert!(app.chat.session_id.is_none());
         app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
-        assert!(app.pending_question.is_none());
+        assert!(app.pending_question.is_some());
+        assert!(!app.pending_question.as_ref().unwrap().submitting);
+        assert!(app
+            .notifications
+            .last()
+            .is_some_and(|notice| notice.text.contains("different session")));
     }
 
     #[tokio::test]
     async fn no_options_opens_in_free_text_mode() {
         let app = app_with_question(vec![]);
         assert!(app.pending_question.as_ref().unwrap().custom.is_some());
+    }
+
+    #[tokio::test]
+    async fn closed_questions_never_expose_custom_input() {
+        let mut app = app_with_question(vec!["One"]);
+        app.pending_question.as_mut().unwrap().allow_custom = false;
+
+        app.handle_question_key(key(KeyCode::Char('c')))
+            .await
+            .unwrap();
+
+        assert!(app.pending_question.as_ref().unwrap().custom.is_none());
+
+        let closed_empty = active_question(
+            "sess-1",
+            "No choices".to_string(),
+            None,
+            "tool-closed",
+            false,
+            "must not open",
+        );
+        assert!(closed_empty.custom.is_none());
+    }
+
+    #[test]
+    fn modal_hints_follow_allow_custom_at_narrow_width() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut closed = app_with_question(vec!["One", "Two"]);
+        closed.pending_question.as_mut().unwrap().allow_custom = false;
+        let backend = TestBackend::new(60, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &closed))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(!text.contains("custom"));
+        assert!(text.contains("v inspect"));
+
+        let open = app_with_question(vec!["One", "Two"]);
+        terminal
+            .draw(|frame| crate::ui::render(frame, &open))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("c custom answer"));
+    }
+
+    #[test]
+    fn http_and_sse_build_equivalent_typed_question_state() {
+        let pending = PendingQuestion {
+            has_pending_question: true,
+            question: "Choose carefully".to_string(),
+            options: Some(vec!["A".to_string(), "B".to_string()]),
+            allow_custom: false,
+            tool_call_id: Some("call-7".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            source: Some("pause_tool".to_string()),
+        };
+        let http = ActiveQuestion::from_pending("sess-7".to_string(), &pending, String::new());
+        let sse = active_question(
+            "sess-7",
+            pending.question.clone(),
+            pending.options.clone(),
+            "call-7",
+            pending.allow_custom,
+            "",
+        );
+
+        assert_eq!(http.identity(), sse.identity());
+        assert_eq!(http.tool_name, sse.tool_name);
+        assert_eq!(http.source, sse.source);
+        assert_eq!(http.options, sse.options);
+        assert_eq!(http.allow_custom, sse.allow_custom);
+        assert_eq!(http.custom, sse.custom);
+    }
+
+    #[tokio::test]
+    async fn numeric_jump_reaches_and_submits_option_beyond_nine() {
+        let options = (1..=12)
+            .map(|number| format!("exact option {number}"))
+            .collect::<Vec<_>>();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let (client, server) = spawn_answer_test_server("sess-1").await;
+        app.client = client;
+        app.chat.session_id = Some("sess-1".to_string());
+        app.pending_question = Some(active_question(
+            "sess-1",
+            "Pick".to_string(),
+            Some(options),
+            "tool-12",
+            false,
+            "",
+        ));
+
+        app.handle_question_key(key(KeyCode::Char('g')))
+            .await
+            .unwrap();
+        app.handle_question_key(key(KeyCode::Char('1')))
+            .await
+            .unwrap();
+        app.handle_question_key(key(KeyCode::Char('2')))
+            .await
+            .unwrap();
+        app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
+        assert_eq!(app.pending_question.as_ref().unwrap().selected, 11);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(tx);
+        app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
+        let event = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            event,
+            AppEvent::AnswerSubmitted {
+                answer,
+                identity: QuestionIdentity {
+                    tool_call_id: Some(tool_call_id),
+                    ..
+                },
+                ..
+            } if answer == "exact option 12" && tool_call_id == "tool-12"
+        ));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn duplicate_labels_remain_distinct_ordered_choices() {
+        let mut app = app_with_question(vec!["Same", "Same", "Other"]);
+        app.handle_question_key(key(KeyCode::Char('g')))
+            .await
+            .unwrap();
+        app.handle_question_key(key(KeyCode::Char('2')))
+            .await
+            .unwrap();
+        app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
+
+        let question = app.pending_question.as_ref().unwrap();
+        assert_eq!(question.options.len(), 3);
+        assert_eq!(question.selected, 1);
+        assert_eq!(question.options[0], question.options[1]);
+    }
+
+    #[test]
+    fn long_unicode_question_and_option_are_inspectable_at_common_widths() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        for width in [60, 80, 120] {
+            let question = format!(
+                "START-问题🎋\n{}\nQUESTION_END",
+                "长文本 🚀 wrapped words ".repeat(80)
+            );
+            let option = format!(
+                "OPTION_START\n{}\nOPTION_END",
+                "选项 🌟 wrapped words ".repeat(80)
+            );
+            let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+            app.pending_question = Some(active_question(
+                "sess-1",
+                question,
+                Some(vec![option]),
+                "tool-1",
+                false,
+                "",
+            ));
+            let backend = TestBackend::new(width, 24);
+            let mut terminal = Terminal::new(backend).unwrap();
+
+            app.pending_question.as_mut().unwrap().inspecting = true;
+            app.pending_question.as_mut().unwrap().inspect_scroll = u16::MAX;
+            terminal
+                .draw(|frame| crate::ui::render(frame, &app))
+                .unwrap();
+            let text: String = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect();
+            assert!(text.contains("QUESTION_END"), "width {width}");
+
+            let question_state = app.pending_question.as_mut().unwrap();
+            question_state.inspect_option = true;
+            question_state.inspect_scroll = u16::MAX;
+            terminal
+                .draw(|frame| crate::ui::render(frame, &app))
+                .unwrap();
+            let text: String = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect();
+            assert!(text.contains("OPTION_END"), "width {width}");
+        }
+    }
+
+    #[tokio::test]
+    async fn inspector_scroll_normalizes_after_terminal_width_increases() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.pending_question = Some(active_question(
+            "sess-1",
+            "wrapped question words ".repeat(160),
+            Some(vec!["A".to_string()]),
+            "tool-1",
+            false,
+            "",
+        ));
+        let question = app.pending_question.as_mut().unwrap();
+        question.inspecting = true;
+        question.inspect_scroll = u16::MAX;
+
+        let mut narrow = Terminal::new(TestBackend::new(60, 24)).unwrap();
+        narrow.draw(|frame| crate::ui::render(frame, &app)).unwrap();
+        let narrow_max = app
+            .pending_question
+            .as_ref()
+            .unwrap()
+            .inspect_max_scroll
+            .get();
+
+        let mut wide = Terminal::new(TestBackend::new(120, 24)).unwrap();
+        wide.draw(|frame| crate::ui::render(frame, &app)).unwrap();
+        let wide_max = app
+            .pending_question
+            .as_ref()
+            .unwrap()
+            .inspect_max_scroll
+            .get();
+        assert!(wide_max < narrow_max);
+
+        app.handle_question_key(key(KeyCode::Up)).await.unwrap();
+        assert_eq!(
+            app.pending_question.as_ref().unwrap().inspect_scroll,
+            wide_max.saturating_sub(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_preserves_draft_selection_and_submission_state() {
+        let mut app = app_with_question(vec!["A", "B"]);
+        app.handle_question_key(key(KeyCode::Char('c')))
+            .await
+            .unwrap();
+        for ch in "draft".chars() {
+            app.handle_question_key(key(KeyCode::Char(ch)))
+                .await
+                .unwrap();
+        }
+        app.handle_question_key(key(KeyCode::Esc)).await.unwrap();
+        app.handle_question_key(key(KeyCode::Down)).await.unwrap();
+        app.pending_question.as_mut().unwrap().submitting = true;
+        let epoch = app.answer_epoch;
+
+        app.handle_sse_event(AgentEvent::NeedClarification {
+            question: "Run this command?".to_string(),
+            options: Some(vec!["A".to_string(), "B".to_string()]),
+            tool_call_id: Some("tool-1".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: true,
+            source: Some("pause_tool".to_string()),
+        })
+        .unwrap();
+
+        let replayed = app.pending_question.as_ref().unwrap();
+        assert_eq!(app.answer_epoch, epoch);
+        assert_eq!(replayed.selected, 1);
+        assert_eq!(replayed.custom_draft, "draft");
+        assert!(replayed.submitting);
+    }
+
+    #[tokio::test]
+    async fn replay_of_a_dismissed_question_keeps_it_dismissed() {
+        let mut app = app_with_question(vec!["A", "B"]);
+        app.handle_question_key(key(KeyCode::Esc)).await.unwrap();
+
+        app.handle_sse_event(AgentEvent::NeedClarification {
+            question: "Run this command?".to_string(),
+            options: Some(vec!["Updated A".to_string(), "Updated B".to_string()]),
+            tool_call_id: Some("tool-1".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some("pause_tool".to_string()),
+        })
+        .unwrap();
+
+        assert!(app.pending_question.is_none());
+        let dismissed = app.dismissed_question.as_ref().unwrap();
+        assert_eq!(dismissed.options, ["Updated A", "Updated B"]);
+        assert!(app.status_message.contains("remains dismissed"));
+    }
+
+    #[tokio::test]
+    async fn a_new_question_discards_the_old_dismissed_cache() {
+        let mut app = app_with_question(vec!["Old"]);
+        app.handle_question_key(key(KeyCode::Esc)).await.unwrap();
+
+        app.handle_sse_event(AgentEvent::NeedClarification {
+            question: "New question".to_string(),
+            options: Some(vec!["New answer".to_string()]),
+            tool_call_id: Some("tool-2".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some("pause_tool".to_string()),
+        })
+        .unwrap();
+        assert!(app.dismissed_question.is_none());
+
+        let identity = question_identity(&app);
+        app.handle_event(AppEvent::AnswerSubmitted {
+            epoch: app.answer_epoch,
+            identity,
+            answer: "New answer".to_string(),
+            result: Ok("started".to_string()),
+        })
+        .await
+        .unwrap();
+        assert!(app.pending_question.is_none());
+        assert!(app.dismissed_question.is_none());
+
+        app.reopen_pending_question();
+        assert!(
+            app.pending_question.is_none(),
+            "Ctrl+Q must not resurrect the old consumed question"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_draft_survives_session_switch_and_reconnect() {
+        let mut app = app_with_question(vec!["A", "B"]);
+        app.handle_question_key(key(KeyCode::Char('c')))
+            .await
+            .unwrap();
+        for ch in "keep me".chars() {
+            app.handle_question_key(key(KeyCode::Char(ch)))
+                .await
+                .unwrap();
+        }
+
+        app.opening_session_id = Some("sess-2".to_string());
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "sess-2".to_string(),
+            result: Ok(OpenedSession {
+                messages: Vec::new(),
+                model: "model".to_string(),
+                project_id: None,
+                is_running: false,
+                pending: None,
+                truncated: false,
+                total_message_count: 0,
+            }),
+        })
+        .await
+        .unwrap();
+        app.opening_session_id = Some("sess-1".to_string());
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "sess-1".to_string(),
+            result: Ok(OpenedSession {
+                messages: Vec::new(),
+                model: "model".to_string(),
+                project_id: None,
+                is_running: false,
+                pending: Some(PendingQuestion {
+                    has_pending_question: true,
+                    question: "Run this command?".to_string(),
+                    options: Some(vec!["A".to_string(), "B".to_string()]),
+                    allow_custom: true,
+                    tool_call_id: Some("tool-1".to_string()),
+                    tool_name: Some("ConclusionWithOptions".to_string()),
+                    source: Some("pause_tool".to_string()),
+                }),
+                truncated: false,
+                total_message_count: 0,
+            }),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            app.pending_question.as_ref().unwrap().custom_draft,
+            "keep me"
+        );
+        app.handle_question_key(key(KeyCode::Char('c')))
+            .await
+            .unwrap();
+        assert_eq!(
+            app.pending_question.as_ref().unwrap().custom.as_deref(),
+            Some("keep me")
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_custom_draft_migrates_after_exact_pending_identity_arrives() {
+        let mut app = app_with_question(vec!["A", "B"]);
+        let legacy = app.pending_question.as_mut().unwrap();
+        legacy.tool_call_id = None;
+        legacy.identity_syncing = true;
+        app.handle_question_key(key(KeyCode::Char('c')))
+            .await
+            .unwrap();
+        for ch in "保留这个答案".chars() {
+            app.handle_question_key(key(KeyCode::Char(ch)))
+                .await
+                .unwrap();
+        }
+
+        app.opening_session_id = Some("sess-2".to_string());
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "sess-2".to_string(),
+            result: Ok(OpenedSession {
+                messages: Vec::new(),
+                model: "model".to_string(),
+                project_id: None,
+                is_running: false,
+                pending: None,
+                truncated: false,
+                total_message_count: 0,
+            }),
+        })
+        .await
+        .unwrap();
+
+        app.opening_session_id = Some("sess-1".to_string());
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "sess-1".to_string(),
+            result: Ok(OpenedSession {
+                messages: Vec::new(),
+                model: "model".to_string(),
+                project_id: None,
+                is_running: false,
+                pending: Some(PendingQuestion {
+                    has_pending_question: true,
+                    question: "Run this command?".to_string(),
+                    options: Some(vec!["A".to_string(), "B".to_string()]),
+                    allow_custom: true,
+                    tool_call_id: Some("tool-1".to_string()),
+                    tool_name: Some("ConclusionWithOptions".to_string()),
+                    source: Some("pause_tool".to_string()),
+                }),
+                truncated: false,
+                total_message_count: 0,
+            }),
+        })
+        .await
+        .unwrap();
+
+        let restored = app.pending_question.as_ref().unwrap();
+        assert_eq!(restored.tool_call_id.as_deref(), Some("tool-1"));
+        assert_eq!(restored.custom_draft, "保留这个答案");
+    }
+
+    #[tokio::test]
+    async fn legacy_custom_draft_does_not_cross_a_changed_question_contract() {
+        let mut app = app_with_question(vec!["A", "B"]);
+        let legacy = app.pending_question.as_mut().unwrap();
+        legacy.tool_call_id = None;
+        legacy.identity_syncing = true;
+        legacy.custom_draft = "must stay with the old choices".to_string();
+
+        app.opening_session_id = Some("sess-2".to_string());
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "sess-2".to_string(),
+            result: Ok(OpenedSession {
+                messages: Vec::new(),
+                model: "model".to_string(),
+                project_id: None,
+                is_running: false,
+                pending: None,
+                truncated: false,
+                total_message_count: 0,
+            }),
+        })
+        .await
+        .unwrap();
+
+        app.opening_session_id = Some("sess-1".to_string());
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "sess-1".to_string(),
+            result: Ok(OpenedSession {
+                messages: Vec::new(),
+                model: "model".to_string(),
+                project_id: None,
+                is_running: false,
+                pending: Some(PendingQuestion {
+                    has_pending_question: true,
+                    question: "Run this command?".to_string(),
+                    options: Some(vec!["A".to_string(), "different".to_string()]),
+                    allow_custom: true,
+                    tool_call_id: Some("tool-new".to_string()),
+                    tool_name: Some("ConclusionWithOptions".to_string()),
+                    source: Some("pause_tool".to_string()),
+                }),
+                truncated: false,
+                total_message_count: 0,
+            }),
+        })
+        .await
+        .unwrap();
+
+        assert!(app
+            .pending_question
+            .as_ref()
+            .unwrap()
+            .custom_draft
+            .is_empty());
+    }
+
+    #[test]
+    fn question_draft_cache_is_bounded() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let oldest = QuestionDraftKey::new(
+            "session-0".to_string(),
+            Some("tool-0".to_string()),
+            "question".to_string(),
+            vec!["A".to_string()],
+            true,
+        );
+        for index in 0..=MAX_QUESTION_DRAFTS {
+            app.store_question_draft(
+                QuestionDraftKey::new(
+                    format!("session-{index}"),
+                    Some(format!("tool-{index}")),
+                    "question".to_string(),
+                    vec!["A".to_string()],
+                    true,
+                ),
+                format!("draft-{index}"),
+            );
+        }
+
+        assert_eq!(app.question_drafts.len(), MAX_QUESTION_DRAFTS);
+        assert_eq!(app.question_draft_order.len(), MAX_QUESTION_DRAFTS);
+        assert!(!app.question_drafts.contains_key(&oldest));
+    }
+
+    #[tokio::test]
+    async fn stale_pending_fetch_cannot_replace_another_session_question() {
+        let mut app = app_with_question(vec!["Current"]);
+        let original = app.pending_question.as_ref().unwrap().identity();
+        app.handle_event(AppEvent::PendingQuestionChecked {
+            session_id: "sess-old".to_string(),
+            epoch: app.answer_epoch,
+            result: Ok(PendingQuestion {
+                has_pending_question: true,
+                question: "Stale".to_string(),
+                options: Some(vec!["Wrong".to_string()]),
+                allow_custom: false,
+                tool_call_id: Some("stale-tool".to_string()),
+                ..Default::default()
+            }),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(app.pending_question.as_ref().unwrap().identity(), original);
     }
 
     #[test]
@@ -2839,6 +4637,45 @@ mod question_tests {
         assert!(text.contains("Approve"), "option label missing");
     }
 
+    #[tokio::test]
+    async fn sse_clarification_stays_visible_and_owns_input_over_config_editor() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("sess-1".to_string());
+        app.config_editor = Some(ConfigEditor {
+            textarea: tui_textarea::TextArea::new(vec!["CONFIG_EDITOR_SENTINEL".to_string()]),
+        });
+        app.handle_sse_event(AgentEvent::NeedClarification {
+            question: "VISIBLE_SECURITY_DECISION".to_string(),
+            options: Some(vec!["Approve exact capability".to_string()]),
+            tool_call_id: Some("tool-security".to_string()),
+            tool_name: Some("request_permissions".to_string()),
+            allow_custom: false,
+            source: Some("pause_tool".to_string()),
+        })
+        .unwrap();
+
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("VISIBLE_SECURITY_DECISION"));
+        assert!(text.contains("Clarification needed"));
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(tx);
+        app.handle_key(key(KeyCode::Enter)).await.unwrap();
+        assert!(app.pending_question.as_ref().unwrap().submitting);
+        assert!(app.config_editor.is_some(), "editor draft stays suspended");
+    }
+
     /// Enter dispatches the answer POST off the event loop: the modal stays
     /// open in a submitting state with input disabled (no double-submit on
     /// repeated Enter, no dismissal out from under the request), and the
@@ -2847,6 +4684,8 @@ mod question_tests {
     #[tokio::test]
     async fn submit_dispatches_async_and_sets_in_flight() {
         let mut app = app_with_question(vec!["Approve", "Deny"]);
+        let (client, server) = spawn_answer_test_server("sess-1").await;
+        app.client = client;
         app.chat.session_id = Some("sess-1".to_string());
         let (tx, mut rx) = mpsc::unbounded_channel();
         app.event_tx = Some(tx);
@@ -2870,9 +4709,8 @@ mod question_tests {
             "Esc is disabled while submitting"
         );
 
-        // The spawned task posts its result back (the POST itself fails fast
-        // here — nothing listens on port 0 — which is fine: the dispatch and
-        // its epoch/answer payload are what's under test).
+        // The spawned task posts its result back after the fresh SSE handshake;
+        // the dispatch and its epoch/answer payload are what's under test.
         let event = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv())
             .await
             .expect("async result must be posted back")
@@ -2881,15 +4719,17 @@ mod question_tests {
             epoch,
             answer,
             result,
+            ..
         } = event
         else {
             panic!("expected AnswerSubmitted");
         };
         assert_eq!(answer, "Approve");
         assert_eq!(epoch, app.answer_epoch, "in-flight epoch is current");
-        assert!(result.is_err(), "no server behind port 0");
+        assert!(result.is_ok());
         // The swallowed repeat-Enter must not have dispatched a second POST.
         assert!(rx.try_recv().is_err(), "exactly one dispatch expected");
+        server.await.unwrap();
     }
 
     /// A late `AnswerSubmitted` whose epoch no longer matches (the question
@@ -2905,11 +4745,16 @@ mod question_tests {
         // Submit → the in-flight POST carries this epoch.
         app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
         let stale_epoch = app.answer_epoch;
+        let stale_identity = question_identity(&app);
 
         // A NEW question arrives before the response lands — supersedes it.
         app.handle_sse_event(AgentEvent::NeedClarification {
             question: "Second question?".to_string(),
             options: Some(vec!["A".to_string(), "B".to_string()]),
+            tool_call_id: Some("tool-2".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some("pause_tool".to_string()),
         })
         .unwrap();
         assert_ne!(app.answer_epoch, stale_epoch, "supersede bumps the epoch");
@@ -2917,6 +4762,7 @@ mod question_tests {
         // The stale success response must be discarded, not applied.
         app.handle_event(AppEvent::AnswerSubmitted {
             epoch: stale_epoch,
+            identity: stale_identity,
             answer: "Approve".to_string(),
             result: Ok("started".to_string()),
         })
@@ -2934,10 +4780,12 @@ mod question_tests {
         // Session switch / run finalization also supersede an in-flight answer.
         app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
         let stale_epoch = app.answer_epoch;
+        let stale_identity = question_identity(&app);
         app.finalize_streaming();
         assert_ne!(app.answer_epoch, stale_epoch);
         app.handle_event(AppEvent::AnswerSubmitted {
             epoch: stale_epoch,
+            identity: stale_identity,
             answer: "A".to_string(),
             result: Ok("started".to_string()),
         })
@@ -2958,11 +4806,13 @@ mod question_tests {
 
         app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
         assert!(app.pending_question.as_ref().unwrap().submitting);
+        let identity = question_identity(&app);
 
         app.handle_event(AppEvent::AnswerSubmitted {
             epoch: app.answer_epoch,
+            identity,
             answer: "Approve".to_string(),
-            result: Err("boom".to_string()),
+            result: Err(crate::api::RespondFailure::unavailable("boom")),
         })
         .await
         .unwrap();
@@ -2972,6 +4822,7 @@ mod question_tests {
             .as_ref()
             .expect("question kept for retry");
         assert!(!q.submitting, "input re-enabled for retry");
+        assert_eq!(q.error.as_deref(), Some("boom"));
         let last = app.notifications.last().expect("notified");
         assert_eq!(last.level, NoticeLevel::Error);
         assert!(last.text.contains("boom"));
@@ -2979,6 +4830,85 @@ mod question_tests {
         // And a retry dispatches again.
         app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
         assert!(app.pending_question.as_ref().unwrap().submitting);
+    }
+
+    #[tokio::test]
+    async fn stale_answer_rejection_refreshes_the_authoritative_question() {
+        let mut app = app_with_question(vec!["Old"]);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(tx);
+        app.pending_question.as_mut().unwrap().submitting = true;
+        let old_identity = question_identity(&app);
+
+        app.handle_event(AppEvent::AnswerSubmitted {
+            epoch: app.answer_epoch,
+            identity: old_identity.clone(),
+            answer: "Old".to_string(),
+            result: Err(crate::api::RespondFailure::rejected(
+                reqwest::StatusCode::CONFLICT,
+                "pending question changed".to_string(),
+            )),
+        })
+        .await
+        .unwrap();
+        let refresh_epoch = app.answer_epoch;
+        assert!(app.pending_question.as_ref().unwrap().submitting);
+
+        app.handle_event(AppEvent::PendingQuestionRefreshed {
+            session_id: "sess-1".to_string(),
+            epoch: refresh_epoch,
+            identity: old_identity,
+            result: Ok(PendingQuestion {
+                has_pending_question: true,
+                question: "New question".to_string(),
+                options: Some(vec!["New value".to_string()]),
+                allow_custom: false,
+                tool_call_id: Some("tool-2".to_string()),
+                tool_name: Some("ConclusionWithOptions".to_string()),
+                source: Some("pause_tool".to_string()),
+            }),
+        })
+        .await
+        .unwrap();
+
+        let question = app.pending_question.as_ref().unwrap();
+        assert_eq!(question.tool_call_id.as_deref(), Some("tool-2"));
+        assert_eq!(question.options, ["New value"]);
+        assert!(!question.submitting);
+    }
+
+    #[tokio::test]
+    async fn consumed_answer_rejection_closes_the_stale_modal() {
+        let mut app = app_with_question(vec!["Old"]);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(tx);
+        app.pending_question.as_mut().unwrap().submitting = true;
+        let identity = question_identity(&app);
+
+        app.handle_event(AppEvent::AnswerSubmitted {
+            epoch: app.answer_epoch,
+            identity: identity.clone(),
+            answer: "Old".to_string(),
+            result: Err(crate::api::RespondFailure::rejected(
+                reqwest::StatusCode::BAD_REQUEST,
+                "no pending question".to_string(),
+            )),
+        })
+        .await
+        .unwrap();
+        let refresh_epoch = app.answer_epoch;
+
+        app.handle_event(AppEvent::PendingQuestionRefreshed {
+            session_id: "sess-1".to_string(),
+            epoch: refresh_epoch,
+            identity,
+            result: Ok(PendingQuestion::default()),
+        })
+        .await
+        .unwrap();
+
+        assert!(app.pending_question.is_none());
+        assert!(app.status_message.contains("no longer exists"));
     }
 
     /// Success preserves the pre-existing post-submit semantics: the modal
@@ -2993,8 +4923,10 @@ mod question_tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         app.event_tx = Some(tx);
         app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
+        let identity = question_identity(&app);
         app.handle_event(AppEvent::AnswerSubmitted {
             epoch: app.answer_epoch,
+            identity,
             answer: "Approve".to_string(),
             result: Ok("started".to_string()),
         })
@@ -3011,8 +4943,10 @@ mod question_tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         app.event_tx = Some(tx);
         app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
+        let identity = question_identity(&app);
         app.handle_event(AppEvent::AnswerSubmitted {
             epoch: app.answer_epoch,
+            identity,
             answer: "Approve".to_string(),
             result: Ok("completed".to_string()),
         })
@@ -3020,6 +4954,238 @@ mod question_tests {
         .unwrap();
         assert!(app.pending_question.is_none());
         assert!(!app.chat.streaming, "non-resuming status must not spin");
+    }
+
+    #[tokio::test]
+    async fn connected_reconciliation_cannot_erase_in_flight_completed_answer() {
+        let mut app = app_with_question(vec!["Approve"]);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(tx);
+        app.chat.streaming = true;
+        app.pending_question.as_mut().unwrap().submitting = true;
+        app.pending_reconcile_epoch = 9;
+        let epoch = app.answer_epoch;
+        let identity = question_identity(&app);
+
+        app.handle_session_sse_event(SessionSseEvent::Connected {
+            session_id: "sess-1".to_string(),
+            stream_epoch: app.sse_epoch,
+            reconnecting: false,
+        })
+        .unwrap();
+        assert!(
+            rx.try_recv().is_err(),
+            "submitting handshake must not launch pending reconciliation"
+        );
+
+        // Even a response already queued by a racing request cannot clear the
+        // modal or bump the answer epoch while the POST outcome owns it.
+        app.handle_event(AppEvent::PendingQuestionReconciled {
+            session_id: "sess-1".to_string(),
+            epoch,
+            reconcile_epoch: 9,
+            result: Ok(PendingQuestion::default()),
+        })
+        .await
+        .unwrap();
+        assert!(app.pending_question.is_some());
+        assert_eq!(app.answer_epoch, epoch);
+
+        app.handle_event(AppEvent::AnswerSubmitted {
+            epoch,
+            identity,
+            answer: "Approve".to_string(),
+            result: Ok("completed".to_string()),
+        })
+        .await
+        .unwrap();
+        assert!(app.pending_question.is_none());
+        assert!(!app.chat.streaming);
+        assert_eq!(app.status_message, "Answered: Approve (completed)");
+    }
+
+    #[tokio::test]
+    async fn legacy_question_cannot_submit_until_exact_identity_is_reconciled() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut sse_socket, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut sse_socket).await,
+                "/api/v1/events/sess-legacy"
+            );
+            sse_socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            sse_socket.flush().await.unwrap();
+
+            let (mut respond_socket, _) = listener.accept().await.unwrap();
+            let request = read_test_http_request(&mut respond_socket).await;
+            assert!(request.starts_with("POST /api/v1/respond/sess-legacy "));
+            assert!(
+                request.contains(r#""expected_tool_call_id":"call-exact""#),
+                "exact CAS identity missing from request: {request}"
+            );
+            assert!(
+                request.contains(r#""response":"草稿🙂""#),
+                "custom answer changed in request: {request}"
+            );
+            respond_test_http(
+                &mut respond_socket,
+                "application/json",
+                r#"{"auto_resume_status":"completed"}"#,
+            )
+            .await;
+        });
+
+        let mut app = App::new(BambooClient::new(&base_url));
+        app.chat.session_id = Some("sess-legacy".to_string());
+        app.handle_sse_event(AgentEvent::NeedClarification {
+            question: "Legacy approval?".to_string(),
+            options: Some(vec!["Approve".to_string(), "Deny".to_string()]),
+            tool_call_id: None,
+            tool_name: None,
+            allow_custom: true,
+            source: None,
+        })
+        .unwrap();
+        assert!(app.pending_question.as_ref().unwrap().identity_syncing);
+
+        app.handle_question_key(key(KeyCode::Char('c')))
+            .await
+            .unwrap();
+        for character in "草稿🙂".chars() {
+            app.handle_question_key(key(KeyCode::Char(character)))
+                .await
+                .unwrap();
+        }
+
+        app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
+        let unresolved = app.pending_question.as_ref().unwrap();
+        assert!(!unresolved.submitting);
+        assert_eq!(unresolved.custom.as_deref(), Some("草稿🙂"));
+        assert!(unresolved
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("not sent")));
+        assert!(
+            app.sse_task.is_none(),
+            "no answer stream means no POST can start"
+        );
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(tx);
+        app.pending_reconcile_epoch = 7;
+        let answer_epoch = app.answer_epoch;
+        app.handle_event(AppEvent::PendingQuestionReconciled {
+            session_id: "sess-legacy".to_string(),
+            epoch: answer_epoch,
+            reconcile_epoch: 7,
+            result: Ok(PendingQuestion {
+                has_pending_question: true,
+                question: "Legacy approval?".to_string(),
+                options: Some(vec!["Approve".to_string(), "Deny".to_string()]),
+                allow_custom: true,
+                tool_call_id: Some("call-exact".to_string()),
+                tool_name: Some("ConclusionWithOptions".to_string()),
+                source: Some("pause_tool".to_string()),
+            }),
+        })
+        .await
+        .unwrap();
+
+        let resolved = app.pending_question.as_ref().unwrap();
+        assert_eq!(resolved.tool_call_id.as_deref(), Some("call-exact"));
+        assert!(!resolved.identity_syncing);
+        assert_eq!(resolved.custom.as_deref(), Some("草稿🙂"));
+        app.submit_answer("草稿🙂".to_string());
+        assert!(app.pending_question.as_ref().unwrap().submitting);
+        assert!(app.sse_task.is_some());
+
+        let submitted = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("answer result must return")
+            .expect("event channel must stay open");
+        app.handle_event(submitted).await.unwrap();
+        assert!(app.pending_question.is_none());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stopping_aborts_answer_waiting_for_sse_before_it_can_post() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (sse_seen_tx, sse_seen_rx) = tokio::sync::oneshot::channel();
+        let (release_sse_tx, release_sse_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut sse_socket, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut sse_socket).await,
+                "/api/v1/events/sess-1"
+            );
+            sse_seen_tx.send(()).ok();
+            release_sse_rx.await.unwrap();
+            sse_socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            sse_socket.flush().await.unwrap();
+
+            let (mut stop_socket, _) = listener.accept().await.unwrap();
+            let stop_path = read_test_http_path(&mut stop_socket).await;
+            assert_eq!(stop_path, "/api/v1/stop/sess-1");
+            respond_test_http(
+                &mut stop_socket,
+                "application/json",
+                r#"{"status":"stopped"}"#,
+            )
+            .await;
+
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(300), listener.accept())
+                    .await
+                    .is_err(),
+                "aborted answer task must not POST after SSE becomes ready"
+            );
+        });
+
+        let mut app = app_with_question(vec!["Approve"]);
+        app.client = BambooClient::new(&base_url);
+        app.chat.streaming = true;
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(event_tx);
+
+        app.submit_answer("Approve".to_string());
+        sse_seen_rx.await.unwrap();
+        assert!(app.answer_task.is_some());
+        assert!(app.pending_question.as_ref().unwrap().submitting);
+
+        app.stop_streaming();
+        assert!(
+            app.answer_task.is_none(),
+            "stop must abort the network task"
+        );
+        release_sse_tx.send(()).unwrap();
+
+        let stop_finished =
+            tokio::time::timeout(std::time::Duration::from_secs(5), event_rx.recv())
+                .await
+                .expect("stop result must return")
+                .expect("event channel must stay open");
+        assert!(matches!(stop_finished, AppEvent::StopFinished(Ok(()))));
+        app.handle_event(stop_finished).await.unwrap();
+        assert!(!app.chat.streaming);
+        assert!(app.pending_question.is_none());
+        server.await.unwrap();
     }
 
     /// While the POST is out, the modal renders the submitting state instead
@@ -3054,13 +5220,16 @@ mod question_tests {
 
         let opts: Vec<String> = (1..=30).map(|n| format!("opt{n}")).collect();
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.pending_question = Some(ActiveQuestion {
-            question: "Pick one".to_string(),
-            options: opts,
-            selected: 24, // "25. opt25", deep in the list
-            custom: None,
-            submitting: false,
-        });
+        let mut question = active_question(
+            "sess-1",
+            "Pick one".to_string(),
+            Some(opts),
+            "tool-1",
+            false,
+            "",
+        );
+        question.selected = 24; // "25. opt25", deep in the list
+        app.pending_question = Some(question);
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -3072,6 +5241,72 @@ mod question_tests {
         // an overflow marker indicates hidden options above.
         assert!(text.contains("opt25"), "selected option not in the window");
         assert!(text.contains("more"), "overflow marker missing");
+    }
+
+    #[tokio::test]
+    async fn mouse_click_submits_the_exact_option_value() {
+        use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let options = (1..=30)
+            .map(|index| format!("exact option {index}"))
+            .collect::<Vec<_>>();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let (client, server) = spawn_answer_test_server("sess-1").await;
+        app.client = client;
+        app.chat.session_id = Some("sess-1".to_string());
+        app.pending_question = Some(active_question(
+            "sess-1",
+            "Pick one".to_string(),
+            Some(options),
+            "tool-1",
+            false,
+            "",
+        ));
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let hitbox = *app
+            .pending_question
+            .as_ref()
+            .unwrap()
+            .option_hitboxes
+            .borrow()
+            .last()
+            .unwrap();
+        let expected = app.pending_question.as_ref().unwrap().options[hitbox.index].clone();
+        let mouse = |kind| MouseEvent {
+            kind,
+            column: hitbox.x,
+            row: hitbox.y,
+            modifiers: KeyModifiers::empty(),
+        };
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(tx);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left)));
+        assert_eq!(
+            app.pending_question.as_ref().unwrap().selected,
+            0,
+            "mouse-down must not recenter a long option window"
+        );
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left)));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            event,
+            AppEvent::AnswerSubmitted { answer, .. } if answer == expected
+        ));
+        server.await.unwrap();
     }
 
     fn bare_session(id: &str) -> SessionSummary {
@@ -3611,6 +5846,7 @@ mod question_tests {
             total_tokens: 2,
         });
 
+        app.opening_session_id = Some("s1".to_string());
         app.handle_event(AppEvent::SessionOpened {
             session_id: "s1".to_string(),
             result: Ok(opened(vec![asst_msg("hello again")])),
@@ -3631,6 +5867,660 @@ mod question_tests {
         assert!(app.chat.token_usage.is_none(), "scratch state wiped");
     }
 
+    #[tokio::test]
+    async fn out_of_order_session_open_result_is_ignored() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("current".to_string());
+        app.opening_session_id = Some("newest".to_string());
+
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "older".to_string(),
+            result: Ok(opened(vec![asst_msg("stale")])),
+        })
+        .await
+        .unwrap();
+        assert_eq!(app.chat.session_id.as_deref(), Some("current"));
+        assert_eq!(app.opening_session_id.as_deref(), Some("newest"));
+
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "newest".to_string(),
+            result: Ok(opened(vec![asst_msg("fresh")])),
+        })
+        .await
+        .unwrap();
+        assert_eq!(app.chat.session_id.as_deref(), Some("newest"));
+        assert_eq!(app.chat.messages[0].content, "fresh");
+        assert!(app.opening_session_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn opening_a_stopped_session_detaches_the_previous_stream() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("old".to_string());
+        let (sse_tx, sse_rx) = mpsc::unbounded_channel::<SessionSseEvent>();
+        let old_tx = sse_tx.clone();
+        app.sse_tx = Some(sse_tx);
+        app.sse_rx = Some(sse_rx);
+        app.sse_task = Some(tokio::spawn(std::future::pending()));
+        app.opening_session_id = Some("new".to_string());
+
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "new".to_string(),
+            result: Ok(opened(vec![])),
+        })
+        .await
+        .unwrap();
+
+        assert!(app.sse_tx.is_none());
+        assert!(app.sse_rx.is_none());
+        assert!(app.sse_task.is_none());
+        assert!(
+            old_tx.is_closed(),
+            "the old SSE sender must lose its receiver"
+        );
+    }
+
+    #[test]
+    fn stale_session_sse_event_cannot_mutate_the_current_session() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("new".to_string());
+        let clarification = || AgentEvent::NeedClarification {
+            question: "Old session question".to_string(),
+            options: Some(vec!["Wrong".to_string()]),
+            tool_call_id: Some("old-tool".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some("pause_tool".to_string()),
+        };
+
+        app.handle_session_sse_event(SessionSseEvent::Event {
+            session_id: "old".to_string(),
+            stream_epoch: app.sse_epoch,
+            event: clarification(),
+        })
+        .unwrap();
+        assert!(app.pending_question.is_none());
+
+        app.handle_session_sse_event(SessionSseEvent::Event {
+            session_id: "new".to_string(),
+            stream_epoch: app.sse_epoch,
+            event: clarification(),
+        })
+        .unwrap();
+        assert!(app.pending_question.is_some());
+    }
+
+    #[tokio::test]
+    async fn transport_failure_preserves_question_draft_and_answer_reattaches_stream() {
+        let mut app = app_with_question(vec!["Approve", "Deny"]);
+        app.chat.streaming = true;
+        app.connected = true;
+        app.handle_question_key(key(KeyCode::Char('c')))
+            .await
+            .unwrap();
+        for ch in "keep this draft".chars() {
+            app.handle_question_key(key(KeyCode::Char(ch)))
+                .await
+                .unwrap();
+        }
+        let identity = question_identity(&app);
+        let epoch = app.answer_epoch;
+        let (sse_tx, sse_rx) = mpsc::unbounded_channel();
+        app.sse_tx = Some(sse_tx);
+        app.sse_rx = Some(sse_rx);
+        app.sse_task = Some(tokio::spawn(std::future::pending()));
+
+        app.handle_session_sse_event(SessionSseEvent::TransportFailed {
+            session_id: "sess-1".to_string(),
+            stream_epoch: app.sse_epoch,
+            message: "retry budget exhausted".to_string(),
+        })
+        .unwrap();
+
+        let question = app.pending_question.as_ref().expect("question retained");
+        assert_eq!(question.custom.as_deref(), Some("keep this draft"));
+        assert_eq!(app.answer_epoch, epoch);
+        assert!(
+            app.chat.streaming,
+            "unknown server run stays input-blocking"
+        );
+        assert!(app.stream_disconnected);
+        assert!(!app.connected);
+        assert!(app.sse_task.is_none());
+
+        app.handle_event(AppEvent::AnswerSubmitted {
+            epoch,
+            identity,
+            answer: "keep this draft".to_string(),
+            result: Ok("started".to_string()),
+        })
+        .await
+        .unwrap();
+        assert!(app.pending_question.is_none());
+        assert!(app.chat.streaming);
+        assert!(app.sse_task.is_some(), "successful answer reattaches SSE");
+        app.detach_stream();
+    }
+
+    #[tokio::test]
+    async fn transport_failure_keeps_unknown_active_run_input_blocked_and_partial_output() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("sess-transport".to_string());
+        app.chat.streaming = true;
+        app.chat.current_response = "partial 你好".to_string();
+        app.chat.textarea.input(key(KeyCode::Char('n')));
+        app.chat.textarea.input(key(KeyCode::Char('e')));
+        app.chat.textarea.input(key(KeyCode::Char('w')));
+        let (sse_tx, sse_rx) = mpsc::unbounded_channel();
+        app.sse_tx = Some(sse_tx);
+        app.sse_rx = Some(sse_rx);
+        app.sse_task = Some(tokio::spawn(std::future::pending()));
+
+        app.handle_session_sse_event(SessionSseEvent::TransportFailed {
+            session_id: "sess-transport".to_string(),
+            stream_epoch: app.sse_epoch,
+            message: "network gone".to_string(),
+        })
+        .unwrap();
+        app.handle_chat_key(key(KeyCode::Enter)).await.unwrap();
+
+        assert!(app.chat.streaming);
+        assert!(app.stream_disconnected);
+        assert_eq!(app.chat.current_response, "partial 你好");
+        assert_eq!(app.chat.textarea.lines(), &["new"]);
+        assert!(app.chat.messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stale_transport_failure_cannot_detach_a_new_stream_generation() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("sess-1".to_string());
+        app.sse_epoch = 8;
+        app.sse_task = Some(tokio::spawn(std::future::pending()));
+
+        app.handle_session_sse_event(SessionSseEvent::TransportFailed {
+            session_id: "sess-1".to_string(),
+            stream_epoch: 7,
+            message: "old stream failed".to_string(),
+        })
+        .unwrap();
+
+        assert!(app.sse_task.is_some());
+        assert_eq!(app.sse_epoch, 8);
+        app.detach_stream();
+    }
+
+    #[tokio::test]
+    async fn clarification_boundary_complete_preserves_modal_and_draft() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("sess-1".to_string());
+        app.chat.streaming = true;
+        app.handle_sse_event(AgentEvent::NeedClarification {
+            question: "Choose carefully".to_string(),
+            options: Some(vec!["A".to_string()]),
+            tool_call_id: Some("call-1".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: true,
+            source: Some("pause_tool".to_string()),
+        })
+        .unwrap();
+        app.pending_question.as_mut().unwrap().custom = Some("草稿🙂".to_string());
+        let epoch = app.answer_epoch;
+
+        app.handle_sse_event(AgentEvent::Complete {
+            usage: TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+
+        let question = app.pending_question.as_ref().expect("modal remains");
+        assert_eq!(question.tool_call_id.as_deref(), Some("call-1"));
+        assert_eq!(question.custom.as_deref(), Some("草稿🙂"));
+        assert_eq!(app.answer_epoch, epoch);
+        assert!(app.chat.streaming);
+        app.detach_stream();
+    }
+
+    #[test]
+    fn successor_complete_without_replayed_started_is_terminal_while_answer_submits() {
+        let mut app = app_with_question(vec!["A"]);
+        app.pending_question.as_mut().unwrap().submitting = true;
+        app.handle_sse_event(AgentEvent::Token {
+            content: "恢复完成🙂".to_string(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::Complete {
+            usage: TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+
+        assert!(app.pending_question.is_none());
+        assert!(!app.chat.streaming);
+        assert_eq!(app.chat.messages.last().unwrap().content, "恢复完成🙂");
+    }
+
+    #[tokio::test]
+    async fn non_resuming_answer_status_is_not_overwritten_by_ready() {
+        let mut app = app_with_question(vec!["A"]);
+        let identity = question_identity(&app);
+        let epoch = app.answer_epoch;
+        app.handle_event(AppEvent::AnswerSubmitted {
+            epoch,
+            identity,
+            answer: "A".to_string(),
+            result: Ok("error: session not found".to_string()),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(app.status_message, "Answered: A (error: session not found)");
+    }
+
+    #[tokio::test]
+    async fn fresh_execute_waits_for_sse_subscription_handshake() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (execute_seen_tx, execute_seen_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut sse_socket, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut sse_socket).await,
+                "/api/v1/events/sess-handshake"
+            );
+
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(150), listener.accept())
+                    .await
+                    .is_err(),
+                "execute must not reach the server before SSE responds"
+            );
+            sse_socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            sse_socket.flush().await.unwrap();
+
+            let (mut execute_socket, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut execute_socket).await,
+                "/api/v1/execute/sess-handshake"
+            );
+            execute_seen_tx.send(()).ok();
+            respond_test_http(
+                &mut execute_socket,
+                "application/json",
+                r#"{"session_id":"sess-handshake","status":"started","events_url":"/api/v1/events/sess-handshake"}"#,
+            )
+            .await;
+        });
+
+        let mut app = App::new(BambooClient::new(&base_url));
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(event_tx);
+        app.chat.session_id = Some("sess-handshake".to_string());
+        app.start_stream_and_execute("sess-handshake".to_string());
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), execute_seen_rx)
+            .await
+            .expect("execute should follow the SSE handshake")
+            .unwrap();
+        server.await.unwrap();
+        app.detach_stream();
+    }
+
+    #[tokio::test]
+    async fn answer_replaces_live_old_stream_before_fast_successor_events() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (successor_sent_tx, successor_sent_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut successor_sse, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut successor_sse).await,
+                "/api/v1/events/sess-1"
+            );
+            successor_sse
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            successor_sse.flush().await.unwrap();
+
+            let (mut respond_socket, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut respond_socket).await,
+                "/api/v1/respond/sess-1"
+            );
+
+            // The successor completes before the respond HTTP body is
+            // returned. Only a subscriber installed before POST can observe
+            // this complete sequence.
+            successor_sse
+                .write_all(
+                    concat!(
+                        "data: {\"type\":\"execution_started\",\"run_id\":\"run-successor\",\"session_id\":\"sess-1\",\"started_at\":\"2026-08-10T00:00:00Z\"}\n\n",
+                        "data: {\"type\":\"token\",\"content\":\"快速恢复🙂\"}\n\n",
+                        "data: {\"type\":\"complete\",\"run_id\":\"run-successor\",\"session_id\":\"sess-1\",\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            successor_sse.flush().await.unwrap();
+            successor_sent_tx.send(()).ok();
+            respond_test_http(
+                &mut respond_socket,
+                "application/json",
+                r#"{"auto_resume_status":"started"}"#,
+            )
+            .await;
+        });
+
+        let mut app = app_with_question(vec!["A"]);
+        app.client = BambooClient::new(&base_url);
+        let (app_tx, _app_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(app_tx);
+
+        // Model the dangerous old state: readiness is still true and the task
+        // is still live, but its pause Complete is already queued for the UI.
+        let old_epoch = app.sse_epoch;
+        let (old_tx, old_rx) = mpsc::unbounded_channel();
+        old_tx
+            .send(SessionSseEvent::Event {
+                session_id: "sess-1".to_string(),
+                stream_epoch: old_epoch,
+                event: AgentEvent::Complete {
+                    usage: TokenUsage {
+                        prompt_tokens: 1,
+                        completion_tokens: 1,
+                        total_tokens: 2,
+                    },
+                },
+            })
+            .unwrap();
+        app.sse_tx = Some(old_tx);
+        app.sse_rx = Some(old_rx);
+        app.sse_task = Some(tokio::spawn(std::future::pending()));
+        let (_old_ready_tx, old_ready_rx) = tokio::sync::watch::channel(true);
+        app.sse_ready = Some(old_ready_rx);
+
+        app.submit_answer("A".to_string());
+        assert_ne!(
+            app.sse_epoch, old_epoch,
+            "answer must replace old generation"
+        );
+        successor_sent_rx.await.unwrap();
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while app
+            .chat
+            .messages
+            .last()
+            .is_none_or(|message| message.content != "快速恢复🙂")
+        {
+            assert!(tokio::time::Instant::now() < deadline);
+            app.poll_sse();
+            tokio::task::yield_now().await;
+        }
+
+        assert!(app.pending_question.is_none());
+        assert!(!app.chat.streaming);
+        assert_eq!(app.chat.messages.last().unwrap().content, "快速恢复🙂");
+        server.await.unwrap();
+        app.detach_stream();
+    }
+
+    #[tokio::test]
+    async fn reconnect_recovers_a_clarification_created_during_the_sse_gap() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let fake_server = tokio::spawn(async move {
+            let mut event_connections = 0;
+            let mut pending_requests = 0;
+            while event_connections < 2 || pending_requests < 2 {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let path = read_test_http_path(&mut stream).await;
+                if path == "/api/v1/events/sess-gap" {
+                    event_connections += 1;
+                    if event_connections == 1 {
+                        // Drop the first stream. The authoritative question is
+                        // created during this gap and is deliberately absent
+                        // from critical-event replay.
+                        respond_test_http(&mut stream, "text/event-stream", "").await;
+                    } else {
+                        respond_test_http(
+                            &mut stream,
+                            "text/event-stream",
+                            "data: {\"type\":\"complete\",\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\n",
+                        )
+                        .await;
+                    }
+                } else if path == "/api/v1/respond/sess-gap/pending" {
+                    pending_requests += 1;
+                    if pending_requests == 1 {
+                        respond_test_http(
+                            &mut stream,
+                            "application/json",
+                            r#"{"has_pending_question":false}"#,
+                        )
+                        .await;
+                    } else {
+                        respond_test_http(
+                            &mut stream,
+                            "application/json",
+                            r#"{"has_pending_question":true,"question":"Recovered gap question","options":["Approve"],"allow_custom":false,"tool_call_id":"gap-tool","tool_name":"request_permissions","source":"pause_tool"}"#,
+                        )
+                        .await;
+                    }
+                } else {
+                    panic!("unexpected fake-server path: {path}");
+                }
+            }
+        });
+
+        let mut app = App::new(BambooClient::new(&base_url));
+        app.chat.session_id = Some("sess-gap".to_string());
+        let (app_tx, mut app_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(app_tx);
+        let (sse_tx, mut sse_rx) = mpsc::unbounded_channel();
+        let (sse_task, _ready) = SseStream::start(&base_url, "sess-gap", 0, sse_tx).unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let message = sse_rx.recv().await.expect("SSE control event");
+                let reconnected = matches!(
+                    &message,
+                    SessionSseEvent::Connected {
+                        reconnecting: true,
+                        ..
+                    }
+                );
+                app.handle_session_sse_event(message).unwrap();
+                if reconnected {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("SSE should reconnect after the deliberate gap");
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while app.pending_question.is_none() {
+                let reconciled = app_rx
+                    .recv()
+                    .await
+                    .expect("app event channel should stay open");
+                assert!(matches!(
+                    &reconciled,
+                    AppEvent::PendingQuestionReconciled { session_id, .. }
+                        if session_id == "sess-gap"
+                ));
+                app.handle_event(reconciled).await.unwrap();
+            }
+        })
+        .await
+        .expect("reconnect reconciliation should recover the question");
+
+        let question = app
+            .pending_question
+            .as_ref()
+            .expect("reconnect should recover the missed clarification");
+        assert_eq!(question.question, "Recovered gap question");
+        assert_eq!(question.tool_call_id.as_deref(), Some("gap-tool"));
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), fake_server)
+            .await
+            .expect("fake server should serve every request")
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), sse_task)
+            .await
+            .expect("terminal replay should stop the SSE task")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn older_reconciliation_response_cannot_supersede_newer_request() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("sess-race".to_string());
+        app.pending_reconcile_epoch = 2;
+        let answer_epoch = app.answer_epoch;
+
+        // Request 1 finishes after request 2 has already been issued. It must
+        // be discarded before it can bump answer_epoch and thereby invalidate
+        // request 2's authoritative response.
+        app.handle_event(AppEvent::PendingQuestionReconciled {
+            session_id: "sess-race".to_string(),
+            epoch: answer_epoch,
+            reconcile_epoch: 1,
+            result: Ok(PendingQuestion {
+                has_pending_question: true,
+                question: "Stale question A".to_string(),
+                options: Some(vec!["A".to_string()]),
+                allow_custom: false,
+                tool_call_id: Some("tool-a".to_string()),
+                tool_name: Some("ConclusionWithOptions".to_string()),
+                source: Some("pause_tool".to_string()),
+            }),
+        })
+        .await
+        .unwrap();
+        assert!(app.pending_question.is_none());
+        assert_eq!(app.answer_epoch, answer_epoch);
+
+        app.handle_event(AppEvent::PendingQuestionReconciled {
+            session_id: "sess-race".to_string(),
+            epoch: answer_epoch,
+            reconcile_epoch: 2,
+            result: Ok(PendingQuestion {
+                has_pending_question: true,
+                question: "Current question B".to_string(),
+                options: Some(vec!["B".to_string()]),
+                allow_custom: false,
+                tool_call_id: Some("tool-b".to_string()),
+                tool_name: Some("ConclusionWithOptions".to_string()),
+                source: Some("pause_tool".to_string()),
+            }),
+        })
+        .await
+        .unwrap();
+
+        let question = app.pending_question.as_ref().expect("newest result wins");
+        assert_eq!(question.question, "Current question B");
+        assert_eq!(question.tool_call_id.as_deref(), Some("tool-b"));
+    }
+
+    #[tokio::test]
+    async fn initial_sse_handshake_recovers_a_question_created_before_subscription() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let fake_server = tokio::spawn(async move {
+            let mut events_served = false;
+            let mut pending_served = false;
+            while !events_served || !pending_served {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                match read_test_http_path(&mut stream).await.as_str() {
+                    "/api/v1/events/sess-initial-gap" => {
+                        events_served = true;
+                        // No NeedClarification replay: the question existed
+                        // before this first subscription was established.
+                        respond_test_http(
+                            &mut stream,
+                            "text/event-stream",
+                            "data: {\"type\":\"complete\",\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\n",
+                        )
+                        .await;
+                    }
+                    "/api/v1/respond/sess-initial-gap/pending" => {
+                        pending_served = true;
+                        respond_test_http(
+                            &mut stream,
+                            "application/json",
+                            r#"{"has_pending_question":true,"question":"Initial gap question","options":["Continue"],"allow_custom":false,"tool_call_id":"initial-gap-tool","tool_name":"request_permissions","source":"pause_tool"}"#,
+                        )
+                        .await;
+                    }
+                    path => panic!("unexpected fake-server path: {path}"),
+                }
+            }
+        });
+
+        let mut app = App::new(BambooClient::new(&base_url));
+        app.chat.session_id = Some("sess-initial-gap".to_string());
+        let (app_tx, mut app_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(app_tx);
+        let (sse_tx, mut sse_rx) = mpsc::unbounded_channel();
+        let (sse_task, _ready) =
+            SseStream::start(&base_url, "sess-initial-gap", 0, sse_tx).unwrap();
+
+        let connected = tokio::time::timeout(std::time::Duration::from_secs(5), sse_rx.recv())
+            .await
+            .expect("initial SSE handshake should finish")
+            .expect("SSE control channel should stay open");
+        assert!(matches!(
+            &connected,
+            SessionSseEvent::Connected {
+                reconnecting: false,
+                ..
+            }
+        ));
+        app.handle_session_sse_event(connected).unwrap();
+
+        let reconciled = tokio::time::timeout(std::time::Duration::from_secs(5), app_rx.recv())
+            .await
+            .expect("initial pending reconciliation should finish")
+            .expect("app event channel should stay open");
+        app.handle_event(reconciled).await.unwrap();
+        let question = app
+            .pending_question
+            .as_ref()
+            .expect("initial handshake must recover the pre-subscription question");
+        assert_eq!(question.question, "Initial gap question");
+        assert_eq!(question.tool_call_id.as_deref(), Some("initial-gap-tool"));
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), fake_server)
+            .await
+            .expect("fake server should serve initial sync")
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), sse_task)
+            .await
+            .expect("terminal frame should stop the SSE task")
+            .unwrap();
+    }
+
     /// `is_running: true` reattaches the SSE stream and sets `streaming`.
     /// `event_tx` isn't wired in a bare `App::new`, so `attach_stream`'s
     /// `SseStream::start` call still runs (it only spawns a task, no network
@@ -3639,6 +6529,7 @@ mod question_tests {
     async fn session_opened_reattaches_when_running() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
 
+        app.opening_session_id = Some("s1".to_string());
         app.handle_event(AppEvent::SessionOpened {
             session_id: "s1".to_string(),
             result: Ok(OpenedSession {
@@ -3659,6 +6550,7 @@ mod question_tests {
     async fn session_opened_truncated_notifies() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
 
+        app.opening_session_id = Some("s1".to_string());
         app.handle_event(AppEvent::SessionOpened {
             session_id: "s1".to_string(),
             result: Ok(OpenedSession {
@@ -3680,6 +6572,7 @@ mod question_tests {
     async fn session_opened_with_pending_question_opens_modal() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
 
+        app.opening_session_id = Some("s1".to_string());
         app.handle_event(AppEvent::SessionOpened {
             session_id: "s1".to_string(),
             result: Ok(OpenedSession {
@@ -3708,6 +6601,7 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("old".to_string());
 
+        app.opening_session_id = Some("s1".to_string());
         app.handle_event(AppEvent::SessionOpened {
             session_id: "s1".to_string(),
             result: Err("not found".to_string()),
@@ -3725,6 +6619,79 @@ mod question_tests {
         assert_eq!(last.level, NoticeLevel::Error);
     }
 
+    #[tokio::test]
+    async fn pending_question_detail_failure_aborts_session_open() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut history, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut history).await,
+                "/api/v1/history/s1"
+            );
+            respond_test_http(
+                &mut history,
+                "application/json",
+                r#"{"session_id":"s1","messages":[],"truncated":false,"total_message_count":0}"#,
+            )
+            .await;
+
+            let (mut summary, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut summary).await,
+                "/api/v1/sessions/s1"
+            );
+            respond_test_http(
+                &mut summary,
+                "application/json",
+                r#"{"session":{"id":"s1","model":"model","is_running":false,"has_pending_question":true}}"#,
+            )
+            .await;
+
+            let (mut pending, _) = listener.accept().await.unwrap();
+            assert_eq!(
+                read_test_http_path(&mut pending).await,
+                "/api/v1/respond/s1/pending"
+            );
+            let body = r#"{"error":"storage unavailable"}"#;
+            let response = format!(
+                "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            pending.write_all(response.as_bytes()).await.unwrap();
+            pending.shutdown().await.unwrap();
+        });
+
+        let mut app = App::new(BambooClient::new(&base_url));
+        app.chat.session_id = Some("old".to_string());
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(tx);
+        app.resume_session("s1".to_string());
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("resume result should arrive")
+            .expect("event channel should stay open");
+        assert!(matches!(
+            &event,
+            AppEvent::SessionOpened {
+                session_id,
+                result: Err(error),
+            } if session_id == "s1" && error.contains("pending question")
+        ));
+        app.handle_event(event).await.unwrap();
+
+        assert_eq!(app.chat.session_id.as_deref(), Some("old"));
+        assert!(app.pending_question.is_none());
+        assert!(app
+            .notifications
+            .last()
+            .is_some_and(|notice| notice.text.contains("pending question")));
+        server.await.unwrap();
+    }
+
     /// `Ctrl+N` clears every session-scoped field but keeps the model and
     /// stable Project membership.
     #[tokio::test]
@@ -3740,13 +6707,14 @@ mod question_tests {
             completion_tokens: 1,
             total_tokens: 2,
         });
-        app.dismissed_question = Some(ActiveQuestion {
-            question: "q".to_string(),
-            options: vec![],
-            selected: 0,
-            custom: Some(String::new()),
-            submitting: false,
-        });
+        app.dismissed_question = Some(active_question(
+            "s1",
+            "q".to_string(),
+            None,
+            "tool-1",
+            true,
+            "",
+        ));
 
         app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL))
             .await
@@ -3828,28 +6796,71 @@ mod question_tests {
     #[tokio::test]
     async fn pending_question_checked_opens_when_present() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.handle_event(AppEvent::PendingQuestionChecked(Ok(PendingQuestion {
-            has_pending_question: true,
-            question: "Still there?".to_string(),
-            options: Some(vec!["Yes".to_string()]),
-            ..Default::default()
-        })))
+        app.chat.session_id = Some("sess-1".to_string());
+        app.handle_event(AppEvent::PendingQuestionChecked {
+            session_id: "sess-1".to_string(),
+            epoch: app.answer_epoch,
+            result: Ok(PendingQuestion {
+                has_pending_question: true,
+                question: "Still there?".to_string(),
+                options: Some(vec!["Yes".to_string()]),
+                allow_custom: false,
+                tool_call_id: Some("tool-1".to_string()),
+                ..Default::default()
+            }),
+        })
         .await
         .unwrap();
         assert_eq!(
             app.pending_question.as_ref().map(|q| q.question.as_str()),
             Some("Still there?")
         );
+        assert!(app.chat.streaming);
+        assert!(app.sse_task.is_some());
+    }
+
+    #[tokio::test]
+    async fn ctrl_c_after_server_question_recovery_stops_instead_of_quitting() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("sess-1".to_string());
+        app.handle_event(AppEvent::PendingQuestionChecked {
+            session_id: "sess-1".to_string(),
+            epoch: app.answer_epoch,
+            result: Ok(PendingQuestion {
+                has_pending_question: true,
+                question: "Still there?".to_string(),
+                options: Some(vec!["Yes".to_string()]),
+                allow_custom: false,
+                tool_call_id: Some("tool-1".to_string()),
+                ..Default::default()
+            }),
+        })
+        .await
+        .unwrap();
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(event_tx);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+
+        assert!(app.running, "Ctrl+C must not quit while the run is paused");
+        assert_eq!(app.status_message, "Stopping...");
     }
 
     /// ...and reports there's nothing to reopen when the server agrees.
     #[tokio::test]
     async fn pending_question_checked_notifies_when_absent() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.handle_event(AppEvent::PendingQuestionChecked(Ok(PendingQuestion {
-            has_pending_question: false,
-            ..Default::default()
-        })))
+        app.chat.session_id = Some("sess-1".to_string());
+        app.handle_event(AppEvent::PendingQuestionChecked {
+            session_id: "sess-1".to_string(),
+            epoch: app.answer_epoch,
+            result: Ok(PendingQuestion {
+                has_pending_question: false,
+                ..Default::default()
+            }),
+        })
         .await
         .unwrap();
         assert!(app.pending_question.is_none());

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -4,7 +4,8 @@ use crate::api::types::{
     ListSessionsEnvelope, McpServer, PendingQuestion, ProviderCatalog, Schedule, Skill,
     SkillDetail, ToolInfo,
 };
-use crate::app::OpenedSession;
+use crate::api::RespondFailure;
+use crate::app::{OpenedSession, QuestionIdentity};
 
 /// Result of a background API call, delivered back to the event loop so the call
 /// never blocks the UI thread. `Err` carries a display string.
@@ -52,8 +53,31 @@ pub enum AppEvent {
         result: Result<OpenedSession, String>,
     },
     /// `Ctrl+Q` with no cached dismissed question found one on the server (or
-    /// confirmed there isn't one).
-    PendingQuestionChecked(Loaded<PendingQuestion>),
+    /// confirmed there isn't one). Session + epoch bind the async result to
+    /// the context that requested it so a late fetch cannot replace a newer
+    /// session/tool-call question.
+    PendingQuestionChecked {
+        session_id: String,
+        epoch: u64,
+        result: Loaded<PendingQuestion>,
+    },
+    /// Authoritative pending-question state fetched after an SSE handshake.
+    /// The epoch prevents a late fetch from replacing a question or answer
+    /// that changed while the request was in flight.
+    PendingQuestionReconciled {
+        session_id: String,
+        epoch: u64,
+        reconcile_epoch: u64,
+        result: Loaded<PendingQuestion>,
+    },
+    /// Server-state reconciliation after a rejected answer whose 400/409
+    /// status indicates the question may have changed or been consumed.
+    PendingQuestionRefreshed {
+        session_id: String,
+        epoch: u64,
+        identity: QuestionIdentity,
+        result: Loaded<PendingQuestion>,
+    },
     /// The answer POST for the pending question finished (`submit_answer`
     /// spawns it off the event loop — awaiting it inline froze the whole UI
     /// for the round-trip). `epoch` is the submission epoch captured when the
@@ -64,8 +88,9 @@ pub enum AppEvent {
     /// `result` carries the server's `auto_resume_status` on success.
     AnswerSubmitted {
         epoch: u64,
+        identity: QuestionIdentity,
         answer: String,
-        result: Loaded<String>,
+        result: Result<String, RespondFailure>,
     },
     /// `Ctrl+O`'s provider-catalog fetch finished. Dropped by the handler if
     /// `model_picker` was already closed (Esc) before this arrived.

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -3,8 +3,9 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
+use unicode_width::UnicodeWidthChar;
 
-use crate::app::{App, NoticeLevel, Tab};
+use crate::app::{App, NoticeLevel, QuestionOptionHitbox, Tab};
 use crate::theme::{self, colors};
 
 pub struct AppLayout {
@@ -329,114 +330,307 @@ fn submitting_hint() -> Line<'static> {
     ))
 }
 
-/// Modal for an agent question (permission gate / clarification): the operator
-/// selects an option or types a free-text answer. Rendered over everything when
-/// `app.pending_question` is set.
+fn identity_syncing_hint() -> Line<'static> {
+    Line::from(Span::styled(
+        "  Synchronizing exact question identity\u{2026}",
+        Style::default().fg(colors::WARNING),
+    ))
+}
+
+fn hard_wrap_preview(value: &str, width: usize, max_lines: usize) -> (Vec<String>, bool) {
+    let width = width.max(1);
+    if max_lines == 0 {
+        return (Vec::new(), !value.is_empty());
+    }
+    let mut output = Vec::new();
+    let mut logical_lines = value.split('\n').peekable();
+    while let Some(logical) = logical_lines.next() {
+        let mut current = String::new();
+        let mut current_width = 0;
+        for ch in logical.chars() {
+            let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if !current.is_empty() && current_width + char_width > width {
+                output.push(std::mem::take(&mut current));
+                if output.len() == max_lines {
+                    return (output, true);
+                }
+                current_width = 0;
+            }
+            current.push(ch);
+            current_width += char_width;
+        }
+        output.push(current);
+        if output.len() == max_lines {
+            return (output, logical_lines.peek().is_some());
+        }
+    }
+    if output.is_empty() {
+        output.push(String::new());
+    }
+    (output, false)
+}
+
+fn ellipsize(value: &str, width: usize) -> String {
+    let width = width.max(1);
+    let prefix_width_limit = width.saturating_sub(1);
+    let mut prefix = String::new();
+    let mut prefix_width = 0;
+    let mut total_width = 0;
+    let mut truncated = false;
+    for ch in value.chars() {
+        if ch == '\n' {
+            truncated = true;
+            break;
+        }
+        let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if total_width + char_width > width {
+            truncated = true;
+            break;
+        }
+        total_width += char_width;
+        if prefix_width + char_width <= prefix_width_limit {
+            prefix.push(ch);
+            prefix_width += char_width;
+        }
+    }
+    if truncated {
+        prefix.push('…');
+        prefix
+    } else {
+        value.to_string()
+    }
+}
+
+/// Typed clarification modal. The compact view never changes an option's
+/// underlying value; `v` opens a scrollable full-text inspector for the exact
+/// question or selected option, including on narrow terminals.
 pub fn render_question(f: &mut Frame, app: &App) {
     let Some(q) = &app.pending_question else {
         return;
     };
-
+    q.option_hitboxes.borrow_mut().clear();
     let screen = f.area();
-    // Header: title + blank + (wrapped) question + blank. Cap the question to a
-    // few lines so a very long prompt can't push the options/footer off-screen.
-    let mut header: Vec<Line> = vec![
-        Line::from(Span::styled(
-            " Agent needs your input",
-            Style::default()
-                .fg(colors::BRAND)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::raw(""),
-    ];
-    const MAX_QUESTION_LINES: usize = 6;
-    for l in q.question.lines().take(MAX_QUESTION_LINES) {
-        header.push(Line::raw(format!("  {l}")));
+
+    if q.inspecting {
+        let height = screen.height.clamp(6, 24);
+        let area = centered_rect(90, height, screen);
+        f.render_widget(Clear, area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(colors::BRAND))
+            .title(" Clarification text inspector ");
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+        let sections = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(2),
+                Constraint::Min(1),
+                Constraint::Length(3),
+            ])
+            .split(inner);
+        let (label, value) = if q.inspect_option {
+            (
+                format!("Selected option {} (exact value)", q.selected + 1),
+                q.options.get(q.selected).map(String::as_str).unwrap_or(""),
+            )
+        } else {
+            ("Question (full text)".to_string(), q.question.as_str())
+        };
+        let context = q
+            .tool_name
+            .as_deref()
+            .map(|tool| format!("tool: {tool}"))
+            .unwrap_or_else(|| "tool: unknown".to_string());
+        f.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    format!(" {label}"),
+                    Style::default()
+                        .fg(colors::BRAND)
+                        .add_modifier(Modifier::BOLD),
+                )),
+                Line::raw(format!(" {context}")),
+            ]),
+            sections[0],
+        );
+        let paragraph = Paragraph::new(value).wrap(Wrap { trim: false });
+        let wrapped_count = paragraph.line_count(sections[1].width);
+        let max_scroll = u16::try_from(wrapped_count.saturating_sub(sections[1].height as usize))
+            .unwrap_or(u16::MAX);
+        q.inspect_max_scroll.set(max_scroll);
+        f.render_widget(
+            paragraph.scroll((q.inspect_scroll.min(max_scroll), 0)),
+            sections[1],
+        );
+        let footer = if q.options.is_empty() {
+            vec![
+                Line::raw(" ↑/↓/PgUp/PgDn scroll"),
+                Line::raw(" y copy exact"),
+                Line::raw(" v/Esc back"),
+            ]
+        } else {
+            vec![
+                Line::raw(" ↑/↓/PgUp/PgDn scroll"),
+                Line::raw(" Tab question/option"),
+                Line::raw(" y copy exact  ·  v/Esc back"),
+            ]
+        };
+        f.render_widget(Paragraph::new(footer), sections[2]);
+        return;
     }
-    if q.question.lines().count() > MAX_QUESTION_LINES {
-        header.push(Line::raw("  …"));
+
+    let popup_width = (screen.width as usize * 80 / 100).max(1);
+    let text_width = popup_width.saturating_sub(6).max(1);
+    let mut header = vec![Line::from(Span::styled(
+        " Clarification needed",
+        Style::default()
+            .fg(colors::BRAND)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    if q.tool_name.is_some() || q.source.is_some() {
+        let context = format!(
+            "  tool: {}  ·  source: {}",
+            q.tool_name.as_deref().unwrap_or("unknown"),
+            q.source.as_deref().unwrap_or("unknown")
+        );
+        header.push(Line::raw(ellipsize(&context, text_width + 2)));
+    }
+    header.push(Line::raw(""));
+    const QUESTION_PREVIEW_LINES: usize = 4;
+    let (wrapped_question, question_truncated) =
+        hard_wrap_preview(&q.question, text_width, QUESTION_PREVIEW_LINES);
+    for line in &wrapped_question {
+        header.push(Line::raw(format!("  {line}")));
+    }
+    if question_truncated {
+        header.push(Line::raw("  …  (v inspect full question)"));
     }
     header.push(Line::raw(""));
 
-    let mut body: Vec<Line> = Vec::new();
-    match &q.custom {
-        Some(buf) => {
-            body.push(Line::raw("  Type your answer:"));
-            body.push(Line::from(Span::styled(
-                format!("  > {buf}\u{258f}"),
-                Style::default().fg(colors::BRAND),
-            )));
-            body.push(Line::raw(""));
-            if q.submitting {
-                body.push(submitting_hint());
-            } else {
-                body.push(Line::raw(if q.options.is_empty() {
-                    "  Enter answer  ·  Esc dismiss"
-                } else {
-                    "  Enter answer  ·  Esc back to options"
-                }));
-            }
+    let mut body = Vec::new();
+    let mut option_line_positions = Vec::new();
+    if let Some(entry) = &q.number_entry {
+        body.push(Line::raw(format!("  Go to option #: {entry}▏")));
+        body.push(Line::raw(""));
+        body.push(Line::raw("  digits type  ·  Enter select"));
+        body.push(Line::raw("  Backspace edit  ·  Esc cancel"));
+    } else if let Some(buf) = &q.custom {
+        body.push(Line::raw("  Custom answer:"));
+        body.push(Line::from(Span::styled(
+            format!("  > {}▏", ellipsize(buf, text_width.saturating_sub(2))),
+            Style::default().fg(colors::BRAND),
+        )));
+        body.push(Line::raw(""));
+        if q.identity_syncing {
+            body.push(identity_syncing_hint());
+        } else if q.submitting {
+            body.push(submitting_hint());
+        } else if q.options.is_empty() {
+            body.push(Line::raw("  Enter answer  ·  Esc dismiss"));
+            body.push(Line::raw("  Ctrl+V inspect/copy question"));
+        } else {
+            body.push(Line::raw("  Enter answer  ·  Esc options"));
+            body.push(Line::raw("  Ctrl+V inspect/copy question"));
         }
-        None => {
-            // Window the option list around the selection so it stays visible and
-            // the modal never overflows the screen, no matter how many options.
-            let max_h = screen.height.min(22);
-            // rows available for options = modal height - borders(2) - header - footer(1)
-            let budget = (max_h as usize).saturating_sub(2 + header.len() + 1).max(1);
-            let total = q.options.len();
-            let start = if total <= budget {
-                0
+    } else if q.options.is_empty() {
+        body.push(Line::from(Span::styled(
+            "  No selectable answers were supplied and custom input is disabled.",
+            Style::default().fg(colors::WARNING),
+        )));
+        body.push(Line::raw(""));
+        body.push(Line::raw("  v inspect/copy question  ·  Esc dismiss"));
+    } else {
+        let max_h = screen.height.min(24);
+        let reserved =
+            2 + header.len() + 7 + usize::from(q.allow_custom) + usize::from(q.error.is_some());
+        let budget = (max_h as usize).saturating_sub(reserved).max(1);
+        let total = q.options.len();
+        let start = if total <= budget {
+            0
+        } else {
+            q.selected
+                .saturating_sub(budget / 2)
+                .min(total.saturating_sub(budget))
+        };
+        let end = (start + budget).min(total);
+        if start > 0 {
+            body.push(Line::raw(format!("  ↑ {start} more")));
+        }
+        for i in start..end {
+            let selected = i == q.selected;
+            let marker = if selected { "›" } else { " " };
+            let style = if selected {
+                Style::default()
+                    .fg(colors::BRAND)
+                    .add_modifier(Modifier::BOLD)
             } else {
-                q.selected
-                    .saturating_sub(budget / 2)
-                    .min(total.saturating_sub(budget))
+                Style::default()
             };
-            let end = (start + budget).min(total);
-            if start > 0 {
-                body.push(Line::raw(format!("  \u{2191} {start} more")));
-            }
-            for i in start..end {
-                let selected = i == q.selected;
-                let marker = if selected { "\u{203a}" } else { " " };
-                let style = if selected {
-                    Style::default()
-                        .fg(colors::BRAND)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                };
-                body.push(Line::from(Span::styled(
-                    format!("  {marker} {}. {}", i + 1, q.options[i]),
-                    style,
-                )));
-            }
-            if end < total {
-                body.push(Line::raw(format!("  \u{2193} {} more", total - end)));
-            }
-            body.push(Line::raw(""));
-            if q.submitting {
-                body.push(submitting_hint());
-            } else {
-                body.push(Line::raw(
-                    "  \u{2191}/\u{2193} select  ·  Enter answer  ·  1-9 quick  ·  c custom  ·  Esc dismiss",
-                ));
+            let prefix = format!("  {marker} {}. ", i + 1);
+            let option_width = text_width.saturating_sub(prefix.chars().count()).max(1);
+            option_line_positions.push((body.len(), i));
+            body.push(Line::from(Span::styled(
+                format!("{prefix}{}", ellipsize(&q.options[i], option_width)),
+                style,
+            )));
+        }
+        if end < total {
+            body.push(Line::raw(format!("  ↓ {} more", total - end)));
+        }
+        body.push(Line::raw(""));
+        if q.identity_syncing {
+            body.push(identity_syncing_hint());
+        } else if q.submitting {
+            body.push(submitting_hint());
+        } else {
+            body.push(Line::raw("  click option answer  ·  ↑/↓/wheel select"));
+            body.push(Line::raw("  Enter answer  ·  Esc dismiss  ·  1-9 quick"));
+            body.push(Line::raw("  g number  ·  v inspect  ·  y copy"));
+            if q.allow_custom {
+                body.push(Line::raw("  c custom answer"));
             }
         }
     }
-
+    if let Some(error) = &q.error {
+        body.push(Line::from(Span::styled(
+            format!(
+                "  Error: {}",
+                ellipsize(error, text_width.saturating_sub(7))
+            ),
+            Style::default().fg(colors::ERROR),
+        )));
+    }
+    let header_len = header.len();
     let mut lines = header;
     lines.extend(body);
     let height = (lines.len() as u16 + 2).min(screen.height);
-    let area = centered_rect(60, height, screen);
+    let area = centered_rect(80, height, screen);
+    let option_x = area.x.saturating_add(1);
+    let option_width = area.width.saturating_sub(2);
+    let option_bottom = area.y.saturating_add(area.height).saturating_sub(1);
+    *q.option_hitboxes.borrow_mut() = option_line_positions
+        .into_iter()
+        .filter_map(|(body_line, index)| {
+            let y = area
+                .y
+                .saturating_add(1)
+                .saturating_add(header_len as u16)
+                .saturating_add(body_line as u16);
+            (y < option_bottom).then_some(QuestionOptionHitbox {
+                x: option_x,
+                y,
+                width: option_width,
+                index,
+            })
+        })
+        .collect();
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(colors::BRAND))
-        .title(" Question ");
-    let para = Paragraph::new(lines)
-        .block(block)
-        .wrap(Wrap { trim: false });
-    f.render_widget(para, area);
+        .title(" Clarification ");
+    f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
 /// Modal confirming a session delete (`d` on the Sessions tab). Mirrors the

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -37,31 +37,31 @@ pub fn render(f: &mut Frame, app: &App) {
         layout::render_notifications(f, app);
     }
 
-    // Exclusive modals — at most one of these is ever `Some` at a time (see
-    // the precedence comment on `App::handle_key`), so draw order only
-    // matters for visually layering over the help/notification overlays
-    // above; kept in the same 0-5 precedence order as the key routing.
-    if app.serve_offer.is_some() {
-        layout::render_serve_offer(f, app);
-    }
-
-    if app.pending_question.is_some() {
-        layout::render_question(f, app);
-    }
-
-    if app.pending_delete.is_some() {
-        layout::render_delete_confirm(f, app);
-    }
-
-    if app.model_picker.is_some() {
-        layout::render_model_picker(f, app);
+    // A clarification can arrive asynchronously while a local editor or
+    // confirmation is already open. Draw from lowest to highest input
+    // precedence so the modal that owns the keyboard is always the visible
+    // frontmost modal (the reverse of `App::handle_key`'s routing order).
+    if app.config_editor.is_some() {
+        config::render_editor(f, app);
     }
 
     if app.schedule_form.is_some() {
         layout::render_schedule_form(f, app);
     }
 
-    if app.config_editor.is_some() {
-        config::render_editor(f, app);
+    if app.model_picker.is_some() {
+        layout::render_model_picker(f, app);
+    }
+
+    if app.pending_delete.is_some() {
+        layout::render_delete_confirm(f, app);
+    }
+
+    if app.pending_question.is_some() {
+        layout::render_question(f, app);
+    }
+
+    if app.serve_offer.is_some() {
+        layout::render_serve_offer(f, app);
     }
 }

--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use crate::tools::ToolResult;
-use bamboo_domain::{AgentHookPoint, HookResult, TaskItemStatus, TaskList};
+use bamboo_domain::{AgentHookPoint, HookResult, PendingQuestionSource, TaskItemStatus, TaskList};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -212,6 +212,9 @@ pub enum AgentEvent {
         /// Whether the user can provide a free-text response
         #[serde(default = "default_allow_custom")]
         allow_custom: bool,
+        /// Origin of the pending question, when known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<PendingQuestionSource>,
     },
 
     /// Emitted when task list is created or updated.
@@ -775,8 +778,8 @@ impl AgentEvent {
     /// client-side session without a per-session connection. For sub-agent
     /// events the *parent* session id is returned (that is the session a client
     /// observes in its list). Pure streaming/diagnostic variants (`Token`,
-    /// `Complete`, …) return `None`; those are ephemeral and never ride the
-    /// account feed anyway.
+    /// `Complete`, …) return `None`; those are routed by their owning
+    /// per-session forwarder instead.
     pub fn session_id(&self) -> Option<&str> {
         match self {
             AgentEvent::TaskListUpdated { task_list } => Some(task_list.session_id.as_str()),
@@ -823,6 +826,34 @@ impl AgentEvent {
             } => Some(parent_session_id.as_str()),
             _ => None,
         }
+    }
+
+    /// Whether this event carries live session state that a late per-session
+    /// subscriber must replay before consuming the broadcast stream.
+    ///
+    /// This classification is shared by both server-owned and generic engine
+    /// forwarders. Keeping it in core prevents one execution entry point from
+    /// broadcasting a clarification (or other critical state) without first
+    /// populating the runner replay cache.
+    pub fn is_replayable_session_state(&self) -> bool {
+        matches!(
+            self,
+            AgentEvent::TaskListUpdated { .. }
+                | AgentEvent::TaskListCompleted { .. }
+                | AgentEvent::SubAgentStarted { .. }
+                | AgentEvent::SubAgentCompleted { .. }
+                | AgentEvent::ChildApprovalRequested { .. }
+                | AgentEvent::ChildApprovalChanged { .. }
+                | AgentEvent::BashCompleted { .. }
+                | AgentEvent::SessionTitleUpdated { .. }
+                | AgentEvent::SessionPinnedUpdated { .. }
+                | AgentEvent::PlanModeEntered { .. }
+                | AgentEvent::PlanModeExited { .. }
+                | AgentEvent::BudgetExceeded { .. }
+                | AgentEvent::NeedClarification { .. }
+                | AgentEvent::WorkflowActivated { .. }
+                | AgentEvent::WorkflowDeactivated { .. }
+        )
     }
 
     /// Whether this event belongs on the durable account change feed.
@@ -1190,6 +1221,7 @@ mod tests {
             tool_call_id: Some("tool-1".to_string()),
             tool_name: Some("conclusion_with_options".to_string()),
             allow_custom: false,
+            source: Some(PendingQuestionSource::PauseTool),
         };
 
         let value = serde_json::to_value(event).expect("event should serialize");
@@ -1199,6 +1231,7 @@ mod tests {
         assert_eq!(value["tool_call_id"], "tool-1");
         assert_eq!(value["tool_name"], "conclusion_with_options");
         assert_eq!(value["allow_custom"], false);
+        assert_eq!(value["source"], "pause_tool");
     }
 
     #[test]
@@ -1218,12 +1251,14 @@ mod tests {
                 tool_call_id,
                 tool_name,
                 allow_custom,
+                source,
             } => {
                 assert_eq!(question, "Continue?");
                 assert_eq!(options, Some(vec!["Yes".to_string(), "No".to_string()]));
                 assert_eq!(tool_call_id, None);
                 assert_eq!(tool_name, None);
                 assert!(allow_custom); // default_allow_custom returns true
+                assert_eq!(source, None);
             }
             other => panic!("unexpected event: {other:?}"),
         }
@@ -1245,12 +1280,14 @@ mod tests {
                 tool_call_id,
                 tool_name,
                 allow_custom,
+                source,
             } => {
                 assert_eq!(question, "Pick one");
                 assert_eq!(options, None);
                 assert_eq!(tool_call_id, None);
                 assert_eq!(tool_name, None);
                 assert!(!allow_custom);
+                assert_eq!(source, None);
             }
             other => panic!("unexpected event: {other:?}"),
         }
@@ -1493,5 +1530,22 @@ mod tests {
             let encoded = serde_json::to_string(&event).expect("serialize");
             let _: AgentEvent = serde_json::from_str(&encoded).expect("deserialize");
         }
+    }
+
+    #[test]
+    fn clarification_is_shared_replayable_state_but_tokens_are_not() {
+        let clarification = AgentEvent::NeedClarification {
+            question: "Choose".to_string(),
+            options: Some(vec!["A".to_string()]),
+            tool_call_id: Some("call-1".to_string()),
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some(PendingQuestionSource::PauseTool),
+        };
+        assert!(clarification.is_replayable_session_state());
+        assert!(!AgentEvent::Token {
+            content: "ephemeral".to_string(),
+        }
+        .is_replayable_session_state());
     }
 }

--- a/crates/core/bamboo-agent-core/src/lib.rs
+++ b/crates/core/bamboo-agent-core/src/lib.rs
@@ -25,12 +25,12 @@ pub use bamboo_domain::{
 pub use storage::Storage;
 pub use tools::{
     classify_tool, execute_tool_call, finalize_tool_calls, handle_tool_result_with_agentic_support,
-    normalize_tool_name, parse_tool_args, parse_tool_args_best_effort, plan_mode_allows_tool,
-    try_parse_agentic_result, AgenticContext, AgenticTool, AgenticToolResult, BashCompletionInfo,
-    BashCompletionSink, FunctionCall, FunctionSchema, RegistryError, SharedTool,
-    SmartCodeReviewTool, Tool, ToolCall, ToolCallAccumulator, ToolError, ToolExecutionContext,
-    ToolExecutor, ToolGoal, ToolHandlingOutcome, ToolMutability, ToolRegistry, ToolResult,
-    ToolResultImage, ToolSchema,
+    handle_tool_result_with_agentic_support_and_persistence, normalize_tool_name, parse_tool_args,
+    parse_tool_args_best_effort, plan_mode_allows_tool, try_parse_agentic_result, AgenticContext,
+    AgenticTool, AgenticToolResult, BashCompletionInfo, BashCompletionSink, FunctionCall,
+    FunctionSchema, RegistryError, SharedTool, SmartCodeReviewTool, Tool, ToolCall,
+    ToolCallAccumulator, ToolError, ToolExecutionContext, ToolExecutor, ToolGoal,
+    ToolHandlingOutcome, ToolMutability, ToolRegistry, ToolResult, ToolResultImage, ToolSchema,
 };
 pub use tools::{
     AsyncToolCompletionInfo, AsyncToolCompletionSink, AsyncWaitKind, RunningCompletion,

--- a/crates/core/bamboo-agent-core/src/tools/mod.rs
+++ b/crates/core/bamboo-agent-core/src/tools/mod.rs
@@ -116,7 +116,8 @@ pub use registry::{
     global_registry, normalize_tool_name, RegistryError, SharedTool, Tool, ToolRegistry,
 };
 pub use result_handler::{
-    execute_sub_actions, handle_tool_result_with_agentic_support, parse_tool_args,
+    execute_sub_actions, handle_tool_result_with_agentic_support,
+    handle_tool_result_with_agentic_support_and_persistence, parse_tool_args,
     parse_tool_args_best_effort, send_clarification_request, try_parse_agentic_result,
     ToolHandlingOutcome, MAX_SUB_ACTIONS,
 };

--- a/crates/core/bamboo-agent-core/src/tools/result_handler.rs
+++ b/crates/core/bamboo-agent-core/src/tools/result_handler.rs
@@ -201,6 +201,33 @@ pub async fn handle_tool_result_with_agentic_support(
     session_flags: ToolExecutionSessionFlags,
     composition_executor: Option<Arc<CompositionExecutor>>,
 ) -> ToolHandlingOutcome {
+    handle_tool_result_with_agentic_support_and_persistence(
+        result,
+        tool_call,
+        event_tx,
+        session,
+        tools,
+        session_flags,
+        composition_executor,
+        None,
+    )
+    .await
+}
+
+/// Engine integration variant that makes an agentic clarification durable
+/// before publishing `NeedClarification`. The compatibility wrapper above is
+/// retained for in-process callers without a persistence adapter.
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_tool_result_with_agentic_support_and_persistence(
+    result: &ToolResult,
+    tool_call: &ToolCall,
+    event_tx: &mpsc::Sender<AgentEvent>,
+    session: &mut Session,
+    tools: &dyn ToolExecutor,
+    session_flags: ToolExecutionSessionFlags,
+    composition_executor: Option<Arc<CompositionExecutor>>,
+    clarification_persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
+) -> ToolHandlingOutcome {
     let should_wait_for_children = is_waiting_for_children_control(result);
     if should_wait_for_children {
         session.metadata.insert(
@@ -260,16 +287,15 @@ pub async fn handle_tool_result_with_agentic_support(
             ToolHandlingOutcome::Continue
         }
         AgenticToolResult::NeedClarification { question, options } => {
-            send_clarification_request(
+            persist_and_publish_agentic_clarification(
                 event_tx,
-                question.clone(),
-                options.clone(),
-                Some(tool_call.id.clone()),
-                Some(tool_call.function.name.clone()),
+                session,
+                tool_call,
+                question,
+                options,
+                clarification_persistence,
             )
             .await;
-
-            persist_agentic_clarification(session, tool_call, question, options);
 
             ToolHandlingOutcome::AwaitingClarification
         }
@@ -282,17 +308,55 @@ pub async fn handle_tool_result_with_agentic_support(
                 ),
             ));
 
-            execute_sub_actions(
+            execute_sub_actions_with_persistence(
                 &actions,
                 event_tx,
                 session,
                 tools,
                 session_flags,
                 composition_executor,
+                clarification_persistence,
             )
             .await
         }
     }
+}
+
+async fn persist_and_publish_agentic_clarification(
+    event_tx: &mpsc::Sender<AgentEvent>,
+    session: &mut Session,
+    tool_call: &ToolCall,
+    question: String,
+    options: Option<Vec<String>>,
+    clarification_persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
+) -> bool {
+    persist_agentic_clarification(session, tool_call, question.clone(), options.clone());
+    if let Some(persistence) = clarification_persistence {
+        if let Err(error) = persistence.save_runtime_session(session).await {
+            tracing::error!(
+                session_id = %session.id,
+                %error,
+                "Failed to persist agentic clarification; suppressing NeedClarification"
+            );
+            let _ = event_tx
+                .send(AgentEvent::Error {
+                    message: format!(
+                        "Clarification could not be saved; retry after session storage recovers: {error}"
+                    ),
+                })
+                .await;
+            return false;
+        }
+    }
+    send_clarification_request(
+        event_tx,
+        question,
+        options,
+        Some(tool_call.id.clone()),
+        Some(tool_call.function.name.clone()),
+    )
+    .await;
+    true
 }
 
 fn persist_agentic_clarification(
@@ -334,6 +398,7 @@ pub async fn send_clarification_request(
             tool_call_id,
             tool_name,
             allow_custom: true,
+            source: Some(PendingQuestionSource::AgenticClarification),
         })
         .await;
 }
@@ -345,6 +410,27 @@ pub async fn execute_sub_actions(
     tools: &dyn ToolExecutor,
     session_flags: ToolExecutionSessionFlags,
     composition_executor: Option<Arc<CompositionExecutor>>,
+) -> ToolHandlingOutcome {
+    execute_sub_actions_with_persistence(
+        actions,
+        event_tx,
+        session,
+        tools,
+        session_flags,
+        composition_executor,
+        None,
+    )
+    .await
+}
+
+async fn execute_sub_actions_with_persistence(
+    actions: &[ToolCall],
+    event_tx: &mpsc::Sender<AgentEvent>,
+    session: &mut Session,
+    tools: &dyn ToolExecutor,
+    session_flags: ToolExecutionSessionFlags,
+    composition_executor: Option<Arc<CompositionExecutor>>,
+    clarification_persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
 ) -> ToolHandlingOutcome {
     let mut pending: VecDeque<ToolCall> = actions.iter().cloned().collect();
     let mut processed = 0usize;
@@ -453,15 +539,15 @@ pub async fn execute_sub_actions(
                         ));
                     }
                     Some(AgenticToolResult::NeedClarification { question, options }) => {
-                        send_clarification_request(
+                        persist_and_publish_agentic_clarification(
                             event_tx,
-                            question.clone(),
-                            options.clone(),
-                            Some(action.id.clone()),
-                            Some(action.function.name.clone()),
+                            session,
+                            &action,
+                            question,
+                            options,
+                            clarification_persistence,
                         )
                         .await;
-                        persist_agentic_clarification(session, &action, question, options);
                         return ToolHandlingOutcome::AwaitingClarification;
                     }
                     Some(AgenticToolResult::NeedMoreActions {
@@ -519,6 +605,32 @@ mod tests {
 
     struct StaticExecutor {
         results: HashMap<String, ToolResult>,
+    }
+
+    #[derive(Default)]
+    struct BlockingClarificationPersistence {
+        saved: std::sync::Mutex<Vec<Session>>,
+        entered: tokio::sync::Notify,
+        release: tokio::sync::Notify,
+    }
+
+    #[async_trait]
+    impl bamboo_domain::RuntimeSessionPersistence for BlockingClarificationPersistence {
+        async fn save_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
+            self.saved.lock().unwrap().push(session.clone());
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(())
+        }
+    }
+
+    struct FailingClarificationPersistence;
+
+    #[async_trait]
+    impl bamboo_domain::RuntimeSessionPersistence for FailingClarificationPersistence {
+        async fn save_runtime_session(&self, _session: &mut Session) -> std::io::Result<()> {
+            Err(std::io::Error::other("injected clarification save failure"))
+        }
     }
 
     impl StaticExecutor {
@@ -739,6 +851,131 @@ mod tests {
 
         assert!(saw_sub_start);
         assert!(saw_sub_complete);
+    }
+
+    #[tokio::test]
+    async fn nested_clarification_is_persisted_before_its_event_is_published() {
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        let sub_action = make_tool_call("call_sub", "sub_tool", "{}");
+        let parent_call = make_tool_call("call_parent", "smart_tool", "{}");
+        let mut results = HashMap::new();
+        results.insert(
+            "sub_tool".to_string(),
+            ToolResult {
+                success: true,
+                result: serde_json::to_string(&AgenticToolResult::NeedClarification {
+                    question: "Which nested action?".to_string(),
+                    options: Some(vec!["A".to_string(), "B".to_string()]),
+                })
+                .unwrap(),
+                display_preference: None,
+                images: Vec::new(),
+            },
+        );
+        let tools: Arc<dyn ToolExecutor> = Arc::new(StaticExecutor::new(results));
+        let persistence = Arc::new(BlockingClarificationPersistence::default());
+        let persistence_port: Arc<dyn bamboo_domain::RuntimeSessionPersistence> =
+            persistence.clone();
+        let parent_result = ToolResult {
+            success: true,
+            result: serde_json::to_string(&AgenticToolResult::NeedMoreActions {
+                actions: vec![sub_action],
+                reason: "Need nested input".to_string(),
+            })
+            .unwrap(),
+            display_preference: None,
+            images: Vec::new(),
+        };
+
+        let handling = tokio::spawn(async move {
+            let mut session = Session::new("nested-clarification", "test-model");
+            let outcome = handle_tool_result_with_agentic_support_and_persistence(
+                &parent_result,
+                &parent_call,
+                &event_tx,
+                &mut session,
+                tools.as_ref(),
+                ToolExecutionSessionFlags::default(),
+                None,
+                Some(&persistence_port),
+            )
+            .await;
+            (outcome, session)
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            persistence.entered.notified(),
+        )
+        .await
+        .expect("nested clarification should reach persistence");
+        let events_before_save: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+        assert!(!events_before_save
+            .iter()
+            .any(|event| matches!(event, AgentEvent::NeedClarification { .. })));
+        let saved = persistence.saved.lock().unwrap().last().cloned().unwrap();
+        let pending = saved
+            .pending_question
+            .expect("saved nested pending question");
+        assert_eq!(pending.tool_call_id, "call_sub");
+        assert_eq!(pending.tool_name, "sub_tool");
+
+        persistence.release.notify_one();
+        let (outcome, session) = handling.await.unwrap();
+        assert_eq!(outcome, ToolHandlingOutcome::AwaitingClarification);
+        assert_eq!(session.pending_question.unwrap().tool_call_id, "call_sub");
+        let event = tokio::time::timeout(std::time::Duration::from_secs(5), event_rx.recv())
+            .await
+            .expect("clarification should publish after save")
+            .expect("event channel should stay open");
+        assert!(matches!(
+            event,
+            AgentEvent::NeedClarification {
+                tool_call_id: Some(ref id),
+                ..
+            } if id == "call_sub"
+        ));
+    }
+
+    #[tokio::test]
+    async fn failed_agentic_clarification_persistence_is_terminal_and_never_published() {
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        let tool_call = make_tool_call("call_pending", "smart_tool", "{}");
+        let result = ToolResult {
+            success: true,
+            result: serde_json::to_string(&AgenticToolResult::NeedClarification {
+                question: "Choose safely?".to_string(),
+                options: Some(vec!["A".to_string(), "B".to_string()]),
+            })
+            .unwrap(),
+            display_preference: None,
+            images: Vec::new(),
+        };
+        let tools: Arc<dyn ToolExecutor> = Arc::new(StaticExecutor::new(HashMap::new()));
+        let persistence: Arc<dyn bamboo_domain::RuntimeSessionPersistence> =
+            Arc::new(FailingClarificationPersistence);
+        let mut session = Session::new("failed-agentic-clarification", "test-model");
+
+        let outcome = handle_tool_result_with_agentic_support_and_persistence(
+            &result,
+            &tool_call,
+            &event_tx,
+            &mut session,
+            tools.as_ref(),
+            ToolExecutionSessionFlags::default(),
+            None,
+            Some(&persistence),
+        )
+        .await;
+
+        assert_eq!(outcome, ToolHandlingOutcome::AwaitingClarification);
+        let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+        assert!(events.iter().any(
+            |event| matches!(event, AgentEvent::Error { message } if message.contains("could not be saved"))
+        ));
+        assert!(events
+            .iter()
+            .all(|event| !matches!(event, AgentEvent::NeedClarification { .. })));
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-engine/src/events/replayable.rs
+++ b/crates/engine/bamboo-engine/src/events/replayable.rs
@@ -13,7 +13,8 @@
 //! ## Invariant
 //!
 //! No code in the workspace may pair `runner.push_critical_event` with
-//! `sender.send` outside this helper or the server's `spawn_event_forwarder`
+//! `sender.send` outside this helper, the generic engine event forwarder, or
+//! the server's `spawn_event_forwarder`
 //! (in `handlers::agent::execute::runtime::events`).
 //! Hand-rolling the pair has historically led to inverted ordering (broadcast
 //! first, cache second), which leaves a small window where a late subscriber

--- a/crates/engine/bamboo-engine/src/external_agents/mapping.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/mapping.rs
@@ -142,6 +142,7 @@ impl A2AEventMapper {
                     tool_call_id: None,
                     tool_name: None,
                     allow_custom: true,
+                    source: Some(bamboo_agent_core::PendingQuestionSource::ExternalAgent),
                 });
             }
             TaskState::AuthRequired => {
@@ -152,6 +153,7 @@ impl A2AEventMapper {
                     tool_call_id: None,
                     tool_name: None,
                     allow_custom: true,
+                    source: Some(bamboo_agent_core::PendingQuestionSource::ExternalAgent),
                 });
             }
             TaskState::Completed => {

--- a/crates/engine/bamboo-engine/src/gold_auto_answer/mod.rs
+++ b/crates/engine/bamboo-engine/src/gold_auto_answer/mod.rs
@@ -5,8 +5,11 @@ use crate::app_context::AgentSessionContext;
 use crate::events::publish_replayable_session_event;
 use crate::model_config_helper::{resolve_gold_config, GOLD_CONFIG_METADATA_KEY};
 use crate::session_app::repository::SessionAccess;
-use crate::session_app::respond::{submit_pending_response_with_source, ResponseSource};
-use crate::session_app::resume::{resume_session_execution, ResumeExecutionPort};
+use crate::session_app::respond::{
+    acquire_pending_response_guard, inspect_pending_response_guarded,
+    submit_pending_response_with_source_checked_guarded, ResponseSource,
+};
+use crate::session_app::resume::ResumeExecutionPort;
 use crate::session_app::types::{RespondInput, ResumeOutcome};
 
 mod decision;
@@ -193,7 +196,36 @@ where
         };
     };
 
-    let Some(answer) = canonicalize_pending_answer(pending_question, raw_answer) else {
+    // Gold evaluation is intentionally outside the response single-flight, but
+    // the answer transaction re-enters the same gate as HTTP and Connect. A
+    // human may have answered while the evaluator was running; reload before
+    // reserving so stale Gold work cannot replace that successor's runner.
+    let evaluated_tool_call_id = pending_question.tool_call_id.clone();
+    let response_guard = acquire_pending_response_guard(session_id).await;
+    let current = match inspect_pending_response_guarded(state, session_id, &response_guard).await {
+        Ok(Some(session)) => session,
+        Ok(None) => {
+            return GoldAutoAnswerOutcome::Skipped {
+                reason: "session_not_found_after_evaluation".to_string(),
+            };
+        }
+        Err(error) => {
+            return GoldAutoAnswerOutcome::Skipped {
+                reason: format!("response_preflight_failed:{error}"),
+            };
+        }
+    };
+    let Some(current_pending) = current.pending_question.as_ref() else {
+        return GoldAutoAnswerOutcome::Skipped {
+            reason: "pending_question_consumed_during_evaluation".to_string(),
+        };
+    };
+    if current_pending.tool_call_id != evaluated_tool_call_id {
+        return GoldAutoAnswerOutcome::Skipped {
+            reason: "pending_question_changed_during_evaluation".to_string(),
+        };
+    }
+    let Some(answer) = canonicalize_pending_answer(current_pending, raw_answer) else {
         return GoldAutoAnswerOutcome::Skipped {
             reason: "question_decision_answer_not_canonical".to_string(),
         };
@@ -201,11 +233,26 @@ where
 
     tracing::info!(
         session_id = %session_id,
-        tool_name = %pending_question.tool_name,
+        tool_name = %current_pending.tool_name,
         answer = %answer,
         reasoning = %answer_decision.reasoning,
         "Applying Gold auto-answer for pending clarification"
     );
+
+    let handoff = match crate::session_app::resume::reserve_response_resume_handoff(
+        resume_port,
+        session_id,
+        std::time::Duration::from_secs(15),
+    )
+    .await
+    {
+        Ok(handoff) => handoff,
+        Err(_) => {
+            return GoldAutoAnswerOutcome::Skipped {
+                reason: "suspending_runner_still_finalizing".to_string(),
+            };
+        }
+    };
 
     let respond_input = RespondInput {
         session_id: session_id.to_string(),
@@ -213,17 +260,25 @@ where
         model: None,
         model_ref: None,
         provider: None,
-        reasoning_effort: session.reasoning_effort,
+        reasoning_effort: current.reasoning_effort,
     };
 
     // Gold (eval) auto-answers do not record permission grants; eval sessions
     // should run with a permissive posture (e.g. BypassPermissions) so they never
     // pause for approval in the first place.
     let (updated_session, _submitted_answer, plan_mode_transition, _permission_grants) =
-        match submit_pending_response_with_source(state, respond_input, ResponseSource::Gold).await
+        match submit_pending_response_with_source_checked_guarded(
+            state,
+            respond_input,
+            Some(evaluated_tool_call_id),
+            ResponseSource::Gold,
+            &response_guard,
+        )
+        .await
         {
             Ok(result) => result,
             Err(error) => {
+                handoff.abandon().await;
                 tracing::warn!(
                     session_id = %session_id,
                     error = %error,
@@ -235,13 +290,29 @@ where
             }
         };
 
-    if let Some(event) = plan_mode_transition_event(session_id, plan_mode_transition.as_ref()) {
+    let plan_mode_event = plan_mode_transition_event(session_id, plan_mode_transition.as_ref());
+    let resume_config = build_resume_config_snapshot(
+        state,
+        &config_snapshot,
+        &updated_session,
+        Some(gold_config.clone()),
+    );
+    let resume_outcome = crate::session_app::resume::resume_session_execution_with_handoff(
+        resume_port,
+        session_id,
+        updated_session,
+        resume_config,
+        handoff,
+    )
+    .await;
+    drop(response_guard);
+
+    // The execution handoff is already owned by a detached task, so this
+    // replayable metadata publication cannot strand the committed answer if
+    // the Gold evaluator is cancelled while awaiting its runner/cache locks.
+    if let Some(event) = plan_mode_event {
         publish_replayable_session_event(state, session_id, event).await;
     }
-
-    let resume_config =
-        build_resume_config_snapshot(state, &updated_session, Some(gold_config.clone())).await;
-    let resume_outcome = resume_session_execution(resume_port, session_id, resume_config).await;
 
     tracing::info!(
         session_id = %session_id,

--- a/crates/engine/bamboo-engine/src/gold_auto_answer/resume.rs
+++ b/crates/engine/bamboo-engine/src/gold_auto_answer/resume.rs
@@ -6,14 +6,14 @@ use crate::session_app::resolution::resolve_resume_config_snapshot;
 use crate::session_app::respond::PlanModeTransition;
 use crate::session_app::types::ResumeConfigSnapshot;
 
-pub(crate) async fn build_resume_config_snapshot(
+pub(crate) fn build_resume_config_snapshot(
     state: &dyn AgentSessionContext,
+    config_snapshot: &bamboo_llm::Config,
     session: &Session,
     gold_config_override: Option<GoldConfig>,
 ) -> ResumeConfigSnapshot {
-    let config_snapshot = state.config().read().await.clone();
     resolve_resume_config_snapshot(
-        &config_snapshot,
+        config_snapshot,
         state.provider_registry(),
         session,
         gold_config_override,

--- a/crates/engine/bamboo-engine/src/runtime/execution/event_forwarder.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/event_forwarder.rs
@@ -62,6 +62,60 @@ mod tests {
         assert_eq!(session_id.as_deref(), Some("parent-1"));
         assert!(matches!(mirrored, AgentEvent::ChildApprovalChanged { .. }));
     }
+
+    #[tokio::test]
+    async fn delayed_old_forwarder_cannot_publish_after_successor_reservation() {
+        let session_id = "session-generation";
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel(16);
+        let mut successor = AgentRunner::new();
+        successor.run_id = "run-new".to_string();
+        successor.status = super::super::runner_state::AgentStatus::Running;
+        successor.event_sender = broadcast_tx.clone();
+        let runners = Arc::new(RwLock::new(HashMap::from([(
+            session_id.to_string(),
+            successor,
+        )])));
+
+        // The successor is already visible on the shared transport before an
+        // old forwarder task finally gets CPU time.
+        broadcast_tx
+            .send(AgentEvent::ExecutionStarted {
+                run_id: "run-new".to_string(),
+                session_id: session_id.to_string(),
+                started_at: Utc::now().to_rfc3339(),
+            })
+            .unwrap();
+        let (old_tx, old_forwarder) = create_event_forwarder(
+            session_id.to_string(),
+            "run-old".to_string(),
+            broadcast_tx.clone(),
+            runners,
+            None,
+        );
+        let _ = old_tx
+            .send(AgentEvent::NeedClarification {
+                question: "stale".to_string(),
+                options: Some(vec!["A".to_string()]),
+                tool_call_id: Some("old-tool".to_string()),
+                tool_name: Some("ConclusionWithOptions".to_string()),
+                allow_custom: false,
+                source: Some(bamboo_agent_core::PendingQuestionSource::PauseTool),
+            })
+            .await;
+        drop(old_tx);
+        old_forwarder.await.unwrap();
+
+        assert!(matches!(
+            broadcast_rx.recv().await.unwrap(),
+            AgentEvent::ExecutionStarted { ref run_id, .. } if run_id == "run-new"
+        ));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), broadcast_rx.recv())
+                .await
+                .is_err(),
+            "old Started/Need/Complete must all be suppressed"
+        );
+    }
 }
 
 /// Create an MPSC channel for agent events and spawn a forwarding task
@@ -74,6 +128,7 @@ mod tests {
 /// Returns `(mpsc_tx, forwarder_handle)`.
 pub fn create_event_forwarder(
     session_id: String,
+    run_id: String,
     broadcast_tx: broadcast::Sender<AgentEvent>,
     runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
     account_feed_inbox: Option<AccountFeedInbox>,
@@ -81,47 +136,68 @@ pub fn create_event_forwarder(
     let (mpsc_tx, mut mpsc_rx) = mpsc::channel::<AgentEvent>(100);
 
     let forwarder = tokio::spawn(async move {
-        // Emit ExecutionStarted as the first event so the frontend can correlate
-        // all subsequent events to this run via run_id.
+        // The exact reservation generation is captured synchronously by the
+        // caller. Never re-read the replaceable runner registry here: this
+        // task may be scheduled only after a clarification handoff installs a
+        // successor, which would mis-tag the old terminal as the new run.
+        let started_event = AgentEvent::ExecutionStarted {
+            run_id: run_id.clone(),
+            session_id: session_id.clone(),
+            started_at: Utc::now().to_rfc3339(),
+        };
         {
             let runners = runners.read().await;
-            if let Some(runner) = runners.get(&session_id) {
-                let started_event = AgentEvent::ExecutionStarted {
-                    run_id: runner.run_id.clone(),
-                    session_id: session_id.clone(),
-                    started_at: Utc::now().to_rfc3339(),
-                };
-                mirror_to_account_feed(&account_feed_inbox, &session_id, &started_event);
-                let _ = broadcast_tx.send(started_event);
+            if runners
+                .get(&session_id)
+                .is_none_or(|runner| runner.run_id != run_id)
+            {
+                return;
             }
+            mirror_to_account_feed(&account_feed_inbox, &session_id, &started_event);
+            let _ = broadcast_tx.send(started_event);
         }
 
         while let Some(event) = mpsc_rx.recv().await {
-            {
-                let mut runners = runners.write().await;
-                if let Some(runner) = runners.get_mut(&session_id) {
-                    runner.last_event_at = Some(Utc::now());
+            let mut runners = runners.write().await;
+            let Some(runner) = runners
+                .get_mut(&session_id)
+                .filter(|runner| runner.run_id == run_id)
+            else {
+                // A clarification handoff installed a successor before this
+                // delayed forwarder/frame ran. Drop the entire stale stream;
+                // broadcasting even its Started/Need would corrupt the shared
+                // session generation state.
+                return;
+            };
+            runner.last_event_at = Some(Utc::now());
 
-                    match &event {
-                        AgentEvent::TokenBudgetUpdated { .. } => {
-                            runner.last_budget_event = Some(event.clone());
-                        }
-                        AgentEvent::ToolStart { tool_name, .. } => {
-                            runner.last_tool_name = Some(tool_name.clone());
-                            runner.last_tool_phase = Some("begin".to_string());
-                        }
-                        AgentEvent::ToolLifecycle {
-                            tool_name, phase, ..
-                        } => {
-                            runner.last_tool_name = Some(tool_name.clone());
-                            runner.last_tool_phase = Some(phase.clone());
-                        }
-                        AgentEvent::RunnerProgress { round_count, .. } => {
-                            runner.round_count = *round_count;
-                        }
-                        _ => {}
-                    }
+            // Cache live state before publication so a subscriber installed
+            // between a clarification pause and its response sees the exact
+            // boundary. This generic forwarder powers Connect, schedules,
+            // SDK spawn, and child-resume paths, so it must preserve the same
+            // replay invariant as the server-owned forwarder.
+            if event.is_replayable_session_state() {
+                runner.push_critical_event(event.clone());
+            }
+
+            match &event {
+                AgentEvent::TokenBudgetUpdated { .. } => {
+                    runner.last_budget_event = Some(event.clone());
                 }
+                AgentEvent::ToolStart { tool_name, .. } => {
+                    runner.last_tool_name = Some(tool_name.clone());
+                    runner.last_tool_phase = Some("begin".to_string());
+                }
+                AgentEvent::ToolLifecycle {
+                    tool_name, phase, ..
+                } => {
+                    runner.last_tool_name = Some(tool_name.clone());
+                    runner.last_tool_phase = Some(phase.clone());
+                }
+                AgentEvent::RunnerProgress { round_count, .. } => {
+                    runner.round_count = *round_count;
+                }
+                _ => {}
             }
             mirror_to_account_feed(&account_feed_inbox, &session_id, &event);
             let _ = broadcast_tx.send(event);

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
@@ -19,8 +19,8 @@ mod session_effects;
 
 use payload::{parse_user_question_payload, should_handle_user_question_tool, UserQuestionPayload};
 use session_effects::{
-    append_waiting_tool_result_message, emit_need_clarification_event,
-    persist_session_after_question,
+    append_waiting_tool_result_message, emit_clarification_persistence_error,
+    emit_need_clarification_event, persist_session_after_question,
 };
 
 fn stable_plan_hash(plan: &str) -> String {
@@ -230,9 +230,10 @@ fn plan_content_summary(result_payload: &str) -> Option<String> {
 /// B). Unlike [`maybe_handle_user_question_tool`] (which sniffs a `ToolResult`),
 /// this is driven by the `PendingQuestion` the tool built. It synthesizes the
 /// paired placeholder `tool_result` (so the transcript stays paired now that the
-/// tool returns no result), emits the clarification event, sets the pending
-/// question, stamps `runtime.suspend_reason=awaiting_clarification`, and
-/// persists. The caller marks awaiting-clarification and breaks the round.
+/// tool returns no result), sets the pending question, stamps
+/// `runtime.suspend_reason=awaiting_clarification`, persists it, and only then
+/// emits the clarification event. The caller marks awaiting-clarification and
+/// breaks the round.
 ///
 /// Note: plan-file persistence (ExitPlanMode) and child→parent approval
 /// delegation (permission tools) are NOT handled here — those tools stay on the
@@ -248,6 +249,23 @@ pub(super) async fn suspend_for_pending_question(
     round_id: &str,
     config: &AgentLoopConfig,
 ) {
+    // The runner's ToolCall is the authoritative identity. A third-party tool
+    // may accidentally return a PendingQuestion copied from another call; do
+    // not let that split durable state from the SSE event or target the wrong
+    // transcript entry when the answer arrives.
+    if pq.tool_call_id != tool_call.id || pq.tool_name != tool_call.function.name {
+        tracing::warn!(
+            session_id,
+            returned_tool_call_id = %pq.tool_call_id,
+            returned_tool_name = %pq.tool_name,
+            canonical_tool_call_id = %tool_call.id,
+            canonical_tool_name = %tool_call.function.name,
+            "canonicalizing mismatched pending-question tool identity"
+        );
+    }
+    let tool_call_id = tool_call.id.clone();
+    let tool_name = tool_call.function.name.clone();
+
     // The tool's own result IS the paired tool_result (carries the rich display
     // payload: conclusion / plan / permission data), kept identical to the
     // pre-Phase-B transcript.
@@ -270,23 +288,25 @@ pub(super) async fn suspend_for_pending_question(
         options: pq.options.clone(),
         allow_custom: pq.allow_custom,
     };
-    emit_need_clarification_event(event_tx, &payload, &tool_call.id, &tool_call.function.name)
-        .await;
-
+    let source = pq.source.clone();
     session.set_pending_question_with_source(
-        pq.tool_call_id,
-        pq.tool_name,
+        tool_call_id.clone(),
+        tool_name.clone(),
         pq.question,
         pq.options,
         pq.allow_custom,
-        pq.source,
+        source,
     );
     session.metadata.insert(
         "runtime.suspend_reason".to_string(),
         "awaiting_clarification".to_string(),
     );
 
-    persist_session_after_question(config, session, session_id).await;
+    if let Err(error) = persist_session_after_question(config, session, session_id).await {
+        emit_clarification_persistence_error(event_tx, session_id, &error).await;
+        return;
+    }
+    emit_need_clarification_event(event_tx, &payload, &tool_call_id, &tool_name, pq.source).await;
 }
 
 pub(super) struct UserQuestionToolContext<'a> {
@@ -390,23 +410,17 @@ pub(super) async fn maybe_handle_user_question_tool(context: UserQuestionToolCon
             "runtime.suspend_reason".to_string(),
             "awaiting_parent_approval".to_string(),
         );
-        persist_session_after_question(config, session, session_id).await;
+        if let Err(error) = persist_session_after_question(config, session, session_id).await {
+            emit_clarification_persistence_error(event_tx, session_id, &error).await;
+        }
         return true;
     }
-
-    emit_need_clarification_event(
-        event_tx,
-        &question_payload,
-        &tool_call.id,
-        &tool_call.function.name,
-    )
-    .await;
 
     session.set_pending_question_with_source(
         tool_call.id.clone(),
         tool_call.function.name.clone(),
-        question_payload.question,
-        question_payload.options,
+        question_payload.question.clone(),
+        question_payload.options.clone(),
         question_payload.allow_custom,
         bamboo_agent_core::PendingQuestionSource::PauseTool,
     );
@@ -415,7 +429,18 @@ pub(super) async fn maybe_handle_user_question_tool(context: UserQuestionToolCon
         "awaiting_clarification".to_string(),
     );
 
-    persist_session_after_question(config, session, session_id).await;
+    if let Err(error) = persist_session_after_question(config, session, session_id).await {
+        emit_clarification_persistence_error(event_tx, session_id, &error).await;
+        return true;
+    }
+    emit_need_clarification_event(
+        event_tx,
+        &question_payload,
+        &tool_call.id,
+        &tool_call.function.name,
+        bamboo_agent_core::PendingQuestionSource::PauseTool,
+    )
+    .await;
 
     true
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/session_effects.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/session_effects.rs
@@ -2,7 +2,7 @@ use tokio::sync::mpsc;
 
 use crate::runtime::config::AgentLoopConfig;
 use bamboo_agent_core::tools::ToolCall;
-use bamboo_agent_core::{AgentEvent, Session};
+use bamboo_agent_core::{AgentEvent, PendingQuestionSource, Session};
 
 use super::payload::UserQuestionPayload;
 
@@ -31,6 +31,7 @@ pub(super) async fn emit_need_clarification_event(
     payload: &UserQuestionPayload,
     tool_call_id: &str,
     tool_name: &str,
+    source: PendingQuestionSource,
 ) {
     let _ = event_tx
         .send(AgentEvent::NeedClarification {
@@ -43,6 +44,7 @@ pub(super) async fn emit_need_clarification_event(
             tool_call_id: Some(tool_call_id.to_string()),
             tool_name: Some(tool_name.to_string()),
             allow_custom: payload.allow_custom,
+            source: Some(source),
         })
         .await;
 }
@@ -50,15 +52,29 @@ pub(super) async fn emit_need_clarification_event(
 pub(super) async fn persist_session_after_question(
     config: &AgentLoopConfig,
     session: &mut Session,
-    session_id: &str,
-) {
+    _session_id: &str,
+) -> std::io::Result<()> {
     if let Some(ref persistence) = config.persistence {
-        if let Err(error) = persistence.save_runtime_session(session).await {
-            tracing::warn!(
-                "[{}] Failed to save session after user-question tool: {}",
-                session_id,
-                error
-            );
-        }
+        persistence.save_runtime_session(session).await?;
     }
+    Ok(())
+}
+
+pub(super) async fn emit_clarification_persistence_error(
+    event_tx: &mpsc::Sender<AgentEvent>,
+    session_id: &str,
+    error: &std::io::Error,
+) {
+    tracing::error!(
+        session_id,
+        %error,
+        "Failed to persist clarification; suppressing NeedClarification"
+    );
+    let _ = event_tx
+        .send(AgentEvent::Error {
+            message: format!(
+                "Clarification could not be saved; retry after session storage recovers: {error}"
+            ),
+        })
+        .await;
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/tests.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use super::{maybe_handle_user_question_tool, UserQuestionToolContext};
@@ -7,6 +9,17 @@ use bamboo_agent_core::{AgentEvent, Role, Session};
 use bamboo_domain::session::runtime_state::{AgentRuntimeState, PlanModeState, PlanModeStatus};
 use bamboo_memory::plan_store::PlanStore;
 use chrono::Utc;
+
+struct FailingClarificationPersistence;
+
+#[async_trait]
+impl bamboo_domain::RuntimeSessionPersistence for FailingClarificationPersistence {
+    async fn save_runtime_session(&self, _session: &mut Session) -> std::io::Result<()> {
+        Err(std::io::Error::other(
+            "injected pending-question save failure",
+        ))
+    }
+}
 
 #[tokio::test]
 async fn maybe_handle_user_question_tool_sets_pending_question_and_emits_events() {
@@ -87,15 +100,73 @@ async fn maybe_handle_user_question_tool_sets_pending_question_and_emits_events(
             tool_call_id,
             tool_name,
             allow_custom,
+            source,
         } => {
             assert_eq!(question, "Continue?");
             assert_eq!(options, Some(vec!["Yes".to_string(), "No".to_string()]));
             assert_eq!(tool_call_id, Some("ask-1".to_string()));
             assert_eq!(tool_name, Some("request_permissions".to_string()));
             assert!(!allow_custom);
+            assert_eq!(
+                source,
+                Some(bamboo_agent_core::PendingQuestionSource::PauseTool)
+            );
         }
         other => panic!("unexpected second event: {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn legacy_pending_question_persistence_failure_never_publishes_clarification() {
+    let tool_call = ToolCall {
+        id: "ask-failed-save".to_string(),
+        tool_type: "function".to_string(),
+        function: FunctionCall {
+            name: "request_permissions".to_string(),
+            arguments: "{}".to_string(),
+        },
+    };
+    let result = ToolResult {
+        success: true,
+        result: serde_json::json!({
+            "question": "Continue?",
+            "options": ["Yes", "No"],
+            "allow_custom": false
+        })
+        .to_string(),
+        display_preference: Some("request_permissions".to_string()),
+        images: Vec::new(),
+    };
+    let persistence: Arc<dyn bamboo_domain::RuntimeSessionPersistence> =
+        Arc::new(FailingClarificationPersistence);
+    let config = AgentLoopConfig {
+        persistence: Some(persistence),
+        ..AgentLoopConfig::default()
+    };
+    let (tx, mut rx) = mpsc::channel(8);
+    let mut session = Session::new("failed-save", "model");
+
+    assert!(
+        maybe_handle_user_question_tool(UserQuestionToolContext {
+            tool_call: &tool_call,
+            result: &result,
+            session: &mut session,
+            event_tx: &tx,
+            metrics_collector: None,
+            session_id: "failed-save",
+            round_id: "round-1",
+            config: &config,
+        })
+        .await
+    );
+
+    let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert!(events.iter().any(
+        |event| matches!(event, AgentEvent::Error { message } if message.contains("could not be saved"))
+    ));
+    assert!(events
+        .iter()
+        .all(|event| !matches!(event, AgentEvent::NeedClarification { .. })));
 }
 
 #[tokio::test]
@@ -173,6 +244,7 @@ async fn maybe_handle_user_question_tool_handles_request_permissions() {
             tool_call_id,
             tool_name,
             allow_custom,
+            source,
         } => {
             assert!(question.contains("Permission Request"));
             assert_eq!(
@@ -182,6 +254,10 @@ async fn maybe_handle_user_question_tool_handles_request_permissions() {
             assert_eq!(tool_call_id, Some("perm-1".to_string()));
             assert_eq!(tool_name, Some("request_permissions".to_string()));
             assert!(!allow_custom);
+            assert_eq!(
+                source,
+                Some(bamboo_agent_core::PendingQuestionSource::PauseTool)
+            );
         }
         other => panic!("unexpected second event: {other:?}"),
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
@@ -1,4 +1,6 @@
-use bamboo_agent_core::tools::{handle_tool_result_with_agentic_support, ToolHandlingOutcome};
+use bamboo_agent_core::tools::{
+    handle_tool_result_with_agentic_support_and_persistence, ToolHandlingOutcome,
+};
 use bamboo_agent_core::AgentEvent;
 
 use super::super::{clarification, events, task, tool_error_collector};
@@ -152,7 +154,7 @@ pub(super) async fn handle_successful_tool_result(mut ctx: SuccessPathContext<'_
         })
     );
 
-    let outcome = handle_tool_result_with_agentic_support(
+    let outcome = handle_tool_result_with_agentic_support_and_persistence(
         ctx.result,
         ctx.tool_call,
         ctx.event_tx,
@@ -163,6 +165,7 @@ pub(super) async fn handle_successful_tool_result(mut ctx: SuccessPathContext<'_
         // in the agent runtime. Catalog-pinned workflow_run is the single
         // production orchestration authority (#578).
         None,
+        ctx.config.persistence.as_ref(),
     )
     .await;
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -664,6 +664,26 @@ mod hook_tests {
     use bamboo_config::{LifecycleHookGroup, LifecycleHookHandler, LifecycleHooksConfig};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+    #[derive(Default)]
+    struct BlockingPendingPersistence {
+        saved: std::sync::Mutex<Vec<Session>>,
+        entered: tokio::sync::Notify,
+        release: tokio::sync::Notify,
+    }
+
+    #[async_trait]
+    impl bamboo_domain::RuntimeSessionPersistence for BlockingPendingPersistence {
+        async fn save_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
+            self.saved
+                .lock()
+                .expect("pending persistence lock")
+                .push(session.clone());
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(())
+        }
+    }
+
     struct DenyToolHook;
 
     #[async_trait]
@@ -962,6 +982,91 @@ mod hook_tests {
             outcome,
         )
         .await
+    }
+
+    #[tokio::test]
+    async fn needs_human_uses_runner_identity_and_persists_before_clarification_event() {
+        let persistence = Arc::new(BlockingPendingPersistence::default());
+        let config = AgentLoopConfig {
+            persistence: Some(persistence.clone()),
+            ..Default::default()
+        };
+        let tools: Arc<dyn ToolExecutor> = Arc::new(RecordingExecutor(AtomicBool::new(false)));
+        let tool_call = probe_call("canonical-tool");
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        let outcome = ToolExecutionOutcome {
+            result: Ok(ToolResult::text(false, "decision pending")),
+            needs_human: Some(bamboo_agent_core::PendingQuestion {
+                tool_call_id: "stale-call".to_string(),
+                tool_name: "stale-tool".to_string(),
+                question: "Choose?".to_string(),
+                options: vec!["yes".to_string(), "no".to_string()],
+                allow_custom: false,
+                source: bamboo_agent_core::PendingQuestionSource::PauseTool,
+            }),
+            post_tool_hook_eligible: false,
+            tool_duration: std::time::Duration::from_millis(1),
+        };
+
+        let apply = tokio::spawn(async move {
+            let mut session = Session::new("canonical-pending", "model");
+            apply_test_outcome(
+                &config,
+                &tools,
+                &tool_call,
+                &mut session,
+                &event_tx,
+                outcome,
+            )
+            .await
+            .unwrap();
+            session
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            persistence.entered.notified(),
+        )
+        .await
+        .expect("pending-question persistence should begin");
+        let events_before_save: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+        assert!(events_before_save
+            .iter()
+            .any(|event| matches!(event, AgentEvent::ToolComplete { .. })));
+        assert!(!events_before_save
+            .iter()
+            .any(|event| matches!(event, AgentEvent::NeedClarification { .. })));
+
+        let saved = persistence
+            .saved
+            .lock()
+            .expect("pending persistence lock")
+            .last()
+            .cloned()
+            .expect("pending session snapshot");
+        let persisted_question = saved.pending_question.expect("persisted pending question");
+        assert_eq!(persisted_question.tool_call_id, "call-canonical-tool");
+        assert_eq!(persisted_question.tool_name, "canonical-tool");
+
+        persistence.release.notify_one();
+        let session = apply.await.unwrap();
+        let pending = session.pending_question.expect("runtime pending question");
+        assert_eq!(pending.tool_call_id, "call-canonical-tool");
+        assert_eq!(pending.tool_name, "canonical-tool");
+
+        let clarification =
+            tokio::time::timeout(std::time::Duration::from_secs(5), event_rx.recv())
+                .await
+                .expect("clarification event should arrive after persistence")
+                .expect("clarification channel should stay open");
+        assert!(matches!(
+            clarification,
+            AgentEvent::NeedClarification {
+                tool_call_id: Some(ref id),
+                tool_name: Some(ref name),
+                ..
+            } if id == "call-canonical-tool" && name == "canonical-tool"
+        ));
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -449,6 +449,7 @@ async fn run_child_spawn_inner(
     // Create mpsc channel for agent loop → session events sender.
     let (mpsc_tx, _forwarder_handle) = create_event_forwarder(
         job.child_session_id.clone(),
+        run_id.clone(),
         child_tx.clone(),
         ctx.agent_runners.clone(),
         ctx.account_feed_inbox.clone(),

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -49,6 +49,7 @@ use crate::model_config_helper::{
 use crate::session_activation::{
     SessionActivationLaunch, SessionActivationReserveOutcome, SessionActivationSpawner,
 };
+use crate::session_app::execute::consume_pending_clarification_resume;
 use crate::session_app::provider_model::session_effective_model_ref;
 use crate::session_app::resume::{
     resume_session_execution, ResumeExecutionPort, ResumeSpawnRequest,
@@ -953,10 +954,21 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
         .await
     }
 
+    fn dispatch_resume_execution(
+        &self,
+        request: ResumeSpawnRequest,
+    ) -> Result<(), ResumeSpawnRequest> {
+        let owner = self.clone();
+        tokio::spawn(async move {
+            ResumeExecutionPort::spawn_resume_execution(&owner, request).await;
+        });
+        Ok(())
+    }
+
     async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) {
         let ResumeSpawnRequest {
             session_id,
-            session,
+            mut session,
             mut execution_reservation,
             event_sender,
             config,
@@ -1018,6 +1030,7 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
 
         let (mpsc_tx, _forwarder) = create_event_forwarder(
             session_id.clone(),
+            execution_reservation.run_id().to_string(),
             event_sender,
             self.agent_runners.clone(),
             self.account_feed_inbox.clone(),
@@ -1071,6 +1084,7 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
         let guardian_config = read_guardian_config(&session);
         let guardian_spawner = self.guardian_spawner.read().await.clone();
 
+        consume_pending_clarification_resume(&mut session);
         spawn_session_execution(SessionExecutionArgs {
             agent: self.agent.clone(),
             session_id,

--- a/crates/engine/bamboo-engine/src/session_app/errors.rs
+++ b/crates/engine/bamboo-engine/src/session_app/errors.rs
@@ -64,6 +64,8 @@ pub enum RespondError {
     SaveFailed(#[from] SessionSaveError),
     #[error("no pending question waiting for response")]
     NoPendingQuestion,
+    #[error("pending question changed (expected tool call {expected}, actual {actual})")]
+    PendingQuestionMismatch { expected: String, actual: String },
     #[error("invalid response: {0}")]
     InvalidResponse(String),
 }

--- a/crates/engine/bamboo-engine/src/session_app/repository.rs
+++ b/crates/engine/bamboo-engine/src/session_app/repository.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use bamboo_domain::Session;
 
-use super::errors::{SessionLoadError, SessionSaveError};
+use super::errors::{RespondError, SessionLoadError, SessionSaveError};
 use crate::SessionRepository;
 
 /// Trait for loading and persisting sessions.
@@ -38,6 +38,35 @@ pub trait SessionAccess: Send + Sync {
     /// title/title_generated/pinned/title_version
     /// from disk back into `session` (which is why this takes `&mut`).
     async fn save_and_cache(&self, session: &mut Session) -> Result<(), SessionSaveError>;
+
+    /// Inspect the authoritative snapshot used by a pending-response
+    /// transaction, without mutating it. Canonical repositories override this
+    /// so durable consumed-response state wins over a stale cache candidate.
+    async fn inspect_for_response(&self, id: &str) -> Result<Option<Session>, SessionLoadError> {
+        self.load_merged(id).await
+    }
+
+    /// Compare/mutate/persist the latest session for a pending response.
+    /// Implementations backed by a canonical per-session lock override this so
+    /// the whole operation is atomic. The default preserves compatibility for
+    /// lightweight/in-memory adapters; the respond use case also serializes
+    /// its entrypoints so those adapters cannot double-consume concurrently.
+    async fn mutate_for_response(
+        &self,
+        id: &str,
+        mutate: Box<
+            dyn for<'session> FnOnce(&'session mut Session) -> Result<(), RespondError>
+                + Send
+                + 'static,
+        >,
+    ) -> Result<Option<Session>, RespondError> {
+        let Some(mut session) = self.load_merged(id).await? else {
+            return Ok(None);
+        };
+        mutate(&mut session)?;
+        self.save_and_cache(&mut session).await?;
+        Ok(Some(session))
+    }
 }
 
 /// The framework-owned [`SessionRepository`] is the canonical `SessionAccess`.
@@ -58,7 +87,9 @@ impl SessionAccess for SessionRepository {
     }
 
     async fn load_merged(&self, id: &str) -> Result<Option<Session>, SessionLoadError> {
-        Ok(SessionRepository::load_merged(self, id).await)
+        SessionRepository::load_merged_checked(self, id)
+            .await
+            .map_err(|error| SessionLoadError::StorageError(error.to_string()))
     }
 
     async fn save_session(&self, session: &mut Session) -> Result<(), SessionSaveError> {
@@ -72,5 +103,51 @@ impl SessionAccess for SessionRepository {
     async fn save_and_cache(&self, session: &mut Session) -> Result<(), SessionSaveError> {
         SessionRepository::save_and_cache(self, session).await;
         Ok(())
+    }
+
+    async fn inspect_for_response(&self, id: &str) -> Result<Option<Session>, SessionLoadError> {
+        let cache = self.cache().clone();
+        let session_id = id.to_string();
+        self.persistence()
+            .inspect_runtime_session_for_response(id, move || {
+                crate::read_cached_session(&cache, &session_id)
+            })
+            .await
+            .map_err(|error| SessionLoadError::StorageError(error.to_string()))
+    }
+
+    async fn mutate_for_response(
+        &self,
+        id: &str,
+        mutate: Box<
+            dyn for<'session> FnOnce(&'session mut Session) -> Result<(), RespondError>
+                + Send
+                + 'static,
+        >,
+    ) -> Result<Option<Session>, RespondError> {
+        let cache_for_load = self.cache().clone();
+        let publish_cache = self.cache().clone();
+        let session_id = id.to_string();
+        match self
+            .persistence()
+            .mutate_runtime_session_and_publish(
+                id,
+                move || crate::read_cached_session(&cache_for_load, &session_id),
+                move |session| mutate(session),
+                move |saved| {
+                    publish_cache.insert(
+                        saved.id.clone(),
+                        std::sync::Arc::new(parking_lot::RwLock::new(saved.clone())),
+                    );
+                },
+            )
+            .await
+        {
+            Ok(Ok(session)) => Ok(session),
+            Ok(Err(error)) => Err(error),
+            Err(error) => Err(RespondError::SaveFailed(SessionSaveError::StorageError(
+                error.to_string(),
+            ))),
+        }
     }
 }

--- a/crates/engine/bamboo-engine/src/session_app/respond.rs
+++ b/crates/engine/bamboo-engine/src/session_app/respond.rs
@@ -1,10 +1,16 @@
 //! Respond use case: submit a user response to a pending question.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
+
 use bamboo_agent_core::{PendingQuestion, Session};
 use bamboo_domain::session::runtime_state::{AgentRuntimeState, PlanModeState, PlanModeStatus};
 use bamboo_domain::SessionPermissionMode;
 use bamboo_tools::permission::PermissionType;
 use chrono::Utc;
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
 use super::errors::RespondError;
 use super::execute::mark_startup_handoff;
@@ -14,6 +20,126 @@ use super::types::RespondInput;
 
 const CLARIFICATION_RESUME_PENDING_KEY: &str = "clarification_resume_pending";
 const CONCLUSION_WITH_OPTIONS_RESUME_PENDING_KEY: &str = "conclusion_with_options_resume_pending";
+const CONSUMED_CLARIFICATION_IDS_KEY: &str = "clarification.consumed_tool_call_ids";
+
+type AppliedPendingResponse = (
+    String,
+    Option<PlanModeTransition>,
+    Vec<(PermissionType, String)>,
+);
+
+/// Process-local serialization for consuming one pending question. The
+/// persistence layer serializes individual loads and saves, but releasing its
+/// lock between those operations would let two responders both observe and
+/// consume the same question. Every response entrypoint reaches this use case,
+/// so holding this gate across load -> validate -> save makes one consumer win
+/// and forces later callers to reload the already-consumed state.
+struct PendingResponseGate {
+    lock: Arc<Mutex<()>>,
+    waiters: AtomicUsize,
+}
+
+impl PendingResponseGate {
+    fn new() -> Self {
+        Self {
+            lock: Arc::new(Mutex::new(())),
+            waiters: AtomicUsize::new(0),
+        }
+    }
+}
+
+struct PendingResponseWaiter(Arc<PendingResponseGate>);
+
+impl Drop for PendingResponseWaiter {
+    fn drop(&mut self) {
+        self.0.waiters.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+fn pending_response_locks() -> &'static DashMap<String, Weak<PendingResponseGate>> {
+    static LOCKS: OnceLock<DashMap<String, Weak<PendingResponseGate>>> = OnceLock::new();
+    LOCKS.get_or_init(DashMap::new)
+}
+
+fn pending_response_lock(session_id: &str) -> Arc<PendingResponseGate> {
+    let locks = pending_response_locks();
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    match locks.entry(session_id.to_string()) {
+        Entry::Occupied(mut entry) => {
+            if let Some(lock) = entry.get().upgrade() {
+                lock
+            } else {
+                let lock = Arc::new(PendingResponseGate::new());
+                entry.insert(Arc::downgrade(&lock));
+                lock
+            }
+        }
+        Entry::Vacant(entry) => {
+            let lock = Arc::new(PendingResponseGate::new());
+            entry.insert(Arc::downgrade(&lock));
+            lock
+        }
+    }
+}
+
+/// Process-local ownership for one session's complete response transaction.
+/// High-level HTTP, Connect, and Gold paths hold this from authoritative
+/// preflight through successor dispatch, so a stale duplicate cannot reserve
+/// and later cancel a phantom runner after the real successor has completed.
+pub struct PendingResponseGuard {
+    session_id: String,
+    _gate: Arc<PendingResponseGate>,
+    _guard: OwnedMutexGuard<()>,
+}
+
+impl PendingResponseGuard {
+    fn ensure_session(&self, session_id: &str) -> Result<(), RespondError> {
+        if self.session_id == session_id {
+            Ok(())
+        } else {
+            Err(RespondError::InvalidResponse(
+                "response transaction guard belongs to a different session".to_string(),
+            ))
+        }
+    }
+}
+
+/// Acquire the shared response single-flight used by every response source.
+pub async fn acquire_pending_response_guard(session_id: &str) -> PendingResponseGuard {
+    let gate = pending_response_lock(session_id);
+    gate.waiters.fetch_add(1, Ordering::SeqCst);
+    let waiter = PendingResponseWaiter(gate.clone());
+    let guard = gate.lock.clone().lock_owned().await;
+    drop(waiter);
+    PendingResponseGuard {
+        session_id: session_id.to_string(),
+        _gate: gate,
+        _guard: guard,
+    }
+}
+
+/// Number of callers currently waiting to enter a session's response gate.
+/// Exposed for deterministic concurrency tests and lightweight diagnostics.
+#[doc(hidden)]
+pub fn pending_response_waiter_count(session_id: &str) -> usize {
+    pending_response_locks()
+        .get(session_id)
+        .and_then(|entry| entry.upgrade())
+        .map(|gate| gate.waiters.load(Ordering::SeqCst))
+        .unwrap_or(0)
+}
+
+/// Reload the exact snapshot a response CAS would mutate while holding the
+/// shared response single-flight. This must happen before successor
+/// reservation so an already-consumed/stale response allocates no runner.
+pub async fn inspect_pending_response_guarded(
+    repo: &dyn SessionAccess,
+    session_id: &str,
+    guard: &PendingResponseGuard,
+) -> Result<Option<Session>, RespondError> {
+    guard.ensure_session(session_id)?;
+    Ok(repo.inspect_for_response(session_id).await?)
+}
 
 /// Session-metadata key marking a tool call that was approved through a permission
 /// prompt and must be RE-EXECUTED on resume. The gated tool never actually ran
@@ -60,7 +186,58 @@ pub async fn submit_pending_response(
     ),
     RespondError,
 > {
-    submit_pending_response_with_source(repo, input, ResponseSource::Human).await
+    submit_pending_response_checked(repo, input, None).await
+}
+
+/// Submit a response guarded by the exact pending tool-call identity displayed
+/// to a typed client. The separate parameter keeps the established public
+/// [`RespondInput`] struct source-compatible for SDK/in-process callers.
+pub async fn submit_pending_response_checked(
+    repo: &dyn SessionAccess,
+    input: RespondInput,
+    expected_tool_call_id: Option<String>,
+) -> Result<
+    (
+        Session,
+        String,
+        Option<PlanModeTransition>,
+        Vec<(PermissionType, String)>,
+    ),
+    RespondError,
+> {
+    submit_pending_response_with_source_checked(
+        repo,
+        input,
+        expected_tool_call_id,
+        ResponseSource::Human,
+    )
+    .await
+}
+
+/// Human-response variant for callers that already hold the shared response
+/// transaction guard across preflight, reservation, CAS, and dispatch.
+pub async fn submit_pending_response_checked_guarded(
+    repo: &dyn SessionAccess,
+    input: RespondInput,
+    expected_tool_call_id: Option<String>,
+    guard: &PendingResponseGuard,
+) -> Result<
+    (
+        Session,
+        String,
+        Option<PlanModeTransition>,
+        Vec<(PermissionType, String)>,
+    ),
+    RespondError,
+> {
+    submit_pending_response_with_source_checked_guarded(
+        repo,
+        input,
+        expected_tool_call_id,
+        ResponseSource::Human,
+        guard,
+    )
+    .await
 }
 
 pub async fn submit_pending_response_with_source(
@@ -76,17 +253,116 @@ pub async fn submit_pending_response_with_source(
     ),
     RespondError,
 > {
-    // ---- Load session (merged for respond to pick up in-memory pending question) ----
-    let mut session = repo
-        .load_merged(&input.session_id)
+    submit_pending_response_with_source_checked(repo, input, None, response_source).await
+}
+
+pub async fn submit_pending_response_with_source_checked(
+    repo: &dyn SessionAccess,
+    input: RespondInput,
+    expected_tool_call_id: Option<String>,
+    response_source: ResponseSource,
+) -> Result<
+    (
+        Session,
+        String,
+        Option<PlanModeTransition>,
+        Vec<(PermissionType, String)>,
+    ),
+    RespondError,
+> {
+    let guard = acquire_pending_response_guard(&input.session_id).await;
+    submit_pending_response_with_source_checked_guarded(
+        repo,
+        input,
+        expected_tool_call_id,
+        response_source,
+        &guard,
+    )
+    .await
+}
+
+/// Guarded form for high-level response + resume transactions. The caller
+/// must retain `guard` until the exact successor reservation has been handed
+/// to its detached execution owner.
+pub async fn submit_pending_response_with_source_checked_guarded(
+    repo: &dyn SessionAccess,
+    input: RespondInput,
+    expected_tool_call_id: Option<String>,
+    response_source: ResponseSource,
+    guard: &PendingResponseGuard,
+) -> Result<
+    (
+        Session,
+        String,
+        Option<PlanModeTransition>,
+        Vec<(PermissionType, String)>,
+    ),
+    RespondError,
+> {
+    guard.ensure_session(&input.session_id)?;
+
+    let applied = Arc::new(StdMutex::new(None));
+    let mutation_outcome = applied.clone();
+    let mutation_input = input.clone();
+    let mutation_expected_tool_call_id = expected_tool_call_id.clone();
+    let session = repo
+        .mutate_for_response(
+            &input.session_id,
+            Box::new(move |session| {
+                let outcome = apply_pending_response(
+                    session,
+                    &mutation_input,
+                    mutation_expected_tool_call_id.as_deref(),
+                    response_source,
+                )?;
+                *mutation_outcome
+                    .lock()
+                    .expect("response outcome lock poisoned") = Some(outcome);
+                Ok(())
+            }),
+        )
         .await?
         .ok_or_else(|| RespondError::NotFound(input.session_id.clone()))?;
+    let (user_response, plan_mode_transition, permission_grants) = applied
+        .lock()
+        .expect("response outcome lock poisoned")
+        .take()
+        .expect("successful response mutation records its outcome");
 
-    // ---- Take pending question ----
+    tracing::info!(
+        "[{}] Response processed successfully, agent loop can resume",
+        input.session_id
+    );
+
+    Ok((
+        session,
+        user_response,
+        plan_mode_transition,
+        permission_grants,
+    ))
+}
+
+fn apply_pending_response(
+    session: &mut Session,
+    input: &RespondInput,
+    expected_tool_call_id: Option<&str>,
+    response_source: ResponseSource,
+) -> Result<AppliedPendingResponse, RespondError> {
     let pending = session
         .pending_question
         .take()
         .ok_or(RespondError::NoPendingQuestion)?;
+
+    if let Some(expected) = expected_tool_call_id {
+        if pending.tool_call_id != expected {
+            let actual = pending.tool_call_id.clone();
+            session.pending_question = Some(pending);
+            return Err(RespondError::PendingQuestionMismatch {
+                expected: expected.to_string(),
+                actual,
+            });
+        }
+    }
 
     // ---- Validate response ----
     if let Err(error_message) = validate_pending_response(&pending, &input.user_response) {
@@ -102,13 +378,13 @@ pub async fn submit_pending_response_with_source(
         tool_call_id
     );
 
-    let reviewed_plan = extract_exit_plan_from_tool_result_message(&session, &tool_call_id);
+    let reviewed_plan = extract_exit_plan_from_tool_result_message(session, &tool_call_id);
 
     // Permission grants implied by approving a permission prompt. Read from the
     // (still-unmodified) synthesized tool-result payload, BEFORE it is overwritten
     // by the user's selection below.
     let permission_grants = if is_permission_approval(&input.user_response) {
-        extract_permission_grants_from_tool_result_message(&session, &tool_call_id)
+        extract_permission_grants_from_tool_result_message(session, &tool_call_id)
     } else {
         Vec::new()
     };
@@ -124,7 +400,7 @@ pub async fn submit_pending_response_with_source(
 
     // ---- Update or append tool result message ----
     let found = update_or_append_tool_result_message(
-        &mut session,
+        session,
         &tool_call_id,
         &input.user_response,
         response_source,
@@ -144,10 +420,11 @@ pub async fn submit_pending_response_with_source(
 
     // ---- Plan mode state transitions ----
     let plan_mode_transition =
-        apply_plan_mode_transition(&mut session, &pending, &input.user_response, reviewed_plan);
+        apply_plan_mode_transition(session, &pending, &input.user_response, reviewed_plan);
 
     // ---- Clear pending question and set resume marker ----
     session.clear_pending_question();
+    record_consumed_clarification(session, &tool_call_id);
     session.metadata.remove("runtime.suspend_reason");
     session.metadata.insert(
         CLARIFICATION_RESUME_PENDING_KEY.to_string(),
@@ -157,7 +434,7 @@ pub async fn submit_pending_response_with_source(
         CONCLUSION_WITH_OPTIONS_RESUME_PENDING_KEY.to_string(),
         "true".to_string(),
     );
-    mark_startup_handoff(&mut session);
+    mark_startup_handoff(session);
 
     // ---- Merge model/reasoning from request ----
     let request_model_ref = derive_model_ref(
@@ -166,32 +443,37 @@ pub async fn submit_pending_response_with_source(
         input.model.as_deref(),
     );
     if let Some(model_ref) = request_model_ref.as_ref() {
-        persist_model_ref(&mut session, model_ref);
+        persist_model_ref(session, model_ref);
     } else {
-        persist_legacy_model_provider(
-            &mut session,
-            input.model.as_deref(),
-            input.provider.as_deref(),
-        );
+        persist_legacy_model_provider(session, input.model.as_deref(), input.provider.as_deref());
     }
     if let Some(reasoning_effort) = input.reasoning_effort {
         session.reasoning_effort = Some(reasoning_effort);
     }
 
-    // ---- Save ----
-    repo.save_and_cache(&mut session).await?;
-
-    tracing::info!(
-        "[{}] Response processed successfully, agent loop can resume",
-        input.session_id
-    );
-
     Ok((
-        session,
-        input.user_response,
+        input.user_response.clone(),
         plan_mode_transition,
         permission_grants,
     ))
+}
+
+fn record_consumed_clarification(session: &mut Session, tool_call_id: &str) {
+    let mut consumed = session
+        .metadata
+        .get(CONSUMED_CLARIFICATION_IDS_KEY)
+        .and_then(|value| serde_json::from_str::<Vec<String>>(value).ok())
+        .unwrap_or_default();
+    consumed.retain(|existing| existing != tool_call_id);
+    consumed.push(tool_call_id.to_string());
+    if consumed.len() > 64 {
+        consumed.drain(..consumed.len() - 64);
+    }
+    if let Ok(serialized) = serde_json::to_string(&consumed) {
+        session
+            .metadata
+            .insert(CONSUMED_CLARIFICATION_IDS_KEY.to_string(), serialized);
+    }
 }
 
 /// Apply plan mode state transitions based on the pending question tool and user response.
@@ -394,6 +676,94 @@ fn extract_permission_grants_from_tool_result_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Mutex;
+    use tokio::sync::Notify;
+
+    struct TestSessionAccess {
+        session: Mutex<Session>,
+        loads: AtomicUsize,
+        saves: AtomicUsize,
+        block_first_save: AtomicBool,
+        save_started: Notify,
+        release_save: Notify,
+    }
+
+    impl TestSessionAccess {
+        fn with_pending() -> Self {
+            Self::with_pending_and_blocked_save(false)
+        }
+
+        fn with_pending_and_blocked_save(block_first_save: bool) -> Self {
+            let mut session = Session::new("sess-1", "test-model");
+            session.pending_question = Some(make_pending("ConclusionWithOptions"));
+            Self {
+                session: Mutex::new(session),
+                loads: AtomicUsize::new(0),
+                saves: AtomicUsize::new(0),
+                block_first_save: AtomicBool::new(block_first_save),
+                save_started: Notify::new(),
+                release_save: Notify::new(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SessionAccess for TestSessionAccess {
+        async fn load_session(
+            &self,
+            _id: &str,
+        ) -> Result<Option<Session>, super::super::errors::SessionLoadError> {
+            Ok(Some(self.session.lock().unwrap().clone()))
+        }
+
+        async fn load_or_create(
+            &self,
+            _id: &str,
+            _model: &str,
+        ) -> Result<Session, super::super::errors::SessionLoadError> {
+            Ok(self.session.lock().unwrap().clone())
+        }
+
+        async fn load_merged(
+            &self,
+            _id: &str,
+        ) -> Result<Option<Session>, super::super::errors::SessionLoadError> {
+            self.loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(self.session.lock().unwrap().clone()))
+        }
+
+        async fn save_session(
+            &self,
+            session: &mut Session,
+        ) -> Result<(), super::super::errors::SessionSaveError> {
+            if self.block_first_save.swap(false, Ordering::SeqCst) {
+                self.save_started.notify_one();
+                self.release_save.notified().await;
+            }
+            *self.session.lock().unwrap() = session.clone();
+            self.saves.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn save_and_cache(
+            &self,
+            session: &mut Session,
+        ) -> Result<(), super::super::errors::SessionSaveError> {
+            self.save_session(session).await
+        }
+    }
+
+    fn respond_input() -> RespondInput {
+        RespondInput {
+            session_id: "sess-1".to_string(),
+            user_response: "A".to_string(),
+            model: None,
+            model_ref: None,
+            provider: None,
+            reasoning_effort: None,
+        }
+    }
 
     fn make_pending(tool_name: &str) -> PendingQuestion {
         PendingQuestion {
@@ -404,6 +774,130 @@ mod tests {
             allow_custom: false,
             source: bamboo_agent_core::PendingQuestionSource::PauseTool,
         }
+    }
+
+    #[tokio::test]
+    async fn expected_tool_call_id_accepts_the_current_question() {
+        let repo = TestSessionAccess::with_pending();
+
+        submit_pending_response_checked(&repo, respond_input(), Some("call-1".to_string()))
+            .await
+            .expect("matching identity should submit");
+
+        assert_eq!(repo.saves.load(Ordering::SeqCst), 1);
+        assert!(repo.session.lock().unwrap().pending_question.is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_tool_call_id_is_rejected_without_consuming_the_question() {
+        let repo = TestSessionAccess::with_pending();
+
+        let error =
+            submit_pending_response_checked(&repo, respond_input(), Some("stale-call".to_string()))
+                .await
+                .expect_err("stale identity must fail");
+
+        assert!(matches!(
+            error,
+            RespondError::PendingQuestionMismatch {
+                ref expected,
+                ref actual,
+            } if expected == "stale-call" && actual == "call-1"
+        ));
+        assert_eq!(repo.saves.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            repo.session
+                .lock()
+                .unwrap()
+                .pending_question
+                .as_ref()
+                .map(|question| question.tool_call_id.as_str()),
+            Some("call-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn omitted_tool_call_guard_remains_backwards_compatible() {
+        let repo = TestSessionAccess::with_pending();
+
+        submit_pending_response(&repo, respond_input())
+            .await
+            .expect("legacy client should remain accepted");
+
+        assert_eq!(repo.saves.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_responses_consume_a_pending_question_once() {
+        let repo = Arc::new(TestSessionAccess::with_pending_and_blocked_save(true));
+
+        let first_repo = repo.clone();
+        let first = tokio::spawn(async move {
+            submit_pending_response_checked(
+                first_repo.as_ref(),
+                respond_input(),
+                Some("call-1".to_string()),
+            )
+            .await
+        });
+        repo.save_started.notified().await;
+
+        let second_entered = Arc::new(Notify::new());
+        let second_repo = repo.clone();
+        let second_entered_task = second_entered.clone();
+        let second = tokio::spawn(async move {
+            second_entered_task.notify_one();
+            submit_pending_response_checked(
+                second_repo.as_ref(),
+                respond_input(),
+                Some("call-1".to_string()),
+            )
+            .await
+        });
+        second_entered.notified().await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            repo.loads.load(Ordering::SeqCst),
+            1,
+            "the second responder must wait before loading the pending question"
+        );
+        repo.release_save.notify_one();
+
+        first.await.unwrap().expect("first response should win");
+        let error = second
+            .await
+            .unwrap()
+            .expect_err("second response must observe the consumed question");
+        assert!(matches!(error, RespondError::NoPendingQuestion));
+        assert_eq!(repo.loads.load(Ordering::SeqCst), 2);
+        assert_eq!(repo.saves.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_response_waiter_does_not_leak_diagnostics_or_the_gate() {
+        let session_id = "cancelled-response-waiter";
+        let owner = acquire_pending_response_guard(session_id).await;
+        let waiter = tokio::spawn(async move { acquire_pending_response_guard(session_id).await });
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while pending_response_waiter_count(session_id) != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("waiter should reach the gate");
+
+        waiter.abort();
+        let _ = waiter.await;
+        assert_eq!(pending_response_waiter_count(session_id), 0);
+        drop(owner);
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            acquire_pending_response_guard(session_id),
+        )
+        .await
+        .expect("cancelled waiter must not retain the gate");
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/session_app/resume.rs
+++ b/crates/engine/bamboo-engine/src/session_app/resume.rs
@@ -10,7 +10,7 @@ use bamboo_agent_core::AgentEvent;
 use bamboo_domain::Session;
 use tokio::sync::broadcast;
 
-use super::execute::{consume_pending_clarification_resume, has_pending_user_message};
+use super::execute::has_pending_user_message;
 use super::types::{ResumeConfigSnapshot, ResumeOutcome};
 use crate::execution::{SessionExecutionReservation, SessionExecutionReserveOutcome};
 
@@ -49,6 +49,22 @@ pub trait ResumeExecutionPort: Send + Sync {
     /// The adapter creates the mpsc channel, spawns the event forwarder,
     /// and calls the server's agent execution spawner.
     async fn spawn_resume_execution(&self, request: ResumeSpawnRequest);
+
+    /// Transfer a prepared resume request to an execution owner whose lifetime
+    /// is independent of the caller. Implementations that support response
+    /// handoffs return `Ok(())` only after the request (including its exact
+    /// runner reservation) has moved into a detached task.
+    ///
+    /// The default preserves source compatibility for external port adapters;
+    /// they retain the original awaited `spawn_resume_execution` behavior until
+    /// they opt into cancellation-safe dispatch.
+    #[allow(clippy::result_large_err)]
+    fn dispatch_resume_execution(
+        &self,
+        request: ResumeSpawnRequest,
+    ) -> Result<(), ResumeSpawnRequest> {
+        Err(request)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -65,6 +81,93 @@ pub struct ResumeSpawnRequest {
     pub execution_reservation: SessionExecutionReservation,
     pub event_sender: broadcast::Sender<AgentEvent>,
     pub config: ResumeConfigSnapshot,
+}
+
+/// Runner ownership reserved before consuming a pending clarification. This
+/// closes the idle-check -> response-CAS -> resume-reserve gap: no competing
+/// entrypoint can take the successor slot after the answer is durably cleared.
+pub struct ResponseResumeHandoff {
+    execution_reservation: SessionExecutionReservation,
+    event_sender: broadcast::Sender<AgentEvent>,
+}
+
+impl ResponseResumeHandoff {
+    pub fn subscribe(&self) -> broadcast::Receiver<AgentEvent> {
+        self.event_sender.subscribe()
+    }
+
+    pub fn publish_event(&self, event: AgentEvent) {
+        let _ = self.event_sender.send(event);
+    }
+
+    pub async fn abandon(self) {
+        self.execution_reservation.abandon().await;
+    }
+}
+
+/// Atomically acquire the successor runner slot before a response transaction.
+/// An existing suspended owner is allowed to finish; timeout returns its last
+/// run id without consuming the pending question.
+pub async fn reserve_response_resume_handoff(
+    port: &dyn ResumeExecutionPort,
+    session_id: &str,
+    timeout: std::time::Duration,
+) -> Result<ResponseResumeHandoff, ResumeOutcome> {
+    let event_sender = port.get_or_create_event_sender(session_id).await;
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match port
+            .reserve_session_execution(session_id, &event_sender)
+            .await
+        {
+            SessionExecutionReserveOutcome::Reserved(execution_reservation) => {
+                return Ok(ResponseResumeHandoff {
+                    execution_reservation,
+                    event_sender,
+                });
+            }
+            SessionExecutionReserveOutcome::AlreadyRunning { run_id } => {
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(ResumeOutcome::AlreadyRunning { run_id });
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+/// Start a resumed run using ownership acquired before the pending response
+/// was consumed. The supplied session is the exact durable CAS result.
+pub async fn resume_session_execution_with_handoff(
+    port: &dyn ResumeExecutionPort,
+    session_id: &str,
+    session: Session,
+    config: ResumeConfigSnapshot,
+    handoff: ResponseResumeHandoff,
+) -> ResumeOutcome {
+    if !has_pending_user_message(&session) {
+        tokio::spawn(async move {
+            handoff.abandon().await;
+        });
+        return ResumeOutcome::Completed;
+    }
+
+    let ResponseResumeHandoff {
+        execution_reservation,
+        event_sender,
+    } = handoff;
+    let run_id = execution_reservation.run_id().to_string();
+    let request = ResumeSpawnRequest {
+        session_id: session_id.to_string(),
+        session,
+        execution_reservation,
+        event_sender,
+        config,
+    };
+    if let Err(request) = port.dispatch_resume_execution(request) {
+        port.spawn_resume_execution(request).await;
+    }
+    ResumeOutcome::Started { run_id }
 }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +187,7 @@ pub async fn resume_session_execution(
     config: ResumeConfigSnapshot,
 ) -> ResumeOutcome {
     // Load session.
-    let Some(mut session) = port.load_session(session_id).await else {
+    let Some(session) = port.load_session(session_id).await else {
         return ResumeOutcome::NotFound;
     };
 
@@ -105,9 +208,6 @@ pub async fn resume_session_execution(
     };
     let run_id = reservation.run_id().to_string();
 
-    consume_pending_clarification_resume(&mut session);
-    port.save_and_cache_session(&mut session).await;
-
     port.spawn_resume_execution(ResumeSpawnRequest {
         session_id: session_id.to_string(),
         session,
@@ -118,4 +218,206 @@ pub async fn resume_session_execution(
     .await;
 
     ResumeOutcome::Started { run_id }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::{reserve_runner_core, AgentRunner, ReserveOutcome};
+    use bamboo_agent_core::Message;
+    use std::collections::{BTreeSet, HashMap};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::{Mutex, Notify, RwLock};
+
+    struct CancellingResumePort {
+        durable: Mutex<Session>,
+        runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
+        senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
+        spawn_entered: Arc<Notify>,
+        detached_release: Arc<Notify>,
+        detached_finished: Arc<AtomicBool>,
+        saw_marker_at_adapter: Arc<AtomicBool>,
+        save_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ResumeExecutionPort for CancellingResumePort {
+        async fn load_session(&self, _session_id: &str) -> Option<Session> {
+            Some(self.durable.lock().await.clone())
+        }
+
+        async fn save_and_cache_session(&self, session: &mut Session) {
+            self.save_calls.fetch_add(1, Ordering::SeqCst);
+            *self.durable.lock().await = session.clone();
+        }
+
+        async fn reserve_session_execution(
+            &self,
+            session_id: &str,
+            event_sender: &broadcast::Sender<AgentEvent>,
+        ) -> SessionExecutionReserveOutcome {
+            match reserve_runner_core(&self.runners, &self.senders, session_id, event_sender).await
+            {
+                ReserveOutcome::Reserved(reservation) => SessionExecutionReserveOutcome::Reserved(
+                    SessionExecutionReservation::from_pending_registration(
+                        session_id,
+                        reservation,
+                        None,
+                        self.runners.clone(),
+                    ),
+                ),
+                ReserveOutcome::AlreadyRunning(run_id) => {
+                    SessionExecutionReserveOutcome::AlreadyRunning { run_id }
+                }
+            }
+        }
+
+        async fn get_or_create_event_sender(
+            &self,
+            session_id: &str,
+        ) -> broadcast::Sender<AgentEvent> {
+            if let Some(sender) = self.senders.read().await.get(session_id).cloned() {
+                return sender;
+            }
+            let sender = broadcast::channel(16).0;
+            self.senders
+                .write()
+                .await
+                .insert(session_id.to_string(), sender.clone());
+            sender
+        }
+
+        async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) {
+            self.saw_marker_at_adapter.store(
+                request
+                    .session
+                    .metadata
+                    .contains_key("execute.startup_handoff_at"),
+                Ordering::SeqCst,
+            );
+            self.spawn_entered.notify_one();
+            std::future::pending::<()>().await;
+        }
+
+        fn dispatch_resume_execution(
+            &self,
+            request: ResumeSpawnRequest,
+        ) -> Result<(), ResumeSpawnRequest> {
+            self.saw_marker_at_adapter.store(
+                request
+                    .session
+                    .metadata
+                    .contains_key("execute.startup_handoff_at"),
+                Ordering::SeqCst,
+            );
+            let spawn_entered = self.spawn_entered.clone();
+            let detached_release = self.detached_release.clone();
+            let detached_finished = self.detached_finished.clone();
+            tokio::spawn(async move {
+                let mut reservation = request.execution_reservation;
+                reservation
+                    .ensure_registered()
+                    .await
+                    .expect("detached owner registers exact successor");
+                spawn_entered.notify_one();
+                detached_release.notified().await;
+                detached_finished.store(true, Ordering::SeqCst);
+            });
+            Ok(())
+        }
+    }
+
+    fn test_resume_config() -> ResumeConfigSnapshot {
+        ResumeConfigSnapshot {
+            provider_name: "test".to_string(),
+            provider_type: None,
+            fast_model: None,
+            fast_model_ref: None,
+            background_model: None,
+            background_model_ref: None,
+            background_model_provider: None,
+            summarization_model: None,
+            summarization_model_ref: None,
+            summarization_model_provider: None,
+            disabled_tools: BTreeSet::new(),
+            disabled_skill_ids: BTreeSet::new(),
+            image_fallback: None,
+            gold_config: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn caller_cancellation_after_dispatch_keeps_detached_resume_owner() {
+        let mut session = Session::new("resume-cancel", "model");
+        session.add_message(Message::tool_result("call-1", "Selected response: A"));
+        session.metadata.insert(
+            "clarification_resume_pending".to_string(),
+            "true".to_string(),
+        );
+        session.metadata.insert(
+            "execute.startup_handoff_at".to_string(),
+            "2026-08-10T00:00:00.000Z".to_string(),
+        );
+        let port = Arc::new(CancellingResumePort {
+            durable: Mutex::new(session),
+            runners: Arc::new(RwLock::new(HashMap::new())),
+            senders: Arc::new(RwLock::new(HashMap::new())),
+            spawn_entered: Arc::new(Notify::new()),
+            detached_release: Arc::new(Notify::new()),
+            detached_finished: Arc::new(AtomicBool::new(false)),
+            saw_marker_at_adapter: Arc::new(AtomicBool::new(false)),
+            save_calls: AtomicUsize::new(0),
+        });
+
+        let handoff = reserve_response_resume_handoff(
+            port.as_ref(),
+            "resume-cancel",
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect("reserve exact response successor");
+        let committed_session = port.durable.lock().await.clone();
+        let task_port = port.clone();
+        let resume = tokio::spawn(async move {
+            let outcome = resume_session_execution_with_handoff(
+                task_port.as_ref(),
+                "resume-cancel",
+                committed_session,
+                test_resume_config(),
+                handoff,
+            )
+            .await;
+            assert!(matches!(outcome, ResumeOutcome::Started { .. }));
+            std::future::pending::<()>().await
+        });
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            port.spawn_entered.notified(),
+        )
+        .await
+        .expect("detached resume owner must register the successor");
+        resume.abort();
+        let _ = resume.await;
+        port.detached_release.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !port.detached_finished.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached owner must survive caller cancellation");
+
+        assert!(port.saw_marker_at_adapter.load(Ordering::SeqCst));
+        assert_eq!(port.save_calls.load(Ordering::SeqCst), 0);
+        let durable = port.durable.lock().await;
+        assert_eq!(
+            durable
+                .metadata
+                .get("clarification_resume_pending")
+                .map(String::as_str),
+            Some("true")
+        );
+        assert!(durable.metadata.contains_key("execute.startup_handoff_at"));
+    }
 }

--- a/crates/engine/bamboo-engine/src/session_app/types.rs
+++ b/crates/engine/bamboo-engine/src/session_app/types.rs
@@ -193,6 +193,7 @@ pub enum ExecutePreparationOutcome {
 // ---- Respond types ----
 
 /// Input for the respond use case.
+#[derive(Clone)]
 pub struct RespondInput {
     pub session_id: String,
     pub user_response: String,

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -188,18 +188,14 @@ impl SessionRepository {
     /// The cache is refreshed cache-aside but with a no-regression guarantee:
     /// `load_merged` never overwrites a newer cached session with an older
     /// storage copy, so it is safe to call from hot read paths.
-    pub async fn load_merged(&self, session_id: &str) -> Option<Session> {
+    pub async fn load_merged_checked(&self, session_id: &str) -> std::io::Result<Option<Session>> {
         let _guard = self.persistence.acquire_lock(session_id).await;
         let memory_session = read_cached_session(&self.cache, session_id);
-        let storage_session = self
-            .storage
-            .load_session(session_id)
-            .await
-            .unwrap_or_default();
+        let storage_session = self.storage.load_session(session_id).await?;
         #[cfg(test)]
         self.run_post_durable_hook("load_merged", session_id);
 
-        match (memory_session, storage_session) {
+        Ok(match (memory_session, storage_session) {
             (Some(memory), Some(storage)) => {
                 let prefer_storage = should_prefer_storage(&memory, &storage);
                 let diverged = prefer_storage || memory.messages.len() != storage.messages.len();
@@ -253,6 +249,23 @@ impl SessionRepository {
                 Some(storage)
             }
             (None, None) => None,
+        })
+    }
+
+    /// Compatibility wrapper for read paths where the historical contract
+    /// treated a storage failure like absence. Mutating/recovery paths should
+    /// use [`Self::load_merged_checked`] so they can preserve retry state.
+    pub async fn load_merged(&self, session_id: &str) -> Option<Session> {
+        match self.load_merged_checked(session_id).await {
+            Ok(session) => session,
+            Err(error) => {
+                tracing::warn!(
+                    "[{}] Failed to load merged session from storage: {}",
+                    session_id,
+                    error
+                );
+                read_cached_session(&self.cache, session_id)
+            }
         }
     }
 

--- a/crates/infra/bamboo-notification/src/policy.rs
+++ b/crates/infra/bamboo-notification/src/policy.rs
@@ -400,6 +400,7 @@ mod tests {
             tool_call_id: tool_call_id.map(str::to_string),
             tool_name: None,
             allow_custom: true,
+            source: None,
         }
     }
 

--- a/crates/infra/bamboo-notification/src/service.rs
+++ b/crates/infra/bamboo-notification/src/service.rs
@@ -194,6 +194,7 @@ mod tests {
             tool_call_id: Some(tool_call_id.to_string()),
             tool_name: None,
             allow_custom: true,
+            source: None,
         }
     }
 

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -42,8 +42,86 @@ use dashmap::DashMap;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
 const AUTHORITATIVE_METADATA_KEYS: &[&str] = &["gold_config", "workflow.run_ids.v1"];
+const CONSUMED_CLARIFICATION_IDS_KEY: &str = "clarification.consumed_tool_call_ids";
+const RESPONSE_CONTROL_METADATA_KEYS: &[&str] = &[
+    CONSUMED_CLARIFICATION_IDS_KEY,
+    "runtime.suspend_reason",
+    "clarification_resume_pending",
+    "conclusion_with_options_resume_pending",
+    "execute.startup_handoff_at",
+    "permission.reexecute_tool_call_id",
+    "retry_resume_pending",
+    "retry_resume_reason",
+    "provider_name",
+];
 const TASK_CONTROL_PLANE_CONFLICT_PREFIX: &str = "Task control-plane changed while saving session ";
 const MAX_TASK_CONTROL_PLANE_REBASE_RETRIES: usize = 3;
+
+/// A pending response is an authoritative compare-and-consume transaction.
+/// When a stale runner still carries the consumed ask, its terminal save must
+/// adopt the durable response control plane instead of resurrecting the ask or
+/// erasing the resume handoff. The bounded consumed-id ledger distinguishes a
+/// genuinely new pending question from an old snapshot after `pending_question`
+/// itself has been cleared.
+fn adopt_durable_consumed_clarification(session: &mut Session, durable: &Session) -> bool {
+    let Some(incoming_tool_call_id) = session
+        .pending_question
+        .as_ref()
+        .map(|pending| pending.tool_call_id.clone())
+    else {
+        return false;
+    };
+    let consumed = durable
+        .metadata
+        .get(CONSUMED_CLARIFICATION_IDS_KEY)
+        .and_then(|value| serde_json::from_str::<Vec<String>>(value).ok())
+        .unwrap_or_default();
+    if !consumed
+        .iter()
+        .any(|tool_call_id| tool_call_id == &incoming_tool_call_id)
+    {
+        return false;
+    }
+
+    // Durable ordering/content wins (including the selected-response rewrite),
+    // while any truly new runner-only suffix remains append-only.
+    bamboo_domain::append_missing_runtime_messages(session, durable);
+    session
+        .pending_question
+        .clone_from(&durable.pending_question);
+    for key in RESPONSE_CONTROL_METADATA_KEYS {
+        if let Some(value) = durable.metadata.get(*key) {
+            session.metadata.insert((*key).to_string(), value.clone());
+        } else {
+            session.metadata.remove(*key);
+        }
+    }
+    session.model.clone_from(&durable.model);
+    session.model_ref.clone_from(&durable.model_ref);
+    session.reasoning_effort = durable.reasoning_effort;
+    session
+        .agent_runtime_state
+        .clone_from(&durable.agent_runtime_state);
+    if let Some(runtime_metadata) = session.runtime_metadata.as_mut() {
+        runtime_metadata.provider_name = durable
+            .runtime_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.provider_name.clone());
+    } else if durable
+        .runtime_metadata
+        .as_ref()
+        .is_some_and(|metadata| metadata.provider_name.is_some())
+    {
+        session.runtime_metadata = durable.runtime_metadata.as_ref().map(|metadata| {
+            let mut response_metadata = bamboo_domain::SessionRuntimeMetadata::default();
+            response_metadata
+                .provider_name
+                .clone_from(&metadata.provider_name);
+            response_metadata
+        });
+    }
+    true
+}
 
 fn is_task_control_plane_save_conflict(error: &std::io::Error) -> bool {
     error.kind() == std::io::ErrorKind::WouldBlock
@@ -601,12 +679,14 @@ impl LockedSessionStore {
             let durable_count = latest.messages.len();
             let appended = bamboo_domain::append_missing_runtime_messages(session, latest);
             bamboo_domain::merge_session_inbox_admission(session, latest);
+            let adopted_response = adopt_durable_consumed_clarification(session, latest);
             tracing::debug!(
-                "[{}] append-safe runtime checkpoint: durable={}, incoming={}, appended={}, saved={}",
+                "[{}] append-safe runtime checkpoint: durable={}, incoming={}, appended={}, adopted_response={}, saved={}",
                 session.id,
                 durable_count,
                 incoming_count,
                 appended,
+                adopted_response,
                 session.messages.len(),
             );
             apply_authoritative_metadata(session, latest);
@@ -680,6 +760,7 @@ impl LockedSessionStore {
         }
 
         if let Some(latest) = latest.as_ref() {
+            adopt_durable_consumed_clarification(session, latest);
             apply_authoritative_metadata(session, latest);
             let restored = bamboo_domain::restore_missing_admitted_inbox_messages(session, latest);
             if restored > 0 {
@@ -909,6 +990,115 @@ impl LockedSessionStore {
         Ok(Some(session))
     }
 
+    /// Load the authoritative response transaction candidate while the caller
+    /// holds this store's per-session lock. The merge rules intentionally
+    /// match [`Self::mutate_runtime_session_and_publish`], including adoption
+    /// of a clarification that durable storage already consumed.
+    async fn load_response_candidate<C>(
+        &self,
+        session_id: &str,
+        load_cached: C,
+    ) -> std::io::Result<Option<Session>>
+    where
+        C: FnOnce() -> Option<Session> + Send,
+    {
+        let cached_candidate = load_cached();
+        let durable = self.storage.load_session(session_id).await?;
+        let Some(mut session) = (match (cached_candidate, durable.as_ref()) {
+            (Some(cached), Some(durable)) => {
+                let prefer_durable = durable.updated_at > cached.updated_at
+                    || (durable.updated_at == cached.updated_at
+                        && cached.pending_question.is_none()
+                        && durable.pending_question.is_some());
+                Some(if prefer_durable {
+                    durable.clone()
+                } else {
+                    cached
+                })
+            }
+            (Some(cached), None) => Some(cached),
+            (None, durable) => durable.cloned(),
+        }) else {
+            return Ok(None);
+        };
+        if let Some(latest) = durable.as_ref() {
+            // A response transaction starts from an append-safe transcript.
+            // In particular, a cache snapshot that is timestamp-newer but
+            // still carries an already-consumed ask must not resurrect that
+            // ask or discard ordinary messages committed with the answer.
+            adopt_durable_consumed_clarification(&mut session, latest);
+            bamboo_domain::append_missing_runtime_messages(&mut session, latest);
+            apply_authoritative_metadata(&mut session, latest);
+            let restored =
+                bamboo_domain::restore_missing_admitted_inbox_messages(&mut session, latest);
+            if restored > 0 {
+                tracing::warn!(
+                    session_id,
+                    restored,
+                    "restored durable SessionInbox transcript messages into response transaction"
+                );
+            }
+            bamboo_domain::merge_session_inbox_admission(&mut session, latest);
+            adopt_fresher_disk_permission_posture(&mut session, latest);
+            adopt_fresher_durable_model_context_state(&mut session, latest);
+        }
+        Ok(Some(session))
+    }
+
+    /// Inspect the same authoritative snapshot a response mutation would use,
+    /// without persisting or publishing it. Callers use this immediately before
+    /// reserving a successor so an already-consumed response cannot allocate a
+    /// replacement runner.
+    pub async fn inspect_runtime_session_for_response<C>(
+        &self,
+        session_id: &str,
+        load_cached: C,
+    ) -> std::io::Result<Option<Session>>
+    where
+        C: FnOnce() -> Option<Session> + Send,
+    {
+        let _guard = self.acquire_lock(session_id).await;
+        self.load_response_candidate(session_id, load_cached).await
+    }
+
+    /// Atomically load, validate/mutate, persist, and publish one runtime
+    /// session under its canonical per-session lock.
+    ///
+    /// The nested result keeps validation errors distinct from storage errors:
+    /// `Ok(Err(error))` means `mutate` rejected the latest snapshot and no save
+    /// occurred. This is suitable for compare-and-consume operations such as a
+    /// typed pending-question response, where separate load/save calls would
+    /// allow another writer to replace the question between validation and
+    /// persistence.
+    pub async fn mutate_runtime_session_and_publish<C, M, P, E>(
+        &self,
+        session_id: &str,
+        load_cached: C,
+        mutate: M,
+        publish: P,
+    ) -> std::io::Result<Result<Option<Session>, E>>
+    where
+        C: FnOnce() -> Option<Session> + Send,
+        M: FnOnce(&mut Session) -> Result<(), E> + Send,
+        P: FnOnce(&Session) + Send,
+        E: Send,
+    {
+        let _guard = self.acquire_lock(session_id).await;
+        let Some(mut session) = self
+            .load_response_candidate(session_id, load_cached)
+            .await?
+        else {
+            return Ok(Ok(None));
+        };
+        if let Err(error) = mutate(&mut session) {
+            return Ok(Err(error));
+        }
+        self.save_session_rebasing_task_conflicts(&mut session)
+            .await?;
+        publish(&session);
+        Ok(Ok(Some(session)))
+    }
+
     /// Clear the legacy compatibility queue using durable CAS and publish the
     /// saved full snapshot before releasing the same session lock.
     pub async fn clear_legacy_pending_messages_and_publish<F>(
@@ -1056,6 +1246,7 @@ async fn merge_authoritative_metadata_into_stale(
     session: &mut Session,
 ) -> std::io::Result<()> {
     if let Some(latest) = storage.load_session(&session.id).await? {
+        adopt_durable_consumed_clarification(session, &latest);
         apply_authoritative_metadata(session, &latest);
         bamboo_domain::restore_missing_admitted_inbox_messages(session, &latest);
         bamboo_domain::merge_session_inbox_admission(session, &latest);
@@ -1494,6 +1685,193 @@ mod tests {
             Some(transitioned_at),
         )
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn checked_runtime_mutation_persists_a_cache_only_pending_session() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let mut cached = fresh("cache-only-response");
+        cached.set_pending_question(
+            "tool-1".to_string(),
+            "ConclusionWithOptions".to_string(),
+            "Choose".to_string(),
+            vec!["A".to_string()],
+            false,
+        );
+
+        let saved = store
+            .mutate_runtime_session_and_publish(
+                &cached.id.clone(),
+                move || Some(cached),
+                |session| {
+                    assert!(session.pending_question.is_some());
+                    session.clear_pending_question();
+                    Ok::<_, ()>(())
+                },
+                |_| {},
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .expect("cache-only session should be created durably");
+
+        assert!(saved.pending_question.is_none());
+        assert!(storage
+            .load_session("cache-only-response")
+            .await
+            .unwrap()
+            .unwrap()
+            .pending_question
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn checked_runtime_mutation_preserves_durable_authorities_for_newer_cache() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "cached-response-authorities";
+        let mut durable = fresh(session_id);
+        durable.title = "Durable title".to_string();
+        durable.title_version = 4;
+        durable.title_generated = true;
+        durable.metadata_version = 9;
+        set_permission_audit(
+            &mut durable,
+            bamboo_domain::SessionPermissionMode::Auto,
+            7,
+            "bamboo_runtime:durable-auto",
+            "2026-08-10T09:00:00Z",
+        );
+        storage.save_session(&durable).await.unwrap();
+
+        let mut cached = fresh(session_id);
+        cached.title = "Stale cached title".to_string();
+        cached.updated_at = durable.updated_at + chrono::Duration::seconds(1);
+        cached.set_pending_question(
+            "tool-1".to_string(),
+            "ConclusionWithOptions".to_string(),
+            "Choose".to_string(),
+            vec!["A".to_string()],
+            false,
+        );
+
+        store
+            .mutate_runtime_session_and_publish(
+                session_id,
+                move || Some(cached),
+                |session| {
+                    session.clear_pending_question();
+                    Ok::<_, ()>(())
+                },
+                |_| {},
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .expect("session should exist");
+
+        let saved = storage.load_session(session_id).await.unwrap().unwrap();
+        assert_eq!(saved.title, "Durable title");
+        assert_eq!(saved.title_version, 4);
+        assert_eq!(saved.metadata_version, 9);
+        assert_eq!(
+            saved
+                .agent_runtime_state
+                .as_ref()
+                .unwrap()
+                .effective_permission_mode(),
+            bamboo_domain::SessionPermissionMode::Auto
+        );
+        let audit = bamboo_domain::PermissionAuditSnapshot::from_metadata(&saved.metadata).unwrap();
+        assert_eq!(audit.policy_revision, 7);
+        assert_eq!(audit.executor_mapping, "bamboo_runtime:durable-auto");
+    }
+
+    #[tokio::test]
+    async fn checked_runtime_mutation_cannot_resurrect_consumed_ask_from_newer_cache() {
+        use bamboo_domain::session::types::Message;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "cached-consumed-response";
+        let mut stale_cached = fresh(session_id);
+        stale_cached.add_message(Message::tool_result("call-1", "waiting"));
+        stale_cached.set_pending_question(
+            "call-1".to_string(),
+            "ConclusionWithOptions".to_string(),
+            "Choose".to_string(),
+            vec!["A".to_string()],
+            false,
+        );
+
+        let mut durable = stale_cached.clone();
+        durable.clear_pending_question();
+        durable.metadata.insert(
+            CONSUMED_CLARIFICATION_IDS_KEY.to_string(),
+            r#"["call-1"]"#.to_string(),
+        );
+        durable.messages[0].content = "Selected response: A".to_string();
+        durable.add_message(Message::user("durable concurrent message"));
+        storage.save_session(&durable).await.unwrap();
+
+        // A cache write after the durable response can have a newer wall-clock
+        // timestamp while still containing the old runner snapshot.
+        stale_cached.updated_at = durable.updated_at + chrono::Duration::seconds(1);
+        let saved = store
+            .mutate_runtime_session_and_publish(
+                session_id,
+                move || Some(stale_cached),
+                |session| {
+                    assert!(session.pending_question.is_none());
+                    Ok::<_, ()>(())
+                },
+                |_| {},
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert!(saved.pending_question.is_none());
+        assert_eq!(saved.messages.len(), 2);
+        assert_eq!(saved.messages[0].content, "Selected response: A");
+        assert_eq!(saved.messages[1].content, "durable concurrent message");
+    }
+
+    #[tokio::test]
+    async fn response_inspection_adopts_durable_consumption_without_writing() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "inspect-consumed-response";
+        let mut stale_cached = fresh(session_id);
+        stale_cached.set_pending_question(
+            "call-1".to_string(),
+            "ConclusionWithOptions".to_string(),
+            "Choose".to_string(),
+            vec!["A".to_string()],
+            false,
+        );
+
+        let mut durable = stale_cached.clone();
+        durable.clear_pending_question();
+        durable.metadata.insert(
+            CONSUMED_CLARIFICATION_IDS_KEY.to_string(),
+            r#"["call-1"]"#.to_string(),
+        );
+        storage.save_session(&durable).await.unwrap();
+        stale_cached.updated_at = durable.updated_at + chrono::Duration::seconds(1);
+
+        let inspected = store
+            .inspect_runtime_session_for_response(session_id, move || Some(stale_cached))
+            .await
+            .unwrap()
+            .expect("session should be inspectable");
+        assert!(inspected.pending_question.is_none());
+
+        let unchanged = storage.load_session(session_id).await.unwrap().unwrap();
+        assert_eq!(unchanged.updated_at, durable.updated_at);
+        assert!(unchanged.pending_question.is_none());
     }
 
     #[tokio::test]
@@ -1988,6 +2366,135 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn runtime_final_save_cannot_resurrect_a_consumed_clarification() {
+        use bamboo_domain::session::types::Message;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "consumed-clarification-final-save";
+
+        let mut suspended = fresh(session_id);
+        suspended.add_message(Message::tool_result(
+            "call-1",
+            r#"{"status":"awaiting_clarification"}"#,
+        ));
+        suspended.set_pending_question(
+            "call-1".to_string(),
+            "ConclusionWithOptions".to_string(),
+            "Choose".to_string(),
+            vec!["A".to_string()],
+            false,
+        );
+        suspended.metadata.insert(
+            "runtime.suspend_reason".to_string(),
+            "awaiting_clarification".to_string(),
+        );
+        storage.save_session(&suspended).await.unwrap();
+        let mut stale_runner = suspended.clone();
+
+        let mut answered = suspended;
+        answered.clear_pending_question();
+        answered.metadata.remove("runtime.suspend_reason");
+        answered.metadata.insert(
+            CONSUMED_CLARIFICATION_IDS_KEY.to_string(),
+            r#"["call-1"]"#.to_string(),
+        );
+        answered.metadata.insert(
+            "clarification_resume_pending".to_string(),
+            "true".to_string(),
+        );
+        answered.metadata.insert(
+            "conclusion_with_options_resume_pending".to_string(),
+            "true".to_string(),
+        );
+        answered.metadata.insert(
+            "execute.startup_handoff_at".to_string(),
+            "2026-08-10T09:00:00.000Z".to_string(),
+        );
+        let answer = answered
+            .messages
+            .iter_mut()
+            .find(|message| message.tool_call_id.as_deref() == Some("call-1"))
+            .unwrap();
+        answer.content = "Selected response: A".to_string();
+        storage.save_session(&answered).await.unwrap();
+
+        store.merge_save_runtime(&mut stale_runner).await.unwrap();
+
+        let saved = storage.load_session(session_id).await.unwrap().unwrap();
+        assert!(saved.pending_question.is_none());
+        assert!(!saved.metadata.contains_key("runtime.suspend_reason"));
+        assert_eq!(
+            saved
+                .metadata
+                .get("clarification_resume_pending")
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            saved
+                .metadata
+                .get("execute.startup_handoff_at")
+                .map(String::as_str),
+            Some("2026-08-10T09:00:00.000Z")
+        );
+        let answers = saved
+            .messages
+            .iter()
+            .filter(|message| message.tool_call_id.as_deref() == Some("call-1"))
+            .collect::<Vec<_>>();
+        assert_eq!(answers.len(), 1);
+        assert_eq!(answers[0].content, "Selected response: A");
+    }
+
+    #[tokio::test]
+    async fn runtime_checkpoint_cannot_resurrect_a_consumed_clarification() {
+        use bamboo_domain::session::types::Message;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "consumed-clarification-checkpoint";
+        let mut stale_runner = fresh(session_id);
+        stale_runner.add_message(Message::tool_result("call-1", "waiting"));
+        stale_runner.set_pending_question(
+            "call-1".to_string(),
+            "ConclusionWithOptions".to_string(),
+            "Choose".to_string(),
+            vec!["A".to_string()],
+            false,
+        );
+        stale_runner.metadata.insert(
+            "runtime.suspend_reason".to_string(),
+            "awaiting_clarification".to_string(),
+        );
+
+        let mut answered = stale_runner.clone();
+        answered.clear_pending_question();
+        answered.metadata.remove("runtime.suspend_reason");
+        answered.metadata.insert(
+            CONSUMED_CLARIFICATION_IDS_KEY.to_string(),
+            r#"["call-1"]"#.to_string(),
+        );
+        answered.metadata.insert(
+            "clarification_resume_pending".to_string(),
+            "true".to_string(),
+        );
+        answered.messages[0].content = "Selected response: A".to_string();
+        storage.save_session(&answered).await.unwrap();
+
+        store
+            .checkpoint_runtime_session(&mut stale_runner)
+            .await
+            .unwrap();
+
+        let saved = storage.load_session(session_id).await.unwrap().unwrap();
+        assert!(saved.pending_question.is_none());
+        assert!(!saved.metadata.contains_key("runtime.suspend_reason"));
+        assert_eq!(saved.messages.len(), 1);
+        assert_eq!(saved.messages[0].content, "Selected response: A");
     }
 
     #[tokio::test]

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -634,6 +634,7 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
             web::Path::from(session_id.clone()),
             web::Json(RespondRequest {
                 response,
+                expected_tool_call_id: Some(pending.tool_call_id.clone()),
                 model: model_selection.model.clone(),
                 provider: model_selection.provider.clone(),
                 model_ref: model_selection.model_ref.clone(),


### PR DESCRIPTION
## Summary

- preserve the complete typed clarification contract from engine events through HTTP, Connect, and the Bamboo TUI
- render fixed-choice and custom-answer modes correctly, including long Unicode content, duplicate labels, more than nine options, scrolling, copying, retry, and reconnect behavior
- atomically compare and consume the exact pending tool-call identity, then hand off one cancellation-safe successor execution across HTTP, Connect, Gold, and SDK paths
- make clarification persistence and SSE replay durable so stale streams, responses, and session switches cannot submit against the wrong question

## Root cause

The TUI previously projected clarification events as plain question text and lost `tool_call_id`, option, custom-answer, and source semantics. Response paths also did not share one authoritative single-flight boundary from preflight through durable consume and successor dispatch, allowing stale or duplicate responders to race with a newer question or fast-completing successor.

## Test plan

- `cargo test -p bamboo-agent-core -p bamboo-client-core -p bamboo-engine -p bamboo-storage -p bamboo-notification -p bamboo-tui`
- `cargo test -p bamboo-agent-core -p bamboo-client-core -p bamboo-sdk`
- `cargo test -p bamboo-server -- --test-threads=8` (1809 passed, 1 ignored; one unchanged scheduler timing test timed out under full-suite load)
- `cargo test -p bamboo-server schedule_app::scheduler_tool::tests::auto_execute_schedule_runs_forced_ask_tool_without_approval_while_interactive_asks -- --exact --test-threads=1` (passed in 11.76s; source is unchanged from `dev`)
- `cargo test --workspace --all-targets --no-run`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
- strict `-D warnings --no-deps` Clippy checks for changed production libraries (allowing only two `dev`-existing `too_many_arguments` lints in server/storage)
- `git diff --check`

Independent agent review approved frozen diff `71f88eed7ce1d16928d3d7b2b24049f62f82b7b425fce7cbe81b86917ed6d56e` with no Blocker or Major findings.

## Screenshots

N/A. This is terminal UI behavior; 60/80/120-column rendering and interaction states are covered by TUI tests.

Closes #646
