### PR TITLE
feat(tui): add command palette and slash composer

### DIFF
--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -179,6 +179,61 @@ impl BambooClient {
         format!("{}{}", self.base_url, path)
     }
 
+    // ── Command catalog ──
+
+    /// List Bamboo's authoritative command catalog in the active Session's
+    /// Project/workspace scope. Omitting `session_id` intentionally requests
+    /// only the global catalog for a not-yet-created chat.
+    pub async fn list_commands(&self, session_id: Option<&str>) -> Result<CommandListResponse> {
+        let mut request = self.client.get(self.url("/api/v1/commands"));
+        if let Some(session_id) = session_id.filter(|value| !value.trim().is_empty()) {
+            request = request.query(&[("session_id", session_id)]);
+        }
+        let response = request.send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("list commands failed ({status}): {}", body.trim());
+        }
+        Ok(response.json().await?)
+    }
+
+    /// Resolve a prompt/workflow command into preview content. Path segments
+    /// are appended through `Url::path_segments_mut`, so namespaced prompt
+    /// names such as `db/migrate` remain one percent-encoded route parameter.
+    pub async fn get_command(
+        &self,
+        command_type: &str,
+        name: &str,
+        session_id: Option<&str>,
+        arguments: Option<&str>,
+    ) -> Result<CommandDetail> {
+        let mut url = reqwest::Url::parse(&self.base_url)?;
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| anyhow::anyhow!("Bamboo base URL cannot contain command paths"))?;
+            segments.pop_if_empty();
+            segments.extend(["api", "v1", "commands", command_type, name]);
+        }
+        {
+            let mut query = url.query_pairs_mut();
+            if let Some(session_id) = session_id.filter(|value| !value.trim().is_empty()) {
+                query.append_pair("session_id", session_id);
+            }
+            if let Some(arguments) = arguments.filter(|value| !value.is_empty()) {
+                query.append_pair("arguments", arguments);
+            }
+        }
+        let response = self.client.get(url).send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("resolve command failed ({status}): {}", body.trim());
+        }
+        Ok(response.json().await?)
+    }
+
     // ── Chat ──
 
     pub async fn chat(&self, req: ChatRequest) -> Result<ChatResponse> {
@@ -751,6 +806,72 @@ mod tests {
             let error = parse_auto_resume_status(body).unwrap_err();
             assert!(error.should_refresh_question(), "body: {body}");
         }
+    }
+
+    #[tokio::test]
+    async fn command_catalog_is_session_scoped() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut socket).await;
+            assert!(request.starts_with("GET /api/v1/commands?session_id=session-1 HTTP/1.1"));
+            respond(
+                &mut socket,
+                "200 OK",
+                "\"1\"",
+                r#"{"commands":[{"id":"command-workspace-review","name":"review","display_name":"Review","description":"Review changes","type":"prompt","metadata":{"source":"workspace"}}],"total":1}"#,
+            )
+            .await;
+        });
+
+        let catalog = BambooClient::new(&base_url)
+            .list_commands(Some("session-1"))
+            .await
+            .unwrap();
+
+        assert_eq!(catalog.total, 1);
+        assert_eq!(catalog.commands[0].name, "review");
+        assert_eq!(catalog.commands[0].metadata["source"], "workspace");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn command_resolution_encodes_namespaces_and_arguments() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut socket).await;
+            let path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .unwrap();
+            assert!(path.starts_with("/api/v1/commands/prompt/db%2Fmigrate?"));
+            assert!(path.contains("session_id=session-1"));
+            assert!(path.contains("arguments=production+now"));
+            respond(
+                &mut socket,
+                "200 OK",
+                "\"1\"",
+                r#"{"id":"command-workspace-db-migrate","name":"db/migrate","content":"Migrate production now","type":"prompt"}"#,
+            )
+            .await;
+        });
+
+        let detail = BambooClient::new(&base_url)
+            .get_command(
+                "prompt",
+                "db/migrate",
+                Some("session-1"),
+                Some("production now"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(detail.content, "Migrate production now");
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -25,6 +25,49 @@ pub use bamboo_client_core::{
     AgentEvent, ChatRequest, ChatResponse, ExecuteRequest, ExecuteResponse, TokenUsage,
 };
 
+// ── Command catalog ──
+
+/// One entry from the session-aware `GET /api/v1/commands` catalog.
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct CommandItem {
+    pub id: String,
+    pub name: String,
+    pub display_name: String,
+    pub description: String,
+    #[serde(rename = "type")]
+    pub command_type: String,
+    #[serde(default)]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct CommandListResponse {
+    #[serde(default)]
+    pub commands: Vec<CommandItem>,
+    #[serde(default)]
+    pub total: usize,
+}
+
+/// The content-bearing subset returned by prompt/workflow command resolution.
+/// Skill and MCP entries deliberately never use this endpoint in the TUI.
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct CommandDetail {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub content: String,
+    #[serde(rename = "type", default)]
+    pub command_type: String,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
 // ── Sessions ──
 
 /// Subset of the server's `SessionSummary` (see

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -1,5 +1,5 @@
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -12,7 +12,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, watch};
-use tui_textarea::TextArea;
+use tui_textarea::{CursorMove, TextArea};
 
 use crate::api::sse::{SessionSseEvent, SseStream};
 use crate::api::types::*;
@@ -716,6 +716,298 @@ impl SessionPicker {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommandPaletteTrigger {
+    Slash,
+    Global,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BuiltinPaletteAction {
+    NewSession,
+    OpenSession,
+    SelectModel,
+    Help,
+    Notifications,
+    Stop,
+    ToggleDetails,
+    Config,
+    Schedules,
+}
+
+impl BuiltinPaletteAction {
+    fn key(self) -> &'static str {
+        match self {
+            Self::NewSession => "new-session",
+            Self::OpenSession => "open-session",
+            Self::SelectModel => "select-model",
+            Self::Help => "help",
+            Self::Notifications => "notifications",
+            Self::Stop => "stop",
+            Self::ToggleDetails => "toggle-details",
+            Self::Config => "config",
+            Self::Schedules => "schedules",
+        }
+    }
+
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::NewSession => "New session",
+            Self::OpenSession => "Open session",
+            Self::SelectModel => "Select model",
+            Self::Help => "Show help",
+            Self::Notifications => "Show notifications",
+            Self::Stop => "Stop active run",
+            Self::ToggleDetails => "Toggle tool details",
+            Self::Config => "Open config",
+            Self::Schedules => "Open schedules",
+        }
+    }
+
+    pub(crate) fn description(self) -> &'static str {
+        match self {
+            Self::NewSession => "Clear conversation state and start a fresh session",
+            Self::OpenSession => "Search and resume an existing session",
+            Self::SelectModel => "Choose a provider-qualified model",
+            Self::Help => "Show all TUI keyboard shortcuts",
+            Self::Notifications => "Review recent status, warning, and error messages",
+            Self::Stop => "Request cancellation of the currently running agent",
+            Self::ToggleDetails => "Expand or collapse tool arguments and results",
+            Self::Config => "Switch to the configuration tab",
+            Self::Schedules => "Switch to the schedules tab",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum CommandPaletteEntry {
+    Builtin(BuiltinPaletteAction),
+    Server(CommandItem),
+}
+
+impl CommandPaletteEntry {
+    pub(crate) fn key(&self) -> String {
+        match self {
+            Self::Builtin(action) => format!("builtin:{}", action.key()),
+            Self::Server(command) => format!(
+                "server:{}:{}",
+                command.command_type.to_lowercase(),
+                command.name
+            ),
+        }
+    }
+
+    pub(crate) fn display_name(&self) -> &str {
+        match self {
+            Self::Builtin(action) => action.name(),
+            Self::Server(command) if command.display_name.trim().is_empty() => &command.name,
+            Self::Server(command) => &command.display_name,
+        }
+    }
+
+    pub(crate) fn description(&self) -> &str {
+        match self {
+            Self::Builtin(action) => action.description(),
+            Self::Server(command) => &command.description,
+        }
+    }
+
+    pub(crate) fn type_label(&self) -> &str {
+        match self {
+            Self::Builtin(_) => "ui",
+            Self::Server(command) => &command.command_type,
+        }
+    }
+
+    pub(crate) fn source_label(&self) -> &str {
+        match self {
+            Self::Builtin(_) => "builtin",
+            Self::Server(command) => command
+                .metadata
+                .get("source")
+                .and_then(serde_json::Value::as_str)
+                .or_else(|| {
+                    command
+                        .metadata
+                        .get("serverId")
+                        .and_then(serde_json::Value::as_str)
+                })
+                .filter(|source| !source.trim().is_empty())
+                .unwrap_or("server"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ComposerSnapshot {
+    lines: Vec<String>,
+    cursor: (usize, usize),
+}
+
+impl ComposerSnapshot {
+    fn capture(textarea: &TextArea<'_>) -> Self {
+        Self {
+            lines: textarea.lines().to_vec(),
+            cursor: textarea.cursor(),
+        }
+    }
+
+    fn still_matches(&self, textarea: &TextArea<'_>) -> bool {
+        self.lines == textarea.lines() && self.cursor == textarea.cursor()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommandPaletteHitbox {
+    pub index: usize,
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+impl CommandPaletteHitbox {
+    fn contains(&self, column: u16, row: u16) -> bool {
+        column >= self.x
+            && column < self.x.saturating_add(self.width)
+            && row >= self.y
+            && row < self.y.saturating_add(self.height)
+    }
+}
+
+pub struct CommandPalette {
+    pub epoch: u64,
+    pub session_id: Option<String>,
+    pub trigger: CommandPaletteTrigger,
+    /// Search text without the leading slash. For slash invocation, the first
+    /// whitespace-delimited token filters commands and the remainder is kept
+    /// as command arguments.
+    pub input: String,
+    pub entries: Vec<CommandPaletteEntry>,
+    pub visible: Vec<usize>,
+    pub selected: usize,
+    pub loading: bool,
+    pub resolving: bool,
+    pub resolving_key: Option<String>,
+    pub error: Option<String>,
+    pub original_composer: ComposerSnapshot,
+    pub hitboxes: RefCell<Vec<CommandPaletteHitbox>>,
+    pub mouse_pressed_item: Option<usize>,
+}
+
+impl CommandPalette {
+    fn selected_entry(&self) -> Option<&CommandPaletteEntry> {
+        self.visible
+            .get(self.selected)
+            .and_then(|index| self.entries.get(*index))
+    }
+
+    fn search_query(&self) -> &str {
+        match self.trigger {
+            CommandPaletteTrigger::Slash => slash_input_parts(&self.input).0,
+            CommandPaletteTrigger::Global => self.input.as_str(),
+        }
+    }
+
+    fn arguments(&self) -> &str {
+        match self.trigger {
+            CommandPaletteTrigger::Slash => slash_input_parts(&self.input).1,
+            CommandPaletteTrigger::Global => "",
+        }
+    }
+
+    fn refresh_filter(&mut self, preserve_key: Option<String>) {
+        self.visible = ranked_indices(&self.entries, self.search_query(), command_search_text);
+        self.selected = preserve_key
+            .and_then(|key| {
+                self.visible.iter().position(|index| {
+                    self.entries
+                        .get(*index)
+                        .is_some_and(|entry| entry.key() == key)
+                })
+            })
+            .unwrap_or(0)
+            .min(self.visible.len().saturating_sub(1));
+    }
+}
+
+fn slash_input_parts(input: &str) -> (&str, &str) {
+    let query_end = input
+        .char_indices()
+        .find_map(|(index, character)| character.is_whitespace().then_some(index))
+        .unwrap_or(input.len());
+    let arguments = input[query_end..].trim_start_matches(char::is_whitespace);
+    (&input[..query_end], arguments)
+}
+
+fn command_search_text(entry: &CommandPaletteEntry) -> String {
+    match entry {
+        CommandPaletteEntry::Builtin(action) => format!(
+            "{} {} ui builtin {}",
+            action.name(),
+            action.description(),
+            action.key()
+        ),
+        CommandPaletteEntry::Server(command) => format!(
+            "{} {} {} {} {} {} {} {} {}",
+            command.name,
+            command.display_name,
+            command.description,
+            command.command_type,
+            command
+                .metadata
+                .get("source")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default(),
+            command
+                .metadata
+                .get("serverId")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default(),
+            command
+                .metadata
+                .get("originalName")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default(),
+            command.category.as_deref().unwrap_or_default(),
+            command.tags.as_deref().unwrap_or_default().join(" ")
+        ),
+    }
+}
+
+fn builtin_command_palette_entries() -> Vec<CommandPaletteEntry> {
+    [
+        BuiltinPaletteAction::NewSession,
+        BuiltinPaletteAction::OpenSession,
+        BuiltinPaletteAction::SelectModel,
+        BuiltinPaletteAction::Help,
+        BuiltinPaletteAction::Notifications,
+        BuiltinPaletteAction::Stop,
+        BuiltinPaletteAction::ToggleDetails,
+        BuiltinPaletteAction::Config,
+        BuiltinPaletteAction::Schedules,
+    ]
+    .into_iter()
+    .map(CommandPaletteEntry::Builtin)
+    .collect()
+}
+
+/// Merge defensively while preserving the server's first-wins order. The
+/// server already applies workspace > Project > global > preset > catalog >
+/// MCP precedence; keeping the first `(type, name)` prevents a malformed or
+/// mixed-version response from undoing that choice in the TUI.
+fn merged_command_palette_entries(commands: Vec<CommandItem>) -> Vec<CommandPaletteEntry> {
+    let mut entries = builtin_command_palette_entries();
+    let mut seen = HashSet::new();
+    for command in commands {
+        let key = (command.command_type.to_lowercase(), command.name.clone());
+        if seen.insert(key) {
+            entries.push(CommandPaletteEntry::Server(command));
+        }
+    }
+    entries
+}
+
 const MAX_SESSION_PICKER_SESSIONS: usize = 1_000;
 const MAX_RECENT_MODELS: usize = 8;
 
@@ -986,6 +1278,11 @@ pub struct App {
     /// Sessions management tab, closing this overlay leaves the transcript,
     /// composer draft/cursor, and scroll position untouched.
     pub session_picker: Option<SessionPicker>,
+    /// Combined built-in/server command palette (`Ctrl+K` globally or `/` as
+    /// the first composer character). It never mutates the composer until a
+    /// selection succeeds, so cancellation and every async failure preserve
+    /// the exact draft and cursor beneath it.
+    pub command_palette: Option<CommandPalette>,
     /// Pending session-delete confirmation (Sessions tab, `d`): `(id, title)`
     /// of the session awaiting `y`/Enter confirm or `n`/Esc cancel. Kept as a
     /// modal (rather than deleting immediately) so a stray `d` can't destroy a
@@ -1031,6 +1328,8 @@ pub struct App {
     picker_epoch: u64,
     model_picker_task: Option<tokio::task::JoinHandle<()>>,
     session_picker_task: Option<tokio::task::JoinHandle<()>>,
+    command_palette_epoch: u64,
+    command_palette_task: Option<tokio::task::JoinHandle<()>>,
     recent_models: VecDeque<(String, String)>,
     /// Sender into the main event loop, used to post results of background API
     /// calls (so those calls never block the UI thread). Set in [`run`].
@@ -1084,6 +1383,15 @@ fn question_option_at(question: &ActiveQuestion, column: u16, row: u16) -> Optio
         .map(|hitbox| hitbox.index)
 }
 
+fn command_palette_item_at(palette: &CommandPalette, column: u16, row: u16) -> Option<usize> {
+    palette
+        .hitboxes
+        .borrow()
+        .iter()
+        .find(|hitbox| hitbox.contains(column, row))
+        .map(|hitbox| hitbox.index)
+}
+
 /// Copy text through the terminal-standard OSC 52 clipboard sequence. The
 /// payload is base64 encoded, so arbitrary Unicode and line breaks remain
 /// exact and never terminate the control sequence early.
@@ -1118,6 +1426,7 @@ impl App {
             config_editor: None,
             model_picker: None,
             session_picker: None,
+            command_palette: None,
             pending_delete: None,
             deleting_session_id: None,
             notifications: Vec::new(),
@@ -1131,6 +1440,8 @@ impl App {
             picker_epoch: 0,
             model_picker_task: None,
             session_picker_task: None,
+            command_palette_epoch: 0,
+            command_palette_task: None,
             recent_models: VecDeque::new(),
             event_tx: None,
             sse_tx: None,
@@ -1440,6 +1751,7 @@ impl App {
             AppEvent::ChatStarted(r) => match r {
                 Ok(session_id) => {
                     self.chat.session_id = Some(session_id.clone());
+                    self.rebind_command_palette_to_active_session();
                     self.status_message = "Streaming...".to_string();
                     self.start_stream_and_execute(session_id);
                 }
@@ -1493,6 +1805,7 @@ impl App {
                         }
                         self.close_session_picker();
                         self.close_model_picker();
+                        self.close_command_palette();
                         // Reset every per-run scratch field `finalize_streaming`
                         // would otherwise leave behind from whatever was open
                         // before — a resumed session must not inherit stale
@@ -1784,6 +2097,105 @@ impl App {
                             q.error = Some(message.clone());
                         }
                         self.notify(NoticeLevel::Error, format!("Answer rejected: {message}"));
+                    }
+                }
+            }
+            AppEvent::CommandCatalogLoaded {
+                epoch,
+                session_id,
+                result,
+            } => {
+                let current_session = self.chat.session_id.clone();
+                let selected_key = self
+                    .command_palette
+                    .as_ref()
+                    .filter(|palette| {
+                        palette.epoch == epoch
+                            && palette.session_id == session_id
+                            && current_session == session_id
+                    })
+                    .and_then(CommandPalette::selected_entry)
+                    .map(CommandPaletteEntry::key);
+                let Some(palette) = self.command_palette.as_mut().filter(|palette| {
+                    palette.epoch == epoch
+                        && palette.session_id == session_id
+                        && current_session == session_id
+                }) else {
+                    return Ok(());
+                };
+                self.command_palette_task = None;
+                palette.loading = false;
+                match result {
+                    Ok(catalog) => {
+                        palette.entries = merged_command_palette_entries(catalog.commands);
+                        palette.error = None;
+                        palette.refresh_filter(selected_key);
+                    }
+                    Err(error) => {
+                        palette.error = Some(format!(
+                            "Failed to load commands: {error} — press Ctrl+R to retry"
+                        ));
+                    }
+                }
+            }
+            AppEvent::CommandResolved {
+                epoch,
+                session_id,
+                command_key,
+                result,
+            } => {
+                let current_session = self.chat.session_id.clone();
+                let Some(palette) = self.command_palette.as_mut().filter(|palette| {
+                    palette.epoch == epoch
+                        && palette.session_id == session_id
+                        && current_session == session_id
+                        && palette.resolving_key.as_deref() == Some(command_key.as_str())
+                }) else {
+                    return Ok(());
+                };
+                self.command_palette_task = None;
+                palette.resolving = false;
+                palette.resolving_key = None;
+                match result {
+                    Ok(detail) => {
+                        if !palette.original_composer.still_matches(&self.chat.textarea) {
+                            palette.error = Some(
+                                "Composer changed while resolving; draft was not replaced"
+                                    .to_string(),
+                            );
+                            return Ok(());
+                        }
+                        let selected_type = palette
+                            .entries
+                            .iter()
+                            .find(|entry| entry.key() == command_key)
+                            .and_then(|entry| match entry {
+                                CommandPaletteEntry::Server(command) => {
+                                    Some(command.command_type.as_str())
+                                }
+                                CommandPaletteEntry::Builtin(_) => None,
+                            });
+                        let arguments = palette.arguments().to_string();
+                        let mut content = detail.content;
+                        if selected_type.is_some_and(|kind| kind.eq_ignore_ascii_case("workflow"))
+                            && !arguments.is_empty()
+                        {
+                            if !content.is_empty() {
+                                content.push_str("\n\n");
+                            }
+                            content.push_str(&arguments);
+                        }
+                        self.install_command_draft(content);
+                        self.tab = Tab::Chat;
+                        self.close_command_palette();
+                        self.status_message =
+                            "Command loaded into composer — review and press Enter to send"
+                                .to_string();
+                    }
+                    Err(error) => {
+                        palette.error = Some(format!(
+                            "Failed to resolve command: {error} — press Enter to retry"
+                        ));
                     }
                 }
             }
@@ -2245,6 +2657,47 @@ impl App {
             return;
         }
 
+        if self.command_palette.is_some() {
+            let mut activate = false;
+            {
+                let palette = self.command_palette.as_mut().unwrap();
+                if palette.resolving {
+                    return;
+                }
+                match mouse.kind {
+                    MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+                        let delta = if matches!(mouse.kind, MouseEventKind::ScrollUp) {
+                            -3
+                        } else {
+                            3
+                        };
+                        palette.selected =
+                            scroll_selection(palette.selected, palette.visible.len(), delta);
+                        palette.mouse_pressed_item = None;
+                    }
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        palette.mouse_pressed_item =
+                            command_palette_item_at(palette, mouse.column, mouse.row);
+                    }
+                    MouseEventKind::Up(MouseButton::Left) => {
+                        let pressed = palette.mouse_pressed_item.take();
+                        if let Some(index) =
+                            command_palette_item_at(palette, mouse.column, mouse.row)
+                                .filter(|index| Some(*index) == pressed)
+                        {
+                            palette.selected = index.min(palette.visible.len().saturating_sub(1));
+                            activate = true;
+                        }
+                    }
+                    _ => palette.mouse_pressed_item = None,
+                }
+            }
+            if activate {
+                self.activate_command_palette_selection();
+            }
+            return;
+        }
+
         let delta: i32 = match mouse.kind {
             MouseEventKind::ScrollUp => -3,
             MouseEventKind::ScrollDown => 3,
@@ -2341,6 +2794,7 @@ impl App {
             || self.pending_delete.is_some()
             || self.session_picker.is_some()
             || self.model_picker.is_some()
+            || self.command_palette.is_some()
             || self.schedule_form.is_some()
             || self.config_editor.is_some()
     }
@@ -2356,8 +2810,9 @@ impl App {
     ///   2. `pending_delete`   — session delete confirmation
     ///   3. `session_picker`   — Ctrl+P contextual session picker
     ///   4. `model_picker`     — Ctrl+O provider-catalog picker
-    ///   5. `schedule_form`    — new-schedule authoring form
-    ///   6. `config_editor`    — raw config JSON editor
+    ///   5. `command_palette`  — Ctrl+K global or slash composer palette
+    ///   6. `schedule_form`    — new-schedule authoring form
+    ///   7. `config_editor`    — raw config JSON editor
     ///
     /// Runtime modals can coexist in state because a clarification arrives
     /// asynchronously. The renderer layers them in the reverse order below,
@@ -2437,7 +2892,13 @@ impl App {
             return self.handle_model_picker_key(key).await;
         }
 
-        // 5. The schedule-authoring modal likewise captures all input: Tab moves
+        // 5. The command palette owns query/argument editing and selection.
+        if self.command_palette.is_some() {
+            self.handle_command_palette_key(key);
+            return Ok(());
+        }
+
+        // 6. The schedule-authoring modal likewise captures all input: Tab moves
         // between fields and digits belong in cron expressions, so it must run
         // before the global Tab/1-6 tab-switching below (which would otherwise
         // swallow those keys and never reach the form).
@@ -2446,7 +2907,7 @@ impl App {
             return Ok(());
         }
 
-        // 6. The config editor is a full multi-line text buffer, so it must claim
+        // 7. The config editor is a full multi-line text buffer, so it must claim
         // every key (digits, Tab, Enter/newlines) before the global navigation
         // below — same rationale as the schedule form.
         if self.config_editor.is_some() {
@@ -2459,6 +2920,10 @@ impl App {
         // the "no modal open" requirement for Ctrl+N specifically.
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             match key.code {
+                KeyCode::Char('k') => {
+                    self.open_command_palette(CommandPaletteTrigger::Global);
+                    return Ok(());
+                }
                 KeyCode::Char('n') if !self.chat.streaming => {
                     self.new_session();
                     return Ok(());
@@ -3302,6 +3767,14 @@ impl App {
         }
 
         match key.code {
+            KeyCode::Char('/')
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                    && self.chat.textarea.cursor() == (0, 0) =>
+            {
+                self.open_command_palette(CommandPaletteTrigger::Slash);
+            }
             // Alt+Enter (and Shift+Enter, on the kitty-protocol terminals
             // that report it — plain crossterm terminals mostly don't, so
             // this arm is harmless there) inserts a newline instead of
@@ -3589,6 +4062,7 @@ impl App {
     /// membership (the operator picked both deliberately) while dropping
     /// per-session conversation state.
     fn new_session(&mut self) {
+        self.close_command_palette();
         self.stash_question_drafts();
         self.detach_stream();
         self.opening_session_id = None;
@@ -4940,6 +5414,485 @@ impl App {
         }));
     }
 
+    // ── Discoverable command palette (Ctrl+K or leading slash) ──
+
+    fn open_command_palette(&mut self, trigger: CommandPaletteTrigger) {
+        if let Some(task) = self.command_palette_task.take() {
+            task.abort();
+        }
+        self.command_palette_epoch = self.command_palette_epoch.wrapping_add(1);
+        let epoch = self.command_palette_epoch;
+        let mut palette = CommandPalette {
+            epoch,
+            session_id: self.chat.session_id.clone(),
+            trigger,
+            input: String::new(),
+            entries: builtin_command_palette_entries(),
+            visible: Vec::new(),
+            selected: 0,
+            loading: true,
+            resolving: false,
+            resolving_key: None,
+            error: None,
+            original_composer: ComposerSnapshot::capture(&self.chat.textarea),
+            hitboxes: RefCell::new(Vec::new()),
+            mouse_pressed_item: None,
+        };
+        palette.refresh_filter(None);
+        self.help_visible = false;
+        self.notifications_visible = false;
+        self.command_palette = Some(palette);
+        self.load_command_catalog(epoch);
+    }
+
+    fn load_command_catalog(&mut self, epoch: u64) {
+        if let Some(task) = self.command_palette_task.take() {
+            task.abort();
+        }
+        let Some(session_id) = self
+            .command_palette
+            .as_ref()
+            .filter(|palette| palette.epoch == epoch)
+            .map(|palette| palette.session_id.clone())
+        else {
+            return;
+        };
+        let Some(tx) = self.event_tx.clone() else {
+            if let Some(palette) = self.command_palette.as_mut() {
+                palette.loading = false;
+                palette.error = Some(
+                    "Command palette is not attached to an event loop; built-ins remain available"
+                        .to_string(),
+                );
+            }
+            return;
+        };
+        if let Some(palette) = self.command_palette.as_mut() {
+            palette.loading = true;
+            palette.error = None;
+        }
+        let client = self.client.clone();
+        self.command_palette_task = Some(tokio::spawn(async move {
+            let result = client
+                .list_commands(session_id.as_deref())
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::CommandCatalogLoaded {
+                epoch,
+                session_id,
+                result,
+            });
+        }));
+    }
+
+    fn reload_command_catalog(&mut self) {
+        if let Some(task) = self.command_palette_task.take() {
+            task.abort();
+        }
+        let preserve_key = self
+            .command_palette
+            .as_ref()
+            .and_then(CommandPalette::selected_entry)
+            .map(CommandPaletteEntry::key);
+        self.command_palette_epoch = self.command_palette_epoch.wrapping_add(1);
+        let epoch = self.command_palette_epoch;
+        let Some(palette) = self.command_palette.as_mut() else {
+            return;
+        };
+        palette.epoch = epoch;
+        palette.entries = builtin_command_palette_entries();
+        palette.loading = true;
+        palette.resolving = false;
+        palette.resolving_key = None;
+        palette.error = None;
+        palette.mouse_pressed_item = None;
+        palette.refresh_filter(preserve_key);
+        self.load_command_catalog(epoch);
+    }
+
+    /// A palette opened before a newly-created Session receives its id must
+    /// not install the global catalog into that Session context. Keep the
+    /// built-ins and query visible while starting a fresh scoped request.
+    fn rebind_command_palette_to_active_session(&mut self) {
+        let current_session = self.chat.session_id.clone();
+        let changed = self
+            .command_palette
+            .as_ref()
+            .is_some_and(|palette| palette.session_id != current_session);
+        if !changed {
+            return;
+        }
+        if let Some(task) = self.command_palette_task.take() {
+            task.abort();
+        }
+        let preserve_key = self
+            .command_palette
+            .as_ref()
+            .and_then(CommandPalette::selected_entry)
+            .filter(|entry| matches!(entry, CommandPaletteEntry::Builtin(_)))
+            .map(CommandPaletteEntry::key);
+        self.command_palette_epoch = self.command_palette_epoch.wrapping_add(1);
+        let epoch = self.command_palette_epoch;
+        let Some(palette) = self.command_palette.as_mut() else {
+            return;
+        };
+        palette.epoch = epoch;
+        palette.session_id = current_session;
+        palette.entries = builtin_command_palette_entries();
+        palette.loading = true;
+        palette.resolving = false;
+        palette.resolving_key = None;
+        palette.error = None;
+        palette.mouse_pressed_item = None;
+        palette.refresh_filter(preserve_key);
+        self.load_command_catalog(epoch);
+    }
+
+    fn close_command_palette(&mut self) {
+        if let Some(task) = self.command_palette_task.take() {
+            task.abort();
+        }
+        self.command_palette_epoch = self.command_palette_epoch.wrapping_add(1);
+        self.command_palette = None;
+    }
+
+    fn handle_command_palette_key(&mut self, key: KeyEvent) {
+        let resolving = self
+            .command_palette
+            .as_ref()
+            .is_some_and(|palette| palette.resolving);
+        if resolving {
+            if key.code == KeyCode::Esc {
+                self.close_command_palette();
+            }
+            return;
+        }
+
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            match key.code {
+                KeyCode::Char('k') => {
+                    self.close_command_palette();
+                    return;
+                }
+                KeyCode::Char('u') => {
+                    if let Some(palette) = self.command_palette.as_mut() {
+                        let preserve = palette.selected_entry().map(CommandPaletteEntry::key);
+                        palette.input.clear();
+                        palette.error = None;
+                        palette.refresh_filter(preserve);
+                    }
+                    return;
+                }
+                KeyCode::Char('r') => {
+                    if self
+                        .command_palette
+                        .as_ref()
+                        .is_some_and(|palette| !palette.loading)
+                    {
+                        self.reload_command_catalog();
+                    }
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        match key.code {
+            KeyCode::Up => {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    palette.selected = palette.selected.saturating_sub(1);
+                    palette.error = None;
+                }
+            }
+            KeyCode::Down => {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    if palette.selected + 1 < palette.visible.len() {
+                        palette.selected += 1;
+                    }
+                    palette.error = None;
+                }
+            }
+            KeyCode::PageUp => {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    palette.selected = palette.selected.saturating_sub(8);
+                    palette.error = None;
+                }
+            }
+            KeyCode::PageDown => {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    palette.selected = palette
+                        .selected
+                        .saturating_add(8)
+                        .min(palette.visible.len().saturating_sub(1));
+                    palette.error = None;
+                }
+            }
+            KeyCode::Home => {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    palette.selected = 0;
+                    palette.error = None;
+                }
+            }
+            KeyCode::End => {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    palette.selected = palette.visible.len().saturating_sub(1);
+                    palette.error = None;
+                }
+            }
+            KeyCode::Enter => self.activate_command_palette_selection(),
+            KeyCode::Esc => self.close_command_palette(),
+            KeyCode::Backspace => {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    let preserve = palette.selected_entry().map(CommandPaletteEntry::key);
+                    palette.input.pop();
+                    palette.error = None;
+                    palette.refresh_filter(preserve);
+                }
+            }
+            KeyCode::Char(character)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    let preserve = palette.selected_entry().map(CommandPaletteEntry::key);
+                    palette.input.push(character);
+                    palette.error = None;
+                    palette.refresh_filter(preserve);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn command_palette_disabled_reason(
+        &self,
+        entry: &CommandPaletteEntry,
+    ) -> Option<&'static str> {
+        match entry {
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::NewSession)
+            | CommandPaletteEntry::Builtin(BuiltinPaletteAction::OpenSession)
+            | CommandPaletteEntry::Builtin(BuiltinPaletteAction::SelectModel)
+                if self.chat.streaming =>
+            {
+                Some("Unavailable while an agent run is active")
+            }
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::NewSession)
+            | CommandPaletteEntry::Builtin(BuiltinPaletteAction::OpenSession)
+            | CommandPaletteEntry::Builtin(BuiltinPaletteAction::SelectModel)
+                if self.opening_session_id.is_some() =>
+            {
+                Some("Unavailable while a session is resuming")
+            }
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop) if !self.chat.streaming => {
+                Some("No active run to stop")
+            }
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::ToggleDetails)
+                if self.chat.current_tool_calls.is_empty()
+                    && self
+                        .chat
+                        .messages
+                        .iter()
+                        .all(|message| message.tool_calls.is_empty()) =>
+            {
+                Some("No tool details in this conversation")
+            }
+            CommandPaletteEntry::Server(_) if self.chat.streaming => {
+                Some("Composer commands are unavailable while a run is active")
+            }
+            CommandPaletteEntry::Server(_) if self.opening_session_id.is_some() => {
+                Some("Composer commands are unavailable while a session is resuming")
+            }
+            CommandPaletteEntry::Server(_)
+                if self.chat.session_id.as_ref().is_some_and(|session_id| {
+                    self.deleting_session_id.as_deref() == Some(session_id.as_str())
+                }) =>
+            {
+                Some("Composer commands are unavailable while the session is being deleted")
+            }
+            CommandPaletteEntry::Server(command)
+                if !matches!(
+                    command.command_type.to_ascii_lowercase().as_str(),
+                    "prompt" | "workflow" | "skill" | "mcp"
+                ) =>
+            {
+                Some("Unsupported server command type")
+            }
+            _ => None,
+        }
+    }
+
+    fn activate_command_palette_selection(&mut self) {
+        let Some(entry) = self
+            .command_palette
+            .as_ref()
+            .and_then(CommandPalette::selected_entry)
+            .cloned()
+        else {
+            if let Some(palette) = self.command_palette.as_mut() {
+                palette.error = Some(if palette.loading {
+                    "Commands are still loading".to_string()
+                } else {
+                    "No command matches the current query".to_string()
+                });
+            }
+            return;
+        };
+
+        if let Some(reason) = self.command_palette_disabled_reason(&entry) {
+            if let Some(palette) = self.command_palette.as_mut() {
+                palette.error = Some(reason.to_string());
+            }
+            return;
+        }
+
+        match entry {
+            CommandPaletteEntry::Builtin(action) => self.run_builtin_palette_action(action),
+            CommandPaletteEntry::Server(command) => {
+                match command.command_type.to_ascii_lowercase().as_str() {
+                    "prompt" | "workflow" => self.resolve_command_into_composer(command),
+                    "skill" | "mcp" => self.insert_slash_command(command),
+                    _ => {
+                        if let Some(palette) = self.command_palette.as_mut() {
+                            palette.error = Some("Unsupported server command type".to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn run_builtin_palette_action(&mut self, action: BuiltinPaletteAction) {
+        self.close_command_palette();
+        match action {
+            BuiltinPaletteAction::NewSession => self.new_session(),
+            BuiltinPaletteAction::OpenSession => {
+                self.tab = Tab::Chat;
+                self.open_session_picker();
+            }
+            BuiltinPaletteAction::SelectModel => {
+                self.tab = Tab::Chat;
+                self.open_model_picker();
+            }
+            BuiltinPaletteAction::Help => self.help_visible = true,
+            BuiltinPaletteAction::Notifications => {
+                self.notifications_visible = true;
+                self.unseen_alerts = 0;
+            }
+            BuiltinPaletteAction::Stop => self.stop_streaming(),
+            BuiltinPaletteAction::ToggleDetails => {
+                self.chat.expand_tools = !self.chat.expand_tools;
+                self.status_message = if self.chat.expand_tools {
+                    "Tool details expanded"
+                } else {
+                    "Tool details collapsed"
+                }
+                .to_string();
+            }
+            BuiltinPaletteAction::Config => {
+                self.tab = Tab::Config;
+                self.load_tab_data();
+            }
+            BuiltinPaletteAction::Schedules => {
+                self.tab = Tab::Schedules;
+                self.load_tab_data();
+            }
+        }
+    }
+
+    fn resolve_command_into_composer(&mut self, command: CommandItem) {
+        let Some(tx) = self.event_tx.clone() else {
+            if let Some(palette) = self.command_palette.as_mut() {
+                palette.error = Some(
+                    "Command resolution cannot run without the event loop; draft preserved"
+                        .to_string(),
+                );
+            }
+            return;
+        };
+        if let Some(task) = self.command_palette_task.take() {
+            task.abort();
+        }
+        self.command_palette_epoch = self.command_palette_epoch.wrapping_add(1);
+        let epoch = self.command_palette_epoch;
+        let Some(palette) = self.command_palette.as_mut() else {
+            return;
+        };
+        let session_id = palette.session_id.clone();
+        let arguments = palette.arguments().to_string();
+        let command_key = CommandPaletteEntry::Server(command.clone()).key();
+        palette.epoch = epoch;
+        palette.resolving = true;
+        palette.resolving_key = Some(command_key.clone());
+        palette.error = None;
+        let command_type = command.command_type.clone();
+        let command_name = command.name.clone();
+        let client = self.client.clone();
+        self.command_palette_task = Some(tokio::spawn(async move {
+            let result = client
+                .get_command(
+                    &command_type,
+                    &command_name,
+                    session_id.as_deref(),
+                    (!arguments.is_empty()).then_some(arguments.as_str()),
+                )
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::CommandResolved {
+                epoch,
+                session_id,
+                command_key,
+                result,
+            });
+        }));
+    }
+
+    fn insert_slash_command(&mut self, command: CommandItem) {
+        let Some(palette) = self.command_palette.as_ref() else {
+            return;
+        };
+        if !palette.original_composer.still_matches(&self.chat.textarea) {
+            if let Some(palette) = self.command_palette.as_mut() {
+                palette.error =
+                    Some("Composer changed while selecting; draft was not replaced".to_string());
+            }
+            return;
+        }
+        let arguments = palette.arguments();
+        let mut draft = format!("/{}", command.name.trim_start_matches('/'));
+        if !arguments.is_empty() {
+            draft.push(' ');
+            draft.push_str(arguments);
+        }
+        self.install_command_draft(draft);
+        self.tab = Tab::Chat;
+        self.close_command_palette();
+        self.status_message = match command.command_type.to_ascii_lowercase().as_str() {
+            "skill" => "Skill command inserted — review and press Enter to send",
+            "mcp" => "MCP command inserted — review and press Enter to send",
+            _ => "Command inserted — review and press Enter to send",
+        }
+        .to_string();
+    }
+
+    fn install_command_draft(&mut self, content: String) {
+        let lines = if content.is_empty() {
+            vec![String::new()]
+        } else {
+            content.split('\n').map(str::to_string).collect::<Vec<_>>()
+        };
+        let row = lines.len().saturating_sub(1).min(u16::MAX as usize) as u16;
+        let column = lines
+            .last()
+            .map(|line| line.chars().count())
+            .unwrap_or_default()
+            .min(u16::MAX as usize) as u16;
+        let mut textarea = TextArea::from(lines);
+        textarea.set_placeholder_text(CHAT_PLACEHOLDER);
+        textarea.move_cursor(CursorMove::Jump(row, column));
+        self.chat.textarea = textarea;
+    }
+
     // ── Searchable model picker (Ctrl+O) ──
 
     fn open_model_picker(&mut self) {
@@ -5146,6 +6099,511 @@ impl App {
         self.chat.provider = Some(model.reference.provider.clone());
         self.model_picker = None;
         self.status_message = format!("Model: {} ({provider_label})", model.display_name);
+    }
+}
+
+#[cfg(test)]
+mod command_palette_tests {
+    use super::*;
+    use crossterm::event::{
+        KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    };
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn modified_key(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    fn command(name: &str, command_type: &str, source: &str) -> CommandItem {
+        CommandItem {
+            id: format!("{command_type}-{source}-{name}"),
+            name: name.to_string(),
+            display_name: name.replace('-', " "),
+            description: format!("{source} {command_type} for {name}"),
+            command_type: command_type.to_string(),
+            category: None,
+            tags: None,
+            metadata: serde_json::json!({ "source": source }),
+        }
+    }
+
+    fn install_test_palette(
+        app: &mut App,
+        trigger: CommandPaletteTrigger,
+        input: &str,
+        entries: Vec<CommandPaletteEntry>,
+    ) {
+        app.command_palette_epoch = app.command_palette_epoch.wrapping_add(1);
+        let mut palette = CommandPalette {
+            epoch: app.command_palette_epoch,
+            session_id: app.chat.session_id.clone(),
+            trigger,
+            input: input.to_string(),
+            entries,
+            visible: Vec::new(),
+            selected: 0,
+            loading: false,
+            resolving: false,
+            resolving_key: None,
+            error: None,
+            original_composer: ComposerSnapshot::capture(&app.chat.textarea),
+            hitboxes: RefCell::new(Vec::new()),
+            mouse_pressed_item: None,
+        };
+        palette.refresh_filter(None);
+        app.command_palette = Some(palette);
+    }
+
+    #[tokio::test]
+    async fn leading_slash_opens_palette_and_escape_preserves_exact_composer() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.textarea.insert_str("draft text");
+        app.chat.textarea.move_cursor(CursorMove::Jump(0, 0));
+        let before = ComposerSnapshot::capture(&app.chat.textarea);
+
+        app.handle_chat_key(key(KeyCode::Char('/'))).await.unwrap();
+        assert_eq!(
+            app.command_palette.as_ref().map(|palette| palette.trigger),
+            Some(CommandPaletteTrigger::Slash)
+        );
+        app.handle_command_palette_key(key(KeyCode::Char('r')));
+        app.handle_command_palette_key(key(KeyCode::Char('e')));
+        app.handle_command_palette_key(key(KeyCode::Char('v')));
+        assert_eq!(app.command_palette.as_ref().unwrap().search_query(), "rev");
+        app.handle_command_palette_key(key(KeyCode::Esc));
+
+        assert!(app.command_palette.is_none());
+        assert!(before.still_matches(&app.chat.textarea));
+
+        app.chat.textarea.move_cursor(CursorMove::End);
+        app.handle_chat_key(key(KeyCode::Char('/'))).await.unwrap();
+        assert!(app.command_palette.is_none());
+        assert_eq!(app.chat.textarea.lines(), ["draft text/"]);
+    }
+
+    #[test]
+    fn slash_query_filters_live_while_preserving_arguments() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let entries = vec![
+            CommandPaletteEntry::Server(command("review", "prompt", "workspace")),
+            CommandPaletteEntry::Server(command("release", "workflow", "project")),
+        ];
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Slash,
+            "rv production now",
+            entries,
+        );
+
+        let palette = app.command_palette.as_ref().unwrap();
+        assert_eq!(palette.search_query(), "rv");
+        assert_eq!(palette.arguments(), "production now");
+        assert_eq!(palette.visible, [0]);
+        assert_eq!(palette.selected_entry().unwrap().display_name(), "review");
+    }
+
+    #[test]
+    fn server_source_precedence_is_first_wins_and_builtins_remain_distinct() {
+        let mut workspace = command("review", "prompt", "workspace");
+        workspace.description = "workspace winner".to_string();
+        let mut global = command("review", "prompt", "global");
+        global.description = "global duplicate".to_string();
+        let entries = merged_command_palette_entries(vec![
+            workspace,
+            global,
+            command("review", "workflow", "project"),
+        ]);
+
+        assert!(matches!(
+            entries.first(),
+            Some(CommandPaletteEntry::Builtin(_))
+        ));
+        let server = entries
+            .iter()
+            .filter_map(|entry| match entry {
+                CommandPaletteEntry::Server(command) => Some(command),
+                CommandPaletteEntry::Builtin(_) => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(server.len(), 2);
+        assert_eq!(server[0].description, "workspace winner");
+        assert_eq!(server[0].metadata["source"], "workspace");
+        assert_eq!(server[1].command_type, "workflow");
+    }
+
+    #[tokio::test]
+    async fn ctrl_k_is_global_and_stop_remains_available_while_streaming() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = Tab::Config;
+        app.chat.streaming = true;
+
+        app.handle_key(modified_key(KeyCode::Char('k'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        let palette = app.command_palette.as_mut().unwrap();
+        let stop = palette
+            .visible
+            .iter()
+            .position(|index| {
+                matches!(
+                    palette.entries.get(*index),
+                    Some(CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop))
+                )
+            })
+            .unwrap();
+        palette.selected = stop;
+
+        app.activate_command_palette_selection();
+        assert!(!app.chat.streaming);
+        assert!(app.command_palette.is_none());
+        assert_eq!(app.status_message, "Stopped");
+    }
+
+    #[tokio::test]
+    async fn catalog_failure_and_stale_epoch_leave_composer_and_palette_interactive() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-1".to_string());
+        app.chat.textarea.insert_str("keep this draft");
+        app.chat.textarea.move_cursor(CursorMove::Jump(0, 4));
+        let before = ComposerSnapshot::capture(&app.chat.textarea);
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Global,
+            "",
+            builtin_command_palette_entries(),
+        );
+        let epoch = app.command_palette.as_ref().unwrap().epoch;
+        app.command_palette.as_mut().unwrap().loading = true;
+
+        app.handle_event(AppEvent::CommandCatalogLoaded {
+            epoch,
+            session_id: Some("session-1".to_string()),
+            result: Err("offline".to_string()),
+        })
+        .await
+        .unwrap();
+        let palette = app.command_palette.as_ref().unwrap();
+        assert!(!palette.loading);
+        assert!(palette
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("offline")));
+        assert!(before.still_matches(&app.chat.textarea));
+
+        app.command_palette.as_mut().unwrap().epoch = epoch.wrapping_add(1);
+        app.handle_event(AppEvent::CommandCatalogLoaded {
+            epoch,
+            session_id: Some("session-1".to_string()),
+            result: Ok(CommandListResponse {
+                commands: vec![command("stale", "prompt", "global")],
+                total: 1,
+            }),
+        })
+        .await
+        .unwrap();
+        assert!(app
+            .command_palette
+            .as_ref()
+            .unwrap()
+            .entries
+            .iter()
+            .all(|entry| !matches!(entry, CommandPaletteEntry::Server(_))));
+        assert!(before.still_matches(&app.chat.textarea));
+    }
+
+    #[tokio::test]
+    async fn catalog_result_requires_the_same_active_session() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-1".to_string());
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Global,
+            "",
+            builtin_command_palette_entries(),
+        );
+        let epoch = app.command_palette.as_ref().unwrap().epoch;
+        app.command_palette.as_mut().unwrap().loading = true;
+        app.chat.session_id = Some("session-2".to_string());
+
+        app.handle_event(AppEvent::CommandCatalogLoaded {
+            epoch,
+            session_id: Some("session-1".to_string()),
+            result: Ok(CommandListResponse {
+                commands: vec![command("wrong-session", "prompt", "workspace")],
+                total: 1,
+            }),
+        })
+        .await
+        .unwrap();
+
+        let palette = app.command_palette.as_ref().unwrap();
+        assert!(palette.loading);
+        assert!(palette
+            .entries
+            .iter()
+            .all(|entry| !matches!(entry, CommandPaletteEntry::Server(_))));
+    }
+
+    #[tokio::test]
+    async fn catalog_refresh_preserves_selection_and_exposes_mcp_server_source() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-1".to_string());
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Global,
+            "",
+            builtin_command_palette_entries(),
+        );
+        let palette = app.command_palette.as_mut().unwrap();
+        palette.selected = palette
+            .visible
+            .iter()
+            .position(|index| {
+                matches!(
+                    palette.entries.get(*index),
+                    Some(CommandPaletteEntry::Builtin(BuiltinPaletteAction::Config))
+                )
+            })
+            .unwrap();
+        palette.loading = true;
+        let epoch = palette.epoch;
+        let selected_key = palette.selected_entry().unwrap().key();
+        let mut mcp = command("filesystem/read", "mcp", "unused");
+        mcp.metadata = serde_json::json!({
+            "serverId": "filesystem",
+            "originalName": "read_file"
+        });
+
+        app.handle_event(AppEvent::CommandCatalogLoaded {
+            epoch,
+            session_id: Some("session-1".to_string()),
+            result: Ok(CommandListResponse {
+                commands: vec![mcp],
+                total: 1,
+            }),
+        })
+        .await
+        .unwrap();
+
+        let palette = app.command_palette.as_ref().unwrap();
+        assert_eq!(palette.selected_entry().unwrap().key(), selected_key);
+        let mcp = palette
+            .entries
+            .iter()
+            .find(|entry| matches!(entry, CommandPaletteEntry::Server(_)))
+            .unwrap();
+        assert_eq!(mcp.source_label(), "filesystem");
+        assert!(command_search_text(mcp).contains("read_file"));
+    }
+
+    #[test]
+    fn active_session_rebind_reloads_scope_without_touching_draft_or_query() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.textarea.insert_str("exact draft");
+        app.chat.textarea.move_cursor(CursorMove::Jump(0, 5));
+        let before = ComposerSnapshot::capture(&app.chat.textarea);
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Global,
+            "config",
+            merged_command_palette_entries(vec![command("old", "prompt", "global")]),
+        );
+        let old_epoch = app.command_palette.as_ref().unwrap().epoch;
+        app.chat.session_id = Some("session-2".to_string());
+
+        app.rebind_command_palette_to_active_session();
+
+        let palette = app.command_palette.as_ref().unwrap();
+        assert_ne!(palette.epoch, old_epoch);
+        assert_eq!(palette.session_id.as_deref(), Some("session-2"));
+        assert_eq!(palette.input, "config");
+        assert!(palette
+            .entries
+            .iter()
+            .all(|entry| matches!(entry, CommandPaletteEntry::Builtin(_))));
+        assert!(before.still_matches(&app.chat.textarea));
+    }
+
+    #[tokio::test]
+    async fn workflow_resolution_populates_preview_and_never_auto_sends() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-1".to_string());
+        app.chat.textarea.insert_str("original");
+        app.chat.textarea.move_cursor(CursorMove::Jump(0, 3));
+        let workflow = command("release", "workflow", "project");
+        let entry = CommandPaletteEntry::Server(workflow.clone());
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Slash,
+            "release production now",
+            vec![entry.clone()],
+        );
+        let palette = app.command_palette.as_mut().unwrap();
+        palette.resolving = true;
+        palette.resolving_key = Some(entry.key());
+        let epoch = palette.epoch;
+
+        app.handle_event(AppEvent::CommandResolved {
+            epoch,
+            session_id: Some("session-1".to_string()),
+            command_key: entry.key(),
+            result: Ok(CommandDetail {
+                id: workflow.id,
+                name: workflow.name,
+                content: "Review the release plan".to_string(),
+                command_type: "workflow".to_string(),
+                metadata: serde_json::Value::Null,
+            }),
+        })
+        .await
+        .unwrap();
+
+        assert!(app.command_palette.is_none());
+        assert_eq!(
+            app.chat.textarea.lines(),
+            ["Review the release plan", "", "production now"]
+        );
+        assert!(!app.chat.streaming);
+        assert!(app.chat.messages.is_empty());
+        assert!(app.status_message.contains("review and press Enter"));
+    }
+
+    #[tokio::test]
+    async fn stale_resolution_cannot_replace_draft() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-1".to_string());
+        app.chat.textarea.insert_str("untouched");
+        let before = ComposerSnapshot::capture(&app.chat.textarea);
+        let prompt = command("review", "prompt", "workspace");
+        let entry = CommandPaletteEntry::Server(prompt.clone());
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Slash,
+            "review",
+            vec![entry.clone()],
+        );
+        let palette = app.command_palette.as_mut().unwrap();
+        palette.resolving = true;
+        palette.resolving_key = Some(entry.key());
+        let stale_epoch = palette.epoch;
+        palette.epoch = stale_epoch.wrapping_add(1);
+
+        app.handle_event(AppEvent::CommandResolved {
+            epoch: stale_epoch,
+            session_id: Some("session-1".to_string()),
+            command_key: entry.key(),
+            result: Ok(CommandDetail {
+                id: prompt.id,
+                name: prompt.name,
+                content: "must not land".to_string(),
+                command_type: "prompt".to_string(),
+                metadata: serde_json::Value::Null,
+            }),
+        })
+        .await
+        .unwrap();
+
+        assert!(before.still_matches(&app.chat.textarea));
+        assert!(app.command_palette.is_some());
+    }
+
+    #[tokio::test]
+    async fn resolution_failure_keeps_exact_draft_and_returns_to_editing() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-1".to_string());
+        app.chat.textarea.insert_str("keep me");
+        app.chat.textarea.move_cursor(CursorMove::Jump(0, 2));
+        let before = ComposerSnapshot::capture(&app.chat.textarea);
+        let prompt = command("review", "prompt", "workspace");
+        let entry = CommandPaletteEntry::Server(prompt);
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Slash,
+            "review src",
+            vec![entry.clone()],
+        );
+        let palette = app.command_palette.as_mut().unwrap();
+        palette.resolving = true;
+        palette.resolving_key = Some(entry.key());
+        let epoch = palette.epoch;
+
+        app.handle_event(AppEvent::CommandResolved {
+            epoch,
+            session_id: Some("session-1".to_string()),
+            command_key: entry.key(),
+            result: Err("server unavailable".to_string()),
+        })
+        .await
+        .unwrap();
+
+        let palette = app.command_palette.as_ref().unwrap();
+        assert!(!palette.resolving);
+        assert!(palette
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("server unavailable")));
+        assert!(before.still_matches(&app.chat.textarea));
+        app.handle_command_palette_key(key(KeyCode::Backspace));
+        assert_eq!(app.command_palette.as_ref().unwrap().input, "review sr");
+    }
+
+    #[test]
+    fn skill_and_mcp_selection_only_insert_existing_slash_semantics() {
+        for command_type in ["skill", "mcp"] {
+            let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+            let server = command("inspect", command_type, "server");
+            install_test_palette(
+                &mut app,
+                CommandPaletteTrigger::Slash,
+                "inspect src/main.rs",
+                vec![CommandPaletteEntry::Server(server)],
+            );
+
+            app.activate_command_palette_selection();
+
+            assert_eq!(app.chat.textarea.lines(), ["/inspect src/main.rs"]);
+            assert!(!app.chat.streaming);
+            assert!(app.chat.messages.is_empty());
+            assert!(app.command_palette.is_none());
+        }
+    }
+
+    #[test]
+    fn mouse_click_activates_the_same_selected_entry_as_keyboard() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Global,
+            "",
+            vec![CommandPaletteEntry::Builtin(BuiltinPaletteAction::Help)],
+        );
+        app.command_palette
+            .as_ref()
+            .unwrap()
+            .hitboxes
+            .borrow_mut()
+            .push(CommandPaletteHitbox {
+                index: 0,
+                x: 10,
+                y: 5,
+                width: 20,
+                height: 2,
+            });
+        let mouse = |kind| MouseEvent {
+            kind,
+            column: 12,
+            row: 6,
+            modifiers: KeyModifiers::empty(),
+        };
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left)));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left)));
+
+        assert!(app.command_palette.is_none());
+        assert!(app.help_visible);
     }
 }
 

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -917,6 +917,10 @@ impl CommandPalette {
     }
 
     fn refresh_filter(&mut self, preserve_key: Option<String>) {
+        // A pointer press is tied to the exact rendered result set. Any
+        // catalog or query change invalidates those visible indices before a
+        // later mouse-up can activate a different command in the same row.
+        self.mouse_pressed_item = None;
         self.visible = ranked_indices(&self.entries, self.search_query(), command_search_text);
         self.selected = preserve_key
             .and_then(|key| {
@@ -2125,6 +2129,7 @@ impl App {
                 };
                 self.command_palette_task = None;
                 palette.loading = false;
+                palette.mouse_pressed_item = None;
                 match result {
                     Ok(catalog) => {
                         palette.entries = merged_command_palette_entries(catalog.commands);
@@ -5500,7 +5505,6 @@ impl App {
             return;
         };
         palette.epoch = epoch;
-        palette.entries = builtin_command_palette_entries();
         palette.loading = true;
         palette.resolving = false;
         palette.resolving_key = None;
@@ -6399,6 +6403,70 @@ mod command_palette_tests {
         assert!(command_search_text(mcp).contains("read_file"));
     }
 
+    #[tokio::test]
+    async fn ctrl_r_refresh_preserves_a_server_command_selection() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-1".to_string());
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Global,
+            "",
+            merged_command_palette_entries(vec![
+                command("review", "prompt", "workspace"),
+                command("summarize", "prompt", "global"),
+            ]),
+        );
+        let palette = app.command_palette.as_mut().unwrap();
+        palette.selected = palette
+            .visible
+            .iter()
+            .position(|index| {
+                palette
+                    .entries
+                    .get(*index)
+                    .is_some_and(|entry| entry.key() == "server:prompt:review")
+            })
+            .unwrap();
+        let selected_key = palette.selected_entry().unwrap().key();
+
+        app.handle_command_palette_key(modified_key(KeyCode::Char('r'), KeyModifiers::CONTROL));
+        let epoch = app.command_palette.as_ref().unwrap().epoch;
+        assert_eq!(
+            app.command_palette
+                .as_ref()
+                .unwrap()
+                .selected_entry()
+                .unwrap()
+                .key(),
+            selected_key,
+            "refresh must retain the old catalog until its replacement arrives"
+        );
+
+        app.handle_event(AppEvent::CommandCatalogLoaded {
+            epoch,
+            session_id: Some("session-1".to_string()),
+            result: Ok(CommandListResponse {
+                commands: vec![
+                    command("summarize", "prompt", "global"),
+                    command("review", "prompt", "workspace"),
+                ],
+                total: 2,
+            }),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            app.command_palette
+                .as_ref()
+                .unwrap()
+                .selected_entry()
+                .unwrap()
+                .key(),
+            selected_key
+        );
+    }
+
     #[test]
     fn active_session_rebind_reloads_scope_without_touching_draft_or_query() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
@@ -6604,6 +6672,64 @@ mod command_palette_tests {
 
         assert!(app.command_palette.is_none());
         assert!(app.help_visible);
+    }
+
+    #[tokio::test]
+    async fn catalog_change_between_mouse_down_and_up_cancels_activation() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("session-1".to_string());
+        install_test_palette(
+            &mut app,
+            CommandPaletteTrigger::Global,
+            "",
+            vec![CommandPaletteEntry::Builtin(BuiltinPaletteAction::Help)],
+        );
+        let epoch = app.command_palette.as_ref().unwrap().epoch;
+        app.command_palette
+            .as_ref()
+            .unwrap()
+            .hitboxes
+            .borrow_mut()
+            .push(CommandPaletteHitbox {
+                index: 0,
+                x: 10,
+                y: 5,
+                width: 20,
+                height: 2,
+            });
+        let mouse = |kind| MouseEvent {
+            kind,
+            column: 12,
+            row: 6,
+            modifiers: KeyModifiers::empty(),
+        };
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left)));
+        assert_eq!(
+            app.command_palette.as_ref().unwrap().mouse_pressed_item,
+            Some(0)
+        );
+
+        app.handle_event(AppEvent::CommandCatalogLoaded {
+            epoch,
+            session_id: Some("session-1".to_string()),
+            result: Ok(CommandListResponse {
+                commands: vec![command("review", "prompt", "workspace")],
+                total: 1,
+            }),
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            app.command_palette.as_ref().unwrap().mouse_pressed_item,
+            None
+        );
+
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left)));
+
+        assert!(app.command_palette.is_some());
+        assert_eq!(app.chat.session_id.as_deref(), Some("session-1"));
+        assert!(!app.help_visible);
     }
 }
 

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -1,8 +1,8 @@
 use crossterm::event::{KeyEvent, MouseEvent};
 
 use crate::api::types::{
-    CatalogModel, ListSessionsEnvelope, McpServer, PendingQuestion, ProviderCatalog, Schedule,
-    Skill, SkillDetail, ToolInfo,
+    CatalogModel, CommandDetail, CommandListResponse, ListSessionsEnvelope, McpServer,
+    PendingQuestion, ProviderCatalog, Schedule, Skill, SkillDetail, ToolInfo,
 };
 use crate::api::{RespondFailure, SessionMutationFailure, VersionedSession};
 use crate::app::{OpenedSession, QuestionIdentity, SessionPickerIntent};
@@ -103,6 +103,22 @@ pub enum AppEvent {
         identity: QuestionIdentity,
         answer: String,
         result: Result<String, RespondFailure>,
+    },
+    /// Session-aware command catalog loaded for an open palette. Both the
+    /// palette epoch and Session id must still match before it can replace the
+    /// visible server entries.
+    CommandCatalogLoaded {
+        epoch: u64,
+        session_id: Option<String>,
+        result: Loaded<CommandListResponse>,
+    },
+    /// Prompt/workflow preview resolution completed. Selection never sends a
+    /// chat turn; the matching handler only fills the composer draft.
+    CommandResolved {
+        epoch: u64,
+        session_id: Option<String>,
+        command_key: String,
+        result: Loaded<CommandDetail>,
     },
     /// `Ctrl+O`'s provider-catalog fetch finished. `epoch` makes close/reopen
     /// safe when an older HTTP response arrives after the new overlay opened.

--- a/crates/app/bamboo-tui/src/search.rs
+++ b/crates/app/bamboo-tui/src/search.rs
@@ -1,7 +1,7 @@
-//! Small, allocation-bounded fuzzy search shared by the session and model
-//! pickers. The TUI deliberately keeps this local instead of pulling in a
-//! second command-palette dependency: catalogs are small (hundreds of rows),
-//! and a deterministic subsequence score is easier to keep selection-stable.
+//! Small, allocation-bounded fuzzy search shared by the session, model, and
+//! command pickers. The TUI deliberately keeps this local instead of pulling
+//! in another palette dependency: catalogs are small (hundreds of rows), and
+//! a deterministic subsequence score is easier to keep selection-stable.
 
 /// Return ranked item indices for `query`.
 ///

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -1194,26 +1194,30 @@ fn render_command_palette_view(
     let area = centered_rect(94, height, screen);
 
     if let Some(hitboxes) = hitboxes {
-        let width = area.width.saturating_sub(2);
-        *hitboxes.borrow_mut() = rendered
-            .item_rows
-            .iter()
-            .filter_map(|(index, row, row_height)| {
-                let y = area.y.saturating_add(1).saturating_add(*row);
-                let available = area
-                    .y
-                    .saturating_add(area.height.saturating_sub(1))
-                    .saturating_sub(y);
-                let height = (*row_height).min(available);
-                (width > 0 && height > 0).then_some(CommandPaletteHitbox {
-                    index: *index,
-                    x: area.x.saturating_add(1),
-                    y,
-                    width,
-                    height,
+        if view.resolving {
+            hitboxes.borrow_mut().clear();
+        } else {
+            let width = area.width.saturating_sub(2);
+            *hitboxes.borrow_mut() = rendered
+                .item_rows
+                .iter()
+                .filter_map(|(index, row, row_height)| {
+                    let y = area.y.saturating_add(1).saturating_add(*row);
+                    let available = area
+                        .y
+                        .saturating_add(area.height.saturating_sub(1))
+                        .saturating_sub(y);
+                    let height = (*row_height).min(available);
+                    (width > 0 && height > 0).then_some(CommandPaletteHitbox {
+                        index: *index,
+                        x: area.x.saturating_add(1),
+                        y,
+                        width,
+                        height,
+                    })
                 })
-            })
-            .collect();
+                .collect();
+        }
     }
 
     f.render_widget(Clear, area);
@@ -1248,6 +1252,12 @@ fn command_palette_lines(
         ""
     };
     let search_width = row_width.saturating_sub(10).max(1);
+    let search_cursor = if view.resolving { "" } else { "▏" };
+    let search_style = if view.resolving {
+        Style::default().fg(colors::INACTIVE)
+    } else {
+        Style::default().fg(colors::BRAND)
+    };
     let mut lines = vec![
         Line::from(Span::styled(
             title,
@@ -1259,11 +1269,12 @@ fn command_palette_lines(
             Span::styled(" Search: ", Style::default().fg(colors::SUBTLE)),
             Span::styled(
                 format!(
-                    "{}{}▏",
+                    "{}{}{}",
                     query_prefix,
-                    clip_tail_cells(view.input, search_width.saturating_sub(query_prefix.len()))
+                    clip_tail_cells(view.input, search_width.saturating_sub(query_prefix.len())),
+                    search_cursor
                 ),
-                Style::default().fg(colors::BRAND),
+                search_style,
             ),
         ]),
         Line::raw(""),
@@ -1330,9 +1341,11 @@ fn command_palette_lines(
                 continue;
             };
             let first_row = lines.len() as u16;
-            let is_selected = visible_index == selected;
+            let is_selected = !view.resolving && visible_index == selected;
             let marker = if is_selected { "›" } else { " " };
-            let name_style = if is_selected {
+            let name_style = if view.resolving {
+                Style::default().fg(colors::INACTIVE)
+            } else if is_selected {
                 Style::default()
                     .fg(colors::BRAND)
                     .add_modifier(Modifier::BOLD)
@@ -1378,7 +1391,9 @@ fn command_palette_lines(
                     Style::default().fg(colors::INACTIVE)
                 },
             )));
-            item_rows.push((visible_index, first_row, 2));
+            if !view.resolving {
+                item_rows.push((visible_index, first_row, 2));
+            }
         }
         if end < total {
             lines.push(Line::from(Span::styled(
@@ -1395,7 +1410,10 @@ fn command_palette_lines(
         )));
     }
     lines.push(Line::raw(""));
-    if row_width < 70 {
+    if view.resolving {
+        lines.push(Line::raw("  Input paused while the preview resolves"));
+        lines.push(Line::raw("  Esc cancel"));
+    } else if row_width < 70 {
         lines.push(Line::raw("  ↑/↓/wheel select · Enter use · Esc cancel"));
         lines.push(Line::raw("  Ctrl+R retry/refresh · Ctrl+U clear"));
     } else {
@@ -1731,7 +1749,44 @@ mod tests {
             24,
             72,
         );
-        assert!(palette_text(&resolving.lines).contains("Resolving preview"));
+        let resolving_text = palette_text(&resolving.lines);
+        assert!(resolving_text.contains("Resolving preview"));
+        assert!(resolving_text.contains("Input paused"));
+        assert!(resolving_text.contains("Esc cancel"));
+        assert!(!resolving_text.contains('▏'));
+        assert!(!resolving_text.contains("Enter use"));
+        assert!(!resolving_text.contains("Ctrl+R"));
+        assert!(resolving.item_rows.is_empty());
+
+        let hitboxes = RefCell::new(vec![CommandPaletteHitbox {
+            index: 0,
+            x: 1,
+            y: 1,
+            width: 10,
+            height: 2,
+        }]);
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_command_palette_view(
+                    frame,
+                    CommandPaletteView {
+                        trigger: CommandPaletteTrigger::Global,
+                        input: "review",
+                        entries: &entries,
+                        visible: &visible,
+                        selected: 0,
+                        loading: false,
+                        resolving: true,
+                        error: None,
+                        disabled_reasons: &disabled_reasons,
+                    },
+                    Some(&hitboxes),
+                )
+            })
+            .unwrap();
+        assert!(hitboxes.borrow().is_empty());
 
         let no_commands = command_palette_lines(
             &CommandPaletteView {

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -5,7 +7,10 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::{App, NoticeLevel, QuestionOptionHitbox, SessionPickerMode, Tab};
+use crate::app::{
+    App, CommandPaletteEntry, CommandPaletteHitbox, CommandPaletteTrigger, NoticeLevel,
+    QuestionOptionHitbox, SessionPickerMode, Tab,
+};
 use crate::theme::{self, colors};
 use crate::ui::sessions::{session_row_line, truncate_cells};
 
@@ -178,6 +183,7 @@ const HELP_LEFT: &[(&str, &str)] = &[
     ("g / G", "Jump to top / bottom (Chat)"),
 ];
 const HELP_RIGHT: &[(&str, &str)] = &[
+    ("Ctrl+K", "Command palette"),
     ("Ctrl+N", "New session"),
     ("Ctrl+O", "Model picker (Chat)"),
     ("Ctrl+P", "Session picker (Chat)"),
@@ -1124,6 +1130,297 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
     f.render_widget(para, area);
 }
 
+/// Combined built-in and session-aware command palette. Each result owns two
+/// fixed terminal rows, which makes both keyboard windowing and mouse hitboxes
+/// deterministic even when descriptions are long or the terminal is narrow.
+/// The list is clipped instead of wrapped so a row can never push the footer
+/// below the popup or move beneath the pointer between mouse-down/up events.
+pub fn render_command_palette(f: &mut Frame, app: &App) {
+    let Some(palette) = &app.command_palette else {
+        return;
+    };
+    let disabled_reasons = palette
+        .entries
+        .iter()
+        .map(|entry| {
+            app.command_palette_disabled_reason(entry)
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+    let view = CommandPaletteView {
+        trigger: palette.trigger,
+        input: &palette.input,
+        entries: &palette.entries,
+        visible: &palette.visible,
+        selected: palette.selected,
+        loading: palette.loading,
+        resolving: palette.resolving,
+        error: palette.error.as_deref(),
+        disabled_reasons: &disabled_reasons,
+    };
+    render_command_palette_view(f, view, Some(&palette.hitboxes));
+}
+
+struct CommandPaletteView<'a> {
+    trigger: CommandPaletteTrigger,
+    input: &'a str,
+    entries: &'a [CommandPaletteEntry],
+    visible: &'a [usize],
+    selected: usize,
+    loading: bool,
+    resolving: bool,
+    error: Option<&'a str>,
+    disabled_reasons: &'a [Option<String>],
+}
+
+struct CommandPaletteRender {
+    lines: Vec<Line<'static>>,
+    /// `(visible index, first content-row, height)` for the rows actually
+    /// present in this frame. The content row is relative to the block's
+    /// inner top edge and becomes an absolute hitbox after centering.
+    item_rows: Vec<(usize, u16, u16)>,
+}
+
+fn render_command_palette_view(
+    f: &mut Frame,
+    view: CommandPaletteView<'_>,
+    hitboxes: Option<&RefCell<Vec<CommandPaletteHitbox>>>,
+) {
+    let screen = f.area();
+    let popup_width = ((screen.width as u32 * 94 / 100) as u16).max(1);
+    let row_width = popup_width.saturating_sub(4) as usize;
+    let rendered = command_palette_lines(&view, screen.height, row_width);
+    let height = (rendered.lines.len() as u16 + 2).min(screen.height);
+    let area = centered_rect(94, height, screen);
+
+    if let Some(hitboxes) = hitboxes {
+        let width = area.width.saturating_sub(2);
+        *hitboxes.borrow_mut() = rendered
+            .item_rows
+            .iter()
+            .filter_map(|(index, row, row_height)| {
+                let y = area.y.saturating_add(1).saturating_add(*row);
+                let available = area
+                    .y
+                    .saturating_add(area.height.saturating_sub(1))
+                    .saturating_sub(y);
+                let height = (*row_height).min(available);
+                (width > 0 && height > 0).then_some(CommandPaletteHitbox {
+                    index: *index,
+                    x: area.x.saturating_add(1),
+                    y,
+                    width,
+                    height,
+                })
+            })
+            .collect();
+    }
+
+    f.render_widget(Clear, area);
+    let title = match view.trigger {
+        CommandPaletteTrigger::Slash => " Slash commands ",
+        CommandPaletteTrigger::Global => " Command palette ",
+    };
+    let border_color = if view.resolving {
+        colors::WARNING
+    } else {
+        colors::BRAND
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color))
+        .title(title);
+    f.render_widget(Paragraph::new(rendered.lines).block(block), area);
+}
+
+fn command_palette_lines(
+    view: &CommandPaletteView<'_>,
+    screen_height: u16,
+    row_width: usize,
+) -> CommandPaletteRender {
+    let title = match view.trigger {
+        CommandPaletteTrigger::Slash => " Slash commands",
+        CommandPaletteTrigger::Global => " Command palette",
+    };
+    let query_prefix = if matches!(view.trigger, CommandPaletteTrigger::Slash) {
+        "/"
+    } else {
+        ""
+    };
+    let search_width = row_width.saturating_sub(10).max(1);
+    let mut lines = vec![
+        Line::from(Span::styled(
+            title,
+            Style::default()
+                .fg(colors::BRAND)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(vec![
+            Span::styled(" Search: ", Style::default().fg(colors::SUBTLE)),
+            Span::styled(
+                format!(
+                    "{}{}▏",
+                    query_prefix,
+                    clip_tail_cells(view.input, search_width.saturating_sub(query_prefix.len()))
+                ),
+                Style::default().fg(colors::BRAND),
+            ),
+        ]),
+        Line::raw(""),
+    ];
+
+    if view.resolving {
+        lines.push(Line::from(Span::styled(
+            "  Resolving preview…",
+            Style::default().fg(colors::WARNING),
+        )));
+    } else if view.loading {
+        lines.push(Line::from(Span::styled(
+            clip_cells(
+                "  Loading session commands… built-ins remain available",
+                row_width,
+            ),
+            Style::default().fg(colors::INACTIVE),
+        )));
+    }
+
+    let status_rows = usize::from(view.loading || view.resolving);
+    let error_rows = usize::from(view.error.is_some());
+    // Border (2), header (3), status/error, footer (3), and at most two
+    // above/below indicators are reserved before selecting the two-row item
+    // window. The selected item is therefore always fully visible at 60,
+    // 80, and 120 columns on ordinary 24-row terminals.
+    let max_content_rows = screen_height.min(26).saturating_sub(2) as usize;
+    let non_list_rows = 3 + status_rows + error_rows + 3;
+    let list_rows = max_content_rows.saturating_sub(non_list_rows);
+    let max_items = list_rows.saturating_sub(2).max(2) / 2;
+    let total = view.visible.len();
+    let mut item_rows = Vec::new();
+
+    if total == 0 {
+        lines.push(Line::from(Span::styled(
+            if view.entries.is_empty() && !view.loading {
+                "  No commands available"
+            } else if view.loading {
+                "  Waiting for commands…"
+            } else {
+                "  No commands match this search"
+            },
+            Style::default().fg(colors::INACTIVE),
+        )));
+    } else {
+        let selected = view.selected.min(total.saturating_sub(1));
+        let window_len = max_items.max(1).min(total);
+        let start = selected
+            .saturating_sub(window_len / 2)
+            .min(total.saturating_sub(window_len));
+        let end = (start + window_len).min(total);
+        if start > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("  ↑ {start} more"),
+                Style::default().fg(colors::SUBTLE),
+            )));
+        }
+
+        for visible_index in start..end {
+            let Some(entry_index) = view.visible.get(visible_index) else {
+                continue;
+            };
+            let Some(entry) = view.entries.get(*entry_index) else {
+                continue;
+            };
+            let first_row = lines.len() as u16;
+            let is_selected = visible_index == selected;
+            let marker = if is_selected { "›" } else { " " };
+            let name_style = if is_selected {
+                Style::default()
+                    .fg(colors::BRAND)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let badge = clip_cells(
+                &format!("[{} · {}]", entry.type_label(), entry.source_label()),
+                (row_width / 2).max(1),
+            );
+            let badge_width: usize = badge
+                .chars()
+                .map(|c| UnicodeWidthChar::width(c).unwrap_or(0))
+                .sum();
+            let name_width = row_width.saturating_sub(badge_width + 6);
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {marker} "), name_style),
+                Span::styled(
+                    clip_cells(entry.display_name(), name_width.max(1)),
+                    name_style,
+                ),
+                Span::raw("  "),
+                Span::styled(badge, palette_type_style(entry.type_label())),
+            ]));
+
+            let disabled = view.disabled_reasons.get(*entry_index).cloned().flatten();
+            let description = disabled
+                .as_ref()
+                .map(|reason| format!("Disabled: {reason}"))
+                .unwrap_or_else(|| {
+                    let description = entry.description().trim();
+                    if description.is_empty() {
+                        "No description".to_string()
+                    } else {
+                        description.to_string()
+                    }
+                });
+            lines.push(Line::from(Span::styled(
+                clip_cells(&format!("      {description}"), row_width),
+                if disabled.is_some() {
+                    Style::default().fg(colors::ERROR)
+                } else {
+                    Style::default().fg(colors::INACTIVE)
+                },
+            )));
+            item_rows.push((visible_index, first_row, 2));
+        }
+        if end < total {
+            lines.push(Line::from(Span::styled(
+                format!("  ↓ {} more", total - end),
+                Style::default().fg(colors::SUBTLE),
+            )));
+        }
+    }
+
+    if let Some(error) = view.error {
+        lines.push(Line::from(Span::styled(
+            clip_cells(&format!("  {error}"), row_width),
+            Style::default().fg(colors::ERROR),
+        )));
+    }
+    lines.push(Line::raw(""));
+    if row_width < 70 {
+        lines.push(Line::raw("  ↑/↓/wheel select · Enter use · Esc cancel"));
+        lines.push(Line::raw("  Ctrl+R retry/refresh · Ctrl+U clear"));
+    } else {
+        lines.push(Line::raw(
+            "  ↑/↓/PgUp/PgDn/wheel select · Enter use · Esc cancel",
+        ));
+        lines.push(Line::raw(
+            "  Type to search · Ctrl+R refresh · Ctrl+U clear",
+        ));
+    }
+
+    CommandPaletteRender { lines, item_rows }
+}
+
+fn palette_type_style(command_type: &str) -> Style {
+    let color = match command_type {
+        "prompt" => colors::BRAND,
+        "workflow" => colors::SUCCESS,
+        "skill" => colors::WARNING,
+        "mcp" => colors::TOOL_RUNNING,
+        _ => colors::INACTIVE,
+    };
+    Style::default().fg(color)
+}
+
 fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {
     // u32 math so a very wide terminal (width ≥ 820) can't overflow the u16
     // multiply of `r.width * percent_x`.
@@ -1191,11 +1488,64 @@ fn clip_tail_cells(value: &str, max_width: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{clip_cells, clip_tail_cells};
+    use std::cell::RefCell;
+
+    use super::{
+        clip_cells, clip_tail_cells, command_palette_lines, render_command_palette_view,
+        CommandPaletteView,
+    };
+    use crate::api::types::CommandItem;
     use crate::api::BambooClient;
-    use crate::app::App;
+    use crate::app::{
+        App, BuiltinPaletteAction, CommandPaletteEntry, CommandPaletteHitbox, CommandPaletteTrigger,
+    };
     use ratatui::backend::TestBackend;
+    use ratatui::text::Line;
     use ratatui::Terminal;
+    use unicode_width::UnicodeWidthStr;
+
+    fn command(
+        name: impl Into<String>,
+        command_type: &str,
+        source: &str,
+        description: impl Into<String>,
+    ) -> CommandPaletteEntry {
+        let name = name.into();
+        CommandPaletteEntry::Server(CommandItem {
+            id: format!("{command_type}:{name}"),
+            display_name: name.clone(),
+            name,
+            description: description.into(),
+            command_type: command_type.to_string(),
+            category: None,
+            tags: None,
+            metadata: serde_json::json!({ "source": source }),
+        })
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    fn palette_text(lines: &[Line<'_>]) -> String {
+        lines.iter().map(line_text).collect::<Vec<_>>().join("\n")
+    }
+
+    fn terminal_text(terminal: &Terminal<TestBackend>) -> String {
+        let buffer = terminal.backend().buffer();
+        let area = buffer.area;
+        (area.y..area.y.saturating_add(area.height))
+            .map(|row| {
+                (area.x..area.x.saturating_add(area.width))
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 
     /// The two-column help overlay must fit a normal-height terminal without
     /// vertical clipping and must still mention the headline bindings — the
@@ -1214,6 +1564,7 @@ mod tests {
         let buf = terminal.backend().buffer().clone();
         let text: String = buf.content().iter().map(|c| c.symbol()).collect();
         for needle in [
+            "Ctrl+K",
             "Ctrl+N",
             "Ctrl+O",
             "Ctrl+P",
@@ -1238,5 +1589,236 @@ mod tests {
         assert_eq!(clip_tail_cells("abcdef", 4), "…def");
         assert_eq!(clip_tail_cells("会话标题", 5), "…标题");
         assert_eq!(clip_tail_cells("界", 1), "…");
+    }
+
+    #[test]
+    fn command_palette_render_snapshots_are_responsive_at_60_80_120() {
+        let mut entries = vec![
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::NewSession),
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop),
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::ToggleDetails),
+        ];
+        entries.extend((0..12).map(|index| {
+            if index == 7 {
+                command(
+                    "Deploy production",
+                    "workflow",
+                    "workspace",
+                    "Preview a deploy workflow without sending it",
+                )
+            } else {
+                command(
+                    format!("Command {index}"),
+                    if index % 2 == 0 { "prompt" } else { "skill" },
+                    if index % 3 == 0 { "project" } else { "global" },
+                    format!("Description for command {index}"),
+                )
+            }
+        }));
+        let visible = (0..entries.len()).collect::<Vec<_>>();
+        let selected = 10; // `Deploy production` after the three built-ins.
+        let disabled_reasons = vec![None; entries.len()];
+
+        for width in [60, 80, 120] {
+            let hitboxes = RefCell::<Vec<CommandPaletteHitbox>>::new(Vec::new());
+            let view = CommandPaletteView {
+                trigger: CommandPaletteTrigger::Slash,
+                input: "dep production",
+                entries: &entries,
+                visible: &visible,
+                selected,
+                loading: false,
+                resolving: false,
+                error: None,
+                disabled_reasons: &disabled_reasons,
+            };
+            let backend = TestBackend::new(width, 24);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| render_command_palette_view(frame, view, Some(&hitboxes)))
+                .unwrap();
+
+            let text = terminal_text(&terminal);
+            for needle in [
+                "Slash commands",
+                "/dep production",
+                "Deploy production",
+                "workflow · workspace",
+                "Enter use",
+                "Ctrl+R",
+            ] {
+                assert!(
+                    text.contains(needle),
+                    "{width}-column palette missing {needle:?}:\n{text}"
+                );
+            }
+            assert!(text.contains("↑ "), "selected window lost its upper marker");
+            assert!(text.contains("↓ "), "selected window lost its lower marker");
+
+            let hitboxes = hitboxes.borrow();
+            assert!(
+                hitboxes.iter().any(|hitbox| hitbox.index == selected),
+                "{width}-column palette did not expose the selected row hitbox"
+            );
+            assert!(hitboxes.iter().all(|hitbox| {
+                hitbox.height == 2
+                    && hitbox.x.saturating_add(hitbox.width) <= width
+                    && hitbox.y.saturating_add(hitbox.height) <= 24
+            }));
+
+            let row_width = ((width as u32 * 94 / 100) as usize).saturating_sub(4);
+            let pure = command_palette_lines(
+                &CommandPaletteView {
+                    trigger: CommandPaletteTrigger::Slash,
+                    input: "dep production",
+                    entries: &entries,
+                    visible: &visible,
+                    selected,
+                    loading: false,
+                    resolving: false,
+                    error: None,
+                    disabled_reasons: &disabled_reasons,
+                },
+                24,
+                row_width,
+            );
+            assert!(pure
+                .lines
+                .iter()
+                .map(line_text)
+                .all(|line| UnicodeWidthStr::width(line.as_str()) <= row_width));
+        }
+    }
+
+    #[test]
+    fn command_palette_renders_loading_error_empty_and_resolving_states() {
+        let entries = vec![command("Review", "prompt", "workspace", "Review changes")];
+        let disabled_reasons = vec![None; entries.len()];
+        let empty_visible = Vec::new();
+        let loading = command_palette_lines(
+            &CommandPaletteView {
+                trigger: CommandPaletteTrigger::Global,
+                input: "missing",
+                entries: &entries,
+                visible: &empty_visible,
+                selected: 0,
+                loading: true,
+                resolving: false,
+                error: Some("API unavailable — Ctrl+R to retry"),
+                disabled_reasons: &disabled_reasons,
+            },
+            24,
+            72,
+        );
+        let text = palette_text(&loading.lines);
+        assert!(text.contains("Loading session commands"));
+        assert!(text.contains("Waiting for commands"));
+        assert!(text.contains("API unavailable"));
+
+        let visible = vec![0];
+        let resolving = command_palette_lines(
+            &CommandPaletteView {
+                trigger: CommandPaletteTrigger::Global,
+                input: "review",
+                entries: &entries,
+                visible: &visible,
+                selected: 0,
+                loading: false,
+                resolving: true,
+                error: None,
+                disabled_reasons: &disabled_reasons,
+            },
+            24,
+            72,
+        );
+        assert!(palette_text(&resolving.lines).contains("Resolving preview"));
+
+        let no_commands = command_palette_lines(
+            &CommandPaletteView {
+                trigger: CommandPaletteTrigger::Global,
+                input: "",
+                entries: &[],
+                visible: &[],
+                selected: 0,
+                loading: false,
+                resolving: false,
+                error: None,
+                disabled_reasons: &[],
+            },
+            24,
+            72,
+        );
+        assert!(palette_text(&no_commands.lines).contains("No commands available"));
+
+        let no_matches = command_palette_lines(
+            &CommandPaletteView {
+                trigger: CommandPaletteTrigger::Global,
+                input: "missing",
+                entries: &entries,
+                visible: &[],
+                selected: 0,
+                loading: false,
+                resolving: false,
+                error: None,
+                disabled_reasons: &disabled_reasons,
+            },
+            24,
+            72,
+        );
+        assert!(palette_text(&no_matches.lines).contains("No commands match"));
+    }
+
+    #[test]
+    fn disabled_reasons_match_runtime_availability_and_label_type_source() {
+        let entries = vec![
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::NewSession),
+            CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop),
+            command(
+                "Deploy production",
+                "workflow",
+                "workspace",
+                "Preview deploy workflow",
+            ),
+        ];
+        let visible = vec![0, 1, 2];
+        let disabled_reasons = vec![
+            Some("Unavailable while an agent run is active".to_string()),
+            None,
+            Some("Composer commands are unavailable while a run is active".to_string()),
+        ];
+        let rendered = command_palette_lines(
+            &CommandPaletteView {
+                trigger: CommandPaletteTrigger::Global,
+                input: "",
+                entries: &entries,
+                visible: &visible,
+                selected: 1,
+                loading: false,
+                resolving: false,
+                error: None,
+                disabled_reasons: &disabled_reasons,
+            },
+            24,
+            80,
+        );
+        let lines = rendered.lines.iter().map(line_text).collect::<Vec<_>>();
+        let description_for = |visible_index| {
+            let (_, first_row, _) = rendered
+                .item_rows
+                .iter()
+                .find(|(index, _, _)| *index == visible_index)
+                .copied()
+                .unwrap();
+            &lines[first_row as usize + 1]
+        };
+
+        assert!(description_for(0).contains("Disabled: Unavailable"));
+        assert_eq!(
+            description_for(1).trim(),
+            BuiltinPaletteAction::Stop.description()
+        );
+        assert!(description_for(2).contains("Disabled: Composer commands"));
+        assert!(description_for(2).contains("run is active"));
+        assert!(palette_text(&rendered.lines).contains("workflow · workspace"));
     }
 }

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -49,6 +49,10 @@ pub fn render(f: &mut Frame, app: &App) {
         layout::render_schedule_form(f, app);
     }
 
+    if app.command_palette.is_some() {
+        layout::render_command_palette(f, app);
+    }
+
     if app.model_picker.is_some() {
         layout::render_model_picker(f, app);
     }


### PR DESCRIPTION
## Summary

- add a global `Ctrl+K` command palette plus a leading-slash composer for built-in actions and server prompt, workflow, skill, and MCP commands
- load and resolve the catalog asynchronously with session-bound stale-response guards, safe preview/insertion semantics, and exact draft preservation
- add responsive keyboard and mouse rendering with source/type badges, disabled reasons, stable refresh/press behavior, and focused acceptance coverage

Closes #635

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-tui --all-targets -- -D warnings`
- `cargo test -p bamboo-tui` (204 passed)
- `cargo test` (full workspace passed)

## Screenshots

N/A - this is a terminal UI. Responsive 60, 80, and 120 column render buffers are covered by tests.
