### PR TITLE
feat(tui): add searchable session and model pickers

### DIFF
--- a/crates/app/bamboo-client-core/src/lib.rs
+++ b/crates/app/bamboo-client-core/src/lib.rs
@@ -27,6 +27,11 @@ pub struct ChatRequest {
     /// Optional model override. Omitted from the request body when `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Provider paired with `model`. Supplying both preserves the catalog's
+    /// exact provider/model identity instead of falling back to whichever
+    /// provider was previously active for a same-named model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -47,9 +52,11 @@ mod chat_request_tests {
             session_id: None,
             project_id: Some("project-client".to_string()),
             model: Some("gpt-5".to_string()),
+            provider: Some("openai".to_string()),
         })
         .unwrap();
         assert_eq!(value["project_id"], "project-client");
+        assert_eq!(value["provider"], "openai");
         assert!(value.get("session_id").is_none());
     }
 }
@@ -60,6 +67,24 @@ mod chat_request_tests {
 pub struct ExecuteRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+}
+
+#[cfg(test)]
+mod execute_request_tests {
+    use super::ExecuteRequest;
+
+    #[test]
+    fn execute_request_keeps_provider_paired_with_model() {
+        let value = serde_json::to_value(ExecuteRequest {
+            model: Some("shared".to_string()),
+            provider: Some("provider-b".to_string()),
+        })
+        .unwrap();
+        assert_eq!(value["model"], "shared");
+        assert_eq!(value["provider"], "provider-b");
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -3,8 +3,83 @@ pub mod types;
 
 use anyhow::Result;
 use reqwest::Client;
+use std::fmt;
 
 use types::*;
+
+#[derive(Debug, Clone)]
+pub struct VersionedSession {
+    pub summary: SessionSummary,
+    pub metadata_version: u64,
+}
+
+/// Recoverable failure from a session metadata PATCH. The picker keeps its
+/// query, selected row, and rename draft open for every variant; `conflict`
+/// specifically identifies a 412 so the UI can explain the refetch/retry path.
+#[derive(Debug, Clone)]
+pub struct SessionMutationFailure {
+    pub conflict: bool,
+    pub current_version: Option<u64>,
+    message: String,
+}
+
+impl SessionMutationFailure {
+    fn transport(error: reqwest::Error) -> Self {
+        Self {
+            conflict: false,
+            current_version: None,
+            message: format!("session update transport failed: {error}"),
+        }
+    }
+
+    fn protocol(message: impl Into<String>) -> Self {
+        Self {
+            conflict: false,
+            current_version: None,
+            message: message.into(),
+        }
+    }
+
+    fn rejected(status: reqwest::StatusCode, body: String, etag: Option<u64>) -> Self {
+        let body = body.trim();
+        Self {
+            conflict: status == reqwest::StatusCode::PRECONDITION_FAILED,
+            current_version: etag,
+            message: if body.is_empty() {
+                format!("session update failed ({status})")
+            } else {
+                format!("session update failed ({status}): {body}")
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_conflict(current_version: u64) -> Self {
+        Self {
+            conflict: true,
+            current_version: Some(current_version),
+            message: "version conflict".to_string(),
+        }
+    }
+}
+
+impl fmt::Display for SessionMutationFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SessionMutationFailure {}
+
+fn parse_etag(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    let raw = headers.get(reqwest::header::ETAG)?.to_str().ok()?.trim();
+    raw.strip_prefix("W/")
+        .unwrap_or(raw)
+        .trim()
+        .trim_matches('"')
+        .parse()
+        .ok()
+}
 
 #[derive(Debug, Clone)]
 pub struct RespondFailure {
@@ -284,6 +359,30 @@ impl BambooClient {
         Ok(envelope.session)
     }
 
+    /// Fetch a session together with its metadata ETag. Rename and pin flows
+    /// retain this version while the operator edits, then send it back via
+    /// `If-Match` so concurrent updates become a recoverable 412 instead of a
+    /// silent last-writer-wins overwrite.
+    pub async fn get_session_versioned(&self, session_id: &str) -> Result<VersionedSession> {
+        let resp = self
+            .client
+            .get(self.url(&format!("/api/v1/sessions/{}", session_id)))
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("get session failed ({status}): {body}");
+        }
+        let metadata_version = parse_etag(resp.headers())
+            .ok_or_else(|| anyhow::anyhow!("get session response omitted metadata ETag"))?;
+        let envelope: GetSessionEnvelope = resp.json().await?;
+        Ok(VersionedSession {
+            summary: envelope.session,
+            metadata_version,
+        })
+    }
+
     pub async fn delete_session(&self, id: &str) -> Result<()> {
         let resp = self
             .client
@@ -296,6 +395,44 @@ impl BambooClient {
             anyhow::bail!("delete session failed ({status}): {body}");
         }
         Ok(())
+    }
+
+    pub async fn patch_session_metadata(
+        &self,
+        session_id: &str,
+        expected_version: u64,
+        patch: &PatchSessionMetadataRequest,
+    ) -> std::result::Result<VersionedSession, SessionMutationFailure> {
+        let resp = self
+            .client
+            .patch(self.url(&format!("/api/v1/sessions/{}", session_id)))
+            .header(reqwest::header::IF_MATCH, format!("\"{expected_version}\""))
+            .json(patch)
+            .send()
+            .await
+            .map_err(SessionMutationFailure::transport)?;
+        let status = resp.status();
+        let metadata_version = parse_etag(resp.headers());
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(SessionMutationFailure::rejected(
+                status,
+                body,
+                metadata_version,
+            ));
+        }
+        let metadata_version = metadata_version.ok_or_else(|| {
+            SessionMutationFailure::protocol("session PATCH response omitted metadata ETag")
+        })?;
+        let envelope: GetSessionEnvelope = resp.json().await.map_err(|error| {
+            SessionMutationFailure::protocol(format!(
+                "session PATCH returned an unreadable response: {error}"
+            ))
+        })?;
+        Ok(VersionedSession {
+            summary: envelope.session,
+            metadata_version,
+        })
     }
 
     // ── Provider catalog (model picker, Ctrl+O) ──
@@ -317,11 +454,9 @@ impl BambooClient {
         Ok(catalog)
     }
 
-    /// PATCH the active session's model after the picker applies a selection.
-    /// Fire-and-forget from the caller's point of view (the model already
-    /// took effect locally via `chat.model`) — this just keeps the server's
-    /// session record from drifting, so a failure is reported via `notify`,
-    /// never treated as fatal to the model change itself.
+    /// PATCH the active session's model before the picker commits a selection
+    /// locally. The caller keeps the overlay open on failure so the visible
+    /// model badge can never drift from the persisted session record.
     pub async fn patch_session_model(&self, session_id: &str, model: &str) -> Result<()> {
         let resp = self
             .client
@@ -533,7 +668,53 @@ impl BambooClient {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_auto_resume_status;
+    use super::*;
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) -> String {
+        use tokio::io::AsyncReadExt;
+
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            if let Some(index) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                break index + 4;
+            }
+            let read = stream.read(&mut chunk).await.unwrap();
+            if read == 0 {
+                break request.len();
+            }
+            request.extend_from_slice(&chunk[..read]);
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        while request.len() < header_end + content_length {
+            let read = stream.read(&mut chunk).await.unwrap();
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&chunk[..read]);
+        }
+        String::from_utf8_lossy(&request).into_owned()
+    }
+
+    async fn respond(stream: &mut tokio::net::TcpStream, status: &str, etag: &str, body: &str) {
+        use tokio::io::AsyncWriteExt;
+
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nETag: {etag}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+    }
 
     #[test]
     fn auto_resume_status_accepts_only_server_contract_values() {
@@ -559,5 +740,90 @@ mod tests {
             let error = parse_auto_resume_status(body).unwrap_err();
             assert!(error.should_refresh_question(), "body: {body}");
         }
+    }
+
+    #[tokio::test]
+    async fn metadata_patch_round_trips_get_etag_and_if_match() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut get_socket, _) = listener.accept().await.unwrap();
+            let get = read_request(&mut get_socket).await;
+            assert!(get.starts_with("GET /api/v1/sessions/s1 HTTP/1.1"));
+            respond(
+                &mut get_socket,
+                "200 OK",
+                "W/\"7\"",
+                r#"{"session":{"id":"s1","title":"Before"}}"#,
+            )
+            .await;
+
+            let (mut patch_socket, _) = listener.accept().await.unwrap();
+            let patch = read_request(&mut patch_socket).await;
+            assert!(patch.starts_with("PATCH /api/v1/sessions/s1 HTTP/1.1"));
+            assert!(patch.to_ascii_lowercase().contains("if-match: \"7\""));
+            assert!(patch.ends_with(r#"{"title":"After"}"#));
+            respond(
+                &mut patch_socket,
+                "200 OK",
+                "\"8\"",
+                r#"{"session":{"id":"s1","title":"After"}}"#,
+            )
+            .await;
+        });
+
+        let client = BambooClient::new(&base_url);
+        let current = client.get_session_versioned("s1").await.unwrap();
+        assert_eq!(current.metadata_version, 7);
+        assert_eq!(current.summary.title, "Before");
+
+        let updated = client
+            .patch_session_metadata(
+                "s1",
+                current.metadata_version,
+                &PatchSessionMetadataRequest {
+                    title: Some("After".to_string()),
+                    pinned: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated.metadata_version, 8);
+        assert_eq!(updated.summary.title, "After");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn metadata_patch_surfaces_412_and_current_etag() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let patch = read_request(&mut socket).await;
+            assert!(patch.to_ascii_lowercase().contains("if-match: \"4\""));
+            respond(
+                &mut socket,
+                "412 Precondition Failed",
+                "\"5\"",
+                r#"{"error":"metadata changed"}"#,
+            )
+            .await;
+        });
+
+        let failure = BambooClient::new(&base_url)
+            .patch_session_metadata(
+                "s1",
+                4,
+                &PatchSessionMetadataRequest {
+                    title: None,
+                    pinned: Some(true),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(failure.conflict);
+        assert_eq!(failure.current_version, Some(5));
+        assert!(failure.to_string().contains("metadata changed"));
+        server.await.unwrap();
     }
 }

--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -197,12 +197,18 @@ impl BambooClient {
         Ok(chat_resp)
     }
 
-    pub async fn execute(&self, session_id: &str, model: Option<&str>) -> Result<ExecuteResponse> {
+    pub async fn execute(
+        &self,
+        session_id: &str,
+        model: Option<&str>,
+        provider: Option<&str>,
+    ) -> Result<ExecuteResponse> {
         let resp = self
             .client
             .post(self.url(&format!("/api/v1/execute/{}", session_id)))
             .json(&ExecuteRequest {
                 model: model.map(|m| m.to_string()),
+                provider: provider.map(str::to_string),
             })
             .send()
             .await?;
@@ -457,12 +463,17 @@ impl BambooClient {
     /// PATCH the active session's model before the picker commits a selection
     /// locally. The caller keeps the overlay open on failure so the visible
     /// model badge can never drift from the persisted session record.
-    pub async fn patch_session_model(&self, session_id: &str, model: &str) -> Result<()> {
+    pub async fn patch_session_model(
+        &self,
+        session_id: &str,
+        model_ref: &CatalogModelRef,
+    ) -> Result<()> {
         let resp = self
             .client
             .patch(self.url(&format!("/api/v1/sessions/{}", session_id)))
             .json(&PatchSessionModelRequest {
-                model: model.to_string(),
+                model: model_ref.model.clone(),
+                provider: model_ref.provider.clone(),
             })
             .send()
             .await?;
@@ -824,6 +835,31 @@ mod tests {
         assert!(failure.conflict);
         assert_eq!(failure.current_version, Some(5));
         assert!(failure.to_string().contains("metadata changed"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn model_patch_preserves_provider_model_identity() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let patch = read_request(&mut socket).await;
+            assert!(patch.starts_with("PATCH /api/v1/sessions/s1 HTTP/1.1"));
+            assert!(patch.ends_with(r#"{"model":"shared","provider":"provider-b"}"#));
+            respond(&mut socket, "200 OK", "\"1\"", "{}").await;
+        });
+
+        BambooClient::new(&base_url)
+            .patch_session_model(
+                "s1",
+                &CatalogModelRef {
+                    provider: "provider-b".to_string(),
+                    model: "shared".to_string(),
+                },
+            )
+            .await
+            .unwrap();
         server.await.unwrap();
     }
 }

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -47,6 +47,10 @@ pub struct SessionSummary {
     #[serde(default)]
     pub model: String,
     #[serde(default)]
+    pub model_ref: Option<CatalogModelRef>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
     pub is_running: bool,
     #[serde(default)]
     pub has_pending_question: bool,
@@ -320,11 +324,10 @@ pub struct ScheduleRunConfigReq {
 // ── Provider catalog (model picker, Ctrl+O) ──
 
 /// Mirrors the server's `ProviderModelRef` (`crates/core/bamboo-domain`) on
-/// the wire: `{"provider": "...", "model": "..."}`. `model` alone (NOT
-/// `provider/model`) is the string form `ChatRequest.model` /
-/// `ExecuteRequest.model` / `PatchSessionRequest.model` actually resolve —
-/// see `apply_model` in `app.rs`.
-#[derive(Deserialize, Debug, Clone, Default)]
+/// the wire: `{"provider": "...", "model": "..."}`. The TUI keeps those
+/// fields separate on Chat/Execute/PATCH requests so same-named models from
+/// different providers remain unambiguous without inventing a combined id.
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct CatalogModelRef {
     #[serde(default)]
     pub provider: String,
@@ -356,12 +359,13 @@ pub struct ProviderCatalog {
     pub models: Vec<CatalogModel>,
 }
 
-/// Body of `PATCH /api/v1/sessions/{id}` for the model-picker's
-/// fire-and-forget session update. Must match the server's
-/// `PatchSessionRequest.model` field name.
-#[derive(Serialize)]
+/// Body of `PATCH /api/v1/sessions/{id}` for the model-picker's exact
+/// provider/model update. The server derives and persists its typed
+/// `model_ref` when both legacy-compatible fields are present.
+#[derive(Serialize, Debug, Clone)]
 pub struct PatchSessionModelRequest {
     pub model: String,
+    pub provider: String,
 }
 
 /// Canonical metadata subset used by the session picker's rename/pin actions.
@@ -692,9 +696,10 @@ mod tests {
     fn patch_session_model_request_serializes_model_field() {
         let req = PatchSessionModelRequest {
             model: "gpt-4.1".to_string(),
+            provider: "openai".to_string(),
         };
         let json = serde_json::to_string(&req).unwrap();
-        assert_eq!(json, r#"{"model":"gpt-4.1"}"#);
+        assert_eq!(json, r#"{"model":"gpt-4.1","provider":"openai"}"#);
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -364,6 +364,17 @@ pub struct PatchSessionModelRequest {
     pub model: String,
 }
 
+/// Canonical metadata subset used by the session picker's rename/pin actions.
+/// Both fields are optional so one PATCH can express exactly one deliberate UI
+/// mutation while the `If-Match` header protects it from stale overwrites.
+#[derive(Serialize, Debug, Clone, Default)]
+pub struct PatchSessionMetadataRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pinned: Option<bool>,
+}
+
 // ── Skills ──
 
 #[derive(Deserialize, Debug, Clone)]
@@ -684,5 +695,23 @@ mod tests {
         };
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(json, r#"{"model":"gpt-4.1"}"#);
+    }
+
+    #[test]
+    fn patch_session_metadata_omits_unrelated_fields() {
+        let rename = PatchSessionMetadataRequest {
+            title: Some("Renamed".to_string()),
+            pinned: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&rename).unwrap(),
+            r#"{"title":"Renamed"}"#
+        );
+
+        let pin = PatchSessionMetadataRequest {
+            title: None,
+            pinned: Some(true),
+        };
+        assert_eq!(serde_json::to_string(&pin).unwrap(), r#"{"pinned":true}"#);
     }
 }

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -135,6 +135,10 @@ pub struct ChatState {
     pub current_tool_calls: Vec<ToolCallDisplay>,
     pub current_reasoning: String,
     pub model: String,
+    /// Provider paired with `model` when the selection has an authoritative
+    /// catalog/session identity. Kept across Ctrl+N so a new session does not
+    /// silently fall back to another provider for a same-named model.
+    pub provider: Option<String>,
     pub token_usage: Option<TokenUsage>,
     pub plan_mode: bool,
     /// When true, tool-call arguments and results render in full instead
@@ -161,6 +165,7 @@ impl ChatState {
             current_tool_calls: Vec::new(),
             current_reasoning: String::new(),
             model: String::new(),
+            provider: None,
             token_usage: None,
             plan_mode: false,
             expand_tools: false,
@@ -176,6 +181,7 @@ impl ChatState {
 pub struct OpenedSession {
     pub messages: Vec<ChatMessage>,
     pub model: String,
+    pub provider: Option<String>,
     pub project_id: Option<String>,
     pub is_running: bool,
     pub pending: Option<PendingQuestion>,
@@ -635,6 +641,11 @@ pub enum SessionPickerMode {
     Rename {
         session_id: String,
         draft: String,
+        /// Title represented by the ETag preparation snapshot. A fresh GET
+        /// must reconcile this baseline before its version can authorize the
+        /// draft, otherwise a stale list row could silently revert a rename.
+        base_title: String,
+        draft_dirty: bool,
         metadata_version: Option<u64>,
         loading_version: bool,
         submitting: bool,
@@ -672,6 +683,9 @@ pub struct SessionPicker {
     pub visible: Vec<usize>,
     pub query: String,
     pub selected: usize,
+    /// Once the operator moves or filters the cursor, later lazy pages must
+    /// preserve that choice instead of jumping back to the active session.
+    pub selection_touched: bool,
     pub loading: bool,
     pub error: Option<String>,
     pub total: usize,
@@ -740,14 +754,38 @@ fn session_search_text(session: &SessionSummary) -> String {
     )
 }
 
+fn current_model_key(
+    models: &[CatalogModel],
+    current_provider: Option<&str>,
+    current_model: &str,
+) -> Option<(String, String)> {
+    if current_model.trim().is_empty() {
+        return None;
+    }
+    if let Some(provider) = current_provider.filter(|provider| !provider.trim().is_empty()) {
+        return Some((provider.to_string(), current_model.to_string()));
+    }
+
+    // Legacy sessions expose only a bare model id. Treat it as Current only
+    // when the catalog maps that id to exactly one provider; duplicate ids are
+    // deliberately left unmarked rather than claiming several providers are
+    // simultaneously active.
+    let mut matches = models
+        .iter()
+        .filter(|model| model.reference.model == current_model)
+        .map(model_key);
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
+}
+
 fn sort_catalog_models(
     models: &mut [CatalogModel],
-    current_model: &str,
+    current: Option<&(String, String)>,
     recent: &VecDeque<(String, String)>,
 ) {
     models.sort_by_key(|model| {
         let key = model_key(model);
-        let current_rank = usize::from(model.reference.model != current_model);
+        let current_rank = usize::from(current != Some(&key));
         let recent_rank = recent
             .iter()
             .position(|candidate| candidate == &key)
@@ -1316,13 +1354,22 @@ impl App {
             AppEvent::ActionDone {
                 outcome,
                 reload_tab,
+                session_picker_epoch,
             } => {
+                let succeeded = outcome.is_ok();
                 match outcome {
                     Ok(msg) => self.notify(NoticeLevel::Info, msg),
                     Err(msg) => self.notify(NoticeLevel::Error, msg),
                 }
                 if reload_tab {
-                    if self.session_picker.is_some() {
+                    let reload_origin_picker = succeeded
+                        && session_picker_epoch.is_some_and(|epoch| {
+                            self.session_picker.as_ref().is_some_and(|picker| {
+                                picker.epoch == epoch
+                                    && matches!(picker.mode, SessionPickerMode::Browse)
+                            })
+                        });
+                    if reload_origin_picker {
                         self.reload_session_picker();
                     }
                     self.load_tab_data();
@@ -1375,6 +1422,15 @@ impl App {
                 self.opening_session_id = None;
                 match result {
                     Ok(opened) => {
+                        // Contextual pickers are bound to the chat session
+                        // visible beneath them. A concurrently completing
+                        // resume invalidates that context and any in-flight
+                        // model PATCH result before installing the new session.
+                        if self.session_picker.is_some() {
+                            self.pending_delete = None;
+                        }
+                        self.close_session_picker();
+                        self.close_model_picker();
                         // Reset every per-run scratch field `finalize_streaming`
                         // would otherwise leave behind from whatever was open
                         // before — a resumed session must not inherit stale
@@ -1382,6 +1438,7 @@ impl App {
                         self.detach_stream();
                         self.chat.session_id = Some(session_id.clone());
                         self.chat.model = opened.model;
+                        self.chat.provider = opened.provider;
                         self.chat.project_id = opened.project_id;
                         self.chat.current_response.clear();
                         self.chat.current_tool_calls.clear();
@@ -1686,9 +1743,18 @@ impl App {
                 picker.loading = false;
                 match result {
                     Ok(mut catalog) => {
+                        catalog.models.retain(|model| {
+                            !model.reference.provider.trim().is_empty()
+                                && !model.reference.model.trim().is_empty()
+                        });
+                        let current = current_model_key(
+                            &catalog.models,
+                            self.chat.provider.as_deref(),
+                            &self.chat.model,
+                        );
                         sort_catalog_models(
                             &mut catalog.models,
-                            &self.chat.model,
+                            current.as_ref(),
                             &self.recent_models,
                         );
                         picker.models = catalog.models;
@@ -1706,6 +1772,7 @@ impl App {
             }
             AppEvent::ModelPatched {
                 epoch,
+                session_id,
                 model,
                 result,
             } => {
@@ -1718,6 +1785,13 @@ impl App {
                 };
                 self.model_picker_task = None;
                 picker.applying = false;
+                if self.chat.session_id.as_deref() != Some(session_id.as_str()) {
+                    picker.error = Some(
+                        "Active session changed while applying the model — reopen the picker"
+                            .to_string(),
+                    );
+                    return Ok(());
+                }
                 match result {
                     Ok(()) => self.commit_model_selection(model),
                     Err(error) => {
@@ -1742,6 +1816,7 @@ impl App {
                 self.session_picker_task = None;
                 picker.loading = false;
                 let selected_before = picker.selected_session().map(|session| session.id.clone());
+                let loaded_page = result.is_ok();
                 match result {
                     Ok(envelope) => {
                         if offset == 0 {
@@ -1768,27 +1843,31 @@ impl App {
                             .flatten()
                             .filter(|next| *next > offset);
                         picker.error = None;
-                        let preserve_id = self
-                            .chat
-                            .session_id
-                            .clone()
-                            .filter(|active_id| {
-                                picker
-                                    .sessions
-                                    .iter()
-                                    .any(|session| &session.id == active_id)
-                            })
-                            .or(selected_before);
+                        let preserve_id = if picker.selection_touched {
+                            selected_before
+                        } else {
+                            self.chat
+                                .session_id
+                                .clone()
+                                .filter(|active_id| {
+                                    picker
+                                        .sessions
+                                        .iter()
+                                        .any(|session| &session.id == active_id)
+                                })
+                                .or(selected_before)
+                        };
                         picker.refresh_filter(preserve_id);
                     }
                     Err(error) => {
                         picker.error = Some(format!(
-                            "Failed to load sessions: {error} — press r to retry"
+                            "Failed to load sessions: {error} — press Ctrl+R to retry"
                         ));
                     }
                 }
                 let should_continue = self.session_picker.as_ref().is_some_and(|picker| {
-                    !picker.query.is_empty()
+                    loaded_page
+                        && !picker.query.is_empty()
                         && picker.next_offset.is_some()
                         && picker.sessions.len() < MAX_SESSION_PICKER_SESSIONS
                 });
@@ -1816,6 +1895,8 @@ impl App {
                 let mut patch = None;
                 match result {
                     Ok(versioned) => {
+                        let fresh_title = versioned.summary.title.clone();
+                        let fresh_version = versioned.metadata_version;
                         if let Some(existing) = picker
                             .sessions
                             .iter_mut()
@@ -1825,14 +1906,34 @@ impl App {
                         }
                         match &mut picker.mode {
                             SessionPickerMode::Rename {
+                                draft,
+                                base_title,
+                                draft_dirty,
                                 metadata_version,
                                 loading_version,
                                 error,
                                 ..
                             } => {
-                                *metadata_version = Some(versioned.metadata_version);
                                 *loading_version = false;
-                                *error = None;
+                                if *draft_dirty && *base_title != fresh_title {
+                                    // The user edited a title derived from a
+                                    // stale list row. Do not bind that draft to
+                                    // a newer ETag until the conflict has been
+                                    // made visible and explicitly retried.
+                                    *metadata_version = None;
+                                    *base_title = fresh_title;
+                                    *error = Some(
+                                        "Title changed on the server; draft preserved — press Ctrl+R to confirm against the latest title"
+                                            .to_string(),
+                                    );
+                                } else {
+                                    if !*draft_dirty {
+                                        *draft = fresh_title.clone();
+                                    }
+                                    *base_title = fresh_title;
+                                    *metadata_version = Some(fresh_version);
+                                    *error = None;
+                                }
                             }
                             SessionPickerMode::Pinning {
                                 target,
@@ -1844,7 +1945,7 @@ impl App {
                                 *loading_version = false;
                                 *submitting = true;
                                 *error = None;
-                                patch = Some((versioned.metadata_version, *target));
+                                patch = Some((fresh_version, *target));
                             }
                             SessionPickerMode::Browse => {}
                         }
@@ -1862,7 +1963,7 @@ impl App {
                         } => {
                             *loading_version = false;
                             *error = Some(format!(
-                                "Failed to prepare update: {error_message} — press r to retry"
+                                "Failed to prepare update: {error_message} — press Ctrl+R to retry"
                             ));
                         }
                         SessionPickerMode::Browse => {}
@@ -1925,7 +2026,8 @@ impl App {
                             .current_version
                             .map(|version| format!(" (server version {version})"))
                             .unwrap_or_default();
-                        let message = format!("{prefix}{current}: {failure} — press r to retry");
+                        let message =
+                            format!("{prefix}{current}: {failure} — press Ctrl+R to retry");
                         match &mut picker.mode {
                             SessionPickerMode::Rename {
                                 metadata_version,
@@ -2045,6 +2147,17 @@ impl App {
             return;
         }
 
+        // Non-pointer modal owners still consume mouse input. In particular,
+        // a delete confirmation must not let the wheel move the Session row
+        // hidden behind it; cancel then returns to the exact prior selection.
+        if self.serve_offer.is_some()
+            || self.pending_delete.is_some()
+            || self.schedule_form.is_some()
+            || self.config_editor.is_some()
+        {
+            return;
+        }
+
         if let Some(picker) = self.session_picker.as_mut() {
             if matches!(picker.mode, SessionPickerMode::Browse) {
                 let delta = match mouse.kind {
@@ -2053,6 +2166,7 @@ impl App {
                     _ => return,
                 };
                 picker.selected = scroll_selection(picker.selected, picker.visible.len(), delta);
+                picker.selection_touched = true;
             }
             return;
         }
@@ -2995,6 +3109,8 @@ impl App {
                 self.pending_delete = None;
                 if let Some(tx) = self.event_tx.clone() {
                     let client = self.client.clone();
+                    let session_picker_epoch =
+                        self.session_picker.as_ref().map(|picker| picker.epoch);
                     tokio::spawn(async move {
                         let outcome = match client.delete_session(&id).await {
                             Ok(()) => Ok("Session deleted".to_string()),
@@ -3003,6 +3119,7 @@ impl App {
                         let _ = tx.send(AppEvent::ActionDone {
                             outcome,
                             reload_tab: true,
+                            session_picker_epoch,
                         });
                     });
                 }
@@ -3170,12 +3287,14 @@ impl App {
         let client = self.client.clone();
         let existing_session = self.chat.session_id.clone();
         let project_id = self.chat.project_id.clone();
+        let provider = self.chat.provider.clone();
         tokio::spawn(async move {
             let req = ChatRequest {
                 message,
                 session_id: existing_session,
                 project_id,
                 model: Some(model),
+                provider,
             };
             let result = client
                 .chat(req)
@@ -3253,6 +3372,7 @@ impl App {
         };
         let client = self.client.clone();
         let model = self.chat.model.clone();
+        let provider = self.chat.provider.clone();
         tokio::spawn(async move {
             let model = if model.is_empty() { None } else { Some(model) };
             let ready = if *sse_ready.borrow() {
@@ -3280,7 +3400,10 @@ impl App {
             // will ever arrive for a run that never started — report it back so
             // the handler can finalize `chat.streaming` instead of spinning
             // forever waiting for events behind a run that doesn't exist.
-            if let Err(e) = client.execute(&session_id, model.as_deref()).await {
+            if let Err(e) = client
+                .execute(&session_id, model.as_deref(), provider.as_deref())
+                .await
+            {
                 let _ = tx.send(AppEvent::ExecuteFailed(e.to_string()));
             }
         });
@@ -3340,9 +3463,15 @@ impl App {
             } else {
                 None
             };
+            let provider = summary
+                .model_ref
+                .as_ref()
+                .map(|model_ref| model_ref.provider.clone())
+                .or_else(|| summary.provider.clone());
             let opened = OpenedSession {
                 messages: map_history(history.messages),
                 model: summary.model,
+                provider,
                 project_id: summary.project_id,
                 is_running: summary.is_running,
                 pending,
@@ -3963,6 +4092,7 @@ impl App {
                         let _ = tx.send(AppEvent::ActionDone {
                             outcome,
                             reload_tab: true,
+                            session_picker_epoch: None,
                         });
                     });
                 }
@@ -4021,6 +4151,7 @@ impl App {
                         let _ = tx.send(AppEvent::ActionDone {
                             outcome,
                             reload_tab: true,
+                            session_picker_epoch: None,
                         });
                     });
                 }
@@ -4040,6 +4171,7 @@ impl App {
                         let _ = tx.send(AppEvent::ActionDone {
                             outcome,
                             reload_tab: false,
+                            session_picker_epoch: None,
                         });
                     });
                 }
@@ -4103,6 +4235,7 @@ impl App {
                         let _ = tx.send(AppEvent::ActionDone {
                             outcome,
                             reload_tab: true,
+                            session_picker_epoch: None,
                         });
                     });
                 }
@@ -4219,6 +4352,7 @@ impl App {
                             let _ = tx.send(AppEvent::ActionDone {
                                 outcome,
                                 reload_tab: true,
+                                session_picker_epoch: None,
                             });
                         });
                     }
@@ -4246,6 +4380,7 @@ impl App {
             visible: Vec::new(),
             query: String::new(),
             selected: 0,
+            selection_touched: false,
             loading: true,
             error: None,
             total: 0,
@@ -4289,6 +4424,7 @@ impl App {
         picker.sessions.clear();
         picker.visible.clear();
         picker.selected = 0;
+        picker.selection_touched = false;
         picker.loading = true;
         picker.error = None;
         picker.total = 0;
@@ -4372,6 +4508,7 @@ impl App {
                     if let Some(picker) = self.session_picker.as_mut() {
                         let preserve = picker.selected_session().map(|s| s.id.clone());
                         picker.query.clear();
+                        picker.selection_touched = true;
                         picker.refresh_filter(preserve);
                     }
                     return;
@@ -4394,10 +4531,12 @@ impl App {
             KeyCode::Up => {
                 if let Some(picker) = self.session_picker.as_mut() {
                     picker.selected = picker.selected.saturating_sub(1);
+                    picker.selection_touched = true;
                 }
             }
             KeyCode::Down => {
                 let load_more = if let Some(picker) = self.session_picker.as_mut() {
+                    picker.selection_touched = true;
                     if picker.selected + 1 < picker.visible.len() {
                         picker.selected += 1;
                         false
@@ -4439,6 +4578,7 @@ impl App {
                 if let Some(picker) = self.session_picker.as_mut() {
                     let preserve = picker.selected_session().map(|s| s.id.clone());
                     picker.query.pop();
+                    picker.selection_touched = true;
                     picker.refresh_filter(preserve);
                 }
             }
@@ -4450,6 +4590,7 @@ impl App {
                 if let Some(picker) = self.session_picker.as_mut() {
                     let preserve = picker.selected_session().map(|s| s.id.clone());
                     picker.query.push(character);
+                    picker.selection_touched = true;
                     picker.refresh_filter(preserve);
                 }
                 if self
@@ -4478,7 +4619,9 @@ impl App {
         if let Some(picker) = self.session_picker.as_mut() {
             picker.mode = SessionPickerMode::Rename {
                 session_id: session_id.clone(),
+                base_title: draft.clone(),
                 draft,
+                draft_dirty: false,
                 metadata_version: None,
                 loading_version: true,
                 submitting: false,
@@ -4521,10 +4664,12 @@ impl App {
         let SessionPickerMode::Rename {
             session_id,
             draft,
+            draft_dirty,
             metadata_version,
             loading_version,
             submitting,
             error,
+            ..
         } = &mut picker.mode
         else {
             return;
@@ -4558,6 +4703,7 @@ impl App {
                 KeyCode::Esc => cancel = true,
                 KeyCode::Backspace => {
                     draft.pop();
+                    *draft_dirty = true;
                     *error = None;
                 }
                 KeyCode::Char(character)
@@ -4566,6 +4712,7 @@ impl App {
                         .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
                 {
                     draft.push(character);
+                    *draft_dirty = true;
                     *error = None;
                 }
                 _ => {}
@@ -4843,15 +4990,16 @@ impl App {
         picker.applying = true;
         picker.error = None;
         let epoch = picker.epoch;
-        let model_id = model.reference.model.clone();
+        let model_ref = model.reference.clone();
         let client = self.client.clone();
         self.model_picker_task = Some(tokio::spawn(async move {
             let result = client
-                .patch_session_model(&session_id, &model_id)
+                .patch_session_model(&session_id, &model_ref)
                 .await
                 .map_err(|error| error.to_string());
             let _ = tx.send(AppEvent::ModelPatched {
                 epoch,
+                session_id,
                 model,
                 result,
             });
@@ -4859,7 +5007,14 @@ impl App {
     }
 
     pub(crate) fn model_group_label(&self, model: &CatalogModel) -> String {
-        if model.reference.model == self.chat.model {
+        let current = self.model_picker.as_ref().and_then(|picker| {
+            current_model_key(
+                &picker.models,
+                self.chat.provider.as_deref(),
+                &self.chat.model,
+            )
+        });
+        if current.as_ref() == Some(&model_key(model)) {
             "Current".to_string()
         } else if self.recent_models.contains(&model_key(model)) {
             "Recent".to_string()
@@ -4875,15 +5030,18 @@ impl App {
 
     fn commit_model_selection(&mut self, model: CatalogModel) {
         let key = model_key(&model);
+        let provider_label = if model.provider_display_name.trim().is_empty() {
+            model.reference.provider.clone()
+        } else {
+            model.provider_display_name.clone()
+        };
         self.recent_models.retain(|candidate| candidate != &key);
         self.recent_models.push_front(key);
         self.recent_models.truncate(MAX_RECENT_MODELS);
         self.chat.model = model.reference.model.clone();
+        self.chat.provider = Some(model.reference.provider.clone());
         self.model_picker = None;
-        self.status_message = format!(
-            "Model: {} ({})",
-            model.display_name, model.provider_display_name
-        );
+        self.status_message = format!("Model: {} ({provider_label})", model.display_name);
     }
 }
 
@@ -5463,6 +5621,7 @@ mod question_tests {
             result: Ok(OpenedSession {
                 messages: Vec::new(),
                 model: "model".to_string(),
+                provider: None,
                 project_id: None,
                 is_running: false,
                 pending: None,
@@ -5478,6 +5637,7 @@ mod question_tests {
             result: Ok(OpenedSession {
                 messages: Vec::new(),
                 model: "model".to_string(),
+                provider: None,
                 project_id: None,
                 is_running: false,
                 pending: Some(PendingQuestion {
@@ -5530,6 +5690,7 @@ mod question_tests {
             result: Ok(OpenedSession {
                 messages: Vec::new(),
                 model: "model".to_string(),
+                provider: None,
                 project_id: None,
                 is_running: false,
                 pending: None,
@@ -5546,6 +5707,7 @@ mod question_tests {
             result: Ok(OpenedSession {
                 messages: Vec::new(),
                 model: "model".to_string(),
+                provider: None,
                 project_id: None,
                 is_running: false,
                 pending: Some(PendingQuestion {
@@ -5583,6 +5745,7 @@ mod question_tests {
             result: Ok(OpenedSession {
                 messages: Vec::new(),
                 model: "model".to_string(),
+                provider: None,
                 project_id: None,
                 is_running: false,
                 pending: None,
@@ -5599,6 +5762,7 @@ mod question_tests {
             result: Ok(OpenedSession {
                 messages: Vec::new(),
                 model: "model".to_string(),
+                provider: None,
                 project_id: None,
                 is_running: false,
                 pending: Some(PendingQuestion {
@@ -6371,6 +6535,8 @@ mod question_tests {
             title: String::new(),
             title_generated: true,
             model: String::new(),
+            model_ref: None,
+            provider: None,
             is_running: false,
             has_pending_question: false,
             last_run_status: None,
@@ -6869,6 +7035,7 @@ mod question_tests {
         OpenedSession {
             messages,
             model: "claude-sonnet-5".to_string(),
+            provider: None,
             project_id: None,
             is_running: false,
             pending: None,
@@ -7754,6 +7921,7 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("s1".to_string());
         app.chat.model = "claude-sonnet-5".to_string();
+        app.chat.provider = Some("anthropic".to_string());
         app.chat.project_id = Some("project-tui".to_string());
         app.chat.messages = vec![asst_msg("leftover")];
         app.chat.current_response = "partial".to_string();
@@ -7788,6 +7956,7 @@ mod question_tests {
             app.chat.model, "claude-sonnet-5",
             "model must survive a new session"
         );
+        assert_eq!(app.chat.provider.as_deref(), Some("anthropic"));
         assert_eq!(
             app.chat.project_id.as_deref(),
             Some("project-tui"),
@@ -8065,6 +8234,7 @@ mod question_tests {
             sessions,
             query: String::new(),
             selected: 0,
+            selection_touched: false,
             loading: false,
             error: None,
             total: 0,
@@ -8211,6 +8381,32 @@ mod question_tests {
     }
 
     #[tokio::test]
+    async fn session_picker_page_failure_stops_until_explicit_retry() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let mut picker = contextual_session_picker(vec![bare_session("s1")]);
+        picker.query = "match".to_string();
+        picker.next_offset = Some(1);
+        picker.total = 2;
+        app.session_picker = Some(picker);
+
+        app.handle_event(AppEvent::SessionPickerPageLoaded {
+            epoch: 7,
+            offset: 1,
+            result: Err("offline".to_string()),
+        })
+        .await
+        .unwrap();
+
+        let picker = app.session_picker.as_ref().unwrap();
+        assert_eq!(picker.next_offset, Some(1), "retry offset stays available");
+        assert!(picker.error.as_deref().unwrap().contains("offline"));
+        assert!(
+            app.session_picker_task.is_none(),
+            "an error must not immediately spawn the same page again"
+        );
+    }
+
+    #[tokio::test]
     async fn active_session_becomes_selected_when_a_later_page_arrives() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("active".to_string());
@@ -8246,12 +8442,143 @@ mod question_tests {
     }
 
     #[tokio::test]
+    async fn lazy_page_preserves_operator_selection_after_navigation() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("active".to_string());
+        let mut picker =
+            contextual_session_picker(vec![bare_session("s1"), bare_session("chosen")]);
+        picker.selected = 1;
+        picker.selection_touched = true;
+        app.session_picker = Some(picker);
+
+        app.handle_event(AppEvent::SessionPickerPageLoaded {
+            epoch: 7,
+            offset: 2,
+            result: Ok(ListSessionsEnvelope {
+                sessions: vec![bare_session("active")],
+                total: 3,
+                limit: 2,
+                offset: 2,
+                next_offset: None,
+            }),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            app.session_picker
+                .as_ref()
+                .unwrap()
+                .selected_session()
+                .unwrap()
+                .id,
+            "chosen"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_version_rebases_an_untouched_rename_draft() {
+        let mut original = bare_session("s1");
+        original.title = "A".to_string();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![original]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
+            session_id: "s1".to_string(),
+            draft: "A".to_string(),
+            base_title: "A".to_string(),
+            draft_dirty: false,
+            metadata_version: None,
+            loading_version: true,
+            submitting: false,
+            error: None,
+        };
+        let mut fresh = bare_session("s1");
+        fresh.title = "B".to_string();
+
+        app.handle_event(AppEvent::SessionPickerVersionLoaded {
+            epoch: 7,
+            session_id: "s1".to_string(),
+            intent: SessionPickerIntent::Rename,
+            result: Ok(crate::api::VersionedSession {
+                summary: fresh,
+                metadata_version: 2,
+            }),
+        })
+        .await
+        .unwrap();
+
+        let SessionPickerMode::Rename {
+            draft,
+            base_title,
+            metadata_version,
+            error,
+            ..
+        } = &app.session_picker.as_ref().unwrap().mode
+        else {
+            panic!("rename mode closed unexpectedly");
+        };
+        assert_eq!(draft, "B");
+        assert_eq!(base_title, "B");
+        assert_eq!(*metadata_version, Some(2));
+        assert!(error.is_none());
+    }
+
+    #[tokio::test]
+    async fn fresh_changed_title_does_not_authorize_a_dirty_stale_draft() {
+        let mut original = bare_session("s1");
+        original.title = "A".to_string();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![original]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
+            session_id: "s1".to_string(),
+            draft: "my edit".to_string(),
+            base_title: "A".to_string(),
+            draft_dirty: true,
+            metadata_version: None,
+            loading_version: true,
+            submitting: false,
+            error: None,
+        };
+        let mut fresh = bare_session("s1");
+        fresh.title = "B".to_string();
+
+        app.handle_event(AppEvent::SessionPickerVersionLoaded {
+            epoch: 7,
+            session_id: "s1".to_string(),
+            intent: SessionPickerIntent::Rename,
+            result: Ok(crate::api::VersionedSession {
+                summary: fresh,
+                metadata_version: 2,
+            }),
+        })
+        .await
+        .unwrap();
+
+        let SessionPickerMode::Rename {
+            draft,
+            base_title,
+            metadata_version,
+            error,
+            ..
+        } = &app.session_picker.as_ref().unwrap().mode
+        else {
+            panic!("rename mode closed unexpectedly");
+        };
+        assert_eq!(draft, "my edit");
+        assert_eq!(base_title, "B");
+        assert!(metadata_version.is_none());
+        assert!(error.as_deref().unwrap().contains("Title changed"));
+    }
+
+    #[tokio::test]
     async fn rename_conflict_preserves_draft_and_exposes_retry() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.session_picker = Some(contextual_session_picker(vec![bare_session("s1")]));
         app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
             session_id: "s1".to_string(),
             draft: "keep my draft".to_string(),
+            base_title: "old title".to_string(),
+            draft_dirty: true,
             metadata_version: Some(1),
             loading_version: false,
             submitting: true,
@@ -8318,6 +8645,8 @@ mod question_tests {
         app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
             session_id: "s1".to_string(),
             draft: "new draft".to_string(),
+            base_title: "old title".to_string(),
+            draft_dirty: true,
             metadata_version: None,
             loading_version: true,
             submitting: false,
@@ -8354,19 +8683,68 @@ mod question_tests {
 
     #[tokio::test]
     async fn contextual_delete_confirmation_owns_input_then_returns_to_picker() {
+        use crossterm::event::{MouseEvent, MouseEventKind};
+
         let mut session = bare_session("s1");
         session.title = "Delete me".to_string();
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.session_picker = Some(contextual_session_picker(vec![session]));
+        app.session_picker = Some(contextual_session_picker(vec![
+            session,
+            bare_session("s2"),
+            bare_session("s3"),
+            bare_session("s4"),
+        ]));
         app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
             .await
             .unwrap();
         assert_eq!(app.pending_delete.as_ref().unwrap().0, "s1");
 
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        });
+        assert_eq!(
+            app.session_picker.as_ref().unwrap().selected,
+            0,
+            "delete confirmation must consume the wheel"
+        );
+
         app.handle_key(key(KeyCode::Char('n'))).await.unwrap();
         assert!(app.pending_delete.is_none());
         assert!(app.session_picker.is_some());
         assert!(app.session_picker.as_ref().unwrap().query.is_empty());
+    }
+
+    #[tokio::test]
+    async fn late_action_completion_cannot_erase_a_newer_rename_editor() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![bare_session("s1")]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
+            session_id: "s1".to_string(),
+            draft: "keep this draft".to_string(),
+            base_title: "old".to_string(),
+            draft_dirty: true,
+            metadata_version: Some(1),
+            loading_version: false,
+            submitting: false,
+            error: None,
+        };
+
+        app.handle_event(AppEvent::ActionDone {
+            outcome: Ok("older delete completed".to_string()),
+            reload_tab: true,
+            session_picker_epoch: Some(7),
+        })
+        .await
+        .unwrap();
+
+        let SessionPickerMode::Rename { draft, .. } = &app.session_picker.as_ref().unwrap().mode
+        else {
+            panic!("late generic completion erased the editor");
+        };
+        assert_eq!(draft, "keep this draft");
     }
 
     #[test]
@@ -8551,6 +8929,7 @@ mod question_tests {
 
         app.handle_event(AppEvent::ModelPatched {
             epoch: 1,
+            session_id: "s1".to_string(),
             model: catalog_model(
                 "anthropic",
                 "claude-sonnet-5",
@@ -8571,6 +8950,82 @@ mod question_tests {
         assert_eq!(app.chat.textarea.lines().join("\n"), "d");
     }
 
+    #[tokio::test]
+    async fn session_switch_invalidates_an_in_flight_model_patch() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-a".to_string());
+        app.chat.model = "model-a".to_string();
+        app.chat.provider = Some("provider-a".to_string());
+        app.model_picker = Some(model_picker(vec![catalog_model(
+            "provider-a",
+            "selected-for-a",
+            "Selected for A",
+            "Provider A",
+        )]));
+        app.model_picker.as_mut().unwrap().applying = true;
+        app.opening_session_id = Some("session-b".to_string());
+
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "session-b".to_string(),
+            result: Ok(OpenedSession {
+                model: "model-b".to_string(),
+                provider: Some("provider-b".to_string()),
+                ..opened(vec![])
+            }),
+        })
+        .await
+        .unwrap();
+        assert!(app.model_picker.is_none());
+
+        app.handle_event(AppEvent::ModelPatched {
+            epoch: 1,
+            session_id: "session-a".to_string(),
+            model: catalog_model(
+                "provider-a",
+                "selected-for-a",
+                "Selected for A",
+                "Provider A",
+            ),
+            result: Ok(()),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(app.chat.session_id.as_deref(), Some("session-b"));
+        assert_eq!(app.chat.model, "model-b");
+        assert_eq!(app.chat.provider.as_deref(), Some("provider-b"));
+    }
+
+    #[test]
+    fn duplicate_model_ids_require_provider_identity_for_current_group() {
+        let models = vec![
+            catalog_model("provider-a", "shared", "Shared A", "Provider A"),
+            catalog_model("provider-b", "shared", "Shared B", "Provider B"),
+        ];
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.model = "shared".to_string();
+        app.model_picker = Some(model_picker(models));
+
+        assert!(app
+            .model_picker
+            .as_ref()
+            .unwrap()
+            .models
+            .iter()
+            .all(|model| app.model_group_label(model) != "Current"));
+
+        app.chat.provider = Some("provider-b".to_string());
+        let labels = app
+            .model_picker
+            .as_ref()
+            .unwrap()
+            .models
+            .iter()
+            .map(|model| app.model_group_label(model))
+            .collect::<Vec<_>>();
+        assert_eq!(labels, vec!["Provider: Provider A", "Current"]);
+    }
+
     #[test]
     fn model_picker_renders_current_recent_and_provider_groups() {
         use ratatui::backend::TestBackend;
@@ -8583,7 +9038,8 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.model = "current".to_string();
         app.recent_models.push_back(model_key(&recent));
-        sort_catalog_models(&mut models, &app.chat.model, &app.recent_models);
+        let current = current_model_key(&models, app.chat.provider.as_deref(), &app.chat.model);
+        sort_catalog_models(&mut models, current.as_ref(), &app.recent_models);
         app.model_picker = Some(model_picker(models));
 
         let backend = TestBackend::new(120, 30);
@@ -8604,9 +9060,9 @@ mod question_tests {
     }
 
     /// `↑/↓` move the selection (clamped); `Enter` applies the highlighted
-    /// model — `chat.model` gets the plain model id (NOT `provider/model`),
-    /// matching what `ChatRequest`/`ExecuteRequest`/`PatchSessionRequest.model`
-    /// resolve on the server.
+    /// model — `chat.model` keeps the plain model id while `chat.provider`
+    /// keeps its paired provider, matching the server's separate compatibility
+    /// fields without collapsing identity into a synthetic string.
     #[tokio::test]
     async fn model_picker_navigation_and_enter_applies() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
@@ -8647,6 +9103,7 @@ mod question_tests {
             app.chat.model, "claude-sonnet-5",
             "chat.model gets the plain model id, not provider/model"
         );
+        assert_eq!(app.chat.provider.as_deref(), Some("anthropic"));
         assert_eq!(app.status_message, "Model: Claude Sonnet 5 (Anthropic)");
     }
 

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -992,6 +992,10 @@ pub struct App {
     /// session, and the actual DELETE runs off the event loop like every other
     /// mutation.
     pub pending_delete: Option<(String, String)>,
+    /// Session id whose DELETE request is currently in flight. When it is the
+    /// active Chat session, submission stays blocked until the result arrives
+    /// so a concurrent chat POST cannot recreate the session being deleted.
+    deleting_session_id: Option<String>,
     /// Capped scrollback of past status messages so errors/warnings aren't lost
     /// when the single status line is overwritten. Viewed with `Ctrl+L`.
     pub notifications: Vec<Notification>,
@@ -1115,6 +1119,7 @@ impl App {
             model_picker: None,
             session_picker: None,
             pending_delete: None,
+            deleting_session_id: None,
             notifications: Vec::new(),
             notifications_visible: false,
             unseen_alerts: 0,
@@ -1374,6 +1379,63 @@ impl App {
                     }
                     self.load_tab_data();
                 }
+            }
+            AppEvent::SessionDeleted {
+                session_id,
+                result,
+                session_picker_epoch,
+            } => {
+                if self.deleting_session_id.as_deref() == Some(session_id.as_str()) {
+                    self.deleting_session_id = None;
+                }
+                let succeeded = result.is_ok();
+                let deleted_active =
+                    succeeded && self.chat.session_id.as_deref() == Some(session_id.as_str());
+                let deleted_opening =
+                    succeeded && self.opening_session_id.as_deref() == Some(session_id.as_str());
+                if deleted_active {
+                    // Detach before another input event can be handled. This
+                    // preserves the deliberate model/Project/composer draft,
+                    // while removing every server-backed trace of the deleted
+                    // session from the Chat view. Preserve an unrelated newer
+                    // resume, but never let a queued resume of this deleted id
+                    // become authoritative again.
+                    let unrelated_opening = self
+                        .opening_session_id
+                        .take()
+                        .filter(|opening| opening != &session_id);
+                    self.new_session();
+                    self.opening_session_id = unrelated_opening;
+                } else if deleted_opening {
+                    // The resume task itself is best-effort and may already
+                    // have queued a result. Clearing its authoritative id
+                    // makes that stale SessionOpened harmless.
+                    self.opening_session_id = None;
+                }
+                match result {
+                    Ok(()) => self.notify(
+                        NoticeLevel::Info,
+                        if deleted_active {
+                            "Session deleted — started a new session"
+                        } else {
+                            "Session deleted"
+                        },
+                    ),
+                    Err(error) => {
+                        self.notify(NoticeLevel::Error, format!("Delete failed: {error}"))
+                    }
+                }
+                let reload_origin_picker = succeeded
+                    && session_picker_epoch.is_some_and(|epoch| {
+                        self.session_picker.as_ref().is_some_and(|picker| {
+                            picker.epoch == epoch
+                                && matches!(picker.mode, SessionPickerMode::Browse)
+                        })
+                    });
+                if reload_origin_picker {
+                    self.reload_session_picker();
+                }
+                self.load_tab_data();
             }
             AppEvent::ChatStarted(r) => match r {
                 Ok(session_id) => {
@@ -3107,22 +3169,42 @@ impl App {
         match key.code {
             KeyCode::Char('y') | KeyCode::Enter => {
                 self.pending_delete = None;
-                if let Some(tx) = self.event_tx.clone() {
-                    let client = self.client.clone();
-                    let session_picker_epoch =
-                        self.session_picker.as_ref().map(|picker| picker.epoch);
-                    tokio::spawn(async move {
-                        let outcome = match client.delete_session(&id).await {
-                            Ok(()) => Ok("Session deleted".to_string()),
-                            Err(e) => Err(format!("Delete failed: {e}")),
-                        };
-                        let _ = tx.send(AppEvent::ActionDone {
-                            outcome,
-                            reload_tab: true,
-                            session_picker_epoch,
-                        });
-                    });
+                if self.deleting_session_id.is_some() {
+                    self.notify(
+                        NoticeLevel::Warn,
+                        "Wait for the current session delete to finish",
+                    );
+                    return Ok(());
                 }
+                if self.chat.streaming && self.chat.session_id.as_deref() == Some(id.as_str()) {
+                    self.notify(
+                        NoticeLevel::Warn,
+                        "Stop the active run before deleting its session",
+                    );
+                    return Ok(());
+                }
+                let Some(tx) = self.event_tx.clone() else {
+                    self.notify(
+                        NoticeLevel::Error,
+                        "Session delete is not attached to an event loop",
+                    );
+                    return Ok(());
+                };
+                self.deleting_session_id = Some(id.clone());
+                self.status_message = "Deleting session...".to_string();
+                let client = self.client.clone();
+                let session_picker_epoch = self.session_picker.as_ref().map(|picker| picker.epoch);
+                tokio::spawn(async move {
+                    let result = client
+                        .delete_session(&id)
+                        .await
+                        .map_err(|error| error.to_string());
+                    let _ = tx.send(AppEvent::SessionDeleted {
+                        session_id: id,
+                        result,
+                        session_picker_epoch,
+                    });
+                });
             }
             KeyCode::Char('n') | KeyCode::Esc => {
                 self.pending_delete = None;
@@ -3231,6 +3313,24 @@ impl App {
                 self.chat.textarea.insert_newline();
             }
             KeyCode::Enter => {
+                // Selecting a session starts an asynchronous history/summary
+                // fetch after the picker closes. Keep the existing draft
+                // editable while that fetch is in flight, but never submit it
+                // against the session still visible underneath: a concurrent
+                // `ChatStarted` and `SessionOpened` could otherwise route the
+                // turn (or its provider/model) to different sessions.
+                if self.opening_session_id.is_some() {
+                    self.status_message =
+                        "Session is still resuming — message kept as draft".to_string();
+                    return Ok(());
+                }
+                if self.chat.session_id.as_ref().is_some_and(|session_id| {
+                    self.deleting_session_id.as_deref() == Some(session_id.as_str())
+                }) {
+                    self.status_message =
+                        "Session is being deleted — message kept as draft".to_string();
+                    return Ok(());
+                }
                 let input = self.chat.textarea.lines().join("\n");
                 let input = input.trim().to_string();
                 if input.is_empty() {
@@ -3501,7 +3601,10 @@ impl App {
         self.chat.token_usage = None;
         self.chat.scroll_offset = 0;
         self.chat.auto_scroll = true;
+        self.chat.streaming = false;
         self.chat.plan_mode = false;
+        self.stream_disconnected = false;
+        self.pending_answer_run_started = false;
         self.supersede_pending_answer();
         self.pending_question = None;
         self.dismissed_question = None;
@@ -4948,9 +5051,10 @@ impl App {
             }
             KeyCode::Char('r')
                 if key.modifiers.contains(KeyModifiers::CONTROL)
-                    && self.model_picker.as_ref().is_some_and(|picker| {
-                        picker.error.is_some() && picker.models.is_empty()
-                    }) =>
+                    && self
+                        .model_picker
+                        .as_ref()
+                        .is_some_and(|picker| !picker.loading && picker.visible.is_empty()) =>
             {
                 self.reload_model_catalog();
             }
@@ -6663,6 +6767,122 @@ mod question_tests {
         assert!(app.pending_delete.is_none());
     }
 
+    #[tokio::test]
+    async fn successful_delete_of_active_session_resets_server_backed_chat_state() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("active".to_string());
+        app.chat.project_id = Some("project-1".to_string());
+        app.chat.model = "gpt-5".to_string();
+        app.chat.provider = Some("openai".to_string());
+        app.chat.messages.push(ChatMessage {
+            role: MessageRole::Assistant,
+            content: "old transcript".to_string(),
+            tool_calls: Vec::new(),
+            reasoning: None,
+        });
+        app.chat.current_response = "partial".to_string();
+        app.chat.streaming = true;
+        app.chat.textarea.input(key(KeyCode::Char('d')));
+        app.deleting_session_id = Some("active".to_string());
+
+        app.handle_event(AppEvent::SessionDeleted {
+            session_id: "active".to_string(),
+            result: Ok(()),
+            session_picker_epoch: None,
+        })
+        .await
+        .unwrap();
+
+        assert!(app.deleting_session_id.is_none());
+        assert!(app.chat.session_id.is_none());
+        assert!(app.chat.messages.is_empty());
+        assert!(app.chat.current_response.is_empty());
+        assert!(!app.chat.streaming);
+        assert_eq!(app.chat.model, "gpt-5");
+        assert_eq!(app.chat.provider.as_deref(), Some("openai"));
+        assert_eq!(app.chat.project_id.as_deref(), Some("project-1"));
+        assert_eq!(app.chat.textarea.lines().join("\n"), "d");
+        assert_eq!(
+            app.status_message,
+            "Session deleted — started a new session"
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_delete_of_opening_non_active_session_preserves_current_chat() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("active".to_string());
+        app.chat.messages.push(ChatMessage {
+            role: MessageRole::Assistant,
+            content: "keep transcript".to_string(),
+            tool_calls: Vec::new(),
+            reasoning: None,
+        });
+        app.opening_session_id = Some("delete-me".to_string());
+        app.deleting_session_id = Some("delete-me".to_string());
+
+        app.handle_event(AppEvent::SessionDeleted {
+            session_id: "delete-me".to_string(),
+            result: Ok(()),
+            session_picker_epoch: None,
+        })
+        .await
+        .unwrap();
+
+        assert!(app.deleting_session_id.is_none());
+        assert!(app.opening_session_id.is_none());
+        assert_eq!(app.chat.session_id.as_deref(), Some("active"));
+        assert_eq!(app.chat.messages[0].content, "keep transcript");
+
+        app.handle_event(AppEvent::SessionOpened {
+            session_id: "delete-me".to_string(),
+            result: Ok(opened(vec![asst_msg("must stay stale")])),
+        })
+        .await
+        .unwrap();
+        assert_eq!(app.chat.session_id.as_deref(), Some("active"));
+        assert_eq!(app.chat.messages[0].content, "keep transcript");
+    }
+
+    #[tokio::test]
+    async fn active_session_delete_is_blocked_while_chat_is_streaming() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("active".to_string());
+        app.chat.streaming = true;
+        app.pending_delete = Some(("active".to_string(), "Active".to_string()));
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(event_tx);
+
+        app.handle_delete_confirm_key(key(KeyCode::Enter))
+            .await
+            .unwrap();
+
+        assert!(app.pending_delete.is_none());
+        assert!(app.deleting_session_id.is_none());
+        assert!(event_rx.try_recv().is_err());
+        assert!(app.status_message.contains("Stop the active run"));
+    }
+
+    #[tokio::test]
+    async fn enter_keeps_draft_while_active_session_delete_is_in_flight() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("active".to_string());
+        app.deleting_session_id = Some("active".to_string());
+        for character in "keep me".chars() {
+            app.chat.textarea.input(key(KeyCode::Char(character)));
+        }
+
+        app.handle_chat_key(key(KeyCode::Enter)).await.unwrap();
+
+        assert_eq!(app.chat.textarea.lines().join("\n"), "keep me");
+        assert!(app.chat.messages.is_empty());
+        assert!(!app.chat.streaming);
+        assert_eq!(
+            app.status_message,
+            "Session is being deleted — message kept as draft"
+        );
+    }
+
     /// F1/Ctrl+L must not stack the help/notification overlay on top of an
     /// already-open modal — `any_modal_open` gates them so the keystroke
     /// falls through to the modal's own handler instead (a no-op there,
@@ -7087,6 +7307,31 @@ mod question_tests {
         );
         assert!(app.chat.current_response.is_empty(), "scratch state wiped");
         assert!(app.chat.token_usage.is_none(), "scratch state wiped");
+    }
+
+    /// The session picker closes before its asynchronous resume finishes. A
+    /// plain Enter during that gap must keep the composer draft intact instead
+    /// of starting a chat against the previously visible session.
+    #[tokio::test]
+    async fn chat_enter_during_session_resume_preserves_draft_and_does_not_send() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-a".to_string());
+        app.opening_session_id = Some("session-b".to_string());
+        for character in "send after resume".chars() {
+            app.chat.textarea.input(key(KeyCode::Char(character)));
+        }
+
+        app.handle_chat_key(key(KeyCode::Enter)).await.unwrap();
+
+        assert_eq!(app.chat.session_id.as_deref(), Some("session-a"));
+        assert_eq!(app.opening_session_id.as_deref(), Some("session-b"));
+        assert_eq!(app.chat.textarea.lines().join("\n"), "send after resume");
+        assert!(app.chat.messages.is_empty());
+        assert!(!app.chat.streaming);
+        assert_eq!(
+            app.status_message,
+            "Session is still resuming — message kept as draft"
+        );
     }
 
     #[tokio::test]
@@ -7822,6 +8067,9 @@ mod question_tests {
     async fn session_opened_failure_notifies_and_leaves_chat_untouched() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("old".to_string());
+        app.chat.textarea.input(key(KeyCode::Char('d')));
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(event_tx);
 
         app.opening_session_id = Some("s1".to_string());
         app.handle_event(AppEvent::SessionOpened {
@@ -7836,9 +8084,19 @@ mod question_tests {
             Some("old"),
             "a failed resume must not clobber the current session"
         );
+        assert!(
+            app.opening_session_id.is_none(),
+            "the failed resume must release the send gate"
+        );
         let last = app.notifications.last().expect("failure notified");
         assert!(last.text.contains("not found"));
         assert_eq!(last.level, NoticeLevel::Error);
+        assert!(app.status_message.contains("Failed to open session"));
+
+        app.handle_chat_key(key(KeyCode::Enter)).await.unwrap();
+        assert!(app.chat.streaming, "the retained draft can now be sent");
+        assert_eq!(app.chat.messages.last().unwrap().content, "d");
+        assert!(app.chat.textarea.lines().join("\n").is_empty());
     }
 
     #[tokio::test]
@@ -8797,6 +9055,114 @@ mod question_tests {
         assert!(text.contains("Esc cancel"));
     }
 
+    #[test]
+    fn session_rename_renders_only_the_title_input_cursor() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![bare_session("s1")]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
+            session_id: "s1".to_string(),
+            draft: "New title".to_string(),
+            base_title: "Old title".to_string(),
+            draft_dirty: true,
+            metadata_version: Some(1),
+            loading_version: false,
+            submitting: false,
+            error: None,
+        };
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::layout::render_session_picker(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(text.contains("Title:"));
+        assert!(!text.contains("Search:"));
+        assert_eq!(text.matches('▏').count(), 1, "rename has one focused field");
+    }
+
+    #[test]
+    fn session_rename_saving_hides_cursor_and_disabled_shortcuts() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![bare_session("s1")]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
+            session_id: "s1".to_string(),
+            draft: "New title".to_string(),
+            base_title: "Old title".to_string(),
+            draft_dirty: true,
+            metadata_version: Some(1),
+            loading_version: false,
+            submitting: true,
+            error: None,
+        };
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::layout::render_session_picker(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(text.contains("Saving..."));
+        assert!(!text.contains('▏'));
+        assert!(!text.contains("Enter save"));
+        assert!(!text.contains("Ctrl+R"));
+        assert!(!text.contains("Esc"));
+    }
+
+    #[test]
+    fn session_pin_saving_hides_disabled_shortcuts() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![bare_session("s1")]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Pinning {
+            session_id: "s1".to_string(),
+            target: true,
+            loading_version: false,
+            submitting: true,
+            error: None,
+        };
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::layout::render_session_picker(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(text.contains("Pinning selected session..."));
+        assert!(text.contains("Saving..."));
+        assert!(!text.contains("Ctrl+R"));
+        assert!(!text.contains("Esc"));
+    }
+
     // ── Model picker ──
 
     fn catalog_model(
@@ -9121,6 +9487,69 @@ mod question_tests {
             app.model_picker.is_some(),
             "no models to apply yet — picker stays open"
         );
+    }
+
+    #[tokio::test]
+    async fn model_picker_ctrl_r_refreshes_a_nonempty_catalog_with_no_matches() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.picker_epoch = 1;
+        app.model_picker = Some(model_picker(vec![catalog_model(
+            "openai", "gpt-4.1", "GPT-4.1", "OpenAI",
+        )]));
+        {
+            let picker = app.model_picker.as_mut().unwrap();
+            picker.query = "no-such-model".to_string();
+            picker.refresh_filter(None);
+            assert!(picker.visible.is_empty());
+        }
+
+        app.handle_model_picker_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+
+        let picker = app.model_picker.as_ref().unwrap();
+        assert_eq!(picker.epoch, 2, "Ctrl+R must dispatch a catalog reload");
+        assert!(
+            picker
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("not attached")),
+            "the test has no event loop, proving reload reached load_model_catalog"
+        );
+    }
+
+    #[test]
+    fn model_picker_no_match_refreshing_hides_the_disabled_retry_shortcut() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.model_picker = Some(model_picker(vec![catalog_model(
+            "openai", "gpt-4.1", "GPT-4.1", "OpenAI",
+        )]));
+        {
+            let picker = app.model_picker.as_mut().unwrap();
+            picker.query = "no-such-model".to_string();
+            picker.refresh_filter(None);
+            picker.loading = true;
+        }
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::layout::render_model_picker(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(text.contains("Refreshing model catalog..."));
+        assert!(text.contains("Esc cancel"));
+        assert!(!text.contains("Ctrl+R"));
     }
 
     /// `Esc` closes the picker without touching `chat.model`.

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -19,6 +19,7 @@ use crate::api::types::*;
 use crate::api::{BambooClient, RespondFailure};
 use crate::event::AppEvent;
 use crate::history::map_history;
+use crate::search::ranked_indices;
 use crate::ui;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -575,9 +576,190 @@ pub struct ConfigEditor {
 /// `loading: true` and an empty list; the provider-catalog fetch runs off the
 /// event loop and lands via `AppEvent::CatalogLoaded`.
 pub struct ModelPicker {
+    pub epoch: u64,
     pub models: Vec<CatalogModel>,
+    pub visible: Vec<usize>,
+    pub query: String,
     pub selected: usize,
     pub loading: bool,
+    pub applying: bool,
+    pub error: Option<String>,
+}
+
+impl ModelPicker {
+    fn selected_model(&self) -> Option<&CatalogModel> {
+        self.visible
+            .get(self.selected)
+            .and_then(|index| self.models.get(*index))
+    }
+
+    fn refresh_filter(&mut self, preserve: Option<(String, String)>) {
+        // Keep the catalog's current/recent/provider grouping stable while
+        // filtering. `ranked_indices` still supplies fuzzy subsequence
+        // matching, but visible rows retain their pre-grouped source order
+        // instead of interleaving providers by match score.
+        let ranked = ranked_indices(&self.models, &self.query, model_search_text);
+        let mut matched = vec![false; self.models.len()];
+        for index in ranked {
+            if let Some(slot) = matched.get_mut(index) {
+                *slot = true;
+            }
+        }
+        self.visible = matched
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, is_match)| is_match.then_some(index))
+            .collect();
+        self.selected = preserve
+            .and_then(|key| {
+                self.visible.iter().position(|index| {
+                    self.models
+                        .get(*index)
+                        .is_some_and(|model| model_key(model) == key)
+                })
+            })
+            .unwrap_or(0)
+            .min(self.visible.len().saturating_sub(1));
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionPickerIntent {
+    Rename,
+    Pin(bool),
+}
+
+#[derive(Debug)]
+pub enum SessionPickerMode {
+    Browse,
+    Rename {
+        session_id: String,
+        draft: String,
+        metadata_version: Option<u64>,
+        loading_version: bool,
+        submitting: bool,
+        error: Option<String>,
+    },
+    Pinning {
+        session_id: String,
+        target: bool,
+        loading_version: bool,
+        submitting: bool,
+        error: Option<String>,
+    },
+}
+
+impl SessionPickerMode {
+    fn matches(&self, session_id: &str, intent: &SessionPickerIntent) -> bool {
+        match (self, intent) {
+            (Self::Rename { session_id: id, .. }, SessionPickerIntent::Rename) => id == session_id,
+            (
+                Self::Pinning {
+                    session_id: id,
+                    target,
+                    ..
+                },
+                SessionPickerIntent::Pin(expected),
+            ) => id == session_id && target == expected,
+            _ => false,
+        }
+    }
+}
+
+pub struct SessionPicker {
+    pub epoch: u64,
+    pub sessions: Vec<SessionSummary>,
+    pub visible: Vec<usize>,
+    pub query: String,
+    pub selected: usize,
+    pub loading: bool,
+    pub error: Option<String>,
+    pub total: usize,
+    pub page_limit: usize,
+    pub next_offset: Option<usize>,
+    pub mode: SessionPickerMode,
+}
+
+impl SessionPicker {
+    fn selected_session(&self) -> Option<&SessionSummary> {
+        self.visible
+            .get(self.selected)
+            .and_then(|index| self.sessions.get(*index))
+    }
+
+    fn refresh_filter(&mut self, preserve_id: Option<String>) {
+        self.visible = ranked_indices(&self.sessions, &self.query, session_search_text);
+        self.selected = preserve_id
+            .and_then(|id| {
+                self.visible.iter().position(|index| {
+                    self.sessions
+                        .get(*index)
+                        .is_some_and(|session| session.id == id)
+                })
+            })
+            .unwrap_or(0)
+            .min(self.visible.len().saturating_sub(1));
+    }
+}
+
+const MAX_SESSION_PICKER_SESSIONS: usize = 1_000;
+const MAX_RECENT_MODELS: usize = 8;
+
+fn model_key(model: &CatalogModel) -> (String, String) {
+    (
+        model.reference.provider.clone(),
+        model.reference.model.clone(),
+    )
+}
+
+fn model_search_text(model: &CatalogModel) -> String {
+    format!(
+        "{} {} {} {}",
+        model.display_name,
+        model.provider_display_name,
+        model.reference.provider,
+        model.reference.model
+    )
+}
+
+fn session_search_text(session: &SessionSummary) -> String {
+    let status = if session.is_running {
+        "running"
+    } else if session.has_pending_question {
+        "question awaiting"
+    } else {
+        session.last_run_status.as_deref().unwrap_or("idle")
+    };
+    format!(
+        "{} {} {} {} {}",
+        session.title,
+        session.model,
+        session.id,
+        status,
+        if session.pinned { "pinned" } else { "" }
+    )
+}
+
+fn sort_catalog_models(
+    models: &mut [CatalogModel],
+    current_model: &str,
+    recent: &VecDeque<(String, String)>,
+) {
+    models.sort_by_key(|model| {
+        let key = model_key(model);
+        let current_rank = usize::from(model.reference.model != current_model);
+        let recent_rank = recent
+            .iter()
+            .position(|candidate| candidate == &key)
+            .unwrap_or(usize::MAX);
+        (
+            current_rank,
+            recent_rank,
+            model.provider_display_name.to_lowercase(),
+            model.display_name.to_lowercase(),
+            key,
+        )
+    });
 }
 
 // ── Auto-serve (local `bamboo serve` bootstrap) ──
@@ -762,6 +944,10 @@ pub struct App {
     /// In-progress model picker (`Ctrl+O`, Chat tab). When `Some`, a modal
     /// captures navigation/apply keystrokes.
     pub model_picker: Option<ModelPicker>,
+    /// In-progress contextual session picker (`Ctrl+P`, Chat tab). Unlike the
+    /// Sessions management tab, closing this overlay leaves the transcript,
+    /// composer draft/cursor, and scroll position untouched.
+    pub session_picker: Option<SessionPicker>,
     /// Pending session-delete confirmation (Sessions tab, `d`): `(id, title)`
     /// of the session awaiting `y`/Enter confirm or `n`/Esc cancel. Kept as a
     /// modal (rather than deleting immediately) so a stray `d` can't destroy a
@@ -798,6 +984,12 @@ pub struct App {
     /// Latest session whose async resume result is authoritative. An older
     /// request finishing later must not switch the operator back.
     opening_session_id: Option<String>,
+    /// Shared monotonic identity for picker fetches/mutations. Closing and
+    /// reopening a picker invalidates every result from the previous overlay.
+    picker_epoch: u64,
+    model_picker_task: Option<tokio::task::JoinHandle<()>>,
+    session_picker_task: Option<tokio::task::JoinHandle<()>>,
+    recent_models: VecDeque<(String, String)>,
     /// Sender into the main event loop, used to post results of background API
     /// calls (so those calls never block the UI thread). Set in [`run`].
     event_tx: Option<mpsc::UnboundedSender<AppEvent>>,
@@ -883,6 +1075,7 @@ impl App {
             schedule_form: None,
             config_editor: None,
             model_picker: None,
+            session_picker: None,
             pending_delete: None,
             notifications: Vec::new(),
             notifications_visible: false,
@@ -892,6 +1085,10 @@ impl App {
             question_drafts: HashMap::new(),
             question_draft_order: VecDeque::new(),
             opening_session_id: None,
+            picker_epoch: 0,
+            model_picker_task: None,
+            session_picker_task: None,
+            recent_models: VecDeque::new(),
             event_tx: None,
             sse_tx: None,
             sse_rx: None,
@@ -1125,6 +1322,9 @@ impl App {
                     Err(msg) => self.notify(NoticeLevel::Error, msg),
                 }
                 if reload_tab {
+                    if self.session_picker.is_some() {
+                        self.reload_session_picker();
+                    }
                     self.load_tab_data();
                 }
             }
@@ -1468,29 +1668,283 @@ impl App {
                     }
                 }
             }
-            AppEvent::CatalogLoaded(r) => {
-                // The picker may already have been closed (Esc) before this
-                // fetch returned — drop the result instead of reopening it.
-                let Some(picker) = self.model_picker.as_mut() else {
+            AppEvent::CatalogLoaded { epoch, result } => {
+                let selected_key = self
+                    .model_picker
+                    .as_ref()
+                    .filter(|picker| picker.epoch == epoch)
+                    .and_then(ModelPicker::selected_model)
+                    .map(model_key);
+                let Some(picker) = self
+                    .model_picker
+                    .as_mut()
+                    .filter(|picker| picker.epoch == epoch)
+                else {
                     return Ok(());
                 };
-                match r {
-                    Ok(catalog) if catalog.models.is_empty() => {
-                        self.model_picker = None;
-                        self.notify(NoticeLevel::Warn, "No models in provider catalog");
-                    }
-                    Ok(catalog) => {
-                        picker.models = catalog.models;
-                        picker.selected = 0;
-                        picker.loading = false;
-                        self.status_message = "Ready".to_string();
-                    }
-                    Err(e) => {
-                        self.model_picker = None;
-                        self.notify(
-                            NoticeLevel::Error,
-                            format!("Failed to load provider catalog: {e}"),
+                self.model_picker_task = None;
+                picker.loading = false;
+                match result {
+                    Ok(mut catalog) => {
+                        sort_catalog_models(
+                            &mut catalog.models,
+                            &self.chat.model,
+                            &self.recent_models,
                         );
+                        picker.models = catalog.models;
+                        picker.error = picker.models.is_empty().then(|| {
+                            "No models in provider catalog — press Ctrl+R to retry".to_string()
+                        });
+                        picker.refresh_filter(selected_key);
+                    }
+                    Err(error) => {
+                        picker.error = Some(format!(
+                            "Failed to load provider catalog: {error} — press Ctrl+R to retry"
+                        ));
+                    }
+                }
+            }
+            AppEvent::ModelPatched {
+                epoch,
+                model,
+                result,
+            } => {
+                let Some(picker) = self
+                    .model_picker
+                    .as_mut()
+                    .filter(|picker| picker.epoch == epoch)
+                else {
+                    return Ok(());
+                };
+                self.model_picker_task = None;
+                picker.applying = false;
+                match result {
+                    Ok(()) => self.commit_model_selection(model),
+                    Err(error) => {
+                        picker.error = Some(format!(
+                            "Failed to update session model: {error} — press Enter to retry or Esc to cancel"
+                        ));
+                    }
+                }
+            }
+            AppEvent::SessionPickerPageLoaded {
+                epoch,
+                offset,
+                result,
+            } => {
+                let Some(picker) = self
+                    .session_picker
+                    .as_mut()
+                    .filter(|picker| picker.epoch == epoch)
+                else {
+                    return Ok(());
+                };
+                self.session_picker_task = None;
+                picker.loading = false;
+                let selected_before = picker.selected_session().map(|session| session.id.clone());
+                match result {
+                    Ok(envelope) => {
+                        if offset == 0 {
+                            picker.sessions.clear();
+                        }
+                        for session in envelope.sessions {
+                            if picker.sessions.len() >= MAX_SESSION_PICKER_SESSIONS {
+                                break;
+                            }
+                            if let Some(existing) = picker
+                                .sessions
+                                .iter_mut()
+                                .find(|existing| existing.id == session.id)
+                            {
+                                *existing = session;
+                            } else {
+                                picker.sessions.push(session);
+                            }
+                        }
+                        picker.total = envelope.total;
+                        picker.page_limit = envelope.limit;
+                        picker.next_offset = (picker.sessions.len() < MAX_SESSION_PICKER_SESSIONS)
+                            .then_some(envelope.next_offset)
+                            .flatten()
+                            .filter(|next| *next > offset);
+                        picker.error = None;
+                        let preserve_id = self
+                            .chat
+                            .session_id
+                            .clone()
+                            .filter(|active_id| {
+                                picker
+                                    .sessions
+                                    .iter()
+                                    .any(|session| &session.id == active_id)
+                            })
+                            .or(selected_before);
+                        picker.refresh_filter(preserve_id);
+                    }
+                    Err(error) => {
+                        picker.error = Some(format!(
+                            "Failed to load sessions: {error} — press r to retry"
+                        ));
+                    }
+                }
+                let should_continue = self.session_picker.as_ref().is_some_and(|picker| {
+                    !picker.query.is_empty()
+                        && picker.next_offset.is_some()
+                        && picker.sessions.len() < MAX_SESSION_PICKER_SESSIONS
+                });
+                if should_continue {
+                    self.load_next_session_picker_page();
+                }
+            }
+            AppEvent::SessionPickerVersionLoaded {
+                epoch,
+                session_id,
+                intent,
+                result,
+            } => {
+                let Some(picker) = self
+                    .session_picker
+                    .as_mut()
+                    .filter(|picker| picker.epoch == epoch)
+                else {
+                    return Ok(());
+                };
+                if !picker.mode.matches(&session_id, &intent) {
+                    return Ok(());
+                }
+                self.session_picker_task = None;
+                let mut patch = None;
+                match result {
+                    Ok(versioned) => {
+                        if let Some(existing) = picker
+                            .sessions
+                            .iter_mut()
+                            .find(|session| session.id == session_id)
+                        {
+                            *existing = versioned.summary;
+                        }
+                        match &mut picker.mode {
+                            SessionPickerMode::Rename {
+                                metadata_version,
+                                loading_version,
+                                error,
+                                ..
+                            } => {
+                                *metadata_version = Some(versioned.metadata_version);
+                                *loading_version = false;
+                                *error = None;
+                            }
+                            SessionPickerMode::Pinning {
+                                target,
+                                loading_version,
+                                submitting,
+                                error,
+                                ..
+                            } => {
+                                *loading_version = false;
+                                *submitting = true;
+                                *error = None;
+                                patch = Some((versioned.metadata_version, *target));
+                            }
+                            SessionPickerMode::Browse => {}
+                        }
+                    }
+                    Err(error_message) => match &mut picker.mode {
+                        SessionPickerMode::Rename {
+                            loading_version,
+                            error,
+                            ..
+                        }
+                        | SessionPickerMode::Pinning {
+                            loading_version,
+                            error,
+                            ..
+                        } => {
+                            *loading_version = false;
+                            *error = Some(format!(
+                                "Failed to prepare update: {error_message} — press r to retry"
+                            ));
+                        }
+                        SessionPickerMode::Browse => {}
+                    },
+                }
+                if let Some((version, target)) = patch {
+                    self.spawn_session_picker_patch(
+                        epoch,
+                        session_id,
+                        version,
+                        SessionPickerIntent::Pin(target),
+                        PatchSessionMetadataRequest {
+                            title: None,
+                            pinned: Some(target),
+                        },
+                    );
+                }
+            }
+            AppEvent::SessionPickerPatched {
+                epoch,
+                session_id,
+                intent,
+                result,
+            } => {
+                let Some(picker) = self
+                    .session_picker
+                    .as_mut()
+                    .filter(|picker| picker.epoch == epoch)
+                else {
+                    return Ok(());
+                };
+                if !picker.mode.matches(&session_id, &intent) {
+                    return Ok(());
+                }
+                self.session_picker_task = None;
+                match result {
+                    Ok(versioned) => {
+                        if let Some(existing) = picker
+                            .sessions
+                            .iter_mut()
+                            .find(|session| session.id == session_id)
+                        {
+                            *existing = versioned.summary;
+                        }
+                        picker.mode = SessionPickerMode::Browse;
+                        picker.refresh_filter(Some(session_id));
+                        self.status_message = match intent {
+                            SessionPickerIntent::Rename => "Session renamed".to_string(),
+                            SessionPickerIntent::Pin(true) => "Session pinned".to_string(),
+                            SessionPickerIntent::Pin(false) => "Session unpinned".to_string(),
+                        };
+                    }
+                    Err(failure) => {
+                        let prefix = if failure.conflict {
+                            "Version conflict; refetch before retry"
+                        } else {
+                            "Session update failed"
+                        };
+                        let current = failure
+                            .current_version
+                            .map(|version| format!(" (server version {version})"))
+                            .unwrap_or_default();
+                        let message = format!("{prefix}{current}: {failure} — press r to retry");
+                        match &mut picker.mode {
+                            SessionPickerMode::Rename {
+                                metadata_version,
+                                submitting,
+                                error,
+                                ..
+                            } => {
+                                *metadata_version = None;
+                                *submitting = false;
+                                *error = Some(message);
+                            }
+                            SessionPickerMode::Pinning {
+                                submitting, error, ..
+                            } => {
+                                *submitting = false;
+                                *error = Some(message);
+                            }
+                            SessionPickerMode::Browse => {}
+                        }
                     }
                 }
             }
@@ -1591,6 +2045,30 @@ impl App {
             return;
         }
 
+        if let Some(picker) = self.session_picker.as_mut() {
+            if matches!(picker.mode, SessionPickerMode::Browse) {
+                let delta = match mouse.kind {
+                    MouseEventKind::ScrollUp => -3,
+                    MouseEventKind::ScrollDown => 3,
+                    _ => return,
+                };
+                picker.selected = scroll_selection(picker.selected, picker.visible.len(), delta);
+            }
+            return;
+        }
+
+        if let Some(picker) = self.model_picker.as_mut() {
+            let delta = match mouse.kind {
+                MouseEventKind::ScrollUp => -3,
+                MouseEventKind::ScrollDown => 3,
+                _ => return,
+            };
+            if !picker.loading && !picker.applying {
+                picker.selected = scroll_selection(picker.selected, picker.visible.len(), delta);
+            }
+            return;
+        }
+
         let delta: i32 = match mouse.kind {
             MouseEventKind::ScrollUp => -3,
             MouseEventKind::ScrollDown => 3,
@@ -1680,11 +2158,12 @@ impl App {
 
     /// Whether an exclusive modal currently owns the keyboard. `F1`/Ctrl+`?`/
     /// Ctrl+L are gated on this so they can't stack a second overlay on top
-    /// of one of these six — see the precedence comment on `handle_key`.
+    /// of one of these seven — see the precedence comment on `handle_key`.
     fn any_modal_open(&self) -> bool {
         self.serve_offer.is_some()
             || self.pending_question.is_some()
             || self.pending_delete.is_some()
+            || self.session_picker.is_some()
             || self.model_picker.is_some()
             || self.schedule_form.is_some()
             || self.config_editor.is_some()
@@ -1699,9 +2178,10 @@ impl App {
     ///   0. `serve_offer`      — startup-only "start a local server?" offer
     ///   1. `pending_question` — agent permission/clarification gate
     ///   2. `pending_delete`   — session delete confirmation
-    ///   3. `model_picker`     — Ctrl+O provider-catalog picker
-    ///   4. `schedule_form`    — new-schedule authoring form
-    ///   5. `config_editor`    — raw config JSON editor
+    ///   3. `session_picker`   — Ctrl+P contextual session picker
+    ///   4. `model_picker`     — Ctrl+O provider-catalog picker
+    ///   5. `schedule_form`    — new-schedule authoring form
+    ///   6. `config_editor`    — raw config JSON editor
     ///
     /// Runtime modals can coexist in state because a clarification arrives
     /// asynchronously. The renderer layers them in the reverse order below,
@@ -1769,14 +2249,19 @@ impl App {
             return self.handle_delete_confirm_key(key).await;
         }
 
-        // 3. The model picker likewise captures all input (navigation/apply)
+        // 3. The contextual session picker owns search/navigation/mutations.
+        if self.session_picker.is_some() {
+            return self.handle_session_picker_key(key).await;
+        }
+
+        // 4. The model picker likewise captures all input (navigation/apply)
         // before the global bindings below — same pattern as the other
         // modals.
         if self.model_picker.is_some() {
             return self.handle_model_picker_key(key).await;
         }
 
-        // 4. The schedule-authoring modal likewise captures all input: Tab moves
+        // 5. The schedule-authoring modal likewise captures all input: Tab moves
         // between fields and digits belong in cron expressions, so it must run
         // before the global Tab/1-6 tab-switching below (which would otherwise
         // swallow those keys and never reach the form).
@@ -1785,7 +2270,7 @@ impl App {
             return Ok(());
         }
 
-        // 5. The config editor is a full multi-line text buffer, so it must claim
+        // 6. The config editor is a full multi-line text buffer, so it must claim
         // every key (digits, Tab, Enter/newlines) before the global navigation
         // below — same rationale as the schedule form.
         if self.config_editor.is_some() {
@@ -1808,6 +2293,10 @@ impl App {
                 }
                 KeyCode::Char('o') if self.tab == Tab::Chat && !self.chat.streaming => {
                     self.open_model_picker();
+                    return Ok(());
+                }
+                KeyCode::Char('p') if self.tab == Tab::Chat && !self.chat.streaming => {
+                    self.open_session_picker();
                     return Ok(());
                 }
                 _ => {}
@@ -3746,89 +4235,655 @@ impl App {
         Ok(())
     }
 
-    /// `Ctrl+O` on the Chat tab: open the model picker and load the provider
-    /// catalog off the event loop — the modal opens immediately (`loading:
-    /// true`, empty list) and populates when `AppEvent::CatalogLoaded` lands.
-    fn open_model_picker(&mut self) {
-        self.model_picker = Some(ModelPicker {
-            models: Vec::new(),
+    // ── Contextual session picker (Ctrl+P) ──
+
+    fn open_session_picker(&mut self) {
+        self.picker_epoch = self.picker_epoch.wrapping_add(1);
+        let epoch = self.picker_epoch;
+        self.session_picker = Some(SessionPicker {
+            epoch,
+            sessions: Vec::new(),
+            visible: Vec::new(),
+            query: String::new(),
             selected: 0,
             loading: true,
+            error: None,
+            total: 0,
+            page_limit: 0,
+            next_offset: None,
+            mode: SessionPickerMode::Browse,
         });
-        self.status_message = "Loading models...".to_string();
+        self.load_session_picker_page(epoch, 0);
+    }
+
+    fn close_session_picker(&mut self) {
+        if let Some(task) = self.session_picker_task.take() {
+            task.abort();
+        }
+        self.session_picker = None;
+    }
+
+    /// Give every page or mutation request its own generation. Aborting a
+    /// Tokio task is best-effort: its event may already be queued, so changing
+    /// the epoch is what prevents an old response from satisfying a later
+    /// rename or pin operation for the same session.
+    fn advance_session_picker_epoch(&mut self) -> Option<u64> {
+        if let Some(task) = self.session_picker_task.take() {
+            task.abort();
+        }
+        self.picker_epoch = self.picker_epoch.wrapping_add(1);
+        let picker = self.session_picker.as_mut()?;
+        picker.epoch = self.picker_epoch;
+        Some(self.picker_epoch)
+    }
+
+    fn reload_session_picker(&mut self) {
+        let Some(picker) = self.session_picker.as_mut() else {
+            return;
+        };
+        if let Some(task) = self.session_picker_task.take() {
+            task.abort();
+        }
+        self.picker_epoch = self.picker_epoch.wrapping_add(1);
+        picker.epoch = self.picker_epoch;
+        picker.sessions.clear();
+        picker.visible.clear();
+        picker.selected = 0;
+        picker.loading = true;
+        picker.error = None;
+        picker.total = 0;
+        picker.page_limit = 0;
+        picker.next_offset = None;
+        picker.mode = SessionPickerMode::Browse;
+        self.load_session_picker_page(self.picker_epoch, 0);
+    }
+
+    fn load_session_picker_page(&mut self, epoch: u64, offset: usize) {
+        let Some(tx) = self.event_tx.clone() else {
+            if let Some(picker) = self.session_picker.as_mut() {
+                picker.loading = false;
+                picker.error = Some("Session picker is not attached to an event loop".to_string());
+            }
+            return;
+        };
+        let Some(picker) = self
+            .session_picker
+            .as_mut()
+            .filter(|picker| picker.epoch == epoch)
+        else {
+            return;
+        };
+        picker.loading = true;
+        let limit = (picker.page_limit > 0).then_some(picker.page_limit);
+        let client = self.client.clone();
+        self.session_picker_task = Some(tokio::spawn(async move {
+            let result = client
+                .list_sessions(limit, (offset > 0).then_some(offset))
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::SessionPickerPageLoaded {
+                epoch,
+                offset,
+                result,
+            });
+        }));
+    }
+
+    fn load_next_session_picker_page(&mut self) {
+        if self.session_picker_task.is_some() {
+            return;
+        }
+        let Some((epoch, offset)) = self
+            .session_picker
+            .as_ref()
+            .and_then(|picker| picker.next_offset.map(|offset| (picker.epoch, offset)))
+        else {
+            return;
+        };
+        self.load_session_picker_page(epoch, offset);
+    }
+
+    async fn handle_session_picker_key(&mut self, key: KeyEvent) -> Result<()> {
+        let mode = self
+            .session_picker
+            .as_ref()
+            .map(|picker| match picker.mode {
+                SessionPickerMode::Browse => 0,
+                SessionPickerMode::Rename { .. } => 1,
+                SessionPickerMode::Pinning { .. } => 2,
+            });
+        match mode {
+            Some(0) => self.handle_session_picker_browse_key(key),
+            Some(1) => self.handle_session_picker_rename_key(key),
+            Some(2) => self.handle_session_picker_pinning_key(key),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_session_picker_browse_key(&mut self, key: KeyEvent) {
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            match key.code {
+                KeyCode::Char('r') => {
+                    self.reload_session_picker();
+                    return;
+                }
+                KeyCode::Char('u') => {
+                    if let Some(picker) = self.session_picker.as_mut() {
+                        let preserve = picker.selected_session().map(|s| s.id.clone());
+                        picker.query.clear();
+                        picker.refresh_filter(preserve);
+                    }
+                    return;
+                }
+                KeyCode::Char('d') => {
+                    if let Some(session) = self
+                        .session_picker
+                        .as_ref()
+                        .and_then(SessionPicker::selected_session)
+                    {
+                        self.pending_delete = Some((session.id.clone(), session.title.clone()));
+                    }
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        match key.code {
+            KeyCode::Up => {
+                if let Some(picker) = self.session_picker.as_mut() {
+                    picker.selected = picker.selected.saturating_sub(1);
+                }
+            }
+            KeyCode::Down => {
+                let load_more = if let Some(picker) = self.session_picker.as_mut() {
+                    if picker.selected + 1 < picker.visible.len() {
+                        picker.selected += 1;
+                        false
+                    } else {
+                        picker.next_offset.is_some()
+                    }
+                } else {
+                    false
+                };
+                if load_more {
+                    self.load_next_session_picker_page();
+                }
+            }
+            KeyCode::PageDown | KeyCode::Char(']') => self.load_next_session_picker_page(),
+            KeyCode::Enter => {
+                let session_id = self
+                    .session_picker
+                    .as_ref()
+                    .and_then(SessionPicker::selected_session)
+                    .map(|session| session.id.clone());
+                if let Some(session_id) = session_id {
+                    self.close_session_picker();
+                    self.resume_session(session_id);
+                }
+            }
+            KeyCode::F(2) => self.begin_session_rename(),
+            KeyCode::F(3) => self.begin_session_pin_toggle(),
+            KeyCode::Delete => {
+                if let Some(session) = self
+                    .session_picker
+                    .as_ref()
+                    .and_then(SessionPicker::selected_session)
+                {
+                    self.pending_delete = Some((session.id.clone(), session.title.clone()));
+                }
+            }
+            KeyCode::Esc => self.close_session_picker(),
+            KeyCode::Backspace => {
+                if let Some(picker) = self.session_picker.as_mut() {
+                    let preserve = picker.selected_session().map(|s| s.id.clone());
+                    picker.query.pop();
+                    picker.refresh_filter(preserve);
+                }
+            }
+            KeyCode::Char(character)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                if let Some(picker) = self.session_picker.as_mut() {
+                    let preserve = picker.selected_session().map(|s| s.id.clone());
+                    picker.query.push(character);
+                    picker.refresh_filter(preserve);
+                }
+                if self
+                    .session_picker
+                    .as_ref()
+                    .is_some_and(|picker| !picker.query.is_empty() && picker.next_offset.is_some())
+                {
+                    self.load_next_session_picker_page();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn begin_session_rename(&mut self) {
+        let Some((session_id, draft)) = self.session_picker.as_ref().and_then(|picker| {
+            picker
+                .selected_session()
+                .map(|session| (session.id.clone(), session.title.clone()))
+        }) else {
+            return;
+        };
+        let Some(epoch) = self.advance_session_picker_epoch() else {
+            return;
+        };
+        if let Some(picker) = self.session_picker.as_mut() {
+            picker.mode = SessionPickerMode::Rename {
+                session_id: session_id.clone(),
+                draft,
+                metadata_version: None,
+                loading_version: true,
+                submitting: false,
+                error: None,
+            };
+        }
+        self.spawn_session_picker_version_load(epoch, session_id, SessionPickerIntent::Rename);
+    }
+
+    fn begin_session_pin_toggle(&mut self) {
+        let Some((session_id, target)) = self.session_picker.as_ref().and_then(|picker| {
+            picker
+                .selected_session()
+                .map(|session| (session.id.clone(), !session.pinned))
+        }) else {
+            return;
+        };
+        let Some(epoch) = self.advance_session_picker_epoch() else {
+            return;
+        };
+        if let Some(picker) = self.session_picker.as_mut() {
+            picker.mode = SessionPickerMode::Pinning {
+                session_id: session_id.clone(),
+                target,
+                loading_version: true,
+                submitting: false,
+                error: None,
+            };
+        }
+        self.spawn_session_picker_version_load(epoch, session_id, SessionPickerIntent::Pin(target));
+    }
+
+    fn handle_session_picker_rename_key(&mut self, key: KeyEvent) {
+        let mut retry = None;
+        let mut submit = None;
+        let mut cancel = false;
+        let Some(picker) = self.session_picker.as_mut() else {
+            return;
+        };
+        let SessionPickerMode::Rename {
+            session_id,
+            draft,
+            metadata_version,
+            loading_version,
+            submitting,
+            error,
+        } = &mut picker.mode
+        else {
+            return;
+        };
+
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
+            if !*submitting {
+                *metadata_version = None;
+                *loading_version = true;
+                *error = None;
+                retry = Some((picker.epoch, session_id.clone()));
+            }
+        } else if *submitting {
+            return;
+        } else {
+            match key.code {
+                KeyCode::Enter if !draft.trim().is_empty() => {
+                    if let Some(version) = *metadata_version {
+                        *submitting = true;
+                        *error = None;
+                        submit = Some((
+                            picker.epoch,
+                            session_id.clone(),
+                            version,
+                            draft.trim().to_string(),
+                        ));
+                    } else if !*loading_version {
+                        *error = Some("No current version — press Ctrl+R to retry".to_string());
+                    }
+                }
+                KeyCode::Esc => cancel = true,
+                KeyCode::Backspace => {
+                    draft.pop();
+                    *error = None;
+                }
+                KeyCode::Char(character)
+                    if !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                {
+                    draft.push(character);
+                    *error = None;
+                }
+                _ => {}
+            }
+        }
+
+        if cancel {
+            self.advance_session_picker_epoch();
+            if let Some(picker) = self.session_picker.as_mut() {
+                picker.mode = SessionPickerMode::Browse;
+            }
+        } else if let Some((epoch, session_id)) = retry {
+            let epoch = self.advance_session_picker_epoch().unwrap_or(epoch);
+            self.spawn_session_picker_version_load(epoch, session_id, SessionPickerIntent::Rename);
+        } else if let Some((epoch, session_id, version, title)) = submit {
+            self.spawn_session_picker_patch(
+                epoch,
+                session_id,
+                version,
+                SessionPickerIntent::Rename,
+                PatchSessionMetadataRequest {
+                    title: Some(title),
+                    pinned: None,
+                },
+            );
+        }
+    }
+
+    fn handle_session_picker_pinning_key(&mut self, key: KeyEvent) {
+        let mut retry = None;
+        let mut cancel = false;
+        let Some(picker) = self.session_picker.as_mut() else {
+            return;
+        };
+        let SessionPickerMode::Pinning {
+            session_id,
+            target,
+            loading_version,
+            submitting,
+            error,
+        } = &mut picker.mode
+        else {
+            return;
+        };
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
+            if !*submitting {
+                *loading_version = true;
+                *error = None;
+                retry = Some((picker.epoch, session_id.clone(), *target));
+            }
+        } else if key.code == KeyCode::Esc && !*submitting {
+            cancel = true;
+        }
+
+        if cancel {
+            self.advance_session_picker_epoch();
+            if let Some(picker) = self.session_picker.as_mut() {
+                picker.mode = SessionPickerMode::Browse;
+            }
+        } else if let Some((epoch, session_id, target)) = retry {
+            let epoch = self.advance_session_picker_epoch().unwrap_or(epoch);
+            self.spawn_session_picker_version_load(
+                epoch,
+                session_id,
+                SessionPickerIntent::Pin(target),
+            );
+        }
+    }
+
+    fn spawn_session_picker_version_load(
+        &mut self,
+        epoch: u64,
+        session_id: String,
+        intent: SessionPickerIntent,
+    ) {
+        if let Some(task) = self.session_picker_task.take() {
+            task.abort();
+        }
         let Some(tx) = self.event_tx.clone() else {
             return;
         };
         let client = self.client.clone();
-        tokio::spawn(async move {
-            let r = client
-                .get_provider_catalog()
+        self.session_picker_task = Some(tokio::spawn(async move {
+            let result = client
+                .get_session_versioned(&session_id)
                 .await
-                .map_err(|e| e.to_string());
-            let _ = tx.send(AppEvent::CatalogLoaded(r));
-        });
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::SessionPickerVersionLoaded {
+                epoch,
+                session_id,
+                intent,
+                result,
+            });
+        }));
     }
 
-    /// Drive the model picker modal: `↑/↓`/`j`/`k` move the selection, `Enter`
-    /// applies the highlighted model (a no-op while the catalog is still
-    /// loading — the list is empty, so there's nothing to apply), `Esc`
-    /// closes without changes.
-    async fn handle_model_picker_key(&mut self, key: KeyEvent) -> Result<()> {
+    fn spawn_session_picker_patch(
+        &mut self,
+        epoch: u64,
+        session_id: String,
+        expected_version: u64,
+        intent: SessionPickerIntent,
+        patch: PatchSessionMetadataRequest,
+    ) {
+        if let Some(task) = self.session_picker_task.take() {
+            task.abort();
+        }
+        let Some(tx) = self.event_tx.clone() else {
+            return;
+        };
+        let client = self.client.clone();
+        self.session_picker_task = Some(tokio::spawn(async move {
+            let result = client
+                .patch_session_metadata(&session_id, expected_version, &patch)
+                .await;
+            let _ = tx.send(AppEvent::SessionPickerPatched {
+                epoch,
+                session_id,
+                intent,
+                result,
+            });
+        }));
+    }
+
+    // ── Searchable model picker (Ctrl+O) ──
+
+    fn open_model_picker(&mut self) {
+        self.picker_epoch = self.picker_epoch.wrapping_add(1);
+        let epoch = self.picker_epoch;
+        self.model_picker = Some(ModelPicker {
+            epoch,
+            models: Vec::new(),
+            visible: Vec::new(),
+            query: String::new(),
+            selected: 0,
+            loading: true,
+            applying: false,
+            error: None,
+        });
+        self.load_model_catalog(epoch);
+    }
+
+    fn reload_model_catalog(&mut self) {
+        if let Some(task) = self.model_picker_task.take() {
+            task.abort();
+        }
+        self.picker_epoch = self.picker_epoch.wrapping_add(1);
         let Some(picker) = self.model_picker.as_mut() else {
+            return;
+        };
+        picker.epoch = self.picker_epoch;
+        self.load_model_catalog(self.picker_epoch);
+    }
+
+    fn load_model_catalog(&mut self, epoch: u64) {
+        if let Some(task) = self.model_picker_task.take() {
+            task.abort();
+        }
+        let Some(tx) = self.event_tx.clone() else {
+            if let Some(picker) = self.model_picker.as_mut() {
+                picker.loading = false;
+                picker.error = Some("Model picker is not attached to an event loop".to_string());
+            }
+            return;
+        };
+        if let Some(picker) = self.model_picker.as_mut() {
+            picker.loading = true;
+            picker.error = None;
+        }
+        let client = self.client.clone();
+        self.model_picker_task = Some(tokio::spawn(async move {
+            let result = client
+                .get_provider_catalog()
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::CatalogLoaded { epoch, result });
+        }));
+    }
+
+    fn close_model_picker(&mut self) {
+        if let Some(task) = self.model_picker_task.take() {
+            task.abort();
+        }
+        self.model_picker = None;
+    }
+
+    async fn handle_model_picker_key(&mut self, key: KeyEvent) -> Result<()> {
+        let Some(picker) = self.model_picker.as_ref() else {
             return Ok(());
         };
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                picker.selected = picker.selected.saturating_sub(1);
+        if picker.applying {
+            return Ok(());
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('u') {
+            if let Some(picker) = self.model_picker.as_mut() {
+                let preserve = picker.selected_model().map(model_key);
+                picker.query.clear();
+                picker.refresh_filter(preserve);
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if picker.selected + 1 < picker.models.len() {
-                    picker.selected += 1;
+            return Ok(());
+        }
+
+        match key.code {
+            KeyCode::Up => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.selected = picker.selected.saturating_sub(1);
+                }
+            }
+            KeyCode::Down => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    if picker.selected + 1 < picker.visible.len() {
+                        picker.selected += 1;
+                    }
                 }
             }
             KeyCode::Enter => {
-                if let Some(model) = picker.models.get(picker.selected).cloned() {
-                    self.model_picker = None;
+                let model = self
+                    .model_picker
+                    .as_ref()
+                    .and_then(ModelPicker::selected_model)
+                    .cloned();
+                if let Some(model) = model {
                     self.apply_model(model);
                 }
             }
-            KeyCode::Esc => {
-                self.model_picker = None;
-                self.status_message = "Ready".to_string();
+            KeyCode::Esc => self.close_model_picker(),
+            KeyCode::Backspace => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    let preserve = picker.selected_model().map(model_key);
+                    picker.query.pop();
+                    picker.refresh_filter(preserve);
+                }
+            }
+            KeyCode::Char('r')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.model_picker.as_ref().is_some_and(|picker| {
+                        picker.error.is_some() && picker.models.is_empty()
+                    }) =>
+            {
+                self.reload_model_catalog();
+            }
+            KeyCode::Char(character)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    let preserve = picker.selected_model().map(model_key);
+                    picker.query.push(character);
+                    picker.refresh_filter(preserve);
+                }
             }
             _ => {}
         }
         Ok(())
     }
 
-    /// Apply a model picked from the catalog. `chat.model` gets the plain
-    /// model id — the string form `ChatRequest.model` / `ExecuteRequest.model`
-    /// / `PatchSessionRequest.model` actually resolve on the server (see
-    /// `execute::types::ExecuteRequest`'s doc comment: `request.model` is a
-    /// bare id, not a `provider/model` pair; that pairing only exists via the
-    /// separate `model_ref` field, which this picker deliberately doesn't
-    /// use). If a session is already active, also fires a fire-and-forget
-    /// PATCH so the server-side session record doesn't drift from what the
-    /// next turn will actually send.
+    /// Apply only after the server accepts the active-session PATCH. This
+    /// avoids the old half-applied state where the local badge changed and the
+    /// modal closed even though persistence failed.
     fn apply_model(&mut self, model: CatalogModel) {
+        let Some(session_id) = self.chat.session_id.clone() else {
+            self.commit_model_selection(model);
+            return;
+        };
+        let Some(tx) = self.event_tx.clone() else {
+            if let Some(picker) = self.model_picker.as_mut() {
+                picker.error = Some("Model update cannot run without the event loop".to_string());
+            }
+            return;
+        };
+        let Some(picker) = self.model_picker.as_mut() else {
+            return;
+        };
+        picker.applying = true;
+        picker.error = None;
+        let epoch = picker.epoch;
         let model_id = model.reference.model.clone();
-        self.chat.model = model_id.clone();
-        self.status_message = format!("Model: {}", model.display_name);
-
-        if let (Some(session_id), Some(tx)) = (self.chat.session_id.clone(), self.event_tx.clone())
-        {
-            let client = self.client.clone();
-            tokio::spawn(async move {
-                let outcome = match client.patch_session_model(&session_id, &model_id).await {
-                    Ok(()) => Ok("Session model updated".to_string()),
-                    Err(e) => Err(format!("Failed to update session model: {e}")),
-                };
-                let _ = tx.send(AppEvent::ActionDone {
-                    outcome,
-                    reload_tab: false,
-                });
+        let client = self.client.clone();
+        self.model_picker_task = Some(tokio::spawn(async move {
+            let result = client
+                .patch_session_model(&session_id, &model_id)
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::ModelPatched {
+                epoch,
+                model,
+                result,
             });
+        }));
+    }
+
+    pub(crate) fn model_group_label(&self, model: &CatalogModel) -> String {
+        if model.reference.model == self.chat.model {
+            "Current".to_string()
+        } else if self.recent_models.contains(&model_key(model)) {
+            "Recent".to_string()
+        } else {
+            let provider = if model.provider_display_name.trim().is_empty() {
+                model.reference.provider.as_str()
+            } else {
+                model.provider_display_name.as_str()
+            };
+            format!("Provider: {provider}")
         }
+    }
+
+    fn commit_model_selection(&mut self, model: CatalogModel) {
+        let key = model_key(&model);
+        self.recent_models.retain(|candidate| candidate != &key);
+        self.recent_models.push_front(key);
+        self.recent_models.truncate(MAX_RECENT_MODELS);
+        self.chat.model = model.reference.model.clone();
+        self.model_picker = None;
+        self.status_message = format!(
+            "Model: {} ({})",
+            model.display_name, model.provider_display_name
+        );
     }
 }
 
@@ -4626,7 +5681,7 @@ mod question_tests {
         use ratatui::Terminal;
 
         let app = app_with_question(vec!["Approve", "Deny"]);
-        let backend = TestBackend::new(80, 24);
+        let backend = TestBackend::new(60, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
 
@@ -7001,7 +8056,370 @@ mod question_tests {
         assert_eq!(app.sessions.selected, 1);
     }
 
-    // ── Model picker (WP5) ──
+    // ── Contextual searchable pickers (#636) ──
+
+    fn contextual_session_picker(sessions: Vec<SessionSummary>) -> SessionPicker {
+        SessionPicker {
+            epoch: 7,
+            visible: (0..sessions.len()).collect(),
+            sessions,
+            query: String::new(),
+            selected: 0,
+            loading: false,
+            error: None,
+            total: 0,
+            page_limit: 2,
+            next_offset: None,
+            mode: SessionPickerMode::Browse,
+        }
+    }
+
+    #[tokio::test]
+    async fn ctrl_p_opens_contextual_picker_and_escape_preserves_chat_draft() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.textarea.input(key(KeyCode::Char('d')));
+        app.chat.textarea.input(key(KeyCode::Char('r')));
+        app.chat.scroll_offset = 11;
+        app.status_message = "Keep this exact status".to_string();
+        app.tab = Tab::Sessions;
+        app.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(app.session_picker.is_none(), "Ctrl+P is Chat-tab only");
+
+        app.tab = Tab::Chat;
+        app.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(app.session_picker.is_some());
+        app.handle_session_picker_key(key(KeyCode::Esc))
+            .await
+            .unwrap();
+        assert!(app.session_picker.is_none());
+        assert_eq!(app.chat.textarea.lines().join("\n"), "dr");
+        assert_eq!(app.chat.scroll_offset, 11);
+        assert_eq!(app.status_message, "Keep this exact status");
+    }
+
+    #[tokio::test]
+    async fn ctrl_p_is_ignored_while_streaming() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = Tab::Chat;
+        app.chat.streaming = true;
+        app.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(app.session_picker.is_none());
+    }
+
+    #[tokio::test]
+    async fn session_picker_filters_title_model_id_and_status() {
+        let mut title_match = bare_session("alpha-12345678");
+        title_match.title = "Release investigation".to_string();
+        title_match.model = "claude-sonnet".to_string();
+        let mut model_match = bare_session("beta-87654321");
+        model_match.title = "Other".to_string();
+        model_match.model = "gpt-5.6-sol".to_string();
+        model_match.is_running = true;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![title_match, model_match]));
+        for character in "gpt".chars() {
+            app.handle_session_picker_key(key(KeyCode::Char(character)))
+                .await
+                .unwrap();
+        }
+        let picker = app.session_picker.as_ref().unwrap();
+        assert_eq!(picker.visible.len(), 1);
+        assert_eq!(picker.selected_session().unwrap().id, "beta-87654321");
+
+        for _ in 0..3 {
+            app.handle_session_picker_key(key(KeyCode::Backspace))
+                .await
+                .unwrap();
+        }
+        for character in "running".chars() {
+            app.handle_session_picker_key(key(KeyCode::Char(character)))
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            app.session_picker
+                .as_ref()
+                .unwrap()
+                .selected_session()
+                .unwrap()
+                .id,
+            "beta-87654321"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_picker_pages_append_deduplicate_and_drop_stale_epochs() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![]));
+        app.handle_event(AppEvent::SessionPickerPageLoaded {
+            epoch: 7,
+            offset: 0,
+            result: Ok(ListSessionsEnvelope {
+                sessions: vec![bare_session("s1"), bare_session("s2")],
+                total: 3,
+                limit: 2,
+                offset: 0,
+                next_offset: Some(2),
+            }),
+        })
+        .await
+        .unwrap();
+        app.handle_event(AppEvent::SessionPickerPageLoaded {
+            epoch: 7,
+            offset: 2,
+            result: Ok(ListSessionsEnvelope {
+                sessions: vec![bare_session("s2"), bare_session("s3")],
+                total: 3,
+                limit: 2,
+                offset: 2,
+                next_offset: None,
+            }),
+        })
+        .await
+        .unwrap();
+        app.handle_event(AppEvent::SessionPickerPageLoaded {
+            epoch: 6,
+            offset: 0,
+            result: Ok(ListSessionsEnvelope {
+                sessions: vec![bare_session("stale")],
+                total: 1,
+                limit: 2,
+                offset: 0,
+                next_offset: None,
+            }),
+        })
+        .await
+        .unwrap();
+
+        let picker = app.session_picker.as_ref().unwrap();
+        assert_eq!(
+            picker
+                .sessions
+                .iter()
+                .map(|session| session.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["s1", "s2", "s3"]
+        );
+        assert_eq!(picker.total, 3);
+    }
+
+    #[tokio::test]
+    async fn active_session_becomes_selected_when_a_later_page_arrives() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("active".to_string());
+        app.session_picker = Some(contextual_session_picker(vec![]));
+        for (offset, sessions, next_offset) in [
+            (0, vec![bare_session("s1")], Some(1)),
+            (1, vec![bare_session("active")], None),
+        ] {
+            app.handle_event(AppEvent::SessionPickerPageLoaded {
+                epoch: 7,
+                offset,
+                result: Ok(ListSessionsEnvelope {
+                    sessions,
+                    total: 2,
+                    limit: 1,
+                    offset,
+                    next_offset,
+                }),
+            })
+            .await
+            .unwrap();
+        }
+
+        assert_eq!(
+            app.session_picker
+                .as_ref()
+                .unwrap()
+                .selected_session()
+                .unwrap()
+                .id,
+            "active"
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_conflict_preserves_draft_and_exposes_retry() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![bare_session("s1")]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
+            session_id: "s1".to_string(),
+            draft: "keep my draft".to_string(),
+            metadata_version: Some(1),
+            loading_version: false,
+            submitting: true,
+            error: None,
+        };
+        app.handle_event(AppEvent::SessionPickerPatched {
+            epoch: 7,
+            session_id: "s1".to_string(),
+            intent: SessionPickerIntent::Rename,
+            result: Err(crate::api::SessionMutationFailure::test_conflict(2)),
+        })
+        .await
+        .unwrap();
+
+        let SessionPickerMode::Rename {
+            draft,
+            metadata_version,
+            submitting,
+            error,
+            ..
+        } = &app.session_picker.as_ref().unwrap().mode
+        else {
+            panic!("rename mode must remain open");
+        };
+        assert_eq!(draft, "keep my draft");
+        assert!(metadata_version.is_none());
+        assert!(!submitting);
+        assert!(error.as_deref().unwrap().contains("Version conflict"));
+    }
+
+    #[tokio::test]
+    async fn successful_pin_updates_row_without_closing_picker() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![bare_session("s1")]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Pinning {
+            session_id: "s1".to_string(),
+            target: true,
+            loading_version: false,
+            submitting: true,
+            error: None,
+        };
+        let mut updated = bare_session("s1");
+        updated.pinned = true;
+        app.handle_event(AppEvent::SessionPickerPatched {
+            epoch: 7,
+            session_id: "s1".to_string(),
+            intent: SessionPickerIntent::Pin(true),
+            result: Ok(crate::api::VersionedSession {
+                summary: updated,
+                metadata_version: 2,
+            }),
+        })
+        .await
+        .unwrap();
+        let picker = app.session_picker.as_ref().unwrap();
+        assert!(matches!(picker.mode, SessionPickerMode::Browse));
+        assert!(picker.sessions[0].pinned);
+    }
+
+    #[tokio::test]
+    async fn stale_mutation_response_cannot_satisfy_a_reopened_editor() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![bare_session("s1")]));
+        app.session_picker.as_mut().unwrap().mode = SessionPickerMode::Rename {
+            session_id: "s1".to_string(),
+            draft: "new draft".to_string(),
+            metadata_version: None,
+            loading_version: true,
+            submitting: false,
+            error: None,
+        };
+        app.picker_epoch = 8;
+        app.session_picker.as_mut().unwrap().epoch = 8;
+
+        app.handle_event(AppEvent::SessionPickerVersionLoaded {
+            epoch: 7,
+            session_id: "s1".to_string(),
+            intent: SessionPickerIntent::Rename,
+            result: Ok(crate::api::VersionedSession {
+                summary: bare_session("s1"),
+                metadata_version: 99,
+            }),
+        })
+        .await
+        .unwrap();
+
+        let SessionPickerMode::Rename {
+            draft,
+            metadata_version,
+            loading_version,
+            ..
+        } = &app.session_picker.as_ref().unwrap().mode
+        else {
+            panic!("rename editor closed unexpectedly");
+        };
+        assert_eq!(draft, "new draft");
+        assert!(metadata_version.is_none());
+        assert!(*loading_version);
+    }
+
+    #[tokio::test]
+    async fn contextual_delete_confirmation_owns_input_then_returns_to_picker() {
+        let mut session = bare_session("s1");
+        session.title = "Delete me".to_string();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![session]));
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert_eq!(app.pending_delete.as_ref().unwrap().0, "s1");
+
+        app.handle_key(key(KeyCode::Char('n'))).await.unwrap();
+        assert!(app.pending_delete.is_none());
+        assert!(app.session_picker.is_some());
+        assert!(app.session_picker.as_ref().unwrap().query.is_empty());
+    }
+
+    #[test]
+    fn session_picker_mouse_wheel_moves_filtered_selection() {
+        use crossterm::event::{MouseEvent, MouseEventKind};
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(
+            (0..6)
+                .map(|index| bare_session(&format!("s{index}")))
+                .collect(),
+        ));
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        });
+        assert_eq!(app.session_picker.as_ref().unwrap().selected, 3);
+    }
+
+    #[test]
+    fn session_picker_renders_at_sixty_columns() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut session = bare_session("session-12345678");
+        session.title = "很长的 Unicode 会话标题 for narrow terminals".to_string();
+        session.model = "claude-sonnet-5".to_string();
+        session.pinned = true;
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(vec![session]));
+
+        let backend = TestBackend::new(60, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("Session picker"));
+        assert!(text.contains("Unicode") || text.contains("很长"));
+        assert!(text.contains("★"));
+        assert!(text.contains("F2 rename"));
+        assert!(text.contains("Esc cancel"));
+    }
+
+    // ── Model picker ──
 
     fn catalog_model(
         provider: &str,
@@ -7019,6 +8437,19 @@ mod question_tests {
         }
     }
 
+    fn model_picker(models: Vec<CatalogModel>) -> ModelPicker {
+        ModelPicker {
+            epoch: 1,
+            visible: (0..models.len()).collect(),
+            models,
+            query: String::new(),
+            selected: 0,
+            loading: false,
+            applying: false,
+            error: None,
+        }
+    }
+
     /// `Ctrl+O` opens the picker only on the Chat tab, and only when idle —
     /// same rationale as `Ctrl+N` being a no-op while streaming.
     #[tokio::test]
@@ -7031,6 +8462,8 @@ mod question_tests {
         assert!(app.model_picker.is_none(), "Ctrl+O is Chat-tab only");
 
         app.tab = Tab::Chat;
+        let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
+        app.event_tx = Some(event_tx);
         app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL))
             .await
             .unwrap();
@@ -7050,6 +8483,126 @@ mod question_tests {
         assert!(app.model_picker.is_none());
     }
 
+    #[tokio::test]
+    async fn model_picker_filters_150_grouped_entries_with_stable_selection() {
+        let providers = ["alpha-unique", "beta-unique", "gamma-unique"];
+        let models = (0..150)
+            .map(|index| {
+                let provider = providers[index % providers.len()];
+                catalog_model(
+                    provider,
+                    &format!("model-{index}"),
+                    &format!("Display {index}"),
+                    provider,
+                )
+            })
+            .collect::<Vec<_>>();
+        let target_key = ("alpha-unique".to_string(), "model-117".to_string());
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.model_picker = Some(model_picker(models));
+        let target_index = app
+            .model_picker
+            .as_ref()
+            .unwrap()
+            .models
+            .iter()
+            .position(|model| model_key(model) == target_key)
+            .unwrap();
+        app.model_picker.as_mut().unwrap().selected = target_index;
+
+        for character in "alpha-unique".chars() {
+            app.handle_model_picker_key(key(KeyCode::Char(character)))
+                .await
+                .unwrap();
+        }
+
+        let picker = app.model_picker.as_ref().unwrap();
+        assert_eq!(picker.models.len(), 150);
+        assert_eq!(picker.visible.len(), 50);
+        assert_eq!(model_key(picker.selected_model().unwrap()), target_key);
+        assert!(
+            picker.visible.windows(2).all(|pair| pair[0] < pair[1]),
+            "filter must preserve grouped catalog order"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_patch_failure_preserves_query_selection_and_underlying_chat() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("s1".to_string());
+        app.chat.model = "old-model".to_string();
+        app.chat.textarea.input(key(KeyCode::Char('d')));
+        app.model_picker = Some(model_picker(vec![
+            catalog_model("openai", "gpt-4.1", "GPT-4.1", "OpenAI"),
+            catalog_model(
+                "anthropic",
+                "claude-sonnet-5",
+                "Claude Sonnet 5",
+                "Anthropic",
+            ),
+        ]));
+        {
+            let picker = app.model_picker.as_mut().unwrap();
+            picker.query = "claude".to_string();
+            picker.refresh_filter(None);
+            picker.applying = true;
+        }
+        let selected_key = model_key(app.model_picker.as_ref().unwrap().selected_model().unwrap());
+
+        app.handle_event(AppEvent::ModelPatched {
+            epoch: 1,
+            model: catalog_model(
+                "anthropic",
+                "claude-sonnet-5",
+                "Claude Sonnet 5",
+                "Anthropic",
+            ),
+            result: Err("offline".to_string()),
+        })
+        .await
+        .unwrap();
+
+        let picker = app.model_picker.as_ref().unwrap();
+        assert_eq!(picker.query, "claude");
+        assert_eq!(model_key(picker.selected_model().unwrap()), selected_key);
+        assert!(!picker.applying);
+        assert!(picker.error.as_deref().unwrap().contains("Enter to retry"));
+        assert_eq!(app.chat.model, "old-model");
+        assert_eq!(app.chat.textarea.lines().join("\n"), "d");
+    }
+
+    #[test]
+    fn model_picker_renders_current_recent_and_provider_groups() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let current = catalog_model("openai", "current", "Current Model", "OpenAI");
+        let recent = catalog_model("anthropic", "recent", "Recent Model", "Anthropic");
+        let provider = catalog_model("local", "other", "Other Model", "Local");
+        let mut models = vec![provider, recent.clone(), current];
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.model = "current".to_string();
+        app.recent_models.push_back(model_key(&recent));
+        sort_catalog_models(&mut models, &app.chat.model, &app.recent_models);
+        app.model_picker = Some(model_picker(models));
+
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("Current"));
+        assert!(text.contains("Recent"));
+        assert!(text.contains("Provider: Local"));
+    }
+
     /// `↑/↓` move the selection (clamped); `Enter` applies the highlighted
     /// model — `chat.model` gets the plain model id (NOT `provider/model`),
     /// matching what `ChatRequest`/`ExecuteRequest`/`PatchSessionRequest.model`
@@ -7057,19 +8610,15 @@ mod question_tests {
     #[tokio::test]
     async fn model_picker_navigation_and_enter_applies() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.model_picker = Some(ModelPicker {
-            models: vec![
-                catalog_model("openai", "gpt-4.1", "GPT-4.1", "OpenAI"),
-                catalog_model(
-                    "anthropic",
-                    "claude-sonnet-5",
-                    "Claude Sonnet 5",
-                    "Anthropic",
-                ),
-            ],
-            selected: 0,
-            loading: false,
-        });
+        app.model_picker = Some(model_picker(vec![
+            catalog_model("openai", "gpt-4.1", "GPT-4.1", "OpenAI"),
+            catalog_model(
+                "anthropic",
+                "claude-sonnet-5",
+                "Claude Sonnet 5",
+                "Anthropic",
+            ),
+        ]));
 
         app.handle_model_picker_key(key(KeyCode::Down))
             .await
@@ -7098,7 +8647,7 @@ mod question_tests {
             app.chat.model, "claude-sonnet-5",
             "chat.model gets the plain model id, not provider/model"
         );
-        assert_eq!(app.status_message, "Model: Claude Sonnet 5");
+        assert_eq!(app.status_message, "Model: Claude Sonnet 5 (Anthropic)");
     }
 
     /// `Enter` while the catalog is still loading (empty list) is a no-op —
@@ -7106,11 +8655,8 @@ mod question_tests {
     #[tokio::test]
     async fn model_picker_enter_while_loading_is_noop() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.model_picker = Some(ModelPicker {
-            models: vec![],
-            selected: 0,
-            loading: true,
-        });
+        app.model_picker = Some(model_picker(vec![]));
+        app.model_picker.as_mut().unwrap().loading = true;
         app.handle_model_picker_key(key(KeyCode::Enter))
             .await
             .unwrap();
@@ -7125,11 +8671,12 @@ mod question_tests {
     async fn model_picker_esc_leaves_model_unchanged() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.model = "old-model".to_string();
-        app.model_picker = Some(ModelPicker {
-            models: vec![catalog_model("openai", "gpt-4.1", "GPT-4.1", "OpenAI")],
-            selected: 0,
-            loading: false,
-        });
+        app.chat.textarea.input(key(KeyCode::Char('d')));
+        app.chat.scroll_offset = 9;
+        app.status_message = "Keep model status".to_string();
+        app.model_picker = Some(model_picker(vec![catalog_model(
+            "openai", "gpt-4.1", "GPT-4.1", "OpenAI",
+        )]));
 
         app.handle_model_picker_key(key(KeyCode::Esc))
             .await
@@ -7137,52 +8684,51 @@ mod question_tests {
 
         assert!(app.model_picker.is_none());
         assert_eq!(app.chat.model, "old-model", "Esc must not change the model");
+        assert_eq!(app.chat.textarea.lines().join("\n"), "d");
+        assert_eq!(app.chat.scroll_offset, 9);
+        assert_eq!(app.status_message, "Keep model status");
     }
 
-    /// `CatalogLoaded(Err(...))` notifies and closes the picker instead of
-    /// leaving it stuck on "Loading models...".
+    /// Catalog failures remain recoverable without losing the query/selection.
     #[tokio::test]
-    async fn catalog_loaded_err_notifies_and_closes_picker() {
+    async fn catalog_loaded_err_stays_open_with_retry() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.model_picker = Some(ModelPicker {
-            models: vec![],
-            selected: 0,
-            loading: true,
-        });
+        app.model_picker = Some(model_picker(vec![]));
+        app.model_picker.as_mut().unwrap().loading = true;
 
-        app.handle_event(AppEvent::CatalogLoaded(Err(
-            "connection refused".to_string()
-        )))
+        app.handle_event(AppEvent::CatalogLoaded {
+            epoch: 1,
+            result: Err("connection refused".to_string()),
+        })
         .await
         .unwrap();
 
-        assert!(app.model_picker.is_none());
-        let last = app.notifications.last().expect("notified");
-        assert!(last.text.contains("connection refused"));
-        assert_eq!(last.level, NoticeLevel::Error);
+        let picker = app.model_picker.as_ref().expect("recoverable picker");
+        assert!(!picker.loading);
+        assert!(picker
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("connection refused"));
     }
 
-    /// An empty catalog (no providers configured) notifies a warning instead
-    /// of leaving an empty modal open.
+    /// An empty catalog stays open with an explicit retry action.
     #[tokio::test]
-    async fn catalog_loaded_empty_notifies_warn_and_closes_picker() {
+    async fn catalog_loaded_empty_stays_open_with_retry() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.model_picker = Some(ModelPicker {
-            models: vec![],
-            selected: 0,
-            loading: true,
-        });
+        app.model_picker = Some(model_picker(vec![]));
+        app.model_picker.as_mut().unwrap().loading = true;
 
-        app.handle_event(AppEvent::CatalogLoaded(Ok(ProviderCatalog {
-            models: vec![],
-        })))
+        app.handle_event(AppEvent::CatalogLoaded {
+            epoch: 1,
+            result: Ok(ProviderCatalog { models: vec![] }),
+        })
         .await
         .unwrap();
 
-        assert!(app.model_picker.is_none());
-        let last = app.notifications.last().expect("notified");
-        assert_eq!(last.text, "No models in provider catalog");
-        assert_eq!(last.level, NoticeLevel::Warn);
+        let picker = app.model_picker.as_ref().expect("recoverable picker");
+        assert!(picker.models.is_empty());
+        assert!(picker.error.as_deref().unwrap().contains("No models"));
     }
 
     /// A catalog fetch that lands after the picker was already dismissed
@@ -7192,9 +8738,12 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         assert!(app.model_picker.is_none());
 
-        app.handle_event(AppEvent::CatalogLoaded(Ok(ProviderCatalog {
-            models: vec![catalog_model("openai", "gpt-4.1", "GPT-4.1", "OpenAI")],
-        })))
+        app.handle_event(AppEvent::CatalogLoaded {
+            epoch: 1,
+            result: Ok(ProviderCatalog {
+                models: vec![catalog_model("openai", "gpt-4.1", "GPT-4.1", "OpenAI")],
+            }),
+        })
         .await
         .unwrap();
 
@@ -7210,11 +8759,9 @@ mod question_tests {
         use ratatui::Terminal;
 
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
-        app.model_picker = Some(ModelPicker {
-            models: vec![catalog_model("openai", "gpt-4.1", "GPT-4.1", "OpenAI")],
-            selected: 0,
-            loading: false,
-        });
+        app.model_picker = Some(model_picker(vec![catalog_model(
+            "openai", "gpt-4.1", "GPT-4.1", "OpenAI",
+        )]));
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -7224,6 +8771,8 @@ mod question_tests {
         let text: String = buf.content().iter().map(|c| c.symbol()).collect();
         assert!(text.contains("GPT-4.1"), "model display name missing");
         assert!(text.contains("OpenAI"), "provider display name missing");
+        assert!(text.contains("openai/gpt-4.1"), "provider/model id missing");
+        assert!(text.contains("Esc cancel"), "narrow footer was clipped");
     }
 }
 

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -36,6 +36,14 @@ pub enum AppEvent {
         /// erase a newer picker/editor merely because they finish late.
         session_picker_epoch: Option<u64>,
     },
+    /// A session DELETE finished. Unlike generic actions, this retains the
+    /// deleted id so Chat state can detach atomically when the operator
+    /// deleted the session currently shown beneath either session UI.
+    SessionDeleted {
+        session_id: String,
+        result: Loaded<()>,
+        session_picker_epoch: Option<u64>,
+    },
     /// A chat turn was created + started; carries the new session id.
     ChatStarted(Loaded<String>),
     /// The `execute` POST that kicks off a run failed (server down, 4xx/5xx).

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -31,6 +31,10 @@ pub enum AppEvent {
     ActionDone {
         outcome: Loaded<String>,
         reload_tab: bool,
+        /// The contextual Session picker generation that originated this
+        /// action, if any. Generic background actions must never reload and
+        /// erase a newer picker/editor merely because they finish late.
+        session_picker_epoch: Option<u64>,
     },
     /// A chat turn was created + started; carries the new session id.
     ChatStarted(Loaded<String>),
@@ -102,6 +106,7 @@ pub enum AppEvent {
     /// query/selection and the chat draft survive validation/network errors.
     ModelPatched {
         epoch: u64,
+        session_id: String,
         model: CatalogModel,
         result: Loaded<()>,
     },

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -1,11 +1,11 @@
 use crossterm::event::{KeyEvent, MouseEvent};
 
 use crate::api::types::{
-    ListSessionsEnvelope, McpServer, PendingQuestion, ProviderCatalog, Schedule, Skill,
-    SkillDetail, ToolInfo,
+    CatalogModel, ListSessionsEnvelope, McpServer, PendingQuestion, ProviderCatalog, Schedule,
+    Skill, SkillDetail, ToolInfo,
 };
-use crate::api::RespondFailure;
-use crate::app::{OpenedSession, QuestionIdentity};
+use crate::api::{RespondFailure, SessionMutationFailure, VersionedSession};
+use crate::app::{OpenedSession, QuestionIdentity, SessionPickerIntent};
 
 /// Result of a background API call, delivered back to the event loop so the call
 /// never blocks the UI thread. `Err` carries a display string.
@@ -92,9 +92,41 @@ pub enum AppEvent {
         answer: String,
         result: Result<String, RespondFailure>,
     },
-    /// `Ctrl+O`'s provider-catalog fetch finished. Dropped by the handler if
-    /// `model_picker` was already closed (Esc) before this arrived.
-    CatalogLoaded(Loaded<ProviderCatalog>),
+    /// `Ctrl+O`'s provider-catalog fetch finished. `epoch` makes close/reopen
+    /// safe when an older HTTP response arrives after the new overlay opened.
+    CatalogLoaded {
+        epoch: u64,
+        result: Loaded<ProviderCatalog>,
+    },
+    /// Recoverable model PATCH result. The picker stays open until success so
+    /// query/selection and the chat draft survive validation/network errors.
+    ModelPatched {
+        epoch: u64,
+        model: CatalogModel,
+        result: Loaded<()>,
+    },
+    /// One lazily-loaded page for the contextual session picker. Pages are
+    /// requested serially and capped in memory; stale epochs are discarded.
+    SessionPickerPageLoaded {
+        epoch: u64,
+        offset: usize,
+        result: Loaded<ListSessionsEnvelope>,
+    },
+    /// Fresh session summary + ETag loaded before a rename/pin mutation.
+    SessionPickerVersionLoaded {
+        epoch: u64,
+        session_id: String,
+        intent: SessionPickerIntent,
+        result: Loaded<VersionedSession>,
+    },
+    /// Optimistic rename/pin PATCH completed. A 412 remains typed so the UI
+    /// can preserve the draft and offer an explicit refetch/retry action.
+    SessionPickerPatched {
+        epoch: u64,
+        session_id: String,
+        intent: SessionPickerIntent,
+        result: Result<VersionedSession, SessionMutationFailure>,
+    },
     /// The auto-serve health-poll waiter finished: `Ok(pid)` once
     /// `client.health()` succeeded (carries the spawned server's pid, for the
     /// confirmation notice); `Err(message)` if it never became healthy within

--- a/crates/app/bamboo-tui/src/lib.rs
+++ b/crates/app/bamboo-tui/src/lib.rs
@@ -22,6 +22,7 @@ mod app;
 mod components;
 mod event;
 mod history;
+mod search;
 mod theme;
 mod ui;
 

--- a/crates/app/bamboo-tui/src/search.rs
+++ b/crates/app/bamboo-tui/src/search.rs
@@ -1,0 +1,122 @@
+//! Small, allocation-bounded fuzzy search shared by the session and model
+//! pickers. The TUI deliberately keeps this local instead of pulling in a
+//! second command-palette dependency: catalogs are small (hundreds of rows),
+//! and a deterministic subsequence score is easier to keep selection-stable.
+
+/// Return ranked item indices for `query`.
+///
+/// Every whitespace-separated query token must be a subsequence of the item's
+/// searchable text. Contiguous characters, word boundaries, and early matches
+/// rank higher. Empty queries preserve the caller's source order.
+pub fn ranked_indices<T>(
+    items: &[T],
+    query: &str,
+    mut searchable_text: impl FnMut(&T) -> String,
+) -> Vec<usize> {
+    let tokens: Vec<String> = query
+        .split_whitespace()
+        .map(|token| token.to_lowercase())
+        .filter(|token| !token.is_empty())
+        .collect();
+
+    if tokens.is_empty() {
+        return (0..items.len()).collect();
+    }
+
+    let mut ranked = items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            let haystack = searchable_text(item).to_lowercase();
+            let score = tokens.iter().try_fold(0_i64, |total, token| {
+                fuzzy_subsequence_score(&haystack, token).map(|score| total + score)
+            })?;
+            Some((index, score))
+        })
+        .collect::<Vec<_>>();
+
+    ranked.sort_by(|(left_index, left_score), (right_index, right_score)| {
+        right_score
+            .cmp(left_score)
+            .then_with(|| left_index.cmp(right_index))
+    });
+    ranked.into_iter().map(|(index, _)| index).collect()
+}
+
+fn fuzzy_subsequence_score(haystack: &str, needle: &str) -> Option<i64> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+
+    let haystack_chars = haystack.chars().collect::<Vec<_>>();
+    let mut cursor = 0_usize;
+    let mut previous_match = None;
+    let mut score = 0_i64;
+
+    for wanted in needle.chars() {
+        let relative = haystack_chars[cursor..]
+            .iter()
+            .position(|candidate| *candidate == wanted)?;
+        let matched = cursor + relative;
+
+        // Prefer compact runs and token starts. The constants are deliberately
+        // small; stable source ordering remains the final tie-breaker.
+        score += 10;
+        if previous_match.is_some_and(|previous| previous + 1 == matched) {
+            score += 8;
+        }
+        if matched == 0
+            || haystack_chars
+                .get(matched.saturating_sub(1))
+                .is_some_and(|ch| !ch.is_alphanumeric())
+        {
+            score += 6;
+        }
+        score -= matched.min(64) as i64;
+
+        previous_match = Some(matched);
+        cursor = matched + 1;
+    }
+
+    Some(score)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_preserves_source_order() {
+        let items = ["beta", "alpha"];
+        assert_eq!(
+            ranked_indices(&items, "", |item| (*item).to_string()),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn tokens_match_as_ranked_subsequences() {
+        let items = [
+            "OpenAI GPT 5.6",
+            "Anthropic Claude Sonnet",
+            "OpenAI GPT 4.1",
+        ];
+        assert_eq!(
+            ranked_indices(&items, "oa 56", |item| (*item).to_string()),
+            vec![0]
+        );
+        assert_eq!(
+            ranked_indices(&items, "gpt", |item| (*item).to_string()),
+            vec![0, 2]
+        );
+    }
+
+    #[test]
+    fn matching_is_unicode_and_case_insensitive() {
+        let items = ["会话 Alpha", "Session Beta"];
+        assert_eq!(
+            ranked_indices(&items, "会a", |item| (*item).to_string()),
+            vec![0]
+        );
+    }
+}

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -743,14 +743,18 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
     let screen = f.area();
     let popup_width = ((screen.width as u32 * 94 / 100) as u16).max(1);
     let row_width = popup_width.saturating_sub(4);
-    let mut lines = vec![
-        Line::from(Span::styled(
-            " Sessions",
-            Style::default()
-                .fg(colors::BRAND)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::from(vec![
+    let mut lines = vec![Line::from(Span::styled(
+        " Sessions",
+        Style::default()
+            .fg(colors::BRAND)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    // Search owns keyboard focus only in browse mode. Rename has its own
+    // title editor and cursor, while pinning owns all input as an action
+    // state; showing the search cursor in those modes would imply two active
+    // fields even though keystrokes can reach only one of them.
+    if matches!(&picker.mode, SessionPickerMode::Browse) {
+        lines.push(Line::from(vec![
             Span::styled(" Search: ", Style::default().fg(colors::SUBTLE)),
             Span::styled(
                 format!(
@@ -759,8 +763,8 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                 ),
                 Style::default().fg(colors::BRAND),
             ),
-        ]),
-    ];
+        ]));
+    }
 
     match &picker.mode {
         SessionPickerMode::Browse => {
@@ -862,10 +866,14 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
             lines.push(Line::from(vec![
                 Span::styled("  Title: ", Style::default().fg(colors::SUBTLE)),
                 Span::styled(
-                    format!(
-                        "{}▏",
+                    if *submitting {
                         clip_tail_cells(draft, row_width.saturating_sub(12) as usize)
-                    ),
+                    } else {
+                        format!(
+                            "{}▏",
+                            clip_tail_cells(draft, row_width.saturating_sub(12) as usize)
+                        )
+                    },
                     Style::default().fg(colors::BRAND),
                 ),
             ]));
@@ -883,12 +891,14 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                     Style::default().fg(colors::ERROR),
                 )));
             }
-            lines.push(Line::raw(""));
-            lines.push(Line::raw(if row_width < 70 {
-                "  Enter save · Ctrl+R retry · Esc cancel"
-            } else {
-                "  Enter save · Ctrl+R refetch/retry · Esc keep old title"
-            }));
+            if !*submitting {
+                lines.push(Line::raw(""));
+                lines.push(Line::raw(if row_width < 70 {
+                    "  Enter save · Ctrl+R retry · Esc cancel"
+                } else {
+                    "  Enter save · Ctrl+R refetch/retry · Esc keep old title"
+                }));
+            }
         }
         SessionPickerMode::Pinning {
             target,
@@ -917,8 +927,10 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                     Style::default().fg(colors::ERROR),
                 )));
             }
-            lines.push(Line::raw(""));
-            lines.push(Line::raw("  Ctrl+R refetch/retry · Esc cancel"));
+            if !*submitting {
+                lines.push(Line::raw(""));
+                lines.push(Line::raw("  Ctrl+R refetch/retry · Esc cancel"));
+            }
         }
     }
 
@@ -974,6 +986,10 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
         body.push(Line::raw("  Loading models..."));
         body.push(Line::raw(""));
         body.push(Line::raw("  Esc cancel"));
+    } else if picker.loading && picker.visible.is_empty() {
+        body.push(Line::raw("  Refreshing model catalog..."));
+        body.push(Line::raw(""));
+        body.push(Line::raw("  Esc cancel"));
     } else if picker.visible.is_empty() {
         body.push(Line::raw(if picker.query.is_empty() {
             "  No models available"
@@ -981,7 +997,11 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
             "  No models match this search"
         }));
         body.push(Line::raw(""));
-        body.push(Line::raw("  Edit search · Ctrl+R retry load · Esc cancel"));
+        body.push(Line::raw(if picker.models.is_empty() {
+            "  Edit search · Ctrl+R retry load · Esc cancel"
+        } else {
+            "  Edit search · Ctrl+U clear · Ctrl+R refresh · Esc cancel"
+        }));
     } else {
         let max_h = screen.height.min(22);
         let total = picker.visible.len();

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -5,8 +5,9 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::{App, NoticeLevel, QuestionOptionHitbox, Tab};
+use crate::app::{App, NoticeLevel, QuestionOptionHitbox, SessionPickerMode, Tab};
 use crate::theme::{self, colors};
+use crate::ui::sessions::{session_row_line, truncate_cells};
 
 pub struct AppLayout {
     pub content: Rect,
@@ -179,6 +180,7 @@ const HELP_LEFT: &[(&str, &str)] = &[
 const HELP_RIGHT: &[(&str, &str)] = &[
     ("Ctrl+N", "New session"),
     ("Ctrl+O", "Model picker (Chat)"),
+    ("Ctrl+P", "Session picker (Chat)"),
     ("Ctrl+Q", "Reopen pending question"),
     ("Ctrl+C", "Quit / stop streaming"),
     ("Ctrl+S", "Stop agent execution"),
@@ -731,6 +733,210 @@ pub fn render_schedule_form(f: &mut Frame, app: &App) {
     );
 }
 
+/// Contextual session picker (`Ctrl+P` on Chat). It renders over the
+/// transcript rather than switching to the management tab, so dismissing it
+/// restores the exact composer draft/cursor and transcript scroll beneath it.
+pub fn render_session_picker(f: &mut Frame, app: &App) {
+    let Some(picker) = &app.session_picker else {
+        return;
+    };
+    let screen = f.area();
+    let popup_width = ((screen.width as u32 * 94 / 100) as u16).max(1);
+    let row_width = popup_width.saturating_sub(4);
+    let mut lines = vec![
+        Line::from(Span::styled(
+            " Sessions",
+            Style::default()
+                .fg(colors::BRAND)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(vec![
+            Span::styled(" Search: ", Style::default().fg(colors::SUBTLE)),
+            Span::styled(
+                format!(
+                    "{}▏",
+                    clip_tail_cells(&picker.query, row_width.saturating_sub(10).max(1) as usize)
+                ),
+                Style::default().fg(colors::BRAND),
+            ),
+        ]),
+    ];
+
+    match &picker.mode {
+        SessionPickerMode::Browse => {
+            lines.push(Line::raw(""));
+            if picker.visible.is_empty() {
+                let message = if picker.loading {
+                    "  Loading sessions..."
+                } else if picker.query.is_empty() {
+                    "  No sessions found"
+                } else {
+                    "  No matches in loaded sessions"
+                };
+                lines.push(Line::raw(message));
+            } else {
+                let max_height = screen.height.min(24);
+                let budget = (max_height as usize).saturating_sub(9).max(1);
+                let total = picker.visible.len();
+                let start = if total <= budget {
+                    0
+                } else {
+                    picker
+                        .selected
+                        .saturating_sub(budget / 2)
+                        .min(total.saturating_sub(budget))
+                };
+                let end = (start + budget).min(total);
+                if start > 0 {
+                    lines.push(Line::raw(format!("  ↑ {start} more")));
+                }
+                for visible_index in start..end {
+                    if let Some(session) = picker
+                        .visible
+                        .get(visible_index)
+                        .and_then(|index| picker.sessions.get(*index))
+                    {
+                        lines.push(session_row_line(
+                            session,
+                            visible_index == picker.selected,
+                            row_width,
+                        ));
+                    }
+                }
+                if end < total {
+                    lines.push(Line::raw(format!("  ↓ {} more", total - end)));
+                }
+            }
+            if let Some(error) = &picker.error {
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "  {}",
+                        clip_cells(error, row_width.saturating_sub(2) as usize)
+                    ),
+                    Style::default().fg(colors::ERROR),
+                )));
+            }
+            let cap = if picker.sessions.len() >= 1_000 && picker.sessions.len() < picker.total {
+                " · memory cap reached"
+            } else {
+                ""
+            };
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  loaded {} / {}{}{}",
+                    picker.sessions.len(),
+                    picker.total,
+                    if picker.loading { " · loading" } else { "" },
+                    cap
+                ),
+                Style::default().fg(colors::SUBTLE),
+            )));
+            if row_width < 70 {
+                lines.push(Line::raw("  ↑/↓/wheel · Enter open · F2 rename · F3 pin"));
+                lines.push(Line::raw(
+                    "  Del delete · ] more · Ctrl+R retry · Esc cancel",
+                ));
+            } else {
+                lines.push(Line::raw(
+                    "  ↑/↓/wheel select · Enter open · F2 rename · F3 pin",
+                ));
+                lines.push(Line::raw(
+                    "  Ctrl+D/Delete delete · ] load more · Ctrl+R retry · Esc cancel",
+                ));
+            }
+        }
+        SessionPickerMode::Rename {
+            draft,
+            loading_version,
+            submitting,
+            error,
+            ..
+        } => {
+            lines.push(Line::raw(""));
+            lines.push(Line::from(Span::styled(
+                " Rename session",
+                Style::default()
+                    .fg(colors::BRAND)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            lines.push(Line::from(vec![
+                Span::styled("  Title: ", Style::default().fg(colors::SUBTLE)),
+                Span::styled(
+                    format!(
+                        "{}▏",
+                        clip_tail_cells(draft, row_width.saturating_sub(12) as usize)
+                    ),
+                    Style::default().fg(colors::BRAND),
+                ),
+            ]));
+            if *loading_version {
+                lines.push(Line::raw("  Fetching current version..."));
+            } else if *submitting {
+                lines.push(Line::raw("  Saving..."));
+            }
+            if let Some(error) = error {
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "  {}",
+                        clip_cells(error, row_width.saturating_sub(2) as usize)
+                    ),
+                    Style::default().fg(colors::ERROR),
+                )));
+            }
+            lines.push(Line::raw(""));
+            lines.push(Line::raw(if row_width < 70 {
+                "  Enter save · Ctrl+R retry · Esc cancel"
+            } else {
+                "  Enter save · Ctrl+R refetch/retry · Esc keep old title"
+            }));
+        }
+        SessionPickerMode::Pinning {
+            target,
+            loading_version,
+            submitting,
+            error,
+            ..
+        } => {
+            lines.push(Line::raw(""));
+            lines.push(Line::raw(if *target {
+                "  Pinning selected session..."
+            } else {
+                "  Unpinning selected session..."
+            }));
+            if *loading_version {
+                lines.push(Line::raw("  Fetching current version..."));
+            } else if *submitting {
+                lines.push(Line::raw("  Saving..."));
+            }
+            if let Some(error) = error {
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "  {}",
+                        clip_cells(error, row_width.saturating_sub(2) as usize)
+                    ),
+                    Style::default().fg(colors::ERROR),
+                )));
+            }
+            lines.push(Line::raw(""));
+            lines.push(Line::raw("  Ctrl+R refetch/retry · Esc cancel"));
+        }
+    }
+
+    let height = (lines.len() as u16 + 2).min(screen.height);
+    let area = centered_rect(94, height, screen);
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(colors::BRAND))
+        .title(" Session picker ");
+    f.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
 /// Model picker modal (`Ctrl+O` on the Chat tab): pick a model from the
 /// provider catalog. Mirrors `render_question`'s option-list windowing so the
 /// selection stays visible (and the modal never overflows the screen) no
@@ -741,6 +947,8 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
     };
 
     let screen = f.area();
+    let popup_width = ((screen.width as u32 * 92 / 100) as u16).max(1);
+    let row_width = popup_width.saturating_sub(4) as usize;
     let header: Vec<Line> = vec![
         Line::from(Span::styled(
             " Select a model",
@@ -748,40 +956,99 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
                 .fg(colors::BRAND)
                 .add_modifier(Modifier::BOLD),
         )),
+        Line::from(vec![
+            Span::styled(" Search: ", Style::default().fg(colors::SUBTLE)),
+            Span::styled(
+                format!(
+                    "{}▏",
+                    clip_tail_cells(&picker.query, row_width.saturating_sub(10).max(1))
+                ),
+                Style::default().fg(colors::BRAND),
+            ),
+        ]),
         Line::raw(""),
     ];
 
     let mut body: Vec<Line> = Vec::new();
-    if picker.loading {
+    if picker.loading && picker.models.is_empty() {
         body.push(Line::raw("  Loading models..."));
         body.push(Line::raw(""));
         body.push(Line::raw("  Esc cancel"));
-    } else if picker.models.is_empty() {
-        // Reachable only transiently — an empty catalog closes the picker
-        // and notifies (`AppEvent::CatalogLoaded`) rather than leaving this
-        // rendered — but keep a safe fallback instead of an empty modal.
-        body.push(Line::raw("  No models available"));
+    } else if picker.visible.is_empty() {
+        body.push(Line::raw(if picker.query.is_empty() {
+            "  No models available"
+        } else {
+            "  No models match this search"
+        }));
         body.push(Line::raw(""));
-        body.push(Line::raw("  Esc cancel"));
+        body.push(Line::raw("  Edit search · Ctrl+R retry load · Esc cancel"));
     } else {
         let max_h = screen.height.min(22);
-        // rows available for models = modal height - borders(2) - header - footer(1)
-        let budget = (max_h as usize).saturating_sub(2 + header.len() + 1).max(1);
-        let total = picker.models.len();
-        let start = if total <= budget {
-            0
-        } else {
-            picker
-                .selected
-                .saturating_sub(budget / 2)
-                .min(total.saturating_sub(budget))
-        };
-        let end = (start + budget).min(total);
+        let total = picker.visible.len();
+        let groups = picker
+            .visible
+            .iter()
+            .filter_map(|index| picker.models.get(*index))
+            .map(|model| app.model_group_label(model))
+            .collect::<Vec<_>>();
+
+        // A group heading costs a terminal row too. Grow a balanced window
+        // around the selection using the actual row cost, while reserving two
+        // lines for the possible above/below indicators. This keeps the
+        // highlighted model visible even with 100 providers on a short screen.
+        let line_budget = (max_h as usize)
+            .saturating_sub(2 + header.len() + 2)
+            .saturating_sub(2)
+            .max(2);
+        let selected = picker.selected.min(total.saturating_sub(1));
+        let mut start = selected;
+        let mut end = selected + 1;
+        let mut used = 2; // first group heading + selected model row
+        loop {
+            let mut expanded = false;
+            if start > 0 {
+                let candidate = start - 1;
+                let cost = 1 + usize::from(groups[candidate] != groups[start]);
+                if used + cost <= line_budget {
+                    start = candidate;
+                    used += cost;
+                    expanded = true;
+                }
+            }
+            if end < total {
+                let cost = 1 + usize::from(groups[end] != groups[end - 1]);
+                if used + cost <= line_budget {
+                    used += cost;
+                    end += 1;
+                    expanded = true;
+                }
+            }
+            if !expanded {
+                break;
+            }
+        }
         if start > 0 {
             body.push(Line::raw(format!("  \u{2191} {start} more")));
         }
+        let mut previous_group: Option<&str> = None;
         for i in start..end {
-            let m = &picker.models[i];
+            let Some(m) = picker
+                .visible
+                .get(i)
+                .and_then(|index| picker.models.get(*index))
+            else {
+                continue;
+            };
+            let group = groups.get(i).map(String::as_str).unwrap_or("Provider");
+            if previous_group != Some(group) {
+                body.push(Line::from(Span::styled(
+                    clip_cells(&format!("  {group}"), row_width),
+                    Style::default()
+                        .fg(colors::SUBTLE)
+                        .add_modifier(Modifier::BOLD),
+                )));
+                previous_group = Some(group);
+            }
             let selected = i == picker.selected;
             let marker = if selected { "\u{203a}" } else { " " };
             let style = if selected {
@@ -792,9 +1059,15 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
                 Style::default()
             };
             body.push(Line::from(Span::styled(
-                format!(
-                    "  {marker} {}  ({})",
-                    m.display_name, m.provider_display_name
+                truncate_cells(
+                    &format!(
+                        "  {marker} {} · {} · {}/{}",
+                        m.display_name,
+                        m.provider_display_name,
+                        m.reference.provider,
+                        m.reference.model,
+                    ),
+                    row_width,
                 ),
                 style,
             )));
@@ -803,15 +1076,23 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
             body.push(Line::raw(format!("  \u{2193} {} more", total - end)));
         }
         body.push(Line::raw(""));
-        body.push(Line::raw(
-            "  \u{2191}/\u{2193} select  \u{b7}  Enter apply  \u{b7}  Esc cancel",
-        ));
+        body.push(Line::raw(if picker.applying {
+            "  Applying model..."
+        } else {
+            "  \u{2191}/\u{2193}/wheel select · Enter apply · Esc cancel"
+        }));
+    }
+    if let Some(error) = &picker.error {
+        body.push(Line::from(Span::styled(
+            clip_cells(&format!("  {error}"), row_width),
+            Style::default().fg(colors::ERROR),
+        )));
     }
 
     let mut lines = header;
     lines.extend(body);
     let height = (lines.len() as u16 + 2).min(screen.height);
-    let area = centered_rect(60, height, screen);
+    let area = centered_rect(92, height, screen);
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
@@ -837,8 +1118,60 @@ fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {
     )
 }
 
+fn clip_cells(value: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    let mut output = String::new();
+    let mut used = 0;
+    for character in value.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if used + character_width > max_width {
+            while used > max_width.saturating_sub(1) {
+                let Some(removed) = output.pop() else {
+                    break;
+                };
+                used = used.saturating_sub(UnicodeWidthChar::width(removed).unwrap_or(0));
+            }
+            output.push('…');
+            return output;
+        }
+        output.push(character);
+        used += character_width;
+    }
+    output
+}
+
+fn clip_tail_cells(value: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    let width = value
+        .chars()
+        .map(|character| UnicodeWidthChar::width(character).unwrap_or(0))
+        .sum::<usize>();
+    if width <= max_width {
+        return value.to_string();
+    }
+
+    let target = max_width.saturating_sub(1);
+    let mut suffix = Vec::new();
+    let mut used = 0;
+    for character in value.chars().rev() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if used + character_width > target {
+            break;
+        }
+        suffix.push(character);
+        used += character_width;
+    }
+    suffix.reverse();
+    format!("…{}", suffix.into_iter().collect::<String>())
+}
+
 #[cfg(test)]
 mod tests {
+    use super::{clip_cells, clip_tail_cells};
     use crate::api::BambooClient;
     use crate::app::App;
     use ratatui::backend::TestBackend;
@@ -863,6 +1196,7 @@ mod tests {
         for needle in [
             "Ctrl+N",
             "Ctrl+O",
+            "Ctrl+P",
             "Ctrl+Q",
             "Ctrl+C",
             "Ctrl+S",
@@ -874,5 +1208,15 @@ mod tests {
         ] {
             assert!(text.contains(needle), "help overlay missing {needle:?}");
         }
+    }
+
+    #[test]
+    fn cell_clipping_handles_unicode_and_keeps_the_input_tail_visible() {
+        assert_eq!(clip_cells("abcdef", 4), "abc…");
+        assert_eq!(clip_cells("会话标题", 5), "会话…");
+        assert_eq!(clip_cells("界", 1), "…");
+        assert_eq!(clip_tail_cells("abcdef", 4), "…def");
+        assert_eq!(clip_tail_cells("会话标题", 5), "…标题");
+        assert_eq!(clip_tail_cells("界", 1), "…");
     }
 }

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -53,6 +53,10 @@ pub fn render(f: &mut Frame, app: &App) {
         layout::render_model_picker(f, app);
     }
 
+    if app.session_picker.is_some() {
+        layout::render_session_picker(f, app);
+    }
+
     if app.pending_delete.is_some() {
         layout::render_delete_confirm(f, app);
     }

--- a/crates/app/bamboo-tui/src/ui/sessions.rs
+++ b/crates/app/bamboo-tui/src/ui/sessions.rs
@@ -3,6 +3,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
+use unicode_width::UnicodeWidthChar;
 
 use crate::api::types::SessionSummary;
 use crate::app::App;
@@ -59,42 +60,14 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
 
     // Session list
     let mut lines: Vec<Line> = Vec::new();
-    lines.push(Line::from(Span::styled(
-        "   Title                          Model                 Msgs  Updated       ",
-        Style::default().fg(colors::SUBTLE),
-    )));
+    lines.push(session_header(chunks[1].width));
 
     for (i, session) in app.sessions.sessions.iter().enumerate() {
-        let row_style = if i == app.sessions.selected {
-            Style::default()
-                .fg(colors::BRAND)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(colors::INACTIVE)
-        };
-
-        let title: String = if session.title.is_empty() {
-            "(untitled)".to_string()
-        } else {
-            session.title.chars().take(30).collect()
-        };
-        let model: String = session.model.chars().take(21).collect();
-        let updated = session
-            .updated_at
-            .map(|t| t.format("%m-%d %H:%M").to_string())
-            .unwrap_or_else(|| "-".to_string());
-        let (glyph, glyph_color) = status_glyph(session);
-
-        lines.push(Line::from(vec![
-            Span::styled(format!(" {} ", glyph), Style::default().fg(glyph_color)),
-            Span::styled(
-                format!(
-                    "{:30}  {:21}  {:>4}  {}",
-                    title, model, session.message_count, updated
-                ),
-                row_style,
-            ),
-        ]));
+        lines.push(session_row_line(
+            session,
+            i == app.sessions.selected,
+            chunks[1].width,
+        ));
     }
 
     let list = Paragraph::new(lines);
@@ -120,7 +93,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
 /// Status glyph + color for a session row, in priority order: a running run
 /// outranks a pending question, which outranks a stale error from the last
 /// run — a session can usefully show only one at a time.
-fn status_glyph(session: &SessionSummary) -> (&'static str, Color) {
+pub(crate) fn status_glyph(session: &SessionSummary) -> (&'static str, Color) {
     if session.is_running {
         ("▶", colors::SUCCESS)
     } else if session.has_pending_question {
@@ -136,11 +109,141 @@ fn status_glyph(session: &SessionSummary) -> (&'static str, Color) {
 /// tags (`"completed"`, `"cancelled"`, `"error"`, …); matched case-insensitively
 /// and loosely (`contains`) so a future `"error: timeout"`-style detail still
 /// lights the glyph.
-fn is_error_status(status: Option<&str>) -> bool {
+pub(crate) fn is_error_status(status: Option<&str>) -> bool {
     status.is_some_and(|s| {
         let s = s.to_ascii_lowercase();
         s.contains("error") || s.contains("fail")
     })
+}
+
+pub(crate) fn session_status_label(session: &SessionSummary) -> &'static str {
+    if session.is_running {
+        "running"
+    } else if session.has_pending_question {
+        "question"
+    } else if is_error_status(session.last_run_status.as_deref()) {
+        "error"
+    } else {
+        "idle"
+    }
+}
+
+fn session_header(width: u16) -> Line<'static> {
+    let label = if width >= 90 {
+        "   Title                          Model                 Msgs  Updated"
+    } else if width >= 60 {
+        "   Session                     Model / status"
+    } else {
+        "   Session"
+    };
+    Line::from(Span::styled(
+        label.to_string(),
+        Style::default().fg(colors::SUBTLE),
+    ))
+}
+
+/// Adaptive row shared by the full Sessions tab and the contextual overlay.
+/// Width is measured in terminal cells so long Unicode titles never shift the
+/// model/status columns or make a 60-column picker unusable.
+pub(crate) fn session_row_line(
+    session: &SessionSummary,
+    selected: bool,
+    width: u16,
+) -> Line<'static> {
+    let row_style = if selected {
+        Style::default()
+            .fg(colors::BRAND)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(colors::INACTIVE)
+    };
+    let title = if session.title.trim().is_empty() {
+        "(untitled)"
+    } else {
+        session.title.as_str()
+    };
+    let (glyph, glyph_color) = status_glyph(session);
+    let pin = if session.pinned { "★" } else { " " };
+    let marker = if selected { "›" } else { " " };
+
+    let body = if width >= 90 {
+        let updated = session
+            .updated_at
+            .map(|time| time.format("%m-%d %H:%M").to_string())
+            .unwrap_or_else(|| "-".to_string());
+        format!(
+            "{marker}{pin} {}  {}  {:>4}  {updated}",
+            truncate_cells(title, 30),
+            truncate_cells(&session.model, 20),
+            session.message_count,
+        )
+    } else if width >= 60 {
+        format!(
+            "{marker}{pin} {}  {} · {}",
+            truncate_cells(title, 24),
+            truncate_cells(&session.model, 16),
+            session_status_label(session),
+        )
+    } else if width >= 40 {
+        // Prefix + markers + separators + longest status + short id consume
+        // 28 cells. Give every remaining cell to the title so the row never
+        // wraps at the 60-column acceptance width (overlay row width: 52).
+        let available = width.saturating_sub(28) as usize;
+        let short_id = session.id.chars().take(8).collect::<String>();
+        format!(
+            "{marker}{pin} {} · {} · {short_id}",
+            truncate_cells(title, available.max(1)),
+            session_status_label(session),
+        )
+    } else if width >= 20 {
+        let available = width.saturating_sub(17) as usize;
+        format!(
+            "{marker}{pin} {} · {}",
+            truncate_cells(title, available.max(1)),
+            session_status_label(session),
+        )
+    } else {
+        let available = width.saturating_sub(6) as usize;
+        format!("{marker}{pin} {}", truncate_cells(title, available.max(1)),)
+    };
+
+    Line::from(vec![
+        Span::styled(format!(" {glyph} "), Style::default().fg(glyph_color)),
+        Span::styled(body, row_style),
+    ])
+}
+
+pub(crate) fn truncate_cells(value: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    let width = value
+        .chars()
+        .map(|character| UnicodeWidthChar::width(character).unwrap_or(0))
+        .sum::<usize>();
+    if width <= max_width {
+        let mut output = value.to_string();
+        output.extend(std::iter::repeat_n(' ', max_width - width));
+        return output;
+    }
+
+    let target = max_width.saturating_sub(1);
+    let mut output = String::new();
+    let mut used = 0;
+    for character in value.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if used + character_width > target {
+            break;
+        }
+        output.push(character);
+        used += character_width;
+    }
+    output.push('…');
+    while used + 1 < max_width {
+        output.push(' ');
+        used += 1;
+    }
+    output
 }
 
 #[cfg(test)]
@@ -191,6 +294,24 @@ mod tests {
         assert!(is_error_status(Some("FAILED")));
         assert!(!is_error_status(Some("completed")));
         assert!(!is_error_status(None));
+    }
+
+    #[test]
+    fn adaptive_unicode_rows_never_exceed_their_terminal_width() {
+        let mut s = session("session-12345678");
+        s.title = "很长的 Unicode 会话标题 with an even longer suffix".to_string();
+        s.model = "provider/model-with-a-long-identity".to_string();
+        s.is_running = true;
+        s.pinned = true;
+
+        for width in [18_u16, 32, 40, 52, 60, 90, 120] {
+            let line = session_row_line(&s, true, width);
+            assert!(
+                line.width() <= width as usize,
+                "row width {} exceeded terminal width {width}",
+                line.width()
+            );
+        }
     }
 
     /// Smoke test: the table renders with the new columns and page info without

--- a/crates/app/bamboo-tui/src/ui/sessions.rs
+++ b/crates/app/bamboo-tui/src/ui/sessions.rs
@@ -259,6 +259,8 @@ mod tests {
             title: String::new(),
             title_generated: true,
             model: String::new(),
+            model_ref: None,
+            provider: None,
             is_running: false,
             has_pending_question: false,
             last_run_status: None,


### PR DESCRIPTION
## Summary

- add reusable fuzzy-search behavior for contextual Session and Model overlays while preserving the underlying chat, draft, cursor, and scroll state
- lazily load bounded Session pages with stale-request protection, adaptive status rows, and contextual open, rename, pin/unpin, and delete actions
- use the canonical ETag/If-Match Session metadata PATCH flow and preserve recoverable 412 conflict and model update errors for retry
- group Models by current/recent/provider identity and keep filtering and selection stable for large catalogs

## Test Plan

- cargo fmt --all -- --check
- cargo clippy -p bamboo-tui --all-targets -- -D warnings
- cargo test -p bamboo-tui
- cargo test
- git diff --check

## Screenshots

Not applicable: terminal UI. Automated rendering tests cover adaptive 60-column layouts and Unicode cell widths.

Closes #636