### PR TITLE
feat(tui): add structured conversation blocks

### DIFF
--- a/crates/app/bamboo-server/src/events/replayable_tests.rs
+++ b/crates/app/bamboo-server/src/events/replayable_tests.rs
@@ -39,6 +39,23 @@ async fn install_runner(state: &AppState, session_id: &str) {
         .insert(session_id.to_string(), runner);
 }
 
+fn child_started(session_id: &str, generation: &str) -> AgentEvent {
+    AgentEvent::SubAgentStarted {
+        parent_session_id: session_id.to_string(),
+        child_session_id: "resident-child".to_string(),
+        title: Some(generation.to_string()),
+    }
+}
+
+fn child_completed(session_id: &str) -> AgentEvent {
+    AgentEvent::SubAgentCompleted {
+        parent_session_id: session_id.to_string(),
+        child_session_id: "resident-child".to_string(),
+        status: "completed".to_string(),
+        error: None,
+    }
+}
+
 #[tokio::test]
 async fn caches_before_broadcasting_for_title_event() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -109,6 +126,55 @@ async fn caches_before_broadcasting_for_pinned_event() {
     assert!(matches!(
         received,
         AgentEvent::SessionPinnedUpdated { pinned: true, .. }
+    ));
+}
+
+#[tokio::test]
+async fn child_lifecycle_cache_coalesces_without_dropping_live_transitions() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state init");
+    let session_id = "resident-generations";
+    install_runner(&state, session_id).await;
+
+    let sender = state.get_session_event_sender(session_id).await;
+    let mut subscriber = sender.subscribe();
+    for event in [
+        child_started(session_id, "generation-1"),
+        child_completed(session_id),
+        child_started(session_id, "generation-2"),
+    ] {
+        publish_replayable_session_event(&state, session_id, event).await;
+    }
+
+    // Existing subscribers retain the full ordered lifecycle stream.
+    let first = subscriber.recv().await.expect("generation 1 start");
+    let second = subscriber.recv().await.expect("generation 1 complete");
+    let third = subscriber.recv().await.expect("generation 2 start");
+    assert!(matches!(first, AgentEvent::SubAgentStarted { .. }));
+    assert!(matches!(second, AgentEvent::SubAgentCompleted { .. }));
+    assert!(matches!(
+        third,
+        AgentEvent::SubAgentStarted {
+            title: Some(ref title),
+            ..
+        } if title == "generation-2"
+    ));
+
+    // A late/reconnecting subscriber receives only the newest state for the
+    // stable child id, so no historical generation can consume a current TUI
+    // rerun authorization.
+    let runners = state.agent_runners.read().await;
+    let runner = runners.get(session_id).expect("runner registered");
+    assert_eq!(runner.last_critical_events.len(), 1);
+    assert!(matches!(
+        &runner.last_critical_events[0],
+        AgentEvent::SubAgentStarted {
+            child_session_id,
+            title: Some(title),
+            ..
+        } if child_session_id == "resident-child" && title == "generation-2"
     ));
 }
 

--- a/crates/app/bamboo-server/src/events/replayable_tests.rs
+++ b/crates/app/bamboo-server/src/events/replayable_tests.rs
@@ -4,11 +4,14 @@
 //! they construct a full `AppState` to exercise the trait-based code path.
 
 use crate::app_state::AppState;
+use crate::handlers::agent::events::subscribe_with_runner_snapshot;
 use bamboo_agent_core::AgentEvent;
 use bamboo_agent_core::TitleSource;
 use bamboo_engine::events::publish_replayable_session_event;
 use bamboo_engine::runtime::execution::runner_state::{AgentRunner, AgentStatus};
 use chrono::Utc;
+use std::sync::Arc;
+use std::time::Duration;
 
 fn title_event(session_id: &str) -> AgentEvent {
     AgentEvent::SessionTitleUpdated {
@@ -176,6 +179,69 @@ async fn child_lifecycle_cache_coalesces_without_dropping_live_transitions() {
             ..
         } if child_session_id == "resident-child" && title == "generation-2"
     ));
+}
+
+#[tokio::test]
+async fn subscription_boundary_delivers_each_replayable_event_once() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(
+        AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state init"),
+    );
+    let session_id = "atomic-subscription";
+    install_runner(state.as_ref(), session_id).await;
+    let sender = state.get_session_event_sender(session_id).await;
+
+    // Hold publication ownership while the subscriber attempts to establish
+    // its boundary. Because subscribe + snapshot share the runner read lock,
+    // the publication lands only in the snapshot, never in both sources.
+    let mut runners = state.agent_runners.write().await;
+    let subscriber_state = Arc::clone(&state);
+    let subscriber = tokio::spawn(async move {
+        subscribe_with_runner_snapshot(subscriber_state.as_ref(), session_id).await
+    });
+    tokio::task::yield_now().await;
+
+    let before_boundary = child_started(session_id, "before-boundary");
+    runners
+        .get_mut(session_id)
+        .expect("runner registered")
+        .push_critical_event(before_boundary.clone());
+    let _ = sender.send(before_boundary);
+    drop(runners);
+
+    let (_sender, mut receiver, snapshot) = subscriber.await.expect("subscriber task");
+    let snapshot = snapshot.expect("runner snapshot");
+    assert_eq!(snapshot.last_critical_events.len(), 1);
+    assert!(matches!(
+        &snapshot.last_critical_events[0],
+        AgentEvent::SubAgentStarted {
+            title: Some(title),
+            ..
+        } if title == "before-boundary"
+    ));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), receiver.recv())
+            .await
+            .is_err(),
+        "the snapshot event must not also be buffered live"
+    );
+
+    // Publications after the boundary take the other path: they are absent
+    // from the captured snapshot and arrive exactly once on the receiver.
+    publish_replayable_session_event(state.as_ref(), session_id, child_completed(session_id)).await;
+    let live = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+        .await
+        .expect("live event before timeout")
+        .expect("live channel open");
+    assert!(matches!(live, AgentEvent::SubAgentCompleted { .. }));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), receiver.recv())
+            .await
+            .is_err(),
+        "the live event must be delivered only once"
+    );
 }
 
 #[tokio::test]

--- a/crates/app/bamboo-server/src/handlers/agent/events/handler.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/handler.rs
@@ -2,6 +2,7 @@ use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use serde::Deserialize;
 
 use super::stream::{live_stream_response, terminal_response};
+use super::subscription::subscribe_with_runner_snapshot;
 use super::terminal::terminal_event_if_ready;
 use crate::app_state::{AgentStatus, AppState};
 
@@ -63,19 +64,12 @@ pub async fn handler(
         }));
     }
 
-    let sender = state.get_session_event_sender(&session_id).await;
-    let receiver = sender.subscribe();
+    let (sender, receiver, runner_snapshot) =
+        subscribe_with_runner_snapshot(state.get_ref(), &session_id).await;
 
     // Ensure a backend notification relay is running for this session so that
     // approval/clarification/context/subagent events surface as notifications.
     state.ensure_notification_relay(&session_id, sender.clone());
-
-    // Snapshot runner info (if present). After restarts we may not have runners in-memory,
-    // so don't rely solely on this for "already completed" detection.
-    let runner_snapshot = {
-        let runners = state.agent_runners.read().await;
-        runners.get(&session_id).cloned()
-    };
 
     // Replay last budget event if available (for late subscribers).
     let budget_event_to_replay = runner_snapshot

--- a/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
@@ -2,6 +2,7 @@
 
 mod handler;
 mod stream;
+mod subscription;
 mod terminal;
 
 pub use handler::handler;
@@ -12,6 +13,7 @@ pub use handler::handler;
 //   WS forwarder reuses it rather than reimplementing coalescing.
 pub(crate) use handler::MAX_BATCH_MS;
 pub(crate) use stream::Coalescer;
+pub(crate) use subscription::subscribe_with_runner_snapshot;
 // Reused by the v2 WS `agent.{sid}` forwarder to keep the channel open while
 // child sub-agents are still running (parity with the v1 SSE stream, which does
 // not close on the parent terminal while descendants survive).

--- a/crates/app/bamboo-server/src/handlers/agent/events/subscription.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/subscription.rs
@@ -1,0 +1,34 @@
+use bamboo_agent_core::AgentEvent;
+use tokio::sync::broadcast;
+
+use crate::app_state::{AgentRunner, AppState};
+
+/// Install a live receiver and capture its replay snapshot at one runner-lock
+/// boundary.
+///
+/// Replayable publishers cache and broadcast while holding the runner write
+/// lock. Taking the read lock across both `subscribe` and the cache clone
+/// therefore gives the client exactly one side of every publication:
+///
+/// - a publication completed before this boundary is present in the snapshot;
+/// - a publication completed after it is buffered by the receiver.
+///
+/// Without the shared boundary, an event can be cached, then subscribed, then
+/// broadcast, causing snapshot/live duplication and lifecycle reordering.
+pub(crate) async fn subscribe_with_runner_snapshot(
+    state: &AppState,
+    session_id: &str,
+) -> (
+    broadcast::Sender<AgentEvent>,
+    broadcast::Receiver<AgentEvent>,
+    Option<AgentRunner>,
+) {
+    // Event senders live behind a separate lock. Resolve it before taking the
+    // runner lock so publishers and subscribers use one consistent lock order.
+    let sender = state.get_session_event_sender(session_id).await;
+    let runners = state.agent_runners.read().await;
+    let receiver = sender.subscribe();
+    let runner_snapshot = runners.get(session_id).cloned();
+    drop(runners);
+    (sender, receiver, runner_snapshot)
+}

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -708,18 +708,15 @@ async fn subscribe(
                 return;
             }
 
-            let sender = state.get_session_event_sender(&sid).await;
-            let receiver = sender.subscribe();
+            let (sender, receiver, runner_snapshot) =
+                crate::handlers::agent::events::subscribe_with_runner_snapshot(
+                    state.get_ref(),
+                    &sid,
+                )
+                .await;
             // Keep the notification relay running for this session (parity with
             // the v1 events handler).
             state.ensure_notification_relay(&sid, sender.clone());
-
-            // Snapshot the runner for critical-event + budget replay (mirrors
-            // `events/handler.rs:80-89`).
-            let runner_snapshot = {
-                let runners = state.agent_runners.read().await;
-                runners.get(&sid).cloned()
-            };
             let budget_event_to_replay = runner_snapshot
                 .as_ref()
                 .and_then(|runner| runner.last_budget_event.clone());

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -11,7 +11,6 @@ use chrono::Utc;
 use tokio::sync::{broadcast, RwLock};
 use tokio::time::{sleep, Duration, Instant};
 
-use crate::app_state::session_events::get_or_create_event_sender;
 use crate::app_state::{AgentRunner, AgentStatus};
 use bamboo_agent_core::storage::Storage;
 use bamboo_agent_core::{AgentEvent, Session, SessionKind};
@@ -820,21 +819,17 @@ impl ChildSessionPort for ChildSessionAdapter {
         // suspending it — see `register_parent_wait_for_child` /
         // `register_parent_wait_for_children` and the `SubAgent.wait` action.
         self.scheduler
-            .enqueue(SpawnJob {
-                parent_session_id: parent.id.clone(),
-                child_session_id: child.id.clone(),
-                model,
-                disabled_tools,
-            })
+            .enqueue_announced(
+                SpawnJob {
+                    parent_session_id: parent.id.clone(),
+                    child_session_id: child.id.clone(),
+                    model,
+                    disabled_tools,
+                },
+                Some(child.title.clone()),
+            )
             .await
             .map_err(ChildSessionError::Execution)?;
-
-        let parent_tx = get_or_create_event_sender(&self.session_event_senders, &parent.id).await;
-        let _ = parent_tx.send(AgentEvent::SubAgentStarted {
-            parent_session_id: parent.id.clone(),
-            child_session_id: child.id.clone(),
-            title: Some(child.title.clone()),
-        });
 
         Ok(())
     }
@@ -908,16 +903,19 @@ impl ChildSessionPort for ChildSessionAdapter {
         {
             let mut senders = self.session_event_senders.write().await;
             senders.remove(child_id);
-            if cancelled_running_child {
-                if let Some(parent_tx) = senders.get(parent_session_id) {
-                    let _ = parent_tx.send(AgentEvent::SubAgentCompleted {
+        }
+        if cancelled_running_child {
+            self.scheduler
+                .publish_parent_replayable_event(
+                    parent_session_id,
+                    AgentEvent::SubAgentCompleted {
                         parent_session_id: parent_session_id.to_string(),
                         child_session_id: child_id.to_string(),
                         status: "cancelled".to_string(),
                         error: Some("Child session deleted while running".to_string()),
-                    });
-                }
-            }
+                    },
+                )
+                .await;
         }
 
         Ok(DeleteChildResult {

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -972,8 +972,15 @@ async fn create_requires_session_id_in_tool_context() {
 }
 
 #[tokio::test]
-async fn create_emits_sub_agent_started_event_after_queueing() {
+async fn create_publishes_started_before_fast_completion_and_caches_latest() {
     let mut harness = build_test_harness().await;
+    let mut parent_runner = AgentRunner::new();
+    parent_runner.status = bamboo_engine::AgentStatus::Running;
+    harness
+        .agent_runners
+        .write()
+        .await
+        .insert(harness.parent_session_id.clone(), parent_runner);
 
     let result = invoke_completed(
         &harness.tool,
@@ -1010,27 +1017,65 @@ async fn create_emits_sub_agent_started_event_after_queueing() {
         .expect("tool result should include child_session_id")
         .to_string();
 
-    let started_event = tokio::time::timeout(Duration::from_secs(2), async {
-        loop {
+    let lifecycle = tokio::time::timeout(Duration::from_secs(2), async {
+        let mut lifecycle = Vec::new();
+        while lifecycle.len() < 2 {
             match harness.parent_rx.recv().await {
                 Ok(AgentEvent::SubAgentStarted {
                     parent_session_id: pid,
                     child_session_id: cid,
                     ..
-                }) => break (pid, cid),
+                }) if cid == child_session_id => lifecycle.push(("started", pid, cid)),
+                Ok(AgentEvent::SubAgentCompleted {
+                    parent_session_id: pid,
+                    child_session_id: cid,
+                    ..
+                }) if cid == child_session_id => lifecycle.push(("completed", pid, cid)),
                 Ok(_) => continue,
                 Err(broadcast::error::RecvError::Lagged(_)) => continue,
                 Err(broadcast::error::RecvError::Closed) => {
-                    panic!("parent stream closed before start event")
+                    panic!("parent stream closed before child lifecycle completed")
                 }
             }
         }
+        lifecycle
     })
     .await
-    .expect("should receive SubAgentStarted event quickly");
+    .expect("should receive the fast child lifecycle quickly");
 
-    assert_eq!(started_event.0, harness.parent_session_id);
-    assert_eq!(started_event.1, child_session_id);
+    assert_eq!(lifecycle[0].0, "started");
+    assert_eq!(lifecycle[1].0, "completed");
+    assert!(lifecycle.iter().all(|(_, parent_id, child_id)| parent_id
+        == &harness.parent_session_id
+        && child_id == &child_session_id));
+
+    let runners = harness.agent_runners.read().await;
+    let parent_runner = runners
+        .get(&harness.parent_session_id)
+        .expect("parent runner retained");
+    let cached_child_lifecycle = parent_runner
+        .last_critical_events
+        .iter()
+        .filter(|event| match event {
+            AgentEvent::SubAgentStarted {
+                child_session_id: event_child_id,
+                ..
+            }
+            | AgentEvent::SubAgentCompleted {
+                child_session_id: event_child_id,
+                ..
+            } => event_child_id == &child_session_id,
+            _ => false,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(cached_child_lifecycle.len(), 1);
+    assert!(matches!(
+        cached_child_lifecycle[0],
+        AgentEvent::SubAgentCompleted {
+            child_session_id: cached_child_id,
+            ..
+        } if cached_child_id == &child_session_id
+    ));
 }
 
 #[tokio::test]

--- a/crates/app/bamboo-tui/src/api/sse.rs
+++ b/crates/app/bamboo-tui/src/api/sse.rs
@@ -68,7 +68,7 @@ impl SseStream {
                 )
                 .await;
                 if terminal_seen {
-                    return; // run completed / cancelled / hard error — done.
+                    return; // protocol [DONE] / non-retryable error — done.
                 }
                 ready_tx.send(false).ok();
                 // The UI dropped the receiver ⇒ nothing to reconnect for.
@@ -93,10 +93,10 @@ impl SseStream {
         Ok((task, ready_rx))
     }
 
-    /// One connect + consume cycle. Returns `true` when a terminal event (or a
-    /// non-retryable client error) was seen — the caller should then stop.
-    /// Returns `false` on a retryable outcome (connect error, 5xx, or the stream
-    /// ending without a terminal event), so the caller reconnects.
+    /// One connect + consume cycle. Returns `true` when the protocol `[DONE]`
+    /// sentinel (or a non-retryable client error) was seen — the caller should
+    /// then stop. Returns `false` on a retryable outcome (connect error, 5xx,
+    /// or the stream ending without `[DONE]`), so the caller reconnects.
     async fn consume_once(
         client: &reqwest::Client,
         url: &str,
@@ -169,16 +169,18 @@ impl SseStream {
                     continue;
                 };
                 if Self::parse_sse_block(event_text, session_id, stream_epoch, tx) {
-                    return true; // terminal event delivered
+                    return true; // protocol sentinel delivered
                 }
             }
         }
-        // Stream ended without a terminal event (unexpected EOF) → reconnect.
+        // Stream ended without [DONE] (unexpected EOF) → reconnect.
         false
     }
 
-    /// Parse one SSE block and forward its events. Returns `true` if a terminal
-    /// event (Complete / Cancelled / Error) or a closed receiver was seen.
+    /// Parse one SSE block and forward its events. Agent terminal events do
+    /// not necessarily close the transport: the server keeps the session SSE
+    /// alive while background children emit lifecycle events. Only the
+    /// protocol `[DONE]` sentinel (or a closed receiver) ends this consumer.
     fn parse_sse_block(
         block: &str,
         session_id: &str,
@@ -191,16 +193,13 @@ impl SseStream {
                 continue;
             }
             if let Some(data) = line.strip_prefix("data: ") {
-                if data == "[DONE]" || data == "[KEEPALIVE]" {
+                if data == "[DONE]" {
+                    return true;
+                }
+                if data == "[KEEPALIVE]" {
                     continue;
                 }
                 if let Ok(event) = serde_json::from_str::<AgentEvent>(data) {
-                    let is_terminal = matches!(
-                        &event,
-                        AgentEvent::Complete { .. }
-                            | AgentEvent::Cancelled { .. }
-                            | AgentEvent::Error { .. }
-                    );
                     if tx
                         .send(SessionSseEvent::Event {
                             session_id: session_id.to_string(),
@@ -210,9 +209,6 @@ impl SseStream {
                         .is_err()
                     {
                         return true; // receiver gone — stop
-                    }
-                    if is_terminal {
-                        return true;
                     }
                 }
             }
@@ -240,7 +236,7 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
-    fn parse_block_flags_terminal_events_only() {
+    fn parse_block_only_closes_on_done_sentinel() {
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         // A token is not terminal.
@@ -267,14 +263,38 @@ mod tests {
         ));
         assert!(rx.try_recv().is_err());
 
-        // Complete is terminal.
+        // Parent completion is forwarded but the transport remains open for
+        // late background-child lifecycle events.
         let terminal = SseStream::parse_sse_block(
             r#"data: {"type":"complete","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#,
             "s1",
             7,
             &tx,
         );
-        assert!(terminal);
+        assert!(!terminal);
+        assert!(matches!(
+            rx.try_recv().unwrap(),
+            SessionSseEvent::Event {
+                event: AgentEvent::Complete { .. },
+                ..
+            }
+        ));
+
+        assert!(!SseStream::parse_sse_block(
+            r#"data: {"type":"sub_agent_completed","child_session_id":"child-1","status":"completed"}"#,
+            "s1",
+            7,
+            &tx,
+        ));
+        assert!(matches!(
+            rx.try_recv().unwrap(),
+            SessionSseEvent::Event {
+                event: AgentEvent::SubAgentCompleted { .. },
+                ..
+            }
+        ));
+
+        assert!(SseStream::parse_sse_block("data: [DONE]", "s1", 7, &tx));
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -165,8 +165,9 @@ pub struct HistoryToolCall {
 /// lenient subset of the server's `Message`
 /// (`bamboo-domain::session::types::Message`). Only the fields
 /// `history::map_history` needs are modeled; everything else (content_parts,
-/// image_ocr, phase, compression fields, metadata) is ignored on decode
-/// rather than breaking deserialization.
+/// image_ocr, phase, compression fields) is ignored on decode rather than
+/// breaking deserialization. Metadata is retained leniently because some
+/// servers persist structured child-session summaries there.
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct HistoryMessage {
     #[serde(default)]
@@ -186,6 +187,10 @@ pub struct HistoryMessage {
     pub tool_success: Option<bool>,
     #[serde(default)]
     pub created_at: Option<DateTime<Utc>>,
+    /// Leniently retained so structured UI rows (notably persisted child
+    /// lifecycle summaries) can be reconstructed when a server includes them.
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Wire shape of `GET /api/v1/history/{session_id}` (see the route's ACTUAL

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -286,6 +286,14 @@ pub(crate) fn inspector_lines(value: &str, width: usize) -> Vec<String> {
     wrapped
 }
 
+#[derive(Debug)]
+struct InspectorCacheEntry {
+    source_ptr: usize,
+    source_len: usize,
+    width: usize,
+    lines: Vec<String>,
+}
+
 pub struct ChatState {
     pub session_id: Option<String>,
     /// Project inherited from the opened/selected session and propagated when
@@ -331,6 +339,26 @@ pub struct ChatState {
     pub block_line_ranges: RefCell<Vec<ConversationBlockLineRange>>,
     pub content_height: Cell<u16>,
     pub content_width: Cell<u16>,
+    /// Tool/reasoning payloads can be hundreds of KiB. Cache their wrapped
+    /// rows so the fixed redraw tick only clones the bounded visible window
+    /// instead of re-walking every byte on every frame.
+    inspector_cache: RefCell<HashMap<String, InspectorCacheEntry>>,
+    #[cfg(test)]
+    inspector_cache_builds: Cell<usize>,
+    /// IDs installed from a running session's history (or from an intermediate
+    /// live round flushed while execution continues). Replayed lifecycle
+    /// events update those authoritative rows instead of creating duplicate
+    /// `unknown` live blocks.
+    replay_tool_ids: HashSet<String>,
+    replay_child_ids: HashSet<String>,
+    /// Turn whose stop request has already been dispatched. A late chat POST
+    /// response for this same optimistic turn must not attach SSE and start an
+    /// execution after the operator has asked to cancel it.
+    stop_requested_turn_id: Option<String>,
+    /// The parent emitted its terminal event while background children were
+    /// still running. The transport remains attached until the final child
+    /// lifecycle event arrives.
+    parent_terminal_pending: bool,
     next_ui_id: u64,
 }
 
@@ -364,6 +392,13 @@ impl ChatState {
             block_line_ranges: RefCell::new(Vec::new()),
             content_height: Cell::new(0),
             content_width: Cell::new(0),
+            inspector_cache: RefCell::new(HashMap::new()),
+            #[cfg(test)]
+            inspector_cache_builds: Cell::new(0),
+            replay_tool_ids: HashSet::new(),
+            replay_child_ids: HashSet::new(),
+            stop_requested_turn_id: None,
+            parent_terminal_pending: false,
             next_ui_id: 0,
         }
     }
@@ -395,12 +430,82 @@ impl ChatState {
         }
     }
 
+    pub(crate) fn inspector_slice(
+        &self,
+        key: &str,
+        value: &str,
+        width: usize,
+        start: usize,
+        limit: usize,
+    ) -> (usize, Vec<String>) {
+        let width = width.max(1);
+        let source_ptr = value.as_ptr() as usize;
+        let source_len = value.len();
+        let mut cache = self.inspector_cache.borrow_mut();
+        let rebuild = cache.get(key).is_none_or(|entry| {
+            entry.source_ptr != source_ptr || entry.source_len != source_len || entry.width != width
+        });
+        if rebuild {
+            cache.insert(
+                key.to_string(),
+                InspectorCacheEntry {
+                    source_ptr,
+                    source_len,
+                    width,
+                    lines: inspector_lines(value, width),
+                },
+            );
+            #[cfg(test)]
+            self.inspector_cache_builds
+                .set(self.inspector_cache_builds.get().saturating_add(1));
+        }
+        let entry = cache
+            .get(key)
+            .expect("inspector cache entry was just populated");
+        let total = entry.lines.len();
+        let lines = entry
+            .lines
+            .iter()
+            .skip(start.min(total))
+            .take(limit)
+            .cloned()
+            .collect();
+        (total, lines)
+    }
+
+    fn prepare_replay_reconciliation(&mut self) {
+        self.replay_tool_ids = self
+            .messages
+            .iter()
+            .flat_map(|message| message.tool_calls.iter().map(|tool| tool.id.clone()))
+            .collect();
+        self.replay_child_ids = self
+            .messages
+            .iter()
+            .flat_map(|message| {
+                message
+                    .sub_agents
+                    .iter()
+                    .map(|child| child.child_session_id.clone())
+            })
+            .collect();
+    }
+
+    fn clear_replay_reconciliation(&mut self) {
+        self.replay_tool_ids.clear();
+        self.replay_child_ids.clear();
+        self.stop_requested_turn_id = None;
+        self.parent_terminal_pending = false;
+    }
+
     fn reset_conversation_ui(&mut self) {
         self.block_ui.clear();
         self.focused_block = None;
         self.block_line_ranges.borrow_mut().clear();
         self.content_height.set(0);
         self.content_width.set(0);
+        self.inspector_cache.borrow_mut().clear();
+        self.clear_replay_reconciliation();
         self.unseen_updates = 0;
         self.current_turn_id = None;
         self.current_terminal_status = None;
@@ -637,6 +742,10 @@ impl QuestionOptionHitbox {
 
 /// An agent question awaiting the operator's answer, driven by the modal.
 pub struct ActiveQuestion {
+    /// Immutable render/focus identity. Protocol identity may hydrate from a
+    /// legacy event to a durable tool_call_id, but UI expansion/focus state
+    /// must not jump to a different block when that happens.
+    pub ui_id: String,
     pub session_id: String,
     pub tool_call_id: Option<String>,
     pub tool_name: Option<String>,
@@ -687,7 +796,12 @@ impl ActiveQuestion {
     /// Build the modal state from a `GET .../pending` response. Mirrors the
     /// SSE `NeedClarification` handler: no preset options opens straight into
     /// free-text entry instead of an empty option list.
-    fn from_pending(session_id: String, pending: &PendingQuestion, draft: String) -> Self {
+    fn from_pending(
+        ui_id: String,
+        session_id: String,
+        pending: &PendingQuestion,
+        draft: String,
+    ) -> Self {
         let options = pending.options.clone().unwrap_or_default();
         let custom = if options.is_empty() && pending.allow_custom {
             Some(draft.clone())
@@ -695,6 +809,7 @@ impl ActiveQuestion {
             None
         };
         Self {
+            ui_id,
             session_id,
             tool_call_id: pending.tool_call_id.clone(),
             tool_name: pending.tool_name.clone(),
@@ -1985,25 +2100,43 @@ impl App {
                 }
                 self.load_tab_data();
             }
-            AppEvent::ChatStarted(r) => match r {
-                Ok(session_id) => {
-                    self.chat.session_id = Some(session_id.clone());
-                    self.rebind_command_palette_to_active_session();
-                    self.status_message = "Streaming...".to_string();
-                    self.start_stream_and_execute(session_id);
+            AppEvent::ChatStarted { turn_id, result: r } => {
+                if !self.chat.streaming
+                    || self.chat.current_turn_id.as_deref() != Some(turn_id.as_str())
+                    || self.chat.stop_requested_turn_id.as_deref() == Some(turn_id.as_str())
+                {
+                    return Ok(());
                 }
-                Err(e) => {
-                    // The optimistic user turn already reserved a matching
-                    // assistant turn id. Preserve that turn with an explicit
-                    // terminal block: otherwise the next send clears the
-                    // scratch id and the failed start disappears from the
-                    // structured transcript.
-                    self.chat.current_terminal_status = Some(format!("failed to start: {e}"));
-                    self.finalize_streaming();
-                    self.notify(NoticeLevel::Error, format!("Error: {e}"));
+                match r {
+                    Ok(session_id) => {
+                        self.chat.session_id = Some(session_id.clone());
+                        self.rebind_command_palette_to_active_session();
+                        self.status_message = "Streaming...".to_string();
+                        self.start_stream_and_execute(session_id, turn_id);
+                    }
+                    Err(e) => {
+                        // The optimistic user turn already reserved a matching
+                        // assistant turn id. Preserve that turn with an explicit
+                        // terminal block: otherwise the next send clears the
+                        // scratch id and the failed start disappears from the
+                        // structured transcript.
+                        self.chat.current_terminal_status = Some(format!("failed to start: {e}"));
+                        self.finalize_streaming();
+                        self.notify(NoticeLevel::Error, format!("Error: {e}"));
+                    }
                 }
-            },
-            AppEvent::ExecuteFailed(msg) => {
+            }
+            AppEvent::ExecuteFailed {
+                session_id,
+                turn_id,
+                message: msg,
+            } => {
+                if self.chat.session_id.as_deref() != Some(session_id.as_str())
+                    || !self.chat.streaming
+                    || self.chat.current_turn_id.as_deref() != Some(turn_id.as_str())
+                {
+                    return Ok(());
+                }
                 // The POST that starts the run never succeeded, so no SSE
                 // terminal event is ever coming — finalize here or
                 // `chat.streaming` spins forever.
@@ -2011,7 +2144,19 @@ impl App {
                 self.chat.current_terminal_status = Some(format!("failed to start: {msg}"));
                 self.finalize_streaming();
             }
-            AppEvent::StopFinished(r) => {
+            AppEvent::StopFinished {
+                session_id,
+                turn_id,
+                stream_epoch,
+                result: r,
+            } => {
+                if self.chat.session_id.as_deref() != Some(session_id.as_str())
+                    || self.sse_epoch != stream_epoch
+                    || !self.chat.streaming
+                    || self.chat.current_turn_id.as_deref() != Some(turn_id.as_str())
+                {
+                    return Ok(());
+                }
                 // Finalize regardless of outcome: even if the stop request
                 // failed (server down/unreachable), the operator must regain
                 // control of the input instead of being stuck waiting for a
@@ -2023,20 +2168,11 @@ impl App {
                 // internally, so the outcome-specific message is set AFTER it
                 // (same ordering the old synchronous `stop_streaming` used to
                 // get "Stopped" to stick instead of being overwritten).
-                let has_unflushed_turn = self.chat.streaming
-                    || self.chat.current_turn_id.is_some()
-                    || !self.chat.current_response.is_empty()
-                    || !self.chat.current_tool_calls.is_empty()
-                    || !self.chat.current_reasoning.is_empty()
-                    || !self.chat.sub_agents.is_empty()
-                    || self.chat.current_terminal_status.is_some();
-                if has_unflushed_turn {
-                    self.chat.current_terminal_status = Some(match &r {
-                        Ok(()) => "stopped".to_string(),
-                        Err(error) => format!("stop failed: {error}"),
-                    });
-                    self.finalize_streaming();
-                }
+                self.chat.current_terminal_status = Some(match &r {
+                    Ok(()) => "stopped".to_string(),
+                    Err(error) => format!("stop failed: {error}"),
+                });
+                self.finalize_streaming();
                 match r {
                     Ok(()) => self.status_message = "Stopped".to_string(),
                     Err(e) => self.notify(NoticeLevel::Error, format!("Stop failed: {e}")),
@@ -2112,6 +2248,7 @@ impl App {
                         // before that HTTP response returns. Subscribe now so
                         // even an immediate resumed Token/Complete is observed.
                         if opened.is_running || opened.pending.is_some() {
+                            self.chat.prepare_replay_reconciliation();
                             self.chat.current_turn_id =
                                 Some(format!("session:{session_id}:active"));
                             self.attach_stream(session_id.clone());
@@ -3944,7 +4081,8 @@ impl App {
             None
         }
         .unwrap_or_default();
-        ActiveQuestion::from_pending(session_id, pending, draft)
+        let ui_id = self.chat.allocate_ui_id("question");
+        ActiveQuestion::from_pending(ui_id, session_id, pending, draft)
     }
 
     /// Invalidate any in-flight answer POST by bumping `answer_epoch`. Called
@@ -4368,6 +4506,15 @@ impl App {
         let Some(tx) = self.event_tx.clone() else {
             return;
         };
+        // A completed parent may leave its transport attached solely to watch
+        // background child lifecycle. Supersede that generation before the
+        // next optimistic turn so a replayed old Complete can never finalize
+        // the new run; the fresh subscription replays durable child events.
+        if self.chat.parent_terminal_pending {
+            self.detach_stream();
+            self.chat.parent_terminal_pending = false;
+        }
+        self.chat.stop_requested_turn_id = None;
         let model = if self.chat.model.is_empty() {
             "default".to_string()
         } else {
@@ -4393,7 +4540,7 @@ impl App {
         self.chat.current_tool_calls.clear();
         self.chat.current_reasoning.clear();
         self.chat.sub_agents.clear();
-        self.chat.current_turn_id = Some(assistant_turn_id);
+        self.chat.current_turn_id = Some(assistant_turn_id.clone());
         self.chat.current_terminal_status = None;
         self.status_message = "Sending...".to_string();
 
@@ -4414,7 +4561,10 @@ impl App {
                 .await
                 .map(|resp| resp.session_id)
                 .map_err(|e| e.to_string());
-            let _ = tx.send(AppEvent::ChatStarted(result));
+            let _ = tx.send(AppEvent::ChatStarted {
+                turn_id: assistant_turn_id,
+                result,
+            });
         });
     }
 
@@ -4469,8 +4619,11 @@ impl App {
 
     /// After `chat` returns a session id, open the SSE stream (before execute, so
     /// no early event is missed) and spawn the agent run.
-    fn start_stream_and_execute(&mut self, session_id: String) {
+    fn start_stream_and_execute(&mut self, session_id: String, turn_id: String) {
         if !self.attach_stream(session_id.clone()) {
+            self.chat.current_terminal_status =
+                Some("failed to start: SSE unavailable".to_string());
+            self.finalize_streaming();
             return;
         }
         let Some(mut sse_ready) = self.sse_ready.clone() else {
@@ -4478,15 +4631,23 @@ impl App {
                 NoticeLevel::Error,
                 "SSE readiness channel unavailable; run was not started",
             );
+            self.chat.current_terminal_status =
+                Some("failed to start: SSE readiness unavailable".to_string());
+            self.finalize_streaming();
             return;
         };
         let Some(tx) = self.event_tx.clone() else {
+            self.chat.current_terminal_status =
+                Some("failed to start: event channel unavailable".to_string());
+            self.finalize_streaming();
             return;
         };
         let client = self.client.clone();
         let model = self.chat.model.clone();
         let provider = self.chat.provider.clone();
         tokio::spawn(async move {
+            let execute_session_id = session_id.clone();
+            let execute_turn_id = turn_id.clone();
             let model = if model.is_empty() { None } else { Some(model) };
             let ready = if *sse_ready.borrow() {
                 Ok(())
@@ -4504,9 +4665,11 @@ impl App {
                 })
             };
             if let Err(error) = ready {
-                let _ = tx.send(AppEvent::ExecuteFailed(format!(
-                    "execute not started: {error}"
-                )));
+                let _ = tx.send(AppEvent::ExecuteFailed {
+                    session_id: execute_session_id,
+                    turn_id: execute_turn_id,
+                    message: format!("execute not started: {error}"),
+                });
                 return;
             }
             // If this POST fails (server down, 4xx/5xx), no SSE terminal event
@@ -4517,7 +4680,11 @@ impl App {
                 .execute(&session_id, model.as_deref(), provider.as_deref())
                 .await
             {
-                let _ = tx.send(AppEvent::ExecuteFailed(e.to_string()));
+                let _ = tx.send(AppEvent::ExecuteFailed {
+                    session_id,
+                    turn_id,
+                    message: e.to_string(),
+                });
             }
         });
     }
@@ -4694,10 +4861,79 @@ impl App {
     /// own Complete/Error/Lifecycle update instead of clobbering whichever
     /// entry happens to be last in the list.
     fn find_tool_mut(&mut self, tool_call_id: &str) -> Option<&mut ToolCallDisplay> {
-        self.chat
+        if let Some(index) = self
+            .chat
             .current_tool_calls
-            .iter_mut()
-            .find(|t| t.id == tool_call_id)
+            .iter()
+            .position(|tool| tool.id == tool_call_id)
+        {
+            return self.chat.current_tool_calls.get_mut(index);
+        }
+        if !self.chat.replay_tool_ids.contains(tool_call_id) {
+            return None;
+        }
+        self.chat.messages.iter_mut().rev().find_map(|message| {
+            message
+                .tool_calls
+                .iter_mut()
+                .find(|tool| tool.id == tool_call_id)
+        })
+    }
+
+    fn find_subagent_mut(&mut self, child_session_id: &str) -> Option<&mut SubAgentDisplay> {
+        if let Some(index) = self
+            .chat
+            .sub_agents
+            .iter()
+            .position(|child| child.child_session_id == child_session_id)
+        {
+            return self.chat.sub_agents.get_mut(index);
+        }
+        if !self.chat.replay_child_ids.contains(child_session_id) {
+            return None;
+        }
+        self.chat.messages.iter_mut().rev().find_map(|message| {
+            message
+                .sub_agents
+                .iter_mut()
+                .find(|child| child.child_session_id == child_session_id)
+        })
+    }
+
+    fn has_running_subagents(&self) -> bool {
+        fn running(status: &str) -> bool {
+            matches!(
+                status.to_ascii_lowercase().as_str(),
+                "running" | "running_in_background" | "queued" | "starting" | "in_progress"
+            )
+        }
+
+        self.chat
+            .sub_agents
+            .iter()
+            .any(|child| running(&child.status))
+            || self.chat.messages.iter().any(|message| {
+                message
+                    .sub_agents
+                    .iter()
+                    .any(|child| running(&child.status))
+            })
+    }
+
+    /// A tool-bearing assistant message is one persisted LLM round. The next
+    /// Token/ReasoningToken belongs to the following round, so seal the tool
+    /// round before appending it; otherwise live ordering differs from the
+    /// authoritative history after resume.
+    fn begin_next_round_after_tools(&mut self) {
+        if !self.chat.current_tool_calls.is_empty()
+            && self
+                .chat
+                .current_tool_calls
+                .iter()
+                .all(|tool| matches!(tool.phase.as_str(), "complete" | "error"))
+        {
+            self.flush_streaming_output();
+        }
     }
 
     /// Produce the one structured rendering shape used by both history and
@@ -4828,11 +5064,7 @@ impl App {
         }
         if let Some(question) = self.pending_question.as_ref() {
             blocks.push(ConversationBlock {
-                id: format!(
-                    "question:{}:{}",
-                    question.session_id,
-                    question.tool_call_id.as_deref().unwrap_or("pending")
-                ),
+                id: question.ui_id.clone(),
                 kind: ConversationBlockKind::Question {
                     question: &question.question,
                     source: question.source.as_deref(),
@@ -4842,11 +5074,7 @@ impl App {
             });
         } else if let Some(question) = self.dismissed_question.as_ref() {
             blocks.push(ConversationBlock {
-                id: format!(
-                    "question:{}:{}",
-                    question.session_id,
-                    question.tool_call_id.as_deref().unwrap_or("pending")
-                ),
+                id: question.ui_id.clone(),
                 kind: ConversationBlockKind::Question {
                     question: &question.question,
                     source: question.source.as_deref(),
@@ -4964,6 +5192,7 @@ impl App {
     fn handle_sse_event(&mut self, event: AgentEvent) -> Result<()> {
         match event {
             AgentEvent::Token { content } => {
+                self.begin_next_round_after_tools();
                 self.chat.ensure_current_turn_id();
                 self.chat.current_response.push_str(&content);
                 self.chat.note_update();
@@ -4982,6 +5211,7 @@ impl App {
                 self.stream_disconnected = false;
             }
             AgentEvent::ReasoningToken { content } => {
+                self.begin_next_round_after_tools();
                 let turn_id = self.chat.ensure_current_turn_id();
                 self.chat.register_block(format!("{turn_id}:reasoning"));
                 self.chat.current_reasoning.push_str(&content);
@@ -4992,9 +5222,6 @@ impl App {
                 tool_name,
                 arguments,
             } => {
-                let turn_id = self.chat.ensure_current_turn_id();
-                self.chat
-                    .register_block(tool_block_id(&turn_id, &tool_call_id));
                 let arguments = serde_json::to_string(&arguments).unwrap_or_default();
                 if let Some(tool) = self.find_tool_mut(&tool_call_id) {
                     // A ToolToken can race ahead of ToolStart. Hydrate that
@@ -5006,6 +5233,10 @@ impl App {
                         tool.phase = "running".to_string();
                     }
                 } else {
+                    self.begin_next_round_after_tools();
+                    let turn_id = self.chat.ensure_current_turn_id();
+                    self.chat
+                        .register_block(tool_block_id(&turn_id, &tool_call_id));
                     self.chat.current_tool_calls.push(ToolCallDisplay {
                         id: tool_call_id,
                         tool_name,
@@ -5022,23 +5253,37 @@ impl App {
                 tool_call_id,
                 result,
             } => {
-                let turn_id = self.chat.ensure_current_turn_id();
+                let success = result.success;
+                let result = result.result;
                 match self.find_tool_mut(&tool_call_id) {
                     Some(tc) => {
-                        tc.result = Some(result.result);
-                        tc.phase = "complete".to_string();
+                        if success {
+                            tc.result = Some(result);
+                            tc.error = None;
+                            tc.phase = "complete".to_string();
+                        } else {
+                            tc.result = None;
+                            tc.error = Some(result);
+                            tc.phase = "error".to_string();
+                        }
                     }
                     None => {
                         // No matching ToolStart (dropped/out-of-order) — surface it
                         // defensively instead of silently losing the result.
+                        let (stored_result, stored_error, phase) = if success {
+                            (Some(result), None, "complete")
+                        } else {
+                            (None, Some(result), "error")
+                        };
+                        let turn_id = self.chat.ensure_current_turn_id();
                         self.chat.current_tool_calls.push(ToolCallDisplay {
                             id: tool_call_id.clone(),
                             tool_name: "unknown".to_string(),
                             arguments: String::new(),
-                            result: Some(result.result),
+                            result: stored_result,
                             stream_output: String::new(),
-                            error: None,
-                            phase: "complete".to_string(),
+                            error: stored_error,
+                            phase: phase.to_string(),
                         });
                         self.chat
                             .register_block(tool_block_id(&turn_id, &tool_call_id));
@@ -5050,13 +5295,13 @@ impl App {
                 tool_call_id,
                 error,
             } => {
-                let turn_id = self.chat.ensure_current_turn_id();
                 match self.find_tool_mut(&tool_call_id) {
                     Some(tc) => {
                         tc.error = Some(error);
                         tc.phase = "error".to_string();
                     }
                     None => {
+                        let turn_id = self.chat.ensure_current_turn_id();
                         self.chat.current_tool_calls.push(ToolCallDisplay {
                             id: tool_call_id.clone(),
                             tool_name: "unknown".to_string(),
@@ -5182,14 +5427,12 @@ impl App {
             AgentEvent::Complete { usage } => self.handle_complete(usage),
             AgentEvent::Cancelled { message } => {
                 let message = message.unwrap_or_else(|| "Cancelled".to_string());
-                self.chat.current_terminal_status = Some(message.clone());
                 self.status_message = message;
-                self.finalize_streaming();
+                self.finish_parent_terminal(self.status_message.clone());
             }
             AgentEvent::Error { message } => {
-                self.chat.current_terminal_status = Some(format!("error: {message}"));
                 self.notify(NoticeLevel::Error, format!("Error: {message}"));
-                self.finalize_streaming();
+                self.finish_parent_terminal(format!("error: {message}"));
             }
             AgentEvent::BudgetExceeded {
                 kind,
@@ -5209,10 +5452,10 @@ impl App {
                 tool_call_id,
                 content,
             } => {
-                let turn_id = self.chat.ensure_current_turn_id();
                 if let Some(tool) = self.find_tool_mut(&tool_call_id) {
                     tool.stream_output.push_str(&content);
                 } else {
+                    let turn_id = self.chat.ensure_current_turn_id();
                     self.chat.current_tool_calls.push(ToolCallDisplay {
                         id: tool_call_id.clone(),
                         tool_name: "unknown".to_string(),
@@ -5255,19 +5498,21 @@ impl App {
                 child_session_id,
                 title,
             } => {
-                let turn_id = self.chat.ensure_current_turn_id();
-                self.chat
-                    .register_block(subagent_block_id(&turn_id, &child_session_id));
-                if let Some(existing) = self
-                    .chat
-                    .sub_agents
-                    .iter_mut()
-                    .find(|child| child.child_session_id == child_session_id)
-                {
+                if let Some(existing) = self.find_subagent_mut(&child_session_id) {
                     if title.is_some() {
                         existing.title = title;
                     }
+                    if !matches!(
+                        existing.status.as_str(),
+                        "completed" | "error" | "cancelled" | "skipped" | "timeout"
+                    ) {
+                        existing.status = "running".to_string();
+                        existing.error = None;
+                    }
                 } else {
+                    let turn_id = self.chat.ensure_current_turn_id();
+                    self.chat
+                        .register_block(subagent_block_id(&turn_id, &child_session_id));
                     self.chat.sub_agents.push(SubAgentDisplay {
                         child_session_id,
                         title,
@@ -5283,16 +5528,11 @@ impl App {
                 status,
                 error,
             } => {
-                let turn_id = self.chat.ensure_current_turn_id();
-                if let Some(sa) = self
-                    .chat
-                    .sub_agents
-                    .iter_mut()
-                    .find(|s| s.child_session_id == child_session_id)
-                {
+                if let Some(sa) = self.find_subagent_mut(&child_session_id) {
                     sa.status = status;
                     sa.error = error;
                 } else {
+                    let turn_id = self.chat.ensure_current_turn_id();
                     self.chat
                         .register_block(subagent_block_id(&turn_id, &child_session_id));
                     self.chat.sub_agents.push(SubAgentDisplay {
@@ -5303,6 +5543,12 @@ impl App {
                     });
                 }
                 self.chat.note_update();
+                if self.chat.parent_terminal_pending && !self.has_running_subagents() {
+                    self.chat.parent_terminal_pending = false;
+                    self.detach_stream();
+                    self.stream_disconnected = false;
+                    self.status_message = "Ready".to_string();
+                }
             }
         }
         Ok(())
@@ -5323,6 +5569,31 @@ impl App {
         // an answer, so drop any open (or dismissed-but-cached) question modal
         // to avoid answering a dead session — and invalidate any answer POST
         // still in flight for it.
+        self.supersede_pending_answer();
+        self.pending_question = None;
+        self.dismissed_question = None;
+        self.chat.clear_replay_reconciliation();
+    }
+
+    fn finish_parent_terminal(&mut self, status: String) {
+        self.chat.current_terminal_status = Some(status);
+        if !self.has_running_subagents() {
+            self.finalize_streaming();
+            return;
+        }
+
+        // The parent run is terminal and the composer must be usable now, but
+        // the session stream deliberately remains open while background
+        // children finish. Flush the parent round, retain replay identities,
+        // and detach only after the last child lifecycle event (or when a new
+        // turn supersedes this watcher).
+        self.chat.parent_terminal_pending = true;
+        self.chat.streaming = false;
+        self.chat.note_update();
+        self.flush_streaming_output();
+        self.status_message = "Ready — background child agents still running".to_string();
+        self.stream_disconnected = false;
+        self.pending_answer_run_started = false;
         self.supersede_pending_answer();
         self.pending_question = None;
         self.dismissed_question = None;
@@ -5352,12 +5623,23 @@ impl App {
             }
             return;
         }
-        self.chat.current_terminal_status = Some("completed".to_string());
-        self.finalize_streaming();
         self.chat.token_usage = Some(usage);
+        self.finish_parent_terminal("completed".to_string());
     }
 
     fn flush_streaming_output(&mut self) {
+        self.chat.replay_tool_ids.extend(
+            self.chat
+                .current_tool_calls
+                .iter()
+                .map(|tool| tool.id.clone()),
+        );
+        self.chat.replay_child_ids.extend(
+            self.chat
+                .sub_agents
+                .iter()
+                .map(|child| child.child_session_id.clone()),
+        );
         if !self.chat.current_response.is_empty()
             || !self.chat.current_tool_calls.is_empty()
             || !self.chat.current_reasoning.is_empty()
@@ -5409,9 +5691,17 @@ impl App {
         };
         self.status_message = "Stopping...".to_string();
         let client = self.client.clone();
+        let stream_epoch = self.sse_epoch;
+        let turn_id = self.chat.ensure_current_turn_id();
+        self.chat.stop_requested_turn_id = Some(turn_id.clone());
         tokio::spawn(async move {
             let r = client.stop(&sid).await.map_err(|e| e.to_string());
-            let _ = tx.send(AppEvent::StopFinished(r));
+            let _ = tx.send(AppEvent::StopFinished {
+                session_id: sid,
+                turn_id,
+                stream_epoch,
+                result: r,
+            });
         });
     }
 
@@ -7663,7 +7953,12 @@ mod question_tests {
             tool_name: Some("ConclusionWithOptions".to_string()),
             source: Some("pause_tool".to_string()),
         };
-        ActiveQuestion::from_pending(session_id.to_string(), &pending, draft.to_string())
+        ActiveQuestion::from_pending(
+            format!("test:question:{tool_call_id}"),
+            session_id.to_string(),
+            &pending,
+            draft.to_string(),
+        )
     }
 
     fn app_with_question(options: Vec<&str>) -> App {
@@ -7817,7 +8112,12 @@ mod question_tests {
             tool_name: Some("ConclusionWithOptions".to_string()),
             source: Some("pause_tool".to_string()),
         };
-        let http = ActiveQuestion::from_pending("sess-7".to_string(), &pending, String::new());
+        let http = ActiveQuestion::from_pending(
+            "test:question:http".to_string(),
+            "sess-7".to_string(),
+            &pending,
+            String::new(),
+        );
         let sse = active_question(
             "sess-7",
             pending.question.clone(),
@@ -8035,6 +8335,52 @@ mod question_tests {
         assert_eq!(replayed.selected, 1);
         assert_eq!(replayed.custom_draft, "draft");
         assert!(replayed.submitting);
+    }
+
+    #[test]
+    fn question_ui_identity_survives_protocol_identity_hydration() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("sess-legacy".to_string());
+        app.chat.streaming = true;
+        app.handle_sse_event(AgentEvent::NeedClarification {
+            question: "Legacy question".to_string(),
+            options: Some(vec!["A".to_string()]),
+            tool_call_id: None,
+            tool_name: Some("ConclusionWithOptions".to_string()),
+            allow_custom: false,
+            source: Some("pause_tool".to_string()),
+        })
+        .unwrap();
+
+        let ui_id = app.pending_question.as_ref().unwrap().ui_id.clone();
+        app.chat.focused_block = Some(ui_id.clone());
+        let incoming = app.question_from_pending(
+            "sess-legacy".to_string(),
+            &PendingQuestion {
+                has_pending_question: true,
+                question: "Legacy question".to_string(),
+                options: Some(vec!["A".to_string()]),
+                allow_custom: false,
+                tool_call_id: Some("durable-tool-id".to_string()),
+                tool_name: Some("ConclusionWithOptions".to_string()),
+                source: Some("pause_tool".to_string()),
+            },
+        );
+        assert!(app
+            .pending_question
+            .as_ref()
+            .unwrap()
+            .can_hydrate_identity_from(&incoming));
+        app.pending_question
+            .as_mut()
+            .unwrap()
+            .refresh_contract(incoming);
+
+        let hydrated = app.pending_question.as_ref().unwrap();
+        assert_eq!(hydrated.tool_call_id.as_deref(), Some("durable-tool-id"));
+        assert_eq!(hydrated.ui_id, ui_id);
+        assert_eq!(app.chat.focused_block.as_deref(), Some(ui_id.as_str()));
+        assert_eq!(app.conversation_blocks().last().unwrap().id, ui_id);
     }
 
     #[tokio::test]
@@ -8890,7 +9236,14 @@ mod question_tests {
                 .await
                 .expect("stop result must return")
                 .expect("event channel must stay open");
-        assert!(matches!(stop_finished, AppEvent::StopFinished(Ok(()))));
+        assert!(matches!(
+            &stop_finished,
+            AppEvent::StopFinished {
+                session_id,
+                result: Ok(()),
+                ..
+            } if session_id == "sess-1"
+        ));
         app.handle_event(stop_finished).await.unwrap();
         assert!(!app.chat.streaming);
         assert!(app.pending_question.is_none());
@@ -9530,6 +9883,92 @@ mod question_tests {
         assert_eq!(app.chat.sub_agents[1].status, "completed");
     }
 
+    #[tokio::test]
+    async fn parent_completion_opens_composer_while_late_child_watcher_isolated_from_next_turn() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(event_tx);
+        app.chat.session_id = Some("parent".to_string());
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("turn-a".to_string());
+        app.chat.current_response = "parent answer".to_string();
+        app.sse_task = Some(tokio::spawn(std::future::pending()));
+        let old_epoch = app.sse_epoch;
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "child-late".to_string(),
+            title: Some("background review".to_string()),
+        })
+        .unwrap();
+
+        app.handle_sse_event(AgentEvent::Complete {
+            usage: TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+
+        assert!(!app.chat.streaming, "parent completion opens the send gate");
+        assert!(app.chat.parent_terminal_pending);
+        assert!(app.sse_task.is_some(), "late-child watcher stays attached");
+        assert_eq!(app.chat.messages.last().unwrap().content, "parent answer");
+
+        for character in "next".chars() {
+            app.handle_chat_key(key(KeyCode::Char(character)))
+                .await
+                .unwrap();
+        }
+        app.handle_chat_key(key(KeyCode::Enter)).await.unwrap();
+        assert!(app.chat.streaming, "the next turn starts immediately");
+        assert!(!app.chat.parent_terminal_pending);
+        assert!(
+            app.sse_epoch > old_epoch,
+            "old watcher generation is retired"
+        );
+        let turn_b = app.chat.current_turn_id.clone().unwrap();
+        app.chat.current_response = "new partial".to_string();
+
+        app.handle_session_sse_event(SessionSseEvent::Event {
+            session_id: "parent".to_string(),
+            stream_epoch: old_epoch,
+            event: AgentEvent::Complete {
+                usage: TokenUsage {
+                    prompt_tokens: 9,
+                    completion_tokens: 9,
+                    total_tokens: 18,
+                },
+            },
+        })
+        .unwrap();
+        assert!(app.chat.streaming);
+        assert_eq!(app.chat.current_turn_id.as_deref(), Some(turn_b.as_str()));
+        assert_eq!(app.chat.current_response, "new partial");
+
+        // A replay on the fresh subscription still updates A's durable child
+        // row instead of attaching it to B.
+        app.handle_session_sse_event(SessionSseEvent::Event {
+            session_id: "parent".to_string(),
+            stream_epoch: app.sse_epoch,
+            event: AgentEvent::SubAgentCompleted {
+                child_session_id: "child-late".to_string(),
+                status: "completed".to_string(),
+                error: None,
+            },
+        })
+        .unwrap();
+        let children = app
+            .chat
+            .messages
+            .iter()
+            .flat_map(|message| &message.sub_agents)
+            .filter(|child| child.child_session_id == "child-late")
+            .collect::<Vec<_>>();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].status, "completed");
+        assert!(app.chat.sub_agents.is_empty());
+    }
+
     /// Parallel tool calls: a `ToolComplete` must land on the entry whose
     /// `tool_call_id` it names, not on whichever entry is last in the list.
     #[tokio::test]
@@ -9569,6 +10008,31 @@ mod question_tests {
         assert_eq!(a.phase, "complete");
         assert!(b.result.is_none(), "b's result must be untouched");
         assert_eq!(b.phase, "running", "b must still be running");
+    }
+
+    #[test]
+    fn failed_tool_complete_uses_error_state_in_live_reducer() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "failed".into(),
+            tool_name: "Bash".into(),
+            arguments: serde_json::json!({ "cmd": "false" }),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolComplete {
+            tool_call_id: "failed".into(),
+            result: ToolResult {
+                success: false,
+                result: "exit status 1".into(),
+            },
+        })
+        .unwrap();
+
+        let tool = &app.chat.current_tool_calls[0];
+        assert_eq!(tool.phase, "error");
+        assert_eq!(tool.error.as_deref(), Some("exit status 1"));
+        assert!(tool.result.is_none());
     }
 
     #[tokio::test]
@@ -9674,6 +10138,105 @@ mod question_tests {
     }
 
     #[test]
+    fn live_tool_round_then_final_round_matches_real_split_history_order() {
+        use crate::api::types::{HistoryFunctionCall, HistoryMessage, HistoryToolCall};
+
+        let mapped = map_history(vec![
+            HistoryMessage {
+                id: "history-round-1".to_string(),
+                role: "assistant".to_string(),
+                content: "before tool".to_string(),
+                tool_calls: Some(vec![HistoryToolCall {
+                    id: "call-1".to_string(),
+                    function: HistoryFunctionCall {
+                        name: "Read".to_string(),
+                        arguments: "{\"path\":\"a\"}".to_string(),
+                    },
+                }]),
+                ..Default::default()
+            },
+            HistoryMessage {
+                role: "tool".to_string(),
+                content: "tool result".to_string(),
+                tool_call_id: Some("call-1".to_string()),
+                tool_success: Some(true),
+                ..Default::default()
+            },
+            HistoryMessage {
+                id: "history-round-2".to_string(),
+                role: "assistant".to_string(),
+                content: "final answer".to_string(),
+                ..Default::default()
+            },
+        ]);
+
+        let mut history_app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        history_app.chat.messages = mapped;
+        let mut live_app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        live_app.chat.streaming = true;
+        live_app.chat.current_turn_id = Some("live-round-1".to_string());
+        live_app
+            .handle_sse_event(AgentEvent::Token {
+                content: "before tool".to_string(),
+            })
+            .unwrap();
+        live_app
+            .handle_sse_event(AgentEvent::ToolStart {
+                tool_call_id: "call-1".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: serde_json::json!({ "path": "a" }),
+            })
+            .unwrap();
+        live_app
+            .handle_sse_event(AgentEvent::ToolComplete {
+                tool_call_id: "call-1".to_string(),
+                result: ToolResult {
+                    success: true,
+                    result: "tool result".to_string(),
+                },
+            })
+            .unwrap();
+        live_app
+            .handle_sse_event(AgentEvent::Token {
+                content: "final answer".to_string(),
+            })
+            .unwrap();
+        live_app.chat.streaming = false;
+
+        assert_eq!(live_app.chat.messages.len(), 1);
+        assert_eq!(live_app.chat.messages[0].content, "before tool");
+        assert_eq!(live_app.chat.messages[0].tool_calls.len(), 1);
+        assert_eq!(live_app.chat.current_response, "final answer");
+
+        let describe = |app: &App| {
+            app.conversation_blocks()
+                .into_iter()
+                .filter_map(|block| match block.kind {
+                    ConversationBlockKind::AssistantMarkdown { content, .. } => {
+                        Some(format!("assistant:{content}"))
+                    }
+                    ConversationBlockKind::ToolCall { tool, .. } => Some(format!(
+                        "tool:{}:{}:{}",
+                        tool.id,
+                        tool.tool_name,
+                        tool.display_output()
+                    )),
+                    ConversationBlockKind::TerminalStatus(_) => None,
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(describe(&live_app), describe(&history_app));
+        let live_tool_id = live_app
+            .conversation_blocks()
+            .into_iter()
+            .find(|block| matches!(block.kind, ConversationBlockKind::ToolCall { .. }))
+            .unwrap()
+            .id;
+        assert!(live_tool_id.ends_with(":tool:call-1"));
+    }
+
+    #[test]
     fn long_single_line_tool_tokens_remain_bounded_scrollable_and_lossless() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.streaming = true;
@@ -9719,6 +10282,35 @@ mod question_tests {
             inspector_lines(&output, 17).len() > CONVERSATION_DETAIL_VIEWPORT,
             "a long no-newline payload must be scrollable by visual rows"
         );
+    }
+
+    #[test]
+    fn inspector_wrap_cache_reuses_large_static_payload_across_redraws() {
+        let app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let payload = "界🙂payload".repeat(32_768);
+
+        let (total, first) = app
+            .chat
+            .inspector_slice("large:tool:output", &payload, 72, 0, 10);
+        assert!(total > 10);
+        assert_eq!(first.len(), 10);
+        assert_eq!(app.chat.inspector_cache_builds.get(), 1);
+
+        for start in [0, 1, 25, total.saturating_sub(10)] {
+            let (_, window) =
+                app.chat
+                    .inspector_slice("large:tool:output", &payload, 72, start, 10);
+            assert!(!window.is_empty());
+        }
+        assert_eq!(
+            app.chat.inspector_cache_builds.get(),
+            1,
+            "fixed redraws and viewport scrolling must not rewrap the full payload"
+        );
+
+        app.chat
+            .inspector_slice("large:tool:output", &payload, 71, 0, 10);
+        assert_eq!(app.chat.inspector_cache_builds.get(), 2);
     }
 
     #[tokio::test]
@@ -9919,11 +10511,17 @@ mod question_tests {
     async fn execute_failed_event_clears_streaming() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.streaming = true;
+        app.chat.session_id = Some("s1".to_string());
+        app.chat.current_turn_id = Some("turn-1".to_string());
         app.chat.current_response = "partial".to_string();
 
-        app.handle_event(AppEvent::ExecuteFailed("connection refused".to_string()))
-            .await
-            .unwrap();
+        app.handle_event(AppEvent::ExecuteFailed {
+            session_id: "s1".to_string(),
+            turn_id: "turn-1".to_string(),
+            message: "connection refused".to_string(),
+        })
+        .await
+        .unwrap();
 
         assert!(
             !app.chat.streaming,
@@ -9944,9 +10542,12 @@ mod question_tests {
         app.chat.streaming = true;
         app.chat.current_turn_id = Some("live:assistant:7".to_string());
 
-        app.handle_event(AppEvent::ChatStarted(Err("server unavailable".to_string())))
-            .await
-            .unwrap();
+        app.handle_event(AppEvent::ChatStarted {
+            turn_id: "live:assistant:7".to_string(),
+            result: Err("server unavailable".to_string()),
+        })
+        .await
+        .unwrap();
 
         assert!(!app.chat.streaming);
         assert!(app.chat.current_turn_id.is_none());
@@ -9959,7 +10560,67 @@ mod question_tests {
         assert!(app.status_message.contains("server unavailable"));
     }
 
-    /// `StopFinished(Err)` must still finalize streaming locally so the
+    #[tokio::test]
+    async fn stale_start_and_execute_callbacks_cannot_mutate_a_newer_turn() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("current-session".to_string());
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("new-turn".to_string());
+        app.chat.current_response = "new partial".to_string();
+        app.status_message = "Streaming new turn".to_string();
+
+        app.handle_event(AppEvent::ChatStarted {
+            turn_id: "old-turn".to_string(),
+            result: Ok("stale-session".to_string()),
+        })
+        .await
+        .unwrap();
+        app.handle_event(AppEvent::ExecuteFailed {
+            session_id: "current-session".to_string(),
+            turn_id: "old-turn".to_string(),
+            message: "old execute failed".to_string(),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(app.chat.session_id.as_deref(), Some("current-session"));
+        assert_eq!(app.chat.current_turn_id.as_deref(), Some("new-turn"));
+        assert_eq!(app.chat.current_response, "new partial");
+        assert!(app.chat.streaming);
+        assert_eq!(app.status_message, "Streaming new turn");
+        assert!(app.notifications.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stop_requested_before_chat_response_prevents_late_execution_start() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        app.event_tx = Some(event_tx);
+        app.chat.session_id = Some("existing-session".to_string());
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("turn-being-stopped".to_string());
+
+        app.stop_streaming();
+        assert_eq!(
+            app.chat.stop_requested_turn_id.as_deref(),
+            Some("turn-being-stopped")
+        );
+        app.handle_event(AppEvent::ChatStarted {
+            turn_id: "turn-being-stopped".to_string(),
+            result: Ok("existing-session".to_string()),
+        })
+        .await
+        .unwrap();
+
+        assert!(app.sse_task.is_none());
+        assert_eq!(app.status_message, "Stopping...");
+        assert_eq!(
+            app.chat.current_turn_id.as_deref(),
+            Some("turn-being-stopped")
+        );
+    }
+
+    /// `StopFinished { result: Err, .. }` must still finalize streaming locally so the
     /// operator regains control of the input even when the stop request
     /// itself failed (e.g. the server is unreachable) — `App::running` stays
     /// `true` (the app itself does not exit).
@@ -9968,10 +10629,15 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.streaming = true;
         app.chat.session_id = Some("s1".to_string());
+        app.chat.current_turn_id = Some("turn-1".to_string());
 
-        app.handle_event(AppEvent::StopFinished(
-            Err("server unreachable".to_string()),
-        ))
+        let stream_epoch = app.sse_epoch;
+        app.handle_event(AppEvent::StopFinished {
+            session_id: "s1".to_string(),
+            turn_id: "turn-1".to_string(),
+            stream_epoch,
+            result: Err("server unreachable".to_string()),
+        })
         .await
         .unwrap();
 
@@ -9983,25 +10649,33 @@ mod question_tests {
         assert!(app.status_message.contains("server unreachable"));
     }
 
-    /// `StopFinished(Ok)` finalizes streaming and reports "Stopped".
+    /// `StopFinished { result: Ok, .. }` finalizes streaming and reports "Stopped".
     #[tokio::test]
     async fn stop_success_finalizes_with_stopped_status() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.streaming = true;
         app.chat.session_id = Some("s1".to_string());
+        app.chat.current_turn_id = Some("turn-1".to_string());
 
-        app.handle_event(AppEvent::StopFinished(Ok(())))
-            .await
-            .unwrap();
+        let stream_epoch = app.sse_epoch;
+        app.handle_event(AppEvent::StopFinished {
+            session_id: "s1".to_string(),
+            turn_id: "turn-1".to_string(),
+            stream_epoch,
+            result: Ok(()),
+        })
+        .await
+        .unwrap();
 
         assert!(!app.chat.streaming);
         assert_eq!(app.status_message, "Stopped");
     }
 
     #[tokio::test]
-    async fn cancelled_sse_before_stop_response_does_not_append_a_second_terminal_turn() {
+    async fn stale_stop_response_cannot_finalize_a_newer_turn() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.streaming = true;
+        app.chat.session_id = Some("s1".to_string());
         app.chat.current_turn_id = Some("live:assistant:stop".to_string());
 
         app.handle_sse_event(AgentEvent::Cancelled {
@@ -10010,20 +10684,38 @@ mod question_tests {
         .unwrap();
         assert_eq!(app.chat.messages.len(), 1);
 
-        app.handle_event(AppEvent::StopFinished(Ok(())))
-            .await
-            .unwrap();
+        // The operator starts another turn after the terminal SSE but before
+        // the old HTTP stop response arrives.
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("live:assistant:new".to_string());
+        app.chat.current_response = "new turn output".to_string();
+        app.status_message = "Streaming new turn".to_string();
+
+        app.handle_event(AppEvent::StopFinished {
+            session_id: "s1".to_string(),
+            turn_id: "live:assistant:stop".to_string(),
+            stream_epoch: app.sse_epoch,
+            result: Ok(()),
+        })
+        .await
+        .unwrap();
 
         assert_eq!(
             app.chat.messages.len(),
             1,
             "the HTTP response must not create a second terminal-only turn"
         );
+        assert!(app.chat.streaming, "the newer turn must remain active");
+        assert_eq!(
+            app.chat.current_turn_id.as_deref(),
+            Some("live:assistant:new")
+        );
+        assert_eq!(app.chat.current_response, "new turn output");
         assert_eq!(
             app.chat.messages[0].terminal_status.as_deref(),
             Some("cancelled by operator")
         );
-        assert_eq!(app.status_message, "Stopped");
+        assert_eq!(app.status_message, "Streaming new turn");
     }
 
     // ── Session resume (WP3) ──
@@ -10051,6 +10743,76 @@ mod question_tests {
             sub_agents: Vec::new(),
             terminal_status: None,
         }
+    }
+
+    #[test]
+    fn replayed_running_tool_and_child_update_history_without_duplicate_live_rows() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages.push(ChatMessage {
+            id: "history:active".to_string(),
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCallDisplay {
+                id: "tool-active".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: "{}".to_string(),
+                result: None,
+                stream_output: String::new(),
+                error: None,
+                phase: "pending".to_string(),
+            }],
+            reasoning: None,
+            sub_agents: vec![SubAgentDisplay {
+                child_session_id: "child-active".to_string(),
+                title: Some("worker".to_string()),
+                status: "running".to_string(),
+                error: None,
+            }],
+            terminal_status: None,
+        });
+        app.chat.prepare_replay_reconciliation();
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("session:s1:active".to_string());
+
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "tool-active".to_string(),
+            tool_name: "Read".to_string(),
+            arguments: serde_json::json!({ "path": "a" }),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolToken {
+            tool_call_id: "tool-active".to_string(),
+            content: "partial".to_string(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolComplete {
+            tool_call_id: "tool-active".to_string(),
+            result: ToolResult {
+                success: true,
+                result: "complete result".to_string(),
+            },
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "child-active".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+
+        assert!(app.chat.current_tool_calls.is_empty());
+        assert!(app.chat.sub_agents.is_empty());
+        let history = &app.chat.messages[0];
+        assert_eq!(history.tool_calls.len(), 1);
+        assert_eq!(history.tool_calls[0].tool_name, "Read");
+        assert_eq!(history.tool_calls[0].phase, "complete");
+        assert_eq!(
+            history.tool_calls[0].result.as_deref(),
+            Some("complete result")
+        );
+        assert_eq!(history.tool_calls[0].stream_output, "partial");
+        assert_eq!(history.sub_agents.len(), 1);
+        assert_eq!(history.sub_agents[0].status, "completed");
     }
 
     /// A successful resume installs the mapped history, the model, and the
@@ -10317,6 +11079,12 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("sess-1".to_string());
         app.chat.streaming = true;
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "call-1".to_string(),
+            tool_name: "ConclusionWithOptions".to_string(),
+            arguments: serde_json::json!({ "question": "Choose carefully" }),
+        })
+        .unwrap();
         app.handle_sse_event(AgentEvent::NeedClarification {
             question: "Choose carefully".to_string(),
             options: Some(vec!["A".to_string()]),
@@ -10356,6 +11124,35 @@ mod question_tests {
             vec!["paused — waiting for answer"],
             "a clarification pause must not also claim that the run is running"
         );
+
+        // The pause flushed the still-running question tool into history. A
+        // resumed terminal event must reconcile that exact row, not create an
+        // `unknown` duplicate in live scratch state.
+        app.handle_sse_event(AgentEvent::ExecutionStarted {
+            run_id: "resume-1".to_string(),
+            session_id: "sess-1".to_string(),
+            started_at: "now".to_string(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolComplete {
+            tool_call_id: "call-1".to_string(),
+            result: ToolResult {
+                success: true,
+                result: "A".to_string(),
+            },
+        })
+        .unwrap();
+        assert!(app.chat.current_tool_calls.is_empty());
+        let question_tools = app
+            .chat
+            .messages
+            .iter()
+            .flat_map(|message| &message.tool_calls)
+            .filter(|tool| tool.id == "call-1")
+            .collect::<Vec<_>>();
+        assert_eq!(question_tools.len(), 1);
+        assert_eq!(question_tools[0].phase, "complete");
+        assert_eq!(question_tools[0].result.as_deref(), Some("A"));
         app.detach_stream();
     }
 
@@ -10444,7 +11241,10 @@ mod question_tests {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
         app.event_tx = Some(event_tx);
         app.chat.session_id = Some("sess-handshake".to_string());
-        app.start_stream_and_execute("sess-handshake".to_string());
+        app.start_stream_and_execute(
+            "sess-handshake".to_string(),
+            "live:assistant:handshake".to_string(),
+        );
 
         tokio::time::timeout(std::time::Duration::from_secs(5), execute_seen_rx)
             .await
@@ -10580,7 +11380,7 @@ mod question_tests {
                         respond_test_http(
                             &mut stream,
                             "text/event-stream",
-                            "data: {\"type\":\"complete\",\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\n",
+                            "data: {\"type\":\"complete\",\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\ndata: [DONE]\n\n",
                         )
                         .await;
                     }
@@ -10735,7 +11535,7 @@ mod question_tests {
                         respond_test_http(
                             &mut stream,
                             "text/event-stream",
-                            "data: {\"type\":\"complete\",\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\n",
+                            "data: {\"type\":\"complete\",\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\ndata: [DONE]\n\n",
                         )
                         .await;
                     }

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -13,6 +13,7 @@ use ratatui::Terminal;
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, watch};
 use tui_textarea::{CursorMove, TextArea};
+use unicode_width::UnicodeWidthChar;
 
 use crate::api::sse::{SessionSseEvent, SseStream};
 use crate::api::types::*;
@@ -89,8 +90,27 @@ pub struct ToolCallDisplay {
     pub tool_name: String,
     pub arguments: String,
     pub result: Option<String>,
+    /// Incremental output received through `ToolToken` before the terminal
+    /// result arrives. It belongs to this tool id and must never be mixed into
+    /// assistant markdown.
+    pub stream_output: String,
     pub error: Option<String>,
     pub phase: String,
+}
+
+impl ToolCallDisplay {
+    pub(crate) fn display_output(&self) -> &str {
+        if self.phase == "complete" {
+            self.result
+                .as_deref()
+                .filter(|result| !result.is_empty())
+                .unwrap_or(&self.stream_output)
+        } else if !self.stream_output.is_empty() {
+            &self.stream_output
+        } else {
+            self.result.as_deref().unwrap_or_default()
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -99,19 +119,172 @@ pub struct SubAgentDisplay {
     pub title: Option<String>,
     /// "running" | "completed" | "cancelled" | "error" | "skipped".
     pub status: String,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
+    /// Stable history message id, or a deterministic in-memory id for a live
+    /// turn. Block ids are derived from this plus tool/child ids.
+    pub id: String,
     pub role: MessageRole,
     pub content: String,
     pub tool_calls: Vec<ToolCallDisplay>,
     pub reasoning: Option<String>,
+    pub sub_agents: Vec<SubAgentDisplay>,
+    pub terminal_status: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConversationBlockUiState {
+    pub expanded: bool,
+    /// First visible detail line for bounded tool/reasoning inspectors.
+    pub scroll: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversationBlockLineRange {
+    pub id: String,
+    pub start: u16,
+    pub end: u16,
+}
+
+/// Structured rendering shape shared by resumed history and live streaming.
+/// The payloads borrow the authoritative transcript state; the owned `id` is
+/// the stable key used for focus/expansion/inspector scroll state.
+#[derive(Debug)]
+pub struct ConversationBlock<'a> {
+    pub id: String,
+    pub kind: ConversationBlockKind<'a>,
+}
+
+#[derive(Debug)]
+pub enum ConversationBlockKind<'a> {
+    UserMessage(&'a str),
+    AssistantMarkdown {
+        content: &'a str,
+        streaming: bool,
+    },
+    Reasoning {
+        content: &'a str,
+        streaming: bool,
+    },
+    ToolCall {
+        tool: &'a ToolCallDisplay,
+        streaming: bool,
+    },
+    SubAgent {
+        child: &'a SubAgentDisplay,
+        streaming: bool,
+    },
+    Question {
+        question: &'a str,
+        source: Option<&'a str>,
+        submitting: bool,
+        dismissed: bool,
+    },
+    TerminalStatus(&'a str),
+}
+
+impl ConversationBlock<'_> {
+    fn expandable(&self) -> bool {
+        matches!(
+            self.kind,
+            ConversationBlockKind::Reasoning { .. }
+                | ConversationBlockKind::ToolCall { .. }
+                | ConversationBlockKind::SubAgent { .. }
+        )
+    }
+
+    fn copy_text(&self) -> String {
+        match &self.kind {
+            ConversationBlockKind::UserMessage(content)
+            | ConversationBlockKind::TerminalStatus(content) => (*content).to_string(),
+            ConversationBlockKind::AssistantMarkdown { content, .. }
+            | ConversationBlockKind::Reasoning { content, .. } => (*content).to_string(),
+            ConversationBlockKind::ToolCall { tool, .. } => {
+                let output = tool.display_output();
+                format!(
+                    "{}\nargs: {}\n{}{}",
+                    tool.tool_name,
+                    tool.arguments,
+                    output,
+                    tool.error
+                        .as_ref()
+                        .map(|error| format!("\nError: {error}"))
+                        .unwrap_or_default()
+                )
+            }
+            ConversationBlockKind::SubAgent { child, .. } => format!(
+                "{}\nstatus: {}\nid: {}{}",
+                child.title.as_deref().unwrap_or("sub-agent"),
+                child.status,
+                child.child_session_id,
+                child
+                    .error
+                    .as_ref()
+                    .map(|error| format!("\nerror: {error}"))
+                    .unwrap_or_default()
+            ),
+            ConversationBlockKind::Question { question, .. } => (*question).to_string(),
+        }
+    }
+
+    fn detail_line_count(&self, width: u16) -> usize {
+        match &self.kind {
+            ConversationBlockKind::Reasoning { content, .. } => {
+                inspector_lines(content, width.saturating_sub(1) as usize).len()
+            }
+            ConversationBlockKind::ToolCall { tool, .. } => {
+                inspector_lines(tool.display_output(), width.saturating_sub(3) as usize).len()
+            }
+            _ => 0,
+        }
+    }
 }
 
 /// Textarea placeholder shown on an empty Chat input, kept as one constant so
 /// the initial state and the post-send reset (`handle_chat_key`) can't drift.
 const CHAT_PLACEHOLDER: &str = "Type a message... (Enter send · Alt+Enter newline)";
+pub(crate) const CONVERSATION_DETAIL_VIEWPORT: usize = 10;
+
+fn tool_block_id(turn_id: &str, tool_call_id: &str) -> String {
+    format!("{turn_id}:tool:{tool_call_id}")
+}
+
+fn subagent_block_id(turn_id: &str, child_session_id: &str) -> String {
+    format!("{turn_id}:subagent:{child_session_id}")
+}
+
+/// Split inspector payloads into terminal-width visual lines without changing
+/// their authoritative stored value (copy still uses the original text).
+/// Ratatui can wrap a single logical line into hundreds of rows, so counting
+/// only `str::lines()` would make the supposedly bounded inspector flood the
+/// transcript and leave j/k unable to reach the hidden portions.
+pub(crate) fn inspector_lines(value: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut wrapped = Vec::new();
+    for logical in value.lines() {
+        if logical.is_empty() {
+            wrapped.push(String::new());
+            continue;
+        }
+
+        let mut line = String::new();
+        let mut cells = 0usize;
+        for character in logical.chars() {
+            let character_width = character.width().unwrap_or(1);
+            if !line.is_empty() && cells.saturating_add(character_width) > width {
+                wrapped.push(std::mem::take(&mut line));
+                cells = 0;
+            }
+            line.push(character);
+            cells = cells.saturating_add(character_width);
+        }
+        wrapped.push(line);
+    }
+    wrapped
+}
 
 pub struct ChatState {
     pub session_id: Option<String>,
@@ -130,10 +303,15 @@ pub struct ChatState {
     /// number of up-presses to "catch up" before the view visibly moves.
     pub max_scroll: Cell<u16>,
     pub auto_scroll: bool,
+    /// Number of conversation updates received while auto-scroll is detached.
+    /// It is independent from notification-log alerts.
+    pub unseen_updates: usize,
     pub streaming: bool,
     pub current_response: String,
     pub current_tool_calls: Vec<ToolCallDisplay>,
     pub current_reasoning: String,
+    pub current_turn_id: Option<String>,
+    pub current_terminal_status: Option<String>,
     pub model: String,
     /// Provider paired with `model` when the selection has an authoritative
     /// catalog/session identity. Kept across Ctrl+N so a new session does not
@@ -141,11 +319,19 @@ pub struct ChatState {
     pub provider: Option<String>,
     pub token_usage: Option<TokenUsage>,
     pub plan_mode: bool,
-    /// When true, tool-call arguments and results render in full instead
-    /// of truncated. Toggled with `x` on the Chat tab.
+    /// Expansion default captured by detail blocks when they first appear.
+    /// Existing blocks keep their independent state when this changes.
     pub expand_tools: bool,
     /// Sub-agents spawned by the current run (child lifecycle).
     pub sub_agents: Vec<SubAgentDisplay>,
+    /// Per-block state means expanding or scrolling one detail never alters
+    /// any sibling. `expand_tools` is only the default captured at insertion.
+    pub block_ui: HashMap<String, ConversationBlockUiState>,
+    pub focused_block: Option<String>,
+    pub block_line_ranges: RefCell<Vec<ConversationBlockLineRange>>,
+    pub content_height: Cell<u16>,
+    pub content_width: Cell<u16>,
+    next_ui_id: u64,
 }
 
 impl ChatState {
@@ -160,17 +346,64 @@ impl ChatState {
             scroll_offset: 0,
             max_scroll: Cell::new(0),
             auto_scroll: true,
+            unseen_updates: 0,
             streaming: false,
             current_response: String::new(),
             current_tool_calls: Vec::new(),
             current_reasoning: String::new(),
+            current_turn_id: None,
+            current_terminal_status: None,
             model: String::new(),
             provider: None,
             token_usage: None,
             plan_mode: false,
             expand_tools: false,
             sub_agents: Vec::new(),
+            block_ui: HashMap::new(),
+            focused_block: None,
+            block_line_ranges: RefCell::new(Vec::new()),
+            content_height: Cell::new(0),
+            content_width: Cell::new(0),
+            next_ui_id: 0,
         }
+    }
+
+    fn allocate_ui_id(&mut self, kind: &str) -> String {
+        self.next_ui_id = self.next_ui_id.wrapping_add(1);
+        format!("live:{kind}:{}", self.next_ui_id)
+    }
+
+    fn ensure_current_turn_id(&mut self) -> String {
+        if let Some(id) = &self.current_turn_id {
+            return id.clone();
+        }
+        let id = self.allocate_ui_id("assistant");
+        self.current_turn_id = Some(id.clone());
+        id
+    }
+
+    fn register_block(&mut self, id: String) {
+        self.block_ui.entry(id).or_insert(ConversationBlockUiState {
+            expanded: self.expand_tools,
+            scroll: 0,
+        });
+    }
+
+    fn note_update(&mut self) {
+        if !self.auto_scroll {
+            self.unseen_updates = self.unseen_updates.saturating_add(1);
+        }
+    }
+
+    fn reset_conversation_ui(&mut self) {
+        self.block_ui.clear();
+        self.focused_block = None;
+        self.block_line_ranges.borrow_mut().clear();
+        self.content_height.set(0);
+        self.content_width.set(0);
+        self.unseen_updates = 0;
+        self.current_turn_id = None;
+        self.current_terminal_status = None;
     }
 }
 
@@ -758,7 +991,7 @@ impl BuiltinPaletteAction {
             Self::Help => "Show help",
             Self::Notifications => "Show notifications",
             Self::Stop => "Stop active run",
-            Self::ToggleDetails => "Toggle tool details",
+            Self::ToggleDetails => "Toggle focused details",
             Self::Config => "Open config",
             Self::Schedules => "Open schedules",
         }
@@ -772,7 +1005,7 @@ impl BuiltinPaletteAction {
             Self::Help => "Show all TUI keyboard shortcuts",
             Self::Notifications => "Review recent status, warning, and error messages",
             Self::Stop => "Request cancellation of the currently running agent",
-            Self::ToggleDetails => "Expand or collapse tool arguments and results",
+            Self::ToggleDetails => "Toggle the focused block, or the default for new details",
             Self::Config => "Switch to the configuration tab",
             Self::Schedules => "Switch to the schedules tab",
         }
@@ -1760,7 +1993,13 @@ impl App {
                     self.start_stream_and_execute(session_id);
                 }
                 Err(e) => {
-                    self.chat.streaming = false;
+                    // The optimistic user turn already reserved a matching
+                    // assistant turn id. Preserve that turn with an explicit
+                    // terminal block: otherwise the next send clears the
+                    // scratch id and the failed start disappears from the
+                    // structured transcript.
+                    self.chat.current_terminal_status = Some(format!("failed to start: {e}"));
+                    self.finalize_streaming();
                     self.notify(NoticeLevel::Error, format!("Error: {e}"));
                 }
             },
@@ -1769,6 +2008,7 @@ impl App {
                 // terminal event is ever coming — finalize here or
                 // `chat.streaming` spins forever.
                 self.notify(NoticeLevel::Error, format!("Failed to start run: {msg}"));
+                self.chat.current_terminal_status = Some(format!("failed to start: {msg}"));
                 self.finalize_streaming();
             }
             AppEvent::StopFinished(r) => {
@@ -1780,6 +2020,10 @@ impl App {
                 // internally, so the outcome-specific message is set AFTER it
                 // (same ordering the old synchronous `stop_streaming` used to
                 // get "Stopped" to stick instead of being overwritten).
+                self.chat.current_terminal_status = Some(match &r {
+                    Ok(()) => "stopped".to_string(),
+                    Err(error) => format!("stop failed: {error}"),
+                });
                 self.finalize_streaming();
                 match r {
                     Ok(()) => self.status_message = "Stopped".to_string(),
@@ -1823,6 +2067,7 @@ impl App {
                         self.chat.current_tool_calls.clear();
                         self.chat.current_reasoning.clear();
                         self.chat.sub_agents.clear();
+                        self.chat.reset_conversation_ui();
                         self.chat.token_usage = None;
                         self.chat.scroll_offset = 0;
                         self.chat.streaming = false;
@@ -1835,6 +2080,7 @@ impl App {
 
                         let shown = opened.messages.len();
                         self.chat.messages = opened.messages;
+                        self.sync_conversation_block_ui();
                         self.chat.auto_scroll = true;
                         self.tab = Tab::Chat;
                         self.status_message = "Session resumed".to_string();
@@ -1854,6 +2100,8 @@ impl App {
                         // before that HTTP response returns. Subscribe now so
                         // even an immediate resumed Token/Complete is observed.
                         if opened.is_running || opened.pending.is_some() {
+                            self.chat.current_turn_id =
+                                Some(format!("session:{session_id}:active"));
                             self.attach_stream(session_id.clone());
                             self.chat.streaming = true;
                             self.status_message = if opened.is_running {
@@ -1891,6 +2139,7 @@ impl App {
                         self.supersede_pending_answer();
                         let question = self.question_from_pending(session_id.clone(), &pending);
                         self.pending_question = Some(question);
+                        self.chat.note_update();
                         // Ctrl+Q may recover a server-side pause after the old
                         // event stream was detached. Treat it as an active run
                         // again so Ctrl+C routes to STOP (instead of quitting
@@ -1953,6 +2202,7 @@ impl App {
                             incoming.question
                         );
                         self.pending_question = Some(incoming);
+                        self.chat.note_update();
                     }
                     Ok(_) => {
                         if let Some(question) = self.pending_question.as_mut() {
@@ -2073,6 +2323,11 @@ impl App {
                         // reachable again, so reattach before waiting for the
                         // resumed run's events.
                         if matches!(status.as_str(), "started" | "already_running") {
+                            // Allocate the resumed turn before its first SSE
+                            // event. ExecutionStarted may arrive later with a
+                            // run id; changing the block id at that boundary
+                            // would invalidate focus/expansion state.
+                            self.chat.ensure_current_turn_id();
                             if !self.stream_is_ready() {
                                 self.attach_stream(identity.session_id.clone());
                             }
@@ -2710,7 +2965,10 @@ impl App {
         };
         match self.tab {
             Tab::Chat => {
-                if delta < 0 {
+                self.normalize_conversation_focus();
+                if self.chat.focused_block.is_some() {
+                    self.scroll_focused_block(delta);
+                } else if delta < 0 {
                     self.chat_scroll_up(delta.unsigned_abs() as u16);
                 } else {
                     self.chat_scroll_down(delta as u16);
@@ -2750,18 +3008,28 @@ impl App {
     /// bottom don't leave the opposite key needing an equal number of presses
     /// before the view visibly moves.
     fn chat_scroll_down(&mut self, delta: u16) {
-        self.chat.auto_scroll = false;
-        self.chat.scroll_offset = self
-            .chat
-            .scroll_offset
-            .saturating_add(delta)
-            .min(self.chat.max_scroll.get());
+        let max_scroll = self.chat.max_scroll.get();
+        let current = if self.chat.auto_scroll {
+            max_scroll
+        } else {
+            self.chat.scroll_offset.min(max_scroll)
+        };
+        self.chat.scroll_offset = current.saturating_add(delta).min(max_scroll);
+        self.chat.auto_scroll = self.chat.scroll_offset >= max_scroll;
+        if self.chat.auto_scroll {
+            self.chat.unseen_updates = 0;
+        }
     }
 
     /// Scroll the chat transcript up by `delta` lines; naturally bounded at 0.
     fn chat_scroll_up(&mut self, delta: u16) {
+        let current = if self.chat.auto_scroll {
+            self.chat.max_scroll.get()
+        } else {
+            self.chat.scroll_offset.min(self.chat.max_scroll.get())
+        };
         self.chat.auto_scroll = false;
-        self.chat.scroll_offset = self.chat.scroll_offset.saturating_sub(delta);
+        self.chat.scroll_offset = current.saturating_sub(delta);
     }
 
     /// `g`: jump to the top of the transcript.
@@ -2773,6 +3041,199 @@ impl App {
     /// `G`: jump to the bottom and resume auto-scroll.
     fn chat_scroll_bottom(&mut self) {
         self.chat.auto_scroll = true;
+        self.chat.scroll_offset = self.chat.max_scroll.get();
+        self.chat.unseen_updates = 0;
+    }
+
+    fn focus_last_conversation_block(&mut self) {
+        let len = self.conversation_blocks().len();
+        if len == 0 {
+            self.status_message = "No conversation block to focus".to_string();
+            return;
+        }
+        self.focus_conversation_block_at(len - 1);
+    }
+
+    fn focus_conversation_block_at(&mut self, index: usize) {
+        let id = self
+            .conversation_blocks()
+            .get(index)
+            .map(|block| block.id.clone());
+        let Some(id) = id else {
+            return;
+        };
+        self.chat.focused_block = Some(id.clone());
+        self.scroll_to_conversation_block(&id);
+        self.status_message =
+            "Block focused — ↑/↓ move · Enter use · y copy · Esc composer".to_string();
+    }
+
+    fn move_conversation_block_focus(&mut self, delta: i32) {
+        let ids = self
+            .conversation_blocks()
+            .into_iter()
+            .map(|block| block.id)
+            .collect::<Vec<_>>();
+        if ids.is_empty() {
+            self.chat.focused_block = None;
+            return;
+        }
+        let current = self
+            .chat
+            .focused_block
+            .as_ref()
+            .and_then(|focused| ids.iter().position(|id| id == focused))
+            .unwrap_or(ids.len() - 1);
+        let next = (current as i64 + delta as i64).clamp(0, (ids.len() - 1) as i64) as usize;
+        self.chat.focused_block = Some(ids[next].clone());
+        self.scroll_to_conversation_block(&ids[next]);
+    }
+
+    fn scroll_to_conversation_block(&mut self, id: &str) {
+        let range = self
+            .chat
+            .block_line_ranges
+            .borrow()
+            .iter()
+            .find(|range| range.id == id)
+            .cloned();
+        let Some(range) = range else {
+            return;
+        };
+        let height = self.chat.content_height.get().max(1);
+        let max_scroll = self.chat.max_scroll.get();
+        let current = if self.chat.auto_scroll {
+            max_scroll
+        } else {
+            self.chat.scroll_offset.min(max_scroll)
+        };
+        self.chat.auto_scroll = false;
+        self.chat.scroll_offset = if range.start < current {
+            range.start
+        } else if range.end >= current.saturating_add(height) {
+            range.end.saturating_add(1).saturating_sub(height)
+        } else {
+            current
+        }
+        .min(max_scroll);
+    }
+
+    fn toggle_conversation_details(&mut self) {
+        let focused = self.chat.focused_block.clone();
+        if let Some(id) = focused {
+            let expandable = self
+                .conversation_blocks()
+                .into_iter()
+                .find(|block| block.id == id)
+                .is_some_and(|block| block.expandable());
+            if expandable {
+                let state = self.chat.block_ui.entry(id).or_default();
+                state.expanded = !state.expanded;
+                state.scroll = 0;
+                self.status_message = if state.expanded {
+                    "Focused block expanded".to_string()
+                } else {
+                    "Focused block collapsed".to_string()
+                };
+                return;
+            }
+            self.status_message = "Focused block has no expandable details".to_string();
+            return;
+        }
+
+        // This default is captured only when future detail blocks are
+        // inserted. Existing block state is intentionally untouched.
+        self.chat.expand_tools = !self.chat.expand_tools;
+        self.status_message = if self.chat.expand_tools {
+            "New detail blocks will start expanded".to_string()
+        } else {
+            "New detail blocks will start collapsed".to_string()
+        };
+    }
+
+    fn scroll_focused_block(&mut self, delta: i32) {
+        let Some(id) = self.chat.focused_block.clone() else {
+            return;
+        };
+        let total = self
+            .conversation_blocks()
+            .into_iter()
+            .find(|block| block.id == id)
+            .map(|block| block.detail_line_count(self.chat.content_width.get()))
+            .unwrap_or(0);
+        let state = self.chat.block_ui.entry(id).or_default();
+        if !state.expanded || total <= CONVERSATION_DETAIL_VIEWPORT {
+            return;
+        }
+        let max_scroll = total.saturating_sub(CONVERSATION_DETAIL_VIEWPORT);
+        state.scroll = (state.scroll as i64 + delta as i64).clamp(0, max_scroll as i64) as usize;
+    }
+
+    fn activate_focused_conversation_block(&mut self) {
+        let Some(id) = self.chat.focused_block.clone() else {
+            return;
+        };
+        let child_id = self
+            .conversation_blocks()
+            .into_iter()
+            .find(|block| block.id == id)
+            .and_then(|block| match block.kind {
+                ConversationBlockKind::SubAgent { child, .. } => {
+                    Some(child.child_session_id.clone())
+                }
+                _ => None,
+            });
+        if let Some(child_id) = child_id {
+            if self.chat.streaming {
+                self.toggle_conversation_details();
+                self.status_message = format!(
+                    "{}; child opens after the parent run completes",
+                    self.status_message
+                );
+            } else {
+                self.chat.focused_block = None;
+                self.resume_session(child_id);
+            }
+            return;
+        }
+        self.toggle_conversation_details();
+    }
+
+    fn copy_focused_conversation_block(&mut self) {
+        let Some(id) = self.chat.focused_block.clone() else {
+            return;
+        };
+        let value = self
+            .conversation_blocks()
+            .into_iter()
+            .find(|block| block.id == id)
+            .map(|block| block.copy_text());
+        let Some(value) = value else {
+            return;
+        };
+        match copy_via_osc52(&value) {
+            Ok(()) => self.status_message = "Copied focused block".to_string(),
+            Err(error) => self.notify(
+                NoticeLevel::Error,
+                format!("Failed to copy focused block: {error}"),
+            ),
+        }
+    }
+
+    /// Drop focus when its transient block no longer exists (for example, a
+    /// question block after a successful answer). Without this guard the
+    /// invisible focus owner consumes every composer keystroke until Esc.
+    fn normalize_conversation_focus(&mut self) {
+        let Some(id) = self.chat.focused_block.clone() else {
+            return;
+        };
+        let exists = self
+            .conversation_blocks()
+            .into_iter()
+            .any(|block| block.id == id);
+        if !exists {
+            self.chat.focused_block = None;
+        }
     }
 
     /// Scroll the raw config view down by `delta` lines, clamped to
@@ -3752,43 +4213,75 @@ impl App {
     }
 
     async fn handle_chat_key(&mut self, key: KeyEvent) -> Result<()> {
-        if self.chat.streaming {
+        self.normalize_conversation_focus();
+
+        // Run control and the explicit transcript jumps remain global even
+        // while a conversation block owns the navigation keys.
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
             match key.code {
-                KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                KeyCode::Char('s') if self.chat.streaming => {
                     self.stop_streaming();
+                    return Ok(());
                 }
-                KeyCode::Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    self.chat.expand_tools = !self.chat.expand_tools;
+                KeyCode::Char('g') | KeyCode::End => {
+                    self.chat_scroll_bottom();
+                    return Ok(());
                 }
-                KeyCode::Char('j') | KeyCode::Down => self.chat_scroll_down(3),
-                KeyCode::Char('k') | KeyCode::Up => self.chat_scroll_up(3),
-                KeyCode::PageDown => self.chat_scroll_down(10),
-                KeyCode::PageUp => self.chat_scroll_up(10),
-                KeyCode::Char('g') => self.chat_scroll_top(),
-                KeyCode::Char('G') => self.chat_scroll_bottom(),
+                KeyCode::Home => {
+                    self.chat_scroll_top();
+                    return Ok(());
+                }
                 _ => {}
             }
+        }
+
+        if self.chat.focused_block.is_some() {
+            self.handle_conversation_block_key(key);
             return Ok(());
+        }
+
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            match key.code {
+                KeyCode::Char('b') => {
+                    self.focus_last_conversation_block();
+                    return Ok(());
+                }
+                KeyCode::Char('x') => {
+                    self.toggle_conversation_details();
+                    return Ok(());
+                }
+                _ => {}
+            }
         }
 
         match key.code {
             KeyCode::Char('/')
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                if !self.chat.streaming
+                    && !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
                     && self.chat.textarea.cursor() == (0, 0) =>
             {
                 self.open_command_palette(CommandPaletteTrigger::Slash);
             }
+            KeyCode::PageDown => self.chat_scroll_down(10),
+            KeyCode::PageUp => self.chat_scroll_up(10),
+            KeyCode::Down if key.modifiers.contains(KeyModifiers::ALT) => self.chat_scroll_down(3),
+            KeyCode::Up if key.modifiers.contains(KeyModifiers::ALT) => self.chat_scroll_up(3),
             // Alt+Enter (and Shift+Enter, on the kitty-protocol terminals
-            // that report it — plain crossterm terminals mostly don't, so
-            // this arm is harmless there) inserts a newline instead of
-            // sending, since plain Enter always sends.
+            // that report it) inserts a newline during both idle and active
+            // runs. The draft remains entirely local while streaming.
             KeyCode::Enter
-                if key.modifiers.contains(KeyModifiers::ALT)
-                    || key.modifiers.contains(KeyModifiers::SHIFT) =>
+                if !key.modifiers.intersects(KeyModifiers::CONTROL)
+                    && (key.modifiers.contains(KeyModifiers::ALT)
+                        || key.modifiers.contains(KeyModifiers::SHIFT)) =>
             {
                 self.chat.textarea.insert_newline();
+            }
+            KeyCode::Enter if self.chat.streaming => {
+                self.status_message =
+                    "Run active — draft preserved; press Enter after completion to send"
+                        .to_string();
             }
             KeyCode::Enter => {
                 // Selecting a session starts an asynchronous history/summary
@@ -3818,20 +4311,41 @@ impl App {
                 self.chat.textarea.set_placeholder_text(CHAT_PLACEHOLDER);
                 self.send_message(input);
             }
-            KeyCode::Char('j') | KeyCode::Down => self.chat_scroll_down(3),
-            KeyCode::Char('k') | KeyCode::Up => self.chat_scroll_up(3),
-            KeyCode::PageDown => self.chat_scroll_down(10),
-            KeyCode::PageUp => self.chat_scroll_up(10),
-            KeyCode::Char('g') => self.chat_scroll_top(),
-            KeyCode::Char('G') => self.chat_scroll_bottom(),
-            KeyCode::Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.chat.expand_tools = !self.chat.expand_tools;
-            }
             _ => {
                 self.chat.textarea.input(key);
             }
         }
         Ok(())
+    }
+
+    fn handle_conversation_block_key(&mut self, key: KeyEvent) {
+        if key.code == KeyCode::Esc
+            || (key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('b'))
+        {
+            self.chat.focused_block = None;
+            self.status_message = "Composer focused".to_string();
+            return;
+        }
+
+        match key.code {
+            KeyCode::Up => self.move_conversation_block_focus(-1),
+            KeyCode::Down => self.move_conversation_block_focus(1),
+            KeyCode::Home => self.focus_conversation_block_at(0),
+            KeyCode::End => {
+                let len = self.conversation_blocks().len();
+                self.focus_conversation_block_at(len.saturating_sub(1));
+            }
+            KeyCode::Char('k') => self.scroll_focused_block(-1),
+            KeyCode::Char('j') => self.scroll_focused_block(1),
+            KeyCode::PageUp => self.scroll_focused_block(-(CONVERSATION_DETAIL_VIEWPORT as i32)),
+            KeyCode::PageDown => self.scroll_focused_block(CONVERSATION_DETAIL_VIEWPORT as i32),
+            KeyCode::Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.toggle_conversation_details()
+            }
+            KeyCode::Enter => self.activate_focused_conversation_block(),
+            KeyCode::Char('y') => self.copy_focused_conversation_block(),
+            _ => {}
+        }
     }
 
     /// Send a chat message WITHOUT blocking the event loop: the user turn is
@@ -3849,17 +4363,26 @@ impl App {
         };
 
         // Optimistic UI: show the user's turn and switch to streaming right away.
+        let user_message_id = self.chat.allocate_ui_id("user");
+        let assistant_turn_id = self.chat.allocate_ui_id("assistant");
         self.chat.messages.push(ChatMessage {
+            id: user_message_id,
             role: MessageRole::User,
             content: message.clone(),
             tool_calls: Vec::new(),
             reasoning: None,
+            sub_agents: Vec::new(),
+            terminal_status: None,
         });
         self.chat.auto_scroll = true;
+        self.chat.unseen_updates = 0;
         self.chat.streaming = true;
         self.chat.current_response.clear();
         self.chat.current_tool_calls.clear();
         self.chat.current_reasoning.clear();
+        self.chat.sub_agents.clear();
+        self.chat.current_turn_id = Some(assistant_turn_id);
+        self.chat.current_terminal_status = None;
         self.status_message = "Sending...".to_string();
 
         let client = self.client.clone();
@@ -4077,6 +4600,7 @@ impl App {
         self.chat.current_tool_calls.clear();
         self.chat.current_reasoning.clear();
         self.chat.sub_agents.clear();
+        self.chat.reset_conversation_ui();
         self.chat.token_usage = None;
         self.chat.scroll_offset = 0;
         self.chat.auto_scroll = true;
@@ -4164,6 +4688,197 @@ impl App {
             .find(|t| t.id == tool_call_id)
     }
 
+    /// Produce the one structured rendering shape used by both history and
+    /// live state. No block-level UI state is embedded here: expansion,
+    /// inspector scroll, and focus are looked up independently by `id`.
+    pub(crate) fn conversation_blocks(&self) -> Vec<ConversationBlock<'_>> {
+        let mut blocks = Vec::new();
+        for (index, message) in self.chat.messages.iter().enumerate() {
+            let message_id = if message.id.is_empty() {
+                format!("history:{index}")
+            } else {
+                message.id.clone()
+            };
+            match message.role {
+                MessageRole::User => {
+                    if !message.content.is_empty() {
+                        blocks.push(ConversationBlock {
+                            id: format!("{message_id}:user"),
+                            kind: ConversationBlockKind::UserMessage(&message.content),
+                        });
+                    }
+                }
+                MessageRole::Assistant => {
+                    if !message.content.is_empty() {
+                        blocks.push(ConversationBlock {
+                            id: format!("{message_id}:assistant"),
+                            kind: ConversationBlockKind::AssistantMarkdown {
+                                content: &message.content,
+                                streaming: false,
+                            },
+                        });
+                    }
+                    if let Some(reasoning) = message.reasoning.as_deref() {
+                        if !reasoning.is_empty() {
+                            blocks.push(ConversationBlock {
+                                id: format!("{message_id}:reasoning"),
+                                kind: ConversationBlockKind::Reasoning {
+                                    content: reasoning,
+                                    streaming: false,
+                                },
+                            });
+                        }
+                    }
+                    for tool in &message.tool_calls {
+                        blocks.push(ConversationBlock {
+                            id: tool_block_id(&message_id, &tool.id),
+                            kind: ConversationBlockKind::ToolCall {
+                                tool,
+                                streaming: false,
+                            },
+                        });
+                    }
+                    for child in &message.sub_agents {
+                        blocks.push(ConversationBlock {
+                            id: subagent_block_id(&message_id, &child.child_session_id),
+                            kind: ConversationBlockKind::SubAgent {
+                                child,
+                                streaming: false,
+                            },
+                        });
+                    }
+                    if let Some(status) = message.terminal_status.as_deref() {
+                        blocks.push(ConversationBlock {
+                            id: format!("{message_id}:terminal"),
+                            kind: ConversationBlockKind::TerminalStatus(status),
+                        });
+                    }
+                }
+            }
+        }
+
+        let live_id = self
+            .chat
+            .current_turn_id
+            .as_deref()
+            .or(self.chat.session_id.as_deref())
+            .unwrap_or("live");
+        if !self.chat.current_response.is_empty() {
+            blocks.push(ConversationBlock {
+                id: format!("{live_id}:assistant"),
+                kind: ConversationBlockKind::AssistantMarkdown {
+                    content: &self.chat.current_response,
+                    streaming: self.chat.streaming,
+                },
+            });
+        }
+        if !self.chat.current_reasoning.is_empty() {
+            blocks.push(ConversationBlock {
+                id: format!("{live_id}:reasoning"),
+                kind: ConversationBlockKind::Reasoning {
+                    content: &self.chat.current_reasoning,
+                    streaming: self.chat.streaming,
+                },
+            });
+        }
+        for tool in &self.chat.current_tool_calls {
+            blocks.push(ConversationBlock {
+                id: tool_block_id(live_id, &tool.id),
+                kind: ConversationBlockKind::ToolCall {
+                    tool,
+                    streaming: self.chat.streaming,
+                },
+            });
+        }
+        for child in &self.chat.sub_agents {
+            blocks.push(ConversationBlock {
+                id: subagent_block_id(live_id, &child.child_session_id),
+                kind: ConversationBlockKind::SubAgent {
+                    child,
+                    streaming: self.chat.streaming,
+                },
+            });
+        }
+        let waiting_for_answer = self
+            .pending_question
+            .as_ref()
+            .is_some_and(|question| !question.submitting)
+            || self.dismissed_question.is_some();
+        if self.chat.streaming && !waiting_for_answer {
+            blocks.push(ConversationBlock {
+                id: format!("{live_id}:terminal"),
+                kind: ConversationBlockKind::TerminalStatus(if self.stream_disconnected {
+                    "stream disconnected — draft preserved"
+                } else {
+                    "running — draft sends after completion"
+                }),
+            });
+        }
+        if let Some(question) = self.pending_question.as_ref() {
+            blocks.push(ConversationBlock {
+                id: format!(
+                    "question:{}:{}",
+                    question.session_id,
+                    question.tool_call_id.as_deref().unwrap_or("pending")
+                ),
+                kind: ConversationBlockKind::Question {
+                    question: &question.question,
+                    source: question.source.as_deref(),
+                    submitting: question.submitting,
+                    dismissed: false,
+                },
+            });
+        } else if let Some(question) = self.dismissed_question.as_ref() {
+            blocks.push(ConversationBlock {
+                id: format!(
+                    "question:{}:{}",
+                    question.session_id,
+                    question.tool_call_id.as_deref().unwrap_or("pending")
+                ),
+                kind: ConversationBlockKind::Question {
+                    question: &question.question,
+                    source: question.source.as_deref(),
+                    submitting: false,
+                    dismissed: true,
+                },
+            });
+        }
+        blocks
+    }
+
+    fn sync_conversation_block_ui(&mut self) {
+        let mut ids = Vec::new();
+        for (index, message) in self.chat.messages.iter().enumerate() {
+            let message_id = if message.id.is_empty() {
+                format!("history:{index}")
+            } else {
+                message.id.clone()
+            };
+            if message
+                .reasoning
+                .as_ref()
+                .is_some_and(|value| !value.is_empty())
+            {
+                ids.push(format!("{message_id}:reasoning"));
+            }
+            ids.extend(
+                message
+                    .tool_calls
+                    .iter()
+                    .map(|tool| tool_block_id(&message_id, &tool.id)),
+            );
+            ids.extend(
+                message
+                    .sub_agents
+                    .iter()
+                    .map(|child| subagent_block_id(&message_id, &child.child_session_id)),
+            );
+        }
+        for id in ids {
+            self.chat.register_block(id);
+        }
+    }
+
     fn handle_session_sse_event(&mut self, message: SessionSseEvent) -> Result<()> {
         match message {
             SessionSseEvent::Event {
@@ -4192,6 +4907,7 @@ impl App {
                 self.stream_disconnected = false;
                 if reconnecting {
                     self.status_message = "SSE reconnected — synchronizing".to_string();
+                    self.chat.note_update();
                 }
                 // Answer submission deliberately attaches a fresh stream
                 // before POST. Its watch readiness can wake the POST task
@@ -4226,6 +4942,7 @@ impl App {
                 self.detach_stream();
                 self.connected = false;
                 self.stream_disconnected = true;
+                self.chat.note_update();
                 self.notify(NoticeLevel::Error, format!("SSE disconnected: {message}"));
                 Ok(())
             }
@@ -4233,15 +4950,16 @@ impl App {
     }
 
     fn handle_sse_event(&mut self, event: AgentEvent) -> Result<()> {
-        if self.chat.auto_scroll {
-            // Any incoming event means new content; auto_scroll will reposition.
-        }
         match event {
             AgentEvent::Token { content } => {
+                self.chat.ensure_current_turn_id();
                 self.chat.current_response.push_str(&content);
-                self.chat.auto_scroll = true;
+                self.chat.note_update();
             }
-            AgentEvent::ExecutionStarted { .. } => {
+            AgentEvent::ExecutionStarted { run_id, .. } => {
+                if self.chat.current_turn_id.is_none() {
+                    self.chat.current_turn_id = Some(format!("run:{run_id}"));
+                }
                 if self
                     .pending_question
                     .as_ref()
@@ -4252,62 +4970,96 @@ impl App {
                 self.stream_disconnected = false;
             }
             AgentEvent::ReasoningToken { content } => {
+                let turn_id = self.chat.ensure_current_turn_id();
+                self.chat.register_block(format!("{turn_id}:reasoning"));
                 self.chat.current_reasoning.push_str(&content);
+                self.chat.note_update();
             }
             AgentEvent::ToolStart {
                 tool_call_id,
                 tool_name,
                 arguments,
             } => {
-                self.chat.current_tool_calls.push(ToolCallDisplay {
-                    id: tool_call_id,
-                    tool_name,
-                    arguments: serde_json::to_string(&arguments).unwrap_or_default(),
-                    result: None,
-                    error: None,
-                    phase: "running".to_string(),
-                });
+                let turn_id = self.chat.ensure_current_turn_id();
+                self.chat
+                    .register_block(tool_block_id(&turn_id, &tool_call_id));
+                let arguments = serde_json::to_string(&arguments).unwrap_or_default();
+                if let Some(tool) = self.find_tool_mut(&tool_call_id) {
+                    // A ToolToken can race ahead of ToolStart. Hydrate that
+                    // placeholder in place so its stable block id/output and
+                    // independent UI state survive the reordering.
+                    tool.tool_name = tool_name;
+                    tool.arguments = arguments;
+                    if tool.phase != "complete" && tool.phase != "error" {
+                        tool.phase = "running".to_string();
+                    }
+                } else {
+                    self.chat.current_tool_calls.push(ToolCallDisplay {
+                        id: tool_call_id,
+                        tool_name,
+                        arguments,
+                        result: None,
+                        stream_output: String::new(),
+                        error: None,
+                        phase: "running".to_string(),
+                    });
+                }
+                self.chat.note_update();
             }
             AgentEvent::ToolComplete {
                 tool_call_id,
                 result,
-            } => match self.find_tool_mut(&tool_call_id) {
-                Some(tc) => {
-                    tc.result = Some(result.result);
-                    tc.phase = "complete".to_string();
+            } => {
+                let turn_id = self.chat.ensure_current_turn_id();
+                match self.find_tool_mut(&tool_call_id) {
+                    Some(tc) => {
+                        tc.result = Some(result.result);
+                        tc.phase = "complete".to_string();
+                    }
+                    None => {
+                        // No matching ToolStart (dropped/out-of-order) — surface it
+                        // defensively instead of silently losing the result.
+                        self.chat.current_tool_calls.push(ToolCallDisplay {
+                            id: tool_call_id.clone(),
+                            tool_name: "unknown".to_string(),
+                            arguments: String::new(),
+                            result: Some(result.result),
+                            stream_output: String::new(),
+                            error: None,
+                            phase: "complete".to_string(),
+                        });
+                        self.chat
+                            .register_block(tool_block_id(&turn_id, &tool_call_id));
+                    }
                 }
-                None => {
-                    // No matching ToolStart (dropped/out-of-order) — surface it
-                    // defensively instead of silently losing the result.
-                    self.chat.current_tool_calls.push(ToolCallDisplay {
-                        id: tool_call_id,
-                        tool_name: "unknown".to_string(),
-                        arguments: String::new(),
-                        result: Some(result.result),
-                        error: None,
-                        phase: "complete".to_string(),
-                    });
-                }
-            },
+                self.chat.note_update();
+            }
             AgentEvent::ToolError {
                 tool_call_id,
                 error,
-            } => match self.find_tool_mut(&tool_call_id) {
-                Some(tc) => {
-                    tc.error = Some(error);
-                    tc.phase = "error".to_string();
+            } => {
+                let turn_id = self.chat.ensure_current_turn_id();
+                match self.find_tool_mut(&tool_call_id) {
+                    Some(tc) => {
+                        tc.error = Some(error);
+                        tc.phase = "error".to_string();
+                    }
+                    None => {
+                        self.chat.current_tool_calls.push(ToolCallDisplay {
+                            id: tool_call_id.clone(),
+                            tool_name: "unknown".to_string(),
+                            arguments: String::new(),
+                            result: None,
+                            stream_output: String::new(),
+                            error: Some(error),
+                            phase: "error".to_string(),
+                        });
+                        self.chat
+                            .register_block(tool_block_id(&turn_id, &tool_call_id));
+                    }
                 }
-                None => {
-                    self.chat.current_tool_calls.push(ToolCallDisplay {
-                        id: tool_call_id,
-                        tool_name: "unknown".to_string(),
-                        arguments: String::new(),
-                        result: None,
-                        error: Some(error),
-                        phase: "error".to_string(),
-                    });
-                }
-            },
+                self.chat.note_update();
+            }
             AgentEvent::ToolLifecycle {
                 tool_call_id,
                 phase,
@@ -4332,6 +5084,7 @@ impl App {
                         }
                     }
                 }
+                self.chat.note_update();
                 // No matching entry: a Lifecycle event with no known Start is
                 // dropped (it carries only supplementary progress info, unlike
                 // Complete/Error's definitive terminal result).
@@ -4406,6 +5159,7 @@ impl App {
                 self.status_message =
                     format!("Question: {} (answer in the dialog)", incoming.question);
                 self.pending_question = Some(incoming);
+                self.chat.note_update();
                 if needs_identity_sync {
                     self.status_message = "Synchronizing question identity...".to_string();
                     if let Some(session_id) = self.chat.session_id.clone() {
@@ -4415,10 +5169,13 @@ impl App {
             }
             AgentEvent::Complete { usage } => self.handle_complete(usage),
             AgentEvent::Cancelled { message } => {
-                self.status_message = message.unwrap_or_else(|| "Cancelled".to_string());
+                let message = message.unwrap_or_else(|| "Cancelled".to_string());
+                self.chat.current_terminal_status = Some(message.clone());
+                self.status_message = message;
                 self.finalize_streaming();
             }
             AgentEvent::Error { message } => {
+                self.chat.current_terminal_status = Some(format!("error: {message}"));
                 self.notify(NoticeLevel::Error, format!("Error: {message}"));
                 self.finalize_streaming();
             }
@@ -4436,13 +5193,27 @@ impl App {
                     format!("Run budget exceeded ({kind}: {actual}/{limit}) — stopping."),
                 );
             }
-            AgentEvent::ToolToken { content, .. } => {
-                // Deliberately not routed into the matching ToolCallDisplay by
-                // `tool_call_id`: today's rendering already prints tool output
-                // inline with the response text, and threading a per-call
-                // streaming buffer through to the UI is beyond this fix's
-                // scope. Kept as the simpler, behavior-preserving option.
-                self.chat.current_response.push_str(&content);
+            AgentEvent::ToolToken {
+                tool_call_id,
+                content,
+            } => {
+                let turn_id = self.chat.ensure_current_turn_id();
+                if let Some(tool) = self.find_tool_mut(&tool_call_id) {
+                    tool.stream_output.push_str(&content);
+                } else {
+                    self.chat.current_tool_calls.push(ToolCallDisplay {
+                        id: tool_call_id.clone(),
+                        tool_name: "unknown".to_string(),
+                        arguments: String::new(),
+                        result: None,
+                        stream_output: content,
+                        error: None,
+                        phase: "streaming".to_string(),
+                    });
+                    self.chat
+                        .register_block(tool_block_id(&turn_id, &tool_call_id));
+                }
+                self.chat.note_update();
             }
             AgentEvent::ContextCompressionStatus { phase, status } => {
                 self.status_message = format!("Compression: {} ({})", status, phase);
@@ -4472,25 +5243,35 @@ impl App {
                 child_session_id,
                 title,
             } => {
-                if !self
+                let turn_id = self.chat.ensure_current_turn_id();
+                self.chat
+                    .register_block(subagent_block_id(&turn_id, &child_session_id));
+                if let Some(existing) = self
                     .chat
                     .sub_agents
-                    .iter()
-                    .any(|s| s.child_session_id == child_session_id)
+                    .iter_mut()
+                    .find(|child| child.child_session_id == child_session_id)
                 {
+                    if title.is_some() {
+                        existing.title = title;
+                    }
+                } else {
                     self.chat.sub_agents.push(SubAgentDisplay {
                         child_session_id,
                         title,
                         status: "running".to_string(),
+                        error: None,
                     });
                 }
+                self.chat.note_update();
             }
             AgentEvent::SubAgentHeartbeat { .. } => {}
             AgentEvent::SubAgentCompleted {
                 child_session_id,
                 status,
-                ..
+                error,
             } => {
+                let turn_id = self.chat.ensure_current_turn_id();
                 if let Some(sa) = self
                     .chat
                     .sub_agents
@@ -4498,7 +5279,18 @@ impl App {
                     .find(|s| s.child_session_id == child_session_id)
                 {
                     sa.status = status;
+                    sa.error = error;
+                } else {
+                    self.chat
+                        .register_block(subagent_block_id(&turn_id, &child_session_id));
+                    self.chat.sub_agents.push(SubAgentDisplay {
+                        child_session_id,
+                        title: None,
+                        status,
+                        error,
+                    });
                 }
+                self.chat.note_update();
             }
         }
         Ok(())
@@ -4506,12 +5298,15 @@ impl App {
 
     fn finalize_streaming(&mut self) {
         self.chat.streaming = false;
+        self.chat
+            .current_terminal_status
+            .get_or_insert_with(|| "completed".to_string());
+        self.chat.note_update();
         self.flush_streaming_output();
         self.status_message = "Ready".to_string();
         self.detach_stream();
         self.stream_disconnected = false;
         self.pending_answer_run_started = false;
-        self.chat.sub_agents.clear();
         // A run that ended (completed / cancelled / stopped) can no longer accept
         // an answer, so drop any open (or dismissed-but-cached) question modal
         // to avoid answering a dead session — and invalidate any answer POST
@@ -4534,23 +5329,32 @@ impl App {
             // activation that suspended at NeedClarification. That boundary is
             // not terminal user work: preserve the exact modal/draft and keep
             // the session input-blocked.
+            self.chat.current_terminal_status = Some("paused — waiting for answer".to_string());
+            self.chat.note_update();
             self.flush_streaming_output();
             self.chat.token_usage = Some(usage);
             self.chat.streaming = true;
-            self.chat.sub_agents.clear();
             self.status_message = "Paused — waiting for your answer".to_string();
             if let Some(session_id) = self.chat.session_id.clone() {
                 self.attach_stream(session_id);
             }
             return;
         }
+        self.chat.current_terminal_status = Some("completed".to_string());
         self.finalize_streaming();
         self.chat.token_usage = Some(usage);
     }
 
     fn flush_streaming_output(&mut self) {
-        if !self.chat.current_response.is_empty() || !self.chat.current_tool_calls.is_empty() {
+        if !self.chat.current_response.is_empty()
+            || !self.chat.current_tool_calls.is_empty()
+            || !self.chat.current_reasoning.is_empty()
+            || !self.chat.sub_agents.is_empty()
+            || self.chat.current_terminal_status.is_some()
+        {
+            let id = self.chat.ensure_current_turn_id();
             self.chat.messages.push(ChatMessage {
+                id,
                 role: MessageRole::Assistant,
                 content: std::mem::take(&mut self.chat.current_response),
                 tool_calls: std::mem::take(&mut self.chat.current_tool_calls),
@@ -4559,8 +5363,11 @@ impl App {
                 } else {
                     Some(std::mem::take(&mut self.chat.current_reasoning))
                 },
+                sub_agents: std::mem::take(&mut self.chat.sub_agents),
+                terminal_status: self.chat.current_terminal_status.take(),
             });
         }
+        self.chat.current_turn_id = None;
     }
 
     /// Stop the current run WITHOUT blocking the event loop: the `stop` POST
@@ -4578,11 +5385,13 @@ impl App {
         self.supersede_pending_answer();
         let Some(sid) = self.chat.session_id.clone() else {
             // Nothing to stop server-side; still clear local streaming state.
+            self.chat.current_terminal_status = Some("stopped".to_string());
             self.finalize_streaming();
             self.status_message = "Stopped".to_string();
             return;
         };
         let Some(tx) = self.event_tx.clone() else {
+            self.chat.current_terminal_status = Some("stopped locally".to_string());
             self.finalize_streaming();
             return;
         };
@@ -5674,10 +6483,12 @@ impl App {
         entry: &CommandPaletteEntry,
     ) -> Option<&'static str> {
         match entry {
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::NewSession)
-            | CommandPaletteEntry::Builtin(BuiltinPaletteAction::OpenSession)
-            | CommandPaletteEntry::Builtin(BuiltinPaletteAction::SelectModel)
-                if self.chat.streaming =>
+            entry
+                if self.chat.streaming
+                    && !matches!(
+                        entry,
+                        CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop)
+                    ) =>
             {
                 Some("Unavailable while an agent run is active")
             }
@@ -5690,19 +6501,6 @@ impl App {
             }
             CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop) if !self.chat.streaming => {
                 Some("No active run to stop")
-            }
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::ToggleDetails)
-                if self.chat.current_tool_calls.is_empty()
-                    && self
-                        .chat
-                        .messages
-                        .iter()
-                        .all(|message| message.tool_calls.is_empty()) =>
-            {
-                Some("No tool details in this conversation")
-            }
-            CommandPaletteEntry::Server(_) if self.chat.streaming => {
-                Some("Composer commands are unavailable while a run is active")
             }
             CommandPaletteEntry::Server(_) if self.opening_session_id.is_some() => {
                 Some("Composer commands are unavailable while a session is resuming")
@@ -5784,15 +6582,7 @@ impl App {
                 self.unseen_alerts = 0;
             }
             BuiltinPaletteAction::Stop => self.stop_streaming(),
-            BuiltinPaletteAction::ToggleDetails => {
-                self.chat.expand_tools = !self.chat.expand_tools;
-                self.status_message = if self.chat.expand_tools {
-                    "Tool details expanded"
-                } else {
-                    "Tool details collapsed"
-                }
-                .to_string();
-            }
+            BuiltinPaletteAction::ToggleDetails => self.toggle_conversation_details(),
             BuiltinPaletteAction::Config => {
                 self.tab = Tab::Config;
                 self.load_tab_data();
@@ -8359,10 +9149,13 @@ mod question_tests {
         app.chat.model = "gpt-5".to_string();
         app.chat.provider = Some("openai".to_string());
         app.chat.messages.push(ChatMessage {
+            id: "old-assistant".to_string(),
             role: MessageRole::Assistant,
             content: "old transcript".to_string(),
             tool_calls: Vec::new(),
             reasoning: None,
+            sub_agents: Vec::new(),
+            terminal_status: None,
         });
         app.chat.current_response = "partial".to_string();
         app.chat.streaming = true;
@@ -8397,10 +9190,13 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("active".to_string());
         app.chat.messages.push(ChatMessage {
+            id: "keep-assistant".to_string(),
             role: MessageRole::Assistant,
             content: "keep transcript".to_string(),
             tool_calls: Vec::new(),
             reasoning: None,
+            sub_agents: Vec::new(),
+            terminal_status: None,
         });
         app.opening_session_id = Some("delete-me".to_string());
         app.deleting_session_id = Some("delete-me".to_string());
@@ -8498,6 +9294,7 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.tab = Tab::Chat;
         app.chat.scroll_offset = 10;
+        app.chat.auto_scroll = false;
         // Simulates a render having already established the bound (a real
         // frame always renders before the first input is handled).
         app.chat.max_scroll.set(50);
@@ -8515,12 +9312,10 @@ mod question_tests {
     }
 
     /// Scrolling down is clamped to `max_scroll` (set by the render function
-    /// each frame): spamming `j` past the bottom must not overshoot into a
-    /// dead zone that then eats several `k` presses before the view moves.
-    #[tokio::test]
-    async fn chat_scroll_down_clamps_to_max_scroll() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-        let k = |c| KeyEvent::new(c, KeyModifiers::empty());
+    /// each frame): repeated wheel/PageDown input past the bottom must not
+    /// overshoot into a dead zone before the view moves back up.
+    #[test]
+    fn chat_scroll_down_clamps_to_max_scroll() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.tab = Tab::Chat;
         app.chat.max_scroll.set(5);
@@ -8533,9 +9328,10 @@ mod question_tests {
             "scrolling down must clamp at max_scroll, not grow unbounded"
         );
 
-        // One `k` must immediately move the view (not be swallowed catching
-        // up from an overshot offset).
-        app.handle_key(k(KeyCode::Char('k'))).await.unwrap();
+        // One scroll-up action must immediately move the view (not be
+        // swallowed catching up from an overshot offset). Plain `k` now
+        // belongs to the always-editable composer.
+        app.chat_scroll_up(3);
         assert_eq!(app.chat.scroll_offset, 2);
     }
 
@@ -8702,6 +9498,24 @@ mod question_tests {
         })
         .unwrap();
         assert_eq!(app.chat.sub_agents[0].status, "completed");
+
+        // A replayed/out-of-order Start may carry the title that a defensive
+        // completion placeholder lacked. Hydrate it without reverting the
+        // terminal status or duplicating the row.
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "c2".into(),
+            status: "completed".into(),
+            error: None,
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "c2".into(),
+            title: Some("late title".into()),
+        })
+        .unwrap();
+        assert_eq!(app.chat.sub_agents.len(), 2);
+        assert_eq!(app.chat.sub_agents[1].title.as_deref(), Some("late title"));
+        assert_eq!(app.chat.sub_agents[1].status, "completed");
     }
 
     /// Parallel tool calls: a `ToolComplete` must land on the entry whose
@@ -8743,6 +9557,324 @@ mod question_tests {
         assert_eq!(a.phase, "complete");
         assert!(b.result.is_none(), "b's result must be untouched");
         assert_eq!(b.phase, "running", "b must still be running");
+    }
+
+    #[tokio::test]
+    async fn structured_reducer_routes_interleaved_tools_and_persists_children() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("parent".to_string());
+        app.chat.streaming = true;
+        app.chat.auto_scroll = false;
+        app.chat.scroll_offset = 7;
+
+        // Output may precede Start. The later Start hydrates the same stable
+        // tool block instead of creating a duplicate or leaking into markdown.
+        app.handle_sse_event(AgentEvent::ToolToken {
+            tool_call_id: "b".into(),
+            content: "b0\n".into(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "a".into(),
+            tool_name: "Read".into(),
+            arguments: serde_json::json!({ "path": "a" }),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolToken {
+            tool_call_id: "a".into(),
+            content: "a0\n".into(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "b".into(),
+            tool_name: "Shell".into(),
+            arguments: serde_json::json!({ "cmd": "pwd" }),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolToken {
+            tool_call_id: "b".into(),
+            content: "b1".into(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ReasoningToken {
+            content: "long-lived reasoning".into(),
+        })
+        .unwrap();
+        for (id, title) in [("c1", "research"), ("c2", "review")] {
+            app.handle_sse_event(AgentEvent::SubAgentStarted {
+                child_session_id: id.into(),
+                title: Some(title.into()),
+            })
+            .unwrap();
+        }
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "c1".into(),
+            status: "completed".into(),
+            error: None,
+        })
+        .unwrap();
+
+        assert!(app.chat.current_response.is_empty());
+        assert_eq!(app.chat.current_tool_calls.len(), 2);
+        let b = app
+            .chat
+            .current_tool_calls
+            .iter()
+            .find(|tool| tool.id == "b")
+            .unwrap();
+        assert_eq!(b.tool_name, "Shell");
+        assert_eq!(b.stream_output, "b0\nb1");
+        assert_eq!(app.chat.scroll_offset, 7, "absolute anchor is retained");
+        assert!(app.chat.unseen_updates >= 9);
+
+        let live_ids = app
+            .conversation_blocks()
+            .into_iter()
+            .map(|block| block.id)
+            .collect::<Vec<_>>();
+        for suffix in [":tool:a", ":tool:b", ":subagent:c1", ":subagent:c2"] {
+            assert!(live_ids.iter().any(|actual| actual.ends_with(suffix)));
+        }
+
+        app.chat.current_terminal_status = Some("completed".to_string());
+        app.finalize_streaming();
+        let completed = app.chat.messages.last().unwrap();
+        assert_eq!(completed.tool_calls.len(), 2);
+        assert_eq!(completed.sub_agents.len(), 2);
+        assert_eq!(completed.reasoning.as_deref(), Some("long-lived reasoning"));
+        assert_eq!(completed.terminal_status.as_deref(), Some("completed"));
+        assert!(app.chat.sub_agents.is_empty());
+
+        let completed_ids = app
+            .conversation_blocks()
+            .into_iter()
+            .map(|block| block.id)
+            .collect::<Vec<_>>();
+        for live_id in live_ids
+            .iter()
+            .filter(|id| id.contains(":tool:") || id.contains(":subagent:"))
+        {
+            assert!(
+                completed_ids.iter().any(|actual| actual == live_id),
+                "live block id must survive finalization: {live_id}"
+            );
+        }
+    }
+
+    #[test]
+    fn long_single_line_tool_tokens_remain_bounded_scrollable_and_lossless() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        let output = "界".repeat(120);
+        app.handle_sse_event(AgentEvent::ToolToken {
+            tool_call_id: "visual".into(),
+            content: output.clone(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolComplete {
+            tool_call_id: "visual".into(),
+            result: ToolResult {
+                success: true,
+                result: String::new(),
+            },
+        })
+        .unwrap();
+
+        let turn_id = app.chat.current_turn_id.clone().unwrap();
+        let block_id = tool_block_id(&turn_id, "visual");
+        app.chat.block_ui.get_mut(&block_id).unwrap().expanded = true;
+        app.chat.focused_block = Some(block_id.clone());
+        app.chat.content_width.set(20);
+        let copied = app
+            .conversation_blocks()
+            .into_iter()
+            .find(|block| block.id == block_id)
+            .unwrap()
+            .copy_text();
+        app.scroll_focused_block(1);
+
+        assert_eq!(app.chat.block_ui[&block_id].scroll, 1);
+        assert_eq!(
+            app.chat.current_tool_calls[0].display_output(),
+            output,
+            "an empty terminal result must not discard streamed tool output"
+        );
+        assert!(
+            copied.ends_with(&output),
+            "copy uses the full payload rather than the bounded viewport"
+        );
+        assert!(
+            inspector_lines(&output, 17).len() > CONVERSATION_DETAIL_VIEWPORT,
+            "a long no-newline payload must be scrollable by visual rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_composer_draft_survives_terminal_modal_tab_picker_and_reconnect() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("parent".to_string());
+        app.chat.streaming = true;
+        for character in ['j', 'k', 'g', 'G', ' ', '草', '稿'] {
+            app.handle_chat_key(key(KeyCode::Char(character)))
+                .await
+                .unwrap();
+        }
+        app.handle_chat_key(key(KeyCode::Enter)).await.unwrap();
+        let exact = "jkgG 草稿";
+        assert_eq!(app.chat.textarea.lines().join("\n"), exact);
+        assert!(app.chat.messages.is_empty(), "Enter must not steer mid-run");
+        assert!(app.status_message.contains("draft preserved"));
+
+        app.handle_sse_event(AgentEvent::NeedClarification {
+            question: "Approve?".into(),
+            options: Some(vec!["yes".into(), "no".into()]),
+            tool_call_id: Some("q1".into()),
+            tool_name: Some("Shell".into()),
+            allow_custom: true,
+            source: Some("approval".into()),
+        })
+        .unwrap();
+        app.handle_question_key(key(KeyCode::Esc)).await.unwrap();
+        assert_eq!(app.chat.textarea.lines().join("\n"), exact);
+
+        app.handle_key(key(KeyCode::Tab)).await.unwrap();
+        app.handle_key(key(KeyCode::BackTab)).await.unwrap();
+        assert_eq!(app.tab, Tab::Chat);
+        assert_eq!(app.chat.textarea.lines().join("\n"), exact);
+
+        // A transport loss keeps both the active-run gate and the draft.
+        app.handle_session_sse_event(SessionSseEvent::TransportFailed {
+            session_id: "parent".to_string(),
+            stream_epoch: app.sse_epoch,
+            message: "gone".to_string(),
+        })
+        .unwrap();
+        assert_eq!(app.chat.textarea.lines().join("\n"), exact);
+
+        app.chat.current_terminal_status = Some("cancelled".to_string());
+        app.finalize_streaming();
+        assert_eq!(app.chat.textarea.lines().join("\n"), exact);
+
+        // Idle picker round-trip also leaves the exact textarea and cursor.
+        let cursor = app.chat.textarea.cursor();
+        app.open_model_picker();
+        app.close_model_picker();
+        assert_eq!(app.chat.textarea.lines().join("\n"), exact);
+        assert_eq!(app.chat.textarea.cursor(), cursor);
+    }
+
+    #[test]
+    fn expanding_one_block_does_not_change_siblings_or_the_new_block_default() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        for id in ["a", "b"] {
+            app.handle_sse_event(AgentEvent::ToolStart {
+                tool_call_id: id.into(),
+                tool_name: "Read".into(),
+                arguments: serde_json::json!({}),
+            })
+            .unwrap();
+        }
+        let turn_id = app.chat.current_turn_id.clone().unwrap();
+        let tool_a = tool_block_id(&turn_id, "a");
+        let tool_b = tool_block_id(&turn_id, "b");
+        app.chat.focused_block = Some(tool_a.clone());
+        app.toggle_conversation_details();
+        assert!(app.chat.block_ui[&tool_a].expanded);
+        assert!(!app.chat.block_ui[&tool_b].expanded);
+
+        app.chat.messages.push(ChatMessage {
+            id: "user-1".to_string(),
+            role: MessageRole::User,
+            content: "plain message".to_string(),
+            tool_calls: Vec::new(),
+            reasoning: None,
+            sub_agents: Vec::new(),
+            terminal_status: None,
+        });
+        app.chat.focused_block = Some("user-1:user".to_string());
+        app.toggle_conversation_details();
+        assert!(
+            !app.chat.expand_tools,
+            "a selected non-detail block must not mutate the future default"
+        );
+
+        app.chat.focused_block = None;
+        app.toggle_conversation_details();
+        assert!(app.chat.expand_tools, "future-block default toggled");
+        assert!(!app.chat.block_ui[&tool_b].expanded);
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "c".into(),
+            tool_name: "Read".into(),
+            arguments: serde_json::json!({}),
+        })
+        .unwrap();
+        assert!(app.chat.block_ui[&tool_block_id(&turn_id, "c")].expanded);
+    }
+
+    #[test]
+    fn reasoning_only_and_subagent_only_turns_are_not_dropped() {
+        let mut reasoning = App::new(BambooClient::new("http://127.0.0.1:0"));
+        reasoning.chat.streaming = true;
+        reasoning.chat.current_reasoning = "private chain".to_string();
+        reasoning.chat.current_terminal_status = Some("completed".to_string());
+        reasoning.finalize_streaming();
+        assert_eq!(reasoning.chat.messages.len(), 1);
+        assert_eq!(
+            reasoning.chat.messages[0].reasoning.as_deref(),
+            Some("private chain")
+        );
+
+        let mut child = App::new(BambooClient::new("http://127.0.0.1:0"));
+        child.chat.streaming = true;
+        child.chat.sub_agents.push(SubAgentDisplay {
+            child_session_id: "child-only".to_string(),
+            title: Some("worker".to_string()),
+            status: "completed".to_string(),
+            error: None,
+        });
+        child.chat.current_terminal_status = Some("completed".to_string());
+        child.finalize_streaming();
+        assert_eq!(child.chat.messages.len(), 1);
+        assert_eq!(child.chat.messages[0].sub_agents.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn detached_scroll_accumulates_unseen_until_one_action_jump() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.chat.auto_scroll = false;
+        app.chat.scroll_offset = 11;
+        app.chat.max_scroll.set(40);
+        app.handle_sse_event(AgentEvent::Token {
+            content: "new markdown".into(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ReasoningToken {
+            content: "new reasoning".into(),
+        })
+        .unwrap();
+        assert_eq!(app.chat.scroll_offset, 11);
+        assert_eq!(app.chat.unseen_updates, 2);
+        app.chat.focused_block = Some("any-focused-block".to_string());
+        app.handle_chat_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(app.chat.auto_scroll);
+        assert_eq!(app.chat.unseen_updates, 0);
+        assert_eq!(app.chat.scroll_offset, 40);
+    }
+
+    #[tokio::test]
+    async fn stale_block_focus_does_not_consume_the_next_composer_key() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.chat.focused_block = Some("removed:question".to_string());
+
+        app.handle_chat_key(key(KeyCode::Char('草'))).await.unwrap();
+
+        assert!(app.chat.focused_block.is_none());
+        assert_eq!(app.chat.textarea.lines(), &["草"]);
     }
 
     /// A `ToolComplete`/`ToolError` for an id with no matching `ToolStart` is
@@ -8792,6 +9924,27 @@ mod question_tests {
         let last = app.notifications.last().expect("notify logged an entry");
         assert!(last.text.contains("connection refused"));
         assert_eq!(last.level, NoticeLevel::Error);
+    }
+
+    #[tokio::test]
+    async fn chat_start_failure_preserves_a_terminal_block_for_the_optimistic_turn() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("live:assistant:7".to_string());
+
+        app.handle_event(AppEvent::ChatStarted(Err("server unavailable".to_string())))
+            .await
+            .unwrap();
+
+        assert!(!app.chat.streaming);
+        assert!(app.chat.current_turn_id.is_none());
+        assert_eq!(app.chat.messages.len(), 1);
+        assert_eq!(app.chat.messages[0].id, "live:assistant:7");
+        assert_eq!(
+            app.chat.messages[0].terminal_status.as_deref(),
+            Some("failed to start: server unavailable")
+        );
+        assert!(app.status_message.contains("server unavailable"));
     }
 
     /// `StopFinished(Err)` must still finalize streaming locally so the
@@ -8850,10 +10003,13 @@ mod question_tests {
 
     fn asst_msg(content: &str) -> ChatMessage {
         ChatMessage {
+            id: format!("test:{content}"),
             role: MessageRole::Assistant,
             content: content.to_string(),
             tool_calls: Vec::new(),
             reasoning: None,
+            sub_agents: Vec::new(),
+            terminal_status: None,
         }
     }
 
@@ -9050,6 +10206,21 @@ mod question_tests {
         assert!(app.pending_question.is_none());
         assert!(app.chat.streaming);
         assert!(app.sse_task.is_some(), "successful answer reattaches SSE");
+        let resumed_turn_id = app
+            .chat
+            .current_turn_id
+            .clone()
+            .expect("answer allocates a stable resumed-turn id");
+        app.handle_sse_event(AgentEvent::ExecutionStarted {
+            run_id: "server-run-9".to_string(),
+            session_id: "sess-1".to_string(),
+            started_at: "2026-08-10T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        assert_eq!(
+            app.chat.current_turn_id.as_deref(),
+            Some(resumed_turn_id.as_str())
+        );
         app.detach_stream();
     }
 
@@ -9132,6 +10303,19 @@ mod question_tests {
         assert_eq!(question.custom.as_deref(), Some("草稿🙂"));
         assert_eq!(app.answer_epoch, epoch);
         assert!(app.chat.streaming);
+        let terminal_rows = app
+            .conversation_blocks()
+            .into_iter()
+            .filter_map(|block| match block.kind {
+                ConversationBlockKind::TerminalStatus(status) => Some(status),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            terminal_rows,
+            vec!["paused — waiting for answer"],
+            "a clarification pause must not also claim that the run is running"
+        );
         app.detach_stream();
     }
 
@@ -11458,10 +12642,13 @@ mod auto_serve_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("sess-1".to_string());
         app.chat.messages.push(ChatMessage {
+            id: "local-user".to_string(),
             role: MessageRole::User,
             content: "hi".to_string(),
             tool_calls: Vec::new(),
             reasoning: None,
+            sub_agents: Vec::new(),
+            terminal_status: None,
         });
         let (tx, _rx) = mpsc::unbounded_channel();
         app.event_tx = Some(tx);

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -122,6 +122,13 @@ pub struct SubAgentDisplay {
     pub error: Option<String>,
 }
 
+fn subagent_status_is_running(status: &str) -> bool {
+    matches!(
+        status.to_ascii_lowercase().as_str(),
+        "running" | "running_in_background" | "queued" | "starting" | "in_progress"
+    )
+}
+
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
     /// Stable history message id, or a deterministic in-memory id for a live
@@ -351,6 +358,10 @@ pub struct ChatState {
     /// `unknown` live blocks.
     replay_tool_ids: HashSet<String>,
     replay_child_ids: HashSet<String>,
+    /// Child sessions observed as started in the current turn/stream
+    /// generation. Historical rows are presentation state only and must never
+    /// keep a later parent turn artificially open.
+    active_child_ids: HashSet<String>,
     /// Turn whose stop request has already been dispatched. A late chat POST
     /// response for this same optimistic turn must not attach SSE and start an
     /// execution after the operator has asked to cancel it.
@@ -397,6 +408,7 @@ impl ChatState {
             inspector_cache_builds: Cell::new(0),
             replay_tool_ids: HashSet::new(),
             replay_child_ids: HashSet::new(),
+            active_child_ids: HashSet::new(),
             stop_requested_turn_id: None,
             parent_terminal_pending: false,
             next_ui_id: 0,
@@ -474,10 +486,25 @@ impl ChatState {
     }
 
     fn prepare_replay_reconciliation(&mut self) {
+        // Only the transcript suffix owned by the latest user turn can still
+        // receive lifecycle replay. Older unresolved-looking rows are display
+        // history and provider IDs may be reused by the active turn.
+        let active_turn_start = self
+            .messages
+            .iter()
+            .rposition(|message| matches!(&message.role, MessageRole::User))
+            .map_or(0, |index| index.saturating_add(1));
         self.replay_tool_ids = self
             .messages
             .iter()
-            .flat_map(|message| message.tool_calls.iter().map(|tool| tool.id.clone()))
+            .skip(active_turn_start)
+            .flat_map(|message| {
+                message
+                    .tool_calls
+                    .iter()
+                    .filter(|tool| !matches!(tool.phase.as_str(), "complete" | "error"))
+                    .map(|tool| tool.id.clone())
+            })
             .collect();
         self.replay_child_ids = self
             .messages
@@ -489,11 +516,24 @@ impl ChatState {
                     .map(|child| child.child_session_id.clone())
             })
             .collect();
+        self.active_child_ids = self
+            .messages
+            .iter()
+            .skip(active_turn_start)
+            .flat_map(|message| {
+                message
+                    .sub_agents
+                    .iter()
+                    .filter(|child| subagent_status_is_running(&child.status))
+                    .map(|child| child.child_session_id.clone())
+            })
+            .collect();
     }
 
     fn clear_replay_reconciliation(&mut self) {
         self.replay_tool_ids.clear();
         self.replay_child_ids.clear();
+        self.active_child_ids.clear();
         self.stop_requested_turn_id = None;
         self.parent_terminal_pending = false;
     }
@@ -4514,6 +4554,13 @@ impl App {
             self.detach_stream();
             self.chat.parent_terminal_pending = false;
         }
+        // Tool-call IDs are provider scoped, not globally unique across turns.
+        // A fresh user turn must never reconcile against a pending row from an
+        // older generation. Child history identities remain available for late
+        // lifecycle replay, but only children started in this turn may hold its
+        // parent terminal open.
+        self.chat.replay_tool_ids.clear();
+        self.chat.active_child_ids.clear();
         self.chat.stop_requested_turn_id = None;
         let model = if self.chat.model.is_empty() {
             "default".to_string()
@@ -4860,23 +4907,25 @@ impl App {
     /// that parallel tool calls (multiple in-flight at once) each get their
     /// own Complete/Error/Lifecycle update instead of clobbering whichever
     /// entry happens to be last in the list.
-    fn find_tool_mut(&mut self, tool_call_id: &str) -> Option<&mut ToolCallDisplay> {
-        if let Some(index) = self
-            .chat
-            .current_tool_calls
-            .iter()
-            .position(|tool| tool.id == tool_call_id)
-        {
+    fn find_tool_mut(
+        &mut self,
+        tool_call_id: &str,
+        include_terminal_current: bool,
+    ) -> Option<&mut ToolCallDisplay> {
+        if let Some(index) = self.chat.current_tool_calls.iter().position(|tool| {
+            tool.id == tool_call_id
+                && (include_terminal_current
+                    || !matches!(tool.phase.as_str(), "complete" | "error"))
+        }) {
             return self.chat.current_tool_calls.get_mut(index);
         }
         if !self.chat.replay_tool_ids.contains(tool_call_id) {
             return None;
         }
         self.chat.messages.iter_mut().rev().find_map(|message| {
-            message
-                .tool_calls
-                .iter_mut()
-                .find(|tool| tool.id == tool_call_id)
+            message.tool_calls.iter_mut().find(|tool| {
+                tool.id == tool_call_id && !matches!(tool.phase.as_str(), "complete" | "error")
+            })
         })
     }
 
@@ -4901,23 +4950,7 @@ impl App {
     }
 
     fn has_running_subagents(&self) -> bool {
-        fn running(status: &str) -> bool {
-            matches!(
-                status.to_ascii_lowercase().as_str(),
-                "running" | "running_in_background" | "queued" | "starting" | "in_progress"
-            )
-        }
-
-        self.chat
-            .sub_agents
-            .iter()
-            .any(|child| running(&child.status))
-            || self.chat.messages.iter().any(|message| {
-                message
-                    .sub_agents
-                    .iter()
-                    .any(|child| running(&child.status))
-            })
+        !self.chat.active_child_ids.is_empty()
     }
 
     /// A tool-bearing assistant message is one persisted LLM round. The next
@@ -5223,7 +5256,7 @@ impl App {
                 arguments,
             } => {
                 let arguments = serde_json::to_string(&arguments).unwrap_or_default();
-                if let Some(tool) = self.find_tool_mut(&tool_call_id) {
+                if let Some(tool) = self.find_tool_mut(&tool_call_id, false) {
                     // A ToolToken can race ahead of ToolStart. Hydrate that
                     // placeholder in place so its stable block id/output and
                     // independent UI state survive the reordering.
@@ -5255,7 +5288,7 @@ impl App {
             } => {
                 let success = result.success;
                 let result = result.result;
-                match self.find_tool_mut(&tool_call_id) {
+                match self.find_tool_mut(&tool_call_id, true) {
                     Some(tc) => {
                         if success {
                             tc.result = Some(result);
@@ -5289,13 +5322,17 @@ impl App {
                             .register_block(tool_block_id(&turn_id, &tool_call_id));
                     }
                 }
+                // A replay identity is single-use for the unfinished call it
+                // represents. Providers may reuse the same id in a later LLM
+                // round, which must create a distinct current-turn block.
+                self.chat.replay_tool_ids.remove(&tool_call_id);
                 self.chat.note_update();
             }
             AgentEvent::ToolError {
                 tool_call_id,
                 error,
             } => {
-                match self.find_tool_mut(&tool_call_id) {
+                match self.find_tool_mut(&tool_call_id, true) {
                     Some(tc) => {
                         tc.error = Some(error);
                         tc.phase = "error".to_string();
@@ -5315,6 +5352,7 @@ impl App {
                             .register_block(tool_block_id(&turn_id, &tool_call_id));
                     }
                 }
+                self.chat.replay_tool_ids.remove(&tool_call_id);
                 self.chat.note_update();
             }
             AgentEvent::ToolLifecycle {
@@ -5330,7 +5368,7 @@ impl App {
                 // has set one of those, a later Lifecycle event must not
                 // overwrite it back to a non-terminal phase (the UI's ✓/✗ icon
                 // is keyed on those exact strings).
-                if let Some(tc) = self.find_tool_mut(&tool_call_id) {
+                if let Some(tc) = self.find_tool_mut(&tool_call_id, true) {
                     if tc.phase != "complete" && tc.phase != "error" {
                         tc.phase = phase;
                         if let Some(s) = summary {
@@ -5452,9 +5490,10 @@ impl App {
                 tool_call_id,
                 content,
             } => {
-                if let Some(tool) = self.find_tool_mut(&tool_call_id) {
+                if let Some(tool) = self.find_tool_mut(&tool_call_id, false) {
                     tool.stream_output.push_str(&content);
                 } else {
+                    self.begin_next_round_after_tools();
                     let turn_id = self.chat.ensure_current_turn_id();
                     self.chat.current_tool_calls.push(ToolCallDisplay {
                         id: tool_call_id.clone(),
@@ -5498,6 +5537,13 @@ impl App {
                 child_session_id,
                 title,
             } => {
+                let already_active = self.chat.active_child_ids.contains(&child_session_id);
+                let is_current_row = self
+                    .chat
+                    .sub_agents
+                    .iter()
+                    .any(|child| child.child_session_id == child_session_id);
+                let mut active_in_current_turn = false;
                 if let Some(existing) = self.find_subagent_mut(&child_session_id) {
                     if title.is_some() {
                         existing.title = title;
@@ -5508,17 +5554,28 @@ impl App {
                     ) {
                         existing.status = "running".to_string();
                         existing.error = None;
+                        // Replayed Starts may hydrate old display history. Only
+                        // a child already attributed to the resumed active turn
+                        // (or still held in live scratch state) may hold this
+                        // parent turn open.
+                        active_in_current_turn = already_active || is_current_row;
                     }
                 } else {
                     let turn_id = self.chat.ensure_current_turn_id();
                     self.chat
                         .register_block(subagent_block_id(&turn_id, &child_session_id));
                     self.chat.sub_agents.push(SubAgentDisplay {
-                        child_session_id,
+                        child_session_id: child_session_id.clone(),
                         title,
                         status: "running".to_string(),
                         error: None,
                     });
+                    active_in_current_turn = true;
+                }
+                if active_in_current_turn {
+                    self.chat.active_child_ids.insert(child_session_id);
+                } else {
+                    self.chat.active_child_ids.remove(&child_session_id);
                 }
                 self.chat.note_update();
             }
@@ -5528,6 +5585,7 @@ impl App {
                 status,
                 error,
             } => {
+                self.chat.active_child_ids.remove(&child_session_id);
                 if let Some(sa) = self.find_subagent_mut(&child_session_id) {
                     sa.status = status;
                     sa.error = error;
@@ -5632,6 +5690,7 @@ impl App {
             self.chat
                 .current_tool_calls
                 .iter()
+                .filter(|tool| !matches!(tool.phase.as_str(), "complete" | "error"))
                 .map(|tool| tool.id.clone()),
         );
         self.chat.replay_child_ids.extend(
@@ -9969,6 +10028,155 @@ mod question_tests {
         assert!(app.chat.sub_agents.is_empty());
     }
 
+    #[test]
+    fn historical_running_child_does_not_hold_a_new_parent_turn_open() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages = vec![
+            ChatMessage {
+                id: "history:old-parent".to_string(),
+                role: MessageRole::Assistant,
+                content: "old answer".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: vec![SubAgentDisplay {
+                    child_session_id: "old-child".to_string(),
+                    title: Some("old background work".to_string()),
+                    status: "running_in_background".to_string(),
+                    error: None,
+                }],
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:new-user".to_string(),
+                role: MessageRole::User,
+                content: "new request".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+        ];
+        app.chat.prepare_replay_reconciliation();
+        assert!(app.chat.replay_child_ids.contains("old-child"));
+        assert!(!app.has_running_subagents());
+
+        // A late-subscriber replay can repeat the old Start on the fresh
+        // stream. It may refresh display metadata but must not reclassify that
+        // historical child as belonging to the new parent turn.
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "old-child".to_string(),
+            title: Some("old background work".to_string()),
+        })
+        .unwrap();
+        assert!(!app.has_running_subagents());
+
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("turn:new".to_string());
+        app.chat.current_response = "new answer".to_string();
+        app.handle_complete(TokenUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+        });
+
+        assert!(!app.chat.streaming);
+        assert!(!app.chat.parent_terminal_pending);
+        assert_eq!(app.status_message, "Ready");
+        assert_eq!(app.chat.messages.last().unwrap().content, "new answer");
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
+    }
+
+    #[test]
+    fn current_turn_child_alone_holds_parent_terminal_until_completion() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("turn:current".to_string());
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "current-child".to_string(),
+            title: Some("current work".to_string()),
+        })
+        .unwrap();
+
+        app.handle_complete(TokenUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+        });
+        assert!(app.chat.parent_terminal_pending);
+        assert!(app.chat.active_child_ids.contains("current-child"));
+
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "current-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+
+        assert!(!app.chat.parent_terminal_pending);
+        assert!(app.chat.active_child_ids.is_empty());
+        assert_eq!(app.status_message, "Ready");
+        let child = app
+            .chat
+            .messages
+            .iter()
+            .flat_map(|message| &message.sub_agents)
+            .find(|child| child.child_session_id == "current-child")
+            .unwrap();
+        assert_eq!(child.status, "completed");
+    }
+
+    #[test]
+    fn resumed_latest_turn_child_holds_parent_terminal_until_completion() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages = vec![
+            ChatMessage {
+                id: "history:latest-user".to_string(),
+                role: MessageRole::User,
+                content: "run background work".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:active-parent".to_string(),
+                role: MessageRole::Assistant,
+                content: "parent answer".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: vec![SubAgentDisplay {
+                    child_session_id: "resumed-child".to_string(),
+                    title: Some("background work".to_string()),
+                    status: "running_in_background".to_string(),
+                    error: None,
+                }],
+                terminal_status: None,
+            },
+        ];
+        app.chat.prepare_replay_reconciliation();
+        assert!(app.chat.active_child_ids.contains("resumed-child"));
+
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("session:active".to_string());
+        app.handle_complete(TokenUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+        });
+        assert!(app.chat.parent_terminal_pending);
+
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "resumed-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+
+        assert!(!app.chat.parent_terminal_pending);
+        assert!(app.chat.active_child_ids.is_empty());
+        assert_eq!(app.chat.messages[1].sub_agents[0].status, "completed");
+    }
+
     /// Parallel tool calls: a `ToolComplete` must land on the entry whose
     /// `tool_call_id` it names, not on whichever entry is last in the list.
     #[tokio::test]
@@ -10008,6 +10216,100 @@ mod question_tests {
         assert_eq!(a.phase, "complete");
         assert!(b.result.is_none(), "b's result must be untouched");
         assert_eq!(b.phase, "running", "b must still be running");
+    }
+
+    #[test]
+    fn completed_history_tool_id_can_be_reused_by_a_new_turn() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages.push(ChatMessage {
+            id: "history:old-tool".to_string(),
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCallDisplay {
+                id: "provider-reused-id".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: "{\"path\":\"old\"}".to_string(),
+                result: Some("old result".to_string()),
+                stream_output: String::new(),
+                error: None,
+                phase: "complete".to_string(),
+            }],
+            reasoning: None,
+            sub_agents: Vec::new(),
+            terminal_status: None,
+        });
+        app.chat.prepare_replay_reconciliation();
+        assert!(!app.chat.replay_tool_ids.contains("provider-reused-id"));
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("turn:new".to_string());
+
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "provider-reused-id".to_string(),
+            tool_name: "Write".to_string(),
+            arguments: serde_json::json!({ "path": "new" }),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolComplete {
+            tool_call_id: "provider-reused-id".to_string(),
+            result: ToolResult {
+                success: true,
+                result: "new result".to_string(),
+            },
+        })
+        .unwrap();
+
+        let old = &app.chat.messages[0].tool_calls[0];
+        assert_eq!(old.tool_name, "Read");
+        assert_eq!(old.result.as_deref(), Some("old result"));
+        let current = &app.chat.current_tool_calls[0];
+        assert_eq!(current.tool_name, "Write");
+        assert_eq!(current.result.as_deref(), Some("new result"));
+    }
+
+    #[test]
+    fn sealed_live_tool_id_can_be_reused_by_the_next_round() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("turn:first-round".to_string());
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "provider-reused-id".to_string(),
+            tool_name: "Read".to_string(),
+            arguments: serde_json::json!({ "path": "old" }),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolComplete {
+            tool_call_id: "provider-reused-id".to_string(),
+            result: ToolResult {
+                success: true,
+                result: "old result".to_string(),
+            },
+        })
+        .unwrap();
+
+        // A following round can legally reuse a provider tool-call id, and its
+        // ToolToken may race ahead of ToolStart. The terminal first-round row
+        // must be sealed before the new call starts.
+        app.handle_sse_event(AgentEvent::ToolToken {
+            tool_call_id: "provider-reused-id".to_string(),
+            content: "new partial".to_string(),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "provider-reused-id".to_string(),
+            tool_name: "Write".to_string(),
+            arguments: serde_json::json!({ "path": "new" }),
+        })
+        .unwrap();
+
+        assert_eq!(app.chat.messages.len(), 1);
+        let old = &app.chat.messages[0].tool_calls[0];
+        assert_eq!(old.tool_name, "Read");
+        assert_eq!(old.result.as_deref(), Some("old result"));
+        assert!(!app.chat.replay_tool_ids.contains("provider-reused-id"));
+        assert_eq!(app.chat.current_tool_calls.len(), 1);
+        assert_eq!(app.chat.current_tool_calls[0].tool_name, "Write");
+        assert_eq!(app.chat.current_tool_calls[0].phase, "running");
+        assert_eq!(app.chat.current_tool_calls[0].stream_output, "new partial");
     }
 
     #[test]
@@ -10813,6 +11115,55 @@ mod question_tests {
         assert_eq!(history.tool_calls[0].stream_output, "partial");
         assert_eq!(history.sub_agents.len(), 1);
         assert_eq!(history.sub_agents[0].status, "completed");
+    }
+
+    #[test]
+    fn replay_tool_reconciliation_is_scoped_to_the_latest_user_turn() {
+        let pending_tool = |id: &str| ToolCallDisplay {
+            id: id.to_string(),
+            tool_name: "Read".to_string(),
+            arguments: "{}".to_string(),
+            result: None,
+            stream_output: String::new(),
+            error: None,
+            phase: "pending".to_string(),
+        };
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages = vec![
+            ChatMessage {
+                id: "history:older-assistant".to_string(),
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![pending_tool("provider-reused-id")],
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:latest-user".to_string(),
+                role: MessageRole::User,
+                content: "new turn".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:active-assistant".to_string(),
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![pending_tool("active-id")],
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+        ];
+
+        app.chat.prepare_replay_reconciliation();
+
+        assert!(!app.chat.replay_tool_ids.contains("provider-reused-id"));
+        assert!(app.chat.replay_tool_ids.contains("active-id"));
+        assert_eq!(app.chat.replay_tool_ids.len(), 1);
     }
 
     /// A successful resume installs the mapped history, the model, and the

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -2016,15 +2016,27 @@ impl App {
                 // failed (server down/unreachable), the operator must regain
                 // control of the input instead of being stuck waiting for a
                 // terminal SSE event that a dead server will never send.
+                // If a Cancelled/Complete SSE won the race and already
+                // finalized this turn, do not manufacture a second terminal-
+                // only turn when the HTTP stop response arrives afterward.
                 // `finalize_streaming` resets `status_message` to "Ready"
                 // internally, so the outcome-specific message is set AFTER it
                 // (same ordering the old synchronous `stop_streaming` used to
                 // get "Stopped" to stick instead of being overwritten).
-                self.chat.current_terminal_status = Some(match &r {
-                    Ok(()) => "stopped".to_string(),
-                    Err(error) => format!("stop failed: {error}"),
-                });
-                self.finalize_streaming();
+                let has_unflushed_turn = self.chat.streaming
+                    || self.chat.current_turn_id.is_some()
+                    || !self.chat.current_response.is_empty()
+                    || !self.chat.current_tool_calls.is_empty()
+                    || !self.chat.current_reasoning.is_empty()
+                    || !self.chat.sub_agents.is_empty()
+                    || self.chat.current_terminal_status.is_some();
+                if has_unflushed_turn {
+                    self.chat.current_terminal_status = Some(match &r {
+                        Ok(()) => "stopped".to_string(),
+                        Err(error) => format!("stop failed: {error}"),
+                    });
+                    self.finalize_streaming();
+                }
                 match r {
                     Ok(()) => self.status_message = "Stopped".to_string(),
                     Err(e) => self.notify(NoticeLevel::Error, format!("Stop failed: {e}")),
@@ -9983,6 +9995,34 @@ mod question_tests {
             .unwrap();
 
         assert!(!app.chat.streaming);
+        assert_eq!(app.status_message, "Stopped");
+    }
+
+    #[tokio::test]
+    async fn cancelled_sse_before_stop_response_does_not_append_a_second_terminal_turn() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("live:assistant:stop".to_string());
+
+        app.handle_sse_event(AgentEvent::Cancelled {
+            message: Some("cancelled by operator".to_string()),
+        })
+        .unwrap();
+        assert_eq!(app.chat.messages.len(), 1);
+
+        app.handle_event(AppEvent::StopFinished(Ok(())))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            app.chat.messages.len(),
+            1,
+            "the HTTP response must not create a second terminal-only turn"
+        );
+        assert_eq!(
+            app.chat.messages[0].terminal_status.as_deref(),
+            Some("cancelled by operator")
+        );
         assert_eq!(app.status_message, "Stopped");
     }
 

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -675,7 +675,7 @@ impl ChatState {
         self.current_execution_started = true;
     }
 
-    fn take_child_start_intent(&mut self, child_session_id: &str) -> bool {
+    fn take_child_start_intent(&mut self, child_session_id: &str, allow_any: bool) -> bool {
         let exact =
             self.child_start_intents
                 .iter()
@@ -686,11 +686,15 @@ impl ChatState {
                     _ => None,
                 });
         let matching_tool_call = exact.or_else(|| {
-            self.child_start_intents
-                .iter()
-                .find_map(|(tool_call_id, intent)| {
-                    (intent == &ChildStartIntent::Any).then(|| tool_call_id.clone())
-                })
+            if allow_any {
+                self.child_start_intents
+                    .iter()
+                    .find_map(|(tool_call_id, intent)| {
+                        (intent == &ChildStartIntent::Any).then(|| tool_call_id.clone())
+                    })
+            } else {
+                None
+            }
         });
         matching_tool_call
             .and_then(|tool_call_id| self.child_start_intents.remove(&tool_call_id))
@@ -5723,13 +5727,29 @@ impl App {
                 child_session_id,
                 title,
             } => {
-                let fresh_start = self.chat.take_child_start_intent(&child_session_id);
                 let replay_expected = self
                     .chat
                     .replay_expected_child_ids
                     .contains(&child_session_id);
                 let already_active = self.chat.active_child_ids.contains(&child_session_id);
                 let current_execution_started = self.chat.current_execution_started;
+                let current_row_is_running = self
+                    .chat
+                    .sub_agents
+                    .iter()
+                    .find(|child| child.child_session_id == child_session_id)
+                    .is_some_and(|child| subagent_status_is_running(&child.status));
+                // Exact intents always match their named child. An identity-
+                // agnostic resident create, however, must remain available
+                // when this Start is already attributable to a replayed or
+                // active child; otherwise one child can steal another's
+                // pending create authorization during multi-child replay.
+                let fresh_start = self.chat.take_child_start_intent(
+                    &child_session_id,
+                    !(replay_expected
+                        || already_active
+                        || (current_row_is_running && current_execution_started)),
+                );
                 let is_current_row = self
                     .chat
                     .sub_agents
@@ -10700,6 +10720,143 @@ mod question_tests {
         .unwrap();
         assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
         assert!(!app.has_running_subagents());
+    }
+
+    #[test]
+    fn replayed_active_child_does_not_consume_pending_resident_create() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages = vec![
+            ChatMessage {
+                id: "history:old-parent".to_string(),
+                role: MessageRole::Assistant,
+                content: "resident history".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: vec![
+                    SubAgentDisplay {
+                        child_session_id: "active-child".to_string(),
+                        title: Some("active worker".to_string()),
+                        status: "running_in_background".to_string(),
+                        error: None,
+                    },
+                    SubAgentDisplay {
+                        child_session_id: "resident-child".to_string(),
+                        title: Some("resident worker".to_string()),
+                        status: "completed".to_string(),
+                        error: None,
+                    },
+                ],
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:new-user".to_string(),
+                role: MessageRole::User,
+                content: "continue both workers".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:active-round".to_string(),
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![
+                    ToolCallDisplay {
+                        id: "active-run".to_string(),
+                        tool_name: "SubAgent".to_string(),
+                        arguments: serde_json::json!({
+                            "action": "run",
+                            "child_session_id": "active-child"
+                        })
+                        .to_string(),
+                        result: Some(
+                            serde_json::json!({
+                                "child_session_id": "active-child",
+                                "status": "running_in_background",
+                                "waiting_for_children": true
+                            })
+                            .to_string(),
+                        ),
+                        stream_output: String::new(),
+                        error: None,
+                        phase: "complete".to_string(),
+                    },
+                    ToolCallDisplay {
+                        id: "resident-create".to_string(),
+                        tool_name: "SubAgent".to_string(),
+                        arguments: serde_json::json!({
+                            "action": "create",
+                            "resident_name": "worker",
+                            "prompt": "next task",
+                            "auto_run": true
+                        })
+                        .to_string(),
+                        result: None,
+                        stream_output: String::new(),
+                        error: None,
+                        phase: "pending".to_string(),
+                    },
+                ],
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+        ];
+        app.chat.prepare_replay_reconciliation();
+        assert!(app.chat.replay_expected_child_ids.contains("active-child"));
+        assert!(app.chat.active_child_ids.contains("active-child"));
+        assert_eq!(
+            app.chat.child_start_intents.get("resident-create"),
+            Some(&ChildStartIntent::Any)
+        );
+
+        // The coalesced Start for an already known active child must not take
+        // the identity-agnostic authorization owned by the resident create.
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "active-child".to_string(),
+            title: Some("active worker".to_string()),
+        })
+        .unwrap();
+        assert_eq!(
+            app.chat.child_start_intents.get("resident-create"),
+            Some(&ChildStartIntent::Any)
+        );
+
+        // The following Start is the pending resident generation and may now
+        // consume the Any intent, reviving its physically older terminal row.
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "resident-child".to_string(),
+            title: Some("resident worker rerun".to_string()),
+        })
+        .unwrap();
+        let resident = app
+            .chat
+            .messages
+            .iter()
+            .flat_map(|message| &message.sub_agents)
+            .find(|child| child.child_session_id == "resident-child")
+            .unwrap();
+        assert_eq!(resident.status, "running");
+        assert!(app.chat.active_child_ids.contains("resident-child"));
+        assert!(app.chat.child_start_intents.is_empty());
+
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "resident-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+        let resident = app
+            .chat
+            .messages
+            .iter()
+            .flat_map(|message| &message.sub_agents)
+            .find(|child| child.child_session_id == "resident-child")
+            .unwrap();
+        assert_eq!(resident.status, "completed");
+        assert!(!app.chat.active_child_ids.contains("resident-child"));
+        assert!(app.chat.active_child_ids.contains("active-child"));
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -444,6 +444,12 @@ pub struct ChatState {
     /// generation. Historical rows are presentation state only and must never
     /// keep a later parent turn artificially open.
     active_child_ids: HashSet<String>,
+    /// Child identities attributed to the latest user turn. Unlike
+    /// `active_child_ids`, ownership survives terminal lifecycle frames: a
+    /// reconnect boundary can transiently repeat an older buffered transition,
+    /// and the following Start must still be recognized as this turn's child.
+    /// The set is cleared only when the parent generation is superseded.
+    current_turn_child_ids: HashSet<String>,
     /// A parent `ExecutionStarted` (or authoritative running-session resume)
     /// has established that unmatched child starts belong to this generation.
     /// It stays false before a fresh parent execution has actually started.
@@ -497,6 +503,7 @@ impl ChatState {
             child_start_intents: HashMap::new(),
             replay_expected_child_ids: HashSet::new(),
             active_child_ids: HashSet::new(),
+            current_turn_child_ids: HashSet::new(),
             current_execution_started: false,
             stop_requested_turn_id: None,
             parent_terminal_pending: false,
@@ -647,6 +654,25 @@ impl ChatState {
                 ChildStartIntent::Exact(_) | ChildStartIntent::Any => None,
             })
             .collect();
+        self.current_turn_child_ids = historical_start_calls
+            .iter()
+            .filter_map(|(_, intent, _)| match intent {
+                ChildStartIntent::Exact(child_id) => Some(child_id.clone()),
+                ChildStartIntent::Any => None,
+            })
+            .collect();
+        self.current_turn_child_ids
+            .extend(
+                self.messages
+                    .iter()
+                    .skip(active_turn_start)
+                    .flat_map(|message| {
+                        message
+                            .sub_agents
+                            .iter()
+                            .map(|child| child.child_session_id.clone())
+                    }),
+            );
         self.active_child_ids = self
             .messages
             .iter()
@@ -672,6 +698,8 @@ impl ChatState {
                 })
                 .cloned(),
         );
+        self.current_turn_child_ids
+            .extend(self.active_child_ids.iter().cloned());
         self.current_execution_started = true;
     }
 
@@ -707,6 +735,7 @@ impl ChatState {
         self.child_start_intents.clear();
         self.replay_expected_child_ids.clear();
         self.active_child_ids.clear();
+        self.current_turn_child_ids.clear();
         self.current_execution_started = false;
         self.stop_requested_turn_id = None;
         self.parent_terminal_pending = false;
@@ -4737,6 +4766,7 @@ impl App {
         self.chat.child_start_intents.clear();
         self.chat.replay_expected_child_ids.clear();
         self.chat.active_child_ids.clear();
+        self.chat.current_turn_child_ids.clear();
         self.chat.current_execution_started = false;
         self.chat.stop_requested_turn_id = None;
         let model = if self.chat.model.is_empty() {
@@ -5732,6 +5762,8 @@ impl App {
                     .replay_expected_child_ids
                     .contains(&child_session_id);
                 let already_active = self.chat.active_child_ids.contains(&child_session_id);
+                let owned_by_current_turn =
+                    self.chat.current_turn_child_ids.contains(&child_session_id);
                 let current_execution_started = self.chat.current_execution_started;
                 let current_row_is_running = self
                     .chat
@@ -5748,6 +5780,7 @@ impl App {
                     &child_session_id,
                     !(replay_expected
                         || already_active
+                        || owned_by_current_turn
                         || (current_row_is_running && current_execution_started)),
                 );
                 let is_current_row = self
@@ -5755,40 +5788,43 @@ impl App {
                     .sub_agents
                     .iter()
                     .any(|child| child.child_session_id == child_session_id);
-                let mut active_in_current_turn = false;
-                if let Some(existing) = self.find_subagent_mut(&child_session_id) {
-                    if title.is_some() {
-                        existing.title = title;
-                    }
-                    let terminal = matches!(
-                        existing.status.as_str(),
-                        "completed" | "error" | "cancelled" | "skipped" | "timeout"
-                    );
-                    let belongs_to_current_generation = fresh_start
-                        || replay_expected
-                        || already_active
-                        || (!terminal && is_current_row && current_execution_started);
-                    if fresh_start
-                        || replay_expected
-                        || (!terminal && belongs_to_current_generation)
-                    {
+                let active_in_current_turn =
+                    if let Some(existing) = self.find_subagent_mut(&child_session_id) {
+                        if title.is_some() {
+                            existing.title = title;
+                        }
+                        let belongs_to_current_generation = fresh_start
+                            || replay_expected
+                            || already_active
+                            || owned_by_current_turn
+                            || (is_current_row && current_execution_started);
+                        // Lifecycle frames are state transitions, not historical
+                        // hints. Server replay keeps only the latest child state,
+                        // and ordered live delivery may legitimately start a new
+                        // generation after a terminal frame, so the last frame the
+                        // reducer receives must win for presentation state.
                         existing.status = "running".to_string();
                         existing.error = None;
-                        active_in_current_turn = true;
-                    }
-                } else if fresh_start || replay_expected || current_execution_started {
-                    let turn_id = self.chat.ensure_current_turn_id();
-                    self.chat
-                        .register_block(subagent_block_id(&turn_id, &child_session_id));
-                    self.chat.sub_agents.push(SubAgentDisplay {
-                        child_session_id: child_session_id.clone(),
-                        title,
-                        status: "running".to_string(),
-                        error: None,
-                    });
-                    active_in_current_turn = true;
-                }
+                        belongs_to_current_generation
+                    } else {
+                        let turn_id = self.chat.ensure_current_turn_id();
+                        self.chat
+                            .register_block(subagent_block_id(&turn_id, &child_session_id));
+                        self.chat.sub_agents.push(SubAgentDisplay {
+                            child_session_id: child_session_id.clone(),
+                            title,
+                            status: "running".to_string(),
+                            error: None,
+                        });
+                        fresh_start
+                            || replay_expected
+                            || owned_by_current_turn
+                            || current_execution_started
+                    };
                 if active_in_current_turn {
+                    self.chat
+                        .current_turn_child_ids
+                        .insert(child_session_id.clone());
                     self.chat.active_child_ids.insert(child_session_id);
                 } else {
                     self.chat.active_child_ids.remove(&child_session_id);
@@ -10145,9 +10181,9 @@ mod question_tests {
         .unwrap();
         assert_eq!(app.chat.sub_agents[0].status, "completed");
 
-        // A replayed/out-of-order Start may carry the title that a defensive
-        // completion placeholder lacked. Hydrate it without reverting the
-        // terminal status or duplicating the row.
+        // Lifecycle events are ordered state transitions. A Start after a
+        // terminal placeholder begins the next generation, hydrates its title,
+        // and reuses the stable row.
         app.handle_sse_event(AgentEvent::SubAgentCompleted {
             child_session_id: "c2".into(),
             status: "completed".into(),
@@ -10161,7 +10197,8 @@ mod question_tests {
         .unwrap();
         assert_eq!(app.chat.sub_agents.len(), 2);
         assert_eq!(app.chat.sub_agents[1].title.as_deref(), Some("late title"));
-        assert_eq!(app.chat.sub_agents[1].status, "completed");
+        assert_eq!(app.chat.sub_agents[1].status, "running");
+        assert!(app.chat.active_child_ids.contains("c2"));
     }
 
     #[tokio::test]
@@ -10283,9 +10320,9 @@ mod question_tests {
         assert!(app.chat.replay_child_ids.contains("old-child"));
         assert!(!app.has_running_subagents());
 
-        // A late-subscriber replay can repeat the old Start on the fresh
-        // stream. It may refresh display metadata but must not reclassify that
-        // historical child as belonging to the new parent turn.
+        // An authoritative Start refreshes the historical child's displayed
+        // state, but must not reclassify it as belonging to the new parent
+        // turn.
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "old-child".to_string(),
             title: Some("old background work".to_string()),
@@ -10306,10 +10343,7 @@ mod question_tests {
         assert!(!app.chat.parent_terminal_pending);
         assert_eq!(app.status_message, "Ready");
         assert_eq!(app.chat.messages.last().unwrap().content, "new answer");
-        assert_eq!(
-            app.chat.messages[0].sub_agents[0].status,
-            "running_in_background"
-        );
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
     }
 
     #[test]
@@ -10462,34 +10496,46 @@ mod question_tests {
         })
         .unwrap();
         app.flush_streaming_output();
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
+        assert!(!app.has_running_subagents());
 
-        // A replayed/out-of-order Start without a corresponding SubAgent tool
-        // intent must not revive the completed generation.
+        // A later Start is itself the authoritative transition into a fresh
+        // generation, even if a reconnect no longer has its ToolStart frame.
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "reusable-child".to_string(),
             title: None,
         })
         .unwrap();
-        assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
-        assert!(!app.has_running_subagents());
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
+        assert!(app.has_running_subagents());
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "reusable-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
 
-        // Reconnecting rebuilds replay state from history. The completed
-        // create call must not mint a fresh authorization if the critical
-        // cache replays only its old Start (for example after eviction of the
-        // matching Completed event).
+        // Reconnecting rebuilds stable current-turn ownership from the
+        // completed create result without minting an identity-agnostic intent.
         app.chat.prepare_replay_reconciliation();
         assert!(app.chat.child_start_intents.is_empty());
         assert!(app.chat.replay_expected_child_ids.is_empty());
+        assert!(app.chat.current_turn_child_ids.contains("reusable-child"));
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "reusable-child".to_string(),
             title: None,
         })
         .unwrap();
-        assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
-        assert!(!app.has_running_subagents());
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
+        assert!(app.has_running_subagents());
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "reusable-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
 
-        // The supported `action=run` path authorizes exactly one new lifecycle
-        // for this stable child id.
+        // The supported `action=run` path still consumes its exact intent once.
         app.handle_sse_event(AgentEvent::ToolStart {
             tool_call_id: "rerun-call".to_string(),
             tool_name: "SubAgent".to_string(),
@@ -10499,6 +10545,10 @@ mod question_tests {
             }),
         })
         .unwrap();
+        assert_eq!(
+            app.chat.child_start_intents.get("rerun-call"),
+            Some(&ChildStartIntent::Exact("reusable-child".to_string()))
+        );
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "reusable-child".to_string(),
             title: Some("worker rerun".to_string()),
@@ -10511,16 +10561,12 @@ mod question_tests {
             Some("worker rerun")
         );
         assert!(app.chat.active_child_ids.contains("reusable-child"));
+        assert!(!app.chat.child_start_intents.contains_key("rerun-call"));
 
         app.handle_sse_event(AgentEvent::SubAgentCompleted {
             child_session_id: "reusable-child".to_string(),
             status: "completed".to_string(),
             error: None,
-        })
-        .unwrap();
-        app.handle_sse_event(AgentEvent::SubAgentStarted {
-            child_session_id: "reusable-child".to_string(),
-            title: None,
         })
         .unwrap();
         assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
@@ -10610,8 +10656,7 @@ mod question_tests {
         );
         assert!(app.chat.active_child_ids.contains("reusable-child"));
 
-        // The latest terminal snapshot retires the history expectation; a
-        // subsequent uncorrelated Start cannot revive it.
+        // The latest terminal transition retires active state.
         app.handle_sse_event(AgentEvent::SubAgentCompleted {
             child_session_id: "reusable-child".to_string(),
             status: "completed".to_string(),
@@ -10620,13 +10665,7 @@ mod question_tests {
         .unwrap();
         assert!(!app.has_running_subagents());
         assert!(app.chat.replay_expected_child_ids.is_empty());
-        app.handle_sse_event(AgentEvent::SubAgentStarted {
-            child_session_id: "reusable-child".to_string(),
-            title: None,
-        })
-        .unwrap();
         assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
-        assert!(!app.has_running_subagents());
     }
 
     #[test]
@@ -10706,16 +10745,33 @@ mod question_tests {
         assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
         assert!(app.chat.active_child_ids.contains("resident-child"));
         assert!(app.chat.child_start_intents.is_empty());
+        assert!(app.chat.current_turn_child_ids.contains("resident-child"));
 
+        // A subscribe/snapshot overlap used to be able to produce
+        // S2(snapshot), C1(buffered), S2(buffered). Current-turn ownership is
+        // stable across the transient terminal frame, so the last transition
+        // wins even though the Any intent was already consumed by the first
+        // Start.
         app.handle_sse_event(AgentEvent::SubAgentCompleted {
             child_session_id: "resident-child".to_string(),
             status: "completed".to_string(),
             error: None,
         })
         .unwrap();
+        assert!(!app.chat.active_child_ids.contains("resident-child"));
+        assert!(app.chat.current_turn_child_ids.contains("resident-child"));
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "resident-child".to_string(),
-            title: None,
+            title: Some("resident worker rerun".to_string()),
+        })
+        .unwrap();
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
+        assert!(app.chat.active_child_ids.contains("resident-child"));
+
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "resident-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
         })
         .unwrap();
         assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -437,14 +437,9 @@ pub struct ChatState {
     /// and lets terminal tool events revoke it when enqueue never happened.
     child_start_intents: HashMap<String, ChildStartIntent>,
     /// Child ids whose latest-user-turn history authoritatively describes a
-    /// queued/running generation. A reconnect may replay older lifecycle pairs
-    /// before the Start for this generation, so this expectation deliberately
-    /// survives those older terminal events.
+    /// queued/running generation. The server's replay cache exposes only the
+    /// newest lifecycle state per stable child id.
     replay_expected_child_ids: HashSet<String>,
-    /// Expected children that have crossed an older replayed terminal. A later
-    /// Start is then known to belong to a newer generation of the stable id.
-    replay_child_terminal_seen: HashSet<String>,
-    replay_current_child_started: HashSet<String>,
     /// Child sessions observed as started in the current turn/stream
     /// generation. Historical rows are presentation state only and must never
     /// keep a later parent turn artificially open.
@@ -501,8 +496,6 @@ impl ChatState {
             replay_child_ids: HashSet::new(),
             child_start_intents: HashMap::new(),
             replay_expected_child_ids: HashSet::new(),
-            replay_child_terminal_seen: HashSet::new(),
-            replay_current_child_started: HashSet::new(),
             active_child_ids: HashSet::new(),
             current_execution_started: false,
             stop_requested_turn_id: None,
@@ -654,8 +647,6 @@ impl ChatState {
                 ChildStartIntent::Exact(_) | ChildStartIntent::Any => None,
             })
             .collect();
-        self.replay_child_terminal_seen.clear();
-        self.replay_current_child_started.clear();
         self.active_child_ids = self
             .messages
             .iter()
@@ -711,8 +702,6 @@ impl ChatState {
         self.replay_child_ids.clear();
         self.child_start_intents.clear();
         self.replay_expected_child_ids.clear();
-        self.replay_child_terminal_seen.clear();
-        self.replay_current_child_started.clear();
         self.active_child_ids.clear();
         self.current_execution_started = false;
         self.stop_requested_turn_id = None;
@@ -4743,8 +4732,6 @@ impl App {
         self.chat.replay_tool_ids.clear();
         self.chat.child_start_intents.clear();
         self.chat.replay_expected_child_ids.clear();
-        self.chat.replay_child_terminal_seen.clear();
-        self.chat.replay_current_child_started.clear();
         self.chat.active_child_ids.clear();
         self.chat.current_execution_started = false;
         self.chat.stop_requested_turn_id = None;
@@ -5422,8 +5409,6 @@ impl App {
                 // retires any child-generation expectation reconstructed for
                 // the previous suspended/reconnected run.
                 self.chat.replay_expected_child_ids.clear();
-                self.chat.replay_child_terminal_seen.clear();
-                self.chat.replay_current_child_started.clear();
                 self.chat.current_execution_started = true;
                 if self.chat.current_turn_id.is_none() {
                     self.chat.current_turn_id = Some(format!("run:{run_id}"));
@@ -5743,20 +5728,6 @@ impl App {
                     .chat
                     .replay_expected_child_ids
                     .contains(&child_session_id);
-                if replay_expected
-                    && self
-                        .chat
-                        .replay_child_terminal_seen
-                        .contains(&child_session_id)
-                {
-                    // FIFO critical replay can contain Start₁, Complete₁,
-                    // Start₂ for a stable child id. Once a Start follows an
-                    // older terminal, it is the expected current generation;
-                    // its eventual Complete may retire the expectation.
-                    self.chat
-                        .replay_current_child_started
-                        .insert(child_session_id.clone());
-                }
                 let already_active = self.chat.active_child_ids.contains(&child_session_id);
                 let current_execution_started = self.chat.current_execution_started;
                 let is_current_row = self
@@ -5811,29 +5782,9 @@ impl App {
                 error,
             } => {
                 self.chat.active_child_ids.remove(&child_session_id);
-                if self
-                    .chat
-                    .replay_current_child_started
-                    .remove(&child_session_id)
-                {
-                    self.chat
-                        .replay_expected_child_ids
-                        .remove(&child_session_id);
-                    self.chat
-                        .replay_child_terminal_seen
-                        .remove(&child_session_id);
-                } else if self
-                    .chat
+                self.chat
                     .replay_expected_child_ids
-                    .contains(&child_session_id)
-                {
-                    // Keep the expectation alive: this can be Complete₁ from
-                    // an older cached generation, followed by the current
-                    // generation's Start₂.
-                    self.chat
-                        .replay_child_terminal_seen
-                        .insert(child_session_id.clone());
-                }
+                    .remove(&child_session_id);
                 if let Some(sa) = self.find_subagent_mut(&child_session_id) {
                     sa.status = status;
                     sa.error = error;
@@ -10557,7 +10508,7 @@ mod question_tests {
     }
 
     #[test]
-    fn resumed_completed_rerun_survives_older_generation_replay() {
+    fn resumed_completed_rerun_uses_latest_coalesced_lifecycle() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.messages = vec![
             ChatMessage {
@@ -10624,26 +10575,8 @@ mod question_tests {
             .contains("reusable-child"));
         assert!(app.chat.child_start_intents.is_empty());
 
-        // The server's FIFO critical cache can retain both the previous child
-        // generation and the current rerun. Start₁/Complete₁ must not consume
-        // or revoke the history-backed expectation for Start₂.
-        app.handle_sse_event(AgentEvent::SubAgentStarted {
-            child_session_id: "reusable-child".to_string(),
-            title: Some("old replay".to_string()),
-        })
-        .unwrap();
-        app.handle_sse_event(AgentEvent::SubAgentCompleted {
-            child_session_id: "reusable-child".to_string(),
-            status: "completed".to_string(),
-            error: None,
-        })
-        .unwrap();
-        assert!(!app.has_running_subagents());
-        assert!(app
-            .chat
-            .replay_expected_child_ids
-            .contains("reusable-child"));
-
+        // The server coalesces every older lifecycle generation for this
+        // stable id, so reconnect receives only the current Start.
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "reusable-child".to_string(),
             title: Some("worker retry".to_string()),
@@ -10656,13 +10589,9 @@ mod question_tests {
             Some("worker retry")
         );
         assert!(app.chat.active_child_ids.contains("reusable-child"));
-        assert!(app
-            .chat
-            .replay_current_child_started
-            .contains("reusable-child"));
 
-        // Only the current generation's terminal event retires the replay
-        // expectation; a subsequent stale Start cannot revive it.
+        // The latest terminal snapshot retires the history expectation; a
+        // subsequent uncorrelated Start cannot revive it.
         app.handle_sse_event(AgentEvent::SubAgentCompleted {
             child_session_id: "reusable-child".to_string(),
             status: "completed".to_string(),
@@ -10673,6 +10602,99 @@ mod question_tests {
         assert!(app.chat.replay_expected_child_ids.is_empty());
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "reusable-child".to_string(),
+            title: None,
+        })
+        .unwrap();
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
+        assert!(!app.has_running_subagents());
+    }
+
+    #[test]
+    fn pending_resident_create_keeps_any_intent_through_old_terminal_snapshot() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages = vec![
+            ChatMessage {
+                id: "history:old-parent".to_string(),
+                role: MessageRole::Assistant,
+                content: "old resident result".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: vec![SubAgentDisplay {
+                    child_session_id: "resident-child".to_string(),
+                    title: Some("resident worker".to_string()),
+                    status: "completed".to_string(),
+                    error: None,
+                }],
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:new-user".to_string(),
+                role: MessageRole::User,
+                content: "reuse resident".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:pending-resident-create".to_string(),
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCallDisplay {
+                    id: "resident-create".to_string(),
+                    tool_name: "SubAgent".to_string(),
+                    arguments: serde_json::json!({
+                        "action": "create",
+                        "resident_name": "worker",
+                        "prompt": "next task",
+                        "auto_run": true
+                    })
+                    .to_string(),
+                    result: None,
+                    stream_output: String::new(),
+                    error: None,
+                    phase: "pending".to_string(),
+                }],
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+        ];
+        app.chat.prepare_replay_reconciliation();
+        assert!(app.chat.replay_expected_child_ids.is_empty());
+        assert_eq!(
+            app.chat.child_start_intents.get("resident-create"),
+            Some(&ChildStartIntent::Any)
+        );
+
+        // If the new enqueue has not emitted Start yet, the coalesced replay
+        // can still contain C1 from the prior resident generation. It must not
+        // consume the pending create's identity-agnostic authorization.
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "resident-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+        assert!(app.chat.child_start_intents.contains_key("resident-create"));
+
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "resident-child".to_string(),
+            title: Some("resident worker rerun".to_string()),
+        })
+        .unwrap();
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
+        assert!(app.chat.active_child_ids.contains("resident-child"));
+        assert!(app.chat.child_start_intents.is_empty());
+
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "resident-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "resident-child".to_string(),
             title: None,
         })
         .unwrap();

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -129,6 +129,80 @@ fn subagent_status_is_running(status: &str) -> bool {
     )
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChildStartIntent {
+    Exact(String),
+    Any,
+}
+
+fn is_subagent_tool_name(name: &str) -> bool {
+    name.chars()
+        .filter(|character| !matches!(character, '_' | '-'))
+        .flat_map(char::to_lowercase)
+        .eq("subagent".chars())
+}
+
+fn child_start_intent(tool_name: &str, arguments: &serde_json::Value) -> Option<ChildStartIntent> {
+    if !is_subagent_tool_name(tool_name) {
+        return None;
+    }
+    let action = arguments.get("action")?.as_str()?;
+    let child_id = || {
+        arguments
+            .get("child_session_id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| !id.trim().is_empty())
+            .map(|id| ChildStartIntent::Exact(id.to_string()))
+    };
+    match action {
+        "create"
+            if arguments
+                .get("auto_run")
+                .and_then(serde_json::Value::as_bool)
+                != Some(false) =>
+        {
+            Some(ChildStartIntent::Any)
+        }
+        "run" => child_id(),
+        "send_message"
+            if arguments
+                .get("auto_run")
+                .and_then(serde_json::Value::as_bool)
+                != Some(false) =>
+        {
+            child_id()
+        }
+        "update"
+            if arguments
+                .get("auto_run")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true) =>
+        {
+            child_id()
+        }
+        _ => None,
+    }
+}
+
+fn historical_child_start_intent(tool: &ToolCallDisplay) -> Option<ChildStartIntent> {
+    let arguments = serde_json::from_str(&tool.arguments).ok()?;
+    let intent = child_start_intent(&tool.tool_name, &arguments)?;
+    if intent != ChildStartIntent::Any {
+        return Some(intent);
+    }
+    tool.result
+        .as_deref()
+        .and_then(|result| serde_json::from_str::<serde_json::Value>(result).ok())
+        .and_then(|result| {
+            result
+                .get("child_session_id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|id| !id.trim().is_empty())
+                .map(|id| ChildStartIntent::Exact(id.to_string()))
+        })
+        .or(Some(ChildStartIntent::Any))
+}
+
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
     /// Stable history message id, or a deterministic in-memory id for a live
@@ -358,10 +432,18 @@ pub struct ChatState {
     /// `unknown` live blocks.
     replay_tool_ids: HashSet<String>,
     replay_child_ids: HashSet<String>,
+    /// SubAgent tool calls that can legitimately begin a new lifecycle for an
+    /// existing child id. The tool-call key makes the authorization single-use
+    /// and lets terminal tool events revoke it when enqueue never happened.
+    child_start_intents: HashMap<String, ChildStartIntent>,
     /// Child sessions observed as started in the current turn/stream
     /// generation. Historical rows are presentation state only and must never
     /// keep a later parent turn artificially open.
     active_child_ids: HashSet<String>,
+    /// A parent `ExecutionStarted` (or authoritative running-session resume)
+    /// has established that unmatched child starts belong to this generation.
+    /// It stays false while a fresh subscription replays the previous runner.
+    current_execution_started: bool,
     /// Turn whose stop request has already been dispatched. A late chat POST
     /// response for this same optimistic turn must not attach SSE and start an
     /// execution after the operator has asked to cancel it.
@@ -408,7 +490,9 @@ impl ChatState {
             inspector_cache_builds: Cell::new(0),
             replay_tool_ids: HashSet::new(),
             replay_child_ids: HashSet::new(),
+            child_start_intents: HashMap::new(),
             active_child_ids: HashSet::new(),
+            current_execution_started: false,
             stop_requested_turn_id: None,
             parent_terminal_pending: false,
             next_ui_id: 0,
@@ -516,6 +600,20 @@ impl ChatState {
                     .map(|child| child.child_session_id.clone())
             })
             .collect();
+        self.child_start_intents = self
+            .messages
+            .iter()
+            .skip(active_turn_start)
+            .flat_map(|message| message.tool_calls.iter())
+            // A completed SubAgent call has already emitted its Start before
+            // returning. Re-authorizing it here would let a truncated critical
+            // replay revive a terminal child without a new run. Only an
+            // unfinished call can still own an unseen Start on reconnect.
+            .filter(|tool| !matches!(tool.phase.as_str(), "complete" | "error"))
+            .filter_map(|tool| {
+                historical_child_start_intent(tool).map(|intent| (tool.id.clone(), intent))
+            })
+            .collect();
         self.active_child_ids = self
             .messages
             .iter()
@@ -528,12 +626,54 @@ impl ChatState {
                     .map(|child| child.child_session_id.clone())
             })
             .collect();
+        let intended_child_ids = self
+            .child_start_intents
+            .values()
+            .filter_map(|intent| match intent {
+                ChildStartIntent::Exact(child_id) => Some(child_id.clone()),
+                ChildStartIntent::Any => None,
+            })
+            .collect::<HashSet<_>>();
+        self.active_child_ids
+            .extend(intended_child_ids.into_iter().filter(|child_id| {
+                self.messages.iter().any(|message| {
+                    message.sub_agents.iter().any(|child| {
+                        child.child_session_id == *child_id
+                            && subagent_status_is_running(&child.status)
+                    })
+                })
+            }));
+        self.current_execution_started = true;
+    }
+
+    fn take_child_start_intent(&mut self, child_session_id: &str) -> bool {
+        let exact =
+            self.child_start_intents
+                .iter()
+                .find_map(|(tool_call_id, intent)| match intent {
+                    ChildStartIntent::Exact(child_id) if child_id == child_session_id => {
+                        Some(tool_call_id.clone())
+                    }
+                    _ => None,
+                });
+        let matching_tool_call = exact.or_else(|| {
+            self.child_start_intents
+                .iter()
+                .find_map(|(tool_call_id, intent)| {
+                    (intent == &ChildStartIntent::Any).then(|| tool_call_id.clone())
+                })
+        });
+        matching_tool_call
+            .and_then(|tool_call_id| self.child_start_intents.remove(&tool_call_id))
+            .is_some()
     }
 
     fn clear_replay_reconciliation(&mut self) {
         self.replay_tool_ids.clear();
         self.replay_child_ids.clear();
+        self.child_start_intents.clear();
         self.active_child_ids.clear();
+        self.current_execution_started = false;
         self.stop_requested_turn_id = None;
         self.parent_terminal_pending = false;
     }
@@ -4560,7 +4700,9 @@ impl App {
         // lifecycle replay, but only children started in this turn may hold its
         // parent terminal open.
         self.chat.replay_tool_ids.clear();
+        self.chat.child_start_intents.clear();
         self.chat.active_child_ids.clear();
+        self.chat.current_execution_started = false;
         self.chat.stop_requested_turn_id = None;
         let model = if self.chat.model.is_empty() {
             "default".to_string()
@@ -5231,6 +5373,7 @@ impl App {
                 self.chat.note_update();
             }
             AgentEvent::ExecutionStarted { run_id, .. } => {
+                self.chat.current_execution_started = true;
                 if self.chat.current_turn_id.is_none() {
                     self.chat.current_turn_id = Some(format!("run:{run_id}"));
                 }
@@ -5255,6 +5398,11 @@ impl App {
                 tool_name,
                 arguments,
             } => {
+                if let Some(intent) = child_start_intent(&tool_name, &arguments) {
+                    self.chat
+                        .child_start_intents
+                        .insert(tool_call_id.clone(), intent);
+                }
                 let arguments = serde_json::to_string(&arguments).unwrap_or_default();
                 if let Some(tool) = self.find_tool_mut(&tool_call_id, false) {
                     // A ToolToken can race ahead of ToolStart. Hydrate that
@@ -5326,6 +5474,7 @@ impl App {
                 // represents. Providers may reuse the same id in a later LLM
                 // round, which must create a distinct current-turn block.
                 self.chat.replay_tool_ids.remove(&tool_call_id);
+                self.chat.child_start_intents.remove(&tool_call_id);
                 self.chat.note_update();
             }
             AgentEvent::ToolError {
@@ -5353,6 +5502,7 @@ impl App {
                     }
                 }
                 self.chat.replay_tool_ids.remove(&tool_call_id);
+                self.chat.child_start_intents.remove(&tool_call_id);
                 self.chat.note_update();
             }
             AgentEvent::ToolLifecycle {
@@ -5537,7 +5687,9 @@ impl App {
                 child_session_id,
                 title,
             } => {
+                let fresh_start = self.chat.take_child_start_intent(&child_session_id);
                 let already_active = self.chat.active_child_ids.contains(&child_session_id);
+                let current_execution_started = self.chat.current_execution_started;
                 let is_current_row = self
                     .chat
                     .sub_agents
@@ -5548,19 +5700,19 @@ impl App {
                     if title.is_some() {
                         existing.title = title;
                     }
-                    if !matches!(
+                    let terminal = matches!(
                         existing.status.as_str(),
                         "completed" | "error" | "cancelled" | "skipped" | "timeout"
-                    ) {
+                    );
+                    let belongs_to_current_generation = fresh_start
+                        || already_active
+                        || (!terminal && is_current_row && current_execution_started);
+                    if fresh_start || (!terminal && belongs_to_current_generation) {
                         existing.status = "running".to_string();
                         existing.error = None;
-                        // Replayed Starts may hydrate old display history. Only
-                        // a child already attributed to the resumed active turn
-                        // (or still held in live scratch state) may hold this
-                        // parent turn open.
-                        active_in_current_turn = already_active || is_current_row;
+                        active_in_current_turn = true;
                     }
-                } else {
+                } else if fresh_start || current_execution_started {
                     let turn_id = self.chat.ensure_current_turn_id();
                     self.chat
                         .register_block(subagent_block_id(&turn_id, &child_session_id));
@@ -5634,6 +5786,8 @@ impl App {
     }
 
     fn finish_parent_terminal(&mut self, status: String) {
+        self.chat.child_start_intents.clear();
+        self.chat.current_execution_started = false;
         self.chat.current_terminal_status = Some(status);
         if !self.has_running_subagents() {
             self.finalize_streaming();
@@ -9899,6 +10053,7 @@ mod question_tests {
     async fn subagent_lifecycle_tracks_children() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.streaming = true;
+        app.chat.current_execution_started = true;
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "c1".into(),
             title: Some("research".into()),
@@ -9949,6 +10104,7 @@ mod question_tests {
         app.event_tx = Some(event_tx);
         app.chat.session_id = Some("parent".to_string());
         app.chat.streaming = true;
+        app.chat.current_execution_started = true;
         app.chat.current_turn_id = Some("turn-a".to_string());
         app.chat.current_response = "parent answer".to_string();
         app.sse_task = Some(tokio::spawn(std::future::pending()));
@@ -10083,13 +10239,17 @@ mod question_tests {
         assert!(!app.chat.parent_terminal_pending);
         assert_eq!(app.status_message, "Ready");
         assert_eq!(app.chat.messages.last().unwrap().content, "new answer");
-        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
+        assert_eq!(
+            app.chat.messages[0].sub_agents[0].status,
+            "running_in_background"
+        );
     }
 
     #[test]
     fn current_turn_child_alone_holds_parent_terminal_until_completion() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.streaming = true;
+        app.chat.current_execution_started = true;
         app.chat.current_turn_id = Some("turn:current".to_string());
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "current-child".to_string(),
@@ -10123,6 +10283,178 @@ mod question_tests {
             .find(|child| child.child_session_id == "current-child")
             .unwrap();
         assert_eq!(child.status, "completed");
+    }
+
+    #[test]
+    fn completed_child_id_can_begin_a_fresh_rerun_generation() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.chat.current_execution_started = true;
+        app.chat.current_turn_id = Some("turn:first-run".to_string());
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "create-call".to_string(),
+            tool_name: "SubAgent".to_string(),
+            arguments: serde_json::json!({
+                "action": "create",
+                "title": "worker",
+                "prompt": "first task",
+                "auto_run": true
+            }),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "reusable-child".to_string(),
+            title: Some("worker".to_string()),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::ToolComplete {
+            tool_call_id: "create-call".to_string(),
+            result: ToolResult {
+                success: true,
+                result: serde_json::json!({
+                    "child_session_id": "reusable-child",
+                    "status": "running_in_background"
+                })
+                .to_string(),
+            },
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "reusable-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+        app.flush_streaming_output();
+
+        // A replayed/out-of-order Start without a corresponding SubAgent tool
+        // intent must not revive the completed generation.
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "reusable-child".to_string(),
+            title: None,
+        })
+        .unwrap();
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
+        assert!(!app.has_running_subagents());
+
+        // Reconnecting rebuilds replay state from history. The completed
+        // create call must not mint a fresh authorization if the critical
+        // cache replays only its old Start (for example after eviction of the
+        // matching Completed event).
+        app.chat.prepare_replay_reconciliation();
+        assert!(app.chat.child_start_intents.is_empty());
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "reusable-child".to_string(),
+            title: None,
+        })
+        .unwrap();
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
+        assert!(!app.has_running_subagents());
+
+        // The supported `action=run` path authorizes exactly one new lifecycle
+        // for this stable child id.
+        app.handle_sse_event(AgentEvent::ToolStart {
+            tool_call_id: "rerun-call".to_string(),
+            tool_name: "SubAgent".to_string(),
+            arguments: serde_json::json!({
+                "action": "run",
+                "child_session_id": "reusable-child"
+            }),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "reusable-child".to_string(),
+            title: Some("worker rerun".to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
+        assert_eq!(
+            app.chat.messages[0].sub_agents[0].title.as_deref(),
+            Some("worker rerun")
+        );
+        assert!(app.chat.active_child_ids.contains("reusable-child"));
+
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "reusable-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "reusable-child".to_string(),
+            title: None,
+        })
+        .unwrap();
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
+        assert!(!app.has_running_subagents());
+    }
+
+    #[test]
+    fn resumed_rerun_reactivates_a_child_row_from_an_older_turn() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages = vec![
+            ChatMessage {
+                id: "history:old-parent".to_string(),
+                role: MessageRole::Assistant,
+                content: "old result".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: vec![SubAgentDisplay {
+                    child_session_id: "reusable-child".to_string(),
+                    title: Some("worker".to_string()),
+                    status: "completed".to_string(),
+                    error: None,
+                }],
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:new-user".to_string(),
+                role: MessageRole::User,
+                content: "retry the worker".to_string(),
+                tool_calls: Vec::new(),
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+            ChatMessage {
+                id: "history:rerun-round".to_string(),
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCallDisplay {
+                    id: "rerun-call".to_string(),
+                    tool_name: "SubAgent".to_string(),
+                    arguments: serde_json::json!({
+                        "action": "run",
+                        "child_session_id": "reusable-child"
+                    })
+                    .to_string(),
+                    result: None,
+                    stream_output: String::new(),
+                    error: None,
+                    phase: "pending".to_string(),
+                }],
+                reasoning: None,
+                sub_agents: Vec::new(),
+                terminal_status: None,
+            },
+        ];
+        app.chat.prepare_replay_reconciliation();
+        assert!(!app.has_running_subagents());
+
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "reusable-child".to_string(),
+            title: Some("worker retry".to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "running");
+        assert_eq!(
+            app.chat.messages[0].sub_agents[0].title.as_deref(),
+            Some("worker retry")
+        );
+        assert!(app.chat.active_child_ids.contains("reusable-child"));
+        assert!(!app.chat.child_start_intents.contains_key("rerun-call"));
     }
 
     #[test]
@@ -10342,6 +10674,7 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("parent".to_string());
         app.chat.streaming = true;
+        app.chat.current_execution_started = true;
         app.chat.auto_scroll = false;
         app.chat.scroll_offset = 7;
 

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -436,13 +436,22 @@ pub struct ChatState {
     /// existing child id. The tool-call key makes the authorization single-use
     /// and lets terminal tool events revoke it when enqueue never happened.
     child_start_intents: HashMap<String, ChildStartIntent>,
+    /// Child ids whose latest-user-turn history authoritatively describes a
+    /// queued/running generation. A reconnect may replay older lifecycle pairs
+    /// before the Start for this generation, so this expectation deliberately
+    /// survives those older terminal events.
+    replay_expected_child_ids: HashSet<String>,
+    /// Expected children that have crossed an older replayed terminal. A later
+    /// Start is then known to belong to a newer generation of the stable id.
+    replay_child_terminal_seen: HashSet<String>,
+    replay_current_child_started: HashSet<String>,
     /// Child sessions observed as started in the current turn/stream
     /// generation. Historical rows are presentation state only and must never
     /// keep a later parent turn artificially open.
     active_child_ids: HashSet<String>,
     /// A parent `ExecutionStarted` (or authoritative running-session resume)
     /// has established that unmatched child starts belong to this generation.
-    /// It stays false while a fresh subscription replays the previous runner.
+    /// It stays false before a fresh parent execution has actually started.
     current_execution_started: bool,
     /// Turn whose stop request has already been dispatched. A late chat POST
     /// response for this same optimistic turn must not attach SSE and start an
@@ -491,6 +500,9 @@ impl ChatState {
             replay_tool_ids: HashSet::new(),
             replay_child_ids: HashSet::new(),
             child_start_intents: HashMap::new(),
+            replay_expected_child_ids: HashSet::new(),
+            replay_child_terminal_seen: HashSet::new(),
+            replay_current_child_started: HashSet::new(),
             active_child_ids: HashSet::new(),
             current_execution_started: false,
             stop_requested_turn_id: None,
@@ -600,20 +612,50 @@ impl ChatState {
                     .map(|child| child.child_session_id.clone())
             })
             .collect();
-        self.child_start_intents = self
+        let historical_start_calls = self
             .messages
             .iter()
             .skip(active_turn_start)
             .flat_map(|message| message.tool_calls.iter())
-            // A completed SubAgent call has already emitted its Start before
-            // returning. Re-authorizing it here would let a truncated critical
-            // replay revive a terminal child without a new run. Only an
-            // unfinished call can still own an unseen Start on reconnect.
-            .filter(|tool| !matches!(tool.phase.as_str(), "complete" | "error"))
+            .filter(|tool| tool.phase != "error")
             .filter_map(|tool| {
-                historical_child_start_intent(tool).map(|intent| (tool.id.clone(), intent))
+                historical_child_start_intent(tool).map(|intent| {
+                    (
+                        tool.id.clone(),
+                        intent,
+                        !matches!(tool.phase.as_str(), "complete" | "error"),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        // Only an unfinished call can still own an unseen Start. Completed
+        // calls are considered below solely as evidence that their latest
+        // child generation is queued/running; they never mint a one-shot Start
+        // authorization by themselves.
+        self.child_start_intents = historical_start_calls
+            .iter()
+            .filter(|(_, _, unfinished)| *unfinished)
+            .map(|(tool_call_id, intent, _)| (tool_call_id.clone(), intent.clone()))
+            .collect();
+        self.replay_expected_child_ids = historical_start_calls
+            .iter()
+            .filter_map(|(_, intent, unfinished)| match intent {
+                ChildStartIntent::Exact(child_id)
+                    if *unfinished
+                        || self.messages.iter().any(|message| {
+                            message.sub_agents.iter().any(|child| {
+                                child.child_session_id == *child_id
+                                    && subagent_status_is_running(&child.status)
+                            })
+                        }) =>
+                {
+                    Some(child_id.clone())
+                }
+                ChildStartIntent::Exact(_) | ChildStartIntent::Any => None,
             })
             .collect();
+        self.replay_child_terminal_seen.clear();
+        self.replay_current_child_started.clear();
         self.active_child_ids = self
             .messages
             .iter()
@@ -626,23 +668,19 @@ impl ChatState {
                     .map(|child| child.child_session_id.clone())
             })
             .collect();
-        let intended_child_ids = self
-            .child_start_intents
-            .values()
-            .filter_map(|intent| match intent {
-                ChildStartIntent::Exact(child_id) => Some(child_id.clone()),
-                ChildStartIntent::Any => None,
-            })
-            .collect::<HashSet<_>>();
-        self.active_child_ids
-            .extend(intended_child_ids.into_iter().filter(|child_id| {
-                self.messages.iter().any(|message| {
-                    message.sub_agents.iter().any(|child| {
-                        child.child_session_id == *child_id
-                            && subagent_status_is_running(&child.status)
+        self.active_child_ids.extend(
+            self.replay_expected_child_ids
+                .iter()
+                .filter(|child_id| {
+                    self.messages.iter().any(|message| {
+                        message.sub_agents.iter().any(|child| {
+                            child.child_session_id == child_id.as_str()
+                                && subagent_status_is_running(&child.status)
+                        })
                     })
                 })
-            }));
+                .cloned(),
+        );
         self.current_execution_started = true;
     }
 
@@ -672,6 +710,9 @@ impl ChatState {
         self.replay_tool_ids.clear();
         self.replay_child_ids.clear();
         self.child_start_intents.clear();
+        self.replay_expected_child_ids.clear();
+        self.replay_child_terminal_seen.clear();
+        self.replay_current_child_started.clear();
         self.active_child_ids.clear();
         self.current_execution_started = false;
         self.stop_requested_turn_id = None;
@@ -4701,6 +4742,9 @@ impl App {
         // parent terminal open.
         self.chat.replay_tool_ids.clear();
         self.chat.child_start_intents.clear();
+        self.chat.replay_expected_child_ids.clear();
+        self.chat.replay_child_terminal_seen.clear();
+        self.chat.replay_current_child_started.clear();
         self.chat.active_child_ids.clear();
         self.chat.current_execution_started = false;
         self.chat.stop_requested_turn_id = None;
@@ -5373,6 +5417,13 @@ impl App {
                 self.chat.note_update();
             }
             AgentEvent::ExecutionStarted { run_id, .. } => {
+                // ExecutionStarted is not part of the critical replay cache.
+                // Seeing it therefore begins a successor parent generation and
+                // retires any child-generation expectation reconstructed for
+                // the previous suspended/reconnected run.
+                self.chat.replay_expected_child_ids.clear();
+                self.chat.replay_child_terminal_seen.clear();
+                self.chat.replay_current_child_started.clear();
                 self.chat.current_execution_started = true;
                 if self.chat.current_turn_id.is_none() {
                     self.chat.current_turn_id = Some(format!("run:{run_id}"));
@@ -5688,6 +5739,24 @@ impl App {
                 title,
             } => {
                 let fresh_start = self.chat.take_child_start_intent(&child_session_id);
+                let replay_expected = self
+                    .chat
+                    .replay_expected_child_ids
+                    .contains(&child_session_id);
+                if replay_expected
+                    && self
+                        .chat
+                        .replay_child_terminal_seen
+                        .contains(&child_session_id)
+                {
+                    // FIFO critical replay can contain Start₁, Complete₁,
+                    // Start₂ for a stable child id. Once a Start follows an
+                    // older terminal, it is the expected current generation;
+                    // its eventual Complete may retire the expectation.
+                    self.chat
+                        .replay_current_child_started
+                        .insert(child_session_id.clone());
+                }
                 let already_active = self.chat.active_child_ids.contains(&child_session_id);
                 let current_execution_started = self.chat.current_execution_started;
                 let is_current_row = self
@@ -5705,14 +5774,18 @@ impl App {
                         "completed" | "error" | "cancelled" | "skipped" | "timeout"
                     );
                     let belongs_to_current_generation = fresh_start
+                        || replay_expected
                         || already_active
                         || (!terminal && is_current_row && current_execution_started);
-                    if fresh_start || (!terminal && belongs_to_current_generation) {
+                    if fresh_start
+                        || replay_expected
+                        || (!terminal && belongs_to_current_generation)
+                    {
                         existing.status = "running".to_string();
                         existing.error = None;
                         active_in_current_turn = true;
                     }
-                } else if fresh_start || current_execution_started {
+                } else if fresh_start || replay_expected || current_execution_started {
                     let turn_id = self.chat.ensure_current_turn_id();
                     self.chat
                         .register_block(subagent_block_id(&turn_id, &child_session_id));
@@ -5738,6 +5811,29 @@ impl App {
                 error,
             } => {
                 self.chat.active_child_ids.remove(&child_session_id);
+                if self
+                    .chat
+                    .replay_current_child_started
+                    .remove(&child_session_id)
+                {
+                    self.chat
+                        .replay_expected_child_ids
+                        .remove(&child_session_id);
+                    self.chat
+                        .replay_child_terminal_seen
+                        .remove(&child_session_id);
+                } else if self
+                    .chat
+                    .replay_expected_child_ids
+                    .contains(&child_session_id)
+                {
+                    // Keep the expectation alive: this can be Complete₁ from
+                    // an older cached generation, followed by the current
+                    // generation's Start₂.
+                    self.chat
+                        .replay_child_terminal_seen
+                        .insert(child_session_id.clone());
+                }
                 if let Some(sa) = self.find_subagent_mut(&child_session_id) {
                     sa.status = status;
                     sa.error = error;
@@ -10286,6 +10382,75 @@ mod question_tests {
     }
 
     #[test]
+    fn supported_subagent_actions_identify_new_child_generations() {
+        let exact = |action: serde_json::Value| {
+            child_start_intent("Sub_Agent", &action)
+                == Some(ChildStartIntent::Exact("reusable-child".to_string()))
+        };
+        assert!(exact(serde_json::json!({
+            "action": "run",
+            "child_session_id": "reusable-child"
+        })));
+        assert!(exact(serde_json::json!({
+            "action": "update",
+            "child_session_id": "reusable-child",
+            "auto_run": true
+        })));
+        assert!(exact(serde_json::json!({
+            "action": "send_message",
+            "child_session_id": "reusable-child"
+        })));
+        assert_eq!(
+            child_start_intent(
+                "SubAgent",
+                &serde_json::json!({"action": "create", "auto_run": true})
+            ),
+            Some(ChildStartIntent::Any)
+        );
+
+        let resident_create = ToolCallDisplay {
+            id: "resident-create".to_string(),
+            tool_name: "SubAgent".to_string(),
+            arguments: serde_json::json!({
+                "action": "create",
+                "resident_name": "worker",
+                "auto_run": true
+            })
+            .to_string(),
+            result: Some(
+                serde_json::json!({
+                    "child_session_id": "reusable-child",
+                    "status": "running_in_background"
+                })
+                .to_string(),
+            ),
+            stream_output: String::new(),
+            error: None,
+            phase: "complete".to_string(),
+        };
+        assert_eq!(
+            historical_child_start_intent(&resident_create),
+            Some(ChildStartIntent::Exact("reusable-child".to_string()))
+        );
+
+        for arguments in [
+            serde_json::json!({"action": "create", "auto_run": false}),
+            serde_json::json!({
+                "action": "update",
+                "child_session_id": "reusable-child",
+                "auto_run": false
+            }),
+            serde_json::json!({
+                "action": "send_message",
+                "child_session_id": "reusable-child",
+                "auto_run": false
+            }),
+        ] {
+            assert_eq!(child_start_intent("SubAgent", &arguments), None);
+        }
+    }
+
+    #[test]
     fn completed_child_id_can_begin_a_fresh_rerun_generation() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.streaming = true;
@@ -10343,6 +10508,7 @@ mod question_tests {
         // matching Completed event).
         app.chat.prepare_replay_reconciliation();
         assert!(app.chat.child_start_intents.is_empty());
+        assert!(app.chat.replay_expected_child_ids.is_empty());
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "reusable-child".to_string(),
             title: None,
@@ -10391,7 +10557,7 @@ mod question_tests {
     }
 
     #[test]
-    fn resumed_rerun_reactivates_a_child_row_from_an_older_turn() {
+    fn resumed_completed_rerun_survives_older_generation_replay() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.messages = vec![
             ChatMessage {
@@ -10403,7 +10569,10 @@ mod question_tests {
                 sub_agents: vec![SubAgentDisplay {
                     child_session_id: "reusable-child".to_string(),
                     title: Some("worker".to_string()),
-                    status: "completed".to_string(),
+                    // History's completed waiting-for-children result globally
+                    // upserts this stable row even though it remains physically
+                    // attached to the old assistant turn.
+                    status: "queued".to_string(),
                     error: None,
                 }],
                 terminal_status: None,
@@ -10432,15 +10601,48 @@ mod question_tests {
                     result: None,
                     stream_output: String::new(),
                     error: None,
-                    phase: "pending".to_string(),
+                    phase: "complete".to_string(),
                 }],
                 reasoning: None,
                 sub_agents: Vec::new(),
                 terminal_status: None,
             },
         ];
+        app.chat.messages[2].tool_calls[0].result = Some(
+            serde_json::json!({
+                "child_session_id": "reusable-child",
+                "status": "queued",
+                "waiting_for_children": true
+            })
+            .to_string(),
+        );
         app.chat.prepare_replay_reconciliation();
+        assert!(app.has_running_subagents());
+        assert!(app
+            .chat
+            .replay_expected_child_ids
+            .contains("reusable-child"));
+        assert!(app.chat.child_start_intents.is_empty());
+
+        // The server's FIFO critical cache can retain both the previous child
+        // generation and the current rerun. Start₁/Complete₁ must not consume
+        // or revoke the history-backed expectation for Start₂.
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "reusable-child".to_string(),
+            title: Some("old replay".to_string()),
+        })
+        .unwrap();
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "reusable-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
         assert!(!app.has_running_subagents());
+        assert!(app
+            .chat
+            .replay_expected_child_ids
+            .contains("reusable-child"));
 
         app.handle_sse_event(AgentEvent::SubAgentStarted {
             child_session_id: "reusable-child".to_string(),
@@ -10454,7 +10656,28 @@ mod question_tests {
             Some("worker retry")
         );
         assert!(app.chat.active_child_ids.contains("reusable-child"));
-        assert!(!app.chat.child_start_intents.contains_key("rerun-call"));
+        assert!(app
+            .chat
+            .replay_current_child_started
+            .contains("reusable-child"));
+
+        // Only the current generation's terminal event retires the replay
+        // expectation; a subsequent stale Start cannot revive it.
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "reusable-child".to_string(),
+            status: "completed".to_string(),
+            error: None,
+        })
+        .unwrap();
+        assert!(!app.has_running_subagents());
+        assert!(app.chat.replay_expected_child_ids.is_empty());
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "reusable-child".to_string(),
+            title: None,
+        })
+        .unwrap();
+        assert_eq!(app.chat.messages[0].sub_agents[0].status, "completed");
+        assert!(!app.has_running_subagents());
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -44,16 +44,31 @@ pub enum AppEvent {
         result: Loaded<()>,
         session_picker_epoch: Option<u64>,
     },
-    /// A chat turn was created + started; carries the new session id.
-    ChatStarted(Loaded<String>),
+    /// A chat turn was created + started. The optimistic assistant turn id
+    /// binds this late HTTP result to the draft that originated it.
+    ChatStarted {
+        turn_id: String,
+        result: Loaded<String>,
+    },
     /// The `execute` POST that kicks off a run failed (server down, 4xx/5xx).
     /// Since no SSE terminal event will ever arrive for a run that never
     /// started, this is how `chat.streaming` gets unstuck.
-    ExecuteFailed(String),
+    ExecuteFailed {
+        session_id: String,
+        turn_id: String,
+        message: String,
+    },
     /// The background `stop` POST finished; `Err` still finalizes streaming
     /// locally (see `stop_streaming`) so the operator regains control even if
-    /// the server is unreachable.
-    StopFinished(Loaded<()>),
+    /// the server is unreachable. Session + stream generation bind the late
+    /// HTTP result to the run that originated it, so it cannot stop a newer
+    /// turn that started after a terminal SSE won the race.
+    StopFinished {
+        session_id: String,
+        turn_id: String,
+        stream_epoch: u64,
+        result: Loaded<()>,
+    },
     /// A skill's detail view finished loading (`Enter` on the Skills tab).
     SkillDetailLoaded(Loaded<SkillDetail>),
     /// A session resume (Sessions-tab `Enter` or `--session-id` at startup)

--- a/crates/app/bamboo-tui/src/history.rs
+++ b/crates/app/bamboo-tui/src/history.rs
@@ -13,7 +13,7 @@ use crate::app::{ChatMessage, MessageRole, SubAgentDisplay, ToolCallDisplay};
 /// - `system` messages are dropped — the TUI never displays them.
 /// - `user` messages become a plain `ChatMessage`.
 /// - `assistant` messages become a `ChatMessage` carrying their tool calls
-///   (installed with `phase: "complete"`, no result yet — a paired `tool`
+///   (installed with `phase: "pending"`, no result yet — a paired `tool`
 ///   message fills that in below).
 /// - `tool` messages are not appended as their own transcript entry; instead
 ///   the matching `ToolCallDisplay` (by `tool_call_id`) is located in the
@@ -65,7 +65,7 @@ pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
                         result: None,
                         stream_output: String::new(),
                         error: None,
-                        phase: "complete".to_string(),
+                        phase: "pending".to_string(),
                     })
                     .collect();
                 let reasoning = msg.reasoning.filter(|r| !r.is_empty());
@@ -91,7 +91,6 @@ pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
                 let Some(tool_call_id) = msg.tool_call_id.as_deref() else {
                     continue;
                 };
-                let child = sub_agent_from_tool_result(&msg.content, msg.tool_success);
                 // Scan already-built output back-to-front so a repeated id
                 // across turns pairs with the *nearest preceding* assistant
                 // message, not the first one in the whole transcript.
@@ -102,6 +101,18 @@ pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
                             .iter()
                             .any(|tool| tool.id == tool_call_id)
                 });
+                let trusted_sub_agent_result = parent_index.is_some_and(|parent_index| {
+                    out[parent_index]
+                        .tool_calls
+                        .iter()
+                        .find(|tool| tool.id == tool_call_id)
+                        .is_some_and(|tool| is_sub_agent_tool_name(&tool.tool_name))
+                });
+                let children = if trusted_sub_agent_result {
+                    sub_agents_from_tool_result(&msg.content, msg.tool_success)
+                } else {
+                    Vec::new()
+                };
                 if let Some(parent_index) = parent_index {
                     let tc = out[parent_index]
                         .tool_calls
@@ -116,33 +127,18 @@ pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
                         tc.result = Some(msg.content);
                     }
                 }
-                if let Some(child) = child {
-                    if let Some(existing) = out
-                        .iter_mut()
-                        .rev()
-                        .flat_map(|message| message.sub_agents.iter_mut())
-                        .find(|existing| existing.child_session_id == child.child_session_id)
-                    {
-                        if child.title.is_some() {
-                            existing.title = child.title;
-                        }
-                        existing.status = child.status;
-                        if child.error.is_some() {
-                            existing.error = child.error;
-                        }
-                    } else {
-                        let attach_index = parent_index.or_else(|| {
-                            out.iter()
-                                .rposition(|message| matches!(message.role, MessageRole::Assistant))
-                        });
-                        if let Some(attach_index) = attach_index {
-                            out[attach_index].sub_agents.push(child);
+                for child in children {
+                    if !upsert_sub_agent_in_transcript(&mut out, &child) {
+                        // A child identity parsed from a trusted, paired
+                        // SubAgent result belongs to that assistant turn.
+                        if let Some(parent_index) = parent_index {
+                            out[parent_index].sub_agents.push(child.into_display());
                         }
                     }
                 }
                 // The tool message itself is never rendered as a separate
-                // transcript row. A reconstructable child summary above may
-                // still be retained even when its tool-call pair is absent.
+                // transcript row, and child summaries are accepted only from
+                // the trusted paired SubAgent call above.
             }
             _ => {}
         }
@@ -151,85 +147,218 @@ pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
     out
 }
 
+#[derive(Debug, Clone)]
+struct SubAgentCandidate {
+    child_session_id: String,
+    title: Option<String>,
+    status: Option<String>,
+    /// 0 = absent, 1 = collection fallback, 2 = inferred running,
+    /// 3 = explicit payload status or failed tool result.
+    status_rank: u8,
+    error: Option<String>,
+}
+
+impl SubAgentCandidate {
+    fn merge(&mut self, newer: Self) {
+        if newer.title.is_some() {
+            self.title = newer.title;
+        }
+        if newer.status.is_some() && newer.status_rank >= self.status_rank {
+            self.status = newer.status;
+            self.status_rank = newer.status_rank;
+        }
+        if newer.error.is_some() {
+            self.error = newer.error;
+        }
+    }
+
+    fn merge_into(&self, existing: &mut SubAgentDisplay) {
+        if let Some(title) = &self.title {
+            existing.title = Some(title.clone());
+        }
+        if self.status_rank >= 2 || existing.status == "unknown" {
+            if let Some(status) = &self.status {
+                existing.status = status.clone();
+            }
+        }
+        if let Some(error) = &self.error {
+            existing.error = Some(error.clone());
+        }
+    }
+
+    fn into_display(self) -> SubAgentDisplay {
+        SubAgentDisplay {
+            child_session_id: self.child_session_id,
+            title: self.title,
+            status: self.status.unwrap_or_else(|| "unknown".to_string()),
+            error: self.error,
+        }
+    }
+}
+
+fn is_sub_agent_tool_name(name: &str) -> bool {
+    name.chars()
+        .filter(|character| !matches!(character, '_' | '-'))
+        .flat_map(char::to_lowercase)
+        .eq("subagent".chars())
+}
+
+fn non_empty_string(value: Option<&serde_json::Value>) -> Option<String> {
+    value
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn candidate_from_value(
+    value: &serde_json::Value,
+    success: Option<bool>,
+    fallback_status: Option<&str>,
+    allow_id_alias: bool,
+) -> Option<SubAgentCandidate> {
+    if let Some(child_session_id) = value.as_str().filter(|id| !id.trim().is_empty()) {
+        return Some(SubAgentCandidate {
+            child_session_id: child_session_id.to_string(),
+            title: None,
+            status: if success == Some(false) {
+                Some("error".to_string())
+            } else {
+                fallback_status.map(str::to_string)
+            },
+            status_rank: if success == Some(false) {
+                3
+            } else if fallback_status.is_some() {
+                1
+            } else {
+                0
+            },
+            error: None,
+        });
+    }
+
+    let child_session_id = non_empty_string(value.get("child_session_id").or_else(|| {
+        if allow_id_alias {
+            value.get("id")
+        } else {
+            None
+        }
+    }))?;
+    let (status, status_rank) = if success == Some(false) {
+        (Some("error".to_string()), 3)
+    } else if let Some(status) =
+        non_empty_string(value.get("status").or_else(|| value.get("last_run_status")))
+    {
+        (Some(status), 3)
+    } else if value
+        .get("is_running")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        (Some("running".to_string()), 2)
+    } else if let Some(fallback_status) = fallback_status {
+        (Some(fallback_status.to_string()), 1)
+    } else {
+        (None, 0)
+    };
+    Some(SubAgentCandidate {
+        child_session_id,
+        title: non_empty_string(value.get("title")),
+        status,
+        status_rank,
+        error: non_empty_string(value.get("error").or_else(|| value.get("last_run_error"))),
+    })
+}
+
+fn upsert_candidate(candidates: &mut Vec<SubAgentCandidate>, candidate: SubAgentCandidate) {
+    if let Some(existing) = candidates
+        .iter_mut()
+        .find(|existing| existing.child_session_id == candidate.child_session_id)
+    {
+        existing.merge(candidate);
+    } else {
+        candidates.push(candidate);
+    }
+}
+
+fn extend_candidates_from_collection(
+    candidates: &mut Vec<SubAgentCandidate>,
+    collection: Option<&serde_json::Value>,
+    success: Option<bool>,
+    fallback_status: Option<&str>,
+) {
+    let Some(collection) = collection else {
+        return;
+    };
+    let values: &[serde_json::Value] = match collection.as_array() {
+        Some(values) => values,
+        None => std::slice::from_ref(collection),
+    };
+    for value in values {
+        if let Some(candidate) = candidate_from_value(value, success, fallback_status, true) {
+            upsert_candidate(candidates, candidate);
+        }
+    }
+}
+
 fn sub_agents_from_metadata(metadata: Option<&serde_json::Value>) -> Vec<SubAgentDisplay> {
-    metadata
-        .and_then(|value| value.get("sub_agents").or_else(|| value.get("subagents")))
-        .and_then(serde_json::Value::as_array)
+    let mut candidates = Vec::new();
+    extend_candidates_from_collection(
+        &mut candidates,
+        metadata.and_then(|value| value.get("sub_agents").or_else(|| value.get("subagents"))),
+        None,
+        Some("completed"),
+    );
+    candidates
         .into_iter()
-        .flatten()
-        .filter_map(|child| {
-            let child_session_id = child
-                .get("child_session_id")
-                .or_else(|| child.get("id"))?
-                .as_str()?
-                .to_string();
-            Some(SubAgentDisplay {
-                child_session_id,
-                title: child
-                    .get("title")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_string),
-                status: child
-                    .get("status")
-                    .or_else(|| child.get("last_run_status"))
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or_else(|| {
-                        if child
-                            .get("is_running")
-                            .and_then(serde_json::Value::as_bool)
-                            .unwrap_or(false)
-                        {
-                            "running"
-                        } else {
-                            "completed"
-                        }
-                    })
-                    .to_string(),
-                error: child
-                    .get("error")
-                    .or_else(|| child.get("last_run_error"))
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_string),
-            })
-        })
+        .map(SubAgentCandidate::into_display)
         .collect()
 }
 
-fn sub_agent_from_tool_result(content: &str, success: Option<bool>) -> Option<SubAgentDisplay> {
-    let value: serde_json::Value = serde_json::from_str(content).ok()?;
-    let child_session_id = value.get("child_session_id")?.as_str()?.to_string();
-    Some(SubAgentDisplay {
-        child_session_id,
-        title: value
-            .get("title")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string),
-        status: if success == Some(false) {
-            "error".to_string()
-        } else {
-            value
-                .get("status")
-                .or_else(|| value.get("last_run_status"))
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_else(|| {
-                    if value
-                        .get("is_running")
-                        .and_then(serde_json::Value::as_bool)
-                        .unwrap_or(false)
-                    {
-                        "running"
-                    } else {
-                        "completed"
-                    }
-                })
-                .to_string()
-        },
-        error: value
-            .get("error")
-            .or_else(|| value.get("last_run_error"))
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string),
-    })
+fn sub_agents_from_tool_result(content: &str, success: Option<bool>) -> Vec<SubAgentCandidate> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(content) else {
+        return Vec::new();
+    };
+    let mut candidates = Vec::new();
+
+    if let Some(candidate) = candidate_from_value(&value, success, None, false) {
+        upsert_candidate(&mut candidates, candidate);
+    }
+    extend_candidates_from_collection(&mut candidates, value.get("children"), success, None);
+    extend_candidates_from_collection(
+        &mut candidates,
+        value.get("satisfied_by"),
+        success,
+        Some("completed"),
+    );
+    extend_candidates_from_collection(
+        &mut candidates,
+        value.get("child_session_ids"),
+        success,
+        None,
+    );
+    extend_candidates_from_collection(
+        &mut candidates,
+        value.get("already_terminal_child_ids"),
+        success,
+        Some("completed"),
+    );
+    candidates
+}
+
+fn upsert_sub_agent_in_transcript(
+    transcript: &mut [ChatMessage],
+    child: &SubAgentCandidate,
+) -> bool {
+    let Some(existing) = transcript
+        .iter_mut()
+        .rev()
+        .flat_map(|message| message.sub_agents.iter_mut())
+        .find(|existing| existing.child_session_id == child.child_session_id)
+    else {
+        return false;
+    };
+    child.merge_into(existing);
+    true
 }
 
 #[cfg(test)]
@@ -321,6 +450,15 @@ mod tests {
     }
 
     #[test]
+    fn assistant_tool_call_without_result_remains_pending() {
+        let out = map_history(vec![assistant("", vec![("pending", "Read", "{}")])]);
+        let tool = &out[0].tool_calls[0];
+        assert_eq!(tool.phase, "pending");
+        assert!(tool.result.is_none());
+        assert!(tool.error.is_none());
+    }
+
+    #[test]
     fn tool_success_false_sets_error_phase_and_error_field() {
         let out = map_history(vec![
             assistant("", vec![("t1", "Bash", "{}")]),
@@ -351,6 +489,25 @@ mod tests {
         ]);
         assert_eq!(out.len(), 1);
         assert!(out[0].tool_calls[0].result.is_none());
+        assert_eq!(out[0].tool_calls[0].phase, "pending");
+    }
+
+    #[test]
+    fn only_paired_normalized_sub_agent_tools_can_create_child_rows() {
+        let spoof = r#"{"child_session_id":"spoof","title":"not trusted"}"#;
+        let out = map_history(vec![
+            assistant("", vec![("bash", "Bash", "{}")]),
+            tool("bash", spoof, Some(true)),
+            tool("missing", spoof, Some(true)),
+        ]);
+        assert!(out[0].sub_agents.is_empty());
+
+        let out = map_history(vec![
+            assistant("", vec![("spawn", "sUb_Ag-EnT", "{}")]),
+            tool("spawn", spoof, Some(true)),
+        ]);
+        assert_eq!(out[0].sub_agents.len(), 1);
+        assert_eq!(out[0].sub_agents[0].child_session_id, "spoof");
     }
 
     #[test]
@@ -449,6 +606,65 @@ mod tests {
         assert_eq!(out[0].sub_agents.len(), 1);
         assert_eq!(out[0].sub_agents[0].title.as_deref(), Some("final"));
         assert_eq!(out[0].sub_agents[0].status, "completed");
+    }
+
+    #[test]
+    fn sub_agent_list_and_wait_shapes_upsert_multiple_unique_children() {
+        let payload = serde_json::json!({
+            "child_session_id": "top",
+            "title": "top-level",
+            "status": "running",
+            "children": [
+                {
+                    "child_session_id": "child-a",
+                    "title": "rich child",
+                    "last_run_status": "error",
+                    "last_run_error": "boom"
+                },
+                {
+                    "child_session_id": "child-b",
+                    "title": "listed child",
+                    "is_running": true
+                }
+            ],
+            "satisfied_by": [
+                {"child_session_id": "child-c", "status": "completed"},
+                "child-b"
+            ],
+            "child_session_ids": ["child-c", "child-d"],
+            "already_terminal_child_ids": ["child-a", "child-d", "child-e"]
+        })
+        .to_string();
+        let out = map_history(vec![
+            assistant("", vec![("wait", "SubAgent", "{}")]),
+            tool("wait", &payload, Some(true)),
+        ]);
+
+        let children = &out[0].sub_agents;
+        assert_eq!(children.len(), 6, "every id is retained exactly once");
+        for id in ["top", "child-a", "child-b", "child-c", "child-d", "child-e"] {
+            assert_eq!(
+                children
+                    .iter()
+                    .filter(|child| child.child_session_id == id)
+                    .count(),
+                1,
+                "{id} must be deduplicated"
+            );
+        }
+        let rich = children
+            .iter()
+            .find(|child| child.child_session_id == "child-a")
+            .unwrap();
+        assert_eq!(rich.title.as_deref(), Some("rich child"));
+        assert_eq!(rich.status, "error");
+        assert_eq!(rich.error.as_deref(), Some("boom"));
+        let running = children
+            .iter()
+            .find(|child| child.child_session_id == "child-b")
+            .unwrap();
+        assert_eq!(running.title.as_deref(), Some("listed child"));
+        assert_eq!(running.status, "running");
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/history.rs
+++ b/crates/app/bamboo-tui/src/history.rs
@@ -5,7 +5,7 @@
 //! `HistoryMessage` fixtures without spinning up an `App`.
 
 use crate::api::types::HistoryMessage;
-use crate::app::{ChatMessage, MessageRole, ToolCallDisplay};
+use crate::app::{ChatMessage, MessageRole, SubAgentDisplay, ToolCallDisplay};
 
 /// Map a session's raw history (`GET /api/v1/history/{id}`) into the chat
 /// transcript the Chat tab renders.
@@ -21,12 +21,17 @@ use crate::app::{ChatMessage, MessageRole, ToolCallDisplay};
 ///   (`result`/`error` + terminal `phase`). A tool result with no matching
 ///   call anywhere is dropped silently — there's nothing sensible to attach
 ///   it to.
-/// - A mapped message with empty content, no reasoning, and no tool calls is
-///   dropped (nothing to render).
+/// - A mapped message with empty content, no reasoning, no tool calls, and no
+///   reconstructable child rows is dropped (nothing to render).
 pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
     let mut out: Vec<ChatMessage> = Vec::new();
 
-    for msg in messages {
+    for (index, msg) in messages.into_iter().enumerate() {
+        let message_id = if msg.id.is_empty() {
+            format!("history:{index}:{}", msg.role)
+        } else {
+            msg.id.clone()
+        };
         match msg.role.as_str() {
             "system" => continue,
             "user" => {
@@ -34,10 +39,13 @@ pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
                     continue;
                 }
                 out.push(ChatMessage {
+                    id: message_id,
                     role: MessageRole::User,
                     content: msg.content,
                     tool_calls: Vec::new(),
                     reasoning: None,
+                    sub_agents: Vec::new(),
+                    terminal_status: None,
                 });
             }
             "assistant" => {
@@ -45,40 +53,61 @@ pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
                     .tool_calls
                     .unwrap_or_default()
                     .into_iter()
-                    .map(|tc| ToolCallDisplay {
-                        id: tc.id,
+                    .enumerate()
+                    .map(|(tool_index, tc)| ToolCallDisplay {
+                        id: if tc.id.is_empty() {
+                            format!("{message_id}:tool:{tool_index}")
+                        } else {
+                            tc.id
+                        },
                         tool_name: tc.function.name,
                         arguments: tc.function.arguments,
                         result: None,
+                        stream_output: String::new(),
                         error: None,
                         phase: "complete".to_string(),
                     })
                     .collect();
                 let reasoning = msg.reasoning.filter(|r| !r.is_empty());
-                if msg.content.is_empty() && reasoning.is_none() && tool_calls.is_empty() {
+                let sub_agents = sub_agents_from_metadata(msg.metadata.as_ref());
+                if msg.content.is_empty()
+                    && reasoning.is_none()
+                    && tool_calls.is_empty()
+                    && sub_agents.is_empty()
+                {
                     continue;
                 }
                 out.push(ChatMessage {
+                    id: message_id,
                     role: MessageRole::Assistant,
                     content: msg.content,
                     tool_calls,
                     reasoning,
+                    sub_agents,
+                    terminal_status: None,
                 });
             }
             "tool" => {
                 let Some(tool_call_id) = msg.tool_call_id.as_deref() else {
                     continue;
                 };
+                let child = sub_agent_from_tool_result(&msg.content, msg.tool_success);
                 // Scan already-built output back-to-front so a repeated id
                 // across turns pairs with the *nearest preceding* assistant
                 // message, not the first one in the whole transcript.
-                let found = out.iter_mut().rev().find_map(|m| {
-                    if !matches!(m.role, MessageRole::Assistant) {
-                        return None;
-                    }
-                    m.tool_calls.iter_mut().find(|tc| tc.id == tool_call_id)
+                let parent_index = out.iter().rposition(|message| {
+                    matches!(message.role, MessageRole::Assistant)
+                        && message
+                            .tool_calls
+                            .iter()
+                            .any(|tool| tool.id == tool_call_id)
                 });
-                if let Some(tc) = found {
+                if let Some(parent_index) = parent_index {
+                    let tc = out[parent_index]
+                        .tool_calls
+                        .iter_mut()
+                        .find(|tool| tool.id == tool_call_id)
+                        .expect("parent index was selected by this tool id");
                     if msg.tool_success == Some(false) {
                         tc.phase = "error".to_string();
                         tc.error = Some(msg.content);
@@ -87,13 +116,120 @@ pub fn map_history(messages: Vec<HistoryMessage>) -> Vec<ChatMessage> {
                         tc.result = Some(msg.content);
                     }
                 }
-                // No matching call anywhere: dropped silently.
+                if let Some(child) = child {
+                    if let Some(existing) = out
+                        .iter_mut()
+                        .rev()
+                        .flat_map(|message| message.sub_agents.iter_mut())
+                        .find(|existing| existing.child_session_id == child.child_session_id)
+                    {
+                        if child.title.is_some() {
+                            existing.title = child.title;
+                        }
+                        existing.status = child.status;
+                        if child.error.is_some() {
+                            existing.error = child.error;
+                        }
+                    } else {
+                        let attach_index = parent_index.or_else(|| {
+                            out.iter()
+                                .rposition(|message| matches!(message.role, MessageRole::Assistant))
+                        });
+                        if let Some(attach_index) = attach_index {
+                            out[attach_index].sub_agents.push(child);
+                        }
+                    }
+                }
+                // The tool message itself is never rendered as a separate
+                // transcript row. A reconstructable child summary above may
+                // still be retained even when its tool-call pair is absent.
             }
             _ => {}
         }
     }
 
     out
+}
+
+fn sub_agents_from_metadata(metadata: Option<&serde_json::Value>) -> Vec<SubAgentDisplay> {
+    metadata
+        .and_then(|value| value.get("sub_agents").or_else(|| value.get("subagents")))
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|child| {
+            let child_session_id = child
+                .get("child_session_id")
+                .or_else(|| child.get("id"))?
+                .as_str()?
+                .to_string();
+            Some(SubAgentDisplay {
+                child_session_id,
+                title: child
+                    .get("title")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+                status: child
+                    .get("status")
+                    .or_else(|| child.get("last_run_status"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_else(|| {
+                        if child
+                            .get("is_running")
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(false)
+                        {
+                            "running"
+                        } else {
+                            "completed"
+                        }
+                    })
+                    .to_string(),
+                error: child
+                    .get("error")
+                    .or_else(|| child.get("last_run_error"))
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+            })
+        })
+        .collect()
+}
+
+fn sub_agent_from_tool_result(content: &str, success: Option<bool>) -> Option<SubAgentDisplay> {
+    let value: serde_json::Value = serde_json::from_str(content).ok()?;
+    let child_session_id = value.get("child_session_id")?.as_str()?.to_string();
+    Some(SubAgentDisplay {
+        child_session_id,
+        title: value
+            .get("title")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        status: if success == Some(false) {
+            "error".to_string()
+        } else {
+            value
+                .get("status")
+                .or_else(|| value.get("last_run_status"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_else(|| {
+                    if value
+                        .get("is_running")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false)
+                    {
+                        "running"
+                    } else {
+                        "completed"
+                    }
+                })
+                .to_string()
+        },
+        error: value
+            .get("error")
+            .or_else(|| value.get("last_run_error"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+    })
 }
 
 #[cfg(test)]
@@ -258,5 +394,100 @@ mod tests {
     fn empty_user_message_is_skipped() {
         let out = map_history(vec![user("")]);
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn history_preserves_stable_message_tool_and_child_ids_when_available() {
+        let mut message = assistant("done", vec![("tool-stable", "sub_agent", "{}")]);
+        message.id = "message-stable".to_string();
+        message.metadata = Some(serde_json::json!({
+            "sub_agents": [{
+                "child_session_id": "child-from-metadata",
+                "title": "research",
+                "status": "completed"
+            }]
+        }));
+        let out = map_history(vec![message]);
+        assert_eq!(out[0].id, "message-stable");
+        assert_eq!(out[0].tool_calls[0].id, "tool-stable");
+        assert_eq!(out[0].sub_agents[0].child_session_id, "child-from-metadata");
+
+        let out = map_history(vec![
+            assistant("", vec![("spawn", "sub_agent", "{}")]),
+            tool(
+                "spawn",
+                r#"{"child_session_id":"child-from-result","title":"review"}"#,
+                Some(true),
+            ),
+        ]);
+        assert_eq!(out[0].sub_agents[0].child_session_id, "child-from-result");
+    }
+
+    #[test]
+    fn history_synthesizes_missing_tool_ids_and_merges_child_updates() {
+        let mut message = assistant("", vec![("", "SubAgent", "{}")]);
+        message.id = "assistant-1".to_string();
+        let out = map_history(vec![message]);
+        assert_eq!(out[0].tool_calls[0].id, "assistant-1:tool:0");
+
+        let mut message = assistant("", vec![("spawn", "SubAgent", "{}")]);
+        message.metadata = Some(serde_json::json!({
+            "sub_agents": [{
+                "child_session_id": "child-1",
+                "title": "initial",
+                "status": "running"
+            }]
+        }));
+        let out = map_history(vec![
+            message,
+            tool(
+                "spawn",
+                r#"{"child_session_id":"child-1","title":"final","last_run_status":"completed"}"#,
+                Some(true),
+            ),
+        ]);
+        assert_eq!(out[0].sub_agents.len(), 1);
+        assert_eq!(out[0].sub_agents[0].title.as_deref(), Some("final"));
+        assert_eq!(out[0].sub_agents[0].status, "completed");
+    }
+
+    #[test]
+    fn history_and_live_turns_expose_equivalent_structured_block_shapes() {
+        use crate::api::BambooClient;
+        use crate::app::{App, ConversationBlockKind};
+
+        let mut stored = assistant("answer", vec![("call-1", "Read", "{}")]);
+        stored.id = "message-1".to_string();
+        stored.reasoning = Some("reasoning".to_string());
+        let mapped = map_history(vec![stored, tool("call-1", "result", Some(true))]);
+
+        let mut history_app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        history_app.chat.messages = mapped.clone();
+        let mut live_app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        live_app.chat.current_turn_id = Some("message-1".to_string());
+        live_app.chat.current_response = "answer".to_string();
+        live_app.chat.current_reasoning = "reasoning".to_string();
+        live_app.chat.current_tool_calls = mapped[0].tool_calls.clone();
+
+        let shape = |app: &App| {
+            app.conversation_blocks()
+                .into_iter()
+                .map(|block| match block.kind {
+                    ConversationBlockKind::AssistantMarkdown { .. } => "assistant",
+                    ConversationBlockKind::Reasoning { .. } => "reasoning",
+                    ConversationBlockKind::ToolCall { .. } => "tool",
+                    ConversationBlockKind::UserMessage(_) => "user",
+                    ConversationBlockKind::SubAgent { .. } => "subagent",
+                    ConversationBlockKind::Question { .. } => "question",
+                    ConversationBlockKind::TerminalStatus(_) => "terminal",
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(shape(&history_app), shape(&live_app));
+        assert_eq!(
+            history_app.conversation_blocks()[2].id,
+            live_app.conversation_blocks()[2].id,
+            "tool_call_id is the stable cross-shape UI key"
+        );
     }
 }

--- a/crates/app/bamboo-tui/src/ui/chat.rs
+++ b/crates/app/bamboo-tui/src/ui/chat.rs
@@ -5,8 +5,8 @@ use ratatui::widgets::{Paragraph, Wrap};
 use ratatui::Frame;
 
 use crate::app::{
-    inspector_lines, App, ConversationBlockKind, ConversationBlockLineRange,
-    ConversationBlockUiState, ToolCallDisplay, CONVERSATION_DETAIL_VIEWPORT,
+    App, ConversationBlockKind, ConversationBlockLineRange, ConversationBlockUiState,
+    ToolCallDisplay, CONVERSATION_DETAIL_VIEWPORT,
 };
 use crate::components::markdown;
 use crate::theme::{self, colors};
@@ -18,6 +18,8 @@ const COLLAPSED_DETAIL_LINES: usize = 3;
 /// independent `scroll` offset instead of flooding the whole transcript.
 fn push_tool_detail(
     lines: &mut Vec<Line<'static>>,
+    app: &App,
+    block_id: &str,
     tc: &ToolCallDisplay,
     state: &ConversationBlockUiState,
     focused: bool,
@@ -26,15 +28,21 @@ fn push_tool_detail(
     // Arguments.
     let args = tc.arguments.trim();
     if !args.is_empty() && args != "null" && args != "{}" {
-        let argument_lines = inspector_lines(args, width.saturating_sub(9) as usize);
+        let (argument_count, argument_lines) = app.chat.inspector_slice(
+            &format!("{block_id}:args"),
+            args,
+            width.saturating_sub(9) as usize,
+            0,
+            3,
+        );
         if state.expanded {
-            for aline in argument_lines.iter().take(3) {
+            for aline in &argument_lines {
                 lines.push(Line::from(Span::styled(
                     format!("   args: {aline}"),
                     Style::default().fg(colors::SUBTLE),
                 )));
             }
-            let extra = argument_lines.len().saturating_sub(3);
+            let extra = argument_count.saturating_sub(3);
             if extra > 0 {
                 lines.push(Line::from(Span::styled(
                     format!("   … {extra} more argument lines"),
@@ -46,7 +54,7 @@ fn push_tool_detail(
                 .first()
                 .map(String::as_str)
                 .unwrap_or_default();
-            let ellipsis = if argument_lines.len() > 1 { "…" } else { "" };
+            let ellipsis = if argument_count > 1 { "…" } else { "" };
             lines.push(Line::from(Span::styled(
                 format!("   args: {preview}{ellipsis}"),
                 Style::default().fg(colors::SUBTLE),
@@ -57,31 +65,41 @@ fn push_tool_detail(
     // Result.
     let output = tc.display_output();
     if !output.is_empty() {
-        let output_lines = inspector_lines(output, width.saturating_sub(3) as usize);
         let limit = if state.expanded {
             CONVERSATION_DETAIL_VIEWPORT
         } else {
             COLLAPSED_DETAIL_LINES
         };
-        let max_start = output_lines.len().saturating_sub(limit);
+        let output_key = format!("{block_id}:output");
+        let (output_count, _) =
+            app.chat
+                .inspector_slice(&output_key, output, width.saturating_sub(3) as usize, 0, 0);
+        let max_start = output_count.saturating_sub(limit);
         let start = if state.expanded {
             state.scroll.min(max_start)
         } else {
             0
         };
+        let (_, output_lines) = app.chat.inspector_slice(
+            &output_key,
+            output,
+            width.saturating_sub(3) as usize,
+            start,
+            limit,
+        );
         if start > 0 {
             lines.push(Line::from(Span::styled(
                 format!("   ↑ {start} earlier lines"),
                 Style::default().fg(colors::SUBTLE),
             )));
         }
-        for rline in output_lines.iter().skip(start).take(limit) {
+        for rline in &output_lines {
             lines.push(Line::from(Span::styled(
                 format!("   {rline}"),
                 Style::default().fg(colors::INACTIVE),
             )));
         }
-        let hidden_after = output_lines.len().saturating_sub(start + limit);
+        let hidden_after = output_count.saturating_sub(start + limit);
         if hidden_after > 0 {
             lines.push(Line::from(Span::styled(
                 if state.expanded {
@@ -96,8 +114,14 @@ fn push_tool_detail(
 
     // Error.
     if let Some(err) = &tc.error {
-        let error_lines = inspector_lines(err, width.saturating_sub(10) as usize);
-        for (index, line) in error_lines.iter().take(3).enumerate() {
+        let (error_count, error_lines) = app.chat.inspector_slice(
+            &format!("{block_id}:error"),
+            err,
+            width.saturating_sub(10) as usize,
+            0,
+            3,
+        );
+        for (index, line) in error_lines.iter().enumerate() {
             lines.push(Line::from(Span::styled(
                 if index == 0 {
                     format!("   Error: {line}")
@@ -107,7 +131,7 @@ fn push_tool_detail(
                 Style::default().fg(colors::TOOL_ERROR),
             )));
         }
-        let extra = error_lines.len().saturating_sub(3);
+        let extra = error_count.saturating_sub(3);
         if extra > 0 {
             lines.push(Line::from(Span::styled(
                 format!("   … {extra} more error lines · y copies exact text"),
@@ -215,8 +239,14 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                 lines.extend(rendered);
             }
             ConversationBlockKind::Reasoning { content, streaming } => {
-                let detail = inspector_lines(content, width.saturating_sub(1) as usize);
-                let count = detail.len();
+                let reasoning_key = format!("{}:detail", block.id);
+                let (count, _) = app.chat.inspector_slice(
+                    &reasoning_key,
+                    content,
+                    width.saturating_sub(1) as usize,
+                    0,
+                    0,
+                );
                 lines.push(Line::from(Span::styled(
                     format!(
                         "{} thinking{} · {count} lines",
@@ -228,22 +258,27 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                 if state.expanded {
                     let start = state
                         .scroll
-                        .min(detail.len().saturating_sub(CONVERSATION_DETAIL_VIEWPORT));
+                        .min(count.saturating_sub(CONVERSATION_DETAIL_VIEWPORT));
+                    let (_, detail) = app.chat.inspector_slice(
+                        &reasoning_key,
+                        content,
+                        width.saturating_sub(1) as usize,
+                        start,
+                        CONVERSATION_DETAIL_VIEWPORT,
+                    );
                     if start > 0 {
                         lines.push(Line::from(Span::styled(
                             format!(" ↑ {start} earlier lines"),
                             Style::default().fg(colors::SUBTLE),
                         )));
                     }
-                    for line in detail.iter().skip(start).take(CONVERSATION_DETAIL_VIEWPORT) {
+                    for line in &detail {
                         lines.push(Line::from(Span::styled(
                             format!(" {line}"),
                             Style::default().fg(colors::SUBTLE),
                         )));
                     }
-                    let remaining = detail
-                        .len()
-                        .saturating_sub(start + CONVERSATION_DETAIL_VIEWPORT);
+                    let remaining = count.saturating_sub(start + CONVERSATION_DETAIL_VIEWPORT);
                     if remaining > 0 {
                         lines.push(Line::from(Span::styled(
                             format!(" ↓ {remaining} later lines"),
@@ -287,15 +322,17 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                     ),
                     style,
                 )));
-                push_tool_detail(&mut lines, tool, &state, focused, width);
+                push_tool_detail(&mut lines, app, &block.id, tool, &state, focused, width);
             }
             ConversationBlockKind::SubAgent { child, streaming } => {
                 let tick = app.spinner_tick % theme::BRAILLE_SPINNER.len();
                 let (icon, style) = match child.status.as_str() {
-                    "running" if streaming => (
-                        theme::BRAILLE_SPINNER[tick],
-                        Style::default().fg(colors::TOOL_RUNNING),
-                    ),
+                    "running" | "running_in_background" | "queued" | "starting" | "in_progress" => {
+                        (
+                            theme::BRAILLE_SPINNER[tick],
+                            Style::default().fg(colors::TOOL_RUNNING),
+                        )
+                    }
                     "completed" => ("✓", Style::default().fg(colors::TOOL_DONE)),
                     "error" | "cancelled" => ("✗", Style::default().fg(colors::TOOL_ERROR)),
                     _ => ("·", Style::default().fg(colors::INACTIVE)),
@@ -429,10 +466,13 @@ mod tests {
     #[test]
     fn tool_detail_truncates_then_expands() {
         let t = tc("{\"path\":\"x\"}", Some("l1\nl2\nl3\nl4\nl5"));
+        let app = App::new(BambooClient::new("http://127.0.0.1:0"));
 
         let mut lines: Vec<Line> = Vec::new();
         push_tool_detail(
             &mut lines,
+            &app,
+            "test:tool",
             &t,
             &ConversationBlockUiState::default(),
             false,
@@ -444,6 +484,8 @@ mod tests {
         let mut lines: Vec<Line> = Vec::new();
         push_tool_detail(
             &mut lines,
+            &app,
+            "test:tool",
             &t,
             &ConversationBlockUiState {
                 expanded: true,
@@ -458,9 +500,12 @@ mod tests {
 
     #[test]
     fn empty_args_and_no_result_render_nothing() {
+        let app = App::new(BambooClient::new("http://127.0.0.1:0"));
         let mut lines: Vec<Line> = Vec::new();
         push_tool_detail(
             &mut lines,
+            &app,
+            "test:tool",
             &tc("{}", None),
             &ConversationBlockUiState::default(),
             false,

--- a/crates/app/bamboo-tui/src/ui/chat.rs
+++ b/crates/app/bamboo-tui/src/ui/chat.rs
@@ -4,27 +4,49 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 use ratatui::Frame;
 
-use crate::app::{App, MessageRole, ToolCallDisplay};
+use crate::app::{
+    inspector_lines, App, ConversationBlockKind, ConversationBlockLineRange,
+    ConversationBlockUiState, ToolCallDisplay, CONVERSATION_DETAIL_VIEWPORT,
+};
 use crate::components::markdown;
 use crate::theme::{self, colors};
 
-/// Render a tool call's arguments, result, and error under its name line.
-/// Truncated by default (args → one preview line, result → 3 lines); `expand`
-/// (Ctrl+X on the Chat tab) shows everything.
-fn push_tool_detail(lines: &mut Vec<Line<'static>>, tc: &ToolCallDisplay, expand: bool) {
+const COLLAPSED_DETAIL_LINES: usize = 3;
+
+/// Render one tool block's bounded inspector. Expansion is per block, and an
+/// expanded block remains bounded; when focused, j/k or PgUp/PgDn changes its
+/// independent `scroll` offset instead of flooding the whole transcript.
+fn push_tool_detail(
+    lines: &mut Vec<Line<'static>>,
+    tc: &ToolCallDisplay,
+    state: &ConversationBlockUiState,
+    focused: bool,
+    width: u16,
+) {
     // Arguments.
     let args = tc.arguments.trim();
     if !args.is_empty() && args != "null" && args != "{}" {
-        if expand {
-            for aline in args.lines() {
+        let argument_lines = inspector_lines(args, width.saturating_sub(9) as usize);
+        if state.expanded {
+            for aline in argument_lines.iter().take(3) {
                 lines.push(Line::from(Span::styled(
                     format!("   args: {aline}"),
                     Style::default().fg(colors::SUBTLE),
                 )));
             }
+            let extra = argument_lines.len().saturating_sub(3);
+            if extra > 0 {
+                lines.push(Line::from(Span::styled(
+                    format!("   … {extra} more argument lines"),
+                    Style::default().fg(colors::SUBTLE),
+                )));
+            }
         } else {
-            let preview: String = args.chars().take(88).collect();
-            let ellipsis = if args.chars().count() > 88 { "…" } else { "" };
+            let preview = argument_lines
+                .first()
+                .map(String::as_str)
+                .unwrap_or_default();
+            let ellipsis = if argument_lines.len() > 1 { "…" } else { "" };
             lines.push(Line::from(Span::styled(
                 format!("   args: {preview}{ellipsis}"),
                 Style::default().fg(colors::SUBTLE),
@@ -33,18 +55,40 @@ fn push_tool_detail(lines: &mut Vec<Line<'static>>, tc: &ToolCallDisplay, expand
     }
 
     // Result.
-    if let Some(result) = &tc.result {
-        let max = if expand { usize::MAX } else { 3 };
-        for rline in result.lines().take(max) {
+    let output = tc.display_output();
+    if !output.is_empty() {
+        let output_lines = inspector_lines(output, width.saturating_sub(3) as usize);
+        let limit = if state.expanded {
+            CONVERSATION_DETAIL_VIEWPORT
+        } else {
+            COLLAPSED_DETAIL_LINES
+        };
+        let max_start = output_lines.len().saturating_sub(limit);
+        let start = if state.expanded {
+            state.scroll.min(max_start)
+        } else {
+            0
+        };
+        if start > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("   ↑ {start} earlier lines"),
+                Style::default().fg(colors::SUBTLE),
+            )));
+        }
+        for rline in output_lines.iter().skip(start).take(limit) {
             lines.push(Line::from(Span::styled(
                 format!("   {rline}"),
                 Style::default().fg(colors::INACTIVE),
             )));
         }
-        let total = result.lines().count();
-        if !expand && total > 3 {
+        let hidden_after = output_lines.len().saturating_sub(start + limit);
+        if hidden_after > 0 {
             lines.push(Line::from(Span::styled(
-                format!("   … ({} more — Ctrl+X to expand)", total - 3),
+                if state.expanded {
+                    format!("   ↓ {hidden_after} later lines")
+                } else {
+                    format!("   … {hidden_after} more — focus then Enter to inspect")
+                },
                 Style::default().fg(colors::SUBTLE),
             )));
         }
@@ -52,16 +96,40 @@ fn push_tool_detail(lines: &mut Vec<Line<'static>>, tc: &ToolCallDisplay, expand
 
     // Error.
     if let Some(err) = &tc.error {
+        let error_lines = inspector_lines(err, width.saturating_sub(10) as usize);
+        for (index, line) in error_lines.iter().take(3).enumerate() {
+            lines.push(Line::from(Span::styled(
+                if index == 0 {
+                    format!("   Error: {line}")
+                } else {
+                    format!("          {line}")
+                },
+                Style::default().fg(colors::TOOL_ERROR),
+            )));
+        }
+        let extra = error_lines.len().saturating_sub(3);
+        if extra > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("   … {extra} more error lines · y copies exact text"),
+                Style::default().fg(colors::TOOL_ERROR),
+            )));
+        }
+    }
+    if focused {
         lines.push(Line::from(Span::styled(
-            format!("   Error: {err}"),
-            Style::default().fg(colors::TOOL_ERROR),
+            if state.expanded {
+                "   Enter collapse · j/k scroll · y copy"
+            } else {
+                "   Enter expand · y copy"
+            },
+            Style::default().fg(colors::SUBTLE),
         )));
     }
 }
 
 pub fn render(f: &mut Frame, content: Rect, input: Rect, app: &App) {
-    let lines = build_message_lines(app, content.width);
-    let total_lines = lines.len() as u16;
+    let rendered = build_conversation_lines(app, content.width);
+    let total_lines = rendered.visual_line_count;
 
     let visible_height = content.height;
     let max_scroll = total_lines.saturating_sub(visible_height);
@@ -69,172 +137,250 @@ pub fn render(f: &mut Frame, content: Rect, input: Rect, app: &App) {
     // not this frame's layout) can clamp `scroll_offset` — see
     // `ChatState::max_scroll`'s doc comment.
     app.chat.max_scroll.set(max_scroll);
+    app.chat.content_height.set(visible_height);
+    app.chat.content_width.set(content.width);
+    *app.chat.block_line_ranges.borrow_mut() = rendered.ranges;
     let scroll_offset = if app.chat.auto_scroll {
         max_scroll
     } else {
         app.chat.scroll_offset.min(max_scroll)
     };
 
-    let messages = Paragraph::new(lines)
+    let messages = Paragraph::new(rendered.lines)
         .wrap(Wrap { trim: false })
         .scroll((scroll_offset, 0));
 
     f.render_widget(messages, content);
 
-    // Input area
-    if app.chat.streaming {
-        let blocked = Paragraph::new(Line::from(vec![
-            Span::styled("❯ ", Style::default().fg(colors::BRAND)),
-            Span::styled(
-                "Waiting for response... (Ctrl+S to stop, j/k to scroll)",
-                Style::default().fg(colors::INACTIVE),
-            ),
-        ]));
-        f.render_widget(blocked, input);
-    } else {
-        f.render_widget(&app.chat.textarea, input);
-    }
+    // The composer remains the stable editing surface while a run is active.
+    // Enter is gated in `handle_chat_key`; editing here never implies mid-run
+    // steering or a new server-side queue.
+    f.render_widget(&app.chat.textarea, input);
 }
 
-fn build_message_lines(app: &App, width: u16) -> Vec<Line<'static>> {
-    let mut lines: Vec<Line> = Vec::new();
+struct RenderedConversation {
+    lines: Vec<Line<'static>>,
+    ranges: Vec<ConversationBlockLineRange>,
+    visual_line_count: u16,
+}
 
-    for msg in &app.chat.messages {
-        match msg.role {
-            MessageRole::User => {
-                // User message: "> text" prefix style
+fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
+    let mut lines: Vec<Line> = Vec::new();
+    let mut ranges = Vec::new();
+    let mut visual_line_count = 0usize;
+
+    for block in app.conversation_blocks() {
+        let first_logical_line = lines.len();
+        let start = visual_line_count;
+        let focused = app.chat.focused_block.as_deref() == Some(block.id.as_str());
+        let state = app
+            .chat
+            .block_ui
+            .get(&block.id)
+            .cloned()
+            .unwrap_or_default();
+        match block.kind {
+            ConversationBlockKind::UserMessage(content) => {
                 lines.push(Line::from(Span::styled(
-                    ">",
-                    Style::default().fg(colors::USER_PREFIX),
+                    if focused { "▸ user" } else { ">" },
+                    Style::default()
+                        .fg(colors::USER_PREFIX)
+                        .add_modifier(if focused {
+                            ratatui::style::Modifier::BOLD
+                        } else {
+                            ratatui::style::Modifier::empty()
+                        }),
                 )));
-                for line in msg.content.lines() {
+                for line in content.lines() {
                     lines.push(Line::from(Span::styled(
                         line.to_string(),
                         Style::default().fg(colors::USER_PREFIX),
                     )));
                 }
-                lines.push(Line::raw(""));
             }
-            MessageRole::Assistant => {
-                // Assistant message: markdown rendered content
-                let rendered = markdown::render_markdown(&msg.content, width);
+            ConversationBlockKind::AssistantMarkdown { content, streaming } => {
+                if focused {
+                    lines.push(Line::from(Span::styled(
+                        if streaming {
+                            "▸ assistant · streaming"
+                        } else {
+                            "▸ assistant"
+                        },
+                        Style::default()
+                            .fg(colors::BRAND)
+                            .add_modifier(ratatui::style::Modifier::BOLD),
+                    )));
+                }
+                let rendered = markdown::render_markdown(content, width);
                 lines.extend(rendered);
-
-                // Tool calls
-                for tc in &msg.tool_calls {
-                    let (icon, style) = match tc.phase.as_str() {
-                        "complete" => ("✓", Style::default().fg(colors::TOOL_DONE)),
-                        "error" => ("✗", Style::default().fg(colors::TOOL_ERROR)),
-                        _ => ("●", Style::default().fg(colors::TOOL_RUNNING)),
-                    };
-                    lines.push(Line::from(Span::styled(
-                        format!(" {} {}", icon, tc.tool_name),
-                        style,
-                    )));
-                    push_tool_detail(&mut lines, tc, app.chat.expand_tools);
-                }
-
-                // Reasoning / thinking block
-                if let Some(reasoning) = &msg.reasoning {
-                    let sep_len: usize = 40;
-                    lines.push(Line::from(Span::styled(
-                        format!("── thinking {}", "─".repeat(sep_len.saturating_sub(14))),
-                        Style::default().fg(colors::THINKING),
-                    )));
-                    for rline in reasoning.lines().take(5) {
-                        lines.push(Line::from(Span::styled(
-                            format!(" {}", rline),
-                            Style::default().fg(colors::SUBTLE),
-                        )));
-                    }
-                    let total = reasoning.lines().count();
-                    if total > 5 {
-                        lines.push(Line::from(Span::styled(
-                            format!(" ... ({} more lines)", total - 5),
-                            Style::default().fg(colors::SUBTLE),
-                        )));
-                    }
-                    lines.push(Line::from(Span::styled(
-                        "─".repeat(sep_len),
-                        Style::default().fg(colors::THINKING),
-                    )));
-                }
-
-                lines.push(Line::raw(""));
             }
-        }
-    }
-
-    // Current streaming response
-    if app.chat.streaming {
-        if !app.chat.current_response.is_empty() {
-            let rendered = markdown::render_markdown(&app.chat.current_response, width);
-            lines.extend(rendered);
-        } else {
-            lines.push(Line::from(Span::styled(
-                "...",
-                Style::default().fg(colors::INACTIVE),
-            )));
-        }
-
-        // Streaming tool calls
-        for tc in &app.chat.current_tool_calls {
-            let tick = app.spinner_tick % theme::BRAILLE_SPINNER.len();
-            let (icon, style) = match tc.phase.as_str() {
-                "complete" => ("✓", Style::default().fg(colors::TOOL_DONE)),
-                "error" => ("✗", Style::default().fg(colors::TOOL_ERROR)),
-                _ => (
-                    theme::BRAILLE_SPINNER[tick],
-                    Style::default().fg(colors::TOOL_RUNNING),
-                ),
-            };
-            lines.push(Line::from(Span::styled(
-                format!(" {} {}", icon, tc.tool_name),
-                style,
-            )));
-            push_tool_detail(&mut lines, tc, app.chat.expand_tools);
-        }
-
-        // Sub-agents spawned by this run.
-        if !app.chat.sub_agents.is_empty() {
-            for sa in &app.chat.sub_agents {
-                let (icon, style) = match sa.status.as_str() {
-                    "running" => {
-                        let tick = app.spinner_tick % theme::BRAILLE_SPINNER.len();
-                        (
-                            theme::BRAILLE_SPINNER[tick],
-                            Style::default().fg(colors::TOOL_RUNNING),
-                        )
+            ConversationBlockKind::Reasoning { content, streaming } => {
+                let detail = inspector_lines(content, width.saturating_sub(1) as usize);
+                let count = detail.len();
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "{} thinking{} · {count} lines",
+                        if focused { "▸" } else { "──" },
+                        if streaming { " · streaming" } else { "" }
+                    ),
+                    Style::default().fg(colors::THINKING),
+                )));
+                if state.expanded {
+                    let start = state
+                        .scroll
+                        .min(detail.len().saturating_sub(CONVERSATION_DETAIL_VIEWPORT));
+                    if start > 0 {
+                        lines.push(Line::from(Span::styled(
+                            format!(" ↑ {start} earlier lines"),
+                            Style::default().fg(colors::SUBTLE),
+                        )));
                     }
+                    for line in detail.iter().skip(start).take(CONVERSATION_DETAIL_VIEWPORT) {
+                        lines.push(Line::from(Span::styled(
+                            format!(" {line}"),
+                            Style::default().fg(colors::SUBTLE),
+                        )));
+                    }
+                    let remaining = detail
+                        .len()
+                        .saturating_sub(start + CONVERSATION_DETAIL_VIEWPORT);
+                    if remaining > 0 {
+                        lines.push(Line::from(Span::styled(
+                            format!(" ↓ {remaining} later lines"),
+                            Style::default().fg(colors::SUBTLE),
+                        )));
+                    }
+                } else {
+                    lines.push(Line::from(Span::styled(
+                        format!(" {count} reasoning lines hidden — focus then Enter to show"),
+                        Style::default().fg(colors::SUBTLE),
+                    )));
+                }
+                if focused {
+                    lines.push(Line::from(Span::styled(
+                        if state.expanded {
+                            " Enter hide · j/k scroll · y copy"
+                        } else {
+                            " Enter show · y copy"
+                        },
+                        Style::default().fg(colors::SUBTLE),
+                    )));
+                }
+            }
+            ConversationBlockKind::ToolCall { tool, streaming } => {
+                let tick = app.spinner_tick % theme::BRAILLE_SPINNER.len();
+                let (icon, style) = match tool.phase.as_str() {
+                    "complete" => ("✓", Style::default().fg(colors::TOOL_DONE)),
+                    "error" => ("✗", Style::default().fg(colors::TOOL_ERROR)),
+                    _ if streaming => (
+                        theme::BRAILLE_SPINNER[tick],
+                        Style::default().fg(colors::TOOL_RUNNING),
+                    ),
+                    _ => ("●", Style::default().fg(colors::TOOL_RUNNING)),
+                };
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        " {} {icon} {} · {}",
+                        if focused { "▸" } else { " " },
+                        tool.tool_name,
+                        tool.phase
+                    ),
+                    style,
+                )));
+                push_tool_detail(&mut lines, tool, &state, focused, width);
+            }
+            ConversationBlockKind::SubAgent { child, streaming } => {
+                let tick = app.spinner_tick % theme::BRAILLE_SPINNER.len();
+                let (icon, style) = match child.status.as_str() {
+                    "running" if streaming => (
+                        theme::BRAILLE_SPINNER[tick],
+                        Style::default().fg(colors::TOOL_RUNNING),
+                    ),
                     "completed" => ("✓", Style::default().fg(colors::TOOL_DONE)),
                     "error" | "cancelled" => ("✗", Style::default().fg(colors::TOOL_ERROR)),
                     _ => ("·", Style::default().fg(colors::INACTIVE)),
                 };
-                let label = sa.title.clone().unwrap_or_else(|| {
-                    let short: String = sa.child_session_id.chars().take(8).collect();
-                    format!("sub-agent {short}")
-                });
+                let label = child.title.as_deref().unwrap_or("sub-agent");
                 lines.push(Line::from(Span::styled(
-                    format!(" {icon} ▸ {label} ({})", sa.status),
+                    format!(
+                        " {} {icon} {label} ({}) · {}",
+                        if focused { "▸" } else { " " },
+                        child.status,
+                        child.child_session_id
+                    ),
                     style,
                 )));
+                if state.expanded {
+                    if let Some(error) = &child.error {
+                        lines.push(Line::from(Span::styled(
+                            format!("   Error: {error}"),
+                            Style::default().fg(colors::TOOL_ERROR),
+                        )));
+                    }
+                }
+                if focused {
+                    lines.push(Line::from(Span::styled(
+                        if streaming {
+                            "   Enter expand/collapse · child opens after parent run · y copy"
+                        } else {
+                            "   Enter open child · Ctrl+X expand/collapse · y copy"
+                        },
+                        Style::default().fg(colors::SUBTLE),
+                    )));
+                }
             }
-        }
-
-        // Streaming thinking
-        if !app.chat.current_reasoning.is_empty() {
-            let sep_len: usize = 40;
-            lines.push(Line::from(Span::styled(
-                format!("── thinking {}", "─".repeat(sep_len.saturating_sub(14))),
-                Style::default().fg(colors::THINKING),
-            )));
-            for rline in app.chat.current_reasoning.lines().take(3) {
+            ConversationBlockKind::Question {
+                question,
+                source,
+                submitting,
+                dismissed,
+            } => {
+                let kind = if source.is_some_and(|source| {
+                    let source = source.to_ascii_lowercase();
+                    source.contains("permission") || source.contains("approval")
+                }) {
+                    "approval"
+                } else {
+                    "question"
+                };
+                let status = if submitting {
+                    "submitting"
+                } else if dismissed {
+                    "dismissed · Ctrl+Q reopen"
+                } else {
+                    "answer in modal"
+                };
                 lines.push(Line::from(Span::styled(
-                    format!(" {}", rline),
-                    Style::default().fg(colors::SUBTLE),
+                    format!(
+                        " {} ? {kind} · {status}: {question}",
+                        if focused { "▸" } else { " " }
+                    ),
+                    Style::default().fg(colors::WARNING),
+                )));
+            }
+            ConversationBlockKind::TerminalStatus(status) => {
+                lines.push(Line::from(Span::styled(
+                    format!(" {} ─ {status}", if focused { "▸" } else { " " }),
+                    Style::default().fg(if status.starts_with("error") {
+                        colors::TOOL_ERROR
+                    } else {
+                        colors::INACTIVE
+                    }),
                 )));
             }
         }
+        let block_visual_lines = Paragraph::new(lines[first_logical_line..].to_vec())
+            .wrap(Wrap { trim: false })
+            .line_count(width.max(1));
+        visual_line_count = visual_line_count.saturating_add(block_visual_lines);
+        let end = visual_line_count.saturating_sub(1);
+        ranges.push(ConversationBlockLineRange {
+            id: block.id,
+            start: u16::try_from(start).unwrap_or(u16::MAX),
+            end: u16::try_from(end).unwrap_or(u16::MAX),
+        });
+        lines.push(Line::raw(""));
+        visual_line_count = visual_line_count.saturating_add(1);
     }
 
     // Empty state
@@ -248,14 +394,25 @@ fn build_message_lines(app: &App, width: u16) -> Vec<Line<'static>> {
             "  Tip: Use --model <name> to set the model.",
             Style::default().fg(colors::SUBTLE),
         )));
+        visual_line_count = Paragraph::new(lines.clone())
+            .wrap(Wrap { trim: false })
+            .line_count(width.max(1));
     }
 
-    lines
+    RenderedConversation {
+        lines,
+        ranges,
+        visual_line_count: u16::try_from(visual_line_count).unwrap_or(u16::MAX),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::BambooClient;
+    use crate::app::{ChatMessage, MessageRole, SubAgentDisplay};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
 
     fn tc(args: &str, result: Option<&str>) -> ToolCallDisplay {
         ToolCallDisplay {
@@ -263,6 +420,7 @@ mod tests {
             tool_name: "Read".into(),
             arguments: args.into(),
             result: result.map(String::from),
+            stream_output: String::new(),
             error: None,
             phase: "complete".into(),
         }
@@ -273,12 +431,27 @@ mod tests {
         let t = tc("{\"path\":\"x\"}", Some("l1\nl2\nl3\nl4\nl5"));
 
         let mut lines: Vec<Line> = Vec::new();
-        push_tool_detail(&mut lines, &t, false);
+        push_tool_detail(
+            &mut lines,
+            &t,
+            &ConversationBlockUiState::default(),
+            false,
+            100,
+        );
         // args(1) + 3 result lines + "N more" marker(1) = 5
         assert_eq!(lines.len(), 5);
 
         let mut lines: Vec<Line> = Vec::new();
-        push_tool_detail(&mut lines, &t, true);
+        push_tool_detail(
+            &mut lines,
+            &t,
+            &ConversationBlockUiState {
+                expanded: true,
+                scroll: 0,
+            },
+            false,
+            100,
+        );
         // args(1) + all 5 result lines = 6
         assert_eq!(lines.len(), 6);
     }
@@ -286,7 +459,187 @@ mod tests {
     #[test]
     fn empty_args_and_no_result_render_nothing() {
         let mut lines: Vec<Line> = Vec::new();
-        push_tool_detail(&mut lines, &tc("{}", None), false);
+        push_tool_detail(
+            &mut lines,
+            &tc("{}", None),
+            &ConversationBlockUiState::default(),
+            false,
+            100,
+        );
         assert!(lines.is_empty());
+    }
+
+    fn rendered_text(rendered: &RenderedConversation) -> String {
+        rendered
+            .lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn per_block_reasoning_and_tool_inspectors_are_independent_and_bounded() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let output = (0..30)
+            .map(|index| format!("result-{index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        app.chat.messages.push(ChatMessage {
+            id: "message-1".to_string(),
+            role: MessageRole::Assistant,
+            content: "answer".to_string(),
+            reasoning: Some(
+                (0..25)
+                    .map(|index| format!("reason-{index}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            ),
+            tool_calls: vec![ToolCallDisplay {
+                id: "call-1".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: "{}".to_string(),
+                result: Some(output),
+                stream_output: String::new(),
+                error: None,
+                phase: "complete".to_string(),
+            }],
+            sub_agents: vec![SubAgentDisplay {
+                child_session_id: "child-123456789".to_string(),
+                title: Some("research".to_string()),
+                status: "completed".to_string(),
+                error: None,
+            }],
+            terminal_status: Some("completed".to_string()),
+        });
+        app.chat.block_ui.insert(
+            "message-1:tool:call-1".to_string(),
+            ConversationBlockUiState {
+                expanded: true,
+                scroll: 5,
+            },
+        );
+        app.chat.block_ui.insert(
+            "message-1:reasoning".to_string(),
+            ConversationBlockUiState::default(),
+        );
+        app.chat.focused_block = Some("message-1:tool:call-1".to_string());
+
+        let rendered = build_conversation_lines(&app, 100);
+        let text = rendered_text(&rendered);
+        assert!(text.contains("25 reasoning lines hidden"));
+        assert!(!text.contains("reason-0"));
+        assert!(text.contains("result-5"));
+        assert!(text.contains("result-14"));
+        assert!(!text.contains("result-4"));
+        assert!(!text.contains("result-15"));
+        assert!(text.contains("15 later lines"));
+        assert!(text.contains("research (completed) · child-123456789"));
+        assert!(text.contains("Enter collapse · j/k scroll · y copy"));
+        assert!(rendered
+            .ranges
+            .iter()
+            .any(|range| range.id == "message-1:tool:call-1"));
+    }
+
+    #[test]
+    fn narrow_long_single_lines_use_visual_ranges_and_bounded_inspectors() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.messages.push(ChatMessage {
+            id: "message-narrow".to_string(),
+            role: MessageRole::Assistant,
+            content: "answer".to_string(),
+            reasoning: Some("界".repeat(80)),
+            tool_calls: vec![ToolCallDisplay {
+                id: "call-narrow".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: "x".repeat(120),
+                result: Some("y".repeat(200)),
+                stream_output: String::new(),
+                error: None,
+                phase: "complete".to_string(),
+            }],
+            sub_agents: Vec::new(),
+            terminal_status: Some("completed".to_string()),
+        });
+        for id in [
+            "message-narrow:reasoning",
+            "message-narrow:tool:call-narrow",
+        ] {
+            app.chat.block_ui.insert(
+                id.to_string(),
+                ConversationBlockUiState {
+                    expanded: true,
+                    scroll: 0,
+                },
+            );
+        }
+
+        let width = 20;
+        let rendered = build_conversation_lines(&app, width);
+        let exact_visual_count = Paragraph::new(rendered.lines.clone())
+            .wrap(Wrap { trim: false })
+            .line_count(width);
+        assert_eq!(rendered.visual_line_count as usize, exact_visual_count);
+        let text = rendered_text(&rendered);
+        assert!(text.contains("later lines"));
+        assert!(text.contains("more argument lines"));
+        assert!(
+            rendered.lines.len() < 40,
+            "long no-newline payloads must stay bounded"
+        );
+        assert!(rendered.visual_line_count as usize > rendered.lines.len());
+    }
+
+    #[test]
+    fn testbackend_keeps_streaming_composer_visible_with_structured_rows() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("parent".to_string());
+        app.chat.streaming = true;
+        app.chat.current_turn_id = Some("run:1".to_string());
+        for character in "draft during run".chars() {
+            app.chat.textarea.input(crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Char(character),
+                crossterm::event::KeyModifiers::empty(),
+            ));
+        }
+        app.chat.current_tool_calls.push(ToolCallDisplay {
+            id: "tool-live".to_string(),
+            tool_name: "Shell".to_string(),
+            arguments: "{\"cmd\":\"pwd\"}".to_string(),
+            result: None,
+            stream_output: "workspace".to_string(),
+            error: None,
+            phase: "streaming".to_string(),
+        });
+        app.chat.sub_agents.push(SubAgentDisplay {
+            child_session_id: "child-live".to_string(),
+            title: Some("reviewer".to_string()),
+            status: "running".to_string(),
+            error: None,
+        });
+
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("draft during run"));
+        assert!(text.contains("Shell · streaming"));
+        assert!(text.contains("reviewer (running)"));
+        assert!(text.contains("draft editable; Enter sends after run"));
+        assert!(!text.contains("Waiting for response"));
     }
 }

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -71,6 +71,21 @@ pub fn render_status_info(f: &mut Frame, area: Rect, app: &App) {
             Style::default().fg(colors::TOOL_RUNNING),
         ));
         spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
+        spans.push(Span::styled(
+            " draft editable; Enter sends after run ",
+            Style::default().fg(colors::INACTIVE),
+        ));
+        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
+    }
+
+    if app.chat.unseen_updates > 0 {
+        spans.push(Span::styled(
+            format!(" ↓ {} new · Ctrl+G jump ", app.chat.unseen_updates),
+            Style::default()
+                .fg(colors::WARNING)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
     }
 
     // Model
@@ -178,9 +193,13 @@ const HELP_LEFT: &[(&str, &str)] = &[
     ("Enter", "Send / select / resume session"),
     ("Alt+Enter", "Insert newline (Chat)"),
     ("\u{2191}/\u{2193}, Wheel", "Move selection (lists)"),
-    ("j/k, Wheel", "Scroll (Chat/Config)"),
-    ("PgUp/PgDn", "Scroll by page (Chat/Config)"),
-    ("g / G", "Jump to top / bottom (Chat)"),
+    ("PgUp/PgDn", "Scroll transcript (Chat/Config)"),
+    ("Alt+↑/↓", "Scroll transcript (Chat)"),
+    ("Ctrl+Home/G", "Top / bottom (Chat)"),
+    ("Ctrl+B", "Focus conversation blocks"),
+    ("Block ↑/↓", "Previous / next block"),
+    ("Block Enter", "Expand / open child session"),
+    ("Block j/k/y", "Inspect scroll / copy exact block"),
 ];
 const HELP_RIGHT: &[(&str, &str)] = &[
     ("Ctrl+K", "Command palette"),
@@ -190,7 +209,7 @@ const HELP_RIGHT: &[(&str, &str)] = &[
     ("Ctrl+Q", "Reopen pending question"),
     ("Ctrl+C", "Quit / stop streaming"),
     ("Ctrl+S", "Stop agent execution"),
-    ("Ctrl+X", "Expand/collapse tool detail"),
+    ("Ctrl+X", "Focused detail / new-block default"),
     ("Ctrl+L", "Notification log"),
     ("] / [", "Next / previous page (Sessions)"),
     ("d", "Delete, with confirm (Sessions/Schedules)"),

--- a/crates/engine/bamboo-engine/src/events/replayable.rs
+++ b/crates/engine/bamboo-engine/src/events/replayable.rs
@@ -39,7 +39,8 @@ use crate::app_context::AgentSessionContext;
 ///
 /// 1. `runner.push_critical_event(event.clone())` — populate the late-subscriber
 ///    replay cache while the event is still un-broadcast.
-/// 2. `sender.send(event)` — broadcast to all live subscribers.
+/// 2. `sender.send(event)` — broadcast to all live subscribers before releasing
+///    the runner lock that guards subscription snapshots.
 ///
 /// If no runner exists for `session_id` (the session has not started yet, or
 /// has already terminated), the cache step is silently skipped and the event
@@ -49,18 +50,24 @@ pub async fn publish_replayable_session_event(
     session_id: &str,
     event: AgentEvent,
 ) {
+    // Resolve the sender first so publishers and subscribers never invert the
+    // session-event and runner lock order.
+    let sender = ctx.get_session_event_sender(session_id).await;
     {
         let mut runners = ctx.agent_runners().write().await;
         if let Some(runner) = runners.get_mut(session_id) {
             runner.push_critical_event(event.clone());
         }
+
+        // Mirror onto the account-wide change feed (sequenced + journaled).
+        // The sink filters ephemeral events internally; metadata events
+        // published here (title/pinned) are durable and will be sequenced.
+        ctx.account_sink().record(Some(session_id), &event);
+
+        // Keep cache mutation and live publication inside one runner-lock
+        // boundary. Subscribers clone the cache while holding the matching
+        // read lock, so an event can appear in either their snapshot or their
+        // receiver, never both.
+        let _ = sender.send(event);
     }
-
-    // Mirror onto the account-wide change feed (sequenced + journaled). The
-    // sink filters ephemeral events internally; metadata events published here
-    // (title/pinned) are durable and will be sequenced.
-    ctx.account_sink().record(Some(session_id), &event);
-
-    let sender = ctx.get_session_event_sender(session_id).await;
-    let _ = sender.send(event);
 }

--- a/crates/engine/bamboo-engine/src/events/replayable.rs
+++ b/crates/engine/bamboo-engine/src/events/replayable.rs
@@ -1,8 +1,9 @@
 //! Replayable session-event publishing infrastructure.
 //!
-//! This module owns the **single canonical path** for publishing UI-replayable
-//! session events. Every replayable event must go through
-//! [`publish_replayable_session_event`] so that:
+//! This module owns the canonical [`AgentSessionContext`] path for publishing
+//! UI-replayable session events. Every replayable event must go through an
+//! atomic publisher — this helper, the runtime child-event publisher, or an
+//! event forwarder — so that:
 //!
 //! 1. The event is cached on the session's runner for late-subscriber replay
 //!    *before* any subscriber sees it on the live broadcast channel.
@@ -13,7 +14,8 @@
 //! ## Invariant
 //!
 //! No code in the workspace may pair `runner.push_critical_event` with
-//! `sender.send` outside this helper, the generic engine event forwarder, or
+//! `sender.send` outside this helper, the runtime
+//! `ReplayableSessionEventPublisher`, the generic engine event forwarder, or
 //! the server's `spawn_event_forwarder`
 //! (in `handlers::agent::execute::runtime::events`).
 //! Hand-rolling the pair has historically led to inverted ordering (broadcast

--- a/crates/engine/bamboo-engine/src/runtime/execution/runner_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/runner_state.rs
@@ -11,6 +11,18 @@ use uuid::Uuid;
 
 use bamboo_agent_core::AgentEvent;
 
+fn subagent_lifecycle_child_id(event: &AgentEvent) -> Option<&str> {
+    match event {
+        AgentEvent::SubAgentStarted {
+            child_session_id, ..
+        }
+        | AgentEvent::SubAgentCompleted {
+            child_session_id, ..
+        } => Some(child_session_id),
+        _ => None,
+    }
+}
+
 /// Status of an agent execution runner.
 ///
 /// Represents the lifecycle state of an agent run from initialization
@@ -140,9 +152,15 @@ impl AgentRunner {
         }
     }
 
-    /// Push a critical event into the bounded replay cache.
+    /// Push a critical state event into the bounded replay cache.
     ///
-    /// If the cache is full, the oldest entry is evicted.
+    /// Sub-agent lifecycle entries are snapshots keyed by stable child id, not
+    /// an event log: a rerunnable/resident child can produce many generations,
+    /// and replaying older Start/Complete pairs makes the current generation
+    /// ambiguous to reconnecting clients. Keep only the newest lifecycle state
+    /// for each child while live subscribers still receive every event.
+    ///
+    /// If the remaining cache is full, the oldest entry is evicted.
     pub fn push_critical_event(&mut self, event: AgentEvent) {
         let lifecycle_id = match &event {
             AgentEvent::WorkflowActivated { event_id, .. }
@@ -166,9 +184,96 @@ impl AgentRunner {
         }) {
             return;
         }
+        if let Some(child_session_id) = subagent_lifecycle_child_id(&event) {
+            self.last_critical_events
+                .retain(|existing| subagent_lifecycle_child_id(existing) != Some(child_session_id));
+        }
         if self.last_critical_events.len() >= Self::CRITICAL_EVENTS_CAPACITY {
             self.last_critical_events.remove(0);
         }
         self.last_critical_events.push(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn started(child_session_id: &str, title: &str) -> AgentEvent {
+        AgentEvent::SubAgentStarted {
+            parent_session_id: "parent".to_string(),
+            child_session_id: child_session_id.to_string(),
+            title: Some(title.to_string()),
+        }
+    }
+
+    fn completed(child_session_id: &str, status: &str) -> AgentEvent {
+        AgentEvent::SubAgentCompleted {
+            parent_session_id: "parent".to_string(),
+            child_session_id: child_session_id.to_string(),
+            status: status.to_string(),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn critical_replay_keeps_only_latest_generation_state_per_child() {
+        let mut runner = AgentRunner::new();
+
+        // A stable resident child may be reused repeatedly inside one parent
+        // runner. Reconnect must see S3 only, never the ambiguous historical
+        // sequence S1,C1,S2,C2,S3.
+        for event in [
+            started("resident", "generation-1"),
+            completed("resident", "completed"),
+            started("resident", "generation-2"),
+            completed("resident", "completed"),
+            started("resident", "generation-3"),
+        ] {
+            runner.push_critical_event(event);
+        }
+
+        assert_eq!(runner.last_critical_events.len(), 1);
+        assert!(matches!(
+            &runner.last_critical_events[0],
+            AgentEvent::SubAgentStarted {
+                child_session_id,
+                title: Some(title),
+                ..
+            } if child_session_id == "resident" && title == "generation-3"
+        ));
+
+        runner.push_critical_event(completed("resident", "completed"));
+        assert_eq!(runner.last_critical_events.len(), 1);
+        assert!(matches!(
+            &runner.last_critical_events[0],
+            AgentEvent::SubAgentCompleted {
+                child_session_id,
+                status,
+                ..
+            } if child_session_id == "resident" && status == "completed"
+        ));
+    }
+
+    #[test]
+    fn subagent_coalescing_preserves_other_children_and_recency() {
+        let mut runner = AgentRunner::new();
+        runner.push_critical_event(started("child-a", "a1"));
+        runner.push_critical_event(started("child-b", "b1"));
+        runner.push_critical_event(completed("child-a", "completed"));
+
+        assert_eq!(runner.last_critical_events.len(), 2);
+        assert!(matches!(
+            &runner.last_critical_events[0],
+            AgentEvent::SubAgentStarted {
+                child_session_id, ..
+            } if child_session_id == "child-b"
+        ));
+        assert!(matches!(
+            &runner.last_critical_events[1],
+            AgentEvent::SubAgentCompleted {
+                child_session_id, ..
+            } if child_session_id == "child-a"
+        ));
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/execution/session_events.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/session_events.rs
@@ -11,6 +11,9 @@ use tokio::sync::{broadcast, RwLock};
 
 use bamboo_agent_core::AgentEvent;
 
+use super::event_forwarder::AccountFeedInbox;
+use super::runner_state::AgentRunner;
+
 /// Default broadcast channel capacity for session event senders.
 pub const SESSION_EVENT_CHANNEL_CAPACITY: usize = 1000;
 
@@ -39,4 +42,50 @@ pub async fn get_or_create_event_sender(
     let (sender, _) = broadcast::channel(SESSION_EVENT_CHANNEL_CAPACITY);
     write.insert(session_id.to_string(), sender.clone());
     sender
+}
+
+/// Atomic cache + account-feed + broadcast publisher for replayable session
+/// events produced outside an agent event forwarder.
+///
+/// Subscribers establish their receiver and clone `last_critical_events` while
+/// holding the matching runner read lock. Keeping cache mutation and broadcast
+/// inside the write lock means each publication appears either in that replay
+/// snapshot or in the live receiver, never both and never neither.
+#[derive(Clone)]
+pub(crate) struct ReplayableSessionEventPublisher {
+    runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
+    senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
+    account_feed_inbox: Option<AccountFeedInbox>,
+}
+
+impl ReplayableSessionEventPublisher {
+    pub(crate) fn new(
+        runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
+        senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
+        account_feed_inbox: Option<AccountFeedInbox>,
+    ) -> Self {
+        Self {
+            runners,
+            senders,
+            account_feed_inbox,
+        }
+    }
+
+    pub(crate) async fn publish(&self, session_id: &str, event: AgentEvent) {
+        debug_assert!(event.is_replayable_session_state());
+        // Resolve the sender before the runner lock. The SSE/WS subscription
+        // boundary uses the same sender-then-runner lock order.
+        let sender = get_or_create_event_sender(&self.senders, session_id).await;
+        let mut runners = self.runners.write().await;
+        if let Some(runner) = runners.get_mut(session_id) {
+            runner.push_critical_event(event.clone());
+        }
+        if let Some(inbox) = &self.account_feed_inbox {
+            if event.is_durable_change() {
+                let route_session_id = event.session_id().unwrap_or(session_id);
+                let _ = inbox.try_send((Some(route_session_id.to_string()), event.clone()));
+            }
+        }
+        let _ = sender.send(event);
+    }
 }

--- a/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
@@ -114,6 +114,18 @@ pub struct SpawnContext {
     pub account_feed_inbox: Option<super::event_forwarder::AccountFeedInbox>,
 }
 
+impl SpawnContext {
+    pub(crate) fn replayable_event_publisher(
+        &self,
+    ) -> super::session_events::ReplayableSessionEventPublisher {
+        super::session_events::ReplayableSessionEventPublisher::new(
+            self.agent_runners.clone(),
+            self.session_event_senders.clone(),
+            self.account_feed_inbox.clone(),
+        )
+    }
+}
+
 #[derive(Clone)]
 pub struct SpawnScheduler {
     tx: mpsc::Sender<SpawnJob>,
@@ -148,13 +160,9 @@ impl SpawnScheduler {
                         error = %join_error,
                         "spawn job panicked; publishing terminal error completion"
                     );
-                    let parent_tx = super::session_events::get_or_create_event_sender(
-                        &worker_ctx.session_event_senders,
-                        &job_for_panic.parent_session_id,
-                    )
-                    .await;
+                    let publisher = worker_ctx.replayable_event_publisher();
                     publish_child_completion_parts(
-                        &parent_tx,
+                        &publisher,
                         worker_ctx.completion_handler.clone(),
                         job_for_panic.parent_session_id.clone(),
                         job_for_panic.child_session_id.clone(),
@@ -179,12 +187,46 @@ impl SpawnScheduler {
     }
 
     pub async fn enqueue(&self, job: SpawnJob) -> Result<(), String> {
+        self.enqueue_announced(job, None).await
+    }
+
+    /// Reserve queue capacity, publish the observable child Start, and only
+    /// then release the job to the worker. This preserves S→C ordering even
+    /// when child loading/execution fails immediately.
+    pub async fn enqueue_announced(
+        &self,
+        job: SpawnJob,
+        title: Option<String>,
+    ) -> Result<(), String> {
         let ctx = self.ctx.clone();
         let preparation_job = job.clone();
         reserve_prepare_and_send(&self.tx, job, async move {
             Self::prepare_child_launch(&ctx, &preparation_job).await;
+            ctx.replayable_event_publisher()
+                .publish(
+                    &preparation_job.parent_session_id,
+                    AgentEvent::SubAgentStarted {
+                        parent_session_id: preparation_job.parent_session_id.clone(),
+                        child_session_id: preparation_job.child_session_id.clone(),
+                        title,
+                    },
+                )
+                .await;
         })
         .await
+    }
+
+    /// Publish replayable parent-session state through the scheduler's shared
+    /// runner/cache/account/broadcast boundary.
+    pub async fn publish_parent_replayable_event(
+        &self,
+        parent_session_id: &str,
+        event: AgentEvent,
+    ) {
+        self.ctx
+            .replayable_event_publisher()
+            .publish(parent_session_id, event)
+            .await;
     }
 
     /// Launch through the canonical child core using a runner slot already
@@ -198,16 +240,16 @@ impl SpawnScheduler {
         let ctx = self.ctx.clone();
         tokio::spawn(async move {
             Self::prepare_child_launch(&ctx, &job).await;
-            let parent_tx = super::session_events::get_or_create_event_sender(
-                &ctx.session_event_senders,
-                &job.parent_session_id,
-            )
-            .await;
-            let _ = parent_tx.send(AgentEvent::SubAgentStarted {
-                parent_session_id: job.parent_session_id.clone(),
-                child_session_id: job.child_session_id.clone(),
-                title: None,
-            });
+            ctx.replayable_event_publisher()
+                .publish(
+                    &job.parent_session_id,
+                    AgentEvent::SubAgentStarted {
+                        parent_session_id: job.parent_session_id.clone(),
+                        child_session_id: job.child_session_id.clone(),
+                        title: None,
+                    },
+                )
+                .await;
             if let Err(error) =
                 crate::sdk::spawn::run_child_spawn_reserved(ctx, job.clone(), reservation).await
             {
@@ -305,16 +347,21 @@ pub(crate) fn watchdog_policy_for_session(session: &Session) -> ChildWatchdogPol
 }
 
 async fn publish_child_completion(
-    parent_tx: &broadcast::Sender<AgentEvent>,
+    publisher: &super::session_events::ReplayableSessionEventPublisher,
     completion_handler: Option<Arc<dyn ChildCompletionHandler>>,
     completion: ChildCompletion,
 ) {
-    let _ = parent_tx.send(AgentEvent::SubAgentCompleted {
-        parent_session_id: completion.parent_session_id.clone(),
-        child_session_id: completion.child_session_id.clone(),
-        status: completion.status.clone(),
-        error: completion.error.clone(),
-    });
+    publisher
+        .publish(
+            &completion.parent_session_id,
+            AgentEvent::SubAgentCompleted {
+                parent_session_id: completion.parent_session_id.clone(),
+                child_session_id: completion.child_session_id.clone(),
+                status: completion.status.clone(),
+                error: completion.error.clone(),
+            },
+        )
+        .await;
 
     if let Some(handler) = completion_handler {
         // Contain a panicking handler: this call frequently runs on the caller's
@@ -341,7 +388,7 @@ async fn publish_child_completion(
 }
 
 pub(crate) async fn publish_child_completion_parts(
-    parent_tx: &broadcast::Sender<AgentEvent>,
+    publisher: &super::session_events::ReplayableSessionEventPublisher,
     completion_handler: Option<Arc<dyn ChildCompletionHandler>>,
     parent_session_id: String,
     child_session_id: String,
@@ -349,7 +396,7 @@ pub(crate) async fn publish_child_completion_parts(
     error: Option<String>,
 ) {
     publish_child_completion(
-        parent_tx,
+        publisher,
         completion_handler,
         ChildCompletion {
             parent_session_id,

--- a/crates/engine/bamboo-engine/src/sdk/runner.rs
+++ b/crates/engine/bamboo-engine/src/sdk/runner.rs
@@ -66,12 +66,27 @@ impl ChildRunner {
         }
     }
 
+    async fn announce_started(&self, input: &RunChildInput) {
+        self.ctx
+            .replayable_event_publisher()
+            .publish(
+                &input.parent_session_id,
+                AgentEvent::SubAgentStarted {
+                    parent_session_id: input.parent_session_id.clone(),
+                    child_session_id: input.child_session_id.clone(),
+                    title: None,
+                },
+            )
+            .await;
+    }
+
     /// Run a child session via the canonical spawn core.
     ///
     /// ANTI-FORK: constructs a [`SpawnJob`] and delegates to
     /// [`crate::sdk::spawn::run_child_spawn`]; there is no inline execute/finalize.
     pub async fn run_child(&self, input: RunChildInput) -> Result<(), String> {
         let job = self.build_job(&input);
+        self.announce_started(&input).await;
         crate::sdk::spawn::run_child_spawn(self.ctx.clone(), job).await
     }
 
@@ -91,6 +106,7 @@ impl ChildRunner {
                 .await;
         let rx = child_tx.subscribe();
         let job = self.build_job(&input);
+        self.announce_started(&input).await;
         crate::sdk::spawn::run_child_spawn(self.ctx.clone(), job).await?;
         Ok(rx)
     }

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -117,10 +117,9 @@ fn reconcile_actor_host_wait(
 /// not found) before the background task is spawned.
 ///
 /// Preserves EXACTLY the canonical behavior:
-/// - Scheduler callers own launch announcements: queued adapter launches
-///   retain their titled event, while reserved SessionInbox activation emits
-///   an untitled event from [`crate::execution::SpawnScheduler`].
-///   Direct SDK callers remain responsible for their own announcement.
+/// - Launch wrappers own announcements: [`crate::execution::SpawnScheduler`]
+///   publishes before queued/reserved jobs become runnable, while
+///   [`crate::sdk::runner::ChildRunner`] announces direct SDK launches.
 /// - Event forwarder + 5s heartbeat tasks, watchdog, runner reservation.
 /// - Full real [`ExecuteRequest`] field set incl. split provider fields.
 /// - Terminal status strings `completed | cancelled | error | skipped | timeout`.
@@ -146,6 +145,7 @@ async fn run_child_spawn_inner(
     // Ensure both session event streams exist.
     let parent_tx =
         get_or_create_event_sender(&ctx.session_event_senders, &job.parent_session_id).await;
+    let parent_event_publisher = ctx.replayable_event_publisher();
     let child_tx =
         get_or_create_event_sender(&ctx.session_event_senders, &job.child_session_id).await;
 
@@ -160,7 +160,7 @@ async fn run_child_spawn_inner(
         Ok(None) => {
             let error = "child session not found".to_string();
             publish_child_completion_parts(
-                &parent_tx,
+                &parent_event_publisher,
                 ctx.completion_handler.clone(),
                 job.parent_session_id.clone(),
                 job.child_session_id.clone(),
@@ -173,7 +173,7 @@ async fn run_child_spawn_inner(
         Err(e) => {
             let error = format!("failed to load child session: {e}");
             publish_child_completion_parts(
-                &parent_tx,
+                &parent_event_publisher,
                 ctx.completion_handler.clone(),
                 job.parent_session_id.clone(),
                 job.child_session_id.clone(),
@@ -260,7 +260,7 @@ async fn run_child_spawn_inner(
                 .await;
         }
         publish_child_completion_parts(
-            &parent_tx,
+            &parent_event_publisher,
             ctx.completion_handler.clone(),
             job.parent_session_id.clone(),
             job.child_session_id.clone(),
@@ -301,7 +301,7 @@ async fn run_child_spawn_inner(
             Arc::new(parking_lot::RwLock::new(session)),
         );
         publish_child_completion_parts(
-            &parent_tx,
+            &parent_event_publisher,
             ctx.completion_handler.clone(),
             job.parent_session_id.clone(),
             job.child_session_id.clone(),
@@ -359,7 +359,7 @@ async fn run_child_spawn_inner(
         }
         let setup_error = error.to_string();
         publish_child_completion_parts(
-            &parent_tx,
+            &parent_event_publisher,
             ctx.completion_handler.clone(),
             job.parent_session_id.clone(),
             job.child_session_id.clone(),
@@ -477,7 +477,7 @@ async fn run_child_spawn_inner(
     let agent = ctx.agent.clone();
     let external_runner = ctx.external_child_runner.clone();
     let done = forwarder_done.clone();
-    let parent_tx_for_done = parent_tx.clone();
+    let parent_event_publisher_for_done = parent_event_publisher.clone();
     let parent_id_for_done = job.parent_session_id.clone();
     let child_id_for_done = job.child_session_id.clone();
     let session_event_senders = ctx.session_event_senders.clone();
@@ -730,7 +730,7 @@ async fn run_child_spawn_inner(
         // same durable completion path used by success/error/cancel/timeout.
         done.cancel();
         publish_child_completion_parts(
-            &parent_tx_for_done,
+            &parent_event_publisher_for_done,
             completion_handler,
             parent_id_for_done,
             child_id_for_done,

--- a/crates/engine/bamboo-engine/src/sdk/tests.rs
+++ b/crates/engine/bamboo-engine/src/sdk/tests.rs
@@ -2314,6 +2314,14 @@ async fn s_t2_2_run_child_never_disables_tools() {
 async fn s_t2_4_run_child_model_override_is_persisted() {
     let harness = build_harness(Arc::new(CompletedProvider), Vec::new(), &[]).await;
     let runner = ChildRunner::new(harness.ctx.clone());
+    let mut parent_runner = crate::execution::AgentRunner::new();
+    parent_runner.status = crate::execution::AgentStatus::Running;
+    harness
+        .ctx
+        .agent_runners
+        .write()
+        .await
+        .insert(harness.parent_session_id.clone(), parent_runner);
 
     // Child session was persisted with model "gpt-5"; run with a different model.
     let override_model = "claude-3-7-sonnet";
@@ -2327,7 +2335,44 @@ async fn s_t2_4_run_child_model_override_is_persisted() {
         .await
         .unwrap();
 
-    let _ = collect_until_completed(&mut parent_rx).await;
+    let events = collect_until_completed(&mut parent_rx).await;
+    assert!(matches!(
+        events.first(),
+        Some(AgentEvent::SubAgentStarted {
+            child_session_id,
+            ..
+        }) if child_session_id == &harness.child_session_id
+    ));
+    assert!(matches!(
+        events.last(),
+        Some(AgentEvent::SubAgentCompleted {
+            child_session_id,
+            ..
+        }) if child_session_id == &harness.child_session_id
+    ));
+
+    let runners = harness.ctx.agent_runners.read().await;
+    let cached_lifecycle = runners
+        .get(&harness.parent_session_id)
+        .expect("parent runner retained")
+        .last_critical_events
+        .iter()
+        .filter(|event| match event {
+            AgentEvent::SubAgentStarted {
+                child_session_id, ..
+            }
+            | AgentEvent::SubAgentCompleted {
+                child_session_id, ..
+            } => child_session_id == &harness.child_session_id,
+            _ => false,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(cached_lifecycle.len(), 1);
+    assert!(matches!(
+        cached_lifecycle[0],
+        AgentEvent::SubAgentCompleted { .. }
+    ));
+    drop(runners);
 
     let persisted = harness
         .storage

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -2660,14 +2660,15 @@ impl ChildCompletionCoordinator {
         status: &str,
         error: Option<String>,
     ) {
-        let parent_tx = crate::execution::session_events::get_or_create_event_sender(
-            &self.session_event_senders,
-            parent_session_id,
-        )
-        .await;
+        let publisher =
+            crate::runtime::execution::session_events::ReplayableSessionEventPublisher::new(
+                self.agent_runners.clone(),
+                self.session_event_senders.clone(),
+                self.account_feed_inbox.clone(),
+            );
         let handler: Arc<dyn ChildCompletionHandler> = Arc::new(self.clone());
         crate::runtime::execution::spawn::publish_child_completion_parts(
-            &parent_tx,
+            &publisher,
             Some(handler),
             parent_session_id.to_string(),
             child_session_id.to_string(),


### PR DESCRIPTION
## Summary

- render user, assistant, reasoning, tool, sub-agent, question/approval, and terminal activity as stable conversation blocks
- add independent block focus, expansion, bounded scrolling, exact copy, child-session navigation, and unseen-update anchoring
- keep the composer editable through active runs and preserve drafts across completion, cancellation, questions, pickers, tab changes, and reconnects
- reconstruct equivalent history blocks from trusted tool-result and message metadata, including pending tools and multi-child list/wait results
- reconcile replayed tools and children without duplicate live rows, and preserve assistant/tool/assistant ordering across true multi-round runs
- bind async start, execute, stop, and stream callbacks to exact session/turn/epoch identities so stale completions cannot mutate newer turns
- keep late child lifecycle events attached after parent completion while allowing the next draft to send immediately and isolating the old stream
- preserve immutable question UI identity during protocol hydration and cache bounded inspector wrapping for large payloads
- coalesce cached SubAgent lifecycle state by stable child id so reconnect sees only the latest generation while live subscribers retain every transition
- establish SSE/WS live subscriptions and runner replay snapshots at one lock boundary so each replayable event appears on exactly one side
- route all production child lifecycle publishers through the same atomic cache/account-feed/broadcast boundary
- reserve queue capacity and publish Started before releasing work, preserving strict Started → Completed ordering even for immediate setup failures
- cover direct ChildRunner SDK launches and queued/reserved server launches through the same lifecycle contract
- reduce child lifecycle frames as authoritative transitions while preserving separate current-turn ownership across reconnect reconciliation
- keep identity-agnostic resident-create starts isolated from replayed or already-active sibling children

Fixes #637

## Test Plan

- `cargo test -p bamboo-tui -- --quiet` (241 passed at `12b1f700`)
- `cargo test -p bamboo-engine -- --quiet` (1,356 unit tests and 1 doc test passed)
- `cargo test -p bamboo-server tools::sub_agent_tests -- --quiet` (39 passed)
- `cargo test -p bamboo-server replay -- --quiet` (30 server unit tests and 2 WS tests passed)
- `cargo clippy -p bamboo-engine --lib --no-deps -- -D warnings`
- `cargo clippy -p bamboo-server --all-targets --no-deps -- -D warnings -A clippy::too_many_arguments`
- `cargo clippy -p bamboo-tui --all-targets --no-deps -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- full-workspace validation is also enforced by the exact-head GitHub Actions Test and Lint checks

## Screenshots

N/A — terminal-native behavior is covered with Ratatui TestBackend and reducer tests.