### PR TITLE
feat(tui): make terminal shell responsive and accessible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tui-textarea-2",
+ "unicode-segmentation",
  "unicode-width",
 ]
 

--- a/crates/app/bamboo-tui/Cargo.toml
+++ b/crates/app/bamboo-tui/Cargo.toml
@@ -37,3 +37,4 @@ anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 base64 = "0.23"
 unicode-width = "0.2"
+unicode-segmentation = "1"

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -9,11 +9,11 @@ use chrono::{DateTime, Utc};
 use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers};
 use futures::StreamExt;
 use ratatui::backend::CrosstermBackend;
+use ratatui::style::{Modifier, Style};
 use ratatui::Terminal;
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, watch};
 use tui_textarea::{CursorMove, TextArea};
-use unicode_width::UnicodeWidthChar;
 
 use crate::api::sse::{SessionSseEvent, SseStream};
 use crate::api::types::*;
@@ -343,28 +343,7 @@ fn subagent_block_id(turn_id: &str, child_session_id: &str) -> String {
 /// only `str::lines()` would make the supposedly bounded inspector flood the
 /// transcript and leave j/k unable to reach the hidden portions.
 pub(crate) fn inspector_lines(value: &str, width: usize) -> Vec<String> {
-    let width = width.max(1);
-    let mut wrapped = Vec::new();
-    for logical in value.lines() {
-        if logical.is_empty() {
-            wrapped.push(String::new());
-            continue;
-        }
-
-        let mut line = String::new();
-        let mut cells = 0usize;
-        for character in logical.chars() {
-            let character_width = character.width().unwrap_or(1);
-            if !line.is_empty() && cells.saturating_add(character_width) > width {
-                wrapped.push(std::mem::take(&mut line));
-                cells = 0;
-            }
-            line.push(character);
-            cells = cells.saturating_add(character_width);
-        }
-        wrapped.push(line);
-    }
-    wrapped
+    crate::text::hard_wrap(value, width)
 }
 
 #[derive(Debug)]
@@ -469,6 +448,7 @@ impl ChatState {
     pub fn new() -> Self {
         let mut textarea = TextArea::default();
         textarea.set_placeholder_text(CHAT_PLACEHOLDER);
+        apply_textarea_palette(&mut textarea, crate::theme::ThemePalette::TrueColor);
         Self {
             session_id: None,
             project_id: None,
@@ -753,6 +733,20 @@ impl ChatState {
         self.current_turn_id = None;
         self.current_terminal_status = None;
     }
+}
+
+/// Remove `tui-textarea`'s fixed DarkGray/LightBlue defaults and express all
+/// editor state through Bamboo's selected palette.  Reversed/underlined
+/// modifiers remain meaningful in no-colour mode without assuming a terminal
+/// background, while the placeholder follows the semantic inactive role.
+fn apply_textarea_palette(textarea: &mut TextArea<'_>, palette: crate::theme::ThemePalette) {
+    textarea.set_style(Style::default());
+    textarea.set_placeholder_style(
+        Style::default().fg(palette.color(crate::theme::ColorRole::Inactive)),
+    );
+    textarea.set_cursor_line_style(Style::default().add_modifier(Modifier::UNDERLINED));
+    textarea.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
+    textarea.set_selection_style(Style::default().add_modifier(Modifier::REVERSED));
 }
 
 /// Result of a session resume (history + summary + pending question fetched
@@ -1150,6 +1144,7 @@ pub struct ScheduleForm {
     pub prompt: String,
     /// Focused field: 0 = name, 1 = cron, 2 = prompt.
     pub field: usize,
+    pub error: Option<String>,
 }
 
 impl ScheduleForm {
@@ -1167,6 +1162,7 @@ impl ScheduleForm {
 /// it is PATCHed to the server.
 pub struct ConfigEditor {
     pub textarea: TextArea<'static>,
+    pub error: Option<String>,
 }
 
 /// In-progress model picker (`Ctrl+O` on the Chat tab). Opens immediately with
@@ -1184,7 +1180,7 @@ pub struct ModelPicker {
 }
 
 impl ModelPicker {
-    fn selected_model(&self) -> Option<&CatalogModel> {
+    pub(crate) fn selected_model(&self) -> Option<&CatalogModel> {
         self.visible
             .get(self.selected)
             .and_then(|index| self.models.get(*index))
@@ -1286,7 +1282,7 @@ pub struct SessionPicker {
 }
 
 impl SessionPicker {
-    fn selected_session(&self) -> Option<&SessionSummary> {
+    pub(crate) fn selected_session(&self) -> Option<&SessionSummary> {
         self.visible
             .get(self.selected)
             .and_then(|index| self.sessions.get(*index))
@@ -1826,6 +1822,9 @@ pub fn discover_bamboo_bin(
 pub struct App {
     pub running: bool,
     pub tab: Tab,
+    pub theme: crate::theme::ThemePalette,
+    pub terminal_width: u16,
+    pub terminal_height: u16,
     pub client: BambooClient,
     pub chat: ChatState,
     pub sessions: SessionsState,
@@ -1836,6 +1835,8 @@ pub struct App {
     pub status_message: String,
     pub connected: bool,
     pub help_visible: bool,
+    pub help_scroll: u16,
+    pub help_max_scroll: Cell<u16>,
     pub spinner_tick: usize,
     /// Startup-only "start a local server?" y/n offer; see [`ServeOffer`].
     /// Set at most once, by `run`'s initial health check, and cleared by
@@ -1884,15 +1885,24 @@ pub struct App {
     /// session, and the actual DELETE runs off the event loop like every other
     /// mutation.
     pub pending_delete: Option<(String, String)>,
+    /// Pending schedule-delete confirmation (`d` on the Schedules tab):
+    /// `(id, name)` awaiting `y`/Enter confirm or `n`/Esc cancel.
+    pub pending_schedule_delete: Option<(String, String)>,
     /// Session id whose DELETE request is currently in flight. When it is the
     /// active Chat session, submission stays blocked until the result arrives
     /// so a concurrent chat POST cannot recreate the session being deleted.
     deleting_session_id: Option<String>,
+    /// Schedule id whose DELETE request is currently in flight.
+    deleting_schedule_id: Option<String>,
     /// Capped scrollback of past status messages so errors/warnings aren't lost
     /// when the single status line is overwritten. Viewed with `Ctrl+L`.
     pub notifications: Vec<Notification>,
     /// Whether the notification-log overlay is open.
     pub notifications_visible: bool,
+    /// First notification row shown in the log (newest-first). The renderer
+    /// records a bounded maximum so resize and input always stay reachable.
+    pub notification_scroll: u16,
+    pub notification_max_scroll: Cell<u16>,
     /// Count of warn/error notifications since the log was last opened; shown as
     /// a badge in the status bar.
     pub unseen_alerts: usize,
@@ -2002,6 +2012,9 @@ impl App {
         Self {
             running: true,
             tab: Tab::Chat,
+            theme: crate::theme::ThemePalette::TrueColor,
+            terminal_width: u16::MAX,
+            terminal_height: u16::MAX,
             client,
             chat: ChatState::new(),
             sessions: SessionsState::new(),
@@ -2012,6 +2025,8 @@ impl App {
             status_message: String::new(),
             connected: false,
             help_visible: false,
+            help_scroll: 0,
+            help_max_scroll: Cell::new(0),
             spinner_tick: 0,
             serve_offer: None,
             spawned_server: None,
@@ -2023,9 +2038,13 @@ impl App {
             session_picker: None,
             command_palette: None,
             pending_delete: None,
+            pending_schedule_delete: None,
             deleting_session_id: None,
+            deleting_schedule_id: None,
             notifications: Vec::new(),
             notifications_visible: false,
+            notification_scroll: 0,
+            notification_max_scroll: Cell::new(0),
             unseen_alerts: 0,
             answer_epoch: 0,
             answer_task: None,
@@ -2047,6 +2066,16 @@ impl App {
             sse_ready: None,
             stream_disconnected: false,
             pending_answer_run_started: false,
+        }
+    }
+
+    /// Select the semantic palette and apply it to stateful third-party
+    /// widgets whose styles are stored rather than resolved during render.
+    pub fn set_theme(&mut self, palette: crate::theme::ThemePalette) {
+        self.theme = palette;
+        apply_textarea_palette(&mut self.chat.textarea, palette);
+        if let Some(editor) = self.config_editor.as_mut() {
+            apply_textarea_palette(&mut editor.textarea, palette);
         }
     }
 
@@ -2109,7 +2138,9 @@ impl App {
                     Ok(Event::Mouse(mouse)) if tx.send(AppEvent::Mouse(mouse)).is_err() => {
                         break;
                     }
-                    Ok(Event::Resize(_, _)) if tx.send(AppEvent::Resize).is_err() => {
+                    Ok(Event::Resize(width, height))
+                        if tx.send(AppEvent::Resize(width, height)).is_err() =>
+                    {
                         break;
                     }
                     _ => {}
@@ -2127,6 +2158,9 @@ impl App {
 
         // Main event loop.
         while self.running {
+            let size = terminal.size()?;
+            self.terminal_width = size.width;
+            self.terminal_height = size.height;
             self.poll_sse();
             self.spinner_tick = self.spinner_tick.wrapping_add(1);
             terminal.draw(|f| ui::render(f, self))?;
@@ -2173,17 +2207,102 @@ impl App {
     }
 
     async fn handle_event(&mut self, event: AppEvent) -> Result<()> {
-        if self.help_visible && !self.any_modal_open() {
-            if let AppEvent::Key(_) = &event {
-                self.help_visible = false;
+        if let AppEvent::Resize(width, height) = event {
+            self.terminal_width = width;
+            self.terminal_height = height;
+            return Ok(());
+        }
+
+        let terminal_too_small = self.terminal_width < crate::ui::MIN_TERMINAL_WIDTH
+            || self.terminal_height < crate::ui::MIN_TERMINAL_HEIGHT;
+
+        // Stop/quit is the one global escape hatch that must preempt Help and
+        // the full-value log just as it preempts every interactive modal. At
+        // an unsupported size the only visible contract is "Ctrl+C quits",
+        // so it must quit in one press even when a hidden run is streaming.
+        if matches!(
+            &event,
+            AppEvent::Key(key)
+                if key.modifiers == KeyModifiers::CONTROL
+                    && key.code == KeyCode::Char('c')
+        ) && !terminal_too_small
+            && (self.help_visible || self.notifications_visible)
+        {
+            if self.chat.streaming {
+                self.stop_streaming();
+            } else {
+                self.running = false;
+            }
+            return Ok(());
+        }
+
+        if terminal_too_small {
+            // The compact warning replaces the interactive UI, so hidden
+            // keys and mouse gestures must not mutate it. Background work is
+            // different: SSE, loads, and mutation completions must keep
+            // advancing or a resize could strand the app in a stale state.
+            match &event {
+                AppEvent::Key(key) => {
+                    if key.modifiers == KeyModifiers::CONTROL && key.code == KeyCode::Char('c') {
+                        self.running = false;
+                    }
+                    return Ok(());
+                }
+                AppEvent::Mouse(_) => return Ok(()),
+                _ => {}
+            }
+        }
+
+        if self.notifications_visible {
+            if let AppEvent::Key(key) = &event {
+                let max = self.notification_max_scroll.get();
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        self.notification_scroll = self.notification_scroll.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        self.notification_scroll =
+                            self.notification_scroll.saturating_add(1).min(max);
+                    }
+                    KeyCode::PageUp => {
+                        self.notification_scroll = self.notification_scroll.saturating_sub(10);
+                    }
+                    KeyCode::PageDown => {
+                        self.notification_scroll =
+                            self.notification_scroll.saturating_add(10).min(max);
+                    }
+                    KeyCode::Home => self.notification_scroll = 0,
+                    KeyCode::End => self.notification_scroll = max,
+                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::F(1) => {
+                        self.notifications_visible = false;
+                    }
+                    _ => {}
+                }
                 return Ok(());
             }
         }
 
-        // The notification-log overlay is dismissed by any key.
-        if self.notifications_visible && !self.any_modal_open() {
-            if let AppEvent::Key(_) = &event {
-                self.notifications_visible = false;
+        if self.help_visible && !self.any_modal_open() {
+            if let AppEvent::Key(key) = &event {
+                let max = self.help_max_scroll.get();
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        self.help_scroll = self.help_scroll.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        self.help_scroll = self.help_scroll.saturating_add(1).min(max);
+                    }
+                    KeyCode::PageUp => self.help_scroll = self.help_scroll.saturating_sub(10),
+                    KeyCode::PageDown => {
+                        self.help_scroll = self.help_scroll.saturating_add(10).min(max);
+                    }
+                    KeyCode::Home => self.help_scroll = 0,
+                    KeyCode::End => self.help_scroll = max,
+                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::F(1) => {
+                        self.help_visible = false;
+                    }
+                    _ => {}
+                }
                 return Ok(());
             }
         }
@@ -2340,6 +2459,21 @@ impl App {
                     });
                 if reload_origin_picker {
                     self.reload_session_picker();
+                }
+                self.load_tab_data();
+            }
+            AppEvent::ScheduleDeleted {
+                schedule_id,
+                result,
+            } => {
+                if self.deleting_schedule_id.as_deref() == Some(schedule_id.as_str()) {
+                    self.deleting_schedule_id = None;
+                }
+                match result {
+                    Ok(()) => self.notify(NoticeLevel::Info, "Schedule deleted"),
+                    Err(error) => {
+                        self.notify(NoticeLevel::Error, format!("Delete failed: {error}"))
+                    }
                 }
                 self.load_tab_data();
             }
@@ -3214,6 +3348,32 @@ impl App {
     /// dead input.
     fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
         use crossterm::event::{MouseButton, MouseEventKind};
+        if self.notifications_visible {
+            let max = self.notification_max_scroll.get();
+            match mouse.kind {
+                MouseEventKind::ScrollUp => {
+                    self.notification_scroll = self.notification_scroll.saturating_sub(3);
+                }
+                MouseEventKind::ScrollDown => {
+                    self.notification_scroll = self.notification_scroll.saturating_add(3).min(max);
+                }
+                _ => {}
+            }
+            return;
+        }
+        if self.help_visible && !self.any_modal_open() {
+            let max = self.help_max_scroll.get();
+            match mouse.kind {
+                MouseEventKind::ScrollUp => {
+                    self.help_scroll = self.help_scroll.saturating_sub(3);
+                }
+                MouseEventKind::ScrollDown => {
+                    self.help_scroll = self.help_scroll.saturating_add(3).min(max);
+                }
+                _ => {}
+            }
+            return;
+        }
         if self.pending_question.is_some() {
             let mut submit = None;
             {
@@ -3278,6 +3438,7 @@ impl App {
         // hidden behind it; cancel then returns to the exact prior selection.
         if self.serve_offer.is_some()
             || self.pending_delete.is_some()
+            || self.pending_schedule_delete.is_some()
             || self.schedule_form.is_some()
             || self.config_editor.is_some()
         {
@@ -3645,11 +3806,12 @@ impl App {
 
     /// Whether an exclusive modal currently owns the keyboard. `F1`/Ctrl+`?`/
     /// Ctrl+L are gated on this so they can't stack a second overlay on top
-    /// of one of these seven — see the precedence comment on `handle_key`.
+    /// of one of these eight — see the precedence comment on `handle_key`.
     fn any_modal_open(&self) -> bool {
         self.serve_offer.is_some()
             || self.pending_question.is_some()
             || self.pending_delete.is_some()
+            || self.pending_schedule_delete.is_some()
             || self.session_picker.is_some()
             || self.model_picker.is_some()
             || self.command_palette.is_some()
@@ -3666,11 +3828,12 @@ impl App {
     ///   0. `serve_offer`      — startup-only "start a local server?" offer
     ///   1. `pending_question` — agent permission/clarification gate
     ///   2. `pending_delete`   — session delete confirmation
-    ///   3. `session_picker`   — Ctrl+P contextual session picker
-    ///   4. `model_picker`     — Ctrl+O provider-catalog picker
-    ///   5. `command_palette`  — Ctrl+K global or slash composer palette
-    ///   6. `schedule_form`    — new-schedule authoring form
-    ///   7. `config_editor`    — raw config JSON editor
+    ///   3. `pending_schedule_delete` — schedule delete confirmation
+    ///   4. `session_picker`   — Ctrl+P contextual session picker
+    ///   5. `model_picker`     — Ctrl+O provider-catalog picker
+    ///   6. `command_palette`  — Ctrl+K global or slash composer palette
+    ///   7. `schedule_form`    — new-schedule authoring form
+    ///   8. `config_editor`    — raw config JSON editor
     ///
     /// Runtime modals can coexist in state because a clarification arrives
     /// asynchronously. The renderer layers them in the reverse order below,
@@ -3709,10 +3872,12 @@ impl App {
                 // F1 opens help on every tab, including Chat, regardless of
                 // modifiers — unlike `?` it never collides with typing.
                 self.help_visible = true;
+                self.help_scroll = 0;
                 return Ok(());
             }
-            (KeyModifiers::CONTROL, KeyCode::Char('l')) if !self.any_modal_open() => {
+            (KeyModifiers::CONTROL, KeyCode::Char('l')) => {
                 self.notifications_visible = true;
+                self.notification_scroll = 0;
                 self.unseen_alerts = 0;
                 return Ok(());
             }
@@ -3738,25 +3903,32 @@ impl App {
             return self.handle_delete_confirm_key(key).await;
         }
 
-        // 3. The contextual session picker owns search/navigation/mutations.
+        // 3. Schedule deletion is also destructive and requires a second,
+        // explicit keystroke before the request can be sent.
+        if self.pending_schedule_delete.is_some() {
+            self.handle_schedule_delete_confirm_key(key);
+            return Ok(());
+        }
+
+        // 4. The contextual session picker owns search/navigation/mutations.
         if self.session_picker.is_some() {
             return self.handle_session_picker_key(key).await;
         }
 
-        // 4. The model picker likewise captures all input (navigation/apply)
+        // 5. The model picker likewise captures all input (navigation/apply)
         // before the global bindings below — same pattern as the other
         // modals.
         if self.model_picker.is_some() {
             return self.handle_model_picker_key(key).await;
         }
 
-        // 5. The command palette owns query/argument editing and selection.
+        // 6. The command palette owns query/argument editing and selection.
         if self.command_palette.is_some() {
             self.handle_command_palette_key(key);
             return Ok(());
         }
 
-        // 6. The schedule-authoring modal likewise captures all input: Tab moves
+        // 7. The schedule-authoring modal likewise captures all input: Tab moves
         // between fields and digits belong in cron expressions, so it must run
         // before the global Tab/1-6 tab-switching below (which would otherwise
         // swallow those keys and never reach the form).
@@ -3765,7 +3937,7 @@ impl App {
             return Ok(());
         }
 
-        // 7. The config editor is a full multi-line text buffer, so it must claim
+        // 8. The config editor is a full multi-line text buffer, so it must claim
         // every key (digits, Tab, Enter/newlines) before the global navigation
         // below — same rationale as the schedule form.
         if self.config_editor.is_some() {
@@ -3808,6 +3980,7 @@ impl App {
         // Chat-safe way to reach help.
         if key.code == KeyCode::Char('?') && self.tab != Tab::Chat {
             self.help_visible = true;
+            self.help_scroll = 0;
             return Ok(());
         }
 
@@ -4538,6 +4711,50 @@ impl App {
         Ok(())
     }
 
+    /// Drive the schedule-delete confirmation. The server round-trip is
+    /// spawned off the event loop so redraw and input remain responsive.
+    fn handle_schedule_delete_confirm_key(&mut self, key: KeyEvent) {
+        let Some((id, _name)) = self.pending_schedule_delete.clone() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Enter => {
+                self.pending_schedule_delete = None;
+                if self.deleting_schedule_id.is_some() {
+                    self.notify(
+                        NoticeLevel::Warn,
+                        "Wait for the current schedule delete to finish",
+                    );
+                    return;
+                }
+                let Some(tx) = self.event_tx.clone() else {
+                    self.notify(
+                        NoticeLevel::Error,
+                        "Schedule delete is not attached to an event loop",
+                    );
+                    return;
+                };
+                self.deleting_schedule_id = Some(id.clone());
+                self.status_message = "Deleting schedule...".to_string();
+                let client = self.client.clone();
+                tokio::spawn(async move {
+                    let result = client
+                        .delete_schedule(&id)
+                        .await
+                        .map_err(|error| error.to_string());
+                    let _ = tx.send(AppEvent::ScheduleDeleted {
+                        schedule_id: id,
+                        result,
+                    });
+                });
+            }
+            KeyCode::Char('n') | KeyCode::Esc => {
+                self.pending_schedule_delete = None;
+            }
+            _ => {}
+        }
+    }
+
     /// Load the current tab's data WITHOUT blocking the event loop: mark the
     /// tab loading and spawn the fetch, which posts its result back as an
     /// `AppEvent` handled in `handle_event`.
@@ -4702,6 +4919,7 @@ impl App {
                 }
                 self.chat.textarea = TextArea::default();
                 self.chat.textarea.set_placeholder_text(CHAT_PLACEHOLDER);
+                apply_textarea_palette(&mut self.chat.textarea, self.theme);
                 self.send_message(input);
             }
             _ => {
@@ -6142,27 +6360,21 @@ impl App {
                 self.schedules.selected = self.schedules.selected.saturating_sub(1);
             }
             KeyCode::Char('d') => {
-                // Spawned off the event loop like every other mutation here
-                // (see `handle_mcp_key`'s connect/disconnect) — an inline
-                // `.await` on the UI thread would freeze the whole app
-                // (spinner, redraw, SSE receipt) for the round-trip.
-                if let (Some(schedule), Some(tx)) = (
-                    self.schedules.schedules.get(self.schedules.selected),
-                    self.event_tx.clone(),
-                ) {
-                    let id = schedule.id.clone();
-                    let client = self.client.clone();
-                    tokio::spawn(async move {
-                        let outcome = match client.delete_schedule(&id).await {
-                            Ok(()) => Ok("Schedule deleted".to_string()),
-                            Err(e) => Err(format!("Delete failed: {e}")),
-                        };
-                        let _ = tx.send(AppEvent::ActionDone {
-                            outcome,
-                            reload_tab: true,
-                            session_picker_epoch: None,
-                        });
-                    });
+                if self.deleting_schedule_id.is_some() {
+                    self.notify(
+                        NoticeLevel::Warn,
+                        "Wait for the current schedule delete to finish",
+                    );
+                    return Ok(());
+                }
+                if let Some(schedule) = self.schedules.schedules.get(self.schedules.selected) {
+                    self.pending_schedule_delete = Some((
+                        schedule.id.clone(),
+                        schedule
+                            .name
+                            .clone()
+                            .unwrap_or_else(|| "(unnamed)".to_string()),
+                    ));
                 }
             }
             KeyCode::Char('r') => {
@@ -6207,6 +6419,7 @@ impl App {
                 form.field = (form.field + 2) % 3;
             }
             KeyCode::Backspace => {
+                form.error = None;
                 form.current_mut().pop();
             }
             KeyCode::Enter => {
@@ -6214,7 +6427,7 @@ impl App {
                     || form.cron.trim().is_empty()
                     || form.prompt.trim().is_empty()
                 {
-                    self.status_message = "Fill in name, cron, and prompt".to_string();
+                    form.error = Some("Fill in name, cron, and prompt".to_string());
                     return;
                 }
                 let req = CreateScheduleRequest {
@@ -6250,6 +6463,7 @@ impl App {
                 }
             }
             KeyCode::Char(c) => {
+                form.error = None;
                 form.current_mut().push(c);
             }
             _ => {}
@@ -6319,8 +6533,11 @@ impl App {
                         let pretty =
                             serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string());
                         let lines: Vec<String> = pretty.lines().map(String::from).collect();
+                        let mut textarea = TextArea::new(lines);
+                        apply_textarea_palette(&mut textarea, self.theme);
                         self.config_editor = Some(ConfigEditor {
-                            textarea: TextArea::new(lines),
+                            textarea,
+                            error: None,
                         });
                     }
                     None => {
@@ -6367,12 +6584,15 @@ impl App {
                     }
                 }
                 Err(e) => {
-                    self.notify(NoticeLevel::Error, format!("Invalid JSON: {e}"));
+                    if let Some(editor) = self.config_editor.as_mut() {
+                        editor.error = Some(format!("Invalid JSON: {e}"));
+                    }
                 }
             }
             return Ok(());
         }
         if let Some(editor) = self.config_editor.as_mut() {
+            editor.error = None;
             editor.textarea.input(key);
         }
         Ok(())
@@ -7194,9 +7414,13 @@ impl App {
                 self.tab = Tab::Chat;
                 self.open_model_picker();
             }
-            BuiltinPaletteAction::Help => self.help_visible = true,
+            BuiltinPaletteAction::Help => {
+                self.help_visible = true;
+                self.help_scroll = 0;
+            }
             BuiltinPaletteAction::Notifications => {
                 self.notifications_visible = true;
+                self.notification_scroll = 0;
                 self.unseen_alerts = 0;
             }
             BuiltinPaletteAction::Stop => self.stop_streaming(),
@@ -7301,6 +7525,7 @@ impl App {
             .min(u16::MAX as usize) as u16;
         let mut textarea = TextArea::from(lines);
         textarea.set_placeholder_text(CHAT_PLACEHOLDER);
+        apply_textarea_palette(&mut textarea, self.theme);
         textarea.move_cursor(CursorMove::Jump(row, column));
         self.chat.textarea = textarea;
     }
@@ -8997,7 +9222,7 @@ mod question_tests {
         use ratatui::Terminal;
 
         let app = app_with_question(vec!["Approve", "Deny"]);
-        let backend = TestBackend::new(60, 24);
+        let backend = TestBackend::new(60, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
 
@@ -9006,6 +9231,159 @@ mod question_tests {
         let text: String = buf.content().iter().map(|c| c.symbol()).collect();
         assert!(text.contains("Run this command?"), "question text missing");
         assert!(text.contains("Approve"), "option label missing");
+        assert!(text.contains("Enter answer"), "question action missing");
+    }
+
+    fn minimum_modal_fingerprint(app: &App) -> u64 {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, app))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let mut hash = 0xcbf29ce484222325_u64;
+        let mut feed = |bytes: &[u8]| {
+            for byte in bytes {
+                hash ^= u64::from(*byte);
+                hash = hash.wrapping_mul(0x100000001b3);
+            }
+        };
+        feed(&buffer.area.width.to_le_bytes());
+        feed(&buffer.area.height.to_le_bytes());
+        for cell in buffer.content() {
+            feed(cell.symbol().as_bytes());
+            feed(&[0]);
+            feed(format!("{:?}|{:?}|{:?}", cell.fg, cell.bg, cell.modifier).as_bytes());
+            feed(&[0xff]);
+        }
+        hash
+    }
+
+    #[test]
+    fn every_modal_has_a_fixed_full_buffer_golden_at_minimum_size() {
+        let mut actual = Vec::new();
+
+        let mut help = App::new(BambooClient::new("http://127.0.0.1:0"));
+        help.help_visible = true;
+        actual.push(minimum_modal_fingerprint(&help));
+
+        let mut log = App::new(BambooClient::new("http://127.0.0.1:0"));
+        log.notifications_visible = true;
+        log.status_message = "状态🧭e\u{301}".to_string();
+        actual.push(minimum_modal_fingerprint(&log));
+
+        let mut delete = App::new(BambooClient::new("http://127.0.0.1:0"));
+        delete.pending_delete = Some((
+            "session-full-id".to_string(),
+            "会话🧭e\u{301} long-unbroken-title".repeat(5),
+        ));
+        actual.push(minimum_modal_fingerprint(&delete));
+
+        let mut schedule_delete = App::new(BambooClient::new("http://127.0.0.1:0"));
+        schedule_delete.pending_schedule_delete = Some((
+            "schedule-full-id".to_string(),
+            "计划🧭e\u{301} long-unbroken-name".repeat(5),
+        ));
+        actual.push(minimum_modal_fingerprint(&schedule_delete));
+
+        let mut schedule = App::new(BambooClient::new("http://127.0.0.1:0"));
+        schedule.schedule_form = Some(ScheduleForm {
+            name: "nightly-计划".to_string(),
+            cron: "0 0 * * *".to_string(),
+            prompt: format!("{}TAIL_🧭e\u{301}", "x".repeat(80)),
+            field: 2,
+            error: Some("Prompt cannot be empty".to_string()),
+        });
+        actual.push(minimum_modal_fingerprint(&schedule));
+
+        let mut config = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let mut textarea = TextArea::new(vec!["{ invalid JSON 配置🧭".to_string()]);
+        apply_textarea_palette(&mut textarea, config.theme);
+        config.config_editor = Some(ConfigEditor {
+            textarea,
+            error: Some("Invalid JSON at line 1".to_string()),
+        });
+        actual.push(minimum_modal_fingerprint(&config));
+
+        let mut question = app_with_question(vec!["批准🧭", "Deny"]);
+        question.pending_question.as_mut().unwrap().error = Some("Retry required".to_string());
+        actual.push(minimum_modal_fingerprint(&question));
+
+        let mut model = App::new(BambooClient::new("http://127.0.0.1:0"));
+        model.model_picker = Some(model_picker(vec![catalog_model(
+            "provider-a",
+            "模型🧭e\u{301}",
+            "Unicode model",
+            "Provider A",
+        )]));
+        actual.push(minimum_modal_fingerprint(&model));
+
+        let mut session = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let mut summary = bare_session("session-完整-id");
+        summary.title = "会话🧭e\u{301}".to_string();
+        summary.model = "provider/model".to_string();
+        session.session_picker = Some(contextual_session_picker(vec![summary]));
+        actual.push(minimum_modal_fingerprint(&session));
+
+        let mut commands = App::new(BambooClient::new("http://127.0.0.1:0"));
+        commands.open_command_palette(CommandPaletteTrigger::Global);
+        actual.push(minimum_modal_fingerprint(&commands));
+
+        let mut serve = App::new(BambooClient::new("http://127.0.0.1:0"));
+        serve.serve_offer = Some(ServeOffer {
+            url: format!("http://127.0.0.1:9562/{}", "long-path-".repeat(12)),
+        });
+        actual.push(minimum_modal_fingerprint(&serve));
+
+        assert_eq!(
+            actual,
+            vec![
+                3_754_701_473_256_146_053,
+                8_481_293_528_542_647_595,
+                12_575_992_514_826_633_301,
+                13_989_639_618_912_745_774,
+                465_778_487_439_365_817,
+                14_156_803_428_225_062_900,
+                17_914_074_169_692_835_981,
+                13_149_988_112_385_910_257,
+                5_948_328_123_032_448_941,
+                8_759_320_582_986_254_806,
+                4_446_556_145_525_268_495,
+            ],
+            "minimum-size modal golden changed"
+        );
+    }
+
+    #[test]
+    fn long_custom_question_tail_and_actions_are_visible_at_minimum_size() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = app_with_question(vec![]);
+        app.pending_question.as_mut().unwrap().custom = Some(format!(
+            "{}CUSTOM_TAIL_终点🧭e\u{301}",
+            "long-unbroken-".repeat(20)
+        ));
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("CUSTOM_TAIL_"), "input tail missing:\n{text}");
+        assert!(text.contains('终') && text.contains('点') && text.contains('🧭'));
+        assert!(text.contains('▏'), "input cursor missing:\n{text}");
+        assert!(
+            text.contains("Enter answer"),
+            "question action missing:\n{text}"
+        );
     }
 
     #[tokio::test]
@@ -9017,6 +9395,7 @@ mod question_tests {
         app.chat.session_id = Some("sess-1".to_string());
         app.config_editor = Some(ConfigEditor {
             textarea: tui_textarea::TextArea::new(vec!["CONFIG_EDITOR_SENTINEL".to_string()]),
+            error: None,
         });
         app.handle_sse_event(AgentEvent::NeedClarification {
             question: "VISIBLE_SECURITY_DECISION".to_string(),
@@ -9944,12 +10323,10 @@ mod question_tests {
         );
     }
 
-    /// F1/Ctrl+L must not stack the help/notification overlay on top of an
-    /// already-open modal — `any_modal_open` gates them so the keystroke
-    /// falls through to the modal's own handler instead (a no-op there,
-    /// since neither key means anything to the delete-confirm modal).
+    /// Help stays suppressed over a modal, while Ctrl+L deliberately opens a
+    /// topmost full-value inspector without destroying the underlying state.
     #[tokio::test]
-    async fn f1_and_ctrl_l_are_suppressed_while_a_modal_is_open() {
+    async fn help_is_suppressed_but_full_log_opens_over_a_modal() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.pending_delete = Some(("s1".to_string(), "My session".to_string()));
 
@@ -9963,10 +10340,92 @@ mod question_tests {
             .await
             .unwrap();
         assert!(
-            !app.notifications_visible,
-            "Ctrl+L must not open the log over a modal"
+            app.notifications_visible,
+            "Ctrl+L must expose full clipped values over a modal"
         );
         assert!(app.pending_delete.is_some(), "the modal must stay open");
+
+        use ratatui::backend::TestBackend;
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("delete session id"));
+        assert!(text.contains("s1"));
+        assert!(text.contains("Esc/q close"));
+
+        app.handle_event(AppEvent::Key(key(KeyCode::Esc)))
+            .await
+            .unwrap();
+        assert!(!app.notifications_visible);
+        assert!(app.pending_delete.is_some());
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("Delete session?"));
+    }
+
+    #[tokio::test]
+    async fn ctrl_c_preempts_help_and_full_log() {
+        for full_log in [false, true] {
+            let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+            app.help_visible = !full_log;
+            app.notifications_visible = full_log;
+            app.handle_event(AppEvent::Key(KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL,
+            )))
+            .await
+            .unwrap();
+            assert!(!app.running, "overlay must not trap Ctrl+C");
+        }
+    }
+
+    #[tokio::test]
+    async fn too_small_screen_ctrl_c_quits_once_even_with_hidden_streaming_overlay() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.help_visible = true;
+        app.handle_event(AppEvent::Resize(50, 15)).await.unwrap();
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL,
+        )))
+        .await
+        .unwrap();
+        assert!(!app.running);
+    }
+
+    #[test]
+    fn asynchronous_question_owns_mouse_over_hidden_help() {
+        use crossterm::event::{MouseEvent, MouseEventKind};
+
+        let mut app = app_with_question(vec!["One", "Two", "Three"]);
+        app.help_visible = true;
+        app.help_max_scroll.set(20);
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        });
+        assert_eq!(app.pending_question.as_ref().unwrap().selected, 2);
+        assert_eq!(app.help_scroll, 0, "hidden help must not consume the wheel");
     }
 
     #[test]
@@ -9990,6 +10449,29 @@ mod question_tests {
         assert!(!app.chat.auto_scroll);
         app.handle_mouse(ev(MouseEventKind::ScrollDown));
         assert_eq!(app.chat.scroll_offset, 10);
+    }
+
+    #[tokio::test]
+    async fn below_minimum_size_blocks_input_but_keeps_background_state_live() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = Tab::Chat;
+        app.handle_event(AppEvent::Resize(50, 15)).await.unwrap();
+
+        app.handle_event(AppEvent::Key(key(KeyCode::Char('3'))))
+            .await
+            .unwrap();
+        assert_eq!(app.tab, Tab::Chat);
+        assert_eq!(app.chat.textarea.lines().join("\n"), "");
+
+        app.handle_event(AppEvent::ActionDone {
+            outcome: Err("background failure remains visible".to_string()),
+            reload_tab: false,
+            session_picker_epoch: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(app.status_message, "background failure remains visible");
+        assert_eq!(app.notifications.len(), 1);
     }
 
     /// Scrolling down is clamped to `max_scroll` (set by the render function
@@ -10070,6 +10552,140 @@ mod question_tests {
     }
 
     #[tokio::test]
+    async fn schedule_delete_requires_confirmation_owns_mouse_and_guards_in_flight() {
+        use crossterm::event::{MouseEvent, MouseEventKind};
+
+        let schedule = |index: usize| Schedule {
+            id: format!("schedule-{index}"),
+            name: Some(format!("计划 {index} 🧭")),
+            cron: Some("0 * * * *".to_string()),
+            enabled: Some(true),
+            prompt: None,
+            last_run: None,
+            next_run: None,
+        };
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = Tab::Schedules;
+        app.schedules.schedules = (0..6).map(schedule).collect();
+        app.schedules.selected = 2;
+
+        app.handle_key(key(KeyCode::Char('d'))).await.unwrap();
+        assert_eq!(
+            app.pending_schedule_delete
+                .as_ref()
+                .map(|target| target.0.as_str()),
+            Some("schedule-2")
+        );
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        });
+        assert_eq!(app.schedules.selected, 2, "confirmation must own the wheel");
+        app.handle_key(key(KeyCode::Esc)).await.unwrap();
+        assert!(app.pending_schedule_delete.is_none());
+
+        app.deleting_schedule_id = Some("schedule-1".to_string());
+        app.handle_key(key(KeyCode::Char('d'))).await.unwrap();
+        assert!(app.pending_schedule_delete.is_none());
+        assert!(app.status_message.contains("Wait for the current"));
+    }
+
+    #[test]
+    fn schedule_delete_confirmation_keeps_unicode_target_and_actions_at_minimum_size() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.pending_schedule_delete = Some((
+            "schedule-full-id".to_string(),
+            "计划🧭e\u{301} very long delete target ".repeat(8),
+        ));
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("Delete schedule?"));
+        // Ratatui stores a blank continuation cell after each double-width
+        // glyph; assert the individual glyphs rather than a flat contiguous
+        // byte sequence.
+        assert!(text.contains('计'));
+        assert!(text.contains('划'));
+        assert!(text.contains("y / Enter confirm"));
+        assert!(text.contains("n / Esc cancel"));
+    }
+
+    #[test]
+    fn schedule_form_and_config_editor_keep_inline_errors_actions_and_tail_at_minimum_size() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.schedule_form = Some(ScheduleForm {
+            name: "name".to_string(),
+            cron: "* * * * *".to_string(),
+            prompt: format!("{}PROMPT_TAIL_🧭e\u{301}", "x".repeat(120)),
+            field: 2,
+            error: Some("Cron is required".to_string()),
+        });
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        for needle in [
+            "PROMPT_TAIL_",
+            "Cron is required",
+            "Enter create",
+            "Esc cancel",
+        ] {
+            assert!(
+                text.contains(needle),
+                "schedule form missing {needle:?}:\n{text}"
+            );
+        }
+
+        app.schedule_form = None;
+        let mut textarea = TextArea::new(vec!["{ invalid JSON CONFIG_TAIL_🧭".to_string()]);
+        apply_textarea_palette(&mut textarea, app.theme);
+        app.config_editor = Some(ConfigEditor {
+            textarea,
+            error: Some("Invalid JSON at line 1".to_string()),
+        });
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        for needle in ["CONFIG_TAIL_", "Invalid JSON", "Ctrl+S save", "Esc cancel"] {
+            assert!(
+                text.contains(needle),
+                "config editor missing {needle:?}:\n{text}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn config_editor_opens_validates_and_cancels() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         let plain = |c| KeyEvent::new(c, KeyModifiers::empty());
@@ -10094,7 +10710,13 @@ mod question_tests {
             app.config_editor.is_some(),
             "invalid JSON must keep the editor open"
         );
-        assert!(app.status_message.contains("Invalid JSON"));
+        assert!(
+            app.config_editor
+                .as_ref()
+                .and_then(|editor| editor.error.as_deref())
+                .is_some_and(|error| error.contains("Invalid JSON")),
+            "validation errors must remain visible inside the editor modal"
+        );
 
         // Esc cancels.
         app.handle_key(plain(KeyCode::Esc)).await.unwrap();
@@ -10130,7 +10752,7 @@ mod question_tests {
         assert!(app.notifications_visible);
         assert_eq!(app.unseen_alerts, 0);
 
-        // Any key dismisses the overlay.
+        // Explicit close keys dismiss the overlay; navigation remains inside.
         app.handle_event(AppEvent::Key(KeyEvent::new(
             KeyCode::Char('q'),
             KeyModifiers::empty(),
@@ -10138,6 +10760,67 @@ mod question_tests {
         .await
         .unwrap();
         assert!(!app.notifications_visible);
+    }
+
+    #[test]
+    fn notification_footer_survives_large_terminals_and_deep_scrollback() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        for (width, height) in [(120, 40), (200, 60)] {
+            let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+            app.notifications_visible = true;
+            for index in 0..80 {
+                app.notify(
+                    if index % 2 == 0 {
+                        NoticeLevel::Warn
+                    } else {
+                        NoticeLevel::Info
+                    },
+                    format!("notification-{index}-{}", "long-unbroken".repeat(10)),
+                );
+            }
+            let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+            for offset in [0, u16::MAX / 2, u16::MAX] {
+                app.notification_scroll = offset;
+                terminal
+                    .draw(|frame| crate::ui::render(frame, &app))
+                    .unwrap();
+                let text: String = terminal
+                    .backend()
+                    .buffer()
+                    .content()
+                    .iter()
+                    .map(|cell| cell.symbol())
+                    .collect();
+                assert!(text.contains("Esc/q close"), "{width}x{height}:\n{text}");
+            }
+        }
+    }
+
+    #[test]
+    fn full_value_log_distinguishes_same_model_across_providers() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.model = "shared-model".to_string();
+        app.chat.provider = Some("provider-b".to_string());
+        app.notifications_visible = true;
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("shared-model"));
+        assert!(text.contains("model provider"));
+        assert!(text.contains("provider-b"));
     }
 
     #[test]
@@ -13786,7 +14469,7 @@ mod question_tests {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.session_picker = Some(contextual_session_picker(vec![session]));
 
-        let backend = TestBackend::new(60, 24);
+        let backend = TestBackend::new(60, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| crate::ui::render(frame, &app))
@@ -13803,6 +14486,49 @@ mod question_tests {
         assert!(text.contains("★"));
         assert!(text.contains("F2 rename"));
         assert!(text.contains("Esc cancel"));
+    }
+
+    #[test]
+    fn session_picker_keeps_selection_error_and_both_footers_at_minimum_size() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let sessions = (0..30)
+            .map(|index| {
+                let mut session = bare_session(&format!("session-{index}"));
+                session.title = format!("会话 {index} 🧭");
+                session
+            })
+            .collect::<Vec<_>>();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.session_picker = Some(contextual_session_picker(sessions));
+        let picker = app.session_picker.as_mut().unwrap();
+        picker.selected = 15;
+        picker.error = Some("load failed; Ctrl+R remains reachable".to_string());
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        for needle in [
+            "15 🧭",
+            "load failed",
+            "F2 rename",
+            "Del delete",
+            "Esc cancel",
+        ] {
+            assert!(text.contains(needle), "missing {needle:?}:\n{text}");
+        }
+        assert!(text.contains("more"), "window indicators missing:\n{text}");
     }
 
     #[test]
@@ -14399,7 +15125,7 @@ mod question_tests {
             "openai", "gpt-4.1", "GPT-4.1", "OpenAI",
         )]));
 
-        let backend = TestBackend::new(80, 24);
+        let backend = TestBackend::new(60, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
 
@@ -14409,6 +15135,47 @@ mod question_tests {
         assert!(text.contains("OpenAI"), "provider display name missing");
         assert!(text.contains("openai/gpt-4.1"), "provider/model id missing");
         assert!(text.contains("Esc cancel"), "narrow footer was clipped");
+    }
+
+    #[test]
+    fn model_picker_keeps_no_match_recovery_and_error_at_minimum_size() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.model_picker = Some(model_picker(vec![catalog_model(
+            "provider-with-long-id",
+            "model-with-long-id",
+            "Readable model",
+            "Readable provider",
+        )]));
+        let picker = app.model_picker.as_mut().unwrap();
+        picker.query = "no-match".to_string();
+        picker.refresh_filter(None);
+        picker.error = Some("catalog failed but recovery remains available".to_string());
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        for needle in [
+            "No models match",
+            "Ctrl+U",
+            "Ctrl+R",
+            "Esc cancel",
+            "catalog failed",
+        ] {
+            assert!(text.contains(needle), "missing {needle:?}:\n{text}");
+        }
     }
 }
 
@@ -14536,6 +15303,33 @@ mod auto_serve_tests {
         assert!(app.serve_offer.is_none());
         assert!(app.spawned_server.is_none());
         assert!(app.status_message.contains("--auto-serve"));
+    }
+
+    #[test]
+    fn serve_offer_long_url_keeps_both_actions_visible_at_minimum_size() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = app_with_offer();
+        app.serve_offer.as_mut().unwrap().url = format!(
+            "http://127.0.0.1:9562/{}?token={}",
+            "path-segment/".repeat(10),
+            "界🧭e\u{301}".repeat(20)
+        );
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        for needle in ["Ctrl+L inspect", "y / Enter start", "n / Esc skip"] {
+            assert!(text.contains(needle), "missing {needle:?}:\n{text}");
+        }
     }
 
     #[test]
@@ -14668,7 +15462,7 @@ mod auto_serve_tests {
         use ratatui::Terminal;
 
         let app = app_with_offer();
-        let backend = TestBackend::new(80, 24);
+        let backend = TestBackend::new(60, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
 
@@ -14676,5 +15470,7 @@ mod auto_serve_tests {
         let text: String = buf.content().iter().map(|c| c.symbol()).collect();
         assert!(text.contains("127.0.0.1:9562"), "offer URL missing");
         assert!(text.contains("Start a local"), "offer prompt missing");
+        assert!(text.contains("y / Enter start"), "start action missing");
+        assert!(text.contains("n / Esc skip"), "skip action missing");
     }
 }

--- a/crates/app/bamboo-tui/src/components/markdown.rs
+++ b/crates/app/bamboo-tui/src/components/markdown.rs
@@ -38,13 +38,13 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
         if let Some((level, content)) = heading(body) {
             let style = if level <= 1 {
                 Style::default()
-                    .fg(colors::BRAND)
+                    .fg(colors::brand())
                     .add_modifier(Modifier::BOLD)
             } else if level == 2 {
                 Style::default().add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
-                    .fg(colors::INACTIVE)
+                    .fg(colors::inactive())
                     .add_modifier(Modifier::BOLD)
             };
             let mut spans = vec![Span::styled(content.to_string(), style)];
@@ -63,7 +63,7 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
         {
             let mut spans = vec![Span::styled(
                 format!("{indent}│ "),
-                Style::default().fg(colors::THINKING),
+                Style::default().fg(colors::thinking()),
             )];
             spans.extend(parse_inline(content));
             lines.push(Line::from(spans));
@@ -74,7 +74,7 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
         if let Some((num, content)) = ordered_item(body) {
             let mut spans = vec![Span::styled(
                 format!("{indent}  {num}. "),
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             )];
             spans.extend(parse_inline(content));
             lines.push(Line::from(spans));
@@ -85,7 +85,7 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
         if let Some(content) = body.strip_prefix("- ").or_else(|| body.strip_prefix("* ")) {
             let mut spans = vec![Span::styled(
                 format!("{indent}  • "),
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             )];
             spans.extend(parse_inline(content));
             lines.push(Line::from(spans));
@@ -138,25 +138,30 @@ fn ordered_item(body: &str) -> Option<(&str, &str)> {
 
 fn render_code_block(lines: &mut Vec<Line>, code_lines: &[String], width: usize) {
     let inner_width = width.saturating_sub(4);
-    let top_border = format!("┌{}┐", "─".repeat(inner_width));
-    let bottom_border = format!("└{}┘", "─".repeat(inner_width));
+    // The content rows reserve one space on either side of the code. Keep the
+    // horizontal borders at the same terminal-cell width as those rows.
+    let border_width = inner_width.saturating_add(2);
+    let top_border = format!("┌{}┐", "─".repeat(border_width));
+    let bottom_border = format!("└{}┘", "─".repeat(border_width));
 
     lines.push(Line::from(Span::styled(
         top_border,
-        Style::default().fg(colors::CODE_BORDER),
+        Style::default().fg(colors::code_border()),
     )));
 
     for code_line in code_lines {
-        let padded = format!("│ {:<width$} │", code_line, width = inner_width);
+        let visible = crate::text::clip_cells(code_line, inner_width);
+        let padding = inner_width.saturating_sub(crate::text::display_width(&visible));
+        let padded = format!("│ {visible}{} │", " ".repeat(padding));
         lines.push(Line::from(Span::styled(
             padded,
-            Style::default().fg(colors::INACTIVE),
+            Style::default().fg(colors::inactive()),
         )));
     }
 
     lines.push(Line::from(Span::styled(
         bottom_border,
-        Style::default().fg(colors::CODE_BORDER),
+        Style::default().fg(colors::code_border()),
     )));
 }
 
@@ -183,7 +188,7 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
             spans.push(Span::styled(
                 code,
                 Style::default()
-                    .fg(colors::INACTIVE)
+                    .fg(colors::inactive())
                     .add_modifier(Modifier::REVERSED),
             ));
             continue;
@@ -196,13 +201,13 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
                 spans.push(Span::styled(
                     label,
                     Style::default()
-                        .fg(colors::BRAND)
+                        .fg(colors::brand())
                         .add_modifier(Modifier::UNDERLINED),
                 ));
                 if !url.is_empty() {
                     spans.push(Span::styled(
                         format!(" ({url})"),
-                        Style::default().fg(colors::SUBTLE),
+                        Style::default().fg(colors::subtle()),
                     ));
                 }
                 continue;
@@ -357,5 +362,16 @@ mod tests {
     fn italic_and_bold_distinct() {
         let out = render("_em_ and **strong** and `code`");
         assert_eq!(out[0], "em and strong and code");
+    }
+
+    #[test]
+    fn unicode_code_block_borders_share_one_cell_width() {
+        let rendered = render_markdown("```\n界e\u{301}👨‍👩‍👧‍👦\n```", 18);
+        let widths = rendered
+            .iter()
+            .map(|line| crate::text::display_width(&text_of(line)))
+            .collect::<Vec<_>>();
+        assert!(widths.iter().all(|width| *width == widths[0]), "{widths:?}");
+        assert_eq!(widths[0], 18);
     }
 }

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -16,7 +16,7 @@ pub enum AppEvent {
     Mouse(MouseEvent),
     /// Terminal resized; the next loop iteration redraws at the new size (the
     /// dimensions themselves aren't needed — ratatui re-measures on draw).
-    Resize,
+    Resize(u16, u16),
 
     // ── Non-blocking API results (posted by spawned tasks) ──
     SessionsLoaded(Loaded<ListSessionsEnvelope>),
@@ -43,6 +43,12 @@ pub enum AppEvent {
         session_id: String,
         result: Loaded<()>,
         session_picker_epoch: Option<u64>,
+    },
+    /// A schedule DELETE finished. Retaining the id prevents repeated confirm
+    /// keystrokes from issuing concurrent DELETE requests for the same row.
+    ScheduleDeleted {
+        schedule_id: String,
+        result: Loaded<()>,
     },
     /// A chat turn was created + started. The optimistic assistant turn id
     /// binds this late HTTP result to the draft that originated it.

--- a/crates/app/bamboo-tui/src/lib.rs
+++ b/crates/app/bamboo-tui/src/lib.rs
@@ -23,10 +23,12 @@ mod components;
 mod event;
 mod history;
 mod search;
+mod text;
 mod theme;
 mod ui;
 
 pub use app::AutoServeMode;
+pub use theme::ThemePalette;
 
 /// Default `--server-url`: the concrete loopback IPv4 (not `localhost`, which
 /// resolves to `::1` first on dual-stack hosts while the server default-binds
@@ -45,6 +47,9 @@ pub struct TuiOptions {
     /// How an unreachable loopback `server_url` is handled at startup:
     /// spawn a local `bamboo serve` automatically, offer y/n, or never.
     pub auto_serve: AutoServeMode,
+    /// Terminal colour strategy. `None` preserves true colour unless the
+    /// conventional `NO_COLOR` environment variable is present.
+    pub theme: Option<ThemePalette>,
 }
 
 impl Default for TuiOptions {
@@ -54,6 +59,7 @@ impl Default for TuiOptions {
             session_id: None,
             model: None,
             auto_serve: AutoServeMode::Prompt,
+            theme: None,
         }
     }
 }
@@ -70,6 +76,9 @@ pub async fn run(opts: TuiOptions) -> Result<()> {
         anyhow::bail!("bamboo tui requires an interactive terminal (stdin/stdout is not a TTY)");
     }
 
+    let palette =
+        theme::resolve_initial_palette(opts.theme, std::env::var_os("NO_COLOR").is_some());
+
     // Setup terminal.
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -80,6 +89,7 @@ pub async fn run(opts: TuiOptions) -> Result<()> {
     // Create client and app.
     let client = api::BambooClient::new(&opts.server_url);
     let mut app = app::App::new(client);
+    app.set_theme(palette);
 
     // Apply options.
     if let Some(session_id) = opts.session_id {

--- a/crates/app/bamboo-tui/src/main.rs
+++ b/crates/app/bamboo-tui/src/main.rs
@@ -3,7 +3,7 @@
 //! `bamboo tui` subcommand; keep the flag surfaces in lock-step.
 
 use anyhow::Result;
-use bamboo_tui::{AutoServeMode, TuiOptions};
+use bamboo_tui::{AutoServeMode, ThemePalette, TuiOptions};
 use clap::Parser;
 
 #[derive(Parser)]
@@ -25,6 +25,11 @@ struct Cli {
     /// Model to use
     #[arg(short, long)]
     model: Option<String>,
+
+    /// Colour palette: truecolor, system (terminal ANSI colours), or no-color.
+    /// `NO_COLOR` selects no-color when this flag is omitted.
+    #[arg(long)]
+    theme: Option<ThemePalette>,
 
     /// If `--server-url` is unreachable and loopback, start a local `bamboo
     /// serve` automatically instead of asking (y/n). No effect for a remote
@@ -55,6 +60,7 @@ async fn main() -> Result<()> {
         session_id: cli.session_id,
         model: cli.model,
         auto_serve,
+        theme: cli.theme,
     })
     .await
 }

--- a/crates/app/bamboo-tui/src/text.rs
+++ b/crates/app/bamboo-tui/src/text.rs
@@ -1,0 +1,131 @@
+//! Terminal-cell-aware text helpers.
+//!
+//! All clipping operates on grapheme clusters, never scalar values. This
+//! keeps combining marks and ZWJ emoji attached to their base glyph while
+//! still measuring the terminal cells they occupy.
+
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+pub fn display_width(value: &str) -> usize {
+    UnicodeWidthStr::width(value)
+}
+
+pub fn clip_cells(value: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    if display_width(value) <= max_width && !value.contains('\n') {
+        return value.to_string();
+    }
+
+    let target = max_width.saturating_sub(1);
+    let mut output = String::new();
+    let mut used = 0;
+    for grapheme in value.graphemes(true) {
+        if grapheme.contains('\n') {
+            break;
+        }
+        let width = display_width(grapheme);
+        if used + width > target {
+            break;
+        }
+        output.push_str(grapheme);
+        used += width;
+    }
+    output.push('…');
+    output
+}
+
+pub fn clip_tail_cells(value: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    if display_width(value) <= max_width && !value.contains('\n') {
+        return value.to_string();
+    }
+
+    let target = max_width.saturating_sub(1);
+    let mut suffix = Vec::new();
+    let mut used = 0;
+    for grapheme in value.graphemes(true).rev() {
+        if grapheme.contains('\n') {
+            break;
+        }
+        let width = display_width(grapheme);
+        if used + width > target {
+            break;
+        }
+        suffix.push(grapheme);
+        used += width;
+    }
+    suffix.reverse();
+    format!("…{}", suffix.concat())
+}
+
+pub fn truncate_cells(value: &str, max_width: usize) -> String {
+    let mut output = clip_cells(value, max_width);
+    let width = display_width(&output);
+    if width < max_width {
+        output.extend(std::iter::repeat_n(' ', max_width - width));
+    }
+    output
+}
+
+pub fn hard_wrap(value: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut output = Vec::new();
+    for logical in value.split('\n') {
+        let mut current = String::new();
+        let mut used = 0;
+        for grapheme in logical.graphemes(true) {
+            let grapheme_width = display_width(grapheme);
+            if !current.is_empty() && used + grapheme_width > width {
+                output.push(std::mem::take(&mut current));
+                used = 0;
+            }
+            current.push_str(grapheme);
+            used += grapheme_width;
+        }
+        output.push(current);
+    }
+    if output.is_empty() {
+        output.push(String::new());
+    }
+    output
+}
+
+pub fn wrapped_lines(value: &str, width: usize) -> Vec<String> {
+    hard_wrap(value, width)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clipping_never_splits_combining_or_zwj_graphemes() {
+        assert_eq!(clip_cells("Ae\u{301}B", 2), "A…");
+        assert_eq!(clip_cells("A👨‍👩‍👧‍👦B", 3), "A…");
+        assert_eq!(clip_tail_cells("Ae\u{301}B", 2), "…B");
+        assert_eq!(clip_tail_cells("A👨‍👩‍👧‍👦B", 3), "…B");
+    }
+
+    #[test]
+    fn wrapping_preserves_exact_grapheme_content() {
+        let input = "e\u{301}👨‍👩‍👧‍👦界suffix";
+        let lines = hard_wrap(input, 3);
+        assert_eq!(lines.concat(), input);
+        assert!(lines.iter().all(|line| display_width(line) <= 3));
+    }
+
+    #[test]
+    fn wrapping_never_splits_graphemes_at_cell_boundaries() {
+        let input = "ab👨‍👩‍👧‍👦e\u{301}界tail";
+        let lines = hard_wrap(input, 4);
+        assert_eq!(lines.concat(), input);
+        assert!(lines.iter().all(|line| display_width(line) <= 4));
+        assert!(lines.iter().any(|line| line.contains("👨‍👩‍👧‍👦")));
+        assert!(lines.iter().any(|line| line.contains("e\u{301}")));
+    }
+}

--- a/crates/app/bamboo-tui/src/theme.rs
+++ b/crates/app/bamboo-tui/src/theme.rs
@@ -1,18 +1,303 @@
+//! Terminal colour palette selection.
+//!
+//! Renderers resolve semantic roles through [`color`] (or the convenience
+//! functions in [`colors`]) so the palette selected for one frame is applied
+//! consistently without hard-coded colours leaking into widgets.
+
+use std::cell::Cell;
+use std::fmt;
+use std::str::FromStr;
+
+use ratatui::style::Color;
+
+/// The terminal colour strategy used by the TUI.
+///
+/// `System` deliberately uses named ANSI colours rather than fixed RGB values,
+/// allowing the terminal's own light/dark palette to provide the contrast.
+/// `NoColor` maps every role to [`Color::Reset`]; callers must therefore keep
+/// semantic text and glyphs (for example `error`/`!`/`x`) alongside colour.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ThemePalette {
+    /// Bamboo's existing 24-bit RGB palette.
+    #[default]
+    TrueColor = 0,
+    /// Named ANSI colours supplied by the terminal theme.
+    System = 1,
+    /// No foreground colour overrides.
+    NoColor = 2,
+}
+
+impl ThemePalette {
+    /// Canonical CLI/config spelling.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TrueColor => "truecolor",
+            Self::System => "system",
+            Self::NoColor => "no-color",
+        }
+    }
+
+    /// Whether this palette uses colour to enhance the UI.
+    pub const fn uses_color(self) -> bool {
+        !matches!(self, Self::NoColor)
+    }
+
+    /// Resolve one semantic role without consulting global state.
+    pub const fn color(self, role: ColorRole) -> Color {
+        match self {
+            Self::TrueColor => role.truecolor(),
+            Self::System => role.system_color(),
+            Self::NoColor => Color::Reset,
+        }
+    }
+}
+
+impl fmt::Display for ThemePalette {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Error returned when a CLI/config palette value is not recognised.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThemePaletteParseError {
+    value: String,
+}
+
+impl fmt::Display for ThemePaletteParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "unknown theme palette {:?}; expected truecolor, system, or no-color",
+            self.value
+        )
+    }
+}
+
+impl std::error::Error for ThemePaletteParseError {}
+
+impl FromStr for ThemePalette {
+    type Err = ThemePaletteParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let normalized = value.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "truecolor" | "true-color" | "24bit" | "24-bit" => Ok(Self::TrueColor),
+            "system" | "ansi" => Ok(Self::System),
+            "no-color" | "nocolor" | "none" => Ok(Self::NoColor),
+            _ => Err(ThemePaletteParseError {
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+/// Semantic foreground roles shared by all palettes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorRole {
+    Brand,
+    UserPrefix,
+    ToolRunning,
+    ToolDone,
+    ToolError,
+    Inactive,
+    Subtle,
+    Thinking,
+    CodeBorder,
+    Success,
+    Error,
+    Warning,
+}
+
+impl ColorRole {
+    const fn truecolor(self) -> Color {
+        match self {
+            Self::Brand => Color::Rgb(215, 119, 87),
+            Self::UserPrefix => Color::Rgb(122, 180, 232),
+            Self::ToolRunning | Self::Thinking => Color::Rgb(147, 165, 255),
+            Self::ToolDone | Self::Success => Color::Rgb(78, 186, 101),
+            Self::ToolError | Self::Error => Color::Rgb(255, 107, 128),
+            Self::Inactive => Color::Rgb(153, 153, 153),
+            Self::Subtle | Self::CodeBorder => Color::Rgb(80, 80, 80),
+            Self::Warning => Color::Rgb(255, 193, 7),
+        }
+    }
+
+    const fn system_color(self) -> Color {
+        match self {
+            Self::Brand => Color::Magenta,
+            Self::UserPrefix => Color::Cyan,
+            Self::ToolRunning | Self::Thinking => Color::Blue,
+            Self::ToolDone | Self::Success => Color::Green,
+            Self::ToolError | Self::Error => Color::Red,
+            // Reset inherits the terminal's foreground, which remains legible
+            // on both light and dark user-selected palettes.
+            Self::Inactive | Self::Subtle | Self::CodeBorder => Color::Reset,
+            Self::Warning => Color::Yellow,
+        }
+    }
+}
+
+thread_local! {
+    static ACTIVE_PALETTE: Cell<ThemePalette> = const { Cell::new(ThemePalette::TrueColor) };
+}
+
+/// Return the currently selected process-wide palette.
+pub fn active_palette() -> ThemePalette {
+    ACTIVE_PALETTE.get()
+}
+
+/// Resolve colours under `palette` for one synchronous render operation.
+/// The previous value is restored even when renderers are nested. A
+/// thread-local scope keeps parallel TestBackend snapshots independent.
+pub fn with_palette<T>(palette: ThemePalette, render: impl FnOnce() -> T) -> T {
+    struct Restore(ThemePalette);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            ACTIVE_PALETTE.set(self.0);
+        }
+    }
+
+    let restore = Restore(ACTIVE_PALETTE.replace(palette));
+    let result = render();
+    drop(restore);
+    result
+}
+
+/// Resolve the initial palette from an explicit CLI/config selection and the
+/// conventional `NO_COLOR` environment signal.
+///
+/// An explicit selection wins, allowing `--theme truecolor` to override an
+/// inherited `NO_COLOR`. Without an explicit selection, the presence of
+/// `NO_COLOR` selects [`ThemePalette::NoColor`], including when its value is
+/// empty. Otherwise the existing true-colour appearance is preserved.
+pub const fn resolve_initial_palette(
+    explicit: Option<ThemePalette>,
+    no_color_present: bool,
+) -> ThemePalette {
+    match explicit {
+        Some(palette) => palette,
+        None if no_color_present => ThemePalette::NoColor,
+        None => ThemePalette::TrueColor,
+    }
+}
+
+/// Resolve a semantic colour using the current process-wide palette.
+pub fn color(role: ColorRole) -> Color {
+    active_palette().color(role)
+}
+
 pub mod colors {
+    use super::{color, ColorRole};
     use ratatui::style::Color;
 
-    pub const BRAND: Color = Color::Rgb(215, 119, 87);
-    pub const USER_PREFIX: Color = Color::Rgb(122, 180, 232);
-    pub const TOOL_RUNNING: Color = Color::Rgb(147, 165, 255);
-    pub const TOOL_DONE: Color = Color::Rgb(78, 186, 101);
-    pub const TOOL_ERROR: Color = Color::Rgb(255, 107, 128);
-    pub const INACTIVE: Color = Color::Rgb(153, 153, 153);
-    pub const SUBTLE: Color = Color::Rgb(80, 80, 80);
-    pub const THINKING: Color = Color::Rgb(147, 165, 255);
-    pub const CODE_BORDER: Color = Color::Rgb(80, 80, 80);
-    pub const SUCCESS: Color = Color::Rgb(78, 186, 101);
-    pub const ERROR: Color = Color::Rgb(255, 107, 128);
-    pub const WARNING: Color = Color::Rgb(255, 193, 7);
+    macro_rules! palette_color {
+        ($name:ident, $role:ident) => {
+            #[doc = concat!("Return the current palette's `", stringify!($role), "` colour.")]
+            pub fn $name() -> Color {
+                color(ColorRole::$role)
+            }
+        };
+    }
+
+    palette_color!(brand, Brand);
+    palette_color!(user_prefix, UserPrefix);
+    palette_color!(tool_running, ToolRunning);
+    palette_color!(tool_done, ToolDone);
+    palette_color!(tool_error, ToolError);
+    palette_color!(inactive, Inactive);
+    palette_color!(subtle, Subtle);
+    palette_color!(thinking, Thinking);
+    palette_color!(code_border, CodeBorder);
+    palette_color!(success, Success);
+    palette_color!(error, Error);
+    palette_color!(warning, Warning);
 }
 
 pub const BRAILLE_SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_ROLES: [ColorRole; 12] = [
+        ColorRole::Brand,
+        ColorRole::UserPrefix,
+        ColorRole::ToolRunning,
+        ColorRole::ToolDone,
+        ColorRole::ToolError,
+        ColorRole::Inactive,
+        ColorRole::Subtle,
+        ColorRole::Thinking,
+        ColorRole::CodeBorder,
+        ColorRole::Success,
+        ColorRole::Error,
+        ColorRole::Warning,
+    ];
+
+    #[test]
+    fn parses_cli_palette_names_and_aliases() {
+        for (value, expected) in [
+            ("truecolor", ThemePalette::TrueColor),
+            ("TRUE-COLOR", ThemePalette::TrueColor),
+            ("24-bit", ThemePalette::TrueColor),
+            ("system", ThemePalette::System),
+            ("ansi", ThemePalette::System),
+            ("no-color", ThemePalette::NoColor),
+            ("none", ThemePalette::NoColor),
+        ] {
+            assert_eq!(value.parse::<ThemePalette>().unwrap(), expected);
+        }
+
+        let error = "rainbow".parse::<ThemePalette>().unwrap_err().to_string();
+        assert!(error.contains("rainbow"));
+        assert!(error.contains("truecolor, system, or no-color"));
+    }
+
+    #[test]
+    fn displays_canonical_cli_names() {
+        assert_eq!(ThemePalette::TrueColor.to_string(), "truecolor");
+        assert_eq!(ThemePalette::System.to_string(), "system");
+        assert_eq!(ThemePalette::NoColor.to_string(), "no-color");
+    }
+
+    #[test]
+    fn explicit_selection_precedes_no_color_and_default_is_truecolor() {
+        assert_eq!(
+            resolve_initial_palette(Some(ThemePalette::System), true),
+            ThemePalette::System
+        );
+        assert_eq!(resolve_initial_palette(None, true), ThemePalette::NoColor);
+        assert_eq!(
+            resolve_initial_palette(None, false),
+            ThemePalette::TrueColor
+        );
+    }
+
+    #[test]
+    fn no_color_resets_every_semantic_role() {
+        assert!(!ThemePalette::NoColor.uses_color());
+        for role in ALL_ROLES {
+            assert_eq!(ThemePalette::NoColor.color(role), Color::Reset);
+        }
+    }
+
+    #[test]
+    fn system_palette_uses_terminal_colors_and_reset_for_neutral_roles() {
+        assert_eq!(ThemePalette::System.color(ColorRole::Brand), Color::Magenta);
+        assert_eq!(ThemePalette::System.color(ColorRole::Success), Color::Green);
+        assert_eq!(ThemePalette::System.color(ColorRole::Error), Color::Red);
+        assert_eq!(
+            ThemePalette::System.color(ColorRole::Warning),
+            Color::Yellow
+        );
+        assert_eq!(
+            ThemePalette::System.color(ColorRole::Inactive),
+            Color::Reset
+        );
+        assert!(ALL_ROLES
+            .into_iter()
+            .all(|role| !matches!(ThemePalette::System.color(role), Color::Rgb(_, _, _))));
+    }
+}

--- a/crates/app/bamboo-tui/src/ui/chat.rs
+++ b/crates/app/bamboo-tui/src/ui/chat.rs
@@ -39,14 +39,14 @@ fn push_tool_detail(
             for aline in &argument_lines {
                 lines.push(Line::from(Span::styled(
                     format!("   args: {aline}"),
-                    Style::default().fg(colors::SUBTLE),
+                    Style::default().fg(colors::subtle()),
                 )));
             }
             let extra = argument_count.saturating_sub(3);
             if extra > 0 {
                 lines.push(Line::from(Span::styled(
                     format!("   … {extra} more argument lines"),
-                    Style::default().fg(colors::SUBTLE),
+                    Style::default().fg(colors::subtle()),
                 )));
             }
         } else {
@@ -57,7 +57,7 @@ fn push_tool_detail(
             let ellipsis = if argument_count > 1 { "…" } else { "" };
             lines.push(Line::from(Span::styled(
                 format!("   args: {preview}{ellipsis}"),
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             )));
         }
     }
@@ -90,13 +90,13 @@ fn push_tool_detail(
         if start > 0 {
             lines.push(Line::from(Span::styled(
                 format!("   ↑ {start} earlier lines"),
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             )));
         }
         for rline in &output_lines {
             lines.push(Line::from(Span::styled(
                 format!("   {rline}"),
-                Style::default().fg(colors::INACTIVE),
+                Style::default().fg(colors::inactive()),
             )));
         }
         let hidden_after = output_count.saturating_sub(start + limit);
@@ -107,7 +107,7 @@ fn push_tool_detail(
                 } else {
                     format!("   … {hidden_after} more — focus then Enter to inspect")
                 },
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             )));
         }
     }
@@ -128,14 +128,14 @@ fn push_tool_detail(
                 } else {
                     format!("          {line}")
                 },
-                Style::default().fg(colors::TOOL_ERROR),
+                Style::default().fg(colors::tool_error()),
             )));
         }
         let extra = error_count.saturating_sub(3);
         if extra > 0 {
             lines.push(Line::from(Span::styled(
                 format!("   … {extra} more error lines · y copies exact text"),
-                Style::default().fg(colors::TOOL_ERROR),
+                Style::default().fg(colors::tool_error()),
             )));
         }
     }
@@ -146,7 +146,7 @@ fn push_tool_detail(
             } else {
                 "   Enter expand · y copy"
             },
-            Style::default().fg(colors::SUBTLE),
+            Style::default().fg(colors::subtle()),
         )));
     }
 }
@@ -208,7 +208,7 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                 lines.push(Line::from(Span::styled(
                     if focused { "▸ user" } else { ">" },
                     Style::default()
-                        .fg(colors::USER_PREFIX)
+                        .fg(colors::user_prefix())
                         .add_modifier(if focused {
                             ratatui::style::Modifier::BOLD
                         } else {
@@ -218,7 +218,7 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                 for line in content.lines() {
                     lines.push(Line::from(Span::styled(
                         line.to_string(),
-                        Style::default().fg(colors::USER_PREFIX),
+                        Style::default().fg(colors::user_prefix()),
                     )));
                 }
             }
@@ -231,7 +231,7 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                             "▸ assistant"
                         },
                         Style::default()
-                            .fg(colors::BRAND)
+                            .fg(colors::brand())
                             .add_modifier(ratatui::style::Modifier::BOLD),
                     )));
                 }
@@ -253,7 +253,7 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                         if focused { "▸" } else { "──" },
                         if streaming { " · streaming" } else { "" }
                     ),
-                    Style::default().fg(colors::THINKING),
+                    Style::default().fg(colors::thinking()),
                 )));
                 if state.expanded {
                     let start = state
@@ -269,26 +269,26 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                     if start > 0 {
                         lines.push(Line::from(Span::styled(
                             format!(" ↑ {start} earlier lines"),
-                            Style::default().fg(colors::SUBTLE),
+                            Style::default().fg(colors::subtle()),
                         )));
                     }
                     for line in &detail {
                         lines.push(Line::from(Span::styled(
                             format!(" {line}"),
-                            Style::default().fg(colors::SUBTLE),
+                            Style::default().fg(colors::subtle()),
                         )));
                     }
                     let remaining = count.saturating_sub(start + CONVERSATION_DETAIL_VIEWPORT);
                     if remaining > 0 {
                         lines.push(Line::from(Span::styled(
                             format!(" ↓ {remaining} later lines"),
-                            Style::default().fg(colors::SUBTLE),
+                            Style::default().fg(colors::subtle()),
                         )));
                     }
                 } else {
                     lines.push(Line::from(Span::styled(
                         format!(" {count} reasoning lines hidden — focus then Enter to show"),
-                        Style::default().fg(colors::SUBTLE),
+                        Style::default().fg(colors::subtle()),
                     )));
                 }
                 if focused {
@@ -298,20 +298,20 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                         } else {
                             " Enter show · y copy"
                         },
-                        Style::default().fg(colors::SUBTLE),
+                        Style::default().fg(colors::subtle()),
                     )));
                 }
             }
             ConversationBlockKind::ToolCall { tool, streaming } => {
                 let tick = app.spinner_tick % theme::BRAILLE_SPINNER.len();
                 let (icon, style) = match tool.phase.as_str() {
-                    "complete" => ("✓", Style::default().fg(colors::TOOL_DONE)),
-                    "error" => ("✗", Style::default().fg(colors::TOOL_ERROR)),
+                    "complete" => ("✓", Style::default().fg(colors::tool_done())),
+                    "error" => ("✗", Style::default().fg(colors::tool_error())),
                     _ if streaming => (
                         theme::BRAILLE_SPINNER[tick],
-                        Style::default().fg(colors::TOOL_RUNNING),
+                        Style::default().fg(colors::tool_running()),
                     ),
-                    _ => ("●", Style::default().fg(colors::TOOL_RUNNING)),
+                    _ => ("●", Style::default().fg(colors::tool_running())),
                 };
                 lines.push(Line::from(Span::styled(
                     format!(
@@ -330,12 +330,12 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                     "running" | "running_in_background" | "queued" | "starting" | "in_progress" => {
                         (
                             theme::BRAILLE_SPINNER[tick],
-                            Style::default().fg(colors::TOOL_RUNNING),
+                            Style::default().fg(colors::tool_running()),
                         )
                     }
-                    "completed" => ("✓", Style::default().fg(colors::TOOL_DONE)),
-                    "error" | "cancelled" => ("✗", Style::default().fg(colors::TOOL_ERROR)),
-                    _ => ("·", Style::default().fg(colors::INACTIVE)),
+                    "completed" => ("✓", Style::default().fg(colors::tool_done())),
+                    "error" | "cancelled" => ("✗", Style::default().fg(colors::tool_error())),
+                    _ => ("·", Style::default().fg(colors::inactive())),
                 };
                 let label = child.title.as_deref().unwrap_or("sub-agent");
                 lines.push(Line::from(Span::styled(
@@ -351,7 +351,7 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                     if let Some(error) = &child.error {
                         lines.push(Line::from(Span::styled(
                             format!("   Error: {error}"),
-                            Style::default().fg(colors::TOOL_ERROR),
+                            Style::default().fg(colors::tool_error()),
                         )));
                     }
                 }
@@ -362,7 +362,7 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                         } else {
                             "   Enter open child · Ctrl+X expand/collapse · y copy"
                         },
-                        Style::default().fg(colors::SUBTLE),
+                        Style::default().fg(colors::subtle()),
                     )));
                 }
             }
@@ -392,16 +392,16 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                         " {} ? {kind} · {status}: {question}",
                         if focused { "▸" } else { " " }
                     ),
-                    Style::default().fg(colors::WARNING),
+                    Style::default().fg(colors::warning()),
                 )));
             }
             ConversationBlockKind::TerminalStatus(status) => {
                 lines.push(Line::from(Span::styled(
                     format!(" {} ─ {status}", if focused { "▸" } else { " " }),
                     Style::default().fg(if status.starts_with("error") {
-                        colors::TOOL_ERROR
+                        colors::tool_error()
                     } else {
-                        colors::INACTIVE
+                        colors::inactive()
                     }),
                 )));
             }
@@ -424,12 +424,12 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
     if lines.is_empty() {
         lines.push(Line::from(Span::styled(
             "  No messages yet. Type a message below to start.",
-            Style::default().fg(colors::INACTIVE),
+            Style::default().fg(colors::inactive()),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "  Tip: Use --model <name> to set the model.",
-            Style::default().fg(colors::SUBTLE),
+            Style::default().fg(colors::subtle()),
         )));
         visual_line_count = Paragraph::new(lines.clone())
             .wrap(Wrap { trim: false })

--- a/crates/app/bamboo-tui/src/ui/config.rs
+++ b/crates/app/bamboo-tui/src/ui/config.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::App;
@@ -10,14 +10,14 @@ use crate::theme::colors;
 pub fn render(f: &mut Frame, area: Rect, app: &App) {
     if app.config.loading && app.config.config.is_none() {
         let loading =
-            Paragraph::new("Loading config...").style(Style::default().fg(colors::INACTIVE));
+            Paragraph::new("Loading config...").style(Style::default().fg(colors::inactive()));
         f.render_widget(loading, area);
         return;
     }
 
     if let Some(err) = &app.config.error {
         let error =
-            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::ERROR));
+            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::error()));
         f.render_widget(error, area);
         return;
     }
@@ -29,52 +29,52 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
         None => "No config loaded".to_string(),
     };
 
-    let total_lines = config_text.lines().count() as u16;
-    // Recorded every frame so key handlers can clamp `scroll_offset` — see
-    // `ChatState::max_scroll`'s doc comment (same `Cell`-through-`&App`
-    // rationale applies here).
-    app.config
-        .max_scroll
-        .set(total_lines.saturating_sub(area.height));
-
-    let lines: Vec<Line> = config_text
+    let logical_lines: Vec<(String, Style)> = config_text
         .lines()
-        .skip(app.config.scroll_offset as usize)
         .map(|line| {
             let trimmed = line.trim();
             if trimmed.starts_with('"') && trimmed.contains(':') {
-                Line::from(Span::styled(
-                    line.to_string(),
-                    Style::default().fg(colors::BRAND),
-                ))
+                (line.to_string(), Style::default().fg(colors::brand()))
             } else if trimmed.starts_with('"') && trimmed.ends_with('"') {
-                Line::from(Span::styled(
-                    line.to_string(),
-                    Style::default().fg(colors::SUCCESS),
-                ))
+                (line.to_string(), Style::default().fg(colors::success()))
             } else if trimmed == "true" || trimmed == "false" {
-                Line::from(Span::styled(
-                    line.to_string(),
-                    Style::default().fg(colors::WARNING),
-                ))
+                (line.to_string(), Style::default().fg(colors::warning()))
             } else if trimmed.parse::<f64>().is_ok() {
-                Line::from(Span::styled(
-                    line.to_string(),
-                    Style::default().fg(colors::USER_PREFIX),
-                ))
+                (line.to_string(), Style::default().fg(colors::user_prefix()))
             } else {
-                Line::from(Span::raw(line.to_string()))
+                (line.to_string(), Style::default())
             }
         })
         .collect();
 
-    let config = Paragraph::new(lines)
-        .block(Block::default().title(Span::styled(
-            " Config (j/k scroll · e edit)",
-            Style::default().fg(colors::BRAND),
-        )))
-        .wrap(Wrap { trim: false });
-    f.render_widget(config, area);
+    // `Paragraph::wrap` intentionally avoids splitting some long words. JSON
+    // values can contain arbitrarily long tokens, so pre-wrap every logical
+    // line by grapheme/display cells and keep the original semantic style.
+    let lines: Vec<Line> = logical_lines
+        .into_iter()
+        .flat_map(|(line, style)| {
+            crate::text::hard_wrap(&line, area.width.max(1) as usize)
+                .into_iter()
+                .map(move |part| Line::from(Span::styled(part, style)))
+        })
+        .collect();
+
+    let visual_lines = lines.len();
+    let block = Block::default().title(Span::styled(
+        " Config (j/k scroll · e edit)",
+        Style::default().fg(colors::brand()),
+    ));
+    let viewport_height = block.inner(area).height as usize;
+    let config = Paragraph::new(lines).block(block);
+    // Scroll by terminal rows, not JSON logical lines. A single long token
+    // can wrap across multiple screens and must still have a reachable tail.
+    let max_scroll =
+        u16::try_from(visual_lines.saturating_sub(viewport_height)).unwrap_or(u16::MAX);
+    app.config.max_scroll.set(max_scroll);
+    f.render_widget(
+        config.scroll((app.config.scroll_offset.min(max_scroll), 0)),
+        area,
+    );
 }
 
 /// Modal raw-JSON editor, rendered over everything when `app.config_editor` is
@@ -84,15 +84,33 @@ pub fn render_editor(f: &mut Frame, app: &App) {
         return;
     };
     let screen = f.area();
-    let area = centered(screen, 80, 80);
+    let area = centered(screen, 94, 90);
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(colors::BRAND))
-        .title(" Edit config · Ctrl+S save · Esc cancel ");
+        .border_style(Style::default().fg(colors::brand()))
+        .title(" Edit config ");
     let inner = block.inner(area);
     f.render_widget(block, area);
-    f.render_widget(&editor.textarea, inner);
+    let error_height = u16::from(editor.error.is_some());
+    let chunks = ratatui::layout::Layout::vertical([
+        ratatui::layout::Constraint::Min(1),
+        ratatui::layout::Constraint::Length(error_height),
+        ratatui::layout::Constraint::Length(1),
+    ])
+    .split(inner);
+    f.render_widget(&editor.textarea, chunks[0]);
+    if let Some(error) = &editor.error {
+        f.render_widget(
+            Paragraph::new(crate::text::clip_cells(error, chunks[1].width as usize))
+                .style(Style::default().fg(colors::error())),
+            chunks[1],
+        );
+    }
+    f.render_widget(
+        Paragraph::new(" Ctrl+S save · Esc cancel").style(Style::default().fg(colors::inactive())),
+        chunks[2],
+    );
 }
 
 /// Rect covering `pw`%×`ph`% of `r`, centered. Percentage math is done in u32
@@ -103,4 +121,57 @@ fn centered(r: Rect, pw: u16, ph: u16) -> Rect {
     let x = r.x + r.width.saturating_sub(w) / 2;
     let y = r.y + r.height.saturating_sub(h) / 2;
     Rect::new(x, y, w, h)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::BambooClient;
+    use crate::app::{App, Tab};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn long_unbroken_config_value_scrolls_to_its_visual_tail() {
+        let sentinel = "CONFIG_VISUAL_TAIL_终点🧭";
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = Tab::Config;
+        app.config.config = Some(serde_json::json!({
+            "token": format!("{}{}", "a".repeat(2_000), sentinel)
+        }));
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        assert!(app.config.max_scroll.get() > 0);
+
+        app.config.scroll_offset = app.config.max_scroll.get();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(
+            text.contains("CONFIG_VISUAL_TAIL_")
+                && text.contains('终')
+                && text.contains('点')
+                && text.contains('🧭'),
+            "visual tail unreachable:\n{text}"
+        );
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .rev()
+                .any(|cell| cell.symbol() == "}"),
+            "the final JSON row is unreachable:\n{text}"
+        );
+    }
 }

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -14,6 +14,23 @@ use crate::app::{
 use crate::theme::{self, colors};
 use crate::ui::sessions::{session_row_line, truncate_cells};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutMode {
+    Compact,
+    Regular,
+    Wide,
+}
+
+pub fn layout_mode(area: Rect) -> LayoutMode {
+    if area.width < 80 || area.height < 24 {
+        LayoutMode::Compact
+    } else if area.width < 120 || area.height < 40 {
+        LayoutMode::Regular
+    } else {
+        LayoutMode::Wide
+    }
+}
+
 pub struct AppLayout {
     pub content: Rect,
     pub input: Rect,
@@ -24,18 +41,23 @@ pub struct AppLayout {
 pub fn app_layout(area: Rect, app: &App) -> AppLayout {
     let show_input = app.tab == Tab::Chat;
 
+    let input_height = match layout_mode(area) {
+        LayoutMode::Compact => 2,
+        LayoutMode::Regular | LayoutMode::Wide => 3,
+    };
+
     let vertical = Layout::default()
         .direction(Direction::Vertical)
         .constraints(if show_input {
             vec![
-                Constraint::Min(10),   // content
-                Constraint::Length(3), // input
+                Constraint::Min(1),
+                Constraint::Length(input_height),
                 Constraint::Length(1), // status info
                 Constraint::Length(1), // status tabs
             ]
         } else {
             vec![
-                Constraint::Min(10),   // content
+                Constraint::Min(1),
                 Constraint::Length(1), // status info
                 Constraint::Length(1), // status tabs
             ]
@@ -59,128 +81,196 @@ pub fn app_layout(area: Rect, app: &App) -> AppLayout {
     }
 }
 
-pub fn render_status_info(f: &mut Frame, area: Rect, app: &App) {
-    let mut spans = vec![];
+pub fn render_terminal_too_small(f: &mut Frame) {
+    let area = f.area();
+    let lines = vec![
+        Line::from(Span::styled(
+            "Terminal too small",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::raw(format!(
+            "Current: {}x{} · minimum: {}x{}",
+            area.width,
+            area.height,
+            crate::ui::MIN_TERMINAL_WIDTH,
+            crate::ui::MIN_TERMINAL_HEIGHT
+        )),
+        Line::raw("Resize the terminal to continue · Ctrl+C quits"),
+    ];
+    let width = area.width.min(48);
+    let height = area.height.min(5);
+    let popup = Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    );
+    f.render_widget(Clear, popup);
+    f.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}
 
-    // Streaming indicator
+pub fn render_status_info(f: &mut Frame, area: Rect, app: &App) {
+    let available = area.width as usize;
+    if available == 0 {
+        return;
+    }
+    let mut items: Vec<(String, Style)> = Vec::new();
+
+    // Urgent run/question/error state comes first. Lower-priority model,
+    // tokens and session metadata are appended only while cells remain.
     if app.chat.streaming {
         let tick = app.spinner_tick % theme::BRAILLE_SPINNER.len();
         let spinner = theme::BRAILLE_SPINNER[tick];
-        spans.push(Span::styled(
-            format!(" {} Streaming {}", spinner, spinner),
-            Style::default().fg(colors::TOOL_RUNNING),
+        items.push((
+            format!("{spinner} RUNNING"),
+            Style::default().fg(colors::tool_running()),
         ));
-        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
-        spans.push(Span::styled(
-            " draft editable; Enter sends after run ",
-            Style::default().fg(colors::INACTIVE),
+        items.push((
+            "draft editable; Enter sends after run".to_string(),
+            Style::default().fg(colors::inactive()),
         ));
-        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
+    } else if app.pending_question.is_some() || app.dismissed_question.is_some() {
+        items.push((
+            "? QUESTION".to_string(),
+            Style::default()
+                .fg(colors::warning())
+                .add_modifier(Modifier::BOLD),
+        ));
     }
 
     if app.chat.unseen_updates > 0 {
-        spans.push(Span::styled(
-            format!(" ↓ {} new · Ctrl+G jump ", app.chat.unseen_updates),
+        items.push((
+            format!("↓ {} NEW", app.chat.unseen_updates),
             Style::default()
-                .fg(colors::WARNING)
+                .fg(colors::warning())
                 .add_modifier(Modifier::BOLD),
         ));
-        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
     }
 
-    // Model
-    if !app.chat.model.is_empty() {
-        spans.push(Span::styled(
-            format!(" {}", app.chat.model),
-            Style::default().fg(colors::INACTIVE),
-        ));
-        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
-    }
-
-    // Token usage
-    if let Some(usage) = &app.chat.token_usage {
-        spans.push(Span::styled(
-            format!(" {}/{}", usage.completion_tokens, usage.total_tokens),
-            Style::default().fg(colors::INACTIVE),
-        ));
-        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
-    }
-
-    // Session
-    if let Some(sid) = &app.chat.session_id {
-        let short: String = sid.chars().take(8).collect();
-        spans.push(Span::styled(
-            format!(" {}...", short),
-            Style::default().fg(colors::INACTIVE),
-        ));
-        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
-    }
-
-    // Plan mode indicator
     if app.chat.plan_mode {
-        spans.push(Span::styled(
-            " PLAN ",
+        items.push((
+            "PLAN".to_string(),
             Style::default()
-                .fg(colors::WARNING)
+                .fg(colors::warning())
                 .add_modifier(Modifier::BOLD),
         ));
-        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
     }
 
-    // Unseen warning/error badge (Ctrl+L to view the log).
     if app.unseen_alerts > 0 {
-        spans.push(Span::styled(
-            format!(" ⚠ {} ", app.unseen_alerts),
+        items.push((
+            format!("! {} ALERTS", app.unseen_alerts),
             Style::default()
-                .fg(colors::WARNING)
+                .fg(colors::warning())
                 .add_modifier(Modifier::BOLD),
         ));
-        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
     }
 
-    // Connection indicator
-    if app.connected {
-        spans.push(Span::styled(" ● ", Style::default().fg(colors::SUCCESS)));
+    let (connection, connection_style) = if app.connected {
+        ("● ONLINE", Style::default().fg(colors::success()))
     } else {
-        spans.push(Span::styled(" ○ ", Style::default().fg(colors::ERROR)));
-    }
+        ("○ OFFLINE", Style::default().fg(colors::error()))
+    };
+    items.push((connection.to_string(), connection_style));
 
-    // Status message (right-aligned as remaining text)
     if !app.status_message.is_empty() {
-        spans.push(Span::styled(
-            format!(" {}", app.status_message),
-            Style::default().fg(colors::INACTIVE),
+        items.push((
+            app.status_message.clone(),
+            Style::default().fg(colors::inactive()),
         ));
     }
 
-    let line = Line::from(spans);
-    let status = Paragraph::new(line);
-    f.render_widget(status, area);
+    if !app.chat.model.is_empty() {
+        items.push((
+            format!("model {}", app.chat.model),
+            Style::default().fg(colors::inactive()),
+        ));
+    }
+    if let Some(usage) = &app.chat.token_usage {
+        items.push((
+            format!("tokens {}/{}", usage.completion_tokens, usage.total_tokens),
+            Style::default().fg(colors::inactive()),
+        ));
+    }
+    if let Some(sid) = &app.chat.session_id {
+        items.push((
+            format!("session {}", sid.chars().take(8).collect::<String>()),
+            Style::default().fg(colors::inactive()),
+        ));
+    }
+
+    let mut spans = Vec::new();
+    let mut used = 1_usize;
+    spans.push(Span::raw(" "));
+    for (index, (text, style)) in items.into_iter().enumerate() {
+        let separator = usize::from(index > 0) * 3;
+        if used + separator >= available {
+            break;
+        }
+        if index > 0 {
+            spans.push(Span::styled(" · ", Style::default().fg(colors::subtle())));
+            used += 3;
+        }
+        let remaining = available.saturating_sub(used);
+        let clipped = clip_cells(&text, remaining);
+        used += display_width(&clipped);
+        spans.push(Span::styled(clipped, style));
+        if used >= available {
+            break;
+        }
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
 pub fn render_tab_bar(f: &mut Frame, area: Rect, app: &App) {
-    let titles: Vec<Span> = Tab::ALL
+    let mode = layout_mode(area);
+    let full_width = Tab::ALL
         .iter()
         .enumerate()
-        .flat_map(|(i, tab)| {
-            let style = if *tab == app.tab {
-                Style::default()
-                    .fg(colors::BRAND)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(colors::INACTIVE)
-            };
-            let mut spans = vec![Span::styled(format!(" [{}]{} ", i + 1, tab.title()), style)];
+        .map(|(i, tab)| display_width(&format!(" [{}]{} ", i + 1, tab.title())))
+        .sum::<usize>()
+        + Tab::ALL.len().saturating_sub(1);
+    let use_full = mode != LayoutMode::Compact && full_width <= area.width as usize;
+    let mut spans = Vec::new();
+
+    if use_full {
+        for (i, tab) in Tab::ALL.iter().enumerate() {
+            let style = tab_style(*tab == app.tab);
+            spans.push(Span::styled(format!(" [{}]{} ", i + 1, tab.title()), style));
             if i < Tab::ALL.len() - 1 {
                 spans.push(Span::raw(" "));
             }
-            spans
-        })
-        .collect();
+        }
+    } else {
+        let active_index = Tab::ALL.iter().position(|tab| *tab == app.tab).unwrap_or(0);
+        let active = format!(" [{}] {} ", active_index + 1, app.tab.title());
+        let hint = " · Tab/Shift+Tab views · F1 help";
+        let active_width = display_width(&active);
+        let remaining = area.width.saturating_sub(active_width as u16) as usize;
+        spans.push(Span::styled(active, tab_style(true)));
+        if remaining > 0 {
+            spans.push(Span::styled(
+                clip_cells(hint, remaining),
+                Style::default().fg(colors::inactive()),
+            ));
+        }
+    }
 
-    let line = Line::from(titles);
-    let tabs = Paragraph::new(line);
-    f.render_widget(tabs, area);
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn tab_style(active: bool) -> Style {
+    if active {
+        Style::default()
+            .fg(colors::brand())
+            .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+    } else {
+        Style::default().fg(colors::inactive())
+    }
 }
 
 /// Every binding `App::handle_key`/the per-tab handlers respond to, paired
@@ -210,7 +300,7 @@ const HELP_RIGHT: &[(&str, &str)] = &[
     ("Ctrl+C", "Quit / stop streaming"),
     ("Ctrl+S", "Stop agent execution"),
     ("Ctrl+X", "Focused detail / new-block default"),
-    ("Ctrl+L", "Notification log"),
+    ("Ctrl+L", "Full values / notification log"),
     ("] / [", "Next / previous page (Sessions)"),
     ("d", "Delete, with confirm (Sessions/Schedules)"),
     ("n / e", "New schedule / edit config"),
@@ -218,85 +308,292 @@ const HELP_RIGHT: &[(&str, &str)] = &[
     ("F1 / ?", "Toggle this help (? not on Chat)"),
 ];
 
-pub fn render_help(f: &mut Frame) {
+pub fn render_help(f: &mut Frame, app: &App) {
     let screen = f.area();
     const KEY_COL: usize = 17;
-    let mut lines: Vec<Line> = vec![
-        Line::from(Span::styled(
-            " Keybindings",
-            Style::default()
-                .fg(colors::BRAND)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::raw(""),
-    ];
-    let rows = HELP_LEFT.len().max(HELP_RIGHT.len());
-    for i in 0..rows {
-        let (lk, ld) = HELP_LEFT.get(i).copied().unwrap_or(("", ""));
-        let (rk, rd) = HELP_RIGHT.get(i).copied().unwrap_or(("", ""));
-        lines.push(Line::raw(format!(
-            "  {lk:<KEY_COL$}{ld:<34}{rk:<KEY_COL$}{rd}"
-        )));
+    let popup_width = ((screen.width as u32 * 94 / 100) as u16).max(1);
+    let content_width = popup_width.saturating_sub(4) as usize;
+    let two_columns = content_width >= 96;
+    let mut entries = Vec::new();
+    if two_columns {
+        for i in 0..HELP_LEFT.len().max(HELP_RIGHT.len()) {
+            let (lk, ld) = HELP_LEFT.get(i).copied().unwrap_or(("", ""));
+            let (rk, rd) = HELP_RIGHT.get(i).copied().unwrap_or(("", ""));
+            entries.push(format!("  {lk:<KEY_COL$}{ld:<31}{rk:<KEY_COL$}{rd}"));
+        }
+    } else {
+        for (key, description) in HELP_LEFT.iter().chain(HELP_RIGHT.iter()) {
+            entries.push(format!("  {key:<KEY_COL$}{description}"));
+        }
     }
-    lines.push(Line::raw(""));
-    lines.push(Line::raw("  Press any key to close"));
 
-    let height = (lines.len() as u16 + 2).min(screen.height);
-    let area = centered_rect(90, height, screen);
+    let height = screen.height.min(26);
+    // The popup, not the terminal, is the limiting viewport. Reserve its two
+    // border rows plus header/footer and both possible overflow indicators so
+    // the close/scroll actions can never be pushed out on a tall narrow PTY.
+    let inner_height = height.saturating_sub(2) as usize;
+    let viewport = inner_height.saturating_sub(4).max(1);
+    let max_scroll = entries.len().saturating_sub(viewport);
+    let max_scroll = u16::try_from(max_scroll).unwrap_or(u16::MAX);
+    app.help_max_scroll.set(max_scroll);
+    let start = app.help_scroll.min(max_scroll) as usize;
+    let end = (start + viewport).min(entries.len());
+    let mut lines = vec![Line::from(Span::styled(
+        format!(
+            " Keybindings · rows {}-{} of {}",
+            if entries.is_empty() { 0 } else { start + 1 },
+            end,
+            entries.len()
+        ),
+        Style::default()
+            .fg(colors::brand())
+            .add_modifier(Modifier::BOLD),
+    ))];
+    if start > 0 {
+        lines.push(Line::raw(format!("  ↑ {start} earlier")));
+    }
+    lines.extend(
+        entries[start..end]
+            .iter()
+            .map(|line| Line::raw(clip_cells(line, content_width))),
+    );
+    if end < entries.len() {
+        lines.push(Line::raw(format!("  ↓ {} later", entries.len() - end)));
+    }
+    lines.push(Line::raw("  ↑/↓/PgUp/PgDn · Home/End · Esc/q close"));
+
+    let area = centered_rect(94, height, screen);
     f.render_widget(Clear, area);
     let help = Paragraph::new(lines).block(
         Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(colors::BRAND)),
+            .border_style(Style::default().fg(colors::brand())),
     );
     f.render_widget(help, area);
 }
 
 /// Notification-log overlay (`Ctrl+L`): recent status messages newest-first,
 /// colored by level, so errors/warnings aren't lost when the status line is
-/// overwritten. Dismissed by any key.
+/// overwritten. Esc/q closes it; navigation keys scroll internally.
 pub fn render_notifications(f: &mut Frame, app: &App) {
     let screen = f.area();
-    let mut lines: Vec<Line> = vec![
-        Line::from(Span::styled(
-            " Notifications",
-            Style::default()
-                .fg(colors::BRAND)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::raw(""),
-    ];
-
-    if app.notifications.is_empty() {
-        lines.push(Line::raw("  (nothing yet)"));
-    } else {
-        // Newest first; cap to what a reasonably tall modal can show.
-        let max_rows = (screen.height.saturating_sub(6)).min(30) as usize;
-        for n in app.notifications.iter().rev().take(max_rows) {
-            let (tag, color) = match n.level {
-                NoticeLevel::Info => ("info", colors::INACTIVE),
-                NoticeLevel::Warn => ("warn", colors::WARNING),
-                NoticeLevel::Error => ("err ", colors::ERROR),
-            };
-            lines.push(Line::from(vec![
+    let popup_width = ((screen.width as u32 * 94 / 100) as u16).max(1);
+    let content_width = popup_width.saturating_sub(4) as usize;
+    let mut entries: Vec<Line> = Vec::new();
+    {
+        let mut push_full_value = |label: &str, value: &str, color| {
+            if value.is_empty() {
+                return;
+            }
+            let prefix = format!("  {label}: ");
+            let continuation = " ".repeat(display_width(&prefix));
+            let text_width = content_width.saturating_sub(display_width(&prefix)).max(1);
+            let wrapped = crate::text::wrapped_lines(value, text_width);
+            entries.push(Line::from(vec![
+                Span::styled(prefix, Style::default().fg(colors::subtle())),
                 Span::styled(
-                    format!("  {} ", n.at.format("%H:%M:%S")),
-                    Style::default().fg(colors::SUBTLE),
+                    wrapped.first().cloned().unwrap_or_default(),
+                    Style::default().fg(color),
                 ),
-                Span::styled(format!("{tag}  "), Style::default().fg(color)),
-                Span::styled(n.text.clone(), Style::default().fg(color)),
             ]));
+            entries.extend(wrapped.into_iter().skip(1).map(|line| {
+                Line::from(vec![
+                    Span::raw(continuation.clone()),
+                    Span::styled(line, Style::default().fg(color)),
+                ])
+            }));
+        };
+
+        push_full_value(
+            "session",
+            app.chat.session_id.as_deref().unwrap_or(""),
+            colors::inactive(),
+        );
+        push_full_value("model", &app.chat.model, colors::inactive());
+        if let Some(provider) = app.chat.provider.as_deref() {
+            push_full_value("model provider", provider, colors::inactive());
+        }
+        push_full_value("status", &app.status_message, colors::inactive());
+        if let Some((id, title)) = &app.pending_delete {
+            push_full_value("delete session id", id, colors::error());
+            push_full_value("delete session title", title, colors::error());
+        }
+        if let Some((id, name)) = &app.pending_schedule_delete {
+            push_full_value("delete schedule id", id, colors::error());
+            push_full_value("delete schedule name", name, colors::error());
+        }
+        if let Some(offer) = &app.serve_offer {
+            push_full_value("server URL", &offer.url, colors::warning());
+        }
+        if let Some(session) = app
+            .session_picker
+            .as_ref()
+            .and_then(|picker| picker.selected_session())
+        {
+            push_full_value("selected session id", &session.id, colors::inactive());
+            push_full_value("selected session title", &session.title, colors::inactive());
+            push_full_value("selected session model", &session.model, colors::inactive());
+        }
+        if let Some(model) = app
+            .model_picker
+            .as_ref()
+            .and_then(|picker| picker.selected_model())
+        {
+            push_full_value(
+                "selected model name",
+                &model.display_name,
+                colors::inactive(),
+            );
+            push_full_value(
+                "selected model provider",
+                &model.provider_display_name,
+                colors::inactive(),
+            );
+            push_full_value(
+                "selected model id",
+                &format!("{}/{}", model.reference.provider, model.reference.model),
+                colors::inactive(),
+            );
+        }
+        let current_error = match app.tab {
+            Tab::Chat => None,
+            Tab::Sessions => app.sessions.error.as_deref(),
+            Tab::Mcp => app.mcp.error.as_deref(),
+            Tab::Schedules => app.schedules.error.as_deref(),
+            Tab::Skills => app.skills.error.as_deref(),
+            Tab::Config => app.config.error.as_deref(),
+        };
+        if let Some(error) = current_error {
+            push_full_value("view error", error, colors::error());
+        }
+        if let Some(error) = app
+            .pending_question
+            .as_ref()
+            .and_then(|question| question.error.as_deref())
+        {
+            push_full_value("question error", error, colors::error());
+        }
+        if let Some(error) = app
+            .model_picker
+            .as_ref()
+            .and_then(|picker| picker.error.as_deref())
+        {
+            push_full_value("model error", error, colors::error());
+        }
+        if let Some(error) = app
+            .session_picker
+            .as_ref()
+            .and_then(|picker| picker.error.as_deref())
+        {
+            push_full_value("session error", error, colors::error());
+        }
+        if let Some(picker) = &app.session_picker {
+            let mutation_error = match &picker.mode {
+                SessionPickerMode::Rename { error, .. }
+                | SessionPickerMode::Pinning { error, .. } => error.as_deref(),
+                SessionPickerMode::Browse => None,
+            };
+            if let Some(error) = mutation_error {
+                push_full_value("session mutation error", error, colors::error());
+            }
+        }
+        if let Some(error) = app
+            .command_palette
+            .as_ref()
+            .and_then(|palette| palette.error.as_deref())
+        {
+            push_full_value("command error", error, colors::error());
+        }
+        if let Some(error) = app
+            .config_editor
+            .as_ref()
+            .and_then(|editor| editor.error.as_deref())
+        {
+            push_full_value("editor error", error, colors::error());
+        }
+        if let Some(error) = app
+            .schedule_form
+            .as_ref()
+            .and_then(|form| form.error.as_deref())
+        {
+            push_full_value("form error", error, colors::error());
         }
     }
-    lines.push(Line::raw(""));
-    lines.push(Line::raw("  Press any key to close"));
 
-    let height = (lines.len() as u16 + 2).min(screen.height);
-    let area = centered_rect(70, height, screen);
+    if !entries.is_empty() && !app.notifications.is_empty() {
+        entries.push(Line::raw(""));
+    }
+    if app.notifications.is_empty() && entries.is_empty() {
+        entries.push(Line::raw("  (nothing yet)"));
+    } else {
+        for n in app.notifications.iter().rev() {
+            let (tag, color) = match n.level {
+                NoticeLevel::Info => ("info", colors::inactive()),
+                NoticeLevel::Warn => ("warn", colors::warning()),
+                NoticeLevel::Error => ("err ", colors::error()),
+            };
+            let marker = match n.level {
+                NoticeLevel::Info => "i",
+                NoticeLevel::Warn => "!",
+                NoticeLevel::Error => "x",
+            };
+            let prefix = format!("  {} {marker} {tag}  ", n.at.format("%H:%M:%S"));
+            let continuation = " ".repeat(display_width(&prefix));
+            let text_width = content_width.saturating_sub(display_width(&prefix)).max(1);
+            let wrapped = crate::text::wrapped_lines(&n.text, text_width);
+            entries.push(Line::from(vec![
+                Span::styled(prefix, Style::default().fg(colors::subtle())),
+                Span::styled(
+                    wrapped.first().cloned().unwrap_or_default(),
+                    Style::default().fg(color),
+                ),
+            ]));
+            entries.extend(wrapped.into_iter().skip(1).map(|line| {
+                Line::from(vec![
+                    Span::raw(continuation.clone()),
+                    Span::styled(line, Style::default().fg(color)),
+                ])
+            }));
+        }
+    }
+
+    let height = screen.height.min(32);
+    let inner_height = height.saturating_sub(2) as usize;
+    // Header, fixed action footer and both optional overflow indicators.
+    let viewport_rows = inner_height.saturating_sub(4).max(1);
+    let max_scroll = entries.len().saturating_sub(viewport_rows);
+    let max_scroll = u16::try_from(max_scroll).unwrap_or(u16::MAX);
+    app.notification_max_scroll.set(max_scroll);
+    let start = app.notification_scroll.min(max_scroll) as usize;
+    let end = (start + viewport_rows).min(entries.len());
+    let mut lines = vec![Line::from(Span::styled(
+        format!(
+            " Notifications · rows {}-{} of {}",
+            if entries.is_empty() { 0 } else { start + 1 },
+            end,
+            entries.len()
+        ),
+        Style::default()
+            .fg(colors::brand())
+            .add_modifier(Modifier::BOLD),
+    ))];
+    if start > 0 {
+        lines.push(Line::raw(format!("  ↑ {start} newer lines")));
+    }
+    lines.extend(entries[start..end].iter().cloned());
+    if end < entries.len() {
+        lines.push(Line::raw(format!(
+            "  ↓ {} older lines",
+            entries.len() - end
+        )));
+    }
+    lines.push(Line::raw("  ↑/↓/PgUp/PgDn scroll · Home/End · Esc/q close"));
+
+    let area = centered_rect(94, height, screen);
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(colors::BRAND))
+        .border_style(Style::default().fg(colors::brand()))
         .title(" Log ");
     f.render_widget(
         Paragraph::new(lines)
@@ -317,27 +614,34 @@ pub fn render_serve_offer(f: &mut Frame, app: &App) {
         return;
     };
 
+    let popup_width = ((f.area().width as u32 * 90 / 100) as u16).max(1);
+    let value_width = popup_width.saturating_sub(6) as usize;
     let lines = vec![
         Line::from(Span::styled(
             " Local server not reachable",
             Style::default()
-                .fg(colors::WARNING)
+                .fg(colors::warning())
                 .add_modifier(Modifier::BOLD),
         )),
         Line::raw(""),
-        Line::raw(format!("  {}", offer.url)),
+        Line::raw(format!(
+            "  {}",
+            crate::text::clip_cells(&offer.url, value_width)
+        )),
+        Line::raw("  Ctrl+L inspect full URL"),
         Line::raw(""),
         Line::raw("  Start a local `bamboo serve`?"),
         Line::raw(""),
-        Line::raw("  y / Enter start  ·  n / Esc skip"),
+        Line::raw("  y / Enter start"),
+        Line::raw("  n / Esc skip"),
     ];
 
     let height = (lines.len() as u16 + 2).min(f.area().height);
-    let area = centered_rect(56, height, f.area());
+    let area = centered_rect(90, height, f.area());
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(colors::WARNING))
+        .border_style(Style::default().fg(colors::warning()))
         .title(" Auto-serve ");
     f.render_widget(
         Paragraph::new(lines)
@@ -353,79 +657,29 @@ pub fn render_serve_offer(f: &mut Frame, app: &App) {
 fn submitting_hint() -> Line<'static> {
     Line::from(Span::styled(
         "  Submitting answer\u{2026}",
-        Style::default().fg(colors::WARNING),
+        Style::default().fg(colors::warning()),
     ))
 }
 
 fn identity_syncing_hint() -> Line<'static> {
     Line::from(Span::styled(
         "  Synchronizing exact question identity\u{2026}",
-        Style::default().fg(colors::WARNING),
+        Style::default().fg(colors::warning()),
     ))
 }
 
 fn hard_wrap_preview(value: &str, width: usize, max_lines: usize) -> (Vec<String>, bool) {
-    let width = width.max(1);
     if max_lines == 0 {
         return (Vec::new(), !value.is_empty());
     }
-    let mut output = Vec::new();
-    let mut logical_lines = value.split('\n').peekable();
-    while let Some(logical) = logical_lines.next() {
-        let mut current = String::new();
-        let mut current_width = 0;
-        for ch in logical.chars() {
-            let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-            if !current.is_empty() && current_width + char_width > width {
-                output.push(std::mem::take(&mut current));
-                if output.len() == max_lines {
-                    return (output, true);
-                }
-                current_width = 0;
-            }
-            current.push(ch);
-            current_width += char_width;
-        }
-        output.push(current);
-        if output.len() == max_lines {
-            return (output, logical_lines.peek().is_some());
-        }
-    }
-    if output.is_empty() {
-        output.push(String::new());
-    }
-    (output, false)
+    let mut output = crate::text::hard_wrap(value, width);
+    let truncated = output.len() > max_lines;
+    output.truncate(max_lines);
+    (output, truncated)
 }
 
 fn ellipsize(value: &str, width: usize) -> String {
-    let width = width.max(1);
-    let prefix_width_limit = width.saturating_sub(1);
-    let mut prefix = String::new();
-    let mut prefix_width = 0;
-    let mut total_width = 0;
-    let mut truncated = false;
-    for ch in value.chars() {
-        if ch == '\n' {
-            truncated = true;
-            break;
-        }
-        let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if total_width + char_width > width {
-            truncated = true;
-            break;
-        }
-        total_width += char_width;
-        if prefix_width + char_width <= prefix_width_limit {
-            prefix.push(ch);
-            prefix_width += char_width;
-        }
-    }
-    if truncated {
-        prefix.push('…');
-        prefix
-    } else {
-        value.to_string()
-    }
+    crate::text::clip_cells(value, width.max(1))
 }
 
 /// Typed clarification modal. The compact view never changes an option's
@@ -444,7 +698,7 @@ pub fn render_question(f: &mut Frame, app: &App) {
         f.render_widget(Clear, area);
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(colors::BRAND))
+            .border_style(Style::default().fg(colors::brand()))
             .title(" Clarification text inspector ");
         let inner = block.inner(area);
         f.render_widget(block, area);
@@ -474,7 +728,7 @@ pub fn render_question(f: &mut Frame, app: &App) {
                 Line::from(Span::styled(
                     format!(" {label}"),
                     Style::default()
-                        .fg(colors::BRAND)
+                        .fg(colors::brand())
                         .add_modifier(Modifier::BOLD),
                 )),
                 Line::raw(format!(" {context}")),
@@ -512,7 +766,7 @@ pub fn render_question(f: &mut Frame, app: &App) {
     let mut header = vec![Line::from(Span::styled(
         " Clarification needed",
         Style::default()
-            .fg(colors::BRAND)
+            .fg(colors::brand())
             .add_modifier(Modifier::BOLD),
     ))];
     if q.tool_name.is_some() || q.source.is_some() {
@@ -545,8 +799,11 @@ pub fn render_question(f: &mut Frame, app: &App) {
     } else if let Some(buf) = &q.custom {
         body.push(Line::raw("  Custom answer:"));
         body.push(Line::from(Span::styled(
-            format!("  > {}▏", ellipsize(buf, text_width.saturating_sub(2))),
-            Style::default().fg(colors::BRAND),
+            format!(
+                "  > {}▏",
+                crate::text::clip_tail_cells(buf, text_width.saturating_sub(1))
+            ),
+            Style::default().fg(colors::brand()),
         )));
         body.push(Line::raw(""));
         if q.identity_syncing {
@@ -563,7 +820,7 @@ pub fn render_question(f: &mut Frame, app: &App) {
     } else if q.options.is_empty() {
         body.push(Line::from(Span::styled(
             "  No selectable answers were supplied and custom input is disabled.",
-            Style::default().fg(colors::WARNING),
+            Style::default().fg(colors::warning()),
         )));
         body.push(Line::raw(""));
         body.push(Line::raw("  v inspect/copy question  ·  Esc dismiss"));
@@ -589,7 +846,7 @@ pub fn render_question(f: &mut Frame, app: &App) {
             let marker = if selected { "›" } else { " " };
             let style = if selected {
                 Style::default()
-                    .fg(colors::BRAND)
+                    .fg(colors::brand())
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
@@ -625,7 +882,7 @@ pub fn render_question(f: &mut Frame, app: &App) {
                 "  Error: {}",
                 ellipsize(error, text_width.saturating_sub(7))
             ),
-            Style::default().fg(colors::ERROR),
+            Style::default().fg(colors::error()),
         )));
     }
     let header_len = header.len();
@@ -655,16 +912,20 @@ pub fn render_question(f: &mut Frame, app: &App) {
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(colors::BRAND))
+        .border_style(Style::default().fg(colors::brand()))
         .title(" Clarification ");
     f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-/// Modal confirming a session delete (`d` on the Sessions tab). Mirrors the
-/// question modal's key rationale: a destructive action must not fire on a
-/// single stray keystroke, so it stops here until `y`/Enter or `n`/Esc.
+/// Modal confirming a destructive delete from the Sessions or Schedules tab.
+/// A destructive action must not fire on a single stray keystroke, so it
+/// stops here until `y`/Enter or `n`/Esc.
 pub fn render_delete_confirm(f: &mut Frame, app: &App) {
-    let Some((_, title)) = &app.pending_delete else {
+    let (kind, title) = if let Some((_, title)) = &app.pending_delete {
+        ("session", title)
+    } else if let Some((_, name)) = &app.pending_schedule_delete {
+        ("schedule", name)
+    } else {
         return;
     };
     let display_title: &str = if title.is_empty() {
@@ -673,27 +934,38 @@ pub fn render_delete_confirm(f: &mut Frame, app: &App) {
         title
     };
 
-    let lines = vec![
+    let screen = f.area();
+    let popup_width = ((screen.width as u32 * 90 / 100) as u16).max(1);
+    let text_width = popup_width.saturating_sub(6) as usize;
+    let (title_lines, title_truncated) = hard_wrap_preview(display_title, text_width, 4);
+    let mut lines = vec![
         Line::from(Span::styled(
-            " Delete session?",
+            format!(" Delete {kind}?"),
             Style::default()
-                .fg(colors::ERROR)
+                .fg(colors::error())
                 .add_modifier(Modifier::BOLD),
         )),
         Line::raw(""),
-        Line::raw(format!("  \"{}\"", display_title)),
-        Line::raw(""),
-        Line::raw("  This cannot be undone."),
-        Line::raw(""),
-        Line::raw("  y / Enter confirm  ·  n / Esc cancel"),
     ];
+    lines.extend(
+        title_lines
+            .into_iter()
+            .map(|line| Line::raw(format!("  {line}"))),
+    );
+    if title_truncated {
+        lines.push(Line::raw("  … title shortened for this screen"));
+    }
+    lines.push(Line::raw(""));
+    lines.push(Line::raw("  This cannot be undone."));
+    lines.push(Line::raw(""));
+    lines.push(Line::raw("  y / Enter confirm  ·  n / Esc cancel"));
 
-    let height = (lines.len() as u16 + 2).min(f.area().height);
-    let area = centered_rect(50, height, f.area());
+    let height = (lines.len() as u16 + 2).min(screen.height);
+    let area = centered_rect(90, height, screen);
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(colors::ERROR))
+        .border_style(Style::default().fg(colors::error()))
         .title(" Confirm ");
     f.render_widget(
         Paragraph::new(lines)
@@ -708,6 +980,9 @@ pub fn render_schedule_form(f: &mut Frame, app: &App) {
     let Some(form) = &app.schedule_form else {
         return;
     };
+    let screen = f.area();
+    let popup_width = ((screen.width as u32 * 90 / 100) as u16).max(1);
+    let value_width = popup_width.saturating_sub(16) as usize;
     let fields = [
         ("Name", &form.name),
         ("Cron", &form.cron),
@@ -717,7 +992,7 @@ pub fn render_schedule_form(f: &mut Frame, app: &App) {
         Line::from(Span::styled(
             " New schedule",
             Style::default()
-                .fg(colors::BRAND)
+                .fg(colors::brand())
                 .add_modifier(Modifier::BOLD),
         )),
         Line::raw(""),
@@ -726,29 +1001,49 @@ pub fn render_schedule_form(f: &mut Frame, app: &App) {
         let focused = i == form.field;
         let cursor = if focused { "\u{258f}" } else { "" };
         let style = if focused {
-            Style::default().fg(colors::BRAND)
+            Style::default().fg(colors::brand())
         } else {
-            Style::default().fg(colors::INACTIVE)
+            Style::default().fg(colors::inactive())
         };
         lines.push(Line::from(vec![
             Span::styled(
                 format!("  {label:<7}: "),
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             ),
-            Span::styled(format!("{val}{cursor}"), style),
+            Span::styled(
+                if focused {
+                    format!(
+                        "{}{}",
+                        clip_tail_cells(val, value_width.saturating_sub(1)),
+                        cursor
+                    )
+                } else {
+                    clip_cells(val, value_width)
+                },
+                style,
+            ),
         ]));
+    }
+    if let Some(error) = &form.error {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "  ! {}",
+                clip_cells(error, popup_width.saturating_sub(6) as usize)
+            ),
+            Style::default().fg(colors::error()),
+        )));
     }
     lines.push(Line::raw(""));
     lines.push(Line::raw(
         "  Tab / \u{2191}\u{2193} field  \u{b7}  Enter create  \u{b7}  Esc cancel",
     ));
 
-    let height = (lines.len() as u16 + 2).min(f.area().height);
-    let area = centered_rect(60, height, f.area());
+    let height = (lines.len() as u16 + 2).min(screen.height);
+    let area = centered_rect(90, height, screen);
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(colors::BRAND))
+        .border_style(Style::default().fg(colors::brand()))
         .title(" Schedule ");
     f.render_widget(
         Paragraph::new(lines)
@@ -771,7 +1066,7 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
     let mut lines = vec![Line::from(Span::styled(
         " Sessions",
         Style::default()
-            .fg(colors::BRAND)
+            .fg(colors::brand())
             .add_modifier(Modifier::BOLD),
     ))];
     // Search owns keyboard focus only in browse mode. Rename has its own
@@ -780,13 +1075,13 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
     // fields even though keystrokes can reach only one of them.
     if matches!(&picker.mode, SessionPickerMode::Browse) {
         lines.push(Line::from(vec![
-            Span::styled(" Search: ", Style::default().fg(colors::SUBTLE)),
+            Span::styled(" Search: ", Style::default().fg(colors::subtle())),
             Span::styled(
                 format!(
                     "{}▏",
                     clip_tail_cells(&picker.query, row_width.saturating_sub(10).max(1) as usize)
                 ),
-                Style::default().fg(colors::BRAND),
+                Style::default().fg(colors::brand()),
             ),
         ]));
     }
@@ -804,18 +1099,34 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                 };
                 lines.push(Line::raw(message));
             } else {
-                let max_height = screen.height.min(24);
-                let budget = (max_height as usize).saturating_sub(9).max(1);
                 let total = picker.visible.len();
-                let start = if total <= budget {
-                    0
-                } else {
-                    picker
-                        .selected
-                        .saturating_sub(budget / 2)
-                        .min(total.saturating_sub(budget))
-                };
-                let end = (start + budget).min(total);
+                // Reserve the border, header/search/blank, optional error,
+                // loaded count, both fixed action rows, and both possible
+                // above/below indicators before allocating list rows.
+                let fixed_rows = 2 // border
+                    + lines.len()
+                    + usize::from(picker.error.is_some())
+                    + 3; // loaded count + two action rows
+                let remaining = (screen.height as usize).saturating_sub(fixed_rows);
+                let selected = picker.selected.min(total.saturating_sub(1));
+                let mut start = selected;
+                let mut end = selected + 1;
+                loop {
+                    let indicators = usize::from(start > 0) + usize::from(end < total);
+                    let mut expanded = false;
+                    if start > 0 && end - (start - 1) + indicators <= remaining {
+                        start -= 1;
+                        expanded = true;
+                    }
+                    let indicators = usize::from(start > 0) + usize::from(end < total);
+                    if end < total && (end + 1) - start + indicators <= remaining {
+                        end += 1;
+                        expanded = true;
+                    }
+                    if !expanded {
+                        break;
+                    }
+                }
                 if start > 0 {
                     lines.push(Line::raw(format!("  ↑ {start} more")));
                 }
@@ -842,7 +1153,7 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                         "  {}",
                         clip_cells(error, row_width.saturating_sub(2) as usize)
                     ),
-                    Style::default().fg(colors::ERROR),
+                    Style::default().fg(colors::error()),
                 )));
             }
             let cap = if picker.sessions.len() >= 1_000 && picker.sessions.len() < picker.total {
@@ -858,7 +1169,7 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                     if picker.loading { " · loading" } else { "" },
                     cap
                 ),
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             )));
             if row_width < 70 {
                 lines.push(Line::raw("  ↑/↓/wheel · Enter open · F2 rename · F3 pin"));
@@ -885,11 +1196,11 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
             lines.push(Line::from(Span::styled(
                 " Rename session",
                 Style::default()
-                    .fg(colors::BRAND)
+                    .fg(colors::brand())
                     .add_modifier(Modifier::BOLD),
             )));
             lines.push(Line::from(vec![
-                Span::styled("  Title: ", Style::default().fg(colors::SUBTLE)),
+                Span::styled("  Title: ", Style::default().fg(colors::subtle())),
                 Span::styled(
                     if *submitting {
                         clip_tail_cells(draft, row_width.saturating_sub(12) as usize)
@@ -899,7 +1210,7 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                             clip_tail_cells(draft, row_width.saturating_sub(12) as usize)
                         )
                     },
-                    Style::default().fg(colors::BRAND),
+                    Style::default().fg(colors::brand()),
                 ),
             ]));
             if *loading_version {
@@ -913,7 +1224,7 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                         "  {}",
                         clip_cells(error, row_width.saturating_sub(2) as usize)
                     ),
-                    Style::default().fg(colors::ERROR),
+                    Style::default().fg(colors::error()),
                 )));
             }
             if !*submitting {
@@ -949,7 +1260,7 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                         "  {}",
                         clip_cells(error, row_width.saturating_sub(2) as usize)
                     ),
-                    Style::default().fg(colors::ERROR),
+                    Style::default().fg(colors::error()),
                 )));
             }
             if !*submitting {
@@ -964,7 +1275,7 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(colors::BRAND))
+        .border_style(Style::default().fg(colors::brand()))
         .title(" Session picker ");
     f.render_widget(
         Paragraph::new(lines)
@@ -990,17 +1301,17 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
         Line::from(Span::styled(
             " Select a model",
             Style::default()
-                .fg(colors::BRAND)
+                .fg(colors::brand())
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(vec![
-            Span::styled(" Search: ", Style::default().fg(colors::SUBTLE)),
+            Span::styled(" Search: ", Style::default().fg(colors::subtle())),
             Span::styled(
                 format!(
                     "{}▏",
                     clip_tail_cells(&picker.query, row_width.saturating_sub(10).max(1))
                 ),
-                Style::default().fg(colors::BRAND),
+                Style::default().fg(colors::brand()),
             ),
         ]),
         Line::raw(""),
@@ -1022,11 +1333,19 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
             "  No models match this search"
         }));
         body.push(Line::raw(""));
-        body.push(Line::raw(if picker.models.is_empty() {
-            "  Edit search · Ctrl+R retry load · Esc cancel"
+        if row_width < 70 && picker.models.is_empty() {
+            body.push(Line::raw("  Edit search · Ctrl+R retry load"));
+            body.push(Line::raw("  Esc cancel"));
+        } else if row_width < 70 {
+            body.push(Line::raw("  Edit search · Ctrl+U clear"));
+            body.push(Line::raw("  Ctrl+R refresh · Esc cancel"));
         } else {
-            "  Edit search · Ctrl+U clear · Ctrl+R refresh · Esc cancel"
-        }));
+            body.push(Line::raw(if picker.models.is_empty() {
+                "  Edit search · Ctrl+R retry load · Esc cancel"
+            } else {
+                "  Edit search · Ctrl+U clear · Ctrl+R refresh · Esc cancel"
+            }));
+        }
     } else {
         let max_h = screen.height.min(22);
         let total = picker.visible.len();
@@ -1038,11 +1357,12 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
             .collect::<Vec<_>>();
 
         // A group heading costs a terminal row too. Grow a balanced window
-        // around the selection using the actual row cost, while reserving two
-        // lines for the possible above/below indicators. This keeps the
-        // highlighted model visible even with 100 providers on a short screen.
+        // around the selection using the actual row cost, while reserving
+        // border, indicators, action footer, and an optional error. This keeps
+        // both the highlighted model and recovery action visible on a short
+        // screen even with 100 providers.
         let line_budget = (max_h as usize)
-            .saturating_sub(2 + header.len() + 2)
+            .saturating_sub(2 + header.len() + 2 + usize::from(picker.error.is_some()))
             .saturating_sub(2)
             .max(2);
         let selected = picker.selected.min(total.saturating_sub(1));
@@ -1089,7 +1409,7 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
                 body.push(Line::from(Span::styled(
                     clip_cells(&format!("  {group}"), row_width),
                     Style::default()
-                        .fg(colors::SUBTLE)
+                        .fg(colors::subtle())
                         .add_modifier(Modifier::BOLD),
                 )));
                 previous_group = Some(group);
@@ -1098,7 +1418,7 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
             let marker = if selected { "\u{203a}" } else { " " };
             let style = if selected {
                 Style::default()
-                    .fg(colors::BRAND)
+                    .fg(colors::brand())
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
@@ -1130,7 +1450,7 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
     if let Some(error) = &picker.error {
         body.push(Line::from(Span::styled(
             clip_cells(&format!("  {error}"), row_width),
-            Style::default().fg(colors::ERROR),
+            Style::default().fg(colors::error()),
         )));
     }
 
@@ -1141,7 +1461,7 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(colors::BRAND))
+        .border_style(Style::default().fg(colors::brand()))
         .title(" Model ");
     let para = Paragraph::new(lines)
         .block(block)
@@ -1245,9 +1565,9 @@ fn render_command_palette_view(
         CommandPaletteTrigger::Global => " Command palette ",
     };
     let border_color = if view.resolving {
-        colors::WARNING
+        colors::warning()
     } else {
-        colors::BRAND
+        colors::brand()
     };
     let block = Block::default()
         .borders(Borders::ALL)
@@ -1273,19 +1593,19 @@ fn command_palette_lines(
     let search_width = row_width.saturating_sub(10).max(1);
     let search_cursor = if view.resolving { "" } else { "▏" };
     let search_style = if view.resolving {
-        Style::default().fg(colors::INACTIVE)
+        Style::default().fg(colors::inactive())
     } else {
-        Style::default().fg(colors::BRAND)
+        Style::default().fg(colors::brand())
     };
     let mut lines = vec![
         Line::from(Span::styled(
             title,
             Style::default()
-                .fg(colors::BRAND)
+                .fg(colors::brand())
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(vec![
-            Span::styled(" Search: ", Style::default().fg(colors::SUBTLE)),
+            Span::styled(" Search: ", Style::default().fg(colors::subtle())),
             Span::styled(
                 format!(
                     "{}{}{}",
@@ -1302,7 +1622,7 @@ fn command_palette_lines(
     if view.resolving {
         lines.push(Line::from(Span::styled(
             "  Resolving preview…",
-            Style::default().fg(colors::WARNING),
+            Style::default().fg(colors::warning()),
         )));
     } else if view.loading {
         lines.push(Line::from(Span::styled(
@@ -1310,7 +1630,7 @@ fn command_palette_lines(
                 "  Loading session commands… built-ins remain available",
                 row_width,
             ),
-            Style::default().fg(colors::INACTIVE),
+            Style::default().fg(colors::inactive()),
         )));
     }
 
@@ -1336,7 +1656,7 @@ fn command_palette_lines(
             } else {
                 "  No commands match this search"
             },
-            Style::default().fg(colors::INACTIVE),
+            Style::default().fg(colors::inactive()),
         )));
     } else {
         let selected = view.selected.min(total.saturating_sub(1));
@@ -1348,7 +1668,7 @@ fn command_palette_lines(
         if start > 0 {
             lines.push(Line::from(Span::styled(
                 format!("  ↑ {start} more"),
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             )));
         }
 
@@ -1363,10 +1683,10 @@ fn command_palette_lines(
             let is_selected = !view.resolving && visible_index == selected;
             let marker = if is_selected { "›" } else { " " };
             let name_style = if view.resolving {
-                Style::default().fg(colors::INACTIVE)
+                Style::default().fg(colors::inactive())
             } else if is_selected {
                 Style::default()
-                    .fg(colors::BRAND)
+                    .fg(colors::brand())
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
@@ -1405,9 +1725,9 @@ fn command_palette_lines(
             lines.push(Line::from(Span::styled(
                 clip_cells(&format!("      {description}"), row_width),
                 if disabled.is_some() {
-                    Style::default().fg(colors::ERROR)
+                    Style::default().fg(colors::error())
                 } else {
-                    Style::default().fg(colors::INACTIVE)
+                    Style::default().fg(colors::inactive())
                 },
             )));
             if !view.resolving {
@@ -1417,7 +1737,7 @@ fn command_palette_lines(
         if end < total {
             lines.push(Line::from(Span::styled(
                 format!("  ↓ {} more", total - end),
-                Style::default().fg(colors::SUBTLE),
+                Style::default().fg(colors::subtle()),
             )));
         }
     }
@@ -1425,7 +1745,7 @@ fn command_palette_lines(
     if let Some(error) = view.error {
         lines.push(Line::from(Span::styled(
             clip_cells(&format!("  {error}"), row_width),
-            Style::default().fg(colors::ERROR),
+            Style::default().fg(colors::error()),
         )));
     }
     lines.push(Line::raw(""));
@@ -1449,11 +1769,11 @@ fn command_palette_lines(
 
 fn palette_type_style(command_type: &str) -> Style {
     let color = match command_type {
-        "prompt" => colors::BRAND,
-        "workflow" => colors::SUCCESS,
-        "skill" => colors::WARNING,
-        "mcp" => colors::TOOL_RUNNING,
-        _ => colors::INACTIVE,
+        "prompt" => colors::brand(),
+        "workflow" => colors::success(),
+        "skill" => colors::warning(),
+        "mcp" => colors::tool_running(),
+        _ => colors::inactive(),
     };
     Style::default().fg(color)
 }
@@ -1472,55 +1792,16 @@ fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {
     )
 }
 
+fn display_width(value: &str) -> usize {
+    crate::text::display_width(value)
+}
+
 fn clip_cells(value: &str, max_width: usize) -> String {
-    if max_width == 0 {
-        return String::new();
-    }
-    let mut output = String::new();
-    let mut used = 0;
-    for character in value.chars() {
-        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
-        if used + character_width > max_width {
-            while used > max_width.saturating_sub(1) {
-                let Some(removed) = output.pop() else {
-                    break;
-                };
-                used = used.saturating_sub(UnicodeWidthChar::width(removed).unwrap_or(0));
-            }
-            output.push('…');
-            return output;
-        }
-        output.push(character);
-        used += character_width;
-    }
-    output
+    crate::text::clip_cells(value, max_width)
 }
 
 fn clip_tail_cells(value: &str, max_width: usize) -> String {
-    if max_width == 0 {
-        return String::new();
-    }
-    let width = value
-        .chars()
-        .map(|character| UnicodeWidthChar::width(character).unwrap_or(0))
-        .sum::<usize>();
-    if width <= max_width {
-        return value.to_string();
-    }
-
-    let target = max_width.saturating_sub(1);
-    let mut suffix = Vec::new();
-    let mut used = 0;
-    for character in value.chars().rev() {
-        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
-        if used + character_width > target {
-            break;
-        }
-        suffix.push(character);
-        used += character_width;
-    }
-    suffix.reverse();
-    format!("…{}", suffix.into_iter().collect::<String>())
+    crate::text::clip_tail_cells(value, max_width)
 }
 
 #[cfg(test)]
@@ -1537,6 +1818,7 @@ mod tests {
         App, BuiltinPaletteAction, CommandPaletteEntry, CommandPaletteHitbox, CommandPaletteTrigger,
     };
     use ratatui::backend::TestBackend;
+    use ratatui::style::Color;
     use ratatui::text::Line;
     use ratatui::Terminal;
     use unicode_width::UnicodeWidthStr;
@@ -1584,37 +1866,212 @@ mod tests {
             .join("\n")
     }
 
-    /// The two-column help overlay must fit a normal-height terminal without
-    /// vertical clipping and must still mention the headline bindings — the
-    /// single-column version it replaced listed 29 lines in a fixed 25-row
-    /// modal and silently clipped the bottom entries on anything but a tall
-    /// terminal.
+    /// Stable FNV-1a digest over every rendered cell (symbol, colours and
+    /// modifiers). Unlike substring smoke assertions, a border shift, clipped
+    /// footer or semantic-style regression changes the checked-in golden.
+    fn buffer_fingerprint(terminal: &Terminal<TestBackend>) -> u64 {
+        let buffer = terminal.backend().buffer();
+        let mut hash = 0xcbf29ce484222325_u64;
+        let mut feed = |bytes: &[u8]| {
+            for byte in bytes {
+                hash ^= u64::from(*byte);
+                hash = hash.wrapping_mul(0x100000001b3);
+            }
+        };
+        feed(&buffer.area.width.to_le_bytes());
+        feed(&buffer.area.height.to_le_bytes());
+        for cell in buffer.content() {
+            feed(cell.symbol().as_bytes());
+            feed(&[0]);
+            feed(format!("{:?}|{:?}|{:?}", cell.fg, cell.bg, cell.modifier).as_bytes());
+            feed(&[0xff]);
+        }
+        hash
+    }
+
     #[test]
-    fn help_overlay_fits_one_screen_and_lists_bindings() {
+    fn testbackend_goldens_cover_every_view_across_the_size_matrix() {
+        let sizes = [(50, 15), (60, 20), (80, 24), (120, 40), (200, 60)];
+        // Row-major: size, then `Tab::ALL`. Regenerate deliberately only when
+        // the complete rendered buffers have been reviewed.
+        let expected: [[u64; 6]; 5] = [
+            [
+                6_299_991_410_263_413_121,
+                6_299_991_410_263_413_121,
+                6_299_991_410_263_413_121,
+                6_299_991_410_263_413_121,
+                6_299_991_410_263_413_121,
+                6_299_991_410_263_413_121,
+            ],
+            [
+                13_961_651_686_046_235_677,
+                11_742_776_756_959_909_217,
+                12_352_841_898_830_756_966,
+                4_443_987_425_997_024_917,
+                10_477_181_847_636_759_683,
+                15_082_888_787_617_642_176,
+            ],
+            [
+                918_489_227_128_278_874,
+                12_868_650_456_892_988_142,
+                12_186_984_790_712_334_581,
+                17_105_919_049_885_996_702,
+                10_233_178_872_994_130_974,
+                10_014_260_811_141_985_839,
+            ],
+            [
+                12_989_858_624_620_429_706,
+                2_072_895_420_946_121_702,
+                13_799_275_926_493_068_613,
+                17_299_515_908_042_385_638,
+                14_066_239_811_268_707_862,
+                15_506_557_407_010_776_391,
+            ],
+            [
+                16_362_527_783_164_490_822,
+                10_339_770_751_650_844_978,
+                7_745_323_598_988_951_513,
+                12_921_833_252_336_354_826,
+                5_191_433_621_793_189_186,
+                15_064_146_538_247_429_787,
+            ],
+        ];
+        let mut actual = [[0_u64; 6]; 5];
+        for (size_index, (width, height)) in sizes.into_iter().enumerate() {
+            for (tab_index, tab) in crate::app::Tab::ALL.into_iter().enumerate() {
+                let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+                app.tab = tab;
+                app.connected = true;
+                app.chat.model = "provider/模型🧭e\u{301}".to_string();
+                app.chat.session_id = Some("session-full-identifier".to_string());
+                app.status_message = "deterministic status".to_string();
+                let backend = TestBackend::new(width, height);
+                let mut terminal = Terminal::new(backend).unwrap();
+                terminal
+                    .draw(|frame| crate::ui::render(frame, &app))
+                    .unwrap();
+                let golden = terminal_text(&terminal);
+                actual[size_index][tab_index] = buffer_fingerprint(&terminal);
+                assert!(!golden.is_empty(), "empty {width}x{height} {tab:?}");
+                if width < crate::ui::MIN_TERMINAL_WIDTH || height < crate::ui::MIN_TERMINAL_HEIGHT
+                {
+                    assert!(golden.contains("Terminal too small"));
+                    assert!(golden.contains("50x15"));
+                } else {
+                    assert!(
+                        golden.contains(tab.title()),
+                        "{width}x{height} {tab:?}:\n{golden}"
+                    );
+                    assert!(golden.contains("ONLINE"));
+                    assert!(golden.contains("F1 help") || golden.contains("[1]Chat"));
+                }
+            }
+        }
+        assert_eq!(actual, expected, "full-buffer size/view golden changed");
+    }
+
+    #[test]
+    fn theme_variant_goldens_preserve_text_and_change_only_semantic_colors() {
+        let mut texts = Vec::new();
+        let mut fingerprints = Vec::new();
+        for palette in [
+            crate::theme::ThemePalette::TrueColor,
+            crate::theme::ThemePalette::System,
+            crate::theme::ThemePalette::NoColor,
+        ] {
+            let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+            app.set_theme(palette);
+            app.connected = false;
+            app.unseen_alerts = 2;
+            app.status_message = "full state meaning".to_string();
+            let backend = TestBackend::new(80, 24);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| crate::ui::render(frame, &app))
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            let text = terminal_text(&terminal);
+            fingerprints.push(buffer_fingerprint(&terminal));
+            assert!(text.contains("OFFLINE"));
+            assert!(text.contains("2 ALERTS"));
+            match palette {
+                crate::theme::ThemePalette::TrueColor => assert!(buffer
+                    .content()
+                    .iter()
+                    .any(|cell| matches!(cell.fg, Color::Rgb(_, _, _)))),
+                crate::theme::ThemePalette::System => assert!(buffer
+                    .content()
+                    .iter()
+                    .all(|cell| !matches!(cell.fg, Color::Rgb(_, _, _)))),
+                crate::theme::ThemePalette::NoColor => assert!(buffer
+                    .content()
+                    .iter()
+                    .all(|cell| cell.fg == Color::Reset && cell.bg == Color::Reset)),
+            }
+            texts.push(text);
+        }
+        assert_eq!(texts[0], texts[1]);
+        assert_eq!(texts[1], texts[2]);
+        assert_eq!(
+            fingerprints,
+            [
+                14_548_917_146_417_123_609,
+                8_988_964_665_087_750_412,
+                13_378_690_012_755_700_490,
+            ],
+            "full-buffer theme golden changed"
+        );
+    }
+
+    #[test]
+    fn help_overlay_is_scrollable_and_reaches_every_binding_at_minimum_size() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.help_visible = true;
 
-        let backend = TestBackend::new(100, 24);
+        let backend = TestBackend::new(60, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+        let first = terminal_text(&terminal);
+        assert!(first.contains("Alt+Enter"));
+        assert!(first.contains("PgUp/PgDn"));
+        assert!(app.help_max_scroll.get() > 0);
 
-        let buf = terminal.backend().buffer().clone();
-        let text: String = buf.content().iter().map(|c| c.symbol()).collect();
+        app.help_scroll = app.help_max_scroll.get();
+        terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+        let last = terminal_text(&terminal);
+        let reachable = format!("{first}\n{last}");
         for needle in [
             "Ctrl+K",
-            "Ctrl+N",
-            "Ctrl+O",
             "Ctrl+P",
-            "Ctrl+Q",
             "Ctrl+C",
-            "Ctrl+S",
-            "Ctrl+X",
             "Ctrl+L",
-            "Alt+Enter",
-            "F1",
-            "Press any key to close",
+            "F1 / ?",
+            "Esc/q close",
         ] {
-            assert!(text.contains(needle), "help overlay missing {needle:?}");
+            assert!(
+                reachable.contains(needle),
+                "help overlay never exposes {needle:?}:\n{reachable}"
+            );
+        }
+    }
+
+    #[test]
+    fn help_footer_stays_visible_and_last_binding_reachable_on_tall_narrow_terminals() {
+        for (width, height) in [(60, 40), (80, 40)] {
+            let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+            app.help_visible = true;
+            let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+            terminal
+                .draw(|frame| crate::ui::render(frame, &app))
+                .unwrap();
+            assert!(app.help_max_scroll.get() > 0);
+            app.help_scroll = app.help_max_scroll.get();
+            terminal
+                .draw(|frame| crate::ui::render(frame, &app))
+                .unwrap();
+            let text = terminal_text(&terminal);
+            assert!(text.contains("F1 / ?"), "{width}x{height}:\n{text}");
+            assert!(text.contains("Esc/q close"), "{width}x{height}:\n{text}");
         }
     }
 

--- a/crates/app/bamboo-tui/src/ui/mcp.rs
+++ b/crates/app/bamboo-tui/src/ui/mcp.rs
@@ -6,102 +6,100 @@ use ratatui::Frame;
 
 use crate::app::App;
 use crate::theme::colors;
+use crate::ui::sessions::{truncate_cells, visible_window};
 
 pub fn render(f: &mut Frame, area: Rect, app: &App) {
     if app.mcp.loading && app.mcp.servers.is_empty() {
         let loading =
-            Paragraph::new("Loading MCP servers...").style(Style::default().fg(colors::INACTIVE));
+            Paragraph::new("Loading MCP servers...").style(Style::default().fg(colors::inactive()));
         f.render_widget(loading, area);
         return;
     }
 
     if let Some(err) = &app.mcp.error {
         let error =
-            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::ERROR));
+            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::error()));
         f.render_widget(error, area);
         return;
     }
 
+    let compact = area.width < 80 || area.height < 18;
+    let tools_height = if compact { 3 } else { 5 };
     let chunks = ratatui::layout::Layout::default()
         .direction(ratatui::layout::Direction::Vertical)
         .constraints([
             ratatui::layout::Constraint::Length(1),
-            ratatui::layout::Constraint::Min(5),
-            ratatui::layout::Constraint::Min(3),
+            ratatui::layout::Constraint::Min(1),
+            ratatui::layout::Constraint::Length(tools_height),
             ratatui::layout::Constraint::Length(1),
         ])
         .split(area);
 
     // Header
-    let header = Paragraph::new(Line::from(vec![
-        Span::styled(
-            " MCP Servers",
+    let header = if compact {
+        Line::from(Span::styled(
+            format!(" MCP servers · {} configured", app.mcp.servers.len()),
             Style::default()
-                .fg(colors::BRAND)
+                .fg(colors::brand())
                 .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw("   "),
-        Span::styled("[r] Refresh", Style::default().fg(colors::INACTIVE)),
-        Span::raw("  "),
-        Span::styled("[t] Tools", Style::default().fg(colors::INACTIVE)),
-        Span::raw("  "),
-        Span::styled(
-            "[Enter] Connect/Disc",
-            Style::default().fg(colors::INACTIVE),
-        ),
-    ]));
+        ))
+    } else {
+        Line::from(vec![
+            Span::styled(
+                " MCP Servers",
+                Style::default()
+                    .fg(colors::brand())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("   "),
+            Span::styled("[r] Refresh", Style::default().fg(colors::inactive())),
+            Span::raw("  "),
+            Span::styled("[t] Tools", Style::default().fg(colors::inactive())),
+            Span::raw("  "),
+            Span::styled(
+                "[Enter] Connect/Disc",
+                Style::default().fg(colors::inactive()),
+            ),
+        ])
+    };
+    let header = Paragraph::new(header);
     f.render_widget(header, chunks[0]);
 
     // Server list
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
-        " Name              Transport     Status      Enabled",
-        Style::default().fg(colors::SUBTLE),
+        truncate_cells(
+            if compact {
+                "   Name · connection · enabled"
+            } else {
+                "   Name  Transport  Connection  Enabled"
+            },
+            chunks[1].width as usize,
+        ),
+        Style::default().fg(colors::subtle()),
     )));
 
-    for (i, server) in app.mcp.servers.iter().enumerate() {
-        let style = if i == app.mcp.selected {
-            Style::default()
-                .fg(colors::BRAND)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(colors::INACTIVE)
-        };
-
-        let name = server
-            .name
-            .as_deref()
-            .unwrap_or(&server.id)
-            .chars()
-            .take(18)
-            .collect::<String>();
-        let connected = server.connected.unwrap_or(false);
-        let status_str = if connected {
-            "Connected"
-        } else {
-            "Disconnected"
-        };
-        let status_style = if connected {
-            Style::default().fg(colors::SUCCESS)
-        } else {
-            Style::default().fg(colors::ERROR)
-        };
-
-        lines.push(Line::from(vec![
-            Span::styled(format!(" {:18}  ", name), style),
-            Span::styled(format!("{:13}  ", "stdio"), style),
-            Span::styled(format!("{:11} ", status_str), status_style),
-            Span::styled(
-                format!(" {}", if server.enabled { "Yes" } else { "No" }),
-                style,
-            ),
-        ]));
+    let selected = app
+        .mcp
+        .selected
+        .min(app.mcp.servers.len().saturating_sub(1));
+    let capacity = chunks[1].height.saturating_sub(1) as usize;
+    let visible = visible_window(app.mcp.servers.len(), selected, capacity);
+    for (i, server) in app
+        .mcp
+        .servers
+        .iter()
+        .enumerate()
+        .take(visible.end)
+        .skip(visible.start)
+    {
+        lines.push(server_row_line(server, i == selected, chunks[1].width));
     }
 
     if app.mcp.servers.is_empty() {
         lines.push(Line::from(Span::styled(
             "  No MCP servers configured.",
-            Style::default().fg(colors::INACTIVE),
+            Style::default().fg(colors::inactive()),
         )));
     }
 
@@ -113,23 +111,155 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     if !app.mcp.tools.is_empty() {
         tool_lines.push(Line::from(Span::styled(
             " Tools",
-            Style::default().fg(colors::BRAND),
+            Style::default().fg(colors::brand()),
         )));
-        for tool in &app.mcp.tools {
+        for tool in app
+            .mcp
+            .tools
+            .iter()
+            .take(chunks[2].height.saturating_sub(1) as usize)
+        {
             let desc = tool.description.as_deref().unwrap_or("");
-            tool_lines.push(Line::from(format!("  {} - {}", tool.name, desc)));
+            tool_lines.push(Line::from(truncate_cells(
+                &format!("  {} - {}", tool.name, desc),
+                chunks[2].width as usize,
+            )));
         }
     } else {
         tool_lines.push(Line::from(Span::styled(
-            " Select a server and press 't' to view tools",
-            Style::default().fg(colors::INACTIVE),
+            truncate_cells(
+                " Select a server and press 't' for tools",
+                chunks[2].width as usize,
+            ),
+            Style::default().fg(colors::inactive()),
         )));
     }
     let tools = Paragraph::new(tool_lines);
     f.render_widget(tools, chunks[2]);
 
     // Footer
-    let footer = Paragraph::new(" [Enter] Connect/Disconnect · [t] Refresh Tools · [r] Refresh")
-        .style(Style::default().fg(colors::INACTIVE));
+    let footer_text = if compact {
+        " Enter connect · t tools · r refresh"
+    } else {
+        " [Enter] Connect/Disconnect · [t] Refresh Tools · [r] Refresh"
+    };
+    let footer = Paragraph::new(footer_text).style(Style::default().fg(colors::inactive()));
     f.render_widget(footer, chunks[3]);
+}
+
+fn server_row_line(
+    server: &crate::api::types::McpServer,
+    selected: bool,
+    width: u16,
+) -> Line<'static> {
+    let row_style = if selected {
+        Style::default()
+            .fg(colors::brand())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(colors::inactive())
+    };
+    let connected = server.connected.unwrap_or(false);
+    let (connection_glyph, connection, connection_style) = if connected {
+        ("●", "connected", Style::default().fg(colors::success()))
+    } else {
+        ("○", "disconnected", Style::default().fg(colors::error()))
+    };
+    let enabled = if server.enabled {
+        "enabled"
+    } else {
+        "disabled"
+    };
+    let marker = if selected { "›" } else { " " };
+    let name = server.name.as_deref().unwrap_or(&server.id);
+
+    if width < 80 {
+        // marker/glyph + two separators + status columns consume 30 cells.
+        let name_width = width.saturating_sub(30).max(1) as usize;
+        Line::from(vec![
+            Span::styled(format!("{marker} {connection_glyph} "), row_style),
+            Span::styled(truncate_cells(name, name_width), row_style),
+            Span::styled(" · ", row_style),
+            Span::styled(truncate_cells(connection, 12), connection_style),
+            Span::styled(" · ", row_style),
+            Span::styled(truncate_cells(enabled, 8), row_style),
+        ])
+    } else {
+        let name_width = width.saturating_sub(40).max(1) as usize;
+        let transport = server
+            .transport
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .or_else(|| server.transport.as_str())
+            .unwrap_or("stdio");
+        Line::from(vec![
+            Span::styled(format!("{marker} "), row_style),
+            Span::styled(truncate_cells(name, name_width), row_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(transport, 12), row_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(connection, 12), connection_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(enabled, 8), row_style),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::McpServer;
+    use crate::api::BambooClient;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn server(index: usize) -> McpServer {
+        McpServer {
+            id: format!("server-{index}"),
+            name: Some(format!("普通服务 {index}")),
+            enabled: index.is_multiple_of(2),
+            transport: serde_json::json!({"type": "stdio"}),
+            connected: Some(index.is_multiple_of(3)),
+        }
+    }
+
+    #[test]
+    fn compact_unicode_mcp_keeps_selection_status_and_actions_visible() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = crate::app::Tab::Mcp;
+        app.mcp.servers = (0..30).map(server).collect();
+        app.mcp.selected = 24;
+        app.mcp.servers[24].name = Some("selected-服务🧭e\u{301}".to_string());
+        app.mcp.servers[24].connected = Some(false);
+        app.mcp.servers[24].enabled = false;
+
+        let row = server_row_line(&app.mcp.servers[24], true, 50);
+        assert!(row.width() <= 50);
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(text.contains("selected-"), "selected row missing:\n{text}");
+        assert!(text.contains('🧭'), "Unicode fixture missing:\n{text}");
+        assert!(
+            text.contains("disconnected"),
+            "text status missing:\n{text}"
+        );
+        assert!(text.contains("disabled"), "enabled state missing:\n{text}");
+        assert!(
+            text.contains("Enter connect"),
+            "compact action footer missing:\n{text}"
+        );
+        assert!(text.contains('›'), "selected-row glyph missing:\n{text}");
+    }
 }

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -10,7 +10,19 @@ use ratatui::Frame;
 
 use crate::app::App;
 
+pub const MIN_TERMINAL_WIDTH: u16 = 60;
+pub const MIN_TERMINAL_HEIGHT: u16 = 20;
+
 pub fn render(f: &mut Frame, app: &App) {
+    crate::theme::with_palette(app.theme, || render_with_palette(f, app));
+}
+
+fn render_with_palette(f: &mut Frame, app: &App) {
+    if f.area().width < MIN_TERMINAL_WIDTH || f.area().height < MIN_TERMINAL_HEIGHT {
+        layout::render_terminal_too_small(f);
+        return;
+    }
+
     let chunks = layout::app_layout(f.area(), app);
 
     // Content area
@@ -29,12 +41,7 @@ pub fn render(f: &mut Frame, app: &App) {
 
     // Help overlay
     if app.help_visible {
-        layout::render_help(f);
-    }
-
-    // Notification-log overlay
-    if app.notifications_visible {
-        layout::render_notifications(f, app);
+        layout::render_help(f, app);
     }
 
     // A clarification can arrive asynchronously while a local editor or
@@ -61,7 +68,7 @@ pub fn render(f: &mut Frame, app: &App) {
         layout::render_session_picker(f, app);
     }
 
-    if app.pending_delete.is_some() {
+    if app.pending_delete.is_some() || app.pending_schedule_delete.is_some() {
         layout::render_delete_confirm(f, app);
     }
 
@@ -71,5 +78,12 @@ pub fn render(f: &mut Frame, app: &App) {
 
     if app.serve_offer.is_some() {
         layout::render_serve_offer(f, app);
+    }
+
+    // The full-value log is deliberately last: Ctrl+L remains available over
+    // every modal so clipped session/model/error text can always be inspected
+    // without discarding the underlying draft or confirmation.
+    if app.notifications_visible {
+        layout::render_notifications(f, app);
     }
 }

--- a/crates/app/bamboo-tui/src/ui/schedules.rs
+++ b/crates/app/bamboo-tui/src/ui/schedules.rs
@@ -6,22 +6,24 @@ use ratatui::Frame;
 
 use crate::app::App;
 use crate::theme::colors;
+use crate::ui::sessions::{truncate_cells, visible_window};
 
 pub fn render(f: &mut Frame, area: Rect, app: &App) {
     if app.schedules.loading && app.schedules.schedules.is_empty() {
         let loading =
-            Paragraph::new("Loading schedules...").style(Style::default().fg(colors::INACTIVE));
+            Paragraph::new("Loading schedules...").style(Style::default().fg(colors::inactive()));
         f.render_widget(loading, area);
         return;
     }
 
     if let Some(err) = &app.schedules.error {
         let error =
-            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::ERROR));
+            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::error()));
         f.render_widget(error, area);
         return;
     }
 
+    let compact = area.width < 80 || area.height < 18;
     let chunks = ratatui::layout::Layout::default()
         .direction(ratatui::layout::Direction::Vertical)
         .constraints([
@@ -32,70 +34,67 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
         .split(area);
 
     // Header
-    let header = Paragraph::new(Line::from(vec![
-        Span::styled(
-            " Schedules",
+    let header = if compact {
+        Line::from(Span::styled(
+            format!(" Schedules · {} configured", app.schedules.schedules.len()),
             Style::default()
-                .fg(colors::BRAND)
+                .fg(colors::brand())
                 .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw("   "),
-        Span::styled("[d] Delete", Style::default().fg(colors::INACTIVE)),
-        Span::raw("  "),
-        Span::styled("[r] Run now", Style::default().fg(colors::INACTIVE)),
-    ]));
+        ))
+    } else {
+        Line::from(vec![
+            Span::styled(
+                " Schedules",
+                Style::default()
+                    .fg(colors::brand())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("   "),
+            Span::styled("[n] New", Style::default().fg(colors::inactive())),
+            Span::raw("  "),
+            Span::styled("[d] Delete", Style::default().fg(colors::inactive())),
+            Span::raw("  "),
+            Span::styled("[r] Run now", Style::default().fg(colors::inactive())),
+        ])
+    };
+    let header = Paragraph::new(header);
     f.render_widget(header, chunks[0]);
 
     // Schedule list
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
-        " Name              Cron              Enabled  Last Run",
-        Style::default().fg(colors::SUBTLE),
+        truncate_cells(
+            if compact {
+                "  Name · status · schedule"
+            } else {
+                "  Name  Schedule  Status  Last run"
+            },
+            chunks[1].width as usize,
+        ),
+        Style::default().fg(colors::subtle()),
     )));
 
-    for (i, schedule) in app.schedules.schedules.iter().enumerate() {
-        let style = if i == app.schedules.selected {
-            Style::default()
-                .fg(colors::BRAND)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(colors::INACTIVE)
-        };
-
-        let name = schedule
-            .name
-            .as_deref()
-            .unwrap_or(&schedule.id)
-            .chars()
-            .take(18)
-            .collect::<String>();
-        let cron = schedule
-            .cron
-            .as_deref()
-            .unwrap_or("-")
-            .chars()
-            .take(18)
-            .collect::<String>();
-        let enabled = if schedule.enabled.unwrap_or(false) {
-            "Yes"
-        } else {
-            "No"
-        };
-        let last_run = schedule
-            .last_run
-            .map(|t| t.format("%m-%d %H:%M").to_string())
-            .unwrap_or_else(|| "-".to_string());
-
-        lines.push(Line::from(Span::styled(
-            format!(" {:18} {:18} {:8} {}", name, cron, enabled, last_run),
-            style,
-        )));
+    let selected = app
+        .schedules
+        .selected
+        .min(app.schedules.schedules.len().saturating_sub(1));
+    let capacity = chunks[1].height.saturating_sub(1) as usize;
+    let visible = visible_window(app.schedules.schedules.len(), selected, capacity);
+    for (i, schedule) in app
+        .schedules
+        .schedules
+        .iter()
+        .enumerate()
+        .take(visible.end)
+        .skip(visible.start)
+    {
+        lines.push(schedule_row_line(schedule, i == selected, chunks[1].width));
     }
 
     if app.schedules.schedules.is_empty() {
         lines.push(Line::from(Span::styled(
             "  No schedules configured.",
-            Style::default().fg(colors::INACTIVE),
+            Style::default().fg(colors::inactive()),
         )));
     }
 
@@ -103,7 +102,127 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     f.render_widget(list, chunks[1]);
 
     // Footer
-    let footer =
-        Paragraph::new(" [d] Delete · [r] Run now").style(Style::default().fg(colors::INACTIVE));
+    let footer_text = if compact {
+        " n new · d delete · r run now"
+    } else {
+        " [n] New · [d] Delete · [r] Run now"
+    };
+    let footer = Paragraph::new(footer_text).style(Style::default().fg(colors::inactive()));
     f.render_widget(footer, chunks[2]);
+}
+
+fn schedule_row_line(
+    schedule: &crate::api::types::Schedule,
+    selected: bool,
+    width: u16,
+) -> Line<'static> {
+    let row_style = if selected {
+        Style::default()
+            .fg(colors::brand())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(colors::inactive())
+    };
+    let enabled = if schedule.enabled.unwrap_or(false) {
+        "enabled"
+    } else {
+        "disabled"
+    };
+    let status_style = if schedule.enabled.unwrap_or(false) {
+        Style::default().fg(colors::success())
+    } else {
+        Style::default().fg(colors::inactive())
+    };
+    let marker = if selected { "›" } else { " " };
+    let name = schedule.name.as_deref().unwrap_or(&schedule.id);
+    let cron = schedule.cron.as_deref().unwrap_or("-");
+
+    if width < 80 {
+        // marker + two separators + status consume 16 cells; split the rest
+        // between the human name and the schedule expression.
+        let available = width.saturating_sub(16).max(2) as usize;
+        let name_width = (available * 3 / 5).max(1);
+        let cron_width = available.saturating_sub(name_width).max(1);
+        Line::from(vec![
+            Span::styled(format!("{marker} "), row_style),
+            Span::styled(truncate_cells(name, name_width), row_style),
+            Span::styled(" · ", row_style),
+            Span::styled(truncate_cells(enabled, 8), status_style),
+            Span::styled(" · ", row_style),
+            Span::styled(truncate_cells(cron, cron_width), row_style),
+        ])
+    } else {
+        let last_run = schedule
+            .last_run
+            .map(|time| time.format("%m-%d %H:%M").to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let name_width = width.saturating_sub(45).max(1) as usize;
+        Line::from(vec![
+            Span::styled(format!("{marker} "), row_style),
+            Span::styled(truncate_cells(name, name_width), row_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(cron, 18), row_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(enabled, 8), status_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(&last_run, 11), row_style),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::Schedule;
+    use crate::api::BambooClient;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn schedule(index: usize) -> Schedule {
+        Schedule {
+            id: format!("schedule-{index}"),
+            name: Some(format!("普通计划 {index}")),
+            cron: Some("*/15 * * * *".to_string()),
+            enabled: Some(index.is_multiple_of(2)),
+            prompt: None,
+            last_run: None,
+            next_run: None,
+        }
+    }
+
+    #[test]
+    fn compact_unicode_schedule_keeps_selection_status_and_actions_visible() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = crate::app::Tab::Schedules;
+        app.schedules.schedules = (0..30).map(schedule).collect();
+        app.schedules.selected = 24;
+        app.schedules.schedules[24].name = Some("selected-计划🧭e\u{301}".to_string());
+        app.schedules.schedules[24].enabled = Some(true);
+
+        let row = schedule_row_line(&app.schedules.schedules[24], true, 50);
+        assert!(row.width() <= 50);
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(text.contains("selected-"), "selected row missing:\n{text}");
+        assert!(text.contains('🧭'), "Unicode fixture missing:\n{text}");
+        assert!(text.contains("enabled"), "text status missing:\n{text}");
+        assert!(
+            text.contains("r run now"),
+            "compact action footer missing:\n{text}"
+        );
+        assert!(text.contains("n new"), "new action footer missing:\n{text}");
+        assert!(text.contains('›'), "selected-row glyph missing:\n{text}");
+    }
 }

--- a/crates/app/bamboo-tui/src/ui/sessions.rs
+++ b/crates/app/bamboo-tui/src/ui/sessions.rs
@@ -3,30 +3,30 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
-use unicode_width::UnicodeWidthChar;
 
 use crate::api::types::SessionSummary;
 use crate::app::App;
+use crate::text;
 use crate::theme::colors;
 
 pub fn render(f: &mut Frame, area: Rect, app: &App) {
     if app.sessions.loading && app.sessions.sessions.is_empty() {
         let loading =
-            Paragraph::new("Loading sessions...").style(Style::default().fg(colors::INACTIVE));
+            Paragraph::new("Loading sessions...").style(Style::default().fg(colors::inactive()));
         f.render_widget(loading, area);
         return;
     }
 
     if let Some(err) = &app.sessions.error {
         let error =
-            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::ERROR));
+            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::error()));
         f.render_widget(error, area);
         return;
     }
 
     if app.sessions.sessions.is_empty() {
         let empty = Paragraph::new("No sessions found.\n\nPress 'r' to refresh.")
-            .style(Style::default().fg(colors::INACTIVE));
+            .style(Style::default().fg(colors::inactive()));
         f.render_widget(empty, area);
         return;
     }
@@ -42,32 +42,51 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
         .split(area);
 
     // Header
-    let header = Paragraph::new(Line::from(vec![
-        Span::styled(
-            " Sessions",
+    let header = if area.width < 80 {
+        Line::from(Span::styled(
+            format!(" Sessions · {} total", app.sessions.total),
             Style::default()
-                .fg(colors::BRAND)
+                .fg(colors::brand())
                 .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw("   "),
-        Span::styled("[r] Refresh", Style::default().fg(colors::INACTIVE)),
-        Span::raw("  "),
-        Span::styled("[d] Delete", Style::default().fg(colors::INACTIVE)),
-        Span::raw("  "),
-        Span::styled("[Enter] Open", Style::default().fg(colors::INACTIVE)),
-    ]));
+        ))
+    } else {
+        Line::from(vec![
+            Span::styled(
+                " Sessions",
+                Style::default()
+                    .fg(colors::brand())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("   "),
+            Span::styled("[r] Refresh", Style::default().fg(colors::inactive())),
+            Span::raw("  "),
+            Span::styled("[d] Delete", Style::default().fg(colors::inactive())),
+            Span::raw("  "),
+            Span::styled("[Enter] Open", Style::default().fg(colors::inactive())),
+        ])
+    };
+    let header = Paragraph::new(header);
     f.render_widget(header, chunks[0]);
 
     // Session list
     let mut lines: Vec<Line> = Vec::new();
     lines.push(session_header(chunks[1].width));
 
-    for (i, session) in app.sessions.sessions.iter().enumerate() {
-        lines.push(session_row_line(
-            session,
-            i == app.sessions.selected,
-            chunks[1].width,
-        ));
+    let selected = app
+        .sessions
+        .selected
+        .min(app.sessions.sessions.len().saturating_sub(1));
+    let capacity = chunks[1].height.saturating_sub(1) as usize;
+    let visible = visible_window(app.sessions.sessions.len(), selected, capacity);
+    for (i, session) in app
+        .sessions
+        .sessions
+        .iter()
+        .enumerate()
+        .take(visible.end)
+        .skip(visible.start)
+    {
+        lines.push(session_row_line(session, i == selected, chunks[1].width));
     }
 
     let list = Paragraph::new(lines);
@@ -81,13 +100,39 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
         " page {}/{} · total {} · [ ] to page",
         page, pages, app.sessions.total
     ))
-    .style(Style::default().fg(colors::SUBTLE));
+    .style(Style::default().fg(colors::subtle()));
     f.render_widget(page_info, chunks[2]);
 
     // Footer
-    let footer = Paragraph::new(" [Enter] Open in Chat · [d] Delete · [r] Refresh")
-        .style(Style::default().fg(colors::INACTIVE));
+    let footer_text = if area.width < 80 {
+        " Enter open · d delete · r refresh"
+    } else {
+        " [Enter] Open in Chat · [d] Delete · [r] Refresh"
+    };
+    let footer = Paragraph::new(footer_text).style(Style::default().fg(colors::inactive()));
     f.render_widget(footer, chunks[3]);
+}
+
+/// Select the contiguous list window that keeps `selected` visible.
+///
+/// Lists use this after reserving one line for their column header. Keeping the
+/// selected item at the bottom while moving forward is predictable and leaves
+/// the maximum amount of preceding context at compact terminal heights.
+pub(crate) fn visible_window(
+    item_count: usize,
+    selected: usize,
+    capacity: usize,
+) -> std::ops::Range<usize> {
+    if item_count == 0 || capacity == 0 {
+        return 0..0;
+    }
+    let selected = selected.min(item_count - 1);
+    let capacity = capacity.min(item_count);
+    let start = selected
+        .saturating_add(1)
+        .saturating_sub(capacity)
+        .min(item_count - capacity);
+    start..start + capacity
 }
 
 /// Status glyph + color for a session row, in priority order: a running run
@@ -95,13 +140,13 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
 /// run — a session can usefully show only one at a time.
 pub(crate) fn status_glyph(session: &SessionSummary) -> (&'static str, Color) {
     if session.is_running {
-        ("▶", colors::SUCCESS)
+        ("▶", colors::success())
     } else if session.has_pending_question {
-        ("?", colors::WARNING)
+        ("?", colors::warning())
     } else if is_error_status(session.last_run_status.as_deref()) {
-        ("✗", colors::ERROR)
+        ("✗", colors::error())
     } else {
-        (" ", colors::INACTIVE)
+        (" ", colors::inactive())
     }
 }
 
@@ -138,7 +183,7 @@ fn session_header(width: u16) -> Line<'static> {
     };
     Line::from(Span::styled(
         label.to_string(),
-        Style::default().fg(colors::SUBTLE),
+        Style::default().fg(colors::subtle()),
     ))
 }
 
@@ -152,10 +197,10 @@ pub(crate) fn session_row_line(
 ) -> Line<'static> {
     let row_style = if selected {
         Style::default()
-            .fg(colors::BRAND)
+            .fg(colors::brand())
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(colors::INACTIVE)
+        Style::default().fg(colors::inactive())
     };
     let title = if session.title.trim().is_empty() {
         "(untitled)"
@@ -214,36 +259,7 @@ pub(crate) fn session_row_line(
 }
 
 pub(crate) fn truncate_cells(value: &str, max_width: usize) -> String {
-    if max_width == 0 {
-        return String::new();
-    }
-    let width = value
-        .chars()
-        .map(|character| UnicodeWidthChar::width(character).unwrap_or(0))
-        .sum::<usize>();
-    if width <= max_width {
-        let mut output = value.to_string();
-        output.extend(std::iter::repeat_n(' ', max_width - width));
-        return output;
-    }
-
-    let target = max_width.saturating_sub(1);
-    let mut output = String::new();
-    let mut used = 0;
-    for character in value.chars() {
-        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
-        if used + character_width > target {
-            break;
-        }
-        output.push(character);
-        used += character_width;
-    }
-    output.push('…');
-    while used + 1 < max_width {
-        output.push(' ');
-        used += 1;
-    }
-    output
+    text::truncate_cells(value, max_width)
 }
 
 #[cfg(test)]
@@ -314,6 +330,57 @@ mod tests {
                 line.width()
             );
         }
+    }
+
+    #[test]
+    fn visible_window_keeps_a_deep_selection_on_screen() {
+        assert_eq!(visible_window(20, 0, 5), 0..5);
+        assert_eq!(visible_window(20, 11, 5), 7..12);
+        assert_eq!(visible_window(3, 99, 5), 0..3);
+        assert_eq!(visible_window(20, 11, 0), 0..0);
+    }
+
+    #[test]
+    fn compact_unicode_session_keeps_selection_status_and_actions_visible() {
+        use crate::api::BambooClient;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = crate::app::Tab::Sessions;
+        app.sessions.sessions = (0..30)
+            .map(|index| {
+                let mut value = session(&format!("session-{index:02}"));
+                value.title = format!("普通会话 {index}");
+                value.model = "provider/模型-alpha".to_string();
+                value
+            })
+            .collect();
+        app.sessions.selected = 24;
+        app.sessions.sessions[24].title = "selected-会话🧭e\u{301}".to_string();
+        app.sessions.sessions[24].is_running = true;
+        app.sessions.total = 30;
+        app.sessions.page_limit = 30;
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("selected-"), "selected row missing:\n{text}");
+        assert!(text.contains('🧭'), "Unicode fixture missing:\n{text}");
+        assert!(text.contains("running"), "text status missing:\n{text}");
+        assert!(
+            text.contains("Enter open"),
+            "compact action footer missing:\n{text}"
+        );
+        assert!(text.contains('›'), "selected-row glyph missing:\n{text}");
     }
 
     /// Smoke test: the table renders with the new columns and page info without

--- a/crates/app/bamboo-tui/src/ui/skills.rs
+++ b/crates/app/bamboo-tui/src/ui/skills.rs
@@ -6,37 +6,48 @@ use ratatui::Frame;
 
 use crate::app::App;
 use crate::theme::colors;
+use crate::ui::sessions::{truncate_cells, visible_window};
 
 pub fn render(f: &mut Frame, area: Rect, app: &App) {
     if app.skills.loading && app.skills.skills.is_empty() {
         let loading =
-            Paragraph::new("Loading skills...").style(Style::default().fg(colors::INACTIVE));
+            Paragraph::new("Loading skills...").style(Style::default().fg(colors::inactive()));
         f.render_widget(loading, area);
         return;
     }
 
     if let Some(err) = &app.skills.error {
         let error =
-            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::ERROR));
+            Paragraph::new(format!("Error: {}", err)).style(Style::default().fg(colors::error()));
         f.render_widget(error, area);
         return;
     }
 
+    let compact = area.width < 80 || area.height < 18;
+    let detail_height = match (&app.skills.detail, compact) {
+        (Some(_), true) => 3,
+        (Some(_), false) => 5,
+        (None, _) => 0,
+    };
     let chunks = ratatui::layout::Layout::default()
         .direction(ratatui::layout::Direction::Vertical)
         .constraints([
             ratatui::layout::Constraint::Length(1),
-            ratatui::layout::Constraint::Min(5),
-            ratatui::layout::Constraint::Min(3),
+            ratatui::layout::Constraint::Min(1),
+            ratatui::layout::Constraint::Length(detail_height),
             ratatui::layout::Constraint::Length(1),
         ])
         .split(area);
 
     // Header
     let header = Paragraph::new(Line::from(Span::styled(
-        " Skills",
+        if compact {
+            format!(" Skills · {} available", app.skills.skills.len())
+        } else {
+            " Skills".to_string()
+        },
         Style::default()
-            .fg(colors::BRAND)
+            .fg(colors::brand())
             .add_modifier(Modifier::BOLD),
     )));
     f.render_widget(header, chunks[0]);
@@ -44,39 +55,38 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     // Skill list
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
-        " ID                Name              Description",
-        Style::default().fg(colors::SUBTLE),
+        truncate_cells(
+            if compact {
+                "   Name · status · description"
+            } else {
+                "   ID  Name  Status  Description"
+            },
+            chunks[1].width as usize,
+        ),
+        Style::default().fg(colors::subtle()),
     )));
 
-    for (i, skill) in app.skills.skills.iter().enumerate() {
-        let style = if i == app.skills.selected {
-            Style::default()
-                .fg(colors::BRAND)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(colors::INACTIVE)
-        };
-
-        let id = skill.id.chars().take(18).collect::<String>();
-        let name = skill.name.chars().take(18).collect::<String>();
-        let desc = skill
-            .description
-            .as_deref()
-            .unwrap_or("-")
-            .chars()
-            .take(40)
-            .collect::<String>();
-
-        lines.push(Line::from(Span::styled(
-            format!(" {:18} {:18} {}", id, name, desc),
-            style,
-        )));
+    let selected = app
+        .skills
+        .selected
+        .min(app.skills.skills.len().saturating_sub(1));
+    let capacity = chunks[1].height.saturating_sub(1) as usize;
+    let visible = visible_window(app.skills.skills.len(), selected, capacity);
+    for (i, skill) in app
+        .skills
+        .skills
+        .iter()
+        .enumerate()
+        .take(visible.end)
+        .skip(visible.start)
+    {
+        lines.push(skill_row_line(skill, i == selected, chunks[1].width));
     }
 
     if app.skills.skills.is_empty() {
         lines.push(Line::from(Span::styled(
             "  No skills available.",
-            Style::default().fg(colors::INACTIVE),
+            Style::default().fg(colors::inactive()),
         )));
     }
 
@@ -86,21 +96,132 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     // Detail
     if let Some(detail) = &app.skills.detail {
         let mut detail_lines = vec![Line::from(Span::styled(
-            format!(" {} - {}", detail.name, detail.id),
-            Style::default().fg(colors::BRAND),
+            truncate_cells(
+                &format!(" {} - {}", detail.name, detail.id),
+                chunks[2].width as usize,
+            ),
+            Style::default().fg(colors::brand()),
         ))];
         if let Some(desc) = &detail.description {
-            detail_lines.push(Line::from(format!("  {}", desc)));
+            detail_lines.push(Line::from(truncate_cells(
+                &format!("  {}", desc),
+                chunks[2].width as usize,
+            )));
         }
         if let Some(tools) = &detail.tools {
-            detail_lines.push(Line::from(format!("  Tools: {}", tools.join(", "))));
+            detail_lines.push(Line::from(truncate_cells(
+                &format!("  Tools: {}", tools.join(", ")),
+                chunks[2].width as usize,
+            )));
         }
         let detail_widget = Paragraph::new(detail_lines);
         f.render_widget(detail_widget, chunks[2]);
     }
 
     // Footer
-    let footer =
-        Paragraph::new(" [Enter] View details").style(Style::default().fg(colors::INACTIVE));
+    let footer_text = if compact {
+        " Enter details"
+    } else {
+        " [Enter] View details"
+    };
+    let footer = Paragraph::new(footer_text).style(Style::default().fg(colors::inactive()));
     f.render_widget(footer, chunks[3]);
+}
+
+fn skill_row_line(skill: &crate::api::types::Skill, selected: bool, width: u16) -> Line<'static> {
+    let row_style = if selected {
+        Style::default()
+            .fg(colors::brand())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(colors::inactive())
+    };
+    let (status_glyph, status, status_style) = match skill.enabled {
+        Some(true) => ("✓", "enabled", Style::default().fg(colors::success())),
+        Some(false) => ("○", "disabled", Style::default().fg(colors::inactive())),
+        None => ("?", "unknown", Style::default().fg(colors::warning())),
+    };
+    let marker = if selected { "›" } else { " " };
+    let description = skill.description.as_deref().unwrap_or("-");
+
+    if width < 80 {
+        // marker/glyph + separators + status consume 18 cells; split the rest
+        // between the skill name and description.
+        let available = width.saturating_sub(18).max(2) as usize;
+        let name_width = (available * 3 / 5).max(1);
+        let description_width = available.saturating_sub(name_width).max(1);
+        Line::from(vec![
+            Span::styled(format!("{marker} {status_glyph} "), status_style),
+            Span::styled(truncate_cells(&skill.name, name_width), row_style),
+            Span::styled(" · ", row_style),
+            Span::styled(truncate_cells(status, 8), status_style),
+            Span::styled(" · ", row_style),
+            Span::styled(truncate_cells(description, description_width), row_style),
+        ])
+    } else {
+        let description_width = width.saturating_sub(54).max(1) as usize;
+        Line::from(vec![
+            Span::styled(format!("{marker} {status_glyph} "), status_style),
+            Span::styled(truncate_cells(&skill.id, 18), row_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(&skill.name, 18), row_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(status, 8), status_style),
+            Span::styled("  ", row_style),
+            Span::styled(truncate_cells(description, description_width), row_style),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::Skill;
+    use crate::api::BambooClient;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn skill(index: usize) -> Skill {
+        Skill {
+            id: format!("skill-{index}"),
+            name: format!("普通技能 {index}"),
+            description: Some("处理 Unicode 描述和很长的文字".to_string()),
+            enabled: Some(index.is_multiple_of(2)),
+        }
+    }
+
+    #[test]
+    fn compact_unicode_skill_keeps_selection_status_and_actions_visible() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = crate::app::Tab::Skills;
+        app.skills.skills = (0..30).map(skill).collect();
+        app.skills.selected = 24;
+        app.skills.skills[24].name = "selected-技能🧭e\u{301}".to_string();
+        app.skills.skills[24].enabled = Some(true);
+
+        let row = skill_row_line(&app.skills.skills[24], true, 50);
+        assert!(row.width() <= 50);
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(text.contains("selected-"), "selected row missing:\n{text}");
+        assert!(text.contains('🧭'), "Unicode fixture missing:\n{text}");
+        assert!(text.contains("enabled"), "text status missing:\n{text}");
+        assert!(
+            text.contains("Enter details"),
+            "compact action footer missing:\n{text}"
+        );
+        assert!(text.contains('›'), "selected-row glyph missing:\n{text}");
+    }
 }

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -220,6 +220,11 @@ enum Commands {
         #[arg(short, long)]
         model: Option<String>,
 
+        /// Colour palette: truecolor, system (terminal ANSI colours), or
+        /// no-color. `NO_COLOR` selects no-color when omitted.
+        #[arg(long)]
+        theme: Option<bamboo_tui::ThemePalette>,
+
         /// If `--server-url` is unreachable and loopback, start a local
         /// `bamboo serve` automatically instead of asking (y/n). No effect for
         /// a remote (non-loopback) `--server-url` — that always just warns.
@@ -1517,6 +1522,7 @@ async fn run() {
             server_url,
             session_id,
             model,
+            theme,
             auto_serve,
             no_auto_serve,
         } => {
@@ -1535,6 +1541,7 @@ async fn run() {
                 session_id,
                 model,
                 auto_serve,
+                theme,
             })
             .await;
             if let Err(e) = result {
@@ -2289,6 +2296,7 @@ mod tests {
             "server_url",
             "session_id",
             "model",
+            "theme",
             "auto_serve",
             "no_auto_serve",
         ] {


### PR DESCRIPTION
## Summary
- make the terminal shell responsive from the supported 60x20 minimum through wide layouts
- add grapheme-safe clipping, scrolling, deterministic status priority, confirmations, and inspectable full values
- add TrueColor, System, and NoColor themes across standalone and embedded TUI entrypoints
- cover views, themes, and modal states with fixed full-buffer TestBackend fingerprints

## Test Plan
- cargo test
- cargo test --locked -p bamboo-tui
- cargo clippy --locked -p bamboo-tui --all-targets -- -D warnings
- cargo fmt --all --check
- git diff --check

## Screenshots
Not included: this terminal UI is verified with fixed full-buffer render goldens across supported dimensions and theme modes.

Closes #638