### PR TITLE
fix(metrics): support model-scoped dashboard rollups

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/chat.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/chat.rs
@@ -2,7 +2,8 @@ use actix_web::{web, HttpResponse, Responder};
 
 use super::super::{internal_error, MetricsDailyQuery, MetricsSessionsQuery, MetricsSummaryQuery};
 use super::filters::{
-    build_sessions_filter, normalize_days, resolve_timeline_granularity, TimelineGranularity,
+    build_chat_timeline_filter, build_sessions_filter, build_summary_filter,
+    resolve_timeline_granularity, TimelineGranularity,
 };
 use crate::app_state::AppState;
 
@@ -14,11 +15,8 @@ pub async fn summary(
     state: web::Data<AppState>,
     query: web::Query<MetricsSummaryQuery>,
 ) -> impl Responder {
-    match state
-        .metrics_service
-        .summary(query.start_date, query.end_date)
-        .await
-    {
+    let filter = build_summary_filter(&query);
+    match state.metrics_service.summary_filtered(filter).await {
         Ok(summary) => HttpResponse::Ok().json(summary),
         Err(error) => internal_error(error),
     }
@@ -32,11 +30,8 @@ pub async fn by_model(
     state: web::Data<AppState>,
     query: web::Query<MetricsSummaryQuery>,
 ) -> impl Responder {
-    match state
-        .metrics_service
-        .by_model(query.start_date, query.end_date)
-        .await
-    {
+    let filter = build_summary_filter(&query);
+    match state.metrics_service.by_model_filtered(filter).await {
         Ok(data) => HttpResponse::Ok().json(data),
         Err(error) => internal_error(error),
     }
@@ -82,25 +77,38 @@ pub async fn daily(
     state: web::Data<AppState>,
     query: web::Query<MetricsDailyQuery>,
 ) -> impl Responder {
-    let days = normalize_days(query.days);
+    let filter = build_chat_timeline_filter(&query);
 
     match resolve_timeline_granularity(query.granularity.as_deref()) {
         TimelineGranularity::Weekly => {
-            match state.metrics_service.weekly(days, query.end_date).await {
+            match state
+                .metrics_service
+                .weekly_for_model(filter.days, filter.end_date, filter.model)
+                .await
+            {
                 Ok(data) => HttpResponse::Ok().json(data),
                 Err(error) => internal_error(error),
             }
         }
         TimelineGranularity::Monthly => {
-            match state.metrics_service.monthly(days, query.end_date).await {
+            match state
+                .metrics_service
+                .monthly_for_model(filter.days, filter.end_date, filter.model)
+                .await
+            {
                 Ok(data) => HttpResponse::Ok().json(data),
                 Err(error) => internal_error(error),
             }
         }
-        TimelineGranularity::Daily => match state.metrics_service.daily(days, query.end_date).await
-        {
-            Ok(data) => HttpResponse::Ok().json(data),
-            Err(error) => internal_error(error),
-        },
+        TimelineGranularity::Daily => {
+            match state
+                .metrics_service
+                .daily_for_model(filter.days, filter.end_date, filter.model)
+                .await
+            {
+                Ok(data) => HttpResponse::Ok().json(data),
+                Err(error) => internal_error(error),
+            }
+        }
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/filters.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/filters.rs
@@ -1,4 +1,8 @@
-use super::super::{ForwardMetricsQuery, MetricsSessionsQuery};
+use chrono::NaiveDate;
+
+use super::super::{
+    ForwardMetricsQuery, MetricsDailyQuery, MetricsSessionsQuery, MetricsSummaryQuery,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::handlers::agent::metrics) enum TimelineGranularity {
@@ -7,13 +11,49 @@ pub(in crate::handlers::agent::metrics) enum TimelineGranularity {
     Monthly,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::handlers::agent::metrics) struct ChatTimelineFilter {
+    pub days: u32,
+    pub end_date: Option<NaiveDate>,
+    pub model: Option<String>,
+}
+
+pub(in crate::handlers::agent::metrics) fn normalize_model_filter(
+    model: Option<&str>,
+) -> Option<String> {
+    model
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+pub(in crate::handlers::agent::metrics) fn build_summary_filter(
+    query: &MetricsSummaryQuery,
+) -> bamboo_metrics::MetricsDateFilter {
+    bamboo_metrics::MetricsDateFilter {
+        start_date: query.start_date,
+        end_date: query.end_date,
+        model: normalize_model_filter(query.model.as_deref()),
+    }
+}
+
+pub(in crate::handlers::agent::metrics) fn build_chat_timeline_filter(
+    query: &MetricsDailyQuery,
+) -> ChatTimelineFilter {
+    ChatTimelineFilter {
+        days: normalize_days(query.days),
+        end_date: query.end_date,
+        model: normalize_model_filter(query.model.as_deref()),
+    }
+}
+
 pub(super) fn build_sessions_filter(
     query: &MetricsSessionsQuery,
 ) -> bamboo_metrics::SessionMetricsFilter {
     bamboo_metrics::SessionMetricsFilter {
         start_date: query.start_date,
         end_date: query.end_date,
-        model: query.model.clone(),
+        model: normalize_model_filter(query.model.as_deref()),
         limit: normalize_limit(query.limit),
     }
 }
@@ -25,7 +65,7 @@ pub(super) fn build_forward_filter(
         start_date: query.start_date,
         end_date: query.end_date,
         endpoint: query.endpoint.clone(),
-        model: query.model.clone(),
+        model: normalize_model_filter(query.model.as_deref()),
         limit: normalize_limit(query.limit),
     }
 }
@@ -37,7 +77,7 @@ pub(super) fn build_forward_grouped_filter(
         start_date: query.start_date,
         end_date: query.end_date,
         endpoint: None,
-        model: query.model.clone(),
+        model: normalize_model_filter(query.model.as_deref()),
         limit: normalize_limit(query.limit),
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/filters.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/filters.rs
@@ -29,8 +29,8 @@ pub(in crate::handlers::agent::metrics) fn normalize_model_filter(
 
 pub(in crate::handlers::agent::metrics) fn build_summary_filter(
     query: &MetricsSummaryQuery,
-) -> bamboo_metrics::MetricsDateFilter {
-    bamboo_metrics::MetricsDateFilter {
+) -> bamboo_metrics::ModelMetricsDateFilter {
+    bamboo_metrics::ModelMetricsDateFilter {
         start_date: query.start_date,
         end_date: query.end_date,
         model: normalize_model_filter(query.model.as_deref()),

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/tests.rs
@@ -1,9 +1,12 @@
 use chrono::NaiveDate;
 
-use super::super::{ForwardMetricsQuery, MetricsSessionsQuery};
+use super::super::{
+    ForwardMetricsQuery, MetricsDailyQuery, MetricsSessionsQuery, MetricsSummaryQuery,
+};
 use super::filters::{
-    build_forward_filter, build_forward_grouped_filter, build_sessions_filter, normalize_days,
-    resolve_timeline_granularity, TimelineGranularity,
+    build_chat_timeline_filter, build_forward_filter, build_forward_grouped_filter,
+    build_sessions_filter, build_summary_filter, normalize_days, resolve_timeline_granularity,
+    TimelineGranularity,
 };
 
 #[test]
@@ -48,6 +51,25 @@ fn build_sessions_filter_copies_query_fields() {
     assert_eq!(filter.end_date, query.end_date);
     assert_eq!(filter.model, query.model);
     assert_eq!(filter.limit, query.limit);
+}
+
+#[test]
+fn chat_summary_and_timeline_filters_trim_model_and_clear_blank_values() {
+    let summary = build_summary_filter(&MetricsSummaryQuery {
+        start_date: Some(NaiveDate::from_ymd_opt(2026, 3, 1).expect("date")),
+        end_date: Some(NaiveDate::from_ymd_opt(2026, 3, 31).expect("date")),
+        model: Some("  gpt-5  ".to_string()),
+    });
+    assert_eq!(summary.model.as_deref(), Some("gpt-5"));
+
+    let timeline = build_chat_timeline_filter(&MetricsDailyQuery {
+        days: Some(14),
+        end_date: Some(NaiveDate::from_ymd_opt(2026, 3, 31).expect("date")),
+        model: Some("   ".to_string()),
+        granularity: Some("weekly".to_string()),
+    });
+    assert_eq!(timeline.days, 14);
+    assert_eq!(timeline.model, None);
 }
 
 #[test]

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/usage.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/usage.rs
@@ -10,6 +10,8 @@ use super::super::{
 use crate::app_state::AppState;
 use bamboo_tools::exposure::canonical_tool_name;
 
+use super::filters::normalize_model_filter;
+
 #[derive(Debug, Clone)]
 struct ParsedMcpAlias {
     server_id: String,
@@ -78,6 +80,7 @@ pub async fn usage_breakdown(
     query: web::Query<MetricsUsageQuery>,
 ) -> impl Responder {
     let session_index_entries = state.session_store.list_index_entries().await;
+    let model_filter = normalize_model_filter(query.model.as_deref());
 
     let mut matched_session_ids: HashSet<String> = HashSet::new();
     let mut total_tool_calls = 0_u64;
@@ -94,7 +97,7 @@ pub async fn usage_breakdown(
     let mut sessions_with_mcp_calls: HashSet<String> = HashSet::new();
 
     for entry in session_index_entries {
-        if let Some(model) = query.model.as_ref() {
+        if let Some(model) = model_filter.as_ref() {
             if entry.model != *model {
                 continue;
             }

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/types.rs
@@ -12,6 +12,8 @@ pub struct MetricsSummaryQuery {
     pub start_date: Option<NaiveDate>,
     /// End date for the metrics range (YYYY-MM-DD)
     pub end_date: Option<NaiveDate>,
+    /// Filter by model name
+    pub model: Option<String>,
 }
 
 /// Query parameters for session metrics requests
@@ -34,6 +36,8 @@ pub struct MetricsDailyQuery {
     pub days: Option<u32>,
     /// End date for the range
     pub end_date: Option<NaiveDate>,
+    /// Filter by model name
+    pub model: Option<String>,
     /// Granularity: "daily", "weekly", or "monthly" (default: "daily").
     /// Unknown values follow the existing timeline policy and fall back to daily.
     pub granularity: Option<String>,
@@ -236,11 +240,12 @@ pub struct UnifiedSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::web;
     use chrono::NaiveDate;
 
     #[test]
     fn test_metrics_summary_query_deserialization() {
-        let json = r#"{"start_date":"2024-01-01","end_date":"2024-01-31"}"#;
+        let json = r#"{"start_date":"2024-01-01","end_date":"2024-01-31","model":"gpt-4"}"#;
         let query: MetricsSummaryQuery = serde_json::from_str(json).unwrap();
 
         assert_eq!(
@@ -251,6 +256,7 @@ mod tests {
             query.end_date,
             Some(NaiveDate::from_ymd_opt(2024, 1, 31).unwrap())
         );
+        assert_eq!(query.model.as_deref(), Some("gpt-4"));
     }
 
     #[test]
@@ -260,6 +266,7 @@ mod tests {
 
         assert!(query.start_date.is_none());
         assert!(query.end_date.is_none());
+        assert!(query.model.is_none());
     }
 
     #[test]
@@ -289,16 +296,34 @@ mod tests {
 
         assert!(query.days.is_none());
         assert!(query.end_date.is_none());
+        assert!(query.model.is_none());
         assert!(query.granularity.is_none());
     }
 
     #[test]
     fn test_metrics_daily_query_with_options() {
-        let json = r#"{"days":30,"granularity":"weekly"}"#;
+        let json = r#"{"days":30,"model":"claude-sonnet","granularity":"weekly"}"#;
         let query: MetricsDailyQuery = serde_json::from_str(json).unwrap();
 
         assert_eq!(query.days, Some(30));
+        assert_eq!(query.model.as_deref(), Some("claude-sonnet"));
         assert_eq!(query.granularity, Some("weekly".to_string()));
+    }
+
+    #[test]
+    fn metrics_model_filters_deserialize_from_http_query_strings() {
+        let summary = web::Query::<MetricsSummaryQuery>::from_query(
+            "start_date=2024-01-01&end_date=2024-01-31&model=gpt-4",
+        )
+        .expect("summary query");
+        assert_eq!(summary.model.as_deref(), Some("gpt-4"));
+
+        let timeline = web::Query::<MetricsDailyQuery>::from_query(
+            "days=30&end_date=2024-01-31&model=claude-sonnet&granularity=monthly",
+        )
+        .expect("timeline query");
+        assert_eq!(timeline.model.as_deref(), Some("claude-sonnet"));
+        assert_eq!(timeline.granularity.as_deref(), Some("monthly"));
     }
 
     #[test]
@@ -327,6 +352,7 @@ mod tests {
         let query = MetricsSummaryQuery {
             start_date: None,
             end_date: None,
+            model: None,
         };
 
         let debug_str = format!("{:?}", query);
@@ -351,6 +377,7 @@ mod tests {
         let query = MetricsDailyQuery {
             days: Some(7),
             end_date: None,
+            model: None,
             granularity: Some("daily".to_string()),
         };
 

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/unified_handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/unified_handlers.rs
@@ -19,7 +19,7 @@ use super::core_handlers::memory::build_memory_summary;
 fn build_unified_summary_filters(
     query: &MetricsSummaryQuery,
 ) -> (
-    bamboo_metrics::MetricsDateFilter,
+    bamboo_metrics::ModelMetricsDateFilter,
     bamboo_metrics::ForwardMetricsFilter,
 ) {
     let chat = build_summary_filter(query);

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/unified_handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/unified_handlers.rs
@@ -4,7 +4,10 @@ use actix_web::{web, HttpResponse, Responder};
 use bamboo_metrics::{DailyMetrics, PeriodMetrics, TokenUsage};
 
 use super::{
-    core_handlers::filters::{normalize_days, resolve_timeline_granularity, TimelineGranularity},
+    core_handlers::filters::{
+        build_chat_timeline_filter, build_summary_filter, resolve_timeline_granularity,
+        TimelineGranularity,
+    },
     internal_error, CombinedSummary, MemoryMetricsQuery, MetricsDailyQuery, MetricsSummaryQuery,
     UnifiedSummary, UnifiedTimelinePoint,
 };
@@ -12,6 +15,40 @@ use crate::app_state::AppState;
 use bamboo_memory::memory_store::MemoryStore;
 
 use super::core_handlers::memory::build_memory_summary;
+
+fn build_unified_summary_filters(
+    query: &MetricsSummaryQuery,
+) -> (
+    bamboo_metrics::MetricsDateFilter,
+    bamboo_metrics::ForwardMetricsFilter,
+) {
+    let chat = build_summary_filter(query);
+    let forward = bamboo_metrics::ForwardMetricsFilter {
+        start_date: chat.start_date,
+        end_date: chat.end_date,
+        endpoint: None,
+        model: chat.model.clone(),
+        limit: None,
+    };
+    (chat, forward)
+}
+
+fn build_unified_timeline_filters(
+    query: &MetricsDailyQuery,
+) -> (
+    super::core_handlers::filters::ChatTimelineFilter,
+    bamboo_metrics::ForwardMetricsFilter,
+) {
+    let chat = build_chat_timeline_filter(query);
+    let forward = bamboo_metrics::ForwardMetricsFilter {
+        start_date: None,
+        end_date: chat.end_date,
+        endpoint: None,
+        model: chat.model.clone(),
+        limit: Some(chat.days),
+    };
+    (chat, forward)
+}
 
 /// Gets unified metrics summary combining chat and forward data
 ///
@@ -21,21 +58,10 @@ pub async fn v2_unified_summary(
     state: web::Data<AppState>,
     query: web::Query<MetricsSummaryQuery>,
 ) -> impl Responder {
-    let chat_result = state
-        .metrics_service
-        .summary(query.start_date, query.end_date)
-        .await;
+    let (chat_filter, forward_filter) = build_unified_summary_filters(&query);
+    let chat_result = state.metrics_service.summary_filtered(chat_filter).await;
 
-    let forward_result = state
-        .metrics_service
-        .forward_summary(bamboo_metrics::ForwardMetricsFilter {
-            start_date: query.start_date,
-            end_date: query.end_date,
-            endpoint: None,
-            model: None,
-            limit: None,
-        })
-        .await;
+    let forward_result = state.metrics_service.forward_summary(forward_filter).await;
 
     let memory_store = MemoryStore::new(state.app_data_dir.clone());
     let memory_result = build_memory_summary(
@@ -101,20 +127,14 @@ pub async fn v2_unified_timeline(
     state: web::Data<AppState>,
     query: web::Query<MetricsDailyQuery>,
 ) -> impl Responder {
-    let days = normalize_days(query.days);
+    let (filter, forward_filter) = build_unified_timeline_filters(&query);
     let granularity = resolve_timeline_granularity(query.granularity.as_deref());
 
-    let chat_result = state.metrics_service.daily(days, query.end_date).await;
-    let forward_result = state
+    let chat_result = state
         .metrics_service
-        .forward_daily(bamboo_metrics::ForwardMetricsFilter {
-            start_date: None,
-            end_date: query.end_date,
-            endpoint: None,
-            model: None,
-            limit: Some(days),
-        })
+        .daily_for_model(filter.days, filter.end_date, filter.model.clone())
         .await;
+    let forward_result = state.metrics_service.forward_daily(forward_filter).await;
 
     match (chat_result, forward_result) {
         (Ok(chat_daily), Ok(forward_daily)) => HttpResponse::Ok().json(build_unified_timeline(
@@ -284,6 +304,39 @@ mod tests {
             model_breakdown: Default::default(),
             tool_breakdown: Default::default(),
         }
+    }
+
+    #[test]
+    fn unified_handlers_apply_one_normalized_model_to_chat_and_forward_sources() {
+        let summary_query = MetricsSummaryQuery {
+            start_date: Some(NaiveDate::from_ymd_opt(2099, 2, 1).expect("date")),
+            end_date: Some(NaiveDate::from_ymd_opt(2099, 2, 28).expect("date")),
+            model: Some("  model-a  ".to_string()),
+        };
+        let (chat_summary, forward_summary) = build_unified_summary_filters(&summary_query);
+        assert_eq!(chat_summary.model.as_deref(), Some("model-a"));
+        assert_eq!(forward_summary.model, chat_summary.model);
+
+        let timeline_query = MetricsDailyQuery {
+            days: Some(7),
+            end_date: summary_query.end_date,
+            model: Some("model-a".to_string()),
+            granularity: Some("weekly".to_string()),
+        };
+        let (chat_timeline, forward_timeline) = build_unified_timeline_filters(&timeline_query);
+        assert_eq!(chat_timeline.model.as_deref(), Some("model-a"));
+        assert_eq!(forward_timeline.model, chat_timeline.model);
+        assert_eq!(forward_timeline.limit, Some(chat_timeline.days));
+
+        let cleared_query = MetricsDailyQuery {
+            days: None,
+            end_date: None,
+            model: Some("   ".to_string()),
+            granularity: None,
+        };
+        let (cleared_chat, cleared_forward) = build_unified_timeline_filters(&cleared_query);
+        assert_eq!(cleared_chat.model, None);
+        assert_eq!(cleared_forward.model, None);
     }
 
     #[test]

--- a/crates/infra/bamboo-infrastructure/src/metrics/mod.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/mod.rs
@@ -14,6 +14,6 @@ pub use storage::{
 pub use types::{
     DailyMetrics, ForwardEndpointMetrics, ForwardMetricsFilter, ForwardMetricsSummary,
     ForwardRequestMetrics, ForwardStatus, MetricsDateFilter, MetricsSummary, ModelMetrics,
-    RoundMetrics, RoundStatus, SessionDetail, SessionMetrics, SessionMetricsFilter, SessionStatus,
-    TokenUsage, ToolCallMetrics,
+    ModelMetricsDateFilter, RoundMetrics, RoundStatus, SessionDetail, SessionMetrics,
+    SessionMetricsFilter, SessionStatus, TokenUsage, ToolCallMetrics,
 };

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
@@ -543,6 +543,43 @@ pub trait MetricsStorage: Send + Sync {
         end_date: Option<NaiveDate>,
     ) -> MetricsResult<Vec<DailyMetrics>>;
 
+    /// Retrieves daily forwarded-request metrics restricted to one model.
+    /// Blank model values have the same meaning as omission.
+    async fn forward_daily_metrics_for_model(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        model: Option<String>,
+    ) -> MetricsResult<Vec<DailyMetrics>> {
+        if normalize_filter_value(model).is_none() {
+            self.forward_daily_metrics(days, end_date).await
+        } else {
+            Err(MetricsError::InvalidData(
+                "model-filtered forward daily metrics are not supported by this storage"
+                    .to_string(),
+            ))
+        }
+    }
+
+    /// Retrieves daily forwarded-request metrics using the same endpoint/model
+    /// semantics as the other forward metrics queries.
+    async fn forward_daily_metrics_filtered(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        endpoint: Option<String>,
+        model: Option<String>,
+    ) -> MetricsResult<Vec<DailyMetrics>> {
+        if normalize_filter_value(endpoint).is_some() {
+            return Err(MetricsError::InvalidData(
+                "endpoint-filtered forward daily metrics are not supported by this storage"
+                    .to_string(),
+            ));
+        }
+        self.forward_daily_metrics_for_model(days, end_date, model)
+            .await
+    }
+
     /// Retrieves aggregated summary statistics for chat sessions.
     ///
     /// Session/status counts are filtered by session start. Token/cache/
@@ -562,6 +599,7 @@ pub trait MetricsStorage: Send + Sync {
     /// let filter = MetricsDateFilter {
     ///     start_date: Some(NaiveDate::from_ymd_opt(2026, 2, 1).unwrap()),
     ///     end_date: Some(NaiveDate::from_ymd_opt(2026, 2, 28).unwrap()),
+    ///     model: None,
     /// };
     ///
     /// let summary = storage.summary(filter).await?;
@@ -696,6 +734,24 @@ pub trait MetricsStorage: Send + Sync {
         days: u32,
         end_date: Option<NaiveDate>,
     ) -> MetricsResult<Vec<DailyMetrics>>;
+
+    /// Retrieves daily chat metrics restricted to one model. Session/status
+    /// dimensions use the session model, while round/cache/token dimensions
+    /// and tool calls use the owning round model. Blank values mean all models.
+    async fn daily_metrics_for_model(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        model: Option<String>,
+    ) -> MetricsResult<Vec<DailyMetrics>> {
+        if normalize_filter_value(model).is_none() {
+            self.daily_metrics(days, end_date).await
+        } else {
+            Err(MetricsError::InvalidData(
+                "model-filtered daily metrics are not supported by this storage".to_string(),
+            ))
+        }
+    }
 
     /// Deletes old round records before a cutoff date.
     ///
@@ -1629,12 +1685,43 @@ impl MetricsStorage for SqliteMetricsStorage {
         days: u32,
         end_date: Option<NaiveDate>,
     ) -> MetricsResult<Vec<DailyMetrics>> {
+        self.forward_daily_metrics_filtered(days, end_date, None, None)
+            .await
+    }
+
+    async fn forward_daily_metrics_for_model(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        model: Option<String>,
+    ) -> MetricsResult<Vec<DailyMetrics>> {
+        self.forward_daily_metrics_filtered(days, end_date, None, model)
+            .await
+    }
+
+    async fn forward_daily_metrics_filtered(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        endpoint: Option<String>,
+        model: Option<String>,
+    ) -> MetricsResult<Vec<DailyMetrics>> {
         let end_date = end_date.unwrap_or_else(|| Utc::now().date_naive());
         let span = days.max(1) - 1;
         let start_date = end_date - chrono::Duration::days(i64::from(span));
+        let endpoint = normalize_filter_value(endpoint);
+        let model = normalize_filter_value(model);
 
         self.with_connection(move |connection| {
-            let mut stmt = connection.prepare(
+            let mut params_vec = Vec::new();
+            let where_clause = build_forward_where_clause(
+                Some(start_date),
+                Some(end_date),
+                endpoint.as_deref(),
+                model.as_deref(),
+                &mut params_vec,
+            );
+            let sql = format!(
                 r#"
                 SELECT
                     date(started_at) AS date_key,
@@ -1643,13 +1730,15 @@ impl MetricsStorage for SqliteMetricsStorage {
                     COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
                     COALESCE(SUM(total_tokens), 0) AS total_tokens
                 FROM forward_request_metrics
-                WHERE started_at >= ?1 AND started_at < ?2
+                {}
                 GROUP BY date_key
                 ORDER BY date_key ASC
                 "#,
-            )?;
+                where_clause
+            );
+            let mut stmt = connection.prepare(&sql)?;
 
-            let mut rows = stmt.query(params![start_date.to_string(), next_day_bound(end_date)])?;
+            let mut rows = stmt.query(params_from_iter(params_vec.iter()))?;
             let mut result = Vec::new();
 
             while let Some(row) = rows.next()? {
@@ -1677,15 +1766,22 @@ impl MetricsStorage for SqliteMetricsStorage {
     }
 
     async fn summary(&self, filter: MetricsDateFilter) -> MetricsResult<MetricsSummary> {
+        let MetricsDateFilter {
+            start_date,
+            end_date,
+            model,
+        } = filter;
+        let model = normalize_filter_value(model);
         self.with_connection(move |connection| {
             // Lifecycle dimensions belong to the session start date. Do not
             // infer status/counts from rounds: a session may have no rounds, or
             // may continue producing rounds on later days.
             let mut session_params = Vec::new();
-            let session_clause = build_session_where_clause(
-                filter.start_date,
-                filter.end_date,
+            let session_clause = build_session_model_where_clause(
+                start_date,
+                end_date,
                 None,
+                model.as_deref(),
                 &mut session_params,
             );
             let session_sql = format!(
@@ -1712,10 +1808,12 @@ impl MetricsStorage for SqliteMetricsStorage {
             // the billed model turn began; nullable `completed_at` is therefore
             // intentionally not used as the attribution key.
             let mut round_params = Vec::new();
-            let round_clause = build_started_at_where_clause(
+            let round_clause = build_started_at_model_where_clause(
                 "started_at",
-                filter.start_date,
-                filter.end_date,
+                "model",
+                start_date,
+                end_date,
+                model.as_deref(),
                 &mut round_params,
             );
             let round_sql = format!(
@@ -1739,13 +1837,31 @@ impl MetricsStorage for SqliteMetricsStorage {
             )?;
 
             let mut tool_params = Vec::new();
-            let tool_clause = build_started_at_where_clause(
-                "started_at",
-                filter.start_date,
-                filter.end_date,
-                &mut tool_params,
-            );
-            let tool_sql = format!("SELECT COUNT(*) FROM tool_call_metrics {}", tool_clause);
+            let tool_clause = if model.is_some() {
+                build_started_at_model_where_clause(
+                    "tool_call_metrics.started_at",
+                    "round_metrics.model",
+                    start_date,
+                    end_date,
+                    model.as_deref(),
+                    &mut tool_params,
+                )
+            } else {
+                build_started_at_where_clause(
+                    "started_at",
+                    start_date,
+                    end_date,
+                    &mut tool_params,
+                )
+            };
+            let tool_sql = if model.is_some() {
+                format!(
+                    "SELECT COUNT(*) FROM tool_call_metrics JOIN round_metrics ON round_metrics.round_id = tool_call_metrics.round_id {}",
+                    tool_clause
+                )
+            } else {
+                format!("SELECT COUNT(*) FROM tool_call_metrics {}", tool_clause)
+            };
             let total_tool_calls = connection.query_row(
                 &tool_sql,
                 params_from_iter(tool_params.iter()),
@@ -1774,26 +1890,30 @@ impl MetricsStorage for SqliteMetricsStorage {
                 sync_mismatch_breakdown: HashMap::new(),
             };
 
-            let mut mismatch_params = Vec::new();
-            let mismatch_clause = build_execute_sync_mismatch_where_clause(
-                filter.start_date,
-                filter.end_date,
-                None,
-                &mut mismatch_params,
-            );
-            let mismatch_sql = format!(
-                "SELECT COALESCE(SUM(count), 0) FROM execute_sync_mismatch_metrics {}",
-                mismatch_clause
-            );
-            let mut mismatch_stmt = connection.prepare(&mismatch_sql)?;
-            summary.total_sync_mismatches = mismatch_stmt
-                .query_row(params_from_iter(mismatch_params.iter()), |row| row.get::<_, i64>(0))?
-                as u64;
-            summary.sync_mismatch_breakdown = load_execute_sync_mismatch_breakdown(
-                connection,
-                filter.start_date,
-                filter.end_date,
-            )?;
+            // Sync-mismatch rows currently have no model column or stable
+            // session/round key. Returning their all-model total in a filtered
+            // summary would mix populations, so filtered summaries explicitly
+            // leave this non-attributable dimension at zero.
+            if model.is_none() {
+                let mut mismatch_params = Vec::new();
+                let mismatch_clause = build_execute_sync_mismatch_where_clause(
+                    start_date,
+                    end_date,
+                    None,
+                    &mut mismatch_params,
+                );
+                let mismatch_sql = format!(
+                    "SELECT COALESCE(SUM(count), 0) FROM execute_sync_mismatch_metrics {}",
+                    mismatch_clause
+                );
+                let mut mismatch_stmt = connection.prepare(&mismatch_sql)?;
+                summary.total_sync_mismatches = mismatch_stmt
+                    .query_row(params_from_iter(mismatch_params.iter()), |row| {
+                        row.get::<_, i64>(0)
+                    })? as u64;
+                summary.sync_mismatch_breakdown =
+                    load_execute_sync_mismatch_breakdown(connection, start_date, end_date)?;
+            }
 
             Ok(summary)
         })
@@ -1801,15 +1921,22 @@ impl MetricsStorage for SqliteMetricsStorage {
     }
 
     async fn by_model(&self, filter: MetricsDateFilter) -> MetricsResult<Vec<ModelMetrics>> {
+        let MetricsDateFilter {
+            start_date,
+            end_date,
+            model,
+        } = filter;
+        let model = normalize_filter_value(model);
         self.with_connection(move |connection| {
             let mut models: HashMap<String, ModelMetrics> = HashMap::new();
 
             // Session counts retain the session row's model/start semantics.
             let mut session_params = Vec::new();
-            let session_clause = build_session_where_clause(
-                filter.start_date,
-                filter.end_date,
+            let session_clause = build_session_model_where_clause(
+                start_date,
+                end_date,
                 None,
+                model.as_deref(),
                 &mut session_params,
             );
             let session_sql = format!(
@@ -1831,10 +1958,12 @@ impl MetricsStorage for SqliteMetricsStorage {
             // Round count, token usage and cache values follow each round's own
             // model and occurrence date, not the session's current model.
             let mut round_params = Vec::new();
-            let round_clause = build_started_at_where_clause(
+            let round_clause = build_started_at_model_where_clause(
                 "started_at",
-                filter.start_date,
-                filter.end_date,
+                "model",
+                start_date,
+                end_date,
+                model.as_deref(),
                 &mut round_params,
             );
             let round_sql = format!(
@@ -1862,10 +1991,12 @@ impl MetricsStorage for SqliteMetricsStorage {
             // A tool call has no model column, so attribute it through its
             // owning round while retaining the tool call's own occurrence date.
             let mut tool_params = Vec::new();
-            let tool_clause = build_started_at_where_clause(
+            let tool_clause = build_started_at_model_where_clause(
                 "tool_call_metrics.started_at",
-                filter.start_date,
-                filter.end_date,
+                "round_metrics.model",
+                start_date,
+                end_date,
+                model.as_deref(),
                 &mut tool_params,
             );
             let tool_sql = format!(
@@ -1899,6 +2030,7 @@ impl MetricsStorage for SqliteMetricsStorage {
 
     async fn sessions(&self, filter: SessionMetricsFilter) -> MetricsResult<Vec<SessionMetrics>> {
         self.with_connection(move |connection| {
+            let model = normalize_filter_value(filter.model);
             let mut params_vec = Vec::new();
             let where_clause = build_session_where_clause(
                 filter.start_date,
@@ -1911,7 +2043,7 @@ impl MetricsStorage for SqliteMetricsStorage {
             } else {
                 vec![where_clause.replacen("WHERE ", "", 1)]
             };
-            if let Some(model) = filter.model {
+            if let Some(model) = model {
                 conditions.push("model = ?".to_string());
                 params_vec.push(model);
             }
@@ -2082,21 +2214,40 @@ impl MetricsStorage for SqliteMetricsStorage {
         days: u32,
         end_date: Option<NaiveDate>,
     ) -> MetricsResult<Vec<DailyMetrics>> {
+        self.daily_metrics_for_model(days, end_date, None).await
+    }
+
+    async fn daily_metrics_for_model(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        model: Option<String>,
+    ) -> MetricsResult<Vec<DailyMetrics>> {
         let end_date = end_date.unwrap_or_else(|| Utc::now().date_naive());
         let span = days.max(1) - 1;
         let start_date = end_date - chrono::Duration::days(i64::from(span));
+        let model = normalize_filter_value(model);
 
         self.with_connection(move |connection| {
             let start_bound = start_date.to_string();
             let end_bound = next_day_bound(end_date);
 
             let mut sessions_by_day =
-                load_session_counts_by_day(connection, &start_bound, &end_bound)?;
-            let mut rounds_by_day =
-                load_round_aggregates_by_day(connection, &start_bound, &end_bound)?;
-            let mut model_by_day =
-                load_model_breakdown_by_day(connection, &start_bound, &end_bound)?;
-            let mut tool_by_day = load_tool_breakdown_by_day(connection, &start_bound, &end_bound)?;
+                load_session_counts_by_day(connection, &start_bound, &end_bound, model.as_deref())?;
+            let mut rounds_by_day = load_round_aggregates_by_day(
+                connection,
+                &start_bound,
+                &end_bound,
+                model.as_deref(),
+            )?;
+            let mut model_by_day = load_model_breakdown_by_day(
+                connection,
+                &start_bound,
+                &end_bound,
+                model.as_deref(),
+            )?;
+            let mut tool_by_day =
+                load_tool_breakdown_by_day(connection, &start_bound, &end_bound, model.as_deref())?;
 
             // A continuation day may have rounds or tools but no new session.
             // Build the output keyset from all three occurrence dimensions so
@@ -2356,6 +2507,12 @@ fn next_day_bound(end: NaiveDate) -> String {
     end.succ_opt().unwrap_or(end).to_string()
 }
 
+fn normalize_filter_value(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
 /// Builds a half-open UTC date range over an internal `started_at` column.
 ///
 /// Round attribution deliberately uses `round_metrics.started_at`: it is the
@@ -2385,6 +2542,27 @@ fn build_started_at_where_clause(
     } else {
         format!("WHERE {}", conditions.join(" AND "))
     }
+}
+
+fn build_started_at_model_where_clause(
+    started_at_column: &'static str,
+    model_column: &'static str,
+    start_date: Option<NaiveDate>,
+    end_date: Option<NaiveDate>,
+    model: Option<&str>,
+    params_vec: &mut Vec<String>,
+) -> String {
+    let mut where_clause =
+        build_started_at_where_clause(started_at_column, start_date, end_date, params_vec);
+    if let Some(model) = model {
+        if where_clause.is_empty() {
+            where_clause = format!("WHERE {model_column} = ?");
+        } else {
+            where_clause.push_str(&format!(" AND {model_column} = ?"));
+        }
+        params_vec.push(model.to_string());
+    }
+    where_clause
 }
 
 fn build_session_where_clause(
@@ -2418,6 +2596,26 @@ fn build_session_where_clause(
     } else {
         format!("WHERE {}", conditions.join(" AND "))
     }
+}
+
+fn build_session_model_where_clause(
+    start_date: Option<NaiveDate>,
+    end_date: Option<NaiveDate>,
+    required_status: Option<&str>,
+    model: Option<&str>,
+    params_vec: &mut Vec<String>,
+) -> String {
+    let mut where_clause =
+        build_session_where_clause(start_date, end_date, required_status, params_vec);
+    if let Some(model) = model {
+        if where_clause.is_empty() {
+            where_clause = "WHERE model = ?".to_string();
+        } else {
+            where_clause.push_str(" AND model = ?");
+        }
+        params_vec.push(model.to_string());
+    }
+    where_clause
 }
 
 fn empty_model_metrics(model: String) -> ModelMetrics {
@@ -2954,16 +3152,28 @@ fn load_session_counts_by_day(
     connection: &Connection,
     start_bound: &str,
     end_bound: &str,
+    model: Option<&str>,
 ) -> MetricsResult<HashMap<NaiveDate, u32>> {
-    let mut stmt = connection.prepare(
+    let model_clause = if model.is_some() {
+        " AND model = ?3"
+    } else {
+        ""
+    };
+    let sql = format!(
         r#"
         SELECT date(started_at) AS date_key, COUNT(*)
         FROM session_metrics
-        WHERE started_at >= ?1 AND started_at < ?2
+        WHERE started_at >= ?1 AND started_at < ?2{}
         GROUP BY date_key
         "#,
-    )?;
-    let mut rows = stmt.query(params![start_bound, end_bound])?;
+        model_clause
+    );
+    let mut params_vec = vec![start_bound.to_string(), end_bound.to_string()];
+    if let Some(model) = model {
+        params_vec.push(model.to_string());
+    }
+    let mut stmt = connection.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params_vec.iter()))?;
     let mut by_day = HashMap::new();
 
     while let Some(row) = rows.next()? {
@@ -2983,8 +3193,14 @@ fn load_round_aggregates_by_day(
     connection: &Connection,
     start_bound: &str,
     end_bound: &str,
+    model: Option<&str>,
 ) -> MetricsResult<HashMap<NaiveDate, DailyRoundAggregate>> {
-    let mut stmt = connection.prepare(
+    let model_clause = if model.is_some() {
+        " AND model = ?3"
+    } else {
+        ""
+    };
+    let sql = format!(
         r#"
         SELECT date(started_at) AS date_key,
                COUNT(*),
@@ -2993,11 +3209,17 @@ fn load_round_aggregates_by_day(
                COALESCE(SUM(total_tokens), 0),
                COALESCE(SUM(prompt_cached_tool_outputs), 0)
         FROM round_metrics
-        WHERE started_at >= ?1 AND started_at < ?2
+        WHERE started_at >= ?1 AND started_at < ?2{}
         GROUP BY date_key
         "#,
-    )?;
-    let mut rows = stmt.query(params![start_bound, end_bound])?;
+        model_clause
+    );
+    let mut params_vec = vec![start_bound.to_string(), end_bound.to_string()];
+    if let Some(model) = model {
+        params_vec.push(model.to_string());
+    }
+    let mut stmt = connection.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params_vec.iter()))?;
     let mut by_day = HashMap::new();
 
     while let Some(row) = rows.next()? {
@@ -3036,8 +3258,14 @@ fn load_model_breakdown_by_day(
     connection: &Connection,
     start_bound: &str,
     end_bound: &str,
+    model: Option<&str>,
 ) -> MetricsResult<HashMap<NaiveDate, HashMap<String, TokenUsage>>> {
-    let mut stmt = connection.prepare(
+    let model_clause = if model.is_some() {
+        " AND model = ?3"
+    } else {
+        ""
+    };
+    let sql = format!(
         r#"
         SELECT date(started_at) AS date_key,
                model,
@@ -3045,12 +3273,18 @@ fn load_model_breakdown_by_day(
                COALESCE(SUM(completion_tokens), 0),
                COALESCE(SUM(total_tokens), 0)
         FROM round_metrics
-        WHERE started_at >= ?1 AND started_at < ?2
+        WHERE started_at >= ?1 AND started_at < ?2{}
         GROUP BY date_key, model
         "#,
-    )?;
+        model_clause
+    );
 
-    let mut rows = stmt.query(params![start_bound, end_bound])?;
+    let mut params_vec = vec![start_bound.to_string(), end_bound.to_string()];
+    if let Some(model) = model {
+        params_vec.push(model.to_string());
+    }
+    let mut stmt = connection.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params_vec.iter()))?;
     let mut by_day: HashMap<NaiveDate, HashMap<String, TokenUsage>> = HashMap::new();
 
     while let Some(row) = rows.next()? {
@@ -3084,17 +3318,30 @@ fn load_tool_breakdown_by_day(
     connection: &Connection,
     start_bound: &str,
     end_bound: &str,
+    model: Option<&str>,
 ) -> MetricsResult<HashMap<NaiveDate, HashMap<String, u32>>> {
-    let mut stmt = connection.prepare(
+    let model_clause = if model.is_some() {
+        " AND round_metrics.model = ?3"
+    } else {
+        ""
+    };
+    let sql = format!(
         r#"
-        SELECT date(started_at) AS date_key, tool_name, COUNT(*)
+        SELECT date(tool_call_metrics.started_at) AS date_key, tool_call_metrics.tool_name, COUNT(*)
         FROM tool_call_metrics
-        WHERE started_at >= ?1 AND started_at < ?2
+        JOIN round_metrics ON round_metrics.round_id = tool_call_metrics.round_id
+        WHERE tool_call_metrics.started_at >= ?1 AND tool_call_metrics.started_at < ?2{}
         GROUP BY date_key, tool_name
         "#,
-    )?;
+        model_clause
+    );
 
-    let mut rows = stmt.query(params![start_bound, end_bound])?;
+    let mut params_vec = vec![start_bound.to_string(), end_bound.to_string()];
+    if let Some(model) = model {
+        params_vec.push(model.to_string());
+    }
+    let mut stmt = connection.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params_vec.iter()))?;
     let mut by_day: HashMap<NaiveDate, HashMap<String, u32>> = HashMap::new();
 
     while let Some(row) = rows.next()? {
@@ -3820,6 +4067,203 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn model_filter_scopes_summary_by_model_and_daily_across_all_dimensions() {
+        let dir = tempdir().expect("temp dir");
+        let storage = SqliteMetricsStorage::new(dir.path().join("metrics.db"));
+        storage.init().await.expect("init storage");
+        let now = Utc
+            .with_ymd_and_hms(2026, 2, 10, 12, 0, 0)
+            .single()
+            .expect("valid datetime");
+
+        for (suffix, model, tool, tokens, cached, status) in [
+            ("a", "model-a", "Read", 10, 2, SessionStatus::Completed),
+            ("b", "model-b", "Write", 20, 4, SessionStatus::Error),
+        ] {
+            let session_id = format!("filtered-session-{suffix}");
+            let round_id = format!("filtered-round-{suffix}");
+            let tool_id = format!("filtered-tool-{suffix}");
+            storage
+                .upsert_session_start(&session_id, model, now)
+                .await
+                .expect("session start");
+            storage
+                .insert_round_start(&round_id, &session_id, model, now)
+                .await
+                .expect("round start");
+            storage
+                .insert_tool_start(&tool_id, &round_id, &session_id, tool, now)
+                .await
+                .expect("tool start");
+            storage
+                .complete_round(
+                    &round_id,
+                    now,
+                    RoundStatus::Success,
+                    TokenUsage {
+                        prompt_tokens: tokens,
+                        completion_tokens: 0,
+                        total_tokens: tokens,
+                    },
+                    cached,
+                    cached,
+                    None,
+                )
+                .await
+                .expect("round completion");
+            storage
+                .record_round_compression(&round_id, now, if model == "model-a" { 3 } else { 7 })
+                .await
+                .expect("round compression");
+            storage
+                .complete_session(&session_id, status, now)
+                .await
+                .expect("session completion");
+        }
+        storage
+            .increment_execute_sync_mismatch("global-only", now)
+            .await
+            .expect("sync mismatch");
+
+        let selected = MetricsDateFilter {
+            model: Some("model-a".to_string()),
+            ..MetricsDateFilter::default()
+        };
+        let summary = storage
+            .summary(selected.clone())
+            .await
+            .expect("filtered summary");
+        assert_eq!(summary.total_sessions, 1);
+        assert_eq!(summary.completed_sessions, 1);
+        assert_eq!(summary.error_sessions, 0);
+        assert_eq!(summary.total_tokens.total_tokens, 10);
+        assert_eq!(summary.total_tool_calls, 1);
+        assert_eq!(summary.prompt_cached_tool_outputs, 2);
+        assert_eq!(summary.tool_context_tokens_saved, 2);
+        assert_eq!(summary.total_compression_events, 1);
+        assert_eq!(summary.total_tokens_saved, 5);
+        assert_eq!(summary.non_tool_compression_tokens_saved, 3);
+        assert_eq!(summary.total_sync_mismatches, 0);
+        assert!(summary.sync_mismatch_breakdown.is_empty());
+
+        let by_model = storage.by_model(selected).await.expect("filtered by-model");
+        assert_eq!(by_model.len(), 1);
+        assert_eq!(by_model[0].model, "model-a");
+        assert_eq!(by_model[0].sessions, 1);
+        assert_eq!(by_model[0].rounds, 1);
+        assert_eq!(by_model[0].tool_calls, 1);
+        assert_eq!(by_model[0].tokens.total_tokens, 10);
+
+        let cleared_by_model = storage
+            .by_model(MetricsDateFilter {
+                model: Some("\t".to_string()),
+                ..MetricsDateFilter::default()
+            })
+            .await
+            .expect("blank model restores all-model by-model metrics");
+        assert_eq!(cleared_by_model.len(), 2);
+        assert!(cleared_by_model.iter().any(|row| row.model == "model-a"));
+        assert!(cleared_by_model.iter().any(|row| row.model == "model-b"));
+
+        let daily = storage
+            .daily_metrics_for_model(1, Some(now.date_naive()), Some("model-a".to_string()))
+            .await
+            .expect("filtered daily");
+        assert_eq!(daily.len(), 1);
+        assert_eq!(daily[0].total_sessions, 1);
+        assert_eq!(daily[0].total_rounds, 1);
+        assert_eq!(daily[0].total_tool_calls, 1);
+        assert_eq!(daily[0].total_token_usage.total_tokens, 10);
+        assert_eq!(
+            daily[0].tool_breakdown,
+            HashMap::from([("Read".to_string(), 1)])
+        );
+        assert_eq!(daily[0].model_breakdown.len(), 1);
+        assert!(daily[0].model_breakdown.contains_key("model-a"));
+
+        let cleared = storage
+            .summary(MetricsDateFilter {
+                model: Some("   ".to_string()),
+                ..MetricsDateFilter::default()
+            })
+            .await
+            .expect("blank model restores all-model summary");
+        assert_eq!(cleared.total_sessions, 2);
+        assert_eq!(cleared.total_tokens.total_tokens, 30);
+        assert_eq!(cleared.total_tool_calls, 2);
+        assert_eq!(cleared.total_sync_mismatches, 1);
+
+        let cleared_daily = storage
+            .daily_metrics_for_model(1, Some(now.date_naive()), Some(" ".to_string()))
+            .await
+            .expect("blank model restores all-model daily");
+        assert_eq!(cleared_daily[0].total_sessions, 2);
+        assert_eq!(cleared_daily[0].total_rounds, 2);
+        assert_eq!(cleared_daily[0].total_tool_calls, 2);
+        assert_eq!(cleared_daily[0].total_token_usage.total_tokens, 30);
+        assert_eq!(cleared_daily[0].model_breakdown.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn forward_daily_model_filter_matches_forward_summary_scope() {
+        let dir = tempdir().expect("temp dir");
+        let storage = SqliteMetricsStorage::new(dir.path().join("metrics.db"));
+        storage.init().await.expect("init storage");
+        let now = Utc
+            .with_ymd_and_hms(2026, 2, 10, 13, 0, 0)
+            .single()
+            .expect("valid datetime");
+
+        for (suffix, model, tokens) in [("a", "model-a", 5), ("b", "model-b", 9)] {
+            let id = format!("forward-filtered-{suffix}");
+            storage
+                .insert_forward_start(&id, "openai.responses", model, false, now)
+                .await
+                .expect("forward start");
+            storage
+                .complete_forward(
+                    &id,
+                    now,
+                    Some(200),
+                    ForwardStatus::Success,
+                    Some(TokenUsage {
+                        prompt_tokens: tokens,
+                        completion_tokens: 0,
+                        total_tokens: tokens,
+                    }),
+                    None,
+                    None,
+                )
+                .await
+                .expect("forward completion");
+        }
+
+        let selected_summary = storage
+            .forward_summary(ForwardMetricsFilter {
+                model: Some("model-a".to_string()),
+                ..ForwardMetricsFilter::default()
+            })
+            .await
+            .expect("filtered forward summary");
+        let selected_daily = storage
+            .forward_daily_metrics_for_model(1, Some(now.date_naive()), Some("model-a".to_string()))
+            .await
+            .expect("filtered forward daily");
+        assert_eq!(selected_summary.total_requests, 1);
+        assert_eq!(selected_summary.total_tokens.total_tokens, 5);
+        assert_eq!(selected_daily.len(), 1);
+        assert_eq!(selected_daily[0].total_sessions, 1);
+        assert_eq!(selected_daily[0].total_token_usage.total_tokens, 5);
+
+        let cleared = storage
+            .forward_daily_metrics_for_model(1, Some(now.date_naive()), Some("  ".to_string()))
+            .await
+            .expect("blank forward model restores all-model daily");
+        assert_eq!(cleared[0].total_sessions, 2);
+        assert_eq!(cleared[0].total_token_usage.total_tokens, 14);
+    }
+
+    #[tokio::test]
     async fn round_rollups_follow_round_day_and_model_while_sessions_follow_start() {
         let dir = tempdir().expect("temp dir");
         let storage = SqliteMetricsStorage::new(dir.path().join("metrics.db"));
@@ -4024,6 +4468,7 @@ mod tests {
             .by_model(MetricsDateFilter {
                 start_date: Some(day_two_date),
                 end_date: Some(day_two_date),
+                model: None,
             })
             .await
             .expect("day-two model rollup");
@@ -4037,6 +4482,7 @@ mod tests {
             .summary(MetricsDateFilter {
                 start_date: Some(day_two_date),
                 end_date: Some(day_two_date),
+                model: None,
             })
             .await
             .expect("day-two summary");
@@ -4477,6 +4923,7 @@ mod tests {
             .summary(MetricsDateFilter {
                 start_date: Some(NaiveDate::from_ymd_opt(2026, 2, 10).expect("valid date")),
                 end_date: Some(NaiveDate::from_ymd_opt(2026, 2, 10).expect("valid date")),
+                model: None,
             })
             .await
             .expect("day a summary");

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
@@ -91,8 +91,8 @@ use thiserror::Error;
 use crate::metrics::types::{
     DailyMetrics, ForwardEndpointMetrics, ForwardMetricsFilter, ForwardMetricsSummary,
     ForwardRequestMetrics, ForwardStatus, ForwardTokenDetails, MetricsDateFilter, MetricsSummary,
-    ModelMetrics, RoundMetrics, RoundStatus, SessionDetail, SessionMetrics, SessionMetricsFilter,
-    SessionStatus, TokenUsage, ToolCallMetrics,
+    ModelMetrics, ModelMetricsDateFilter, RoundMetrics, RoundStatus, SessionDetail, SessionMetrics,
+    SessionMetricsFilter, SessionStatus, TokenUsage, ToolCallMetrics,
 };
 
 /// Result type for metrics storage operations.
@@ -599,7 +599,6 @@ pub trait MetricsStorage: Send + Sync {
     /// let filter = MetricsDateFilter {
     ///     start_date: Some(NaiveDate::from_ymd_opt(2026, 2, 1).unwrap()),
     ///     end_date: Some(NaiveDate::from_ymd_opt(2026, 2, 28).unwrap()),
-    ///     model: None,
     /// };
     ///
     /// let summary = storage.summary(filter).await?;
@@ -607,6 +606,33 @@ pub trait MetricsStorage: Send + Sync {
     /// println!("Total tokens: {}", summary.total_tokens.total_tokens);
     /// ```
     async fn summary(&self, filter: MetricsDateFilter) -> MetricsResult<MetricsSummary>;
+
+    /// Retrieves aggregate chat metrics with an optional model restriction.
+    ///
+    /// The default preserves compatibility for existing storage
+    /// implementations when no model is selected. Implementations that support
+    /// model filtering should override this method.
+    async fn summary_filtered(
+        &self,
+        filter: ModelMetricsDateFilter,
+    ) -> MetricsResult<MetricsSummary> {
+        let ModelMetricsDateFilter {
+            start_date,
+            end_date,
+            model,
+        } = filter;
+        if normalize_filter_value(model).is_none() {
+            self.summary(MetricsDateFilter {
+                start_date,
+                end_date,
+            })
+            .await
+        } else {
+            Err(MetricsError::InvalidData(
+                "model-filtered summary metrics are not supported by this storage".to_string(),
+            ))
+        }
+    }
 
     /// Retrieves metrics grouped by AI model.
     ///
@@ -632,6 +658,33 @@ pub trait MetricsStorage: Send + Sync {
     /// }
     /// ```
     async fn by_model(&self, filter: MetricsDateFilter) -> MetricsResult<Vec<ModelMetrics>>;
+
+    /// Retrieves grouped model metrics with an optional model restriction.
+    ///
+    /// The default preserves compatibility for existing storage
+    /// implementations when no model is selected. Implementations that support
+    /// model filtering should override this method.
+    async fn by_model_filtered(
+        &self,
+        filter: ModelMetricsDateFilter,
+    ) -> MetricsResult<Vec<ModelMetrics>> {
+        let ModelMetricsDateFilter {
+            start_date,
+            end_date,
+            model,
+        } = filter;
+        if normalize_filter_value(model).is_none() {
+            self.by_model(MetricsDateFilter {
+                start_date,
+                end_date,
+            })
+            .await
+        } else {
+            Err(MetricsError::InvalidData(
+                "model-filtered grouped metrics are not supported by this storage".to_string(),
+            ))
+        }
+    }
 
     /// Retrieves session metrics with filtering and pagination.
     ///
@@ -1766,7 +1819,14 @@ impl MetricsStorage for SqliteMetricsStorage {
     }
 
     async fn summary(&self, filter: MetricsDateFilter) -> MetricsResult<MetricsSummary> {
-        let MetricsDateFilter {
+        self.summary_filtered(filter.into()).await
+    }
+
+    async fn summary_filtered(
+        &self,
+        filter: ModelMetricsDateFilter,
+    ) -> MetricsResult<MetricsSummary> {
+        let ModelMetricsDateFilter {
             start_date,
             end_date,
             model,
@@ -1921,7 +1981,14 @@ impl MetricsStorage for SqliteMetricsStorage {
     }
 
     async fn by_model(&self, filter: MetricsDateFilter) -> MetricsResult<Vec<ModelMetrics>> {
-        let MetricsDateFilter {
+        self.by_model_filtered(filter.into()).await
+    }
+
+    async fn by_model_filtered(
+        &self,
+        filter: ModelMetricsDateFilter,
+    ) -> MetricsResult<Vec<ModelMetrics>> {
+        let ModelMetricsDateFilter {
             start_date,
             end_date,
             model,
@@ -3387,8 +3454,8 @@ mod tests {
 
     use super::{MetricsStorage, SqliteMetricsStorage, ToolCallCompletion};
     use crate::metrics::types::{
-        ForwardMetricsFilter, ForwardStatus, ForwardTokenDetails, MetricsDateFilter, RoundStatus,
-        SessionMetricsFilter, SessionStatus, TokenUsage,
+        ForwardMetricsFilter, ForwardStatus, ForwardTokenDetails, MetricsDateFilter,
+        ModelMetricsDateFilter, RoundStatus, SessionMetricsFilter, SessionStatus, TokenUsage,
     };
 
     #[test]
@@ -4125,12 +4192,12 @@ mod tests {
             .await
             .expect("sync mismatch");
 
-        let selected = MetricsDateFilter {
+        let selected = ModelMetricsDateFilter {
             model: Some("model-a".to_string()),
-            ..MetricsDateFilter::default()
+            ..ModelMetricsDateFilter::default()
         };
         let summary = storage
-            .summary(selected.clone())
+            .summary_filtered(selected.clone())
             .await
             .expect("filtered summary");
         assert_eq!(summary.total_sessions, 1);
@@ -4146,7 +4213,10 @@ mod tests {
         assert_eq!(summary.total_sync_mismatches, 0);
         assert!(summary.sync_mismatch_breakdown.is_empty());
 
-        let by_model = storage.by_model(selected).await.expect("filtered by-model");
+        let by_model = storage
+            .by_model_filtered(selected)
+            .await
+            .expect("filtered by-model");
         assert_eq!(by_model.len(), 1);
         assert_eq!(by_model[0].model, "model-a");
         assert_eq!(by_model[0].sessions, 1);
@@ -4155,9 +4225,9 @@ mod tests {
         assert_eq!(by_model[0].tokens.total_tokens, 10);
 
         let cleared_by_model = storage
-            .by_model(MetricsDateFilter {
+            .by_model_filtered(ModelMetricsDateFilter {
                 model: Some("\t".to_string()),
-                ..MetricsDateFilter::default()
+                ..ModelMetricsDateFilter::default()
             })
             .await
             .expect("blank model restores all-model by-model metrics");
@@ -4182,9 +4252,9 @@ mod tests {
         assert!(daily[0].model_breakdown.contains_key("model-a"));
 
         let cleared = storage
-            .summary(MetricsDateFilter {
+            .summary_filtered(ModelMetricsDateFilter {
                 model: Some("   ".to_string()),
-                ..MetricsDateFilter::default()
+                ..ModelMetricsDateFilter::default()
             })
             .await
             .expect("blank model restores all-model summary");
@@ -4468,7 +4538,6 @@ mod tests {
             .by_model(MetricsDateFilter {
                 start_date: Some(day_two_date),
                 end_date: Some(day_two_date),
-                model: None,
             })
             .await
             .expect("day-two model rollup");
@@ -4482,7 +4551,6 @@ mod tests {
             .summary(MetricsDateFilter {
                 start_date: Some(day_two_date),
                 end_date: Some(day_two_date),
-                model: None,
             })
             .await
             .expect("day-two summary");
@@ -4923,7 +4991,6 @@ mod tests {
             .summary(MetricsDateFilter {
                 start_date: Some(NaiveDate::from_ymd_opt(2026, 2, 10).expect("valid date")),
                 end_date: Some(NaiveDate::from_ymd_opt(2026, 2, 10).expect("valid date")),
-                model: None,
             })
             .await
             .expect("day a summary");

--- a/crates/infra/bamboo-infrastructure/src/metrics/types.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/types.rs
@@ -287,6 +287,8 @@ pub struct MetricsDateFilter {
     pub start_date: Option<NaiveDate>,
     /// End date (inclusive)
     pub end_date: Option<NaiveDate>,
+    /// Filter by model name. Blank values are treated as no filter.
+    pub model: Option<String>,
 }
 
 /// Filter for session metrics queries

--- a/crates/infra/bamboo-infrastructure/src/metrics/types.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/types.rs
@@ -287,8 +287,31 @@ pub struct MetricsDateFilter {
     pub start_date: Option<NaiveDate>,
     /// End date (inclusive)
     pub end_date: Option<NaiveDate>,
+}
+
+/// Date and model filter for model-aware aggregate metrics queries.
+///
+/// This is intentionally separate from [`MetricsDateFilter`] so adding model
+/// filtering does not break downstream code that constructs the original
+/// public type with a complete struct literal.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ModelMetricsDateFilter {
+    /// Start date (inclusive)
+    pub start_date: Option<NaiveDate>,
+    /// End date (inclusive)
+    pub end_date: Option<NaiveDate>,
     /// Filter by model name. Blank values are treated as no filter.
     pub model: Option<String>,
+}
+
+impl From<MetricsDateFilter> for ModelMetricsDateFilter {
+    fn from(filter: MetricsDateFilter) -> Self {
+        Self {
+            start_date: filter.start_date,
+            end_date: filter.end_date,
+            model: None,
+        }
+    }
 }
 
 /// Filter for session metrics queries
@@ -533,6 +556,17 @@ mod tests {
         let filter = MetricsDateFilter::default();
         assert!(filter.start_date.is_none());
         assert!(filter.end_date.is_none());
+    }
+
+    #[test]
+    fn model_metrics_date_filter_from_legacy_filter_defaults_to_all_models() {
+        let legacy = MetricsDateFilter {
+            start_date: None,
+            end_date: None,
+        };
+        let filter = ModelMetricsDateFilter::from(legacy);
+
+        assert!(filter.model.is_none());
     }
 
     #[test]

--- a/crates/infra/bamboo-metrics/src/lib.rs
+++ b/crates/infra/bamboo-metrics/src/lib.rs
@@ -24,7 +24,7 @@ pub use storage::{MetricsError, MetricsResult, MetricsStorage, SqliteMetricsStor
 pub use types::{
     DailyMetrics, ForwardEndpointMetrics, ForwardMetricsFilter, ForwardMetricsSummary,
     ForwardRequestMetrics, ForwardStatus, ForwardTokenDetails, MetricsDateFilter, MetricsSummary,
-    ModelMetrics, RoundMetrics, RoundStatus, SessionDetail, SessionMetrics, SessionMetricsFilter,
-    SessionStatus, TokenUsage, ToolCallMetrics,
+    ModelMetrics, ModelMetricsDateFilter, RoundMetrics, RoundStatus, SessionDetail, SessionMetrics,
+    SessionMetricsFilter, SessionStatus, TokenUsage, ToolCallMetrics,
 };
 pub use worker::MetricsWorker;

--- a/crates/infra/bamboo-metrics/src/metrics_service.rs
+++ b/crates/infra/bamboo-metrics/src/metrics_service.rs
@@ -57,12 +57,19 @@ impl MetricsService {
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
     ) -> Result<MetricsSummary, MetricsError> {
-        self.storage
-            .summary(MetricsDateFilter {
-                start_date,
-                end_date,
-            })
-            .await
+        self.summary_filtered(MetricsDateFilter {
+            start_date,
+            end_date,
+            model: None,
+        })
+        .await
+    }
+
+    pub async fn summary_filtered(
+        &self,
+        filter: MetricsDateFilter,
+    ) -> Result<MetricsSummary, MetricsError> {
+        self.storage.summary(filter).await
     }
 
     pub async fn by_model(
@@ -70,12 +77,19 @@ impl MetricsService {
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
     ) -> Result<Vec<ModelMetrics>, MetricsError> {
-        self.storage
-            .by_model(MetricsDateFilter {
-                start_date,
-                end_date,
-            })
-            .await
+        self.by_model_filtered(MetricsDateFilter {
+            start_date,
+            end_date,
+            model: None,
+        })
+        .await
+    }
+
+    pub async fn by_model_filtered(
+        &self,
+        filter: MetricsDateFilter,
+    ) -> Result<Vec<ModelMetrics>, MetricsError> {
+        self.storage.by_model(filter).await
     }
 
     pub async fn sessions(
@@ -97,7 +111,18 @@ impl MetricsService {
         days: u32,
         end_date: Option<NaiveDate>,
     ) -> Result<Vec<DailyMetrics>, MetricsError> {
-        self.storage.daily_metrics(days, end_date).await
+        self.daily_for_model(days, end_date, None).await
+    }
+
+    pub async fn daily_for_model(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        model: Option<String>,
+    ) -> Result<Vec<DailyMetrics>, MetricsError> {
+        self.storage
+            .daily_metrics_for_model(days, end_date, model)
+            .await
     }
 
     pub async fn weekly(
@@ -105,7 +130,16 @@ impl MetricsService {
         days: u32,
         end_date: Option<NaiveDate>,
     ) -> Result<Vec<PeriodMetrics>, MetricsError> {
-        let daily = self.daily(days, end_date).await?;
+        self.weekly_for_model(days, end_date, None).await
+    }
+
+    pub async fn weekly_for_model(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        model: Option<String>,
+    ) -> Result<Vec<PeriodMetrics>, MetricsError> {
+        let daily = self.daily_for_model(days, end_date, model).await?;
         Ok(aggregate_weekly(&daily))
     }
 
@@ -114,7 +148,16 @@ impl MetricsService {
         days: u32,
         end_date: Option<NaiveDate>,
     ) -> Result<Vec<PeriodMetrics>, MetricsError> {
-        let daily = self.daily(days, end_date).await?;
+        self.monthly_for_model(days, end_date, None).await
+    }
+
+    pub async fn monthly_for_model(
+        &self,
+        days: u32,
+        end_date: Option<NaiveDate>,
+        model: Option<String>,
+    ) -> Result<Vec<PeriodMetrics>, MetricsError> {
+        let daily = self.daily_for_model(days, end_date, model).await?;
         Ok(aggregate_monthly(&daily))
     }
 
@@ -145,7 +188,12 @@ impl MetricsService {
         filter: ForwardMetricsFilter,
     ) -> Result<Vec<DailyMetrics>, MetricsError> {
         self.storage
-            .forward_daily_metrics(filter.limit.unwrap_or(30), filter.end_date)
+            .forward_daily_metrics_filtered(
+                filter.limit.unwrap_or(30),
+                filter.end_date,
+                filter.endpoint,
+                filter.model,
+            )
             .await
     }
 }
@@ -156,7 +204,74 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::{RoundStatus, SessionStatus, TokenUsage};
+    use crate::{ForwardStatus, RoundStatus, SessionStatus, TokenUsage};
+
+    #[tokio::test]
+    async fn forward_daily_preserves_endpoint_and_model_filters() {
+        let directory = tempdir().expect("metrics tempdir");
+        let service = MetricsService::new(directory.path().join("metrics.db"))
+            .await
+            .expect("metrics service");
+        let now = Utc::now();
+
+        for (suffix, endpoint, model, tokens) in [
+            ("a", "openai.responses", "model-a", 5),
+            ("b", "openai.responses", "model-b", 9),
+            ("c", "anthropic.messages", "model-a", 11),
+        ] {
+            let forward_id = format!("service-forward-{suffix}");
+            service
+                .storage
+                .insert_forward_start(&forward_id, endpoint, model, false, now)
+                .await
+                .expect("forward start");
+            service
+                .storage
+                .complete_forward(
+                    &forward_id,
+                    now,
+                    Some(200),
+                    ForwardStatus::Success,
+                    Some(TokenUsage {
+                        prompt_tokens: tokens,
+                        completion_tokens: 0,
+                        total_tokens: tokens,
+                    }),
+                    None,
+                    None,
+                )
+                .await
+                .expect("forward completion");
+        }
+
+        let selected = service
+            .forward_daily(ForwardMetricsFilter {
+                end_date: Some(now.date_naive()),
+                endpoint: Some("openai.responses".to_string()),
+                model: Some("model-a".to_string()),
+                limit: Some(1),
+                ..ForwardMetricsFilter::default()
+            })
+            .await
+            .expect("endpoint and model filtered forward daily");
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].total_sessions, 1);
+        assert_eq!(selected[0].total_token_usage.total_tokens, 5);
+
+        let cleared = service
+            .forward_daily(ForwardMetricsFilter {
+                end_date: Some(now.date_naive()),
+                endpoint: Some("openai.responses".to_string()),
+                model: Some("  ".to_string()),
+                limit: Some(1),
+                ..ForwardMetricsFilter::default()
+            })
+            .await
+            .expect("blank model restores all models for selected endpoint");
+        assert_eq!(cleared.len(), 1);
+        assert_eq!(cleared[0].total_sessions, 2);
+        assert_eq!(cleared[0].total_token_usage.total_tokens, 14);
+    }
 
     #[tokio::test]
     async fn weekly_and_monthly_preserve_round_attributed_daily_usage() {
@@ -309,5 +424,43 @@ mod tests {
         );
         assert_eq!(current_month_rollup.total_rounds, 1);
         assert_eq!(current_month_rollup.total_token_usage.total_tokens, 20);
+
+        let selected_weekly = service
+            .weekly_for_model(2, Some(current_month_date), Some("model-a".to_string()))
+            .await
+            .expect("model-filtered weekly metrics");
+        assert_eq!(
+            selected_weekly
+                .iter()
+                .map(|period| period.total_sessions)
+                .sum::<u32>(),
+            1
+        );
+        assert_eq!(
+            selected_weekly
+                .iter()
+                .map(|period| period.total_rounds)
+                .sum::<u32>(),
+            1
+        );
+        assert_eq!(
+            selected_weekly
+                .iter()
+                .map(|period| period.total_token_usage.total_tokens)
+                .sum::<u64>(),
+            10
+        );
+        assert!(selected_weekly
+            .iter()
+            .all(|period| !period.model_breakdown.contains_key("model-b")));
+
+        let selected_monthly = service
+            .monthly_for_model(2, Some(current_month_date), Some("model-a".to_string()))
+            .await
+            .expect("model-filtered monthly metrics");
+        assert_eq!(selected_monthly.len(), 1);
+        assert_eq!(selected_monthly[0].total_sessions, 1);
+        assert_eq!(selected_monthly[0].total_rounds, 1);
+        assert_eq!(selected_monthly[0].total_token_usage.total_tokens, 10);
     }
 }

--- a/crates/infra/bamboo-metrics/src/metrics_service.rs
+++ b/crates/infra/bamboo-metrics/src/metrics_service.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use crate::{
     aggregate_monthly, aggregate_weekly, DailyMetrics, ForwardEndpointMetrics,
     ForwardMetricsFilter, ForwardMetricsSummary, ForwardRequestMetrics, MetricsCollector,
-    MetricsDateFilter, MetricsError, MetricsStorage, MetricsSummary, ModelMetrics, PeriodMetrics,
-    SessionDetail, SessionMetrics, SessionMetricsFilter, SqliteMetricsStorage,
+    MetricsDateFilter, MetricsError, MetricsStorage, MetricsSummary, ModelMetrics,
+    ModelMetricsDateFilter, PeriodMetrics, SessionDetail, SessionMetrics, SessionMetricsFilter,
+    SqliteMetricsStorage,
 };
 use bamboo_agent_core::Session;
 use chrono::NaiveDate;
@@ -57,19 +58,19 @@ impl MetricsService {
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
     ) -> Result<MetricsSummary, MetricsError> {
-        self.summary_filtered(MetricsDateFilter {
-            start_date,
-            end_date,
-            model: None,
-        })
-        .await
+        self.storage
+            .summary(MetricsDateFilter {
+                start_date,
+                end_date,
+            })
+            .await
     }
 
     pub async fn summary_filtered(
         &self,
-        filter: MetricsDateFilter,
+        filter: ModelMetricsDateFilter,
     ) -> Result<MetricsSummary, MetricsError> {
-        self.storage.summary(filter).await
+        self.storage.summary_filtered(filter).await
     }
 
     pub async fn by_model(
@@ -77,19 +78,19 @@ impl MetricsService {
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
     ) -> Result<Vec<ModelMetrics>, MetricsError> {
-        self.by_model_filtered(MetricsDateFilter {
-            start_date,
-            end_date,
-            model: None,
-        })
-        .await
+        self.storage
+            .by_model(MetricsDateFilter {
+                start_date,
+                end_date,
+            })
+            .await
     }
 
     pub async fn by_model_filtered(
         &self,
-        filter: MetricsDateFilter,
+        filter: ModelMetricsDateFilter,
     ) -> Result<Vec<ModelMetrics>, MetricsError> {
-        self.storage.by_model(filter).await
+        self.storage.by_model_filtered(filter).await
     }
 
     pub async fn sessions(
@@ -424,6 +425,17 @@ mod tests {
         );
         assert_eq!(current_month_rollup.total_rounds, 1);
         assert_eq!(current_month_rollup.total_token_usage.total_tokens, 20);
+
+        let legacy_summary = service
+            .summary(None, None)
+            .await
+            .expect("legacy all-model summary");
+        assert_eq!(legacy_summary.total_tokens.total_tokens, 30);
+        let legacy_by_model = service
+            .by_model(None, None)
+            .await
+            .expect("legacy all-model grouped metrics");
+        assert_eq!(legacy_by_model.len(), 2);
 
         let selected_weekly = service
             .weekly_for_model(2, Some(current_month_date), Some("model-a".to_string()))

--- a/crates/infra/bamboo-metrics/tests/public_api_compatibility.rs
+++ b/crates/infra/bamboo-metrics/tests/public_api_compatibility.rs
@@ -1,0 +1,12 @@
+use bamboo_metrics::MetricsDateFilter;
+
+#[test]
+fn legacy_metrics_date_filter_complete_struct_literal_still_compiles() {
+    let filter = MetricsDateFilter {
+        start_date: None,
+        end_date: None,
+    };
+
+    assert!(filter.start_date.is_none());
+    assert!(filter.end_date.is_none());
+}


### PR DESCRIPTION
## Summary

- add normalized `model` filtering to chat summary, daily, by-model, sessions, and unified v2 metrics
- scope tool usage through the owning round and preserve endpoint/model filters for forward daily aggregates
- return an empty sync-mismatch aggregate for model-scoped requests because mismatch rows have no model attribution
- preserve the published `MetricsDateFilter { start_date, end_date }` API and add a separate `ModelMetricsDateFilter` for model-aware queries
- keep legacy storage/service entry points and third-party `MetricsStorage` implementers source-compatible

## Root cause

Lotus exposed a model selector, but several Bamboo rollups ignored the model query. The dashboard therefore combined filtered records with global summary, timeline, tool, cache, compression, and forward values.

## User impact

Supports the complete model-scoped dashboard behavior required by bigduu/Lotus#137 without breaking downstream complete struct literals for the existing public date filter.

## Review follow-up

Independent review caught a source-compatibility regression in the first head. The follow-up restores the original public date filter shape, introduces an additive model-aware type, provides trait defaults, and adds an external-style compile regression test.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-infrastructure -p bamboo-metrics -p bamboo-server --all-targets`
- `cargo test -p bamboo-infrastructure metrics:: --no-fail-fast` (48 passed)
- `cargo test -p bamboo-metrics --no-fail-fast` (13 passed)
- public API compatibility integration test (1 passed)
- `cargo test -p bamboo-server handlers::agent::metrics --no-fail-fast` (28 passed)
- AppState reconciliation regression test (1 passed)
- live isolated API verification for v1 and v2 model-scoped summary/timeline responses

## Screenshots

Not applicable: backend-only changes.