### PR TITLE
fix(server): evict idle rate-limit keys

### DIFF
--- a/crates/app/bamboo-server/src/rate_limit.rs
+++ b/crates/app/bamboo-server/src/rate_limit.rs
@@ -9,6 +9,8 @@
 //! - per-key token-bucket throttling, backed by `governor`'s keyed rate
 //!   limiter (same GCRA algorithm, same `Quota::with_period(..).allow_burst(..)`
 //!   construction actix-governor's `GovernorConfigBuilder::finish()` used);
+//! - request-driven, single-flight eviction of idle keyed state via governor's
+//!   `retain_recent`, with no per-request or per-worker background tasks;
 //! - on throttle: `429 Too Many Requests` with `retry-after` and
 //!   `x-ratelimit-after` headers (seconds until the bucket admits again) and
 //!   Bamboo's canonical nested JSON error envelope;
@@ -24,8 +26,10 @@
 //! if ever needed, not a rewrite.
 
 use std::future::{ready, Ready};
-use std::num::NonZeroU32;
+use std::hash::Hash;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -35,6 +39,7 @@ use actix_web::http::StatusCode;
 use actix_web::{Error, HttpResponse, ResponseError};
 use futures::future::LocalBoxFuture;
 use governor::clock::{Clock, DefaultClock};
+use governor::middleware::NoOpMiddleware;
 use governor::state::keyed::DefaultKeyedStateStore;
 use governor::{Quota, RateLimiter as GovernorRateLimiter};
 
@@ -83,14 +88,142 @@ impl ResponseError for SimpleKeyExtractionError {
     }
 }
 
-type KeyedLimiter<Key> = GovernorRateLimiter<Key, DefaultKeyedStateStore<Key>, DefaultClock>;
+type KeyedLimiter<Key, C = DefaultClock> =
+    GovernorRateLimiter<Key, DefaultKeyedStateStore<Key>, C, NoOpMiddleware<<C as Clock>::Instant>>;
+
+/// Bound the number of newly observed request keys that can accumulate between
+/// governor state-store sweeps. Cleanup is request-driven: an idle server does
+/// no work, and traffic cannot create one background task per request/worker.
+const KEYED_STATE_CLEANUP_EVERY_REQUESTS: NonZeroU64 =
+    NonZeroU64::new(4_096).expect("cleanup interval is non-zero");
+
+struct KeyCleanupSchedule {
+    every_requests: NonZeroU64,
+    requests_since_cleanup: AtomicU64,
+    cleanup_in_progress: AtomicBool,
+    #[cfg(test)]
+    completed_cleanups: AtomicU64,
+}
+
+impl KeyCleanupSchedule {
+    fn new(every_requests: NonZeroU64) -> Self {
+        Self {
+            every_requests,
+            requests_since_cleanup: AtomicU64::new(0),
+            cleanup_in_progress: AtomicBool::new(false),
+            #[cfg(test)]
+            completed_cleanups: AtomicU64::new(0),
+        }
+    }
+
+    fn add_pending_requests(&self, additional: u64) -> u64 {
+        self.requests_since_cleanup
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |pending| {
+                Some(pending.saturating_add(additional))
+            })
+            .expect("saturating counter updates never fail")
+            .saturating_add(additional)
+    }
+
+    fn after_request(&self, cleanup: impl FnOnce()) {
+        let pending = self.add_pending_requests(1);
+        if pending < self.every_requests.get()
+            || self
+                .cleanup_in_progress
+                .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+                .is_err()
+        {
+            return;
+        }
+
+        let _cleanup_guard = CleanupInProgressGuard(&self.cleanup_in_progress);
+        let pending = self.requests_since_cleanup.swap(0, Ordering::AcqRel);
+        if pending < self.every_requests.get() {
+            // A concurrent sweep may have reset the counter after this request
+            // observed it as due. Preserve requests recorded since that sweep.
+            self.add_pending_requests(pending);
+            return;
+        }
+
+        cleanup();
+        #[cfg(test)]
+        self.completed_cleanups.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+struct CleanupInProgressGuard<'a>(&'a AtomicBool);
+
+impl Drop for CleanupInProgressGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+/// Shared keyed governor plus bounded, single-flight state maintenance.
+///
+/// `governor::retain_recent` only evicts a key once its GCRA state is
+/// indistinguishable from a fresh bucket, so a recent or still-throttled key is
+/// never reset by cleanup. The scan runs synchronously on at most one request
+/// after each request-count interval; it does not spawn or retain a task.
+struct ManagedKeyedLimiter<Key, C = DefaultClock>
+where
+    Key: Clone + Eq + Hash,
+    C: Clock,
+{
+    limiter: KeyedLimiter<Key, C>,
+    cleanup: KeyCleanupSchedule,
+}
+
+impl<Key, C> ManagedKeyedLimiter<Key, C>
+where
+    Key: Clone + Eq + Hash,
+    C: Clock,
+{
+    fn new(limiter: KeyedLimiter<Key, C>, cleanup_every: NonZeroU64) -> Self {
+        Self {
+            limiter,
+            cleanup: KeyCleanupSchedule::new(cleanup_every),
+        }
+    }
+
+    fn check_key(&self, key: &Key) -> Result<(), governor::NotUntil<C::Instant>> {
+        let decision = self.limiter.check_key(key);
+        self.cleanup.after_request(|| {
+            let before = self.limiter.len();
+            self.limiter.retain_recent();
+            if self.limiter.len() < before {
+                self.limiter.shrink_to_fit();
+            }
+        });
+        decision
+    }
+
+    fn now(&self) -> C::Instant {
+        self.limiter.clock().now()
+    }
+
+    #[cfg(test)]
+    fn key_count(&self) -> usize {
+        self.limiter.len()
+    }
+
+    #[cfg(test)]
+    fn requests_since_cleanup(&self) -> u64 {
+        self.cleanup.requests_since_cleanup.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn completed_cleanup_count(&self) -> u64 {
+        self.cleanup.completed_cleanups.load(Ordering::Relaxed)
+    }
+}
 
 /// Rate-limiter configuration: a shared quota + key extractor, cheap to
 /// clone (the limiter is behind an `Arc`) so the SAME bucket state is reused
 /// across every `App` factory invocation (actix spins up one `App` per
 /// worker thread) — mirrors `actix_governor::GovernorConfig`.
 pub struct RateLimiterConfig<K: KeyExtractor> {
-    limiter: Arc<KeyedLimiter<K::Key>>,
+    limiter: Arc<ManagedKeyedLimiter<K::Key>>,
     key_extractor: K,
 }
 
@@ -118,7 +251,10 @@ impl<K: KeyExtractor> RateLimiterConfig<K> {
             .expect("period must be non-zero")
             .allow_burst(burst);
         Self {
-            limiter: Arc::new(GovernorRateLimiter::keyed(quota)),
+            limiter: Arc::new(ManagedKeyedLimiter::new(
+                GovernorRateLimiter::keyed(quota),
+                KEYED_STATE_CLEANUP_EVERY_REQUESTS,
+            )),
             key_extractor,
         }
     }
@@ -126,7 +262,7 @@ impl<K: KeyExtractor> RateLimiterConfig<K> {
 
 /// Rate-limiting middleware factory — mirrors `actix_governor::Governor`.
 pub struct RateLimit<K: KeyExtractor> {
-    limiter: Arc<KeyedLimiter<K::Key>>,
+    limiter: Arc<ManagedKeyedLimiter<K::Key>>,
     key_extractor: K,
 }
 
@@ -163,7 +299,7 @@ where
 
 pub struct RateLimitMiddleware<S, K: KeyExtractor> {
     service: Rc<S>,
-    limiter: Arc<KeyedLimiter<K::Key>>,
+    limiter: Arc<ManagedKeyedLimiter<K::Key>>,
     key_extractor: K,
 }
 
@@ -196,9 +332,7 @@ where
                 Box::pin(async move { fut.await.map(|res| res.map_into_left_body()) })
             }
             Err(negative) => {
-                let wait_time = negative
-                    .wait_time_from(DefaultClock::default().now())
-                    .as_secs();
+                let wait_time = negative.wait_time_from(self.limiter.now()).as_secs();
                 let mut response = crate::error::json_error(
                     StatusCode::TOO_MANY_REQUESTS,
                     format!("Too many requests, retry in {wait_time}s"),
@@ -223,7 +357,12 @@ mod tests {
     use super::*;
     use actix_web::http::StatusCode as HttpStatusCode;
     use actix_web::{test, web, App, HttpResponse as Resp};
+    use governor::clock::FakeRelativeClock;
     use std::net::{IpAddr, Ipv4Addr};
+    use std::num::NonZeroU64;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::mpsc;
+    use std::thread;
 
     /// A trivial always-succeeds key extractor keyed on a fixed IP, used to
     /// unit-test the burst/refill behavior of [`RateLimitMiddleware`]
@@ -239,6 +378,196 @@ mod tests {
         fn extract(&self, _req: &ServiceRequest) -> Result<Self::Key, Self::KeyExtractionError> {
             Ok(self.0)
         }
+    }
+
+    #[actix_web::test]
+    async fn request_driven_cleanup_reclaims_stale_keys_and_keeps_recent_keys() {
+        let clock = FakeRelativeClock::default();
+        let quota = Quota::with_period(Duration::from_millis(100))
+            .expect("non-zero period")
+            .allow_burst(NonZeroU32::new(1).expect("non-zero burst"));
+        let limiter: KeyedLimiter<IpAddr, FakeRelativeClock> = GovernorRateLimiter::new(
+            quota,
+            DefaultKeyedStateStore::<IpAddr>::default(),
+            clock.clone(),
+        );
+        let limiter = ManagedKeyedLimiter::new(
+            limiter,
+            NonZeroU64::new(3).expect("non-zero cleanup interval"),
+        );
+        let stale = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let recent = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        let trigger = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+
+        assert!(limiter.check_key(&stale).is_ok());
+        clock.advance(Duration::from_millis(300));
+        assert!(limiter.check_key(&recent).is_ok());
+        assert_eq!(limiter.key_count(), 2);
+        assert_eq!(limiter.completed_cleanup_count(), 0);
+
+        assert!(limiter.check_key(&trigger).is_ok());
+        assert_eq!(limiter.completed_cleanup_count(), 1);
+        assert_eq!(
+            limiter.key_count(),
+            2,
+            "the stale key is evicted while the recent and triggering keys remain"
+        );
+        assert!(
+            limiter.check_key(&recent).is_err(),
+            "a recent key must retain its exhausted bucket instead of becoming fresh"
+        );
+    }
+
+    #[actix_web::test]
+    async fn cleanup_frequency_is_request_bounded_and_shared_by_config_clones() {
+        let key = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+        let config = RateLimiterConfig::new(Duration::from_secs(60), 1, FixedKeyExtractor(key));
+        let cloned = config.clone();
+        let middleware = RateLimit::new(&cloned);
+
+        assert!(Arc::ptr_eq(&config.limiter, &cloned.limiter));
+        assert!(Arc::ptr_eq(&config.limiter, &middleware.limiter));
+        assert!(config.limiter.check_key(&key).is_ok());
+        assert!(
+            cloned.limiter.check_key(&key).is_err(),
+            "clones must share the same per-key bucket"
+        );
+        assert_eq!(middleware.limiter.key_count(), 1);
+        assert_eq!(
+            middleware.limiter.requests_since_cleanup(),
+            2,
+            "the cleanup request counter must be shared with the limiter state"
+        );
+        assert_eq!(middleware.limiter.completed_cleanup_count(), 0);
+
+        let clock = FakeRelativeClock::default();
+        let quota = Quota::with_period(Duration::from_millis(100))
+            .expect("non-zero period")
+            .allow_burst(NonZeroU32::new(1).expect("non-zero burst"));
+        let limiter: KeyedLimiter<u32, FakeRelativeClock> =
+            GovernorRateLimiter::new(quota, DefaultKeyedStateStore::<u32>::default(), clock);
+        let limiter = ManagedKeyedLimiter::new(
+            limiter,
+            NonZeroU64::new(3).expect("non-zero cleanup interval"),
+        );
+
+        for key in 1..=2 {
+            assert!(limiter.check_key(&key).is_ok());
+        }
+        assert_eq!(limiter.completed_cleanup_count(), 0);
+        assert!(limiter.check_key(&3).is_ok());
+        assert_eq!(limiter.completed_cleanup_count(), 1);
+        for key in 4..=5 {
+            assert!(limiter.check_key(&key).is_ok());
+        }
+        assert_eq!(limiter.completed_cleanup_count(), 1);
+        assert!(limiter.check_key(&6).is_ok());
+        assert_eq!(limiter.completed_cleanup_count(), 2);
+
+        limiter
+            .cleanup
+            .requests_since_cleanup
+            .store(u64::MAX, Ordering::Relaxed);
+        assert!(limiter.check_key(&7).is_ok());
+        assert_eq!(limiter.completed_cleanup_count(), 3);
+        assert_eq!(
+            limiter.requests_since_cleanup(),
+            0,
+            "the long-lived request counter must saturate and clean up instead of wrapping"
+        );
+    }
+
+    #[actix_web::test]
+    async fn high_cardinality_cleanup_keeps_only_the_recent_request_window() {
+        const CLEANUP_INTERVAL: u64 = 8;
+
+        let clock = FakeRelativeClock::default();
+        let quota = Quota::with_period(Duration::from_millis(100))
+            .expect("non-zero period")
+            .allow_burst(NonZeroU32::new(1).expect("non-zero burst"));
+        let limiter: KeyedLimiter<u32, FakeRelativeClock> = GovernorRateLimiter::new(
+            quota,
+            DefaultKeyedStateStore::<u32>::default(),
+            clock.clone(),
+        );
+        let limiter = ManagedKeyedLimiter::new(
+            limiter,
+            NonZeroU64::new(CLEANUP_INTERVAL).expect("non-zero cleanup interval"),
+        );
+
+        for round in 0..3 {
+            clock.advance(Duration::from_millis(300));
+            let first_key = round * CLEANUP_INTERVAL;
+            for key in first_key..first_key + CLEANUP_INTERVAL {
+                assert!(limiter.check_key(&(key as u32)).is_ok());
+            }
+
+            assert_eq!(limiter.completed_cleanup_count(), round + 1);
+            assert_eq!(
+                limiter.key_count(),
+                CLEANUP_INTERVAL as usize,
+                "each sweep must reclaim the previous stale high-cardinality window"
+            );
+        }
+    }
+
+    #[actix_web::test]
+    async fn cleanup_is_single_flight_under_concurrent_requests() {
+        const CONCURRENT_REQUESTS: usize = 8;
+
+        let schedule = Arc::new(KeyCleanupSchedule::new(
+            NonZeroU64::new(1).expect("non-zero cleanup interval"),
+        ));
+        let cleanup_calls = Arc::new(AtomicUsize::new(0));
+        let (entered_tx, entered_rx) = mpsc::sync_channel(0);
+        let (release_tx, release_rx) = mpsc::sync_channel(0);
+
+        let first_cleanup = thread::spawn({
+            let schedule = Arc::clone(&schedule);
+            let cleanup_calls = Arc::clone(&cleanup_calls);
+            move || {
+                schedule.after_request(|| {
+                    cleanup_calls.fetch_add(1, Ordering::Relaxed);
+                    entered_tx.send(()).expect("test receiver remains alive");
+                    release_rx.recv().expect("test sender remains alive");
+                });
+            }
+        });
+        entered_rx.recv().expect("cleanup must start");
+
+        let concurrent_requests = (0..CONCURRENT_REQUESTS)
+            .map(|_| {
+                let schedule = Arc::clone(&schedule);
+                let cleanup_calls = Arc::clone(&cleanup_calls);
+                thread::spawn(move || {
+                    schedule.after_request(|| {
+                        cleanup_calls.fetch_add(1, Ordering::Relaxed);
+                    });
+                })
+            })
+            .collect::<Vec<_>>();
+        for request in concurrent_requests {
+            request.join().expect("concurrent request must finish");
+        }
+
+        assert_eq!(cleanup_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(schedule.completed_cleanups.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            schedule.requests_since_cleanup.load(Ordering::Relaxed),
+            CONCURRENT_REQUESTS as u64,
+            "requests arriving during cleanup must be retained for the next sweep"
+        );
+
+        release_tx.send(()).expect("cleanup thread remains alive");
+        first_cleanup.join().expect("cleanup must finish");
+        assert_eq!(schedule.completed_cleanups.load(Ordering::Relaxed), 1);
+
+        schedule.after_request(|| {
+            cleanup_calls.fetch_add(1, Ordering::Relaxed);
+        });
+        assert_eq!(cleanup_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(schedule.completed_cleanups.load(Ordering::Relaxed), 2);
+        assert_eq!(schedule.requests_since_cleanup.load(Ordering::Relaxed), 0);
     }
 
     #[actix_web::test]


### PR DESCRIPTION
## Summary

- wrap the keyed governor limiter with shared request-driven maintenance
- evict idle, fresh-equivalent key state every 4096 requests without resetting active or throttled buckets
- make cleanup single-flight across Actix worker clones and protect the long-lived counter from overflow
- keep retry timing on the limiter's own clock and add deterministic stale-key, high-cardinality, clone-sharing, and concurrency coverage

## Root Cause

The server used governor's keyed state store without ever calling its retention APIs. Keys that stopped sending traffic therefore remained in the map indefinitely, allowing historical client cardinality to grow memory usage over a long-lived process.

## User Impact

Idle rate-limit entries are now reclaimed lazily under traffic while active clients retain their existing quota state. No background task or public API change is introduced.

## Test Plan

- `cargo test -p bamboo-server --lib` (1819 passed, 1 ignored)
- `cargo test -p bamboo-server --lib 'rate_limit::tests::' -- --test-threads=1` (7 passed)
- `cargo test -p bamboo-server --lib 'routes::tests::configure_routes_with_rate_limiting'`
- `cargo test -p bamboo-server --lib 'middleware::cors::tests::'`
- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-server --lib --no-deps -- -D warnings -A clippy::too_many_arguments`
- `cargo metadata --locked --all-features --format-version 1`
- `git diff --check`

Screenshots: N/A (backend-only change).

Fixes #583