### PR TITLE
feat(tui): centralize configurable keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Arguments supported by `bamboo serve` (all override the config file):
 | `bamboo mcp list` | List the MCP servers configured in `config.json` (offline; no server needed). |
 | `bamboo mcp status\|connect\|disconnect\|refresh\|tools\|add\|remove` | Manage MCP servers on a running instance over `/api/v1/mcp`: live connection state + tool counts (`status [--json]`), enable/connect + disable/disconnect a server, re-list tools (`refresh [<id>]`), inspect tools (`tools [<id>] [--json]`), add from a raw JSON payload (`add --json <file\|->`), and delete (`remove <id>`, confirms unless `--yes`; a removed server can be re-added with `add`). |
 
+TUI bindings are context-aware and configurable with `--keymap`; see
+[TUI keybindings](docs/tui-keybindings.md) for the JSON schema, safety rules,
+and terminal fallbacks.
+
 The admin commands (`health` / `status` / `sessions` / `stop` / `history` / `respond` / `session` / `schedules`) are thin HTTP clients over a running `bamboo serve`; point them at a non-default server with `--server-url` / `--port` / `--data-dir`. The read commands (`skills list` / `mcp list`) work offline against `--data-dir` (default `~/.bamboo`); the other `mcp` verbs are server-backed and take the same connection flags. (`bamboo subagent-worker` also exists but is an internal worker process spawned by the server — not for interactive use.)
 
 A global `--log-level <error|warn|info|debug|trace>` sets the default log level for any command when `RUST_LOG` is unset (`RUST_LOG` still wins when present). `bamboo serve` defaults to `info` in every build profile. Embedded debug builds keep `debug` on stdout while date-rotated files default to `info`; at startup, strictly matching historical files are retained by both count and a 128 MiB total byte budget. Daily rotation continues during long-running processes, and startup limits are enforced again on the next process start. Use `--log-level debug`, `-v`, or `RUST_LOG` to opt into more detail; target-specific directives such as `RUST_LOG=h2=debug` override the dependency-noise defaults while leaving each sink's root default unchanged.

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -2287,10 +2287,7 @@ impl App {
             match (is_loopback_url(&url), auto_serve_mode) {
                 (true, AutoServeMode::Auto) => self.spawn_local_server(),
                 (true, AutoServeMode::Prompt) => {
-                    self.status_message = format!(
-                        "Bamboo server is not reachable at {url}. Start a local server? (y/n)"
-                    );
-                    self.serve_offer = Some(ServeOffer { url });
+                    self.open_serve_offer(url);
                 }
                 // Loopback but auto-serve explicitly disabled, or a remote URL
                 // (never auto-started regardless of flags): keep the previous
@@ -2388,6 +2385,16 @@ impl App {
         }
 
         Ok(())
+    }
+
+    fn open_serve_offer(&mut self, url: String) {
+        let confirm =
+            self.action_key_phrase(ActionContext::ServeOffer, ActionId::Confirm, "starts");
+        let reject = self.action_key_phrase(ActionContext::ServeOffer, ActionId::Reject, "skips");
+        self.status_message = format!(
+            "Bamboo server is not reachable at {url}. Start a local server? ({confirm}; {reject})"
+        );
+        self.serve_offer = Some(ServeOffer { url });
     }
 
     fn poll_sse(&mut self) {
@@ -4769,9 +4776,18 @@ impl App {
                 // answer — Ctrl+Q brings the modal back without a round-trip.
                 self.supersede_pending_answer();
                 self.dismissed_question = self.pending_question.take();
-                self.status_message = "Question dismissed (still pending on the server — \
-                    Ctrl+Q to reopen, Ctrl+C stops the run)"
-                    .to_string();
+                let reopen = self.action_key_phrase(
+                    ActionContext::Global,
+                    ActionId::ReopenPendingQuestion,
+                    "reopens",
+                );
+                let stop = self.action_key_phrase(
+                    ActionContext::Global,
+                    ActionId::QuitOrStop,
+                    "stops the run",
+                );
+                self.status_message =
+                    format!("Question dismissed (still pending on the server — {reopen}, {stop})");
             }
             QAction::None => {}
         }
@@ -13997,19 +14013,32 @@ mod question_tests {
         assert_eq!(app.chat.session_id.as_deref(), Some("s1"));
     }
 
-    /// Esc dismisses the question modal but caches it; `Ctrl+Q` brings it
-    /// straight back without a network round-trip.
+    /// Esc dismisses the question modal but caches it; the resolved reopen
+    /// binding brings it straight back without a network round-trip.
     #[tokio::test]
-    async fn esc_then_ctrl_q_restores_the_dismissed_question() {
+    async fn dismiss_status_and_reopen_use_resolved_global_bindings() {
         let mut app = app_with_question(vec!["Approve", "Deny"]);
+        app.set_keymap(
+            Keymap::from_json(
+                r#"{"bindings":[
+                    {"context":"global","action":"reopen-pending-question","keys":["F7"]},
+                    {"context":"global","action":"quit-or-stop","keys":["F8"]}
+                ]}"#,
+            )
+            .unwrap(),
+            None,
+        );
         app.chat.session_id = Some("s1".to_string());
 
         app.handle_question_key(key(KeyCode::Esc)).await.unwrap();
         assert!(app.pending_question.is_none());
         assert!(app.dismissed_question.is_some());
-        assert!(app.status_message.contains("Ctrl+Q"));
+        assert!(app.status_message.contains("F7 reopens"));
+        assert!(app.status_message.contains("F8 stops the run"));
+        assert!(!app.status_message.contains("Ctrl+Q"));
+        assert!(!app.status_message.contains("Ctrl+C"));
 
-        app.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL))
+        app.handle_key(KeyEvent::new(KeyCode::F(7), KeyModifiers::empty()))
             .await
             .unwrap();
 
@@ -15617,6 +15646,27 @@ mod auto_serve_tests {
             url: "http://127.0.0.1:9562".to_string(),
         });
         app
+    }
+
+    #[test]
+    fn serve_offer_status_uses_resolved_confirm_and_reject_bindings() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.set_keymap(
+            Keymap::from_json(
+                r#"{"bindings":[
+                    {"context":"serve-offer","action":"confirm","keys":["F7"]},
+                    {"context":"serve-offer","action":"reject","keys":["F8"]}
+                ]}"#,
+            )
+            .unwrap(),
+            None,
+        );
+        app.open_serve_offer("http://127.0.0.1:9562".to_string());
+
+        assert!(app.status_message.contains("F7 starts"));
+        assert!(app.status_message.contains("F8 skips"));
+        assert!(!app.status_message.contains("(y/n)"));
+        assert!(app.serve_offer.is_some());
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -21,8 +21,8 @@ use crate::api::{BambooClient, RespondFailure};
 use crate::event::AppEvent;
 use crate::history::map_history;
 use crate::keymap::{
-    text_character, ActionAvailability, ActionContext, ActionId, HelpEntry, KeyResolution, Keymap,
-    PendingSequence,
+    text_character, text_widget_input_allowed, ActionAvailability, ActionContext, ActionId,
+    HelpEntry, KeyResolution, Keymap, PendingSequence,
 };
 use crate::search::ranked_indices;
 use crate::ui;
@@ -91,6 +91,71 @@ mod action_keymap_integration_tests {
     }
 
     #[tokio::test]
+    async fn global_quit_preempts_a_pending_leader_at_runtime() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.handle_key(press(KeyCode::Char('\\'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(app.pending_key_sequence.is_some());
+
+        app.handle_key(press(KeyCode::Char('c'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(!app.running);
+        assert!(app.pending_key_sequence.is_none());
+    }
+
+    #[tokio::test]
+    async fn remapped_send_feedback_uses_the_resolved_binding() {
+        let keymap = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"chat","action":"send-message","keys":["F12"]}
+            ]}"#,
+        )
+        .unwrap();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.set_keymap(keymap, None);
+        app.chat.streaming = true;
+        app.handle_key(press(KeyCode::F(12), KeyModifiers::empty()))
+            .await
+            .unwrap();
+        assert!(app.status_message.contains("F12 sends after completion"));
+        assert!(!app.status_message.contains("Enter"));
+    }
+
+    #[tokio::test]
+    async fn rejected_printable_global_prefix_falls_back_without_swallowing_chat_text() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "bamboo-tui-printable-prefix-{}-{unique}.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            r#"{"bindings":[
+                {"context":"global","action":"show-help","keys":["g n"]}
+            ]}"#,
+        )
+        .unwrap();
+        let (keymap, warning) = Keymap::load(Some(&path));
+        std::fs::remove_file(path).unwrap();
+        assert!(warning
+            .as_deref()
+            .is_some_and(|message| message.contains("starts with a printable key")));
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.set_keymap(keymap, warning);
+        app.handle_key(press(KeyCode::Char('g'), KeyModifiers::empty()))
+            .await
+            .unwrap();
+        assert_eq!(app.chat.textarea.lines().join("\n"), "g");
+        assert!(app.pending_key_sequence.is_none());
+    }
+
+    #[tokio::test]
     async fn modified_text_release_and_repeat_events_keep_focus_and_mutations_safe() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.handle_key(press(KeyCode::Char('y'), KeyModifiers::CONTROL))
@@ -99,6 +164,11 @@ mod action_keymap_integration_tests {
         app.handle_key(press(KeyCode::Char('z'), KeyModifiers::ALT))
             .await
             .unwrap();
+        for modifier in [KeyModifiers::SUPER, KeyModifiers::HYPER, KeyModifiers::META] {
+            app.handle_key(press(KeyCode::Char('y'), modifier))
+                .await
+                .unwrap();
+        }
         assert_eq!(app.chat.textarea.lines().join("\n"), "");
 
         app.help_visible = true;
@@ -142,6 +212,16 @@ mod action_keymap_integration_tests {
             app.pending_delete.is_some(),
             "modified text must not confirm a destructive action"
         );
+
+        for modifier in [KeyModifiers::SUPER, KeyModifiers::HYPER, KeyModifiers::META] {
+            app.handle_key(press(KeyCode::Char('y'), modifier))
+                .await
+                .unwrap();
+            assert!(
+                app.pending_delete.is_some(),
+                "{modifier:?}+y must not confirm a destructive action"
+            );
+        }
 
         app.handle_key(press(KeyCode::Char('y'), KeyModifiers::empty()))
             .await
@@ -2161,6 +2241,20 @@ impl App {
             .to_string()
     }
 
+    pub(crate) fn action_key_phrase(
+        &self,
+        context: ActionContext,
+        action: ActionId,
+        verb: &str,
+    ) -> String {
+        let hint = self.key_hint(context, action);
+        if hint == "unbound" {
+            format!("{} is unbound", action.label())
+        } else {
+            format!("{hint} {verb}")
+        }
+    }
+
     pub(crate) fn help_entries(&self) -> Vec<HelpEntry> {
         self.keymap.help_entries()
     }
@@ -2326,7 +2420,7 @@ impl App {
             // advancing or a resize could strand the app in a stale state.
             match &event {
                 AppEvent::Key(key) => {
-                    if key.kind != KeyEventKind::Release
+                    if key.kind == KeyEventKind::Press
                         && self.resolve_context_action(ActionContext::Global, *key)
                             == Some(ActionId::QuitOrStop)
                     {
@@ -2922,6 +3016,11 @@ impl App {
                 session_id,
                 result,
             } => {
+                let retry = self.action_key_phrase(
+                    ActionContext::CommandPalette,
+                    ActionId::Refresh,
+                    "retries",
+                );
                 let current_session = self.chat.session_id.clone();
                 let selected_key = self
                     .command_palette
@@ -2950,9 +3049,7 @@ impl App {
                         palette.refresh_filter(selected_key);
                     }
                     Err(error) => {
-                        palette.error = Some(format!(
-                            "Failed to load commands: {error} — press Ctrl+R to retry"
-                        ));
+                        palette.error = Some(format!("Failed to load commands: {error} — {retry}"));
                     }
                 }
             }
@@ -2962,6 +3059,13 @@ impl App {
                 command_key,
                 result,
             } => {
+                let retry = self.action_key_phrase(
+                    ActionContext::CommandPalette,
+                    ActionId::Activate,
+                    "retries",
+                );
+                let send =
+                    self.action_key_phrase(ActionContext::Chat, ActionId::SendMessage, "sends");
                 let current_session = self.chat.session_id.clone();
                 let Some(palette) = self.command_palette.as_mut().filter(|palette| {
                     palette.epoch == epoch
@@ -3007,17 +3111,20 @@ impl App {
                         self.tab = Tab::Chat;
                         self.close_command_palette();
                         self.status_message =
-                            "Command loaded into composer — review and press Enter to send"
-                                .to_string();
+                            format!("Command loaded into composer — review; {send}");
                     }
                     Err(error) => {
-                        palette.error = Some(format!(
-                            "Failed to resolve command: {error} — press Enter to retry"
-                        ));
+                        palette.error =
+                            Some(format!("Failed to resolve command: {error} — {retry}"));
                     }
                 }
             }
             AppEvent::CatalogLoaded { epoch, result } => {
+                let retry = self.action_key_phrase(
+                    ActionContext::ModelPicker,
+                    ActionId::Refresh,
+                    "retries",
+                );
                 let selected_key = self
                     .model_picker
                     .as_ref()
@@ -3050,14 +3157,15 @@ impl App {
                             &self.recent_models,
                         );
                         picker.models = catalog.models;
-                        picker.error = picker.models.is_empty().then(|| {
-                            "No models in provider catalog — press Ctrl+R to retry".to_string()
-                        });
+                        picker.error = picker
+                            .models
+                            .is_empty()
+                            .then(|| format!("No models in provider catalog — {retry}"));
                         picker.refresh_filter(selected_key);
                     }
                     Err(error) => {
                         picker.error = Some(format!(
-                            "Failed to load provider catalog: {error} — press Ctrl+R to retry"
+                            "Failed to load provider catalog: {error} — {retry}"
                         ));
                     }
                 }
@@ -3068,6 +3176,13 @@ impl App {
                 model,
                 result,
             } => {
+                let retry = self.action_key_phrase(
+                    ActionContext::ModelPicker,
+                    ActionId::Activate,
+                    "retries",
+                );
+                let cancel =
+                    self.action_key_phrase(ActionContext::ModelPicker, ActionId::Cancel, "cancels");
                 let Some(picker) = self
                     .model_picker
                     .as_mut()
@@ -3088,7 +3203,7 @@ impl App {
                     Ok(()) => self.commit_model_selection(model),
                     Err(error) => {
                         picker.error = Some(format!(
-                            "Failed to update session model: {error} — press Enter to retry or Esc to cancel"
+                            "Failed to update session model: {error} — {retry}; {cancel}"
                         ));
                     }
                 }
@@ -3098,6 +3213,11 @@ impl App {
                 offset,
                 result,
             } => {
+                let retry = self.action_key_phrase(
+                    ActionContext::SessionPickerBrowse,
+                    ActionId::Refresh,
+                    "retries",
+                );
                 let Some(picker) = self
                     .session_picker
                     .as_mut()
@@ -3152,9 +3272,7 @@ impl App {
                         picker.refresh_filter(preserve_id);
                     }
                     Err(error) => {
-                        picker.error = Some(format!(
-                            "Failed to load sessions: {error} — press Ctrl+R to retry"
-                        ));
+                        picker.error = Some(format!("Failed to load sessions: {error} — {retry}"));
                     }
                 }
                 let should_continue = self.session_picker.as_ref().is_some_and(|picker| {
@@ -3173,6 +3291,11 @@ impl App {
                 intent,
                 result,
             } => {
+                let retry_context = match &intent {
+                    SessionPickerIntent::Rename => ActionContext::SessionPickerRename,
+                    SessionPickerIntent::Pin(_) => ActionContext::SessionPickerPinning,
+                };
+                let retry = self.action_key_phrase(retry_context, ActionId::Refresh, "retries");
                 let Some(picker) = self
                     .session_picker
                     .as_mut()
@@ -3214,10 +3337,9 @@ impl App {
                                     // made visible and explicitly retried.
                                     *metadata_version = None;
                                     *base_title = fresh_title;
-                                    *error = Some(
-                                        "Title changed on the server; draft preserved — press Ctrl+R to confirm against the latest title"
-                                            .to_string(),
-                                    );
+                                    *error = Some(format!(
+                                        "Title changed on the server; draft preserved — {retry} against the latest title"
+                                    ));
                                 } else {
                                     if !*draft_dirty {
                                         *draft = fresh_title.clone();
@@ -3255,7 +3377,7 @@ impl App {
                         } => {
                             *loading_version = false;
                             *error = Some(format!(
-                                "Failed to prepare update: {error_message} — press Ctrl+R to retry"
+                                "Failed to prepare update: {error_message} — {retry}"
                             ));
                         }
                         SessionPickerMode::Browse => {}
@@ -3280,6 +3402,11 @@ impl App {
                 intent,
                 result,
             } => {
+                let retry_context = match &intent {
+                    SessionPickerIntent::Rename => ActionContext::SessionPickerRename,
+                    SessionPickerIntent::Pin(_) => ActionContext::SessionPickerPinning,
+                };
+                let retry = self.action_key_phrase(retry_context, ActionId::Refresh, "retries");
                 let Some(picker) = self
                     .session_picker
                     .as_mut()
@@ -3318,8 +3445,7 @@ impl App {
                             .current_version
                             .map(|version| format!(" (server version {version})"))
                             .unwrap_or_default();
-                        let message =
-                            format!("{prefix}{current}: {failure} — press Ctrl+R to retry");
+                        let message = format!("{prefix}{current}: {failure} — {retry}");
                         match &mut picker.mode {
                             SessionPickerMode::Rename {
                                 metadata_version,
@@ -3649,8 +3775,23 @@ impl App {
         };
         self.chat.focused_block = Some(id.clone());
         self.scroll_to_conversation_block(&id);
-        self.status_message =
-            "Block focused — ↑/↓ move · Enter use · y copy · Esc composer".to_string();
+        self.status_message = format!(
+            "Block focused — {}/{} move · {} use · {} copy · {} composer",
+            self.primary_key_hint(
+                ActionContext::ConversationBlock,
+                ActionId::PreviousConversationBlock,
+            ),
+            self.primary_key_hint(
+                ActionContext::ConversationBlock,
+                ActionId::NextConversationBlock,
+            ),
+            self.primary_key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+            self.primary_key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+            self.primary_key_hint(
+                ActionContext::ConversationBlock,
+                ActionId::ExitConversationBlocks,
+            ),
+        );
     }
 
     fn move_conversation_block_focus(&mut self, delta: i32) {
@@ -5067,15 +5208,22 @@ impl App {
                 self.open_command_palette(CommandPaletteTrigger::Slash);
             }
             Some(ActionId::OpenSlashPalette) => {
-                self.chat.textarea.input(key);
+                if text_widget_input_allowed(key) {
+                    self.chat.textarea.input(key);
+                }
             }
             Some(ActionId::ScrollTranscriptDown) => self.chat_scroll_down(10),
             Some(ActionId::ScrollTranscriptUp) => self.chat_scroll_up(10),
             Some(ActionId::InsertNewline) => self.chat.textarea.insert_newline(),
             Some(ActionId::SendMessage) if self.chat.streaming => {
-                self.status_message =
-                    "Run active — draft preserved; press Enter after completion to send"
-                        .to_string();
+                self.status_message = format!(
+                    "Run active — draft preserved; {}",
+                    self.action_key_phrase(
+                        ActionContext::Chat,
+                        ActionId::SendMessage,
+                        "sends after completion"
+                    )
+                );
             }
             Some(ActionId::SendMessage) => {
                 // Selecting a session starts an asynchronous history/summary
@@ -5108,7 +5256,9 @@ impl App {
                 self.send_message(input);
             }
             None => {
-                self.chat.textarea.input(key);
+                if text_widget_input_allowed(key) {
+                    self.chat.textarea.input(key);
+                }
             }
             Some(_) => {}
         }
@@ -6048,14 +6198,18 @@ impl App {
                     }
                 }
                 if self.pending_question.is_none() {
+                    let reopen = self.action_key_phrase(
+                        ActionContext::Global,
+                        ActionId::ReopenPendingQuestion,
+                        "reopens",
+                    );
                     if let Some(dismissed) = self.dismissed_question.as_mut() {
                         if dismissed.identity() == incoming.identity() {
                             // Replayed critical events must not undo an explicit
                             // Esc dismissal. Refresh the typed contract/draft in
                             // place and keep the question cached for Ctrl+Q.
                             dismissed.refresh_contract(incoming);
-                            self.status_message =
-                                "Question remains dismissed (Ctrl+Q to reopen)".to_string();
+                            self.status_message = format!("Question remains dismissed ({reopen})");
                             if needs_identity_sync {
                                 if let Some(session_id) = self.chat.session_id.clone() {
                                     self.reconcile_pending_question_after_stream_connect(
@@ -6786,7 +6940,9 @@ impl App {
         if action.is_none() {
             if let Some(editor) = self.config_editor.as_mut() {
                 editor.error = None;
-                editor.textarea.input(key);
+                if text_widget_input_allowed(key) {
+                    editor.textarea.input(key);
+                }
             }
         }
         Ok(())
@@ -7617,12 +7773,13 @@ impl App {
         self.install_command_draft(draft);
         self.tab = Tab::Chat;
         self.close_command_palette();
-        self.status_message = match command.command_type.to_ascii_lowercase().as_str() {
-            "skill" => "Skill command inserted — review and press Enter to send",
-            "mcp" => "MCP command inserted — review and press Enter to send",
-            _ => "Command inserted — review and press Enter to send",
-        }
-        .to_string();
+        let kind = match command.command_type.to_ascii_lowercase().as_str() {
+            "skill" => "Skill",
+            "mcp" => "MCP",
+            _ => "Command",
+        };
+        let send = self.action_key_phrase(ActionContext::Chat, ActionId::SendMessage, "sends");
+        self.status_message = format!("{kind} command inserted — review; {send}");
     }
 
     fn install_command_draft(&mut self, content: String) {
@@ -8037,6 +8194,15 @@ mod command_palette_tests {
     #[tokio::test]
     async fn catalog_failure_and_stale_epoch_leave_composer_and_palette_interactive() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.set_keymap(
+            Keymap::from_json(
+                r#"{"bindings":[
+                    {"context":"command-palette","action":"refresh","keys":["F10"]}
+                ]}"#,
+            )
+            .unwrap(),
+            None,
+        );
         app.chat.session_id = Some("session-1".to_string());
         app.chat.textarea.insert_str("keep this draft");
         app.chat.textarea.move_cursor(CursorMove::Jump(0, 4));
@@ -8063,6 +8229,8 @@ mod command_palette_tests {
             .error
             .as_deref()
             .is_some_and(|error| error.contains("offline")));
+        assert!(palette.error.as_deref().unwrap().contains("F10 retries"));
+        assert!(!palette.error.as_deref().unwrap().contains("Ctrl+R"));
         assert!(before.still_matches(&app.chat.textarea));
 
         app.command_palette.as_mut().unwrap().epoch = epoch.wrapping_add(1);
@@ -8304,7 +8472,7 @@ mod command_palette_tests {
         );
         assert!(!app.chat.streaming);
         assert!(app.chat.messages.is_empty());
-        assert!(app.status_message.contains("review and press Enter"));
+        assert!(app.status_message.contains("review; Enter sends"));
     }
 
     #[tokio::test]
@@ -10540,6 +10708,14 @@ mod question_tests {
         app.chat.streaming = true;
         app.help_visible = true;
         app.handle_event(AppEvent::Resize(50, 15)).await.unwrap();
+        app.handle_event(AppEvent::Key(KeyEvent::new_with_kind(
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL,
+            KeyEventKind::Repeat,
+        )))
+        .await
+        .unwrap();
+        assert!(app.running, "held-key repeat must not quit the TUI");
         app.handle_event(AppEvent::Key(KeyEvent::new(
             KeyCode::Char('c'),
             KeyModifiers::CONTROL,
@@ -14934,7 +15110,7 @@ mod question_tests {
         assert_eq!(picker.query, "claude");
         assert_eq!(model_key(picker.selected_model().unwrap()), selected_key);
         assert!(!picker.applying);
-        assert!(picker.error.as_deref().unwrap().contains("Enter to retry"));
+        assert!(picker.error.as_deref().unwrap().contains("Enter retries"));
         assert_eq!(app.chat.model, "old-model");
         assert_eq!(app.chat.textarea.lines().join("\n"), "d");
     }

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use base64::prelude::{Engine as _, BASE64_STANDARD};
 use chrono::{DateTime, Utc};
-use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, EventStream, KeyEvent, KeyEventKind};
 use futures::StreamExt;
 use ratatui::backend::CrosstermBackend;
 use ratatui::style::{Modifier, Style};
@@ -20,6 +20,10 @@ use crate::api::types::*;
 use crate::api::{BambooClient, RespondFailure};
 use crate::event::AppEvent;
 use crate::history::map_history;
+use crate::keymap::{
+    text_character, ActionAvailability, ActionContext, ActionId, HelpEntry, KeyResolution, Keymap,
+    PendingSequence,
+};
 use crate::search::ranked_indices;
 use crate::ui;
 
@@ -31,6 +35,119 @@ pub enum Tab {
     Schedules,
     Skills,
     Config,
+}
+
+#[cfg(test)]
+mod action_keymap_integration_tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+    fn press(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    #[tokio::test]
+    async fn remapped_global_action_drives_runtime_and_help_from_one_source() {
+        let keymap = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"global","action":"show-help","keys":["F6"]}
+            ]}"#,
+        )
+        .unwrap();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.set_keymap(keymap, None);
+
+        app.handle_key(press(KeyCode::F(1), KeyModifiers::empty()))
+            .await
+            .unwrap();
+        assert!(!app.help_visible);
+
+        app.handle_key(press(KeyCode::F(6), KeyModifiers::empty()))
+            .await
+            .unwrap();
+        assert!(app.help_visible);
+        let help_entries = app.help_entries();
+        assert!(help_entries
+            .iter()
+            .any(|entry| { entry.keys == "F6" && entry.description == "Global · Show help" }));
+        assert!(!help_entries
+            .iter()
+            .any(|entry| { entry.keys == "F1" && entry.description == "Global · Show help" }));
+    }
+
+    #[tokio::test]
+    async fn shared_leader_reaches_global_action_from_chat() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.handle_key(press(KeyCode::Char('\\'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(app.pending_key_sequence.is_some());
+
+        app.handle_key(press(KeyCode::Char('h'), KeyModifiers::empty()))
+            .await
+            .unwrap();
+        assert!(app.help_visible);
+        assert!(app.pending_key_sequence.is_none());
+    }
+
+    #[tokio::test]
+    async fn modified_text_release_and_repeat_events_keep_focus_and_mutations_safe() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.handle_key(press(KeyCode::Char('y'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        app.handle_key(press(KeyCode::Char('z'), KeyModifiers::ALT))
+            .await
+            .unwrap();
+        assert_eq!(app.chat.textarea.lines().join("\n"), "");
+
+        app.help_visible = true;
+        app.help_max_scroll.set(10);
+        app.handle_key(KeyEvent::new_with_kind(
+            KeyCode::Down,
+            KeyModifiers::empty(),
+            KeyEventKind::Repeat,
+        ))
+        .await
+        .unwrap();
+        assert_eq!(app.help_scroll, 1, "safe navigation may auto-repeat");
+
+        app.help_visible = false;
+        app.pending_delete = Some(("s1".to_string(), "Session".to_string()));
+        app.handle_key(KeyEvent::new_with_kind(
+            KeyCode::Char('y'),
+            KeyModifiers::empty(),
+            KeyEventKind::Repeat,
+        ))
+        .await
+        .unwrap();
+        assert!(
+            app.pending_delete.is_some(),
+            "repeat must not confirm delete"
+        );
+
+        app.handle_key(KeyEvent::new_with_kind(
+            KeyCode::Char('y'),
+            KeyModifiers::empty(),
+            KeyEventKind::Release,
+        ))
+        .await
+        .unwrap();
+        assert!(app.pending_delete.is_some(), "release must be ignored");
+
+        app.handle_key(press(KeyCode::Char('y'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(
+            app.pending_delete.is_some(),
+            "modified text must not confirm a destructive action"
+        );
+
+        app.handle_key(press(KeyCode::Char('y'), KeyModifiers::empty()))
+            .await
+            .unwrap();
+        assert!(app.pending_delete.is_none(), "press confirms exactly once");
+    }
 }
 
 impl Tab {
@@ -324,10 +441,15 @@ impl ConversationBlock<'_> {
     }
 }
 
-/// Textarea placeholder shown on an empty Chat input, kept as one constant so
-/// the initial state and the post-send reset (`handle_chat_key`) can't drift.
-const CHAT_PLACEHOLDER: &str = "Type a message... (Enter send · Alt+Enter newline)";
 pub(crate) const CONVERSATION_DETAIL_VIEWPORT: usize = 10;
+
+fn chat_placeholder_for(keymap: &Keymap) -> String {
+    format!(
+        "Type a message... ({} send · {} newline)",
+        keymap.hint(ActionContext::Chat, ActionId::SendMessage),
+        keymap.hint(ActionContext::Chat, ActionId::InsertNewline),
+    )
+}
 
 fn tool_block_id(turn_id: &str, tool_call_id: &str) -> String {
     format!("{turn_id}:tool:{tool_call_id}")
@@ -447,7 +569,7 @@ pub struct ChatState {
 impl ChatState {
     pub fn new() -> Self {
         let mut textarea = TextArea::default();
-        textarea.set_placeholder_text(CHAT_PLACEHOLDER);
+        textarea.set_placeholder_text(chat_placeholder_for(&Keymap::default()));
         apply_textarea_palette(&mut textarea, crate::theme::ThemePalette::TrueColor);
         Self {
             session_id: None,
@@ -1309,66 +1431,9 @@ pub enum CommandPaletteTrigger {
     Global,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum BuiltinPaletteAction {
-    NewSession,
-    OpenSession,
-    SelectModel,
-    Help,
-    Notifications,
-    Stop,
-    ToggleDetails,
-    Config,
-    Schedules,
-}
-
-impl BuiltinPaletteAction {
-    fn key(self) -> &'static str {
-        match self {
-            Self::NewSession => "new-session",
-            Self::OpenSession => "open-session",
-            Self::SelectModel => "select-model",
-            Self::Help => "help",
-            Self::Notifications => "notifications",
-            Self::Stop => "stop",
-            Self::ToggleDetails => "toggle-details",
-            Self::Config => "config",
-            Self::Schedules => "schedules",
-        }
-    }
-
-    pub(crate) fn name(self) -> &'static str {
-        match self {
-            Self::NewSession => "New session",
-            Self::OpenSession => "Open session",
-            Self::SelectModel => "Select model",
-            Self::Help => "Show help",
-            Self::Notifications => "Show notifications",
-            Self::Stop => "Stop active run",
-            Self::ToggleDetails => "Toggle focused details",
-            Self::Config => "Open config",
-            Self::Schedules => "Open schedules",
-        }
-    }
-
-    pub(crate) fn description(self) -> &'static str {
-        match self {
-            Self::NewSession => "Clear conversation state and start a fresh session",
-            Self::OpenSession => "Search and resume an existing session",
-            Self::SelectModel => "Choose a provider-qualified model",
-            Self::Help => "Show all TUI keyboard shortcuts",
-            Self::Notifications => "Review recent status, warning, and error messages",
-            Self::Stop => "Request cancellation of the currently running agent",
-            Self::ToggleDetails => "Toggle the focused block, or the default for new details",
-            Self::Config => "Switch to the configuration tab",
-            Self::Schedules => "Switch to the schedules tab",
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
 pub enum CommandPaletteEntry {
-    Builtin(BuiltinPaletteAction),
+    Builtin(ActionId),
     Server(CommandItem),
 }
 
@@ -1386,7 +1451,7 @@ impl CommandPaletteEntry {
 
     pub(crate) fn display_name(&self) -> &str {
         match self {
-            Self::Builtin(action) => action.name(),
+            Self::Builtin(action) => action.label(),
             Self::Server(command) if command.display_name.trim().is_empty() => &command.name,
             Self::Server(command) => &command.display_name,
         }
@@ -1535,7 +1600,7 @@ fn command_search_text(entry: &CommandPaletteEntry) -> String {
     match entry {
         CommandPaletteEntry::Builtin(action) => format!(
             "{} {} ui builtin {}",
-            action.name(),
+            action.label(),
             action.description(),
             action.key()
         ),
@@ -1567,20 +1632,9 @@ fn command_search_text(entry: &CommandPaletteEntry) -> String {
 }
 
 fn builtin_command_palette_entries() -> Vec<CommandPaletteEntry> {
-    [
-        BuiltinPaletteAction::NewSession,
-        BuiltinPaletteAction::OpenSession,
-        BuiltinPaletteAction::SelectModel,
-        BuiltinPaletteAction::Help,
-        BuiltinPaletteAction::Notifications,
-        BuiltinPaletteAction::Stop,
-        BuiltinPaletteAction::ToggleDetails,
-        BuiltinPaletteAction::Config,
-        BuiltinPaletteAction::Schedules,
-    ]
-    .into_iter()
-    .map(CommandPaletteEntry::Builtin)
-    .collect()
+    ActionId::palette_actions()
+        .map(CommandPaletteEntry::Builtin)
+        .collect()
 }
 
 /// Merge defensively while preserving the server's first-wins order. The
@@ -1823,6 +1877,9 @@ pub struct App {
     pub running: bool,
     pub tab: Tab,
     pub theme: crate::theme::ThemePalette,
+    pub(crate) keymap: Keymap,
+    pending_key_sequence: Option<PendingSequence>,
+    routed_action: Option<(ActionContext, ActionId)>,
     pub terminal_width: u16,
     pub terminal_height: u16,
     pub client: BambooClient,
@@ -2013,6 +2070,9 @@ impl App {
             running: true,
             tab: Tab::Chat,
             theme: crate::theme::ThemePalette::TrueColor,
+            keymap: Keymap::default(),
+            pending_key_sequence: None,
+            routed_action: None,
             terminal_width: u16::MAX,
             terminal_height: u16::MAX,
             client,
@@ -2079,6 +2139,40 @@ impl App {
         }
     }
 
+    pub(crate) fn set_keymap(&mut self, keymap: Keymap, warning: Option<String>) {
+        self.keymap = keymap;
+        self.pending_key_sequence = None;
+        let placeholder = self.chat_placeholder();
+        self.chat.textarea.set_placeholder_text(placeholder);
+        if let Some(warning) = warning {
+            self.notify(NoticeLevel::Warn, warning);
+        }
+    }
+
+    pub(crate) fn key_hint(&self, context: ActionContext, action: ActionId) -> String {
+        self.keymap.hint(context, action)
+    }
+
+    pub(crate) fn primary_key_hint(&self, context: ActionContext, action: ActionId) -> String {
+        self.key_hint(context, action)
+            .split('/')
+            .next()
+            .unwrap_or("unbound")
+            .to_string()
+    }
+
+    pub(crate) fn help_entries(&self) -> Vec<HelpEntry> {
+        self.keymap.help_entries()
+    }
+
+    pub(crate) fn action_hint(&self, action: ActionId) -> Option<String> {
+        self.keymap.action_hint(action)
+    }
+
+    fn chat_placeholder(&self) -> String {
+        chat_placeholder_for(&self.keymap)
+    }
+
     pub async fn run(
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
@@ -2132,7 +2226,10 @@ impl App {
             let mut reader = EventStream::new();
             while let Some(event) = reader.next().await {
                 match event {
-                    Ok(Event::Key(key)) if tx.send(AppEvent::Key(key)).is_err() => {
+                    Ok(Event::Key(key))
+                        if key.kind != KeyEventKind::Release
+                            && tx.send(AppEvent::Key(key)).is_err() =>
+                    {
                         break;
                     }
                     Ok(Event::Mouse(mouse)) if tx.send(AppEvent::Mouse(mouse)).is_err() => {
@@ -2161,6 +2258,12 @@ impl App {
             let size = terminal.size()?;
             self.terminal_width = size.width;
             self.terminal_height = size.height;
+            if let Some(message) = self
+                .keymap
+                .expire(&mut self.pending_key_sequence, std::time::Instant::now())
+            {
+                self.status_message = message;
+            }
             self.poll_sse();
             self.spinner_tick = self.spinner_tick.wrapping_add(1);
             terminal.draw(|f| ui::render(f, self))?;
@@ -2216,26 +2319,6 @@ impl App {
         let terminal_too_small = self.terminal_width < crate::ui::MIN_TERMINAL_WIDTH
             || self.terminal_height < crate::ui::MIN_TERMINAL_HEIGHT;
 
-        // Stop/quit is the one global escape hatch that must preempt Help and
-        // the full-value log just as it preempts every interactive modal. At
-        // an unsupported size the only visible contract is "Ctrl+C quits",
-        // so it must quit in one press even when a hidden run is streaming.
-        if matches!(
-            &event,
-            AppEvent::Key(key)
-                if key.modifiers == KeyModifiers::CONTROL
-                    && key.code == KeyCode::Char('c')
-        ) && !terminal_too_small
-            && (self.help_visible || self.notifications_visible)
-        {
-            if self.chat.streaming {
-                self.stop_streaming();
-            } else {
-                self.running = false;
-            }
-            return Ok(());
-        }
-
         if terminal_too_small {
             // The compact warning replaces the interactive UI, so hidden
             // keys and mouse gestures must not mutate it. Background work is
@@ -2243,67 +2326,16 @@ impl App {
             // advancing or a resize could strand the app in a stale state.
             match &event {
                 AppEvent::Key(key) => {
-                    if key.modifiers == KeyModifiers::CONTROL && key.code == KeyCode::Char('c') {
+                    if key.kind != KeyEventKind::Release
+                        && self.resolve_context_action(ActionContext::Global, *key)
+                            == Some(ActionId::QuitOrStop)
+                    {
                         self.running = false;
                     }
                     return Ok(());
                 }
                 AppEvent::Mouse(_) => return Ok(()),
                 _ => {}
-            }
-        }
-
-        if self.notifications_visible {
-            if let AppEvent::Key(key) = &event {
-                let max = self.notification_max_scroll.get();
-                match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        self.notification_scroll = self.notification_scroll.saturating_sub(1);
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        self.notification_scroll =
-                            self.notification_scroll.saturating_add(1).min(max);
-                    }
-                    KeyCode::PageUp => {
-                        self.notification_scroll = self.notification_scroll.saturating_sub(10);
-                    }
-                    KeyCode::PageDown => {
-                        self.notification_scroll =
-                            self.notification_scroll.saturating_add(10).min(max);
-                    }
-                    KeyCode::Home => self.notification_scroll = 0,
-                    KeyCode::End => self.notification_scroll = max,
-                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::F(1) => {
-                        self.notifications_visible = false;
-                    }
-                    _ => {}
-                }
-                return Ok(());
-            }
-        }
-
-        if self.help_visible && !self.any_modal_open() {
-            if let AppEvent::Key(key) = &event {
-                let max = self.help_max_scroll.get();
-                match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        self.help_scroll = self.help_scroll.saturating_sub(1);
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        self.help_scroll = self.help_scroll.saturating_add(1).min(max);
-                    }
-                    KeyCode::PageUp => self.help_scroll = self.help_scroll.saturating_sub(10),
-                    KeyCode::PageDown => {
-                        self.help_scroll = self.help_scroll.saturating_add(10).min(max);
-                    }
-                    KeyCode::Home => self.help_scroll = 0,
-                    KeyCode::End => self.help_scroll = max,
-                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::F(1) => {
-                        self.help_visible = false;
-                    }
-                    _ => {}
-                }
-                return Ok(());
             }
         }
 
@@ -3819,202 +3851,352 @@ impl App {
             || self.config_editor.is_some()
     }
 
-    /// Route one key event.
-    ///
-    /// Modal precedence (checked top to bottom, each returning early — so
-    /// exactly one visible modal owns the keyboard, and every one of them runs
-    /// before the global bindings further down: Ctrl+N/Ctrl+O/Ctrl+Q, `?`,
-    /// digit tab-switching, Tab/Shift+Tab):
-    ///   0. `serve_offer`      — startup-only "start a local server?" offer
-    ///   1. `pending_question` — agent permission/clarification gate
-    ///   2. `pending_delete`   — session delete confirmation
-    ///   3. `pending_schedule_delete` — schedule delete confirmation
-    ///   4. `session_picker`   — Ctrl+P contextual session picker
-    ///   5. `model_picker`     — Ctrl+O provider-catalog picker
-    ///   6. `command_palette`  — Ctrl+K global or slash composer palette
-    ///   7. `schedule_form`    — new-schedule authoring form
-    ///   8. `config_editor`    — raw config JSON editor
-    ///
-    /// Runtime modals can coexist in state because a clarification arrives
-    /// asynchronously. The renderer layers them in the reverse order below,
-    /// keeping this keyboard owner visible without discarding editor drafts.
-    ///
-    /// `serve_offer` can never actually coexist with 1-5 in practice — `run`
-    /// sets it (if at all) before the main loop starts driving any of the
-    /// others, and it's always cleared before the loop's first redraw — but
-    /// it is still checked first, for the same "whichever modal is open gets
-    /// first refusal at every key" reason as the rest of this list.
-    ///
-    /// Ctrl+C (stop/quit) always preempts every modal. F1/Ctrl+`?`/Ctrl+L
-    /// (help/notifications) are gated on `any_modal_open` below instead: with
-    /// a modal open they fall straight through to that modal's own handler,
-    /// so a stray F1 can't eat the keystroke the modal was waiting for or
-    /// stack the help overlay on top of it.
+    fn pending_question_context(&self) -> ActionContext {
+        match self.pending_question.as_ref() {
+            Some(question) if question.inspecting => ActionContext::QuestionInspect,
+            Some(question) if question.number_entry.is_some() => ActionContext::QuestionNumber,
+            Some(question) if question.custom.is_some() => ActionContext::QuestionCustom,
+            _ => ActionContext::QuestionOptions,
+        }
+    }
+
+    fn session_picker_context(&self) -> ActionContext {
+        match self.session_picker.as_ref().map(|picker| &picker.mode) {
+            Some(SessionPickerMode::Rename { .. }) => ActionContext::SessionPickerRename,
+            Some(SessionPickerMode::Pinning { .. }) => ActionContext::SessionPickerPinning,
+            _ => ActionContext::SessionPickerBrowse,
+        }
+    }
+
+    fn tab_context(&self) -> ActionContext {
+        match self.tab {
+            Tab::Chat if self.chat.focused_block.is_some() => ActionContext::ConversationBlock,
+            Tab::Chat => ActionContext::Chat,
+            Tab::Sessions => ActionContext::Sessions,
+            Tab::Mcp => ActionContext::Mcp,
+            Tab::Schedules => ActionContext::Schedules,
+            Tab::Skills => ActionContext::Skills,
+            Tab::Config => ActionContext::Config,
+        }
+    }
+
+    /// Build the one authoritative precedence stack used by the resolver.
+    /// The first context with a binding wins; global bindings are therefore
+    /// fallbacks behind the visible modal, overlay, or focused widget.
+    fn active_action_contexts(&self) -> Vec<ActionContext> {
+        let primary = if self.notifications_visible {
+            ActionContext::Notifications
+        } else if self.help_visible && !self.any_modal_open() {
+            ActionContext::Help
+        } else if self.serve_offer.is_some() {
+            ActionContext::ServeOffer
+        } else if self.pending_question.is_some() {
+            self.pending_question_context()
+        } else if self.pending_delete.is_some() {
+            ActionContext::SessionDeleteConfirm
+        } else if self.pending_schedule_delete.is_some() {
+            ActionContext::ScheduleDeleteConfirm
+        } else if self.session_picker.is_some() {
+            self.session_picker_context()
+        } else if self.model_picker.is_some() {
+            ActionContext::ModelPicker
+        } else if self.command_palette.is_some() {
+            ActionContext::CommandPalette
+        } else if self.schedule_form.is_some() {
+            ActionContext::ScheduleForm
+        } else if self.config_editor.is_some() {
+            ActionContext::ConfigEditor
+        } else {
+            self.tab_context()
+        };
+
+        let mut contexts = vec![primary];
+        if primary == ActionContext::ConversationBlock {
+            contexts.push(ActionContext::Chat);
+        }
+        if !self.any_modal_open()
+            && !self.help_visible
+            && !self.notifications_visible
+            && self.tab != Tab::Chat
+        {
+            contexts.push(ActionContext::Navigation);
+        }
+        contexts.push(ActionContext::Global);
+        contexts
+    }
+
+    fn resolve_context_action(
+        &mut self,
+        context: ActionContext,
+        key: KeyEvent,
+    ) -> Option<ActionId> {
+        self.resolve_action_in(&[context], key)
+            .map(|(_, action)| action)
+    }
+
+    fn resolve_action_in(
+        &mut self,
+        contexts: &[ActionContext],
+        key: KeyEvent,
+    ) -> Option<(ActionContext, ActionId)> {
+        if let Some((routed_context, action)) = self.routed_action.take() {
+            debug_assert!(contexts.contains(&routed_context));
+            return contexts
+                .contains(&routed_context)
+                .then_some((routed_context, action));
+        }
+        match self.keymap.resolve(
+            contexts,
+            &mut self.pending_key_sequence,
+            key,
+            std::time::Instant::now(),
+        ) {
+            KeyResolution::Action { context, action } => Some((context, action)),
+            KeyResolution::Pending(message) | KeyResolution::Cancelled(message) => {
+                self.status_message = message;
+                None
+            }
+            KeyResolution::NoMatch => None,
+        }
+    }
+
+    /// State-dependent availability shared by direct shortcuts and built-in
+    /// command-palette entries. Focus ownership is checked separately because
+    /// the palette itself is an exclusive modal.
+    fn action_disabled_reason(&self, action: ActionId) -> Option<&'static str> {
+        match action.availability() {
+            ActionAvailability::Always => None,
+            ActionAvailability::Idle | ActionAvailability::ChatIdle if self.chat.streaming => {
+                Some("Unavailable while an agent run is active")
+            }
+            ActionAvailability::Idle | ActionAvailability::ChatIdle
+                if self.opening_session_id.is_some() =>
+            {
+                Some("Unavailable while a session is resuming")
+            }
+            ActionAvailability::ChatIdle | ActionAvailability::Chat if self.tab != Tab::Chat => {
+                Some("Switch to Chat before using this action")
+            }
+            ActionAvailability::ActiveRun if !self.chat.streaming => Some("No active run to stop"),
+            _ => None,
+        }
+    }
+
+    fn global_focus_disabled_reason(&self, action: ActionId) -> Option<&'static str> {
+        (self.any_modal_open()
+            && !matches!(action, ActionId::QuitOrStop | ActionId::ShowNotifications))
+        .then_some("Close the active dialog before using this action")
+    }
+
+    fn surface_disabled_action(&mut self, action: ActionId, reason: &str) {
+        let message = format!("{} — {reason}", action.label());
+        if let Some(question) = self.pending_question.as_mut() {
+            question.error = Some(message.clone());
+        } else if let Some(form) = self.schedule_form.as_mut() {
+            form.error = Some(message.clone());
+        } else if let Some(editor) = self.config_editor.as_mut() {
+            editor.error = Some(message.clone());
+        } else if let Some(palette) = self.command_palette.as_mut() {
+            palette.error = Some(message.clone());
+        } else if let Some(picker) = self.model_picker.as_mut() {
+            picker.error = Some(message.clone());
+        } else if let Some(picker) = self.session_picker.as_mut() {
+            picker.error = Some(message.clone());
+        }
+        self.status_message = message;
+    }
+
+    /// Resolve and dispatch one key. Raw key semantics live only in the
+    /// keymap normalizer and focused text-widget fallbacks below.
     async fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
-        match (key.modifiers, key.code) {
-            (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-                if self.chat.streaming {
-                    self.stop_streaming();
-                    return Ok(());
-                }
-                self.running = false;
-                return Ok(());
-            }
-            (KeyModifiers::CONTROL, KeyCode::Char('?')) if !self.any_modal_open() => {
-                // Most terminals never deliver Ctrl+Shift+/ as Ctrl+'?' (it
-                // maps elsewhere), so this is kept only as a harmless extra —
-                // F1 below and plain `?` (further down, non-Chat tabs) are
-                // the bindings that are actually reachable.
-                self.help_visible = true;
-                return Ok(());
-            }
-            (_, KeyCode::F(1)) if !self.any_modal_open() => {
-                // F1 opens help on every tab, including Chat, regardless of
-                // modifiers — unlike `?` it never collides with typing.
-                self.help_visible = true;
-                self.help_scroll = 0;
-                return Ok(());
-            }
-            (KeyModifiers::CONTROL, KeyCode::Char('l')) => {
-                self.notifications_visible = true;
-                self.notification_scroll = 0;
-                self.unseen_alerts = 0;
-                return Ok(());
-            }
-            _ => {}
-        }
-
-        // 0. The startup "start a local server?" offer captures all input
-        // (Ctrl+C above still quits) until answered — see `ServeOffer`.
-        if self.serve_offer.is_some() {
-            self.handle_serve_offer_key(key);
+        if key.kind == KeyEventKind::Release {
             return Ok(());
         }
-
-        // 1. A pending agent question captures all input (Ctrl+C above still
-        // stops the run) until it is answered or dismissed.
-        if self.pending_question.is_some() {
-            return self.handle_question_key(key).await;
-        }
-
-        // 2. The delete-confirmation modal likewise captures all input before
-        // anything else (including tab-switching digits) can reach it.
-        if self.pending_delete.is_some() {
-            return self.handle_delete_confirm_key(key).await;
-        }
-
-        // 3. Schedule deletion is also destructive and requires a second,
-        // explicit keystroke before the request can be sent.
-        if self.pending_schedule_delete.is_some() {
-            self.handle_schedule_delete_confirm_key(key);
-            return Ok(());
-        }
-
-        // 4. The contextual session picker owns search/navigation/mutations.
-        if self.session_picker.is_some() {
-            return self.handle_session_picker_key(key).await;
-        }
-
-        // 5. The model picker likewise captures all input (navigation/apply)
-        // before the global bindings below — same pattern as the other
-        // modals.
-        if self.model_picker.is_some() {
-            return self.handle_model_picker_key(key).await;
-        }
-
-        // 6. The command palette owns query/argument editing and selection.
-        if self.command_palette.is_some() {
-            self.handle_command_palette_key(key);
-            return Ok(());
-        }
-
-        // 7. The schedule-authoring modal likewise captures all input: Tab moves
-        // between fields and digits belong in cron expressions, so it must run
-        // before the global Tab/1-6 tab-switching below (which would otherwise
-        // swallow those keys and never reach the form).
-        if self.schedule_form.is_some() {
-            self.handle_schedule_form_key(key);
-            return Ok(());
-        }
-
-        // 8. The config editor is a full multi-line text buffer, so it must claim
-        // every key (digits, Tab, Enter/newlines) before the global navigation
-        // below — same rationale as the schedule form.
-        if self.config_editor.is_some() {
-            return self.handle_config_editor_key(key);
-        }
-
-        // Ctrl+N / Ctrl+Q: global, but only reachable once every modal above
-        // has had first refusal at the key (each of those branches returns
-        // early) — so getting here already means no modal is open, matching
-        // the "no modal open" requirement for Ctrl+N specifically.
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            match key.code {
-                KeyCode::Char('k') => {
-                    self.open_command_palette(CommandPaletteTrigger::Global);
-                    return Ok(());
-                }
-                KeyCode::Char('n') if !self.chat.streaming => {
-                    self.new_session();
-                    return Ok(());
-                }
-                KeyCode::Char('q') => {
-                    self.reopen_pending_question();
-                    return Ok(());
-                }
-                KeyCode::Char('o') if self.tab == Tab::Chat && !self.chat.streaming => {
-                    self.open_model_picker();
-                    return Ok(());
-                }
-                KeyCode::Char('p') if self.tab == Tab::Chat && !self.chat.streaming => {
-                    self.open_session_picker();
-                    return Ok(());
-                }
-                _ => {}
+        self.normalize_conversation_focus();
+        let contexts = self.active_action_contexts();
+        let primary = contexts[0];
+        let resolution = self.keymap.resolve(
+            &contexts,
+            &mut self.pending_key_sequence,
+            key,
+            std::time::Instant::now(),
+        );
+        match resolution {
+            KeyResolution::Pending(message) | KeyResolution::Cancelled(message) => {
+                self.status_message = message;
             }
-        }
-
-        // `?` opens help everywhere EXCEPT Chat, where it must type into the
-        // textarea instead (mirrors the digit rule right below: Chat's
-        // textarea wins over global single-key bindings). F1 above is the
-        // Chat-safe way to reach help.
-        if key.code == KeyCode::Char('?') && self.tab != Tab::Chat {
-            self.help_visible = true;
-            self.help_scroll = 0;
-            return Ok(());
-        }
-
-        // 1-6 switch tabs EXCEPT on Chat, where digits must type into the
-        // message instead — otherwise typing e.g. "top 3 issues" silently
-        // jumps to the Config tab on the '3'. Shift+digit (many keyboards'
-        // symbol row) never switches tabs, matching the pre-existing rule.
-        if let KeyCode::Char(c) = key.code {
-            if let Some(digit) = c.to_digit(10) {
-                if (1..=6).contains(&digit)
-                    && !key.modifiers.contains(KeyModifiers::SHIFT)
-                    && self.tab != Tab::Chat
-                {
-                    self.tab = Tab::from_index((digit - 1) as usize).unwrap_or(self.tab);
-                    self.load_tab_data();
+            KeyResolution::NoMatch => {
+                self.dispatch_context_key(primary, None, key).await?;
+            }
+            KeyResolution::Action { context, action } => {
+                if key.kind == KeyEventKind::Repeat && !action.repeatable() {
                     return Ok(());
                 }
-            }
-        }
-
-        match key.code {
-            KeyCode::Tab => {
-                self.tab = self.tab.next();
-                self.load_tab_data();
-            }
-            KeyCode::BackTab => {
-                self.tab = self.tab.prev();
-                self.load_tab_data();
-            }
-            _ => {
-                self.handle_tab_key(key).await?;
+                let disabled_reason = self.action_disabled_reason(action).or_else(|| {
+                    (context == ActionContext::Global)
+                        .then(|| self.global_focus_disabled_reason(action))
+                        .flatten()
+                });
+                if let Some(reason) = disabled_reason {
+                    self.surface_disabled_action(action, reason);
+                } else if context == ActionContext::Global {
+                    self.handle_global_action(action);
+                } else if context == ActionContext::Navigation {
+                    self.handle_navigation_action(action);
+                } else {
+                    self.dispatch_context_key(context, Some(action), key)
+                        .await?;
+                }
             }
         }
         Ok(())
+    }
+
+    fn handle_global_action(&mut self, action: ActionId) {
+        match action {
+            ActionId::QuitOrStop if self.chat.streaming => self.stop_streaming(),
+            ActionId::QuitOrStop => self.running = false,
+            ActionId::ShowHelp => {
+                self.notifications_visible = false;
+                self.help_visible = true;
+                self.help_scroll = 0;
+            }
+            ActionId::ShowNotifications => {
+                self.help_visible = false;
+                self.notifications_visible = true;
+                self.notification_scroll = 0;
+                self.unseen_alerts = 0;
+            }
+            ActionId::OpenCommandPalette => {
+                self.open_command_palette(CommandPaletteTrigger::Global)
+            }
+            ActionId::NewSession => self.new_session(),
+            ActionId::ReopenPendingQuestion => self.reopen_pending_question(),
+            ActionId::OpenModelPicker => self.open_model_picker(),
+            ActionId::OpenSessionPicker => self.open_session_picker(),
+            ActionId::StopRun => self.stop_streaming(),
+            ActionId::ToggleDetails => self.toggle_conversation_details(),
+            ActionId::OpenConfigTab => {
+                self.tab = Tab::Config;
+                self.load_tab_data();
+            }
+            ActionId::OpenSchedulesTab => {
+                self.tab = Tab::Schedules;
+                self.load_tab_data();
+            }
+            ActionId::NextTab => {
+                self.tab = self.tab.next();
+                self.load_tab_data();
+            }
+            ActionId::PreviousTab => {
+                self.tab = self.tab.prev();
+                self.load_tab_data();
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_navigation_action(&mut self, action: ActionId) {
+        let index = match action {
+            ActionId::SwitchTab1 => Some(0),
+            ActionId::SwitchTab2 => Some(1),
+            ActionId::SwitchTab3 => Some(2),
+            ActionId::SwitchTab4 => Some(3),
+            ActionId::SwitchTab5 => Some(4),
+            ActionId::SwitchTab6 => Some(5),
+            ActionId::ShowHelp => {
+                self.help_visible = true;
+                self.help_scroll = 0;
+                None
+            }
+            _ => None,
+        };
+        if let Some(index) = index {
+            self.tab = Tab::from_index(index).unwrap_or(self.tab);
+            self.load_tab_data();
+        }
+    }
+
+    async fn dispatch_context_key(
+        &mut self,
+        context: ActionContext,
+        action: Option<ActionId>,
+        key: KeyEvent,
+    ) -> Result<()> {
+        self.routed_action = action.map(|action| (context, action));
+        match context {
+            ActionContext::Help => self.handle_help_key(key),
+            ActionContext::Notifications => self.handle_notifications_key(key),
+            ActionContext::ServeOffer => self.handle_serve_offer_key(key),
+            ActionContext::QuestionOptions
+            | ActionContext::QuestionCustom
+            | ActionContext::QuestionNumber
+            | ActionContext::QuestionInspect => self.handle_question_key(key).await?,
+            ActionContext::SessionDeleteConfirm => self.handle_delete_confirm_key(key).await?,
+            ActionContext::ScheduleDeleteConfirm => self.handle_schedule_delete_confirm_key(key),
+            ActionContext::SessionPickerBrowse
+            | ActionContext::SessionPickerRename
+            | ActionContext::SessionPickerPinning => self.handle_session_picker_key(key).await?,
+            ActionContext::ModelPicker => self.handle_model_picker_key(key).await?,
+            ActionContext::CommandPalette => self.handle_command_palette_key(key),
+            ActionContext::ScheduleForm => self.handle_schedule_form_key(key),
+            ActionContext::ConfigEditor => self.handle_config_editor_key(key)?,
+            ActionContext::Chat | ActionContext::ConversationBlock => {
+                self.handle_chat_key(key).await?
+            }
+            ActionContext::Sessions => self.handle_sessions_key(key).await?,
+            ActionContext::Mcp => self.handle_mcp_key(key).await?,
+            ActionContext::Schedules => self.handle_schedules_key(key).await?,
+            ActionContext::Skills => self.handle_skills_key(key).await?,
+            ActionContext::Config => self.handle_config_key(key),
+            ActionContext::Global | ActionContext::Navigation => {}
+        }
+        self.routed_action = None;
+        Ok(())
+    }
+
+    fn handle_help_key(&mut self, key: KeyEvent) {
+        let Some(action) = self.resolve_context_action(ActionContext::Help, key) else {
+            return;
+        };
+        let max = self.help_max_scroll.get();
+        match action {
+            ActionId::NavigateUp => self.help_scroll = self.help_scroll.saturating_sub(1),
+            ActionId::NavigateDown => {
+                self.help_scroll = self.help_scroll.saturating_add(1).min(max)
+            }
+            ActionId::PageUp => self.help_scroll = self.help_scroll.saturating_sub(10),
+            ActionId::PageDown => self.help_scroll = self.help_scroll.saturating_add(10).min(max),
+            ActionId::JumpFirst => self.help_scroll = 0,
+            ActionId::JumpLast => self.help_scroll = max,
+            ActionId::Cancel => self.help_visible = false,
+            _ => {}
+        }
+    }
+
+    fn handle_notifications_key(&mut self, key: KeyEvent) {
+        let Some(action) = self.resolve_context_action(ActionContext::Notifications, key) else {
+            return;
+        };
+        let max = self.notification_max_scroll.get();
+        match action {
+            ActionId::NavigateUp => {
+                self.notification_scroll = self.notification_scroll.saturating_sub(1)
+            }
+            ActionId::NavigateDown => {
+                self.notification_scroll = self.notification_scroll.saturating_add(1).min(max)
+            }
+            ActionId::PageUp => {
+                self.notification_scroll = self.notification_scroll.saturating_sub(10)
+            }
+            ActionId::PageDown => {
+                self.notification_scroll = self.notification_scroll.saturating_add(10).min(max)
+            }
+            ActionId::JumpFirst => self.notification_scroll = 0,
+            ActionId::JumpLast => self.notification_scroll = max,
+            ActionId::Cancel => self.notifications_visible = false,
+            _ => {}
+        }
     }
 
     /// Drive the startup "start a local server?" offer (`ServeOffer`):
@@ -4023,12 +4205,15 @@ impl App {
     /// `--auto-serve` or start `bamboo serve` themselves. Every other key is
     /// swallowed — see the modal-precedence doc on `handle_key`.
     fn handle_serve_offer_key(&mut self, key: KeyEvent) {
-        match key.code {
-            KeyCode::Char('y') | KeyCode::Enter => {
+        let Some(action) = self.resolve_context_action(ActionContext::ServeOffer, key) else {
+            return;
+        };
+        match action {
+            ActionId::Confirm => {
                 self.serve_offer = None;
                 self.spawn_local_server();
             }
-            KeyCode::Char('n') | KeyCode::Esc => {
+            ActionId::Reject => {
                 self.serve_offer = None;
                 self.status_message =
                     "Not connected — restart with --auto-serve or start 'bamboo serve' yourself"
@@ -4176,6 +4361,9 @@ impl App {
             Copy(String),
         }
 
+        let context = self.pending_question_context();
+        let key_action = self.resolve_context_action(context, key);
+
         let action = {
             let Some(q) = self.pending_question.as_mut() else {
                 return Ok(());
@@ -4189,25 +4377,25 @@ impl App {
             }
 
             if q.inspecting {
-                match key.code {
-                    KeyCode::Char('v') | KeyCode::Esc => {
+                match key_action {
+                    Some(ActionId::Cancel) => {
                         q.inspecting = false;
                         q.inspect_scroll = 0;
                         QAction::None
                     }
-                    KeyCode::Tab if !q.options.is_empty() => {
+                    Some(ActionId::ToggleInspectorPane) if !q.options.is_empty() => {
                         q.inspect_option = !q.inspect_option;
                         q.inspect_scroll = 0;
                         QAction::None
                     }
-                    KeyCode::Up | KeyCode::Char('k') => {
+                    Some(ActionId::NavigateUp) => {
                         q.inspect_scroll = q
                             .inspect_scroll
                             .min(q.inspect_max_scroll.get())
                             .saturating_sub(1);
                         QAction::None
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
+                    Some(ActionId::NavigateDown) => {
                         q.inspect_scroll = q
                             .inspect_scroll
                             .min(q.inspect_max_scroll.get())
@@ -4215,14 +4403,14 @@ impl App {
                             .min(q.inspect_max_scroll.get());
                         QAction::None
                     }
-                    KeyCode::PageUp => {
+                    Some(ActionId::PageUp) => {
                         q.inspect_scroll = q
                             .inspect_scroll
                             .min(q.inspect_max_scroll.get())
                             .saturating_sub(5);
                         QAction::None
                     }
-                    KeyCode::PageDown => {
+                    Some(ActionId::PageDown) => {
                         q.inspect_scroll = q
                             .inspect_scroll
                             .min(q.inspect_max_scroll.get())
@@ -4230,11 +4418,15 @@ impl App {
                             .min(q.inspect_max_scroll.get());
                         QAction::None
                     }
-                    KeyCode::Home => {
+                    Some(ActionId::JumpFirst) => {
                         q.inspect_scroll = 0;
                         QAction::None
                     }
-                    KeyCode::Char('y') => {
+                    Some(ActionId::JumpLast) => {
+                        q.inspect_scroll = q.inspect_max_scroll.get();
+                        QAction::None
+                    }
+                    Some(ActionId::CopyValue) => {
                         let value = if q.inspect_option {
                             q.options.get(q.selected).cloned().unwrap_or_default()
                         } else {
@@ -4245,20 +4437,16 @@ impl App {
                     _ => QAction::None,
                 }
             } else if let Some(entry) = q.number_entry.as_mut() {
-                match key.code {
-                    KeyCode::Char(d) if d.is_ascii_digit() => {
-                        entry.push(d);
-                        QAction::None
-                    }
-                    KeyCode::Backspace => {
+                match key_action {
+                    Some(ActionId::Backspace) => {
                         entry.pop();
                         QAction::None
                     }
-                    KeyCode::Esc => {
+                    Some(ActionId::Cancel) => {
                         q.number_entry = None;
                         QAction::None
                     }
-                    KeyCode::Enter => {
+                    Some(ActionId::Activate) => {
                         let requested = entry.parse::<usize>().ok();
                         q.number_entry = None;
                         match requested.and_then(|number| number.checked_sub(1)) {
@@ -4272,19 +4460,24 @@ impl App {
                         }
                         QAction::None
                     }
-                    _ => QAction::None,
+                    _ => {
+                        if let Some(digit) = text_character(key).filter(char::is_ascii_digit) {
+                            entry.push(digit);
+                        }
+                        QAction::None
+                    }
                 }
             } else if let Some(buf) = q.custom.as_mut() {
                 // Free-text entry mode.
-                match key.code {
-                    KeyCode::Enter => {
+                match key_action {
+                    Some(ActionId::Activate) => {
                         if buf.trim().is_empty() {
                             QAction::None
                         } else {
                             QAction::Submit(buf.clone())
                         }
                     }
-                    KeyCode::Esc => {
+                    Some(ActionId::Cancel) => {
                         // Back to option-select if there were options, else dismiss.
                         if q.options.is_empty() {
                             QAction::Dismiss
@@ -4292,45 +4485,46 @@ impl App {
                             QAction::CloseCustom
                         }
                     }
-                    KeyCode::Backspace => {
+                    Some(ActionId::Backspace) => {
                         buf.pop();
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    Some(ActionId::InspectValue) => {
                         q.inspecting = true;
                         q.inspect_option = false;
                         q.inspect_scroll = 0;
                         QAction::None
                     }
-                    KeyCode::Char(c) => {
-                        buf.push(c);
-                        q.error = None;
+                    _ => {
+                        if let Some(character) = text_character(key) {
+                            buf.push(character);
+                            q.error = None;
+                        }
                         QAction::None
                     }
-                    _ => QAction::None,
                 }
             } else {
                 // Option-select mode.
-                match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => {
+                match key_action {
+                    Some(ActionId::NavigateUp) => {
                         q.selected = q.selected.saturating_sub(1);
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
+                    Some(ActionId::NavigateDown) => {
                         if q.selected + 1 < q.options.len() {
                             q.selected += 1;
                         }
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::PageUp => {
+                    Some(ActionId::PageUp) => {
                         q.selected = q.selected.saturating_sub(5);
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::PageDown => {
+                    Some(ActionId::PageDown) => {
                         q.selected = q
                             .selected
                             .saturating_add(5)
@@ -4338,35 +4532,35 @@ impl App {
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::Home => {
+                    Some(ActionId::JumpFirst) => {
                         q.selected = 0;
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::End => {
+                    Some(ActionId::JumpLast) => {
                         q.selected = q.options.len().saturating_sub(1);
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::Char('c') if q.allow_custom => {
+                    Some(ActionId::CustomAnswer) if q.allow_custom => {
                         // Switch to free-text entry without discarding a draft
                         // entered before dismissal/session switching.
                         q.custom = Some(std::mem::take(&mut q.custom_draft));
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::Char('g') if !q.options.is_empty() => {
+                    Some(ActionId::NumberAnswer) if !q.options.is_empty() => {
                         q.number_entry = Some(String::new());
                         q.error = None;
                         QAction::None
                     }
-                    KeyCode::Char('v') => {
+                    Some(ActionId::InspectValue) => {
                         q.inspecting = true;
                         q.inspect_option = false;
                         q.inspect_scroll = 0;
                         QAction::None
                     }
-                    KeyCode::Char('y') => {
+                    Some(ActionId::CopyValue) => {
                         let value = q
                             .options
                             .get(q.selected)
@@ -4374,21 +4568,42 @@ impl App {
                             .unwrap_or_else(|| q.question.clone());
                         QAction::Copy(value)
                     }
-                    KeyCode::Enter => q
+                    Some(ActionId::Activate) => q
                         .options
                         .get(q.selected)
                         .cloned()
                         .map(QAction::Submit)
                         .unwrap_or(QAction::None),
-                    KeyCode::Char(d) if ('1'..='9').contains(&d) => {
-                        let idx = d as usize - '1' as usize;
+                    Some(
+                        quick @ (ActionId::QuickAnswer1
+                        | ActionId::QuickAnswer2
+                        | ActionId::QuickAnswer3
+                        | ActionId::QuickAnswer4
+                        | ActionId::QuickAnswer5
+                        | ActionId::QuickAnswer6
+                        | ActionId::QuickAnswer7
+                        | ActionId::QuickAnswer8
+                        | ActionId::QuickAnswer9),
+                    ) => {
+                        let idx = match quick {
+                            ActionId::QuickAnswer1 => 0,
+                            ActionId::QuickAnswer2 => 1,
+                            ActionId::QuickAnswer3 => 2,
+                            ActionId::QuickAnswer4 => 3,
+                            ActionId::QuickAnswer5 => 4,
+                            ActionId::QuickAnswer6 => 5,
+                            ActionId::QuickAnswer7 => 6,
+                            ActionId::QuickAnswer8 => 7,
+                            ActionId::QuickAnswer9 => 8,
+                            _ => unreachable!(),
+                        };
                         q.options
                             .get(idx)
                             .cloned()
                             .map(QAction::Submit)
                             .unwrap_or(QAction::None)
                     }
-                    KeyCode::Esc => QAction::Dismiss,
+                    Some(ActionId::Cancel) => QAction::Dismiss,
                     _ => QAction::None,
                 }
             }
@@ -4663,8 +4878,12 @@ impl App {
         let Some((id, _title)) = self.pending_delete.clone() else {
             return Ok(());
         };
-        match key.code {
-            KeyCode::Char('y') | KeyCode::Enter => {
+        let Some(action) = self.resolve_context_action(ActionContext::SessionDeleteConfirm, key)
+        else {
+            return Ok(());
+        };
+        match action {
+            ActionId::Confirm => {
                 self.pending_delete = None;
                 if self.deleting_session_id.is_some() {
                     self.notify(
@@ -4703,7 +4922,7 @@ impl App {
                     });
                 });
             }
-            KeyCode::Char('n') | KeyCode::Esc => {
+            ActionId::Reject => {
                 self.pending_delete = None;
             }
             _ => {}
@@ -4717,8 +4936,12 @@ impl App {
         let Some((id, _name)) = self.pending_schedule_delete.clone() else {
             return;
         };
-        match key.code {
-            KeyCode::Char('y') | KeyCode::Enter => {
+        let Some(action) = self.resolve_context_action(ActionContext::ScheduleDeleteConfirm, key)
+        else {
+            return;
+        };
+        match action {
+            ActionId::Confirm => {
                 self.pending_schedule_delete = None;
                 if self.deleting_schedule_id.is_some() {
                     self.notify(
@@ -4748,7 +4971,7 @@ impl App {
                     });
                 });
             }
-            KeyCode::Char('n') | KeyCode::Esc => {
+            ActionId::Reject => {
                 self.pending_schedule_delete = None;
             }
             _ => {}
@@ -4810,90 +5033,51 @@ impl App {
         }
     }
 
-    async fn handle_tab_key(&mut self, key: KeyEvent) -> Result<()> {
-        match self.tab {
-            Tab::Chat => self.handle_chat_key(key).await?,
-            Tab::Sessions => self.handle_sessions_key(key).await?,
-            Tab::Mcp => self.handle_mcp_key(key).await?,
-            Tab::Schedules => self.handle_schedules_key(key).await?,
-            Tab::Skills => self.handle_skills_key(key).await?,
-            Tab::Config => self.handle_config_key(key),
-        }
-        Ok(())
-    }
-
     async fn handle_chat_key(&mut self, key: KeyEvent) -> Result<()> {
         self.normalize_conversation_focus();
-
-        // Run control and the explicit transcript jumps remain global even
-        // while a conversation block owns the navigation keys.
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            match key.code {
-                KeyCode::Char('s') if self.chat.streaming => {
-                    self.stop_streaming();
-                    return Ok(());
-                }
-                KeyCode::Char('g') | KeyCode::End => {
-                    self.chat_scroll_bottom();
-                    return Ok(());
-                }
-                KeyCode::Home => {
-                    self.chat_scroll_top();
-                    return Ok(());
-                }
-                _ => {}
-            }
-        }
-
-        if self.chat.focused_block.is_some() {
-            self.handle_conversation_block_key(key);
+        let contexts: &[ActionContext] = if self.chat.focused_block.is_some() {
+            &[
+                ActionContext::ConversationBlock,
+                ActionContext::Chat,
+                ActionContext::Global,
+            ]
+        } else {
+            &[ActionContext::Chat, ActionContext::Global]
+        };
+        let resolved = self.resolve_action_in(contexts, key);
+        if let Some((ActionContext::ConversationBlock, action)) = resolved {
+            self.handle_conversation_block_action(action);
             return Ok(());
         }
 
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            match key.code {
-                KeyCode::Char('b') => {
-                    self.focus_last_conversation_block();
-                    return Ok(());
-                }
-                KeyCode::Char('x') => {
-                    self.toggle_conversation_details();
-                    return Ok(());
-                }
-                _ => {}
+        match resolved.map(|(_, action)| action) {
+            Some(ActionId::QuitOrStop) if self.chat.streaming => self.stop_streaming(),
+            Some(ActionId::QuitOrStop) => self.running = false,
+            Some(ActionId::StopRun) if self.chat.streaming => self.stop_streaming(),
+            Some(ActionId::StopRun) => {
+                self.status_message = "No active run to stop".to_string();
             }
-        }
-
-        match key.code {
-            KeyCode::Char('/')
-                if !self.chat.streaming
-                    && !key
-                        .modifiers
-                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-                    && self.chat.textarea.cursor() == (0, 0) =>
+            Some(ActionId::ScrollTranscriptBottom) => self.chat_scroll_bottom(),
+            Some(ActionId::ScrollTranscriptTop) => self.chat_scroll_top(),
+            Some(ActionId::FocusConversationBlocks) => self.focus_last_conversation_block(),
+            Some(ActionId::ToggleDetails) => self.toggle_conversation_details(),
+            Some(ActionId::OpenSlashPalette)
+                if !self.chat.streaming && self.chat.textarea.cursor() == (0, 0) =>
             {
                 self.open_command_palette(CommandPaletteTrigger::Slash);
             }
-            KeyCode::PageDown => self.chat_scroll_down(10),
-            KeyCode::PageUp => self.chat_scroll_up(10),
-            KeyCode::Down if key.modifiers.contains(KeyModifiers::ALT) => self.chat_scroll_down(3),
-            KeyCode::Up if key.modifiers.contains(KeyModifiers::ALT) => self.chat_scroll_up(3),
-            // Alt+Enter (and Shift+Enter, on the kitty-protocol terminals
-            // that report it) inserts a newline during both idle and active
-            // runs. The draft remains entirely local while streaming.
-            KeyCode::Enter
-                if !key.modifiers.intersects(KeyModifiers::CONTROL)
-                    && (key.modifiers.contains(KeyModifiers::ALT)
-                        || key.modifiers.contains(KeyModifiers::SHIFT)) =>
-            {
-                self.chat.textarea.insert_newline();
+            Some(ActionId::OpenSlashPalette) => {
+                self.chat.textarea.input(key);
             }
-            KeyCode::Enter if self.chat.streaming => {
+            Some(ActionId::ScrollTranscriptDown) => self.chat_scroll_down(10),
+            Some(ActionId::ScrollTranscriptUp) => self.chat_scroll_up(10),
+            Some(ActionId::InsertNewline) => self.chat.textarea.insert_newline(),
+            Some(ActionId::SendMessage) if self.chat.streaming => {
                 self.status_message =
                     "Run active — draft preserved; press Enter after completion to send"
                         .to_string();
             }
-            KeyCode::Enter => {
+            Some(ActionId::SendMessage) => {
                 // Selecting a session starts an asynchronous history/summary
                 // fetch after the picker closes. Keep the existing draft
                 // editable while that fetch is in flight, but never submit it
@@ -4918,43 +5102,43 @@ impl App {
                     return Ok(());
                 }
                 self.chat.textarea = TextArea::default();
-                self.chat.textarea.set_placeholder_text(CHAT_PLACEHOLDER);
+                let placeholder = self.chat_placeholder();
+                self.chat.textarea.set_placeholder_text(placeholder);
                 apply_textarea_palette(&mut self.chat.textarea, self.theme);
                 self.send_message(input);
             }
-            _ => {
+            None => {
                 self.chat.textarea.input(key);
             }
+            Some(_) => {}
         }
         Ok(())
     }
 
-    fn handle_conversation_block_key(&mut self, key: KeyEvent) {
-        if key.code == KeyCode::Esc
-            || (key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('b'))
-        {
-            self.chat.focused_block = None;
-            self.status_message = "Composer focused".to_string();
-            return;
-        }
-
-        match key.code {
-            KeyCode::Up => self.move_conversation_block_focus(-1),
-            KeyCode::Down => self.move_conversation_block_focus(1),
-            KeyCode::Home => self.focus_conversation_block_at(0),
-            KeyCode::End => {
+    fn handle_conversation_block_action(&mut self, action: ActionId) {
+        match action {
+            ActionId::ExitConversationBlocks => {
+                self.chat.focused_block = None;
+                self.status_message = "Composer focused".to_string();
+            }
+            ActionId::PreviousConversationBlock => self.move_conversation_block_focus(-1),
+            ActionId::NextConversationBlock => self.move_conversation_block_focus(1),
+            ActionId::JumpFirst => self.focus_conversation_block_at(0),
+            ActionId::JumpLast => {
                 let len = self.conversation_blocks().len();
                 self.focus_conversation_block_at(len.saturating_sub(1));
             }
-            KeyCode::Char('k') => self.scroll_focused_block(-1),
-            KeyCode::Char('j') => self.scroll_focused_block(1),
-            KeyCode::PageUp => self.scroll_focused_block(-(CONVERSATION_DETAIL_VIEWPORT as i32)),
-            KeyCode::PageDown => self.scroll_focused_block(CONVERSATION_DETAIL_VIEWPORT as i32),
-            KeyCode::Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.toggle_conversation_details()
+            ActionId::ScrollBlockUp => self.scroll_focused_block(-1),
+            ActionId::ScrollBlockDown => self.scroll_focused_block(1),
+            ActionId::ScrollBlockPageUp => {
+                self.scroll_focused_block(-(CONVERSATION_DETAIL_VIEWPORT as i32))
             }
-            KeyCode::Enter => self.activate_focused_conversation_block(),
-            KeyCode::Char('y') => self.copy_focused_conversation_block(),
+            ActionId::ScrollBlockPageDown => {
+                self.scroll_focused_block(CONVERSATION_DETAIL_VIEWPORT as i32)
+            }
+            ActionId::ToggleDetails => self.toggle_conversation_details(),
+            ActionId::Activate => self.activate_focused_conversation_block(),
+            ActionId::CopyValue => self.copy_focused_conversation_block(),
             _ => {}
         }
     }
@@ -6240,15 +6424,16 @@ impl App {
     }
 
     async fn handle_sessions_key(&mut self, key: KeyEvent) -> Result<()> {
-        match key.code {
-            KeyCode::Down if !self.sessions.sessions.is_empty() => {
+        let action = self.resolve_context_action(ActionContext::Sessions, key);
+        match action {
+            Some(ActionId::NavigateDown) if !self.sessions.sessions.is_empty() => {
                 self.sessions.selected =
                     (self.sessions.selected + 1).min(self.sessions.sessions.len() - 1);
             }
-            KeyCode::Up => {
+            Some(ActionId::NavigateUp) => {
                 self.sessions.selected = self.sessions.selected.saturating_sub(1);
             }
-            KeyCode::Enter => {
+            Some(ActionId::Activate) => {
                 // Full resume, off the event loop: history replay + live
                 // reattach (if the run is still going) + pending-question
                 // recovery, all landing in one `SessionOpened` event.
@@ -6256,7 +6441,7 @@ impl App {
                     self.resume_session(session.id.clone());
                 }
             }
-            KeyCode::Char('d') => {
+            Some(ActionId::DeleteSelection) => {
                 // Open a confirmation modal instead of deleting immediately — the
                 // actual DELETE is fired from `handle_delete_confirm_key` off the
                 // event loop, never `?`-propagated on the UI thread.
@@ -6264,17 +6449,17 @@ impl App {
                     self.pending_delete = Some((session.id.clone(), session.title.clone()));
                 }
             }
-            KeyCode::Char('r') => {
+            Some(ActionId::Refresh) => {
                 self.load_tab_data();
             }
-            KeyCode::Char(']') => {
+            Some(ActionId::NextPage) => {
                 if let Some(next) = self.sessions.next_offset {
                     self.sessions.offset = next;
                     self.sessions.selected = 0;
                     self.load_tab_data();
                 }
             }
-            KeyCode::Char('[') if self.sessions.offset > 0 => {
+            Some(ActionId::PreviousPage) if self.sessions.offset > 0 => {
                 let step = self.sessions.page_limit.max(1);
                 self.sessions.offset = self.sessions.offset.saturating_sub(step);
                 self.sessions.selected = 0;
@@ -6286,14 +6471,15 @@ impl App {
     }
 
     async fn handle_mcp_key(&mut self, key: KeyEvent) -> Result<()> {
-        match key.code {
-            KeyCode::Down if !self.mcp.servers.is_empty() => {
+        let action = self.resolve_context_action(ActionContext::Mcp, key);
+        match action {
+            Some(ActionId::NavigateDown) if !self.mcp.servers.is_empty() => {
                 self.mcp.selected = (self.mcp.selected + 1).min(self.mcp.servers.len() - 1);
             }
-            KeyCode::Up => {
+            Some(ActionId::NavigateUp) => {
                 self.mcp.selected = self.mcp.selected.saturating_sub(1);
             }
-            KeyCode::Enter => {
+            Some(ActionId::Activate) => {
                 if let (Some(server), Some(tx)) = (
                     self.mcp.servers.get(self.mcp.selected),
                     self.event_tx.clone(),
@@ -6324,7 +6510,7 @@ impl App {
                     });
                 }
             }
-            KeyCode::Char('t') => {
+            Some(ActionId::ShowTools) => {
                 if let (Some(server), Some(tx)) = (
                     self.mcp.servers.get(self.mcp.selected),
                     self.event_tx.clone(),
@@ -6337,7 +6523,7 @@ impl App {
                     });
                 }
             }
-            KeyCode::Char('r') => {
+            Some(ActionId::Refresh) => {
                 self.load_tab_data();
             }
             _ => {}
@@ -6348,18 +6534,19 @@ impl App {
     async fn handle_schedules_key(&mut self, key: KeyEvent) -> Result<()> {
         // Note: when `schedule_form` is open, `handle_key` routes every key
         // straight to `handle_schedule_form_key` before reaching here.
-        match key.code {
-            KeyCode::Char('n') => {
+        let action = self.resolve_context_action(ActionContext::Schedules, key);
+        match action {
+            Some(ActionId::NewSchedule) => {
                 self.schedule_form = Some(ScheduleForm::default());
             }
-            KeyCode::Down if !self.schedules.schedules.is_empty() => {
+            Some(ActionId::NavigateDown) if !self.schedules.schedules.is_empty() => {
                 self.schedules.selected =
                     (self.schedules.selected + 1).min(self.schedules.schedules.len() - 1);
             }
-            KeyCode::Up => {
+            Some(ActionId::NavigateUp) => {
                 self.schedules.selected = self.schedules.selected.saturating_sub(1);
             }
-            KeyCode::Char('d') => {
+            Some(ActionId::DeleteSelection) => {
                 if self.deleting_schedule_id.is_some() {
                     self.notify(
                         NoticeLevel::Warn,
@@ -6377,7 +6564,7 @@ impl App {
                     ));
                 }
             }
-            KeyCode::Char('r') => {
+            Some(ActionId::RunSchedule) => {
                 if let (Some(schedule), Some(tx)) = (
                     self.schedules.schedules.get(self.schedules.selected),
                     self.event_tx.clone(),
@@ -6405,24 +6592,25 @@ impl App {
     /// Drive the new-schedule form modal. On Enter (all fields filled) it POSTs
     /// create_schedule off the event loop and reloads the tab.
     fn handle_schedule_form_key(&mut self, key: KeyEvent) {
+        let action = self.resolve_context_action(ActionContext::ScheduleForm, key);
         let Some(form) = self.schedule_form.as_mut() else {
             return;
         };
-        match key.code {
-            KeyCode::Esc => {
+        match action {
+            Some(ActionId::Cancel) => {
                 self.schedule_form = None;
             }
-            KeyCode::Tab | KeyCode::Down => {
+            Some(ActionId::NextField) => {
                 form.field = (form.field + 1) % 3;
             }
-            KeyCode::BackTab | KeyCode::Up => {
+            Some(ActionId::PreviousField) => {
                 form.field = (form.field + 2) % 3;
             }
-            KeyCode::Backspace => {
+            Some(ActionId::Backspace) => {
                 form.error = None;
                 form.current_mut().pop();
             }
-            KeyCode::Enter => {
+            Some(ActionId::Activate) => {
                 if form.name.trim().is_empty()
                     || form.cron.trim().is_empty()
                     || form.prompt.trim().is_empty()
@@ -6462,23 +6650,25 @@ impl App {
                     });
                 }
             }
-            KeyCode::Char(c) => {
-                form.error = None;
-                form.current_mut().push(c);
+            _ => {
+                if let Some(character) = text_character(key) {
+                    form.error = None;
+                    form.current_mut().push(character);
+                }
             }
-            _ => {}
         }
     }
 
     async fn handle_skills_key(&mut self, key: KeyEvent) -> Result<()> {
-        match key.code {
-            KeyCode::Down if !self.skills.skills.is_empty() => {
+        let action = self.resolve_context_action(ActionContext::Skills, key);
+        match action {
+            Some(ActionId::NavigateDown) if !self.skills.skills.is_empty() => {
                 self.skills.selected = (self.skills.selected + 1).min(self.skills.skills.len() - 1);
             }
-            KeyCode::Up => {
+            Some(ActionId::NavigateUp) => {
                 self.skills.selected = self.skills.selected.saturating_sub(1);
             }
-            KeyCode::Enter => {
+            Some(ActionId::Activate) => {
                 // Fetch the detail off the event loop: `get_skill` used to be
                 // awaited right here on the UI thread, so a slow/unreachable
                 // server froze every keystroke until it returned.
@@ -6521,12 +6711,13 @@ impl App {
     }
 
     fn handle_config_key(&mut self, key: KeyEvent) {
-        match key.code {
-            KeyCode::Down => self.config_scroll_down(1),
-            KeyCode::Up => self.config_scroll_up(1),
-            KeyCode::PageDown => self.config_scroll_down(10),
-            KeyCode::PageUp => self.config_scroll_up(10),
-            KeyCode::Char('e') => {
+        let action = self.resolve_context_action(ActionContext::Config, key);
+        match action {
+            Some(ActionId::NavigateDown) => self.config_scroll_down(1),
+            Some(ActionId::NavigateUp) => self.config_scroll_up(1),
+            Some(ActionId::PageDown) => self.config_scroll_down(10),
+            Some(ActionId::PageUp) => self.config_scroll_up(10),
+            Some(ActionId::EditConfig) => {
                 // Open the raw-JSON editor prefilled with the current config.
                 match &self.config.config {
                     Some(val) => {
@@ -6553,12 +6744,13 @@ impl App {
     /// JSON and, if valid, PATCHes it to the server off the event loop; `Esc`
     /// cancels. Every other key edits the text buffer.
     fn handle_config_editor_key(&mut self, key: KeyEvent) -> Result<()> {
-        if key.code == KeyCode::Esc {
+        let action = self.resolve_context_action(ActionContext::ConfigEditor, key);
+        if action == Some(ActionId::Cancel) {
             self.config_editor = None;
             self.status_message = "Edit cancelled".to_string();
             return Ok(());
         }
-        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
+        if action == Some(ActionId::SaveConfig) {
             let text = self
                 .config_editor
                 .as_ref()
@@ -6591,9 +6783,11 @@ impl App {
             }
             return Ok(());
         }
-        if let Some(editor) = self.config_editor.as_mut() {
-            editor.error = None;
-            editor.textarea.input(key);
+        if action.is_none() {
+            if let Some(editor) = self.config_editor.as_mut() {
+                editor.error = None;
+                editor.textarea.input(key);
+            }
         }
         Ok(())
     }
@@ -6727,43 +6921,33 @@ impl App {
     }
 
     fn handle_session_picker_browse_key(&mut self, key: KeyEvent) {
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            match key.code {
-                KeyCode::Char('r') => {
-                    self.reload_session_picker();
-                    return;
+        let action = self.resolve_context_action(ActionContext::SessionPickerBrowse, key);
+        match action {
+            Some(ActionId::Refresh) => self.reload_session_picker(),
+            Some(ActionId::ClearInput) => {
+                if let Some(picker) = self.session_picker.as_mut() {
+                    let preserve = picker.selected_session().map(|s| s.id.clone());
+                    picker.query.clear();
+                    picker.selection_touched = true;
+                    picker.refresh_filter(preserve);
                 }
-                KeyCode::Char('u') => {
-                    if let Some(picker) = self.session_picker.as_mut() {
-                        let preserve = picker.selected_session().map(|s| s.id.clone());
-                        picker.query.clear();
-                        picker.selection_touched = true;
-                        picker.refresh_filter(preserve);
-                    }
-                    return;
-                }
-                KeyCode::Char('d') => {
-                    if let Some(session) = self
-                        .session_picker
-                        .as_ref()
-                        .and_then(SessionPicker::selected_session)
-                    {
-                        self.pending_delete = Some((session.id.clone(), session.title.clone()));
-                    }
-                    return;
-                }
-                _ => {}
             }
-        }
-
-        match key.code {
-            KeyCode::Up => {
+            Some(ActionId::DeleteSelection) => {
+                if let Some(session) = self
+                    .session_picker
+                    .as_ref()
+                    .and_then(SessionPicker::selected_session)
+                {
+                    self.pending_delete = Some((session.id.clone(), session.title.clone()));
+                }
+            }
+            Some(ActionId::NavigateUp) => {
                 if let Some(picker) = self.session_picker.as_mut() {
                     picker.selected = picker.selected.saturating_sub(1);
                     picker.selection_touched = true;
                 }
             }
-            KeyCode::Down => {
+            Some(ActionId::NavigateDown) => {
                 let load_more = if let Some(picker) = self.session_picker.as_mut() {
                     picker.selection_touched = true;
                     if picker.selected + 1 < picker.visible.len() {
@@ -6779,8 +6963,8 @@ impl App {
                     self.load_next_session_picker_page();
                 }
             }
-            KeyCode::PageDown | KeyCode::Char(']') => self.load_next_session_picker_page(),
-            KeyCode::Enter => {
+            Some(ActionId::LoadMore) => self.load_next_session_picker_page(),
+            Some(ActionId::Activate) => {
                 let session_id = self
                     .session_picker
                     .as_ref()
@@ -6791,19 +6975,10 @@ impl App {
                     self.resume_session(session_id);
                 }
             }
-            KeyCode::F(2) => self.begin_session_rename(),
-            KeyCode::F(3) => self.begin_session_pin_toggle(),
-            KeyCode::Delete => {
-                if let Some(session) = self
-                    .session_picker
-                    .as_ref()
-                    .and_then(SessionPicker::selected_session)
-                {
-                    self.pending_delete = Some((session.id.clone(), session.title.clone()));
-                }
-            }
-            KeyCode::Esc => self.close_session_picker(),
-            KeyCode::Backspace => {
+            Some(ActionId::RenameSession) => self.begin_session_rename(),
+            Some(ActionId::ToggleSessionPin) => self.begin_session_pin_toggle(),
+            Some(ActionId::Cancel) => self.close_session_picker(),
+            Some(ActionId::Backspace) => {
                 if let Some(picker) = self.session_picker.as_mut() {
                     let preserve = picker.selected_session().map(|s| s.id.clone());
                     picker.query.pop();
@@ -6811,26 +6986,22 @@ impl App {
                     picker.refresh_filter(preserve);
                 }
             }
-            KeyCode::Char(character)
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-            {
-                if let Some(picker) = self.session_picker.as_mut() {
-                    let preserve = picker.selected_session().map(|s| s.id.clone());
-                    picker.query.push(character);
-                    picker.selection_touched = true;
-                    picker.refresh_filter(preserve);
-                }
-                if self
-                    .session_picker
-                    .as_ref()
-                    .is_some_and(|picker| !picker.query.is_empty() && picker.next_offset.is_some())
-                {
-                    self.load_next_session_picker_page();
+            None => {
+                if let Some(character) = text_character(key) {
+                    if let Some(picker) = self.session_picker.as_mut() {
+                        let preserve = picker.selected_session().map(|s| s.id.clone());
+                        picker.query.push(character);
+                        picker.selection_touched = true;
+                        picker.refresh_filter(preserve);
+                    }
+                    if self.session_picker.as_ref().is_some_and(|picker| {
+                        !picker.query.is_empty() && picker.next_offset.is_some()
+                    }) {
+                        self.load_next_session_picker_page();
+                    }
                 }
             }
-            _ => {}
+            Some(_) => {}
         }
     }
 
@@ -6884,6 +7055,7 @@ impl App {
     }
 
     fn handle_session_picker_rename_key(&mut self, key: KeyEvent) {
+        let action = self.resolve_context_action(ActionContext::SessionPickerRename, key);
         let mut retry = None;
         let mut submit = None;
         let mut cancel = false;
@@ -6904,7 +7076,7 @@ impl App {
             return;
         };
 
-        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
+        if action == Some(ActionId::Refresh) {
             if !*submitting {
                 *metadata_version = None;
                 *loading_version = true;
@@ -6914,8 +7086,8 @@ impl App {
         } else if *submitting {
             return;
         } else {
-            match key.code {
-                KeyCode::Enter if !draft.trim().is_empty() => {
+            match action {
+                Some(ActionId::Activate) if !draft.trim().is_empty() => {
                     if let Some(version) = *metadata_version {
                         *submitting = true;
                         *error = None;
@@ -6926,23 +7098,21 @@ impl App {
                             draft.trim().to_string(),
                         ));
                     } else if !*loading_version {
-                        *error = Some("No current version — press Ctrl+R to retry".to_string());
+                        *error = Some("No current version — use Refresh to retry".to_string());
                     }
                 }
-                KeyCode::Esc => cancel = true,
-                KeyCode::Backspace => {
+                Some(ActionId::Cancel) => cancel = true,
+                Some(ActionId::Backspace) => {
                     draft.pop();
                     *draft_dirty = true;
                     *error = None;
                 }
-                KeyCode::Char(character)
-                    if !key
-                        .modifiers
-                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-                {
-                    draft.push(character);
-                    *draft_dirty = true;
-                    *error = None;
+                None => {
+                    if let Some(character) = text_character(key) {
+                        draft.push(character);
+                        *draft_dirty = true;
+                        *error = None;
+                    }
                 }
                 _ => {}
             }
@@ -6971,6 +7141,7 @@ impl App {
     }
 
     fn handle_session_picker_pinning_key(&mut self, key: KeyEvent) {
+        let action = self.resolve_context_action(ActionContext::SessionPickerPinning, key);
         let mut retry = None;
         let mut cancel = false;
         let Some(picker) = self.session_picker.as_mut() else {
@@ -6986,13 +7157,13 @@ impl App {
         else {
             return;
         };
-        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
+        if action == Some(ActionId::Refresh) {
             if !*submitting {
                 *loading_version = true;
                 *error = None;
                 retry = Some((picker.epoch, session_id.clone(), *target));
             }
-        } else if key.code == KeyCode::Esc && !*submitting {
+        } else if action == Some(ActionId::Cancel) && !*submitting {
             cancel = true;
         }
 
@@ -7208,54 +7379,44 @@ impl App {
     }
 
     fn handle_command_palette_key(&mut self, key: KeyEvent) {
+        let action = self.resolve_context_action(ActionContext::CommandPalette, key);
         let resolving = self
             .command_palette
             .as_ref()
             .is_some_and(|palette| palette.resolving);
         if resolving {
-            if key.code == KeyCode::Esc {
+            if action == Some(ActionId::Cancel) {
                 self.close_command_palette();
             }
             return;
         }
 
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            match key.code {
-                KeyCode::Char('k') => {
-                    self.close_command_palette();
-                    return;
+        match action {
+            Some(ActionId::Cancel) => self.close_command_palette(),
+            Some(ActionId::ClearInput) => {
+                if let Some(palette) = self.command_palette.as_mut() {
+                    let preserve = palette.selected_entry().map(CommandPaletteEntry::key);
+                    palette.input.clear();
+                    palette.error = None;
+                    palette.refresh_filter(preserve);
                 }
-                KeyCode::Char('u') => {
-                    if let Some(palette) = self.command_palette.as_mut() {
-                        let preserve = palette.selected_entry().map(CommandPaletteEntry::key);
-                        palette.input.clear();
-                        palette.error = None;
-                        palette.refresh_filter(preserve);
-                    }
-                    return;
-                }
-                KeyCode::Char('r') => {
-                    if self
-                        .command_palette
-                        .as_ref()
-                        .is_some_and(|palette| !palette.loading)
-                    {
-                        self.reload_command_catalog();
-                    }
-                    return;
-                }
-                _ => {}
             }
-        }
-
-        match key.code {
-            KeyCode::Up => {
+            Some(ActionId::Refresh) => {
+                if self
+                    .command_palette
+                    .as_ref()
+                    .is_some_and(|palette| !palette.loading)
+                {
+                    self.reload_command_catalog();
+                }
+            }
+            Some(ActionId::NavigateUp) => {
                 if let Some(palette) = self.command_palette.as_mut() {
                     palette.selected = palette.selected.saturating_sub(1);
                     palette.error = None;
                 }
             }
-            KeyCode::Down => {
+            Some(ActionId::NavigateDown) => {
                 if let Some(palette) = self.command_palette.as_mut() {
                     if palette.selected + 1 < palette.visible.len() {
                         palette.selected += 1;
@@ -7263,13 +7424,13 @@ impl App {
                     palette.error = None;
                 }
             }
-            KeyCode::PageUp => {
+            Some(ActionId::PageUp) => {
                 if let Some(palette) = self.command_palette.as_mut() {
                     palette.selected = palette.selected.saturating_sub(8);
                     palette.error = None;
                 }
             }
-            KeyCode::PageDown => {
+            Some(ActionId::PageDown) => {
                 if let Some(palette) = self.command_palette.as_mut() {
                     palette.selected = palette
                         .selected
@@ -7278,21 +7439,20 @@ impl App {
                     palette.error = None;
                 }
             }
-            KeyCode::Home => {
+            Some(ActionId::JumpFirst) => {
                 if let Some(palette) = self.command_palette.as_mut() {
                     palette.selected = 0;
                     palette.error = None;
                 }
             }
-            KeyCode::End => {
+            Some(ActionId::JumpLast) => {
                 if let Some(palette) = self.command_palette.as_mut() {
                     palette.selected = palette.visible.len().saturating_sub(1);
                     palette.error = None;
                 }
             }
-            KeyCode::Enter => self.activate_command_palette_selection(),
-            KeyCode::Esc => self.close_command_palette(),
-            KeyCode::Backspace => {
+            Some(ActionId::Activate) => self.activate_command_palette_selection(),
+            Some(ActionId::Backspace) => {
                 if let Some(palette) = self.command_palette.as_mut() {
                     let preserve = palette.selected_entry().map(CommandPaletteEntry::key);
                     palette.input.pop();
@@ -7300,19 +7460,17 @@ impl App {
                     palette.refresh_filter(preserve);
                 }
             }
-            KeyCode::Char(character)
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-            {
-                if let Some(palette) = self.command_palette.as_mut() {
-                    let preserve = palette.selected_entry().map(CommandPaletteEntry::key);
-                    palette.input.push(character);
-                    palette.error = None;
-                    palette.refresh_filter(preserve);
+            None => {
+                if let Some(character) = text_character(key) {
+                    if let Some(palette) = self.command_palette.as_mut() {
+                        let preserve = palette.selected_entry().map(CommandPaletteEntry::key);
+                        palette.input.push(character);
+                        palette.error = None;
+                        palette.refresh_filter(preserve);
+                    }
                 }
             }
-            _ => {}
+            Some(_) => {}
         }
     }
 
@@ -7321,24 +7479,9 @@ impl App {
         entry: &CommandPaletteEntry,
     ) -> Option<&'static str> {
         match entry {
-            entry
-                if self.chat.streaming
-                    && !matches!(
-                        entry,
-                        CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop)
-                    ) =>
-            {
+            CommandPaletteEntry::Builtin(action) => self.action_disabled_reason(*action),
+            CommandPaletteEntry::Server(_) if self.chat.streaming => {
                 Some("Unavailable while an agent run is active")
-            }
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::NewSession)
-            | CommandPaletteEntry::Builtin(BuiltinPaletteAction::OpenSession)
-            | CommandPaletteEntry::Builtin(BuiltinPaletteAction::SelectModel)
-                if self.opening_session_id.is_some() =>
-            {
-                Some("Unavailable while a session is resuming")
-            }
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop) if !self.chat.streaming => {
-                Some("No active run to stop")
             }
             CommandPaletteEntry::Server(_) if self.opening_session_id.is_some() => {
                 Some("Composer commands are unavailable while a session is resuming")
@@ -7402,38 +7545,9 @@ impl App {
         }
     }
 
-    fn run_builtin_palette_action(&mut self, action: BuiltinPaletteAction) {
+    fn run_builtin_palette_action(&mut self, action: ActionId) {
         self.close_command_palette();
-        match action {
-            BuiltinPaletteAction::NewSession => self.new_session(),
-            BuiltinPaletteAction::OpenSession => {
-                self.tab = Tab::Chat;
-                self.open_session_picker();
-            }
-            BuiltinPaletteAction::SelectModel => {
-                self.tab = Tab::Chat;
-                self.open_model_picker();
-            }
-            BuiltinPaletteAction::Help => {
-                self.help_visible = true;
-                self.help_scroll = 0;
-            }
-            BuiltinPaletteAction::Notifications => {
-                self.notifications_visible = true;
-                self.notification_scroll = 0;
-                self.unseen_alerts = 0;
-            }
-            BuiltinPaletteAction::Stop => self.stop_streaming(),
-            BuiltinPaletteAction::ToggleDetails => self.toggle_conversation_details(),
-            BuiltinPaletteAction::Config => {
-                self.tab = Tab::Config;
-                self.load_tab_data();
-            }
-            BuiltinPaletteAction::Schedules => {
-                self.tab = Tab::Schedules;
-                self.load_tab_data();
-            }
-        }
+        self.handle_global_action(action);
     }
 
     fn resolve_command_into_composer(&mut self, command: CommandItem) {
@@ -7524,7 +7638,7 @@ impl App {
             .unwrap_or_default()
             .min(u16::MAX as usize) as u16;
         let mut textarea = TextArea::from(lines);
-        textarea.set_placeholder_text(CHAT_PLACEHOLDER);
+        textarea.set_placeholder_text(self.chat_placeholder());
         apply_textarea_palette(&mut textarea, self.theme);
         textarea.move_cursor(CursorMove::Jump(row, column));
         self.chat.textarea = textarea;
@@ -7593,13 +7707,14 @@ impl App {
     }
 
     async fn handle_model_picker_key(&mut self, key: KeyEvent) -> Result<()> {
+        let action = self.resolve_context_action(ActionContext::ModelPicker, key);
         let Some(picker) = self.model_picker.as_ref() else {
             return Ok(());
         };
         if picker.applying {
             return Ok(());
         }
-        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('u') {
+        if action == Some(ActionId::ClearInput) {
             if let Some(picker) = self.model_picker.as_mut() {
                 let preserve = picker.selected_model().map(model_key);
                 picker.query.clear();
@@ -7608,20 +7723,43 @@ impl App {
             return Ok(());
         }
 
-        match key.code {
-            KeyCode::Up => {
+        match action {
+            Some(ActionId::NavigateUp) => {
                 if let Some(picker) = self.model_picker.as_mut() {
                     picker.selected = picker.selected.saturating_sub(1);
                 }
             }
-            KeyCode::Down => {
+            Some(ActionId::NavigateDown) => {
                 if let Some(picker) = self.model_picker.as_mut() {
                     if picker.selected + 1 < picker.visible.len() {
                         picker.selected += 1;
                     }
                 }
             }
-            KeyCode::Enter => {
+            Some(ActionId::PageUp) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.selected = picker.selected.saturating_sub(8);
+                }
+            }
+            Some(ActionId::PageDown) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.selected = picker
+                        .selected
+                        .saturating_add(8)
+                        .min(picker.visible.len().saturating_sub(1));
+                }
+            }
+            Some(ActionId::JumpFirst) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.selected = 0;
+                }
+            }
+            Some(ActionId::JumpLast) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.selected = picker.visible.len().saturating_sub(1);
+                }
+            }
+            Some(ActionId::Activate) => {
                 let model = self
                     .model_picker
                     .as_ref()
@@ -7631,35 +7769,32 @@ impl App {
                     self.apply_model(model);
                 }
             }
-            KeyCode::Esc => self.close_model_picker(),
-            KeyCode::Backspace => {
+            Some(ActionId::Cancel) => self.close_model_picker(),
+            Some(ActionId::Backspace) => {
                 if let Some(picker) = self.model_picker.as_mut() {
                     let preserve = picker.selected_model().map(model_key);
                     picker.query.pop();
                     picker.refresh_filter(preserve);
                 }
             }
-            KeyCode::Char('r')
-                if key.modifiers.contains(KeyModifiers::CONTROL)
-                    && self
-                        .model_picker
-                        .as_ref()
-                        .is_some_and(|picker| !picker.loading && picker.visible.is_empty()) =>
+            Some(ActionId::Refresh)
+                if self
+                    .model_picker
+                    .as_ref()
+                    .is_some_and(|picker| !picker.loading && picker.visible.is_empty()) =>
             {
                 self.reload_model_catalog();
             }
-            KeyCode::Char(character)
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-            {
-                if let Some(picker) = self.model_picker.as_mut() {
-                    let preserve = picker.selected_model().map(model_key);
-                    picker.query.push(character);
-                    picker.refresh_filter(preserve);
+            None => {
+                if let Some(character) = text_character(key) {
+                    if let Some(picker) = self.model_picker.as_mut() {
+                        let preserve = picker.selected_model().map(model_key);
+                        picker.query.push(character);
+                        picker.refresh_filter(preserve);
+                    }
                 }
             }
-            _ => {}
+            Some(_) => {}
         }
         Ok(())
     }
@@ -7887,7 +8022,7 @@ mod command_palette_tests {
             .position(|index| {
                 matches!(
                     palette.entries.get(*index),
-                    Some(CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop))
+                    Some(CommandPaletteEntry::Builtin(ActionId::StopRun))
                 )
             })
             .unwrap();
@@ -8001,7 +8136,7 @@ mod command_palette_tests {
             .position(|index| {
                 matches!(
                     palette.entries.get(*index),
-                    Some(CommandPaletteEntry::Builtin(BuiltinPaletteAction::Config))
+                    Some(CommandPaletteEntry::Builtin(ActionId::OpenConfigTab))
                 )
             })
             .unwrap();
@@ -8279,7 +8414,7 @@ mod command_palette_tests {
             &mut app,
             CommandPaletteTrigger::Global,
             "",
-            vec![CommandPaletteEntry::Builtin(BuiltinPaletteAction::Help)],
+            vec![CommandPaletteEntry::Builtin(ActionId::ShowHelp)],
         );
         app.command_palette
             .as_ref()
@@ -8315,7 +8450,7 @@ mod command_palette_tests {
             &mut app,
             CommandPaletteTrigger::Global,
             "",
-            vec![CommandPaletteEntry::Builtin(BuiltinPaletteAction::Help)],
+            vec![CommandPaletteEntry::Builtin(ActionId::ShowHelp)],
         );
         let epoch = app.command_palette.as_ref().unwrap().epoch;
         app.command_palette
@@ -9340,17 +9475,17 @@ mod question_tests {
         assert_eq!(
             actual,
             vec![
-                3_754_701_473_256_146_053,
-                8_481_293_528_542_647_595,
-                12_575_992_514_826_633_301,
-                13_989_639_618_912_745_774,
-                465_778_487_439_365_817,
-                14_156_803_428_225_062_900,
-                17_914_074_169_692_835_981,
-                13_149_988_112_385_910_257,
-                5_948_328_123_032_448_941,
-                8_759_320_582_986_254_806,
-                4_446_556_145_525_268_495,
+                1_629_717_304_819_081_337,
+                2_435_904_485_675_274_227,
+                8_621_464_252_399_871_012,
+                17_724_800_445_688_683_857,
+                10_255_921_285_737_688_228,
+                13_189_008_884_911_027_983,
+                593_030_052_894_147_164,
+                11_931_795_620_947_757_325,
+                17_529_858_181_845_329_251,
+                7_545_373_857_546_054_913,
+                16_306_463_966_091_440_063,
             ],
             "minimum-size modal golden changed"
         );
@@ -10360,7 +10495,10 @@ mod question_tests {
             .collect::<String>();
         assert!(text.contains("delete session id"));
         assert!(text.contains("s1"));
-        assert!(text.contains("Esc/q close"));
+        assert!(text.contains(&format!(
+            "{} close",
+            app.key_hint(ActionContext::Notifications, ActionId::Cancel)
+        )));
 
         app.handle_event(AppEvent::Key(key(KeyCode::Esc)))
             .await
@@ -10620,8 +10758,14 @@ mod question_tests {
         // byte sequence.
         assert!(text.contains('计'));
         assert!(text.contains('划'));
-        assert!(text.contains("y / Enter confirm"));
-        assert!(text.contains("n / Esc cancel"));
+        assert!(text.contains(&format!(
+            "{} confirm",
+            app.key_hint(ActionContext::ScheduleDeleteConfirm, ActionId::Confirm)
+        )));
+        assert!(text.contains(&format!(
+            "{} cancel",
+            app.key_hint(ActionContext::ScheduleDeleteConfirm, ActionId::Reject)
+        )));
     }
 
     #[test]
@@ -10677,7 +10821,7 @@ mod question_tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        for needle in ["CONFIG_TAIL_", "Invalid JSON", "Ctrl+S save", "Esc cancel"] {
+        for needle in ["CONFIG_TAIL_", "Invalid JSON", "F2 save", "Esc cancel"] {
             assert!(
                 text.contains(needle),
                 "config editor missing {needle:?}:\n{text}"
@@ -10793,7 +10937,13 @@ mod question_tests {
                     .iter()
                     .map(|cell| cell.symbol())
                     .collect();
-                assert!(text.contains("Esc/q close"), "{width}x{height}:\n{text}");
+                assert!(
+                    text.contains(&format!(
+                        "{} close",
+                        app.key_hint(ActionContext::Notifications, ActionId::Cancel)
+                    )),
+                    "{width}x{height}:\n{text}"
+                );
             }
         }
     }
@@ -13959,7 +14109,10 @@ mod question_tests {
         assert!(app.session_picker.is_none());
         assert_eq!(app.chat.textarea.lines().join("\n"), "dr");
         assert_eq!(app.chat.scroll_offset, 11);
-        assert_eq!(app.status_message, "Keep this exact status");
+        assert_eq!(
+            app.status_message,
+            "Open session — Switch to Chat before using this action"
+        );
     }
 
     #[tokio::test]
@@ -14485,7 +14638,7 @@ mod question_tests {
         assert!(text.contains("Unicode") || text.contains("很长"));
         assert!(text.contains("★"));
         assert!(text.contains("F2 rename"));
-        assert!(text.contains("Esc cancel"));
+        assert!(text.contains("Esc"));
     }
 
     #[test]
@@ -14519,13 +14672,7 @@ mod question_tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
 
-        for needle in [
-            "15 🧭",
-            "load failed",
-            "F2 rename",
-            "Del delete",
-            "Esc cancel",
-        ] {
+        for needle in ["15 🧭", "load failed", "F2 rename", "Delete del", "Esc"] {
             assert!(text.contains(needle), "missing {needle:?}:\n{text}");
         }
         assert!(text.contains("more"), "window indicators missing:\n{text}");
@@ -15327,7 +15474,7 @@ mod auto_serve_tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        for needle in ["Ctrl+L inspect", "y / Enter start", "n / Esc skip"] {
+        for needle in ["Ctrl+L", "y/Enter start", "n/Esc skip"] {
             assert!(text.contains(needle), "missing {needle:?}:\n{text}");
         }
     }
@@ -15470,7 +15617,7 @@ mod auto_serve_tests {
         let text: String = buf.content().iter().map(|c| c.symbol()).collect();
         assert!(text.contains("127.0.0.1:9562"), "offer URL missing");
         assert!(text.contains("Start a local"), "offer prompt missing");
-        assert!(text.contains("y / Enter start"), "start action missing");
-        assert!(text.contains("n / Esc skip"), "skip action missing");
+        assert!(text.contains("y/Enter start"), "start action missing");
+        assert!(text.contains("n/Esc skip"), "skip action missing");
     }
 }

--- a/crates/app/bamboo-tui/src/keymap.rs
+++ b/crates/app/bamboo-tui/src/keymap.rs
@@ -1152,8 +1152,10 @@ struct KeyStroke {
 
 impl KeyStroke {
     fn from_event(event: KeyEvent) -> Self {
-        let mut modifiers =
-            event.modifiers & (KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT);
+        // Keep every modifier reported by crossterm.  SUPER/HYPER/META are not
+        // configurable today, but silently discarding them would turn e.g.
+        // Super+Y into plain `y` and could confirm a destructive dialog.
+        let mut modifiers = event.modifiers;
         let code = match event.code {
             KeyCode::BackTab => {
                 modifiers.remove(KeyModifiers::SHIFT);
@@ -1181,6 +1183,15 @@ impl KeyStroke {
         }
         if self.modifiers.contains(KeyModifiers::SHIFT) {
             parts.push("Shift".to_string());
+        }
+        if self.modifiers.contains(KeyModifiers::SUPER) {
+            parts.push("Super".to_string());
+        }
+        if self.modifiers.contains(KeyModifiers::HYPER) {
+            parts.push("Hyper".to_string());
+        }
+        if self.modifiers.contains(KeyModifiers::META) {
+            parts.push("Meta".to_string());
         }
         parts.push(match self.code {
             KeyCode::Backspace => "Backspace".to_string(),
@@ -1220,7 +1231,7 @@ impl KeyStroke {
     }
 
     fn is_plain_printable(&self) -> bool {
-        self.modifiers.is_empty() && matches!(self.code, KeyCode::Char(_))
+        (self.modifiers - KeyModifiers::SHIFT).is_empty() && matches!(self.code, KeyCode::Char(_))
     }
 
     fn is_xon_xoff_or_signal(&self) -> bool {
@@ -1494,12 +1505,15 @@ impl Keymap {
                 )));
             }
             if binding.context == ActionContext::Global
-                && binding.sequence.0.len() == 1
-                && binding.sequence.0[0].is_plain_printable()
+                && binding
+                    .sequence
+                    .0
+                    .first()
+                    .is_some_and(KeyStroke::is_plain_printable)
             {
                 return Err(KeymapError(format!(
-                    "global binding '{}' would steal ordinary Chat text",
-                    binding.sequence.display()
+                    "global binding '{}' starts with a printable key and would steal ordinary Chat text; start it with Leader, Ctrl, Alt, or a function key",
+                    binding.sequence.display(),
                 )));
             }
             for other in self.bindings.iter().skip(index + 1) {
@@ -1537,6 +1551,9 @@ impl Keymap {
             (ActionContext::QuestionOptions, ActionId::Cancel),
             (ActionContext::QuestionCustom, ActionId::Activate),
             (ActionContext::QuestionCustom, ActionId::Cancel),
+            (ActionContext::QuestionNumber, ActionId::Activate),
+            (ActionContext::QuestionNumber, ActionId::Cancel),
+            (ActionContext::QuestionInspect, ActionId::Cancel),
             (ActionContext::SessionDeleteConfirm, ActionId::Confirm),
             (ActionContext::SessionDeleteConfirm, ActionId::Reject),
             (ActionContext::ScheduleDeleteConfirm, ActionId::Confirm),
@@ -1598,6 +1615,25 @@ impl Keymap {
         now: Instant,
     ) -> KeyResolution {
         let stroke = KeyStroke::from_event(event);
+
+        // A single-stroke global quit binding is the emergency escape hatch:
+        // it must preempt an incomplete leader sequence instead of becoming a
+        // (usually invalid) continuation such as `Leader Ctrl+C`.
+        if pending.is_some()
+            && contexts.contains(&ActionContext::Global)
+            && self.bindings.iter().any(|binding| {
+                binding.context == ActionContext::Global
+                    && binding.action == ActionId::QuitOrStop
+                    && binding.sequence.0.as_slice() == std::slice::from_ref(&stroke)
+            })
+        {
+            *pending = None;
+            return KeyResolution::Action {
+                context: ActionContext::Global,
+                action: ActionId::QuitOrStop,
+            };
+        }
+
         if let Some(current) = pending.as_ref() {
             if current.focus_contexts != contexts {
                 *pending = None;
@@ -1617,18 +1653,26 @@ impl Keymap {
                     "Key sequence cancelled because focus changed".to_string(),
                 );
             }
-            if now.duration_since(current.started_at) >= self.timeout {
-                let display = current.sequence.display();
-                *pending = None;
-                return KeyResolution::Cancelled(format!("Key sequence '{display}' timed out"));
-            }
             if stroke.code == KeyCode::Esc && stroke.modifiers.is_empty() {
                 *pending = None;
                 return KeyResolution::Cancelled("Key sequence cancelled".to_string());
             }
-            let mut sequence = current.sequence.clone();
-            sequence.0.push(stroke);
-            return self.resolve_sequence(&candidate_contexts, contexts, sequence, pending, now);
+            if now.duration_since(current.started_at) < self.timeout {
+                let mut sequence = current.sequence.clone();
+                sequence.0.push(stroke);
+                return self.resolve_sequence(
+                    &candidate_contexts,
+                    contexts,
+                    sequence,
+                    pending,
+                    now,
+                );
+            }
+
+            // The timer tick normally expires pending sequences, but an input
+            // event can win the select race.  Reprocess that event as a fresh
+            // key so the first composer character after a timeout is not lost.
+            *pending = None;
         }
 
         let sequence = KeySequence(vec![stroke]);
@@ -1655,32 +1699,38 @@ impl Keymap {
         pending: &mut Option<PendingSequence>,
         now: Instant,
     ) -> KeyResolution {
+        let mut pending_contexts = Vec::new();
         for context in candidate_contexts {
             if let Some(binding) = self
                 .bindings
                 .iter()
                 .find(|binding| binding.context == *context && binding.sequence == sequence)
             {
-                *pending = None;
-                return KeyResolution::Action {
-                    context: *context,
-                    action: binding.action,
-                };
+                // An exact binding wins only when no higher-priority context
+                // still has a longer match.  This preserves modal/focused
+                // precedence without losing shared leaders whose continuations
+                // live in several contexts.
+                if pending_contexts.is_empty() {
+                    *pending = None;
+                    return KeyResolution::Action {
+                        context: *context,
+                        action: binding.action,
+                    };
+                }
+                continue;
+            }
+            if self.bindings.iter().any(|binding| {
+                binding.context == *context
+                    && sequence.is_prefix_of(&binding.sequence)
+                    && binding.sequence != sequence
+            }) {
+                pending_contexts.push(*context);
             }
         }
-        let candidate_contexts = candidate_contexts
-            .iter()
-            .copied()
-            .filter(|context| {
-                self.bindings.iter().any(|binding| {
-                    binding.context == *context && sequence.is_prefix_of(&binding.sequence)
-                })
-            })
-            .collect::<Vec<_>>();
-        if !candidate_contexts.is_empty() {
+        if !pending_contexts.is_empty() {
             let display = sequence.display();
             *pending = Some(PendingSequence {
-                contexts: candidate_contexts,
+                contexts: pending_contexts,
                 focus_contexts: focus_contexts.to_vec(),
                 sequence,
                 started_at: now,
@@ -1759,16 +1809,19 @@ impl Keymap {
 }
 
 pub(crate) fn text_character(event: KeyEvent) -> Option<char> {
-    if event
-        .modifiers
-        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-    {
+    if !(event.modifiers - KeyModifiers::SHIFT).is_empty() {
         return None;
     }
     match event.code {
         KeyCode::Char(character) => Some(character),
         _ => None,
     }
+}
+
+pub(crate) fn text_widget_input_allowed(event: KeyEvent) -> bool {
+    !event
+        .modifiers
+        .intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META)
 }
 
 fn split_binding_list(bindings: &str) -> Result<Vec<String>, KeymapError> {
@@ -2075,6 +2128,152 @@ mod tests {
     }
 
     #[test]
+    fn single_stroke_global_quit_preempts_a_pending_sequence() {
+        let keymap = Keymap::default();
+        let now = Instant::now();
+        let contexts = [ActionContext::Chat, ActionContext::Global];
+        let mut pending = None;
+        assert!(matches!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('\\'), KeyModifiers::CONTROL),
+                now,
+            ),
+            KeyResolution::Pending(_)
+        ));
+
+        assert_eq!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('c'), KeyModifiers::CONTROL),
+                now + Duration::from_millis(10),
+            ),
+            KeyResolution::Action {
+                context: ActionContext::Global,
+                action: ActionId::QuitOrStop,
+            }
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn expired_sequence_reprocesses_the_current_key() {
+        let keymap = Keymap::default();
+        let now = Instant::now();
+        let contexts = [ActionContext::Chat, ActionContext::Global];
+        let mut pending = None;
+        assert!(matches!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('\\'), KeyModifiers::CONTROL),
+                now,
+            ),
+            KeyResolution::Pending(_)
+        ));
+
+        assert_eq!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('a'), KeyModifiers::empty()),
+                now + Duration::from_millis(1_001),
+            ),
+            KeyResolution::NoMatch,
+            "the first composer character after timeout must be handled fresh"
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn cross_context_prefixes_obey_focused_precedence() {
+        let keymap = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"chat","action":"insert-newline","keys":["F2 x"]},
+                {"context":"global","action":"show-help","keys":["F2"]}
+            ]}"#,
+        )
+        .unwrap();
+        let contexts = [ActionContext::Chat, ActionContext::Global];
+        let now = Instant::now();
+        let mut pending = None;
+        assert!(matches!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::F(2), KeyModifiers::empty()),
+                now,
+            ),
+            KeyResolution::Pending(_)
+        ));
+        assert_eq!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('x'), KeyModifiers::empty()),
+                now + Duration::from_millis(10),
+            ),
+            KeyResolution::Action {
+                context: ActionContext::Chat,
+                action: ActionId::InsertNewline,
+            }
+        );
+
+        let reverse = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"chat","action":"insert-newline","keys":["F2"]},
+                {"context":"global","action":"show-help","keys":["F2 x"]}
+            ]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            reverse.resolve(
+                &contexts,
+                &mut None,
+                key(KeyCode::F(2), KeyModifiers::empty()),
+                now,
+            ),
+            KeyResolution::Action {
+                context: ActionContext::Chat,
+                action: ActionId::InsertNewline,
+            }
+        );
+
+        let destructive = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"session-delete-confirm","action":"confirm","keys":["F3 y"]},
+                {"context":"global","action":"show-help","keys":["F3"]}
+            ]}"#,
+        )
+        .unwrap();
+        let modal_contexts = [ActionContext::SessionDeleteConfirm, ActionContext::Global];
+        let mut modal_pending = None;
+        assert!(matches!(
+            destructive.resolve(
+                &modal_contexts,
+                &mut modal_pending,
+                key(KeyCode::F(3), KeyModifiers::empty()),
+                now,
+            ),
+            KeyResolution::Pending(_)
+        ));
+        assert_eq!(
+            destructive.resolve(
+                &modal_contexts,
+                &mut modal_pending,
+                key(KeyCode::Char('y'), KeyModifiers::empty()),
+                now + Duration::from_millis(10),
+            ),
+            KeyResolution::Action {
+                context: ActionContext::SessionDeleteConfirm,
+                action: ActionId::Confirm,
+            }
+        );
+    }
+
+    #[test]
     fn focus_change_cancels_a_pending_sequence_even_when_global_remains() {
         let keymap = Keymap::default();
         let now = Instant::now();
@@ -2206,6 +2405,60 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(required.contains("required action"));
+
+        let printable_prefix = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"global","action":"show-help","keys":["g n"]}
+            ]}"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(printable_prefix.contains("starts with a printable key"));
+        assert!(printable_prefix.contains("ordinary Chat text"));
+
+        let shifted_printable_prefix = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"global","action":"show-help","keys":["Shift+g n"]}
+            ]}"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(shifted_printable_prefix.contains("starts with a printable key"));
+
+        for (context, action) in [
+            ("question-number", "activate"),
+            ("question-number", "cancel"),
+            ("question-inspect", "cancel"),
+        ] {
+            let input = format!(
+                r#"{{"bindings":[{{"context":"{context}","action":"{action}","unbind":true}}]}}"#
+            );
+            let error = Keymap::from_json(&input).unwrap_err().to_string();
+            assert!(
+                error.contains("required action"),
+                "{context}/{action}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_modifiers_do_not_match_actions_or_text() {
+        let keymap = Keymap::default();
+        for modifier in [KeyModifiers::SUPER, KeyModifiers::HYPER, KeyModifiers::META] {
+            let event = key(KeyCode::Char('y'), modifier);
+            assert_eq!(
+                keymap.resolve(
+                    &[ActionContext::SessionDeleteConfirm, ActionContext::Global,],
+                    &mut None,
+                    event,
+                    Instant::now(),
+                ),
+                KeyResolution::NoMatch,
+                "{modifier:?}+y must not confirm"
+            );
+            assert_eq!(text_character(event), None);
+            assert!(!text_widget_input_allowed(event));
+        }
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/keymap.rs
+++ b/crates/app/bamboo-tui/src/keymap.rs
@@ -1,0 +1,2270 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_LEADER: &str = "Ctrl+\\";
+const DEFAULT_LEADER_TIMEOUT_MS: u64 = 1_000;
+const MIN_LEADER_TIMEOUT_MS: u64 = 200;
+const MAX_LEADER_TIMEOUT_MS: u64 = 5_000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ActionContext {
+    Global,
+    Navigation,
+    Help,
+    Notifications,
+    ServeOffer,
+    QuestionOptions,
+    QuestionCustom,
+    QuestionNumber,
+    QuestionInspect,
+    SessionDeleteConfirm,
+    ScheduleDeleteConfirm,
+    Chat,
+    ConversationBlock,
+    Sessions,
+    Mcp,
+    Schedules,
+    ScheduleForm,
+    Skills,
+    Config,
+    ConfigEditor,
+    SessionPickerBrowse,
+    SessionPickerRename,
+    SessionPickerPinning,
+    ModelPicker,
+    CommandPalette,
+}
+
+impl ActionContext {
+    pub(crate) const ALL: [Self; 25] = [
+        Self::Chat,
+        Self::ConversationBlock,
+        Self::Global,
+        Self::Navigation,
+        Self::Help,
+        Self::Notifications,
+        Self::ServeOffer,
+        Self::QuestionOptions,
+        Self::QuestionCustom,
+        Self::QuestionNumber,
+        Self::QuestionInspect,
+        Self::SessionDeleteConfirm,
+        Self::ScheduleDeleteConfirm,
+        Self::Sessions,
+        Self::Mcp,
+        Self::Schedules,
+        Self::ScheduleForm,
+        Self::Skills,
+        Self::Config,
+        Self::ConfigEditor,
+        Self::SessionPickerBrowse,
+        Self::SessionPickerRename,
+        Self::SessionPickerPinning,
+        Self::ModelPicker,
+        Self::CommandPalette,
+    ];
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Global => "Global",
+            Self::Navigation => "Tabs",
+            Self::Help => "Help",
+            Self::Notifications => "Notifications",
+            Self::ServeOffer => "Server prompt",
+            Self::QuestionOptions => "Question options",
+            Self::QuestionCustom => "Question answer",
+            Self::QuestionNumber => "Question number",
+            Self::QuestionInspect => "Question inspector",
+            Self::SessionDeleteConfirm => "Session delete",
+            Self::ScheduleDeleteConfirm => "Schedule delete",
+            Self::Chat => "Chat",
+            Self::ConversationBlock => "Conversation block",
+            Self::Sessions => "Sessions",
+            Self::Mcp => "MCP",
+            Self::Schedules => "Schedules",
+            Self::ScheduleForm => "Schedule form",
+            Self::Skills => "Skills",
+            Self::Config => "Config",
+            Self::ConfigEditor => "Config editor",
+            Self::SessionPickerBrowse => "Session picker",
+            Self::SessionPickerRename => "Session rename",
+            Self::SessionPickerPinning => "Session pin",
+            Self::ModelPicker => "Model picker",
+            Self::CommandPalette => "Command palette",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ActionId {
+    QuitOrStop,
+    ShowHelp,
+    ShowNotifications,
+    OpenCommandPalette,
+    NewSession,
+    ReopenPendingQuestion,
+    OpenModelPicker,
+    OpenSessionPicker,
+    StopRun,
+    ToggleDetails,
+    OpenConfigTab,
+    OpenSchedulesTab,
+    NextTab,
+    PreviousTab,
+    #[serde(rename = "switch-tab-1")]
+    SwitchTab1,
+    #[serde(rename = "switch-tab-2")]
+    SwitchTab2,
+    #[serde(rename = "switch-tab-3")]
+    SwitchTab3,
+    #[serde(rename = "switch-tab-4")]
+    SwitchTab4,
+    #[serde(rename = "switch-tab-5")]
+    SwitchTab5,
+    #[serde(rename = "switch-tab-6")]
+    SwitchTab6,
+    NavigateUp,
+    NavigateDown,
+    PageUp,
+    PageDown,
+    JumpFirst,
+    JumpLast,
+    Activate,
+    Cancel,
+    Backspace,
+    Refresh,
+    ClearInput,
+    Confirm,
+    Reject,
+    OpenSlashPalette,
+    SendMessage,
+    InsertNewline,
+    ScrollTranscriptUp,
+    ScrollTranscriptDown,
+    ScrollTranscriptTop,
+    ScrollTranscriptBottom,
+    FocusConversationBlocks,
+    ExitConversationBlocks,
+    PreviousConversationBlock,
+    NextConversationBlock,
+    ScrollBlockUp,
+    ScrollBlockDown,
+    ScrollBlockPageUp,
+    ScrollBlockPageDown,
+    CopyValue,
+    InspectValue,
+    ToggleInspectorPane,
+    CustomAnswer,
+    NumberAnswer,
+    #[serde(rename = "quick-answer-1")]
+    QuickAnswer1,
+    #[serde(rename = "quick-answer-2")]
+    QuickAnswer2,
+    #[serde(rename = "quick-answer-3")]
+    QuickAnswer3,
+    #[serde(rename = "quick-answer-4")]
+    QuickAnswer4,
+    #[serde(rename = "quick-answer-5")]
+    QuickAnswer5,
+    #[serde(rename = "quick-answer-6")]
+    QuickAnswer6,
+    #[serde(rename = "quick-answer-7")]
+    QuickAnswer7,
+    #[serde(rename = "quick-answer-8")]
+    QuickAnswer8,
+    #[serde(rename = "quick-answer-9")]
+    QuickAnswer9,
+    DeleteSelection,
+    NextPage,
+    PreviousPage,
+    ShowTools,
+    NewSchedule,
+    RunSchedule,
+    NextField,
+    PreviousField,
+    EditConfig,
+    SaveConfig,
+    RenameSession,
+    ToggleSessionPin,
+    LoadMore,
+}
+
+#[derive(Clone, Copy)]
+struct DefaultBinding {
+    context: ActionContext,
+    keys: &'static str,
+}
+
+pub(crate) struct ActionSpec {
+    pub(crate) id: ActionId,
+    pub(crate) label: &'static str,
+    pub(crate) description: &'static str,
+    pub(crate) palette: bool,
+    availability: ActionAvailability,
+    contexts: &'static [ActionContext],
+    defaults: &'static [DefaultBinding],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ActionAvailability {
+    Always,
+    Idle,
+    ChatIdle,
+    ActiveRun,
+    Chat,
+}
+
+macro_rules! spec {
+    ($id:ident, $label:literal, $description:literal, $palette:expr, $availability:ident,
+        [$($context:ident),* $(,)?],
+        [$(($default_context:ident, $keys:literal)),* $(,)?]
+    ) => {
+        ActionSpec {
+            id: ActionId::$id,
+            label: $label,
+            description: $description,
+            palette: $palette,
+            availability: ActionAvailability::$availability,
+            contexts: &[$(ActionContext::$context),*],
+            defaults: &[$(DefaultBinding {
+                context: ActionContext::$default_context,
+                keys: $keys,
+            }),*],
+        }
+    };
+    ($id:ident, $label:literal, $description:literal, $palette:expr,
+        [$($context:ident),* $(,)?],
+        [$(($default_context:ident, $keys:literal)),* $(,)?]
+    ) => {
+        spec!(
+            $id,
+            $label,
+            $description,
+            $palette,
+            Always,
+            [$($context),*],
+            [$(($default_context, $keys)),*]
+        )
+    };
+}
+
+pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
+    spec!(
+        QuitOrStop,
+        "Quit or stop",
+        "Stop an active run, otherwise quit the TUI",
+        false,
+        [Global],
+        [(Global, "Ctrl+C")]
+    ),
+    spec!(
+        ShowHelp,
+        "Show help",
+        "Open the resolved contextual keybinding reference",
+        true,
+        [Global, Navigation],
+        [(Global, "F1; Leader h"), (Navigation, "?")]
+    ),
+    spec!(
+        ShowNotifications,
+        "Show notifications",
+        "Open the full status, warning, and error log",
+        true,
+        [Global],
+        [(Global, "Ctrl+L; Leader l")]
+    ),
+    spec!(
+        OpenCommandPalette,
+        "Command palette",
+        "Search built-in and session-aware commands",
+        false,
+        [Global],
+        [(Global, "Ctrl+K; Leader k")]
+    ),
+    spec!(
+        NewSession,
+        "New session",
+        "Clear conversation state and start a fresh session",
+        true,
+        Idle,
+        [Global],
+        [(Global, "Ctrl+N; Leader n")]
+    ),
+    spec!(
+        ReopenPendingQuestion,
+        "Reopen question",
+        "Restore a dismissed pending agent question",
+        false,
+        [Global],
+        [(Global, "Ctrl+Q; Leader q")]
+    ),
+    spec!(
+        OpenModelPicker,
+        "Select model",
+        "Choose a provider-qualified model",
+        true,
+        ChatIdle,
+        [Global],
+        [(Global, "Ctrl+O; Leader m")]
+    ),
+    spec!(
+        OpenSessionPicker,
+        "Open session",
+        "Search and resume an existing session",
+        true,
+        ChatIdle,
+        [Global],
+        [(Global, "Ctrl+P; Leader p")]
+    ),
+    spec!(
+        StopRun,
+        "Stop active run",
+        "Request cancellation of the active agent run",
+        true,
+        ActiveRun,
+        [Global, Chat],
+        [(Global, "Ctrl+S; Leader s"), (Chat, "Ctrl+S; Leader s")]
+    ),
+    spec!(
+        ToggleDetails,
+        "Toggle focused details",
+        "Toggle the focused block or the default for new details",
+        true,
+        Chat,
+        [Chat, ConversationBlock],
+        [
+            (Chat, "Ctrl+X; Leader x"),
+            (ConversationBlock, "Ctrl+X; Leader x")
+        ]
+    ),
+    spec!(
+        OpenConfigTab,
+        "Open config",
+        "Switch to the configuration tab",
+        true,
+        [Global],
+        []
+    ),
+    spec!(
+        OpenSchedulesTab,
+        "Open schedules",
+        "Switch to the schedules tab",
+        true,
+        [Global],
+        []
+    ),
+    spec!(
+        NextTab,
+        "Next tab",
+        "Switch to the next top-level tab",
+        false,
+        [Global],
+        [(Global, "Tab")]
+    ),
+    spec!(
+        PreviousTab,
+        "Previous tab",
+        "Switch to the previous top-level tab",
+        false,
+        [Global],
+        [(Global, "Shift+Tab")]
+    ),
+    spec!(
+        SwitchTab1,
+        "Open Chat tab",
+        "Switch directly to Chat outside text entry",
+        false,
+        [Navigation],
+        [(Navigation, "1")]
+    ),
+    spec!(
+        SwitchTab2,
+        "Open Sessions tab",
+        "Switch directly to Sessions outside text entry",
+        false,
+        [Navigation],
+        [(Navigation, "2")]
+    ),
+    spec!(
+        SwitchTab3,
+        "Open MCP tab",
+        "Switch directly to MCP outside text entry",
+        false,
+        [Navigation],
+        [(Navigation, "3")]
+    ),
+    spec!(
+        SwitchTab4,
+        "Open Schedules tab",
+        "Switch directly to Schedules outside text entry",
+        false,
+        [Navigation],
+        [(Navigation, "4")]
+    ),
+    spec!(
+        SwitchTab5,
+        "Open Skills tab",
+        "Switch directly to Skills outside text entry",
+        false,
+        [Navigation],
+        [(Navigation, "5")]
+    ),
+    spec!(
+        SwitchTab6,
+        "Open Config tab",
+        "Switch directly to Config outside text entry",
+        false,
+        [Navigation],
+        [(Navigation, "6")]
+    ),
+    spec!(
+        NavigateUp,
+        "Move up",
+        "Move selection or scroll one row upward",
+        false,
+        [
+            Help,
+            Notifications,
+            QuestionOptions,
+            QuestionInspect,
+            Sessions,
+            Mcp,
+            Schedules,
+            Skills,
+            Config,
+            SessionPickerBrowse,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (Help, "Up; k"),
+            (Notifications, "Up; k"),
+            (QuestionOptions, "Up; k"),
+            (QuestionInspect, "Up; k"),
+            (Sessions, "Up"),
+            (Mcp, "Up"),
+            (Schedules, "Up"),
+            (Skills, "Up"),
+            (Config, "Up; k"),
+            (SessionPickerBrowse, "Up"),
+            (ModelPicker, "Up"),
+            (CommandPalette, "Up")
+        ]
+    ),
+    spec!(
+        NavigateDown,
+        "Move down",
+        "Move selection or scroll one row downward",
+        false,
+        [
+            Help,
+            Notifications,
+            QuestionOptions,
+            QuestionInspect,
+            Sessions,
+            Mcp,
+            Schedules,
+            Skills,
+            Config,
+            SessionPickerBrowse,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (Help, "Down; j"),
+            (Notifications, "Down; j"),
+            (QuestionOptions, "Down; j"),
+            (QuestionInspect, "Down; j"),
+            (Sessions, "Down"),
+            (Mcp, "Down"),
+            (Schedules, "Down"),
+            (Skills, "Down"),
+            (Config, "Down; j"),
+            (SessionPickerBrowse, "Down"),
+            (ModelPicker, "Down"),
+            (CommandPalette, "Down")
+        ]
+    ),
+    spec!(
+        PageUp,
+        "Page up",
+        "Move or scroll one page upward",
+        false,
+        [
+            Help,
+            Notifications,
+            QuestionOptions,
+            QuestionInspect,
+            Config,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (Help, "PageUp"),
+            (Notifications, "PageUp"),
+            (QuestionOptions, "PageUp"),
+            (QuestionInspect, "PageUp"),
+            (Config, "PageUp"),
+            (ModelPicker, "PageUp"),
+            (CommandPalette, "PageUp")
+        ]
+    ),
+    spec!(
+        PageDown,
+        "Page down",
+        "Move or scroll one page downward",
+        false,
+        [
+            Help,
+            Notifications,
+            QuestionOptions,
+            QuestionInspect,
+            Config,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (Help, "PageDown"),
+            (Notifications, "PageDown"),
+            (QuestionOptions, "PageDown"),
+            (QuestionInspect, "PageDown"),
+            (Config, "PageDown"),
+            (ModelPicker, "PageDown"),
+            (CommandPalette, "PageDown")
+        ]
+    ),
+    spec!(
+        JumpFirst,
+        "Jump to first",
+        "Move to the first item or row",
+        false,
+        [
+            Help,
+            Notifications,
+            QuestionOptions,
+            QuestionInspect,
+            ConversationBlock,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (Help, "Home"),
+            (Notifications, "Home"),
+            (QuestionOptions, "Home"),
+            (QuestionInspect, "Home"),
+            (ConversationBlock, "Home"),
+            (ModelPicker, "Home"),
+            (CommandPalette, "Home")
+        ]
+    ),
+    spec!(
+        JumpLast,
+        "Jump to last",
+        "Move to the final item or row",
+        false,
+        [
+            Help,
+            Notifications,
+            QuestionOptions,
+            QuestionInspect,
+            ConversationBlock,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (Help, "End"),
+            (Notifications, "End"),
+            (QuestionOptions, "End"),
+            (QuestionInspect, "End"),
+            (ConversationBlock, "End"),
+            (ModelPicker, "End"),
+            (CommandPalette, "End")
+        ]
+    ),
+    spec!(
+        Activate,
+        "Activate",
+        "Use, submit, open, or toggle the selected item",
+        false,
+        [
+            QuestionOptions,
+            QuestionCustom,
+            QuestionNumber,
+            ConversationBlock,
+            Sessions,
+            Mcp,
+            ScheduleForm,
+            Skills,
+            SessionPickerBrowse,
+            SessionPickerRename,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (QuestionOptions, "Enter"),
+            (QuestionCustom, "Enter"),
+            (QuestionNumber, "Enter"),
+            (ConversationBlock, "Enter"),
+            (Sessions, "Enter"),
+            (Mcp, "Enter"),
+            (ScheduleForm, "Enter"),
+            (Skills, "Enter"),
+            (SessionPickerBrowse, "Enter"),
+            (SessionPickerRename, "Enter"),
+            (ModelPicker, "Enter"),
+            (CommandPalette, "Enter")
+        ]
+    ),
+    spec!(
+        Cancel,
+        "Cancel or close",
+        "Cancel the current mode without applying changes",
+        false,
+        [
+            Help,
+            Notifications,
+            QuestionOptions,
+            QuestionCustom,
+            QuestionNumber,
+            QuestionInspect,
+            ScheduleForm,
+            ConfigEditor,
+            SessionPickerBrowse,
+            SessionPickerRename,
+            SessionPickerPinning,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (Help, "Esc; q; F1"),
+            (Notifications, "Esc; q; F1"),
+            (QuestionOptions, "Esc"),
+            (QuestionCustom, "Esc"),
+            (QuestionNumber, "Esc"),
+            (QuestionInspect, "Esc; v"),
+            (ScheduleForm, "Esc"),
+            (ConfigEditor, "Esc"),
+            (SessionPickerBrowse, "Esc"),
+            (SessionPickerRename, "Esc"),
+            (SessionPickerPinning, "Esc"),
+            (ModelPicker, "Esc"),
+            (CommandPalette, "Esc; Ctrl+K")
+        ]
+    ),
+    spec!(
+        Backspace,
+        "Delete previous character",
+        "Remove the previous character from the focused input",
+        false,
+        [
+            QuestionCustom,
+            QuestionNumber,
+            ScheduleForm,
+            SessionPickerBrowse,
+            SessionPickerRename,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (QuestionCustom, "Backspace"),
+            (QuestionNumber, "Backspace"),
+            (ScheduleForm, "Backspace"),
+            (SessionPickerBrowse, "Backspace"),
+            (SessionPickerRename, "Backspace"),
+            (ModelPicker, "Backspace"),
+            (CommandPalette, "Backspace")
+        ]
+    ),
+    spec!(
+        Refresh,
+        "Refresh",
+        "Reload the current catalog or retry its last request",
+        false,
+        [
+            Sessions,
+            Mcp,
+            SessionPickerBrowse,
+            SessionPickerRename,
+            SessionPickerPinning,
+            ModelPicker,
+            CommandPalette
+        ],
+        [
+            (Sessions, "r"),
+            (Mcp, "r"),
+            (SessionPickerBrowse, "Ctrl+R"),
+            (SessionPickerRename, "Ctrl+R"),
+            (SessionPickerPinning, "Ctrl+R"),
+            (ModelPicker, "Ctrl+R"),
+            (CommandPalette, "Ctrl+R")
+        ]
+    ),
+    spec!(
+        ClearInput,
+        "Clear input",
+        "Clear the focused search query",
+        false,
+        [SessionPickerBrowse, ModelPicker, CommandPalette],
+        [
+            (SessionPickerBrowse, "Ctrl+U"),
+            (ModelPicker, "Ctrl+U"),
+            (CommandPalette, "Ctrl+U")
+        ]
+    ),
+    spec!(
+        Confirm,
+        "Confirm",
+        "Accept the pending confirmation",
+        false,
+        [ServeOffer, SessionDeleteConfirm, ScheduleDeleteConfirm],
+        [
+            (ServeOffer, "y; Enter"),
+            (SessionDeleteConfirm, "y; Enter"),
+            (ScheduleDeleteConfirm, "y; Enter")
+        ]
+    ),
+    spec!(
+        Reject,
+        "Reject",
+        "Decline or cancel the pending confirmation",
+        false,
+        [ServeOffer, SessionDeleteConfirm, ScheduleDeleteConfirm],
+        [
+            (ServeOffer, "n; Esc"),
+            (SessionDeleteConfirm, "n; Esc"),
+            (ScheduleDeleteConfirm, "n; Esc")
+        ]
+    ),
+    spec!(
+        OpenSlashPalette,
+        "Slash commands",
+        "Open command discovery from an empty Chat composer",
+        false,
+        [Chat],
+        [(Chat, "/")]
+    ),
+    spec!(
+        SendMessage,
+        "Send message",
+        "Send the current Chat composer draft",
+        false,
+        [Chat],
+        [(Chat, "Enter")]
+    ),
+    spec!(
+        InsertNewline,
+        "Insert newline",
+        "Insert a newline without sending the Chat draft",
+        false,
+        [Chat],
+        [(Chat, "Alt+Enter; Shift+Enter")]
+    ),
+    spec!(
+        ScrollTranscriptUp,
+        "Scroll transcript up",
+        "Scroll the Chat transcript upward",
+        false,
+        [Chat],
+        [(Chat, "PageUp; Alt+Up")]
+    ),
+    spec!(
+        ScrollTranscriptDown,
+        "Scroll transcript down",
+        "Scroll the Chat transcript downward",
+        false,
+        [Chat],
+        [(Chat, "PageDown; Alt+Down")]
+    ),
+    spec!(
+        ScrollTranscriptTop,
+        "Transcript top",
+        "Jump to the top of the Chat transcript",
+        false,
+        [Chat],
+        [(Chat, "Ctrl+Home")]
+    ),
+    spec!(
+        ScrollTranscriptBottom,
+        "Transcript bottom",
+        "Jump to the newest Chat output",
+        false,
+        [Chat],
+        [(Chat, "Ctrl+End; Ctrl+G")]
+    ),
+    spec!(
+        FocusConversationBlocks,
+        "Focus conversation blocks",
+        "Move keyboard focus from the composer into rendered blocks",
+        false,
+        [Chat],
+        [(Chat, "Ctrl+B")]
+    ),
+    spec!(
+        ExitConversationBlocks,
+        "Focus composer",
+        "Return keyboard focus to the Chat composer",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "Esc; Ctrl+B")]
+    ),
+    spec!(
+        PreviousConversationBlock,
+        "Previous block",
+        "Move focus to the previous conversation block",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "Up")]
+    ),
+    spec!(
+        NextConversationBlock,
+        "Next block",
+        "Move focus to the next conversation block",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "Down")]
+    ),
+    spec!(
+        ScrollBlockUp,
+        "Scroll block up",
+        "Scroll the focused detail block upward",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "k")]
+    ),
+    spec!(
+        ScrollBlockDown,
+        "Scroll block down",
+        "Scroll the focused detail block downward",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "j")]
+    ),
+    spec!(
+        ScrollBlockPageUp,
+        "Page block up",
+        "Scroll the focused detail block up by one viewport",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "PageUp")]
+    ),
+    spec!(
+        ScrollBlockPageDown,
+        "Page block down",
+        "Scroll the focused detail block down by one viewport",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "PageDown")]
+    ),
+    spec!(
+        CopyValue,
+        "Copy exact value",
+        "Copy the focused value through OSC 52",
+        false,
+        [ConversationBlock, QuestionOptions, QuestionInspect],
+        [
+            (ConversationBlock, "y"),
+            (QuestionOptions, "y"),
+            (QuestionInspect, "y")
+        ]
+    ),
+    spec!(
+        InspectValue,
+        "Inspect full value",
+        "Open the full question/value inspector",
+        false,
+        [QuestionOptions, QuestionCustom],
+        [(QuestionOptions, "v"), (QuestionCustom, "Ctrl+V")]
+    ),
+    spec!(
+        ToggleInspectorPane,
+        "Toggle inspected value",
+        "Switch between the question and selected option",
+        false,
+        [QuestionInspect],
+        [(QuestionInspect, "Tab")]
+    ),
+    spec!(
+        CustomAnswer,
+        "Custom answer",
+        "Enter a free-text answer",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "c")]
+    ),
+    spec!(
+        NumberAnswer,
+        "Option by number",
+        "Enter a multi-digit option number",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "g")]
+    ),
+    spec!(
+        QuickAnswer1,
+        "Answer option 1",
+        "Submit question option 1",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "1")]
+    ),
+    spec!(
+        QuickAnswer2,
+        "Answer option 2",
+        "Submit question option 2",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "2")]
+    ),
+    spec!(
+        QuickAnswer3,
+        "Answer option 3",
+        "Submit question option 3",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "3")]
+    ),
+    spec!(
+        QuickAnswer4,
+        "Answer option 4",
+        "Submit question option 4",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "4")]
+    ),
+    spec!(
+        QuickAnswer5,
+        "Answer option 5",
+        "Submit question option 5",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "5")]
+    ),
+    spec!(
+        QuickAnswer6,
+        "Answer option 6",
+        "Submit question option 6",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "6")]
+    ),
+    spec!(
+        QuickAnswer7,
+        "Answer option 7",
+        "Submit question option 7",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "7")]
+    ),
+    spec!(
+        QuickAnswer8,
+        "Answer option 8",
+        "Submit question option 8",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "8")]
+    ),
+    spec!(
+        QuickAnswer9,
+        "Answer option 9",
+        "Submit question option 9",
+        false,
+        [QuestionOptions],
+        [(QuestionOptions, "9")]
+    ),
+    spec!(
+        DeleteSelection,
+        "Delete selection",
+        "Open a destructive confirmation for the selected item",
+        false,
+        [Sessions, Schedules, SessionPickerBrowse],
+        [
+            (Sessions, "d"),
+            (Schedules, "d"),
+            (SessionPickerBrowse, "Delete; Ctrl+D")
+        ]
+    ),
+    spec!(
+        NextPage,
+        "Next page",
+        "Load the next page of sessions",
+        false,
+        [Sessions],
+        [(Sessions, "]")]
+    ),
+    spec!(
+        PreviousPage,
+        "Previous page",
+        "Load the previous page of sessions",
+        false,
+        [Sessions],
+        [(Sessions, "[")]
+    ),
+    spec!(
+        ShowTools,
+        "Show tools",
+        "Load tools for the selected MCP server",
+        false,
+        [Mcp],
+        [(Mcp, "t")]
+    ),
+    spec!(
+        NewSchedule,
+        "New schedule",
+        "Open the new schedule form",
+        false,
+        [Schedules],
+        [(Schedules, "n")]
+    ),
+    spec!(
+        RunSchedule,
+        "Run schedule now",
+        "Trigger the selected schedule immediately",
+        false,
+        [Schedules],
+        [(Schedules, "r")]
+    ),
+    spec!(
+        NextField,
+        "Next field",
+        "Move focus to the next form field",
+        false,
+        [ScheduleForm],
+        [(ScheduleForm, "Tab; Down")]
+    ),
+    spec!(
+        PreviousField,
+        "Previous field",
+        "Move focus to the previous form field",
+        false,
+        [ScheduleForm],
+        [(ScheduleForm, "Shift+Tab; Up")]
+    ),
+    spec!(
+        EditConfig,
+        "Edit config",
+        "Open the raw JSON configuration editor",
+        false,
+        [Config],
+        [(Config, "e")]
+    ),
+    spec!(
+        SaveConfig,
+        "Save config",
+        "Validate and save the configuration editor buffer",
+        false,
+        [ConfigEditor],
+        [(ConfigEditor, "F2; Ctrl+S; Leader s")]
+    ),
+    spec!(
+        RenameSession,
+        "Rename session",
+        "Rename the selected session",
+        false,
+        [SessionPickerBrowse],
+        [(SessionPickerBrowse, "F2")]
+    ),
+    spec!(
+        ToggleSessionPin,
+        "Pin or unpin session",
+        "Toggle the selected session's pinned state",
+        false,
+        [SessionPickerBrowse],
+        [(SessionPickerBrowse, "F3")]
+    ),
+    spec!(
+        LoadMore,
+        "Load more",
+        "Load the next session-picker page",
+        false,
+        [SessionPickerBrowse],
+        [(SessionPickerBrowse, "PageDown; ]")]
+    ),
+];
+
+impl ActionId {
+    pub(crate) fn spec(self) -> &'static ActionSpec {
+        ACTION_SPECS
+            .iter()
+            .find(|spec| spec.id == self)
+            .expect("every ActionId must have one ActionSpec")
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        self.spec().label
+    }
+
+    pub(crate) fn description(self) -> &'static str {
+        self.spec().description
+    }
+
+    pub(crate) fn key(self) -> String {
+        serde_json::to_value(self)
+            .ok()
+            .and_then(|value| value.as_str().map(str::to_string))
+            .expect("ActionId serialization must stay a string")
+    }
+
+    pub(crate) fn palette_actions() -> impl Iterator<Item = ActionId> {
+        ACTION_SPECS
+            .iter()
+            .filter(|spec| spec.palette)
+            .map(|spec| spec.id)
+    }
+
+    pub(crate) fn availability(self) -> ActionAvailability {
+        self.spec().availability
+    }
+
+    /// Whether holding the physical key may safely invoke this action more
+    /// than once.  Text entry is handled separately by the focused widget;
+    /// confirmations, submissions, mutations, and application lifecycle
+    /// actions deliberately remain press-only.
+    pub(crate) fn repeatable(self) -> bool {
+        matches!(
+            self,
+            Self::NavigateUp
+                | Self::NavigateDown
+                | Self::PageUp
+                | Self::PageDown
+                | Self::ScrollTranscriptUp
+                | Self::ScrollTranscriptDown
+                | Self::ScrollBlockUp
+                | Self::ScrollBlockDown
+                | Self::ScrollBlockPageUp
+                | Self::ScrollBlockPageDown
+                | Self::Backspace
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct KeyStroke {
+    code: KeyCode,
+    modifiers: KeyModifiers,
+}
+
+impl KeyStroke {
+    fn from_event(event: KeyEvent) -> Self {
+        let mut modifiers =
+            event.modifiers & (KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT);
+        let code = match event.code {
+            KeyCode::BackTab => {
+                modifiers.remove(KeyModifiers::SHIFT);
+                KeyCode::BackTab
+            }
+            KeyCode::Char(character) => {
+                let character = character.to_ascii_lowercase();
+                if !character.is_ascii_alphabetic() {
+                    modifiers.remove(KeyModifiers::SHIFT);
+                }
+                KeyCode::Char(character)
+            }
+            code => code,
+        };
+        Self { code, modifiers }
+    }
+
+    fn display(&self) -> String {
+        let mut parts = Vec::new();
+        if self.modifiers.contains(KeyModifiers::CONTROL) {
+            parts.push("Ctrl".to_string());
+        }
+        if self.modifiers.contains(KeyModifiers::ALT) {
+            parts.push("Alt".to_string());
+        }
+        if self.modifiers.contains(KeyModifiers::SHIFT) {
+            parts.push("Shift".to_string());
+        }
+        parts.push(match self.code {
+            KeyCode::Backspace => "Backspace".to_string(),
+            KeyCode::Enter => "Enter".to_string(),
+            KeyCode::Left => "Left".to_string(),
+            KeyCode::Right => "Right".to_string(),
+            KeyCode::Up => "Up".to_string(),
+            KeyCode::Down => "Down".to_string(),
+            KeyCode::Home => "Home".to_string(),
+            KeyCode::End => "End".to_string(),
+            KeyCode::PageUp => "PageUp".to_string(),
+            KeyCode::PageDown => "PageDown".to_string(),
+            KeyCode::Tab => "Tab".to_string(),
+            KeyCode::BackTab => "Shift+Tab".to_string(),
+            KeyCode::Delete => "Delete".to_string(),
+            KeyCode::Insert => "Insert".to_string(),
+            KeyCode::F(number) => format!("F{number}"),
+            KeyCode::Char(' ') => "Space".to_string(),
+            KeyCode::Char(character)
+                if character.is_ascii_alphabetic() && !self.modifiers.is_empty() =>
+            {
+                character.to_ascii_uppercase().to_string()
+            }
+            KeyCode::Char(character) => character.to_string(),
+            KeyCode::Esc => "Esc".to_string(),
+            KeyCode::Null => "Null".to_string(),
+            KeyCode::CapsLock => "CapsLock".to_string(),
+            KeyCode::ScrollLock => "ScrollLock".to_string(),
+            KeyCode::NumLock => "NumLock".to_string(),
+            KeyCode::PrintScreen => "PrintScreen".to_string(),
+            KeyCode::Pause => "Pause".to_string(),
+            KeyCode::Menu => "Menu".to_string(),
+            KeyCode::KeypadBegin => "KeypadBegin".to_string(),
+            KeyCode::Media(_) | KeyCode::Modifier(_) => "Unsupported".to_string(),
+        });
+        parts.join("+")
+    }
+
+    fn is_plain_printable(&self) -> bool {
+        self.modifiers.is_empty() && matches!(self.code, KeyCode::Char(_))
+    }
+
+    fn is_xon_xoff_or_signal(&self) -> bool {
+        self.modifiers == KeyModifiers::CONTROL
+            && matches!(self.code, KeyCode::Char('q' | 's' | 'z'))
+    }
+
+    fn is_protocol_dependent(&self) -> bool {
+        (self.code == KeyCode::Enter && self.modifiers == KeyModifiers::SHIFT)
+            || (self.code == KeyCode::Char('?') && self.modifiers == KeyModifiers::CONTROL)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct KeySequence(Vec<KeyStroke>);
+
+impl KeySequence {
+    fn display(&self) -> String {
+        self.0
+            .iter()
+            .map(KeyStroke::display)
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn is_prefix_of(&self, other: &Self) -> bool {
+        self.0.len() <= other.0.len() && other.0.starts_with(&self.0)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BindingSource {
+    Default,
+    Custom,
+}
+
+#[derive(Clone, Debug)]
+struct Binding {
+    context: ActionContext,
+    action: ActionId,
+    sequence: KeySequence,
+    source: BindingSource,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PendingSequence {
+    contexts: Vec<ActionContext>,
+    focus_contexts: Vec<ActionContext>,
+    sequence: KeySequence,
+    started_at: Instant,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum KeyResolution {
+    Action {
+        context: ActionContext,
+        action: ActionId,
+    },
+    Pending(String),
+    Cancelled(String),
+    NoMatch,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct HelpEntry {
+    pub(crate) keys: String,
+    pub(crate) description: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Keymap {
+    bindings: Vec<Binding>,
+    leader: KeyStroke,
+    timeout: Duration,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct KeymapConfig {
+    #[serde(default = "default_keymap_version")]
+    version: u32,
+    #[serde(default)]
+    leader: Option<String>,
+    #[serde(default)]
+    leader_timeout_ms: Option<u64>,
+    #[serde(default)]
+    bindings: Vec<KeymapOverride>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct KeymapOverride {
+    context: ActionContext,
+    action: ActionId,
+    #[serde(default)]
+    keys: Vec<String>,
+    #[serde(default)]
+    unbind: bool,
+}
+
+fn default_keymap_version() -> u32 {
+    1
+}
+
+#[derive(Debug)]
+pub(crate) struct KeymapError(String);
+
+impl fmt::Display for KeymapError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for KeymapError {}
+
+impl Default for Keymap {
+    fn default() -> Self {
+        Self::build(None).expect("built-in keymap must remain valid")
+    }
+}
+
+impl Keymap {
+    pub(crate) fn load(path: Option<&Path>) -> (Self, Option<String>) {
+        let Some(path) = path else {
+            return (Self::default(), None);
+        };
+        let loaded = std::fs::read_to_string(path)
+            .map_err(|error| KeymapError(format!("cannot read {}: {error}", path.display())))
+            .and_then(|source| {
+                Self::from_json(&source)
+                    .map_err(|error| KeymapError(format!("{}: {error}", path.display())))
+            });
+        match loaded {
+            Ok(keymap) => (keymap, None),
+            Err(error) => (
+                Self::default(),
+                Some(format!(
+                    "Invalid TUI keymap ({error}); using conflict-safe defaults"
+                )),
+            ),
+        }
+    }
+
+    pub(crate) fn from_json(source: &str) -> Result<Self, KeymapError> {
+        let config: KeymapConfig = serde_json::from_str(source)
+            .map_err(|error| KeymapError(format!("JSON error: {error}")))?;
+        Self::build(Some(config))
+    }
+
+    fn build(config: Option<KeymapConfig>) -> Result<Self, KeymapError> {
+        if config.as_ref().is_some_and(|config| config.version != 1) {
+            let version = config.as_ref().map(|config| config.version).unwrap_or(1);
+            return Err(KeymapError(format!(
+                "unsupported keymap version {} (expected 1)",
+                version
+            )));
+        }
+        let leader_text = config
+            .as_ref()
+            .and_then(|config| config.leader.as_deref())
+            .unwrap_or(DEFAULT_LEADER);
+        let leader = parse_stroke(leader_text)
+            .map_err(|error| KeymapError(format!("invalid leader '{leader_text}': {error}")))?;
+        if leader.is_plain_printable() {
+            return Err(KeymapError(
+                "leader must use Ctrl/Alt or a non-printable key so Chat typing stays safe"
+                    .to_string(),
+            ));
+        }
+        if config.is_some() && leader.is_xon_xoff_or_signal() {
+            return Err(KeymapError(format!(
+                "leader '{}' is reserved by common terminal flow-control/signal handling",
+                leader.display()
+            )));
+        }
+
+        let timeout_ms = config
+            .as_ref()
+            .and_then(|config| config.leader_timeout_ms)
+            .unwrap_or(DEFAULT_LEADER_TIMEOUT_MS);
+        if !(MIN_LEADER_TIMEOUT_MS..=MAX_LEADER_TIMEOUT_MS).contains(&timeout_ms) {
+            return Err(KeymapError(format!(
+                "leader_timeout_ms must be between {MIN_LEADER_TIMEOUT_MS} and {MAX_LEADER_TIMEOUT_MS}"
+            )));
+        }
+
+        let mut bindings = Vec::new();
+        for spec in ACTION_SPECS {
+            for default in spec.defaults {
+                for sequence in split_binding_list(default.keys)? {
+                    bindings.push(Binding {
+                        context: default.context,
+                        action: spec.id,
+                        sequence: parse_sequence(&sequence, &leader)?,
+                        source: BindingSource::Default,
+                    });
+                }
+            }
+        }
+
+        if let Some(config) = config {
+            let mut overridden = HashSet::new();
+            for entry in config.bindings {
+                if !overridden.insert((entry.context, entry.action)) {
+                    return Err(KeymapError(format!(
+                        "duplicate override for {} / {}",
+                        entry.context.label(),
+                        entry.action.label()
+                    )));
+                }
+                if !entry.action.spec().contexts.contains(&entry.context) {
+                    return Err(KeymapError(format!(
+                        "action '{}' is not valid in context '{}'",
+                        entry.action.label(),
+                        entry.context.label()
+                    )));
+                }
+                if entry.unbind && !entry.keys.is_empty() {
+                    return Err(KeymapError(format!(
+                        "{} / {} cannot set both unbind=true and keys",
+                        entry.context.label(),
+                        entry.action.label()
+                    )));
+                }
+                if !entry.unbind && entry.keys.is_empty() {
+                    return Err(KeymapError(format!(
+                        "{} / {} needs at least one key or unbind=true",
+                        entry.context.label(),
+                        entry.action.label()
+                    )));
+                }
+                bindings.retain(|binding| {
+                    binding.context != entry.context || binding.action != entry.action
+                });
+                for sequence in entry.keys {
+                    let sequence = parse_sequence(&sequence, &leader)?;
+                    if sequence.0.iter().any(KeyStroke::is_xon_xoff_or_signal) {
+                        return Err(KeymapError(format!(
+                            "{} / {} uses reserved sequence '{}'; use a leader or function-key fallback",
+                            entry.context.label(),
+                            entry.action.label(),
+                            sequence.display()
+                        )));
+                    }
+                    bindings.push(Binding {
+                        context: entry.context,
+                        action: entry.action,
+                        sequence,
+                        source: BindingSource::Custom,
+                    });
+                }
+            }
+        }
+
+        let keymap = Self {
+            bindings,
+            leader,
+            timeout: Duration::from_millis(timeout_ms),
+        };
+        keymap.validate()?;
+        Ok(keymap)
+    }
+
+    fn validate(&self) -> Result<(), KeymapError> {
+        for (index, binding) in self.bindings.iter().enumerate() {
+            if !binding.action.spec().contexts.contains(&binding.context) {
+                return Err(KeymapError(format!(
+                    "{} is not valid in {}",
+                    binding.action.label(),
+                    binding.context.label()
+                )));
+            }
+            if binding.context == ActionContext::Global
+                && binding.sequence.0.len() == 1
+                && binding.sequence.0[0].is_plain_printable()
+            {
+                return Err(KeymapError(format!(
+                    "global binding '{}' would steal ordinary Chat text",
+                    binding.sequence.display()
+                )));
+            }
+            for other in self.bindings.iter().skip(index + 1) {
+                if binding.context != other.context {
+                    continue;
+                }
+                if binding.sequence == other.sequence {
+                    return Err(KeymapError(format!(
+                        "conflict in {}: '{}' binds both '{}' and '{}'",
+                        binding.context.label(),
+                        binding.sequence.display(),
+                        binding.action.label(),
+                        other.action.label()
+                    )));
+                }
+                if binding.sequence.is_prefix_of(&other.sequence)
+                    || other.sequence.is_prefix_of(&binding.sequence)
+                {
+                    return Err(KeymapError(format!(
+                        "unreachable prefix in {}: '{}' conflicts with '{}'",
+                        binding.context.label(),
+                        binding.sequence.display(),
+                        other.sequence.display()
+                    )));
+                }
+            }
+        }
+
+        for (context, action) in [
+            (ActionContext::Global, ActionId::QuitOrStop),
+            (ActionContext::Global, ActionId::ShowHelp),
+            (ActionContext::ServeOffer, ActionId::Confirm),
+            (ActionContext::ServeOffer, ActionId::Reject),
+            (ActionContext::QuestionOptions, ActionId::Activate),
+            (ActionContext::QuestionOptions, ActionId::Cancel),
+            (ActionContext::QuestionCustom, ActionId::Activate),
+            (ActionContext::QuestionCustom, ActionId::Cancel),
+            (ActionContext::SessionDeleteConfirm, ActionId::Confirm),
+            (ActionContext::SessionDeleteConfirm, ActionId::Reject),
+            (ActionContext::ScheduleDeleteConfirm, ActionId::Confirm),
+            (ActionContext::ScheduleDeleteConfirm, ActionId::Reject),
+        ] {
+            if !self
+                .bindings
+                .iter()
+                .any(|binding| binding.context == context && binding.action == action)
+            {
+                return Err(KeymapError(format!(
+                    "required action '{}' would be unreachable in {}",
+                    action.label(),
+                    context.label()
+                )));
+            }
+        }
+
+        let mut checked = HashSet::new();
+        for binding in self
+            .bindings
+            .iter()
+            .filter(|binding| binding.source == BindingSource::Custom)
+        {
+            if !checked.insert((binding.context, binding.action)) {
+                continue;
+            }
+            let group: Vec<&Binding> = self
+                .bindings
+                .iter()
+                .filter(|candidate| {
+                    candidate.context == binding.context && candidate.action == binding.action
+                })
+                .collect();
+            if !group.is_empty()
+                && group.iter().all(|candidate| {
+                    candidate
+                        .sequence
+                        .0
+                        .iter()
+                        .any(KeyStroke::is_protocol_dependent)
+                })
+            {
+                return Err(KeymapError(format!(
+                    "{} / {} relies only on terminal-protocol-dependent keys; add an Alt, leader, or function-key fallback",
+                    binding.context.label(),
+                    binding.action.label()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        contexts: &[ActionContext],
+        pending: &mut Option<PendingSequence>,
+        event: KeyEvent,
+        now: Instant,
+    ) -> KeyResolution {
+        let stroke = KeyStroke::from_event(event);
+        if let Some(current) = pending.as_ref() {
+            if current.focus_contexts != contexts {
+                *pending = None;
+                return KeyResolution::Cancelled(
+                    "Key sequence cancelled because focus changed".to_string(),
+                );
+            }
+            let candidate_contexts = current
+                .contexts
+                .iter()
+                .copied()
+                .filter(|context| contexts.contains(context))
+                .collect::<Vec<_>>();
+            if candidate_contexts.is_empty() {
+                *pending = None;
+                return KeyResolution::Cancelled(
+                    "Key sequence cancelled because focus changed".to_string(),
+                );
+            }
+            if now.duration_since(current.started_at) >= self.timeout {
+                let display = current.sequence.display();
+                *pending = None;
+                return KeyResolution::Cancelled(format!("Key sequence '{display}' timed out"));
+            }
+            if stroke.code == KeyCode::Esc && stroke.modifiers.is_empty() {
+                *pending = None;
+                return KeyResolution::Cancelled("Key sequence cancelled".to_string());
+            }
+            let mut sequence = current.sequence.clone();
+            sequence.0.push(stroke);
+            return self.resolve_sequence(&candidate_contexts, contexts, sequence, pending, now);
+        }
+
+        let sequence = KeySequence(vec![stroke]);
+        let candidate_contexts = contexts
+            .iter()
+            .copied()
+            .filter(|context| {
+                self.bindings.iter().any(|binding| {
+                    binding.context == *context && sequence.is_prefix_of(&binding.sequence)
+                })
+            })
+            .collect::<Vec<_>>();
+        if !candidate_contexts.is_empty() {
+            return self.resolve_sequence(&candidate_contexts, contexts, sequence, pending, now);
+        }
+        KeyResolution::NoMatch
+    }
+
+    fn resolve_sequence(
+        &self,
+        candidate_contexts: &[ActionContext],
+        focus_contexts: &[ActionContext],
+        sequence: KeySequence,
+        pending: &mut Option<PendingSequence>,
+        now: Instant,
+    ) -> KeyResolution {
+        for context in candidate_contexts {
+            if let Some(binding) = self
+                .bindings
+                .iter()
+                .find(|binding| binding.context == *context && binding.sequence == sequence)
+            {
+                *pending = None;
+                return KeyResolution::Action {
+                    context: *context,
+                    action: binding.action,
+                };
+            }
+        }
+        let candidate_contexts = candidate_contexts
+            .iter()
+            .copied()
+            .filter(|context| {
+                self.bindings.iter().any(|binding| {
+                    binding.context == *context && sequence.is_prefix_of(&binding.sequence)
+                })
+            })
+            .collect::<Vec<_>>();
+        if !candidate_contexts.is_empty() {
+            let display = sequence.display();
+            *pending = Some(PendingSequence {
+                contexts: candidate_contexts,
+                focus_contexts: focus_contexts.to_vec(),
+                sequence,
+                started_at: now,
+            });
+            return KeyResolution::Pending(format!(
+                "Leader {display} — waiting for next key (Esc cancels)"
+            ));
+        }
+        let display = sequence.display();
+        *pending = None;
+        KeyResolution::Cancelled(format!("No action is bound to '{display}'"))
+    }
+
+    pub(crate) fn expire(
+        &self,
+        pending: &mut Option<PendingSequence>,
+        now: Instant,
+    ) -> Option<String> {
+        let current = pending.as_ref()?;
+        if now.duration_since(current.started_at) < self.timeout {
+            return None;
+        }
+        let display = current.sequence.display();
+        *pending = None;
+        Some(format!("Key sequence '{display}' timed out"))
+    }
+
+    pub(crate) fn hint(&self, context: ActionContext, action: ActionId) -> String {
+        let labels = self
+            .bindings
+            .iter()
+            .filter(|binding| binding.context == context && binding.action == action)
+            .map(|binding| binding.sequence.display())
+            .collect::<Vec<_>>();
+        if labels.is_empty() {
+            "unbound".to_string()
+        } else {
+            labels.join("/")
+        }
+    }
+
+    pub(crate) fn action_hint(&self, action: ActionId) -> Option<String> {
+        let labels = self
+            .bindings
+            .iter()
+            .filter(|binding| binding.action == action)
+            .map(|binding| binding.sequence.display())
+            .collect::<Vec<_>>();
+        (!labels.is_empty()).then(|| labels.join("/"))
+    }
+
+    pub(crate) fn help_entries(&self) -> Vec<HelpEntry> {
+        let mut entries = vec![HelpEntry {
+            keys: self.leader.display(),
+            description: "Global · Leader prefix for conflict-safe alternatives".to_string(),
+        }];
+        for context in ActionContext::ALL {
+            for spec in ACTION_SPECS {
+                let keys = self.hint(context, spec.id);
+                if keys == "unbound" {
+                    continue;
+                }
+                entries.push(HelpEntry {
+                    keys,
+                    description: format!("{} · {}", context.label(), spec.label),
+                });
+            }
+        }
+        entries
+    }
+
+    #[cfg(test)]
+    fn leader_label(&self) -> String {
+        self.leader.display()
+    }
+}
+
+pub(crate) fn text_character(event: KeyEvent) -> Option<char> {
+    if event
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+    {
+        return None;
+    }
+    match event.code {
+        KeyCode::Char(character) => Some(character),
+        _ => None,
+    }
+}
+
+fn split_binding_list(bindings: &str) -> Result<Vec<String>, KeymapError> {
+    let values = bindings
+        .split(';')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        Err(KeymapError("binding list is empty".to_string()))
+    } else {
+        Ok(values)
+    }
+}
+
+fn parse_sequence(value: &str, leader: &KeyStroke) -> Result<KeySequence, KeymapError> {
+    let mut strokes = Vec::new();
+    for token in value.split_whitespace() {
+        if token.eq_ignore_ascii_case("leader") {
+            strokes.push(leader.clone());
+        } else {
+            strokes.push(parse_stroke(token).map_err(|error| {
+                KeymapError(format!("invalid key sequence '{value}': {error}"))
+            })?);
+        }
+    }
+    if strokes.is_empty() {
+        return Err(KeymapError("key sequence is empty".to_string()));
+    }
+    Ok(KeySequence(strokes))
+}
+
+fn parse_stroke(value: &str) -> Result<KeyStroke, KeymapError> {
+    let parts = value.split('+').collect::<Vec<_>>();
+    let (code_name, modifier_names) = parts
+        .split_last()
+        .ok_or_else(|| KeymapError("key is empty".to_string()))?;
+    if code_name.is_empty() {
+        return Err(KeymapError("key code is empty".to_string()));
+    }
+    let mut modifiers = KeyModifiers::empty();
+    for modifier in modifier_names {
+        let flag = match modifier.to_ascii_lowercase().as_str() {
+            "ctrl" | "control" => KeyModifiers::CONTROL,
+            "alt" | "option" => KeyModifiers::ALT,
+            "shift" => KeyModifiers::SHIFT,
+            _ => {
+                return Err(KeymapError(format!(
+                    "unknown modifier '{modifier}' (use Ctrl, Alt, or Shift)"
+                )))
+            }
+        };
+        if modifiers.contains(flag) {
+            return Err(KeymapError(format!("duplicate modifier '{modifier}'")));
+        }
+        modifiers.insert(flag);
+    }
+
+    let lowered = code_name.to_ascii_lowercase();
+    let mut code = match lowered.as_str() {
+        "backspace" => KeyCode::Backspace,
+        "enter" | "return" => KeyCode::Enter,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "pageup" | "pgup" => KeyCode::PageUp,
+        "pagedown" | "pgdown" => KeyCode::PageDown,
+        "tab" if modifiers.contains(KeyModifiers::SHIFT) => {
+            modifiers.remove(KeyModifiers::SHIFT);
+            KeyCode::BackTab
+        }
+        "tab" => KeyCode::Tab,
+        "delete" | "del" => KeyCode::Delete,
+        "insert" | "ins" => KeyCode::Insert,
+        "esc" | "escape" => KeyCode::Esc,
+        "space" => KeyCode::Char(' '),
+        "plus" => KeyCode::Char('+'),
+        _ if lowered.starts_with('f') => {
+            let number = lowered[1..]
+                .parse::<u8>()
+                .map_err(|_| KeymapError(format!("unknown key code '{code_name}'")))?;
+            if !(1..=24).contains(&number) {
+                return Err(KeymapError("function key must be F1..F24".to_string()));
+            }
+            KeyCode::F(number)
+        }
+        _ => {
+            let mut characters = code_name.chars();
+            let character = characters
+                .next()
+                .filter(|_| characters.next().is_none())
+                .ok_or_else(|| KeymapError(format!("unknown key code '{code_name}'")))?;
+            KeyCode::Char(character.to_ascii_lowercase())
+        }
+    };
+    if let KeyCode::Char(character) = code {
+        if !character.is_ascii_alphabetic() {
+            modifiers.remove(KeyModifiers::SHIFT);
+        }
+        code = KeyCode::Char(character.to_ascii_lowercase());
+    }
+    Ok(KeyStroke { code, modifiers })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    #[test]
+    fn every_action_has_exactly_one_registry_spec() {
+        let unique = ACTION_SPECS
+            .iter()
+            .map(|spec| spec.id)
+            .collect::<HashSet<_>>();
+        assert_eq!(unique.len(), ACTION_SPECS.len());
+        for action in unique {
+            assert!(!action.label().is_empty());
+            assert!(!action.description().is_empty());
+        }
+        assert_eq!(ActionId::SwitchTab1.key(), "switch-tab-1");
+        assert_eq!(ActionId::QuickAnswer9.key(), "quick-answer-9");
+    }
+
+    #[test]
+    fn every_context_has_resolvable_default_bindings() {
+        let keymap = Keymap::default();
+        for context in ActionContext::ALL {
+            let context_bindings = keymap
+                .bindings
+                .iter()
+                .filter(|binding| binding.context == context)
+                .collect::<Vec<_>>();
+            assert!(
+                !context_bindings.is_empty(),
+                "{} has no default bindings",
+                context.label()
+            );
+            for binding in context_bindings {
+                let mut pending = None;
+                let now = Instant::now();
+                let mut resolution = KeyResolution::NoMatch;
+                for (index, stroke) in binding.sequence.0.iter().enumerate() {
+                    resolution = keymap.resolve(
+                        &[context],
+                        &mut pending,
+                        key(stroke.code, stroke.modifiers),
+                        now + Duration::from_millis(index as u64),
+                    );
+                }
+                assert_eq!(
+                    resolution,
+                    KeyResolution::Action {
+                        context,
+                        action: binding.action,
+                    },
+                    "{} did not resolve {}",
+                    binding.sequence.display(),
+                    binding.action.label()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn conversation_block_activate_remains_reachable() {
+        let keymap = Keymap::default();
+        let mut pending = None;
+        assert_eq!(
+            keymap.resolve(
+                &[
+                    ActionContext::ConversationBlock,
+                    ActionContext::Chat,
+                    ActionContext::Global
+                ],
+                &mut pending,
+                key(KeyCode::Enter, KeyModifiers::empty()),
+                Instant::now(),
+            ),
+            KeyResolution::Action {
+                context: ActionContext::ConversationBlock,
+                action: ActionId::Activate,
+            }
+        );
+    }
+
+    #[test]
+    fn defaults_have_safe_leader_and_required_fallbacks() {
+        let keymap = Keymap::default();
+        assert_eq!(keymap.leader_label(), "Ctrl+\\");
+        assert!(keymap
+            .hint(ActionContext::Global, ActionId::ReopenPendingQuestion)
+            .contains("Ctrl+\\ q"));
+        assert!(keymap
+            .hint(ActionContext::Global, ActionId::StopRun)
+            .contains("Ctrl+\\ s"));
+        assert!(keymap
+            .hint(ActionContext::ConfigEditor, ActionId::SaveConfig)
+            .contains("F2"));
+        assert!(keymap
+            .hint(ActionContext::Chat, ActionId::InsertNewline)
+            .starts_with("Alt+Enter"));
+    }
+
+    #[test]
+    fn leader_sequence_resolves_and_escape_cancels() {
+        let keymap = Keymap::default();
+        let now = Instant::now();
+        let mut pending = None;
+        let first = keymap.resolve(
+            &[ActionContext::Global],
+            &mut pending,
+            key(KeyCode::Char('\\'), KeyModifiers::CONTROL),
+            now,
+        );
+        assert!(matches!(first, KeyResolution::Pending(_)));
+        let second = keymap.resolve(
+            &[ActionContext::Global],
+            &mut pending,
+            key(KeyCode::Char('h'), KeyModifiers::empty()),
+            now + Duration::from_millis(10),
+        );
+        assert_eq!(
+            second,
+            KeyResolution::Action {
+                context: ActionContext::Global,
+                action: ActionId::ShowHelp,
+            }
+        );
+
+        let _ = keymap.resolve(
+            &[ActionContext::Global],
+            &mut pending,
+            key(KeyCode::Char('\\'), KeyModifiers::CONTROL),
+            now,
+        );
+        let cancelled = keymap.resolve(
+            &[ActionContext::Global],
+            &mut pending,
+            key(KeyCode::Esc, KeyModifiers::empty()),
+            now + Duration::from_millis(10),
+        );
+        assert!(matches!(cancelled, KeyResolution::Cancelled(_)));
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn shared_leader_keeps_local_and_global_context_candidates() {
+        let keymap = Keymap::default();
+        let now = Instant::now();
+        let contexts = [ActionContext::Chat, ActionContext::Global];
+
+        let mut pending = None;
+        assert!(matches!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('\\'), KeyModifiers::CONTROL),
+                now,
+            ),
+            KeyResolution::Pending(_)
+        ));
+        assert_eq!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('h'), KeyModifiers::empty()),
+                now,
+            ),
+            KeyResolution::Action {
+                context: ActionContext::Global,
+                action: ActionId::ShowHelp,
+            }
+        );
+
+        assert!(matches!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('\\'), KeyModifiers::CONTROL),
+                now,
+            ),
+            KeyResolution::Pending(_)
+        ));
+        assert_eq!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('x'), KeyModifiers::empty()),
+                now,
+            ),
+            KeyResolution::Action {
+                context: ActionContext::Chat,
+                action: ActionId::ToggleDetails,
+            }
+        );
+    }
+
+    #[test]
+    fn focus_change_cancels_a_pending_sequence_even_when_global_remains() {
+        let keymap = Keymap::default();
+        let now = Instant::now();
+        let mut pending = None;
+        assert!(matches!(
+            keymap.resolve(
+                &[ActionContext::Chat, ActionContext::Global],
+                &mut pending,
+                key(KeyCode::Char('\\'), KeyModifiers::CONTROL),
+                now,
+            ),
+            KeyResolution::Pending(_)
+        ));
+
+        let result = keymap.resolve(
+            &[ActionContext::QuestionOptions, ActionContext::Global],
+            &mut pending,
+            key(KeyCode::Char('h'), KeyModifiers::empty()),
+            now + Duration::from_millis(10),
+        );
+        assert!(
+            matches!(result, KeyResolution::Cancelled(message) if message.contains("focus changed"))
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn leader_timeout_is_bounded_and_reported() {
+        let keymap = Keymap::default();
+        let now = Instant::now();
+        let mut pending = None;
+        let _ = keymap.resolve(
+            &[ActionContext::Global],
+            &mut pending,
+            key(KeyCode::Char('\\'), KeyModifiers::CONTROL),
+            now,
+        );
+        let message = keymap
+            .expire(&mut pending, now + Duration::from_millis(1_001))
+            .expect("sequence should expire");
+        assert!(message.contains("timed out"));
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn context_precedence_keeps_question_digits_out_of_navigation() {
+        let keymap = Keymap::default();
+        let mut pending = None;
+        let resolved = keymap.resolve(
+            &[
+                ActionContext::QuestionOptions,
+                ActionContext::Navigation,
+                ActionContext::Global,
+            ],
+            &mut pending,
+            key(KeyCode::Char('3'), KeyModifiers::empty()),
+            Instant::now(),
+        );
+        assert_eq!(
+            resolved,
+            KeyResolution::Action {
+                context: ActionContext::QuestionOptions,
+                action: ActionId::QuickAnswer3,
+            }
+        );
+    }
+
+    #[test]
+    fn custom_remap_and_unbind_replace_only_one_context() {
+        let keymap = Keymap::from_json(
+            r#"{
+                "leader": "Alt+Space",
+                "leader_timeout_ms": 750,
+                "bindings": [
+                    {"context":"global", "action":"show-notifications", "keys":["F8", "Leader l"]},
+                    {"context":"navigation", "action":"show-help", "unbind":true}
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            keymap.hint(ActionContext::Global, ActionId::ShowNotifications),
+            "F8/Alt+Space l"
+        );
+        assert_eq!(
+            keymap.hint(ActionContext::Navigation, ActionId::ShowHelp),
+            "unbound"
+        );
+        assert!(keymap
+            .hint(ActionContext::Global, ActionId::ShowHelp)
+            .contains("F1"));
+    }
+
+    #[test]
+    fn unsupported_config_version_is_actionable() {
+        let error = Keymap::from_json(r#"{"version":2}"#)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("unsupported keymap version 2"));
+        assert!(error.contains("expected 1"));
+    }
+
+    #[test]
+    fn invalid_maps_reject_conflicts_reserved_and_unreachable_required_actions() {
+        let conflict = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"global","action":"show-help","keys":["F8"]},
+                {"context":"global","action":"show-notifications","keys":["F8"]}
+            ]}"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(conflict.contains("conflict"));
+
+        let reserved = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"global","action":"show-notifications","keys":["Ctrl+S"]}
+            ]}"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(reserved.contains("reserved"));
+
+        let required = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"question-options","action":"activate","unbind":true}
+            ]}"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(required.contains("required action"));
+    }
+
+    #[test]
+    fn invalid_map_load_falls_back_without_losing_quit_or_help() {
+        let temp = std::env::temp_dir().join(format!(
+            "bamboo-tui-keymap-{}-{}.json",
+            std::process::id(),
+            UtcLikeCounter::next()
+        ));
+        std::fs::write(&temp, "{not json").unwrap();
+        let (keymap, warning) = Keymap::load(Some(&temp));
+        std::fs::remove_file(&temp).unwrap();
+        assert!(warning.unwrap().contains("using conflict-safe defaults"));
+        assert_ne!(
+            keymap.hint(ActionContext::Global, ActionId::QuitOrStop),
+            "unbound"
+        );
+        assert_ne!(
+            keymap.hint(ActionContext::Global, ActionId::ShowHelp),
+            "unbound"
+        );
+    }
+
+    struct UtcLikeCounter;
+
+    impl UtcLikeCounter {
+        fn next() -> u64 {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static NEXT: AtomicU64 = AtomicU64::new(1);
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        }
+    }
+
+    #[test]
+    fn shift_enter_requires_a_terminal_independent_fallback() {
+        let error = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"chat","action":"insert-newline","keys":["Shift+Enter"]}
+            ]}"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("terminal-protocol-dependent"));
+    }
+
+    #[test]
+    fn help_is_generated_from_resolved_custom_bindings() {
+        let keymap = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"sessions","action":"delete-selection","keys":["F9"]}
+            ]}"#,
+        )
+        .unwrap();
+        let entries = keymap.help_entries();
+        assert!(entries
+            .iter()
+            .any(|entry| { entry.keys == "F9" && entry.description.contains("Delete selection") }));
+        assert!(!entries.iter().any(|entry| {
+            entry.keys == "d" && entry.description.contains("Sessions · Delete selection")
+        }));
+    }
+}

--- a/crates/app/bamboo-tui/src/keymap.rs
+++ b/crates/app/bamboo-tui/src/keymap.rs
@@ -1407,6 +1407,12 @@ impl Keymap {
                 leader.display()
             )));
         }
+        if config.is_some() && leader.is_protocol_dependent() {
+            return Err(KeymapError(format!(
+                "leader '{}' depends on enhanced terminal key reporting; use Ctrl/Alt with a portable key or a function key",
+                leader.display()
+            )));
+        }
 
         let timeout_ms = config
             .as_ref()
@@ -1542,6 +1548,43 @@ impl Keymap {
             }
         }
 
+        for quit in self.bindings.iter().filter(|binding| {
+            binding.context == ActionContext::Global
+                && binding.action == ActionId::QuitOrStop
+                && binding.sequence.0.len() == 1
+        }) {
+            if let Some(binding) = self.bindings.iter().find(|binding| {
+                binding.sequence.0.len() > 1
+                    && binding
+                        .sequence
+                        .0
+                        .iter()
+                        .any(|stroke| Some(stroke) == quit.sequence.0.first())
+            }) {
+                return Err(KeymapError(format!(
+                    "unreachable binding in {}: '{}' contains single-stroke global quit '{}', which always preempts pending and focused actions",
+                    binding.context.label(),
+                    binding.sequence.display(),
+                    quit.sequence.display(),
+                )));
+            }
+        }
+
+        if let Some(binding) = self.bindings.iter().find(|binding| {
+            binding
+                .sequence
+                .0
+                .iter()
+                .skip(1)
+                .any(|stroke| stroke.code == KeyCode::Esc && stroke.modifiers.is_empty())
+        }) {
+            return Err(KeymapError(format!(
+                "unreachable binding in {}: '{}' contains Esc after the first stroke; Esc always cancels a pending sequence",
+                binding.context.label(),
+                binding.sequence.display(),
+            )));
+        }
+
         for (context, action) in [
             (ActionContext::Global, ActionId::QuitOrStop),
             (ActionContext::Global, ActionId::ShowHelp),
@@ -1616,11 +1659,11 @@ impl Keymap {
     ) -> KeyResolution {
         let stroke = KeyStroke::from_event(event);
 
-        // A single-stroke global quit binding is the emergency escape hatch:
-        // it must preempt an incomplete leader sequence instead of becoming a
-        // (usually invalid) continuation such as `Leader Ctrl+C`.
-        if pending.is_some()
-            && contexts.contains(&ActionContext::Global)
+        // A single-stroke global quit binding is the emergency escape hatch.
+        // It preempts both a higher-context prefix on its first stroke and an
+        // incomplete leader sequence instead of becoming a continuation such
+        // as `Leader Ctrl+C`.
+        if contexts.contains(&ActionContext::Global)
             && self.bindings.iter().any(|binding| {
                 binding.context == ActionContext::Global
                     && binding.action == ActionId::QuitOrStop
@@ -2159,6 +2202,45 @@ mod tests {
     }
 
     #[test]
+    fn single_stroke_global_quit_preempts_an_initial_focused_prefix() {
+        // Build a deliberately unvalidated map to verify the resolver remains
+        // safe even if a future config path bypasses startup validation.
+        let mut keymap = Keymap::default();
+        keymap.bindings.push(Binding {
+            context: ActionContext::Chat,
+            action: ActionId::InsertNewline,
+            sequence: parse_sequence("Ctrl+C x", &keymap.leader).unwrap(),
+            source: BindingSource::Custom,
+        });
+        let contexts = [ActionContext::Chat, ActionContext::Global];
+        let now = Instant::now();
+        let mut pending = None;
+        assert_eq!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('c'), KeyModifiers::CONTROL),
+                now,
+            ),
+            KeyResolution::Action {
+                context: ActionContext::Global,
+                action: ActionId::QuitOrStop,
+            }
+        );
+        assert!(pending.is_none());
+        assert_eq!(
+            keymap.resolve(
+                &contexts,
+                &mut pending,
+                key(KeyCode::Char('x'), KeyModifiers::empty()),
+                now + Duration::from_millis(10),
+            ),
+            KeyResolution::NoMatch,
+            "the shadowed continuation must never fire after emergency quit"
+        );
+    }
+
+    #[test]
     fn expired_sequence_reprocesses_the_current_key() {
         let keymap = Keymap::default();
         let now = Instant::now();
@@ -2397,6 +2479,11 @@ mod tests {
         .to_string();
         assert!(reserved.contains("reserved"));
 
+        let protocol_leader = Keymap::from_json(r#"{"leader":"Ctrl+?"}"#)
+            .unwrap_err()
+            .to_string();
+        assert!(protocol_leader.contains("depends on enhanced terminal key reporting"));
+
         let required = Keymap::from_json(
             r#"{"bindings":[
                 {"context":"question-options","action":"activate","unbind":true}
@@ -2424,6 +2511,30 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(shifted_printable_prefix.contains("starts with a printable key"));
+
+        for (context, action) in [
+            ("chat", "insert-newline"),
+            ("session-delete-confirm", "confirm"),
+        ] {
+            for sequence in ["Ctrl+C x", "F2 Ctrl+C"] {
+                let input = format!(
+                    r#"{{"bindings":[{{"context":"{context}","action":"{action}","keys":["{sequence}"]}}]}}"#
+                );
+                let error = Keymap::from_json(&input).unwrap_err().to_string();
+                assert!(error.contains("contains single-stroke global quit"));
+                assert!(error.contains("always preempts"));
+            }
+        }
+
+        let pending_escape = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"session-delete-confirm","action":"confirm","keys":["F2 Esc"]}
+            ]}"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(pending_escape.contains("contains Esc after the first stroke"));
+        assert!(pending_escape.contains("always cancels a pending sequence"));
 
         for (context, action) in [
             ("question-number", "activate"),

--- a/crates/app/bamboo-tui/src/lib.rs
+++ b/crates/app/bamboo-tui/src/lib.rs
@@ -16,12 +16,14 @@ use crossterm::terminal::{
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::io::{self, IsTerminal};
+use std::path::PathBuf;
 
 mod api;
 mod app;
 mod components;
 mod event;
 mod history;
+mod keymap;
 mod search;
 mod text;
 mod theme;
@@ -50,6 +52,9 @@ pub struct TuiOptions {
     /// Terminal colour strategy. `None` preserves true colour unless the
     /// conventional `NO_COLOR` environment variable is present.
     pub theme: Option<ThemePalette>,
+    /// Optional JSON keymap override. Invalid maps are reported inside the
+    /// TUI and fall back atomically to the conflict-safe defaults.
+    pub keymap: Option<PathBuf>,
 }
 
 impl Default for TuiOptions {
@@ -60,6 +65,7 @@ impl Default for TuiOptions {
             model: None,
             auto_serve: AutoServeMode::Prompt,
             theme: None,
+            keymap: None,
         }
     }
 }
@@ -78,6 +84,10 @@ pub async fn run(opts: TuiOptions) -> Result<()> {
 
     let palette =
         theme::resolve_initial_palette(opts.theme, std::env::var_os("NO_COLOR").is_some());
+    let keymap_path = opts
+        .keymap
+        .or_else(|| std::env::var_os("BAMBOO_TUI_KEYMAP").map(PathBuf::from));
+    let (keymap, keymap_warning) = keymap::Keymap::load(keymap_path.as_deref());
 
     // Setup terminal.
     enable_raw_mode()?;
@@ -90,6 +100,7 @@ pub async fn run(opts: TuiOptions) -> Result<()> {
     let client = api::BambooClient::new(&opts.server_url);
     let mut app = app::App::new(client);
     app.set_theme(palette);
+    app.set_keymap(keymap, keymap_warning);
 
     // Apply options.
     if let Some(session_id) = opts.session_id {

--- a/crates/app/bamboo-tui/src/main.rs
+++ b/crates/app/bamboo-tui/src/main.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use bamboo_tui::{AutoServeMode, ThemePalette, TuiOptions};
 use clap::Parser;
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "bamboo-tui")]
@@ -30,6 +31,11 @@ struct Cli {
     /// `NO_COLOR` selects no-color when this flag is omitted.
     #[arg(long)]
     theme: Option<ThemePalette>,
+
+    /// JSON keymap override with per-context bindings, leader sequences, and
+    /// unbind support. Invalid maps fall back to safe defaults.
+    #[arg(long, value_name = "PATH")]
+    keymap: Option<PathBuf>,
 
     /// If `--server-url` is unreachable and loopback, start a local `bamboo
     /// serve` automatically instead of asking (y/n). No effect for a remote
@@ -61,6 +67,7 @@ async fn main() -> Result<()> {
         model: cli.model,
         auto_serve,
         theme: cli.theme,
+        keymap: cli.keymap,
     })
     .await
 }

--- a/crates/app/bamboo-tui/src/ui/chat.rs
+++ b/crates/app/bamboo-tui/src/ui/chat.rs
@@ -9,6 +9,7 @@ use crate::app::{
     ToolCallDisplay, CONVERSATION_DETAIL_VIEWPORT,
 };
 use crate::components::markdown;
+use crate::keymap::{ActionContext, ActionId};
 use crate::theme::{self, colors};
 
 const COLLAPSED_DETAIL_LINES: usize = 3;
@@ -105,7 +106,10 @@ fn push_tool_detail(
                 if state.expanded {
                     format!("   ↓ {hidden_after} later lines")
                 } else {
-                    format!("   … {hidden_after} more — focus then Enter to inspect")
+                    format!(
+                        "   … {hidden_after} more — focus then {} to inspect",
+                        app.key_hint(ActionContext::ConversationBlock, ActionId::Activate)
+                    )
                 },
                 Style::default().fg(colors::subtle()),
             )));
@@ -134,7 +138,10 @@ fn push_tool_detail(
         let extra = error_count.saturating_sub(3);
         if extra > 0 {
             lines.push(Line::from(Span::styled(
-                format!("   … {extra} more error lines · y copies exact text"),
+                format!(
+                    "   … {extra} more error lines · {} copies exact text",
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue)
+                ),
                 Style::default().fg(colors::tool_error()),
             )));
         }
@@ -142,9 +149,19 @@ fn push_tool_detail(
     if focused {
         lines.push(Line::from(Span::styled(
             if state.expanded {
-                "   Enter collapse · j/k scroll · y copy"
+                format!(
+                    "   {} collapse · {}/{} scroll · {} copy",
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::ScrollBlockUp),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::ScrollBlockDown),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+                )
             } else {
-                "   Enter expand · y copy"
+                format!(
+                    "   {} expand · {} copy",
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+                )
             },
             Style::default().fg(colors::subtle()),
         )));
@@ -287,16 +304,35 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                     }
                 } else {
                     lines.push(Line::from(Span::styled(
-                        format!(" {count} reasoning lines hidden — focus then Enter to show"),
+                        format!(
+                            " {count} reasoning lines hidden — focus then {} to show",
+                            app.key_hint(ActionContext::ConversationBlock, ActionId::Activate)
+                        ),
                         Style::default().fg(colors::subtle()),
                     )));
                 }
                 if focused {
                     lines.push(Line::from(Span::styled(
                         if state.expanded {
-                            " Enter hide · j/k scroll · y copy"
+                            format!(
+                                " {} hide · {}/{} scroll · {} copy",
+                                app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+                                app.key_hint(
+                                    ActionContext::ConversationBlock,
+                                    ActionId::ScrollBlockUp
+                                ),
+                                app.key_hint(
+                                    ActionContext::ConversationBlock,
+                                    ActionId::ScrollBlockDown
+                                ),
+                                app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+                            )
                         } else {
-                            " Enter show · y copy"
+                            format!(
+                                " {} show · {} copy",
+                                app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+                                app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+                            )
                         },
                         Style::default().fg(colors::subtle()),
                     )));
@@ -358,9 +394,21 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                 if focused {
                     lines.push(Line::from(Span::styled(
                         if streaming {
-                            "   Enter expand/collapse · child opens after parent run · y copy"
+                            format!(
+                                "   {} expand/collapse · child opens after parent run · {} copy",
+                                app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+                                app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+                            )
                         } else {
-                            "   Enter open child · Ctrl+X expand/collapse · y copy"
+                            format!(
+                                "   {} open child · {} expand/collapse · {} copy",
+                                app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+                                app.key_hint(
+                                    ActionContext::ConversationBlock,
+                                    ActionId::ToggleDetails
+                                ),
+                                app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+                            )
                         },
                         Style::default().fg(colors::subtle()),
                     )));
@@ -381,11 +429,14 @@ fn build_conversation_lines(app: &App, width: u16) -> RenderedConversation {
                     "question"
                 };
                 let status = if submitting {
-                    "submitting"
+                    "submitting".to_string()
                 } else if dismissed {
-                    "dismissed · Ctrl+Q reopen"
+                    format!(
+                        "dismissed · {} reopen",
+                        app.key_hint(ActionContext::Global, ActionId::ReopenPendingQuestion)
+                    )
                 } else {
-                    "answer in modal"
+                    "answer in modal".to_string()
                 };
                 lines.push(Line::from(Span::styled(
                     format!(
@@ -585,7 +636,14 @@ mod tests {
         assert!(!text.contains("result-15"));
         assert!(text.contains("15 later lines"));
         assert!(text.contains("research (completed) · child-123456789"));
-        assert!(text.contains("Enter collapse · j/k scroll · y copy"));
+        let expected_hint = format!(
+            "{} collapse · {}/{} scroll · {} copy",
+            app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+            app.key_hint(ActionContext::ConversationBlock, ActionId::ScrollBlockUp),
+            app.key_hint(ActionContext::ConversationBlock, ActionId::ScrollBlockDown),
+            app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+        );
+        assert!(text.contains(&expected_hint));
         assert!(rendered
             .ranges
             .iter()

--- a/crates/app/bamboo-tui/src/ui/config.rs
+++ b/crates/app/bamboo-tui/src/ui/config.rs
@@ -5,6 +5,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::App;
+use crate::keymap::{ActionContext, ActionId};
 use crate::theme::colors;
 
 pub fn render(f: &mut Frame, area: Rect, app: &App) {
@@ -61,7 +62,12 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
 
     let visual_lines = lines.len();
     let block = Block::default().title(Span::styled(
-        " Config (j/k scroll · e edit)",
+        format!(
+            " Config ({}/{} scroll · {} edit)",
+            app.key_hint(ActionContext::Config, ActionId::NavigateDown),
+            app.key_hint(ActionContext::Config, ActionId::NavigateUp),
+            app.key_hint(ActionContext::Config, ActionId::EditConfig),
+        ),
         Style::default().fg(colors::brand()),
     ));
     let viewport_height = block.inner(area).height as usize;
@@ -108,7 +114,12 @@ pub fn render_editor(f: &mut Frame, app: &App) {
         );
     }
     f.render_widget(
-        Paragraph::new(" Ctrl+S save · Esc cancel").style(Style::default().fg(colors::inactive())),
+        Paragraph::new(format!(
+            " {} save · {} cancel",
+            app.primary_key_hint(ActionContext::ConfigEditor, ActionId::SaveConfig),
+            app.primary_key_hint(ActionContext::ConfigEditor, ActionId::Cancel),
+        ))
+        .style(Style::default().fg(colors::inactive())),
         chunks[2],
     );
 }

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -11,6 +11,7 @@ use crate::app::{
     App, CommandPaletteEntry, CommandPaletteHitbox, CommandPaletteTrigger, NoticeLevel,
     QuestionOptionHitbox, SessionPickerMode, Tab,
 };
+use crate::keymap::{ActionContext, ActionId};
 use crate::theme::{self, colors};
 use crate::ui::sessions::{session_row_line, truncate_cells};
 
@@ -81,7 +82,7 @@ pub fn app_layout(area: Rect, app: &App) -> AppLayout {
     }
 }
 
-pub fn render_terminal_too_small(f: &mut Frame) {
+pub fn render_terminal_too_small(f: &mut Frame, app: &App) {
     let area = f.area();
     let lines = vec![
         Line::from(Span::styled(
@@ -95,7 +96,10 @@ pub fn render_terminal_too_small(f: &mut Frame) {
             crate::ui::MIN_TERMINAL_WIDTH,
             crate::ui::MIN_TERMINAL_HEIGHT
         )),
-        Line::raw("Resize the terminal to continue · Ctrl+C quits"),
+        Line::raw(format!(
+            "Resize the terminal to continue · {} quits",
+            app.key_hint(ActionContext::Global, ActionId::QuitOrStop)
+        )),
     ];
     let width = area.width.min(48);
     let height = area.height.min(5);
@@ -231,36 +235,72 @@ pub fn render_tab_bar(f: &mut Frame, area: Rect, app: &App) {
     let full_width = Tab::ALL
         .iter()
         .enumerate()
-        .map(|(i, tab)| display_width(&format!(" [{}]{} ", i + 1, tab.title())))
+        .map(|(index, tab)| {
+            display_width(&format!(
+                " [{}]{} ",
+                app.primary_key_hint(ActionContext::Navigation, tab_switch_action(index)),
+                tab.title()
+            ))
+        })
         .sum::<usize>()
         + Tab::ALL.len().saturating_sub(1);
     let use_full = mode != LayoutMode::Compact && full_width <= area.width as usize;
     let mut spans = Vec::new();
 
     if use_full {
-        for (i, tab) in Tab::ALL.iter().enumerate() {
+        for (index, tab) in Tab::ALL.iter().enumerate() {
             let style = tab_style(*tab == app.tab);
-            spans.push(Span::styled(format!(" [{}]{} ", i + 1, tab.title()), style));
-            if i < Tab::ALL.len() - 1 {
+            spans.push(Span::styled(
+                format!(
+                    " [{}]{} ",
+                    app.primary_key_hint(ActionContext::Navigation, tab_switch_action(index)),
+                    tab.title()
+                ),
+                style,
+            ));
+            if index < Tab::ALL.len() - 1 {
                 spans.push(Span::raw(" "));
             }
         }
     } else {
         let active_index = Tab::ALL.iter().position(|tab| *tab == app.tab).unwrap_or(0);
-        let active = format!(" [{}] {} ", active_index + 1, app.tab.title());
-        let hint = " · Tab/Shift+Tab views · F1 help";
+        let active = format!(
+            " [{}] {} ",
+            app.primary_key_hint(ActionContext::Navigation, tab_switch_action(active_index)),
+            app.tab.title()
+        );
+        let hint = format!(
+            " · {}/{} views · {} help",
+            app.key_hint(ActionContext::Global, ActionId::NextTab),
+            app.key_hint(ActionContext::Global, ActionId::PreviousTab),
+            app.key_hint(ActionContext::Global, ActionId::ShowHelp),
+        );
         let active_width = display_width(&active);
         let remaining = area.width.saturating_sub(active_width as u16) as usize;
         spans.push(Span::styled(active, tab_style(true)));
         if remaining > 0 {
             spans.push(Span::styled(
-                clip_cells(hint, remaining),
+                clip_cells(&hint, remaining),
                 Style::default().fg(colors::inactive()),
             ));
         }
     }
 
     f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn tab_switch_action(index: usize) -> ActionId {
+    [
+        ActionId::SwitchTab1,
+        ActionId::SwitchTab2,
+        ActionId::SwitchTab3,
+        ActionId::SwitchTab4,
+        ActionId::SwitchTab5,
+        ActionId::SwitchTab6,
+    ]
+    .get(index)
+    .copied()
+    .unwrap_or(ActionId::SwitchTab1)
 }
 
 fn tab_style(active: bool) -> Style {
@@ -273,57 +313,29 @@ fn tab_style(active: bool) -> Style {
     }
 }
 
-/// Every binding `App::handle_key`/the per-tab handlers respond to, paired
-/// into two side-by-side columns so the overlay stays to one screen instead
-/// of scrolling off a normal-height terminal. Keep in sync with `app.rs` —
-/// this is the single source of truth for "what can I press right now".
-const HELP_LEFT: &[(&str, &str)] = &[
-    ("1-6", "Switch tab (Chat types digits)"),
-    ("Tab / Shift+Tab", "Next / previous tab"),
-    ("Enter", "Send / select / resume session"),
-    ("Alt+Enter", "Insert newline (Chat)"),
-    ("\u{2191}/\u{2193}, Wheel", "Move selection (lists)"),
-    ("PgUp/PgDn", "Scroll transcript (Chat/Config)"),
-    ("Alt+↑/↓", "Scroll transcript (Chat)"),
-    ("Ctrl+Home/G", "Top / bottom (Chat)"),
-    ("Ctrl+B", "Focus conversation blocks"),
-    ("Block ↑/↓", "Previous / next block"),
-    ("Block Enter", "Expand / open child session"),
-    ("Block j/k/y", "Inspect scroll / copy exact block"),
-];
-const HELP_RIGHT: &[(&str, &str)] = &[
-    ("Ctrl+K", "Command palette"),
-    ("Ctrl+N", "New session"),
-    ("Ctrl+O", "Model picker (Chat)"),
-    ("Ctrl+P", "Session picker (Chat)"),
-    ("Ctrl+Q", "Reopen pending question"),
-    ("Ctrl+C", "Quit / stop streaming"),
-    ("Ctrl+S", "Stop agent execution"),
-    ("Ctrl+X", "Focused detail / new-block default"),
-    ("Ctrl+L", "Full values / notification log"),
-    ("] / [", "Next / previous page (Sessions)"),
-    ("d", "Delete, with confirm (Sessions/Schedules)"),
-    ("n / e", "New schedule / edit config"),
-    ("r / t", "Refresh / run · refresh MCP tools"),
-    ("F1 / ?", "Toggle this help (? not on Chat)"),
-];
-
 pub fn render_help(f: &mut Frame, app: &App) {
     let screen = f.area();
-    const KEY_COL: usize = 17;
+    const KEY_COL: usize = 24;
     let popup_width = ((screen.width as u32 * 94 / 100) as u16).max(1);
     let content_width = popup_width.saturating_sub(4) as usize;
-    let two_columns = content_width >= 96;
+    let two_columns = content_width >= 110;
+    let resolved = app.help_entries();
     let mut entries = Vec::new();
     if two_columns {
-        for i in 0..HELP_LEFT.len().max(HELP_RIGHT.len()) {
-            let (lk, ld) = HELP_LEFT.get(i).copied().unwrap_or(("", ""));
-            let (rk, rd) = HELP_RIGHT.get(i).copied().unwrap_or(("", ""));
-            entries.push(format!("  {lk:<KEY_COL$}{ld:<31}{rk:<KEY_COL$}{rd}"));
+        let midpoint = resolved.len().div_ceil(2);
+        let (left, right) = resolved.split_at(midpoint);
+        for index in 0..left.len().max(right.len()) {
+            let left = left.get(index);
+            let right = right.get(index);
+            let lk = left.map(|entry| entry.keys.as_str()).unwrap_or("");
+            let ld = left.map(|entry| entry.description.as_str()).unwrap_or("");
+            let rk = right.map(|entry| entry.keys.as_str()).unwrap_or("");
+            let rd = right.map(|entry| entry.description.as_str()).unwrap_or("");
+            entries.push(format!("  {lk:<KEY_COL$}{ld:<36}{rk:<KEY_COL$}{rd}"));
         }
     } else {
-        for (key, description) in HELP_LEFT.iter().chain(HELP_RIGHT.iter()) {
-            entries.push(format!("  {key:<KEY_COL$}{description}"));
+        for entry in resolved {
+            entries.push(format!("  {:<KEY_COL$}{}", entry.keys, entry.description));
         }
     }
 
@@ -360,7 +372,14 @@ pub fn render_help(f: &mut Frame, app: &App) {
     if end < entries.len() {
         lines.push(Line::raw(format!("  ↓ {} later", entries.len() - end)));
     }
-    lines.push(Line::raw("  ↑/↓/PgUp/PgDn · Home/End · Esc/q close"));
+    lines.push(Line::raw(format!(
+        "  {}/{} · {}/{} · {} close",
+        app.key_hint(ActionContext::Help, ActionId::NavigateUp),
+        app.key_hint(ActionContext::Help, ActionId::NavigateDown),
+        app.key_hint(ActionContext::Help, ActionId::PageUp),
+        app.key_hint(ActionContext::Help, ActionId::PageDown),
+        app.key_hint(ActionContext::Help, ActionId::Cancel),
+    )));
 
     let area = centered_rect(94, height, screen);
     f.render_widget(Clear, area);
@@ -587,7 +606,14 @@ pub fn render_notifications(f: &mut Frame, app: &App) {
             entries.len() - end
         )));
     }
-    lines.push(Line::raw("  ↑/↓/PgUp/PgDn scroll · Home/End · Esc/q close"));
+    lines.push(Line::raw(format!(
+        "  {}/{} · {}/{} · {} close",
+        app.key_hint(ActionContext::Notifications, ActionId::NavigateUp),
+        app.key_hint(ActionContext::Notifications, ActionId::NavigateDown),
+        app.key_hint(ActionContext::Notifications, ActionId::PageUp),
+        app.key_hint(ActionContext::Notifications, ActionId::PageDown),
+        app.key_hint(ActionContext::Notifications, ActionId::Cancel),
+    )));
 
     let area = centered_rect(94, height, screen);
     f.render_widget(Clear, area);
@@ -628,12 +654,21 @@ pub fn render_serve_offer(f: &mut Frame, app: &App) {
             "  {}",
             crate::text::clip_cells(&offer.url, value_width)
         )),
-        Line::raw("  Ctrl+L inspect full URL"),
+        Line::raw(format!(
+            "  {} inspect full URL",
+            app.key_hint(ActionContext::Global, ActionId::ShowNotifications)
+        )),
         Line::raw(""),
         Line::raw("  Start a local `bamboo serve`?"),
         Line::raw(""),
-        Line::raw("  y / Enter start"),
-        Line::raw("  n / Esc skip"),
+        Line::raw(format!(
+            "  {} start",
+            app.key_hint(ActionContext::ServeOffer, ActionId::Confirm)
+        )),
+        Line::raw(format!(
+            "  {} skip",
+            app.key_hint(ActionContext::ServeOffer, ActionId::Reject)
+        )),
     ];
 
     let height = (lines.len() as u16 + 2).min(f.area().height);
@@ -744,17 +779,40 @@ pub fn render_question(f: &mut Frame, app: &App) {
             paragraph.scroll((q.inspect_scroll.min(max_scroll), 0)),
             sections[1],
         );
+        let inspect_scroll = format!(
+            " {}/{} or {}/{} scroll",
+            app.key_hint(ActionContext::QuestionInspect, ActionId::NavigateUp),
+            app.key_hint(ActionContext::QuestionInspect, ActionId::NavigateDown),
+            app.key_hint(ActionContext::QuestionInspect, ActionId::PageUp),
+            app.key_hint(ActionContext::QuestionInspect, ActionId::PageDown),
+        );
         let footer = if q.options.is_empty() {
             vec![
-                Line::raw(" ↑/↓/PgUp/PgDn scroll"),
-                Line::raw(" y copy exact"),
-                Line::raw(" v/Esc back"),
+                Line::raw(inspect_scroll),
+                Line::raw(format!(
+                    " {} copy exact",
+                    app.key_hint(ActionContext::QuestionInspect, ActionId::CopyValue)
+                )),
+                Line::raw(format!(
+                    " {} back",
+                    app.key_hint(ActionContext::QuestionInspect, ActionId::Cancel)
+                )),
             ]
         } else {
             vec![
-                Line::raw(" ↑/↓/PgUp/PgDn scroll"),
-                Line::raw(" Tab question/option"),
-                Line::raw(" y copy exact  ·  v/Esc back"),
+                Line::raw(inspect_scroll),
+                Line::raw(format!(
+                    " {} question/option",
+                    app.key_hint(
+                        ActionContext::QuestionInspect,
+                        ActionId::ToggleInspectorPane
+                    )
+                )),
+                Line::raw(format!(
+                    " {} copy exact · {} back",
+                    app.key_hint(ActionContext::QuestionInspect, ActionId::CopyValue),
+                    app.key_hint(ActionContext::QuestionInspect, ActionId::Cancel),
+                )),
             ]
         };
         f.render_widget(Paragraph::new(footer), sections[2]);
@@ -785,7 +843,10 @@ pub fn render_question(f: &mut Frame, app: &App) {
         header.push(Line::raw(format!("  {line}")));
     }
     if question_truncated {
-        header.push(Line::raw("  …  (v inspect full question)"));
+        header.push(Line::raw(format!(
+            "  …  ({} inspect full question)",
+            app.key_hint(ActionContext::QuestionOptions, ActionId::InspectValue)
+        )));
     }
     header.push(Line::raw(""));
 
@@ -794,8 +855,15 @@ pub fn render_question(f: &mut Frame, app: &App) {
     if let Some(entry) = &q.number_entry {
         body.push(Line::raw(format!("  Go to option #: {entry}▏")));
         body.push(Line::raw(""));
-        body.push(Line::raw("  digits type  ·  Enter select"));
-        body.push(Line::raw("  Backspace edit  ·  Esc cancel"));
+        body.push(Line::raw(format!(
+            "  digits type · {} select",
+            app.key_hint(ActionContext::QuestionNumber, ActionId::Activate)
+        )));
+        body.push(Line::raw(format!(
+            "  {} edit · {} cancel",
+            app.key_hint(ActionContext::QuestionNumber, ActionId::Backspace),
+            app.key_hint(ActionContext::QuestionNumber, ActionId::Cancel),
+        )));
     } else if let Some(buf) = &q.custom {
         body.push(Line::raw("  Custom answer:"));
         body.push(Line::from(Span::styled(
@@ -811,11 +879,25 @@ pub fn render_question(f: &mut Frame, app: &App) {
         } else if q.submitting {
             body.push(submitting_hint());
         } else if q.options.is_empty() {
-            body.push(Line::raw("  Enter answer  ·  Esc dismiss"));
-            body.push(Line::raw("  Ctrl+V inspect/copy question"));
+            body.push(Line::raw(format!(
+                "  {} answer · {} dismiss",
+                app.key_hint(ActionContext::QuestionCustom, ActionId::Activate),
+                app.key_hint(ActionContext::QuestionCustom, ActionId::Cancel),
+            )));
+            body.push(Line::raw(format!(
+                "  {} inspect/copy question",
+                app.key_hint(ActionContext::QuestionCustom, ActionId::InspectValue)
+            )));
         } else {
-            body.push(Line::raw("  Enter answer  ·  Esc options"));
-            body.push(Line::raw("  Ctrl+V inspect/copy question"));
+            body.push(Line::raw(format!(
+                "  {} answer · {} options",
+                app.key_hint(ActionContext::QuestionCustom, ActionId::Activate),
+                app.key_hint(ActionContext::QuestionCustom, ActionId::Cancel),
+            )));
+            body.push(Line::raw(format!(
+                "  {} inspect/copy question",
+                app.key_hint(ActionContext::QuestionCustom, ActionId::InspectValue)
+            )));
         }
     } else if q.options.is_empty() {
         body.push(Line::from(Span::styled(
@@ -823,7 +905,11 @@ pub fn render_question(f: &mut Frame, app: &App) {
             Style::default().fg(colors::warning()),
         )));
         body.push(Line::raw(""));
-        body.push(Line::raw("  v inspect/copy question  ·  Esc dismiss"));
+        body.push(Line::raw(format!(
+            "  {} inspect/copy question · {} dismiss",
+            app.key_hint(ActionContext::QuestionOptions, ActionId::InspectValue),
+            app.key_hint(ActionContext::QuestionOptions, ActionId::Cancel),
+        )));
     } else {
         let max_h = screen.height.min(24);
         let reserved =
@@ -868,11 +954,29 @@ pub fn render_question(f: &mut Frame, app: &App) {
         } else if q.submitting {
             body.push(submitting_hint());
         } else {
-            body.push(Line::raw("  click option answer  ·  ↑/↓/wheel select"));
-            body.push(Line::raw("  Enter answer  ·  Esc dismiss  ·  1-9 quick"));
-            body.push(Line::raw("  g number  ·  v inspect  ·  y copy"));
+            body.push(Line::raw(format!(
+                "  click option · {}/{} or wheel select",
+                app.key_hint(ActionContext::QuestionOptions, ActionId::NavigateUp),
+                app.key_hint(ActionContext::QuestionOptions, ActionId::NavigateDown),
+            )));
+            body.push(Line::raw(format!(
+                "  {} answer · {} dismiss · quick {}…{}",
+                app.key_hint(ActionContext::QuestionOptions, ActionId::Activate),
+                app.key_hint(ActionContext::QuestionOptions, ActionId::Cancel),
+                app.key_hint(ActionContext::QuestionOptions, ActionId::QuickAnswer1),
+                app.key_hint(ActionContext::QuestionOptions, ActionId::QuickAnswer9),
+            )));
+            body.push(Line::raw(format!(
+                "  {} number · {} inspect · {} copy",
+                app.key_hint(ActionContext::QuestionOptions, ActionId::NumberAnswer),
+                app.key_hint(ActionContext::QuestionOptions, ActionId::InspectValue),
+                app.key_hint(ActionContext::QuestionOptions, ActionId::CopyValue),
+            )));
             if q.allow_custom {
-                body.push(Line::raw("  c custom answer"));
+                body.push(Line::raw(format!(
+                    "  {} custom answer",
+                    app.key_hint(ActionContext::QuestionOptions, ActionId::CustomAnswer)
+                )));
             }
         }
     }
@@ -958,7 +1062,16 @@ pub fn render_delete_confirm(f: &mut Frame, app: &App) {
     lines.push(Line::raw(""));
     lines.push(Line::raw("  This cannot be undone."));
     lines.push(Line::raw(""));
-    lines.push(Line::raw("  y / Enter confirm  ·  n / Esc cancel"));
+    let context = if kind == "session" {
+        ActionContext::SessionDeleteConfirm
+    } else {
+        ActionContext::ScheduleDeleteConfirm
+    };
+    lines.push(Line::raw(format!(
+        "  {} confirm · {} cancel",
+        app.key_hint(context, ActionId::Confirm),
+        app.key_hint(context, ActionId::Reject),
+    )));
 
     let height = (lines.len() as u16 + 2).min(screen.height);
     let area = centered_rect(90, height, screen);
@@ -1034,9 +1147,13 @@ pub fn render_schedule_form(f: &mut Frame, app: &App) {
         )));
     }
     lines.push(Line::raw(""));
-    lines.push(Line::raw(
-        "  Tab / \u{2191}\u{2193} field  \u{b7}  Enter create  \u{b7}  Esc cancel",
-    ));
+    lines.push(Line::raw(format!(
+        "  {}/{} field · {} create · {} cancel",
+        app.primary_key_hint(ActionContext::ScheduleForm, ActionId::NextField),
+        app.primary_key_hint(ActionContext::ScheduleForm, ActionId::PreviousField),
+        app.primary_key_hint(ActionContext::ScheduleForm, ActionId::Activate),
+        app.primary_key_hint(ActionContext::ScheduleForm, ActionId::Cancel),
+    )));
 
     let height = (lines.len() as u16 + 2).min(screen.height);
     let area = centered_rect(90, height, screen);
@@ -1171,19 +1288,27 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
                 ),
                 Style::default().fg(colors::subtle()),
             )));
-            if row_width < 70 {
-                lines.push(Line::raw("  ↑/↓/wheel · Enter open · F2 rename · F3 pin"));
-                lines.push(Line::raw(
-                    "  Del delete · ] more · Ctrl+R retry · Esc cancel",
-                ));
-            } else {
-                lines.push(Line::raw(
-                    "  ↑/↓/wheel select · Enter open · F2 rename · F3 pin",
-                ));
-                lines.push(Line::raw(
-                    "  Ctrl+D/Delete delete · ] load more · Ctrl+R retry · Esc cancel",
-                ));
-            }
+            lines.push(Line::raw(format!(
+                "  {}/{} · {} open · {} rename · {} pin",
+                app.primary_key_hint(ActionContext::SessionPickerBrowse, ActionId::NavigateUp),
+                app.primary_key_hint(ActionContext::SessionPickerBrowse, ActionId::NavigateDown),
+                app.primary_key_hint(ActionContext::SessionPickerBrowse, ActionId::Activate),
+                app.primary_key_hint(ActionContext::SessionPickerBrowse, ActionId::RenameSession),
+                app.primary_key_hint(
+                    ActionContext::SessionPickerBrowse,
+                    ActionId::ToggleSessionPin
+                ),
+            )));
+            lines.push(Line::raw(format!(
+                "  {} del · {} more · {} retry · {}",
+                app.primary_key_hint(
+                    ActionContext::SessionPickerBrowse,
+                    ActionId::DeleteSelection
+                ),
+                app.primary_key_hint(ActionContext::SessionPickerBrowse, ActionId::LoadMore),
+                app.primary_key_hint(ActionContext::SessionPickerBrowse, ActionId::Refresh),
+                app.primary_key_hint(ActionContext::SessionPickerBrowse, ActionId::Cancel),
+            )));
         }
         SessionPickerMode::Rename {
             draft,
@@ -1229,11 +1354,12 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
             }
             if !*submitting {
                 lines.push(Line::raw(""));
-                lines.push(Line::raw(if row_width < 70 {
-                    "  Enter save · Ctrl+R retry · Esc cancel"
-                } else {
-                    "  Enter save · Ctrl+R refetch/retry · Esc keep old title"
-                }));
+                lines.push(Line::raw(format!(
+                    "  {} save · {} refetch/retry · {} keep old title",
+                    app.key_hint(ActionContext::SessionPickerRename, ActionId::Activate),
+                    app.key_hint(ActionContext::SessionPickerRename, ActionId::Refresh),
+                    app.key_hint(ActionContext::SessionPickerRename, ActionId::Cancel),
+                )));
             }
         }
         SessionPickerMode::Pinning {
@@ -1265,7 +1391,11 @@ pub fn render_session_picker(f: &mut Frame, app: &App) {
             }
             if !*submitting {
                 lines.push(Line::raw(""));
-                lines.push(Line::raw("  Ctrl+R refetch/retry · Esc cancel"));
+                lines.push(Line::raw(format!(
+                    "  {} refetch/retry · {} cancel",
+                    app.key_hint(ActionContext::SessionPickerPinning, ActionId::Refresh),
+                    app.key_hint(ActionContext::SessionPickerPinning, ActionId::Cancel),
+                )));
             }
         }
     }
@@ -1321,11 +1451,17 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
     if picker.loading && picker.models.is_empty() {
         body.push(Line::raw("  Loading models..."));
         body.push(Line::raw(""));
-        body.push(Line::raw("  Esc cancel"));
+        body.push(Line::raw(format!(
+            "  {} cancel",
+            app.key_hint(ActionContext::ModelPicker, ActionId::Cancel)
+        )));
     } else if picker.loading && picker.visible.is_empty() {
         body.push(Line::raw("  Refreshing model catalog..."));
         body.push(Line::raw(""));
-        body.push(Line::raw("  Esc cancel"));
+        body.push(Line::raw(format!(
+            "  {} cancel",
+            app.key_hint(ActionContext::ModelPicker, ActionId::Cancel)
+        )));
     } else if picker.visible.is_empty() {
         body.push(Line::raw(if picker.query.is_empty() {
             "  No models available"
@@ -1334,16 +1470,38 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
         }));
         body.push(Line::raw(""));
         if row_width < 70 && picker.models.is_empty() {
-            body.push(Line::raw("  Edit search · Ctrl+R retry load"));
-            body.push(Line::raw("  Esc cancel"));
+            body.push(Line::raw(format!(
+                "  Edit search · {} retry load",
+                app.key_hint(ActionContext::ModelPicker, ActionId::Refresh)
+            )));
+            body.push(Line::raw(format!(
+                "  {} cancel",
+                app.key_hint(ActionContext::ModelPicker, ActionId::Cancel)
+            )));
         } else if row_width < 70 {
-            body.push(Line::raw("  Edit search · Ctrl+U clear"));
-            body.push(Line::raw("  Ctrl+R refresh · Esc cancel"));
+            body.push(Line::raw(format!(
+                "  Edit search · {} clear",
+                app.key_hint(ActionContext::ModelPicker, ActionId::ClearInput)
+            )));
+            body.push(Line::raw(format!(
+                "  {} refresh · {} cancel",
+                app.key_hint(ActionContext::ModelPicker, ActionId::Refresh),
+                app.key_hint(ActionContext::ModelPicker, ActionId::Cancel),
+            )));
         } else {
             body.push(Line::raw(if picker.models.is_empty() {
-                "  Edit search · Ctrl+R retry load · Esc cancel"
+                format!(
+                    "  Edit search · {} retry load · {} cancel",
+                    app.key_hint(ActionContext::ModelPicker, ActionId::Refresh),
+                    app.key_hint(ActionContext::ModelPicker, ActionId::Cancel),
+                )
             } else {
-                "  Edit search · Ctrl+U clear · Ctrl+R refresh · Esc cancel"
+                format!(
+                    "  Edit search · {} clear · {} refresh · {} cancel",
+                    app.key_hint(ActionContext::ModelPicker, ActionId::ClearInput),
+                    app.key_hint(ActionContext::ModelPicker, ActionId::Refresh),
+                    app.key_hint(ActionContext::ModelPicker, ActionId::Cancel),
+                )
             }));
         }
     } else {
@@ -1442,9 +1600,15 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
         }
         body.push(Line::raw(""));
         body.push(Line::raw(if picker.applying {
-            "  Applying model..."
+            "  Applying model...".to_string()
         } else {
-            "  \u{2191}/\u{2193}/wheel select · Enter apply · Esc cancel"
+            format!(
+                "  {}/{} or wheel select · {} apply · {} cancel",
+                app.key_hint(ActionContext::ModelPicker, ActionId::NavigateUp),
+                app.key_hint(ActionContext::ModelPicker, ActionId::NavigateDown),
+                app.key_hint(ActionContext::ModelPicker, ActionId::Activate),
+                app.key_hint(ActionContext::ModelPicker, ActionId::Cancel),
+            )
         }));
     }
     if let Some(error) = &picker.error {
@@ -1486,6 +1650,32 @@ pub fn render_command_palette(f: &mut Frame, app: &App) {
                 .map(str::to_string)
         })
         .collect::<Vec<_>>();
+    let binding_hints = palette
+        .entries
+        .iter()
+        .map(|entry| match entry {
+            CommandPaletteEntry::Builtin(action) => app.action_hint(*action),
+            CommandPaletteEntry::Server(_) => None,
+        })
+        .collect::<Vec<_>>();
+    let footer = [
+        format!(
+            "  {}/{} or wheel select · {} use · {} cancel",
+            app.key_hint(ActionContext::CommandPalette, ActionId::NavigateUp),
+            app.key_hint(ActionContext::CommandPalette, ActionId::NavigateDown),
+            app.key_hint(ActionContext::CommandPalette, ActionId::Activate),
+            app.key_hint(ActionContext::CommandPalette, ActionId::Cancel),
+        ),
+        format!(
+            "  Type to search · {} refresh · {} clear",
+            app.key_hint(ActionContext::CommandPalette, ActionId::Refresh),
+            app.key_hint(ActionContext::CommandPalette, ActionId::ClearInput),
+        ),
+        format!(
+            "  {} cancel",
+            app.key_hint(ActionContext::CommandPalette, ActionId::Cancel)
+        ),
+    ];
     let view = CommandPaletteView {
         trigger: palette.trigger,
         input: &palette.input,
@@ -1496,6 +1686,8 @@ pub fn render_command_palette(f: &mut Frame, app: &App) {
         resolving: palette.resolving,
         error: palette.error.as_deref(),
         disabled_reasons: &disabled_reasons,
+        binding_hints: &binding_hints,
+        footer: Some(&footer),
     };
     render_command_palette_view(f, view, Some(&palette.hitboxes));
 }
@@ -1510,6 +1702,8 @@ struct CommandPaletteView<'a> {
     resolving: bool,
     error: Option<&'a str>,
     disabled_reasons: &'a [Option<String>],
+    binding_hints: &'a [Option<String>],
+    footer: Option<&'a [String; 3]>,
 }
 
 struct CommandPaletteRender {
@@ -1722,6 +1916,12 @@ fn command_palette_lines(
                         description.to_string()
                     }
                 });
+            let description = view
+                .binding_hints
+                .get(*entry_index)
+                .and_then(Option::as_deref)
+                .map(|hint| format!("[{hint}] {description}"))
+                .unwrap_or(description);
             lines.push(Line::from(Span::styled(
                 clip_cells(&format!("      {description}"), row_width),
                 if disabled.is_some() {
@@ -1751,16 +1951,34 @@ fn command_palette_lines(
     lines.push(Line::raw(""));
     if view.resolving {
         lines.push(Line::raw("  Input paused while the preview resolves"));
-        lines.push(Line::raw("  Esc cancel"));
-    } else if row_width < 70 {
-        lines.push(Line::raw("  ↑/↓/wheel select · Enter use · Esc cancel"));
-        lines.push(Line::raw("  Ctrl+R retry/refresh · Ctrl+U clear"));
-    } else {
         lines.push(Line::raw(
-            "  ↑/↓/PgUp/PgDn/wheel select · Enter use · Esc cancel",
+            view.footer
+                .map(|footer| footer[2].clone())
+                .unwrap_or_else(|| "  Esc cancel".to_string()),
+        ));
+    } else if row_width < 70 {
+        lines.push(Line::raw(
+            view.footer
+                .map(|footer| footer[0].clone())
+                .unwrap_or_else(|| "  ↑/↓/wheel select · Enter use · Esc cancel".to_string()),
         ));
         lines.push(Line::raw(
-            "  Type to search · Ctrl+R refresh · Ctrl+U clear",
+            view.footer
+                .map(|footer| footer[1].clone())
+                .unwrap_or_else(|| "  Ctrl+R retry/refresh · Ctrl+U clear".to_string()),
+        ));
+    } else {
+        lines.push(Line::raw(
+            view.footer
+                .map(|footer| footer[0].clone())
+                .unwrap_or_else(|| {
+                    "  ↑/↓/PgUp/PgDn/wheel select · Enter use · Esc cancel".to_string()
+                }),
+        ));
+        lines.push(Line::raw(
+            view.footer
+                .map(|footer| footer[1].clone())
+                .unwrap_or_else(|| "  Type to search · Ctrl+R refresh · Ctrl+U clear".to_string()),
         ));
     }
 
@@ -1814,9 +2032,8 @@ mod tests {
     };
     use crate::api::types::CommandItem;
     use crate::api::BambooClient;
-    use crate::app::{
-        App, BuiltinPaletteAction, CommandPaletteEntry, CommandPaletteHitbox, CommandPaletteTrigger,
-    };
+    use crate::app::{App, CommandPaletteEntry, CommandPaletteHitbox, CommandPaletteTrigger};
+    use crate::keymap::{ActionId, Keymap};
     use ratatui::backend::TestBackend;
     use ratatui::style::Color;
     use ratatui::text::Line;
@@ -1890,6 +2107,27 @@ mod tests {
     }
 
     #[test]
+    fn tab_bar_uses_the_resolved_navigation_binding() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let keymap = Keymap::from_json(
+            r#"{"bindings":[
+                {"context":"navigation","action":"switch-tab-1","keys":["F8"]}
+            ]}"#,
+        )
+        .unwrap();
+        app.set_keymap(keymap, None);
+
+        let backend = TestBackend::new(120, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| super::render_tab_bar(frame, frame.area(), &app))
+            .unwrap();
+        let text = terminal_text(&terminal);
+        assert!(text.contains("[F8] Chat"), "{text}");
+        assert!(!text.contains("[1] Chat"), "{text}");
+    }
+
+    #[test]
     fn testbackend_goldens_cover_every_view_across_the_size_matrix() {
         let sizes = [(50, 15), (60, 20), (80, 24), (120, 40), (200, 60)];
         // Row-major: size, then `Tab::ALL`. Regenerate deliberately only when
@@ -1904,36 +2142,36 @@ mod tests {
                 6_299_991_410_263_413_121,
             ],
             [
-                13_961_651_686_046_235_677,
-                11_742_776_756_959_909_217,
-                12_352_841_898_830_756_966,
-                4_443_987_425_997_024_917,
-                10_477_181_847_636_759_683,
-                15_082_888_787_617_642_176,
+                4_879_774_826_948_300_008,
+                11_066_184_476_930_803_934,
+                17_031_078_274_172_910_387,
+                1_143_711_117_080_246_334,
+                7_234_780_119_466_243_444,
+                9_041_972_994_219_815_988,
             ],
             [
-                918_489_227_128_278_874,
-                12_868_650_456_892_988_142,
-                12_186_984_790_712_334_581,
-                17_105_919_049_885_996_702,
-                10_233_178_872_994_130_974,
-                10_014_260_811_141_985_839,
+                7_389_017_022_641_217_323,
+                16_952_033_003_801_489_607,
+                16_463_315_415_164_233_496,
+                5_166_663_855_769_301_145,
+                6_250_935_511_946_659_016,
+                16_254_299_977_599_291_151,
             ],
             [
-                12_989_858_624_620_429_706,
-                2_072_895_420_946_121_702,
-                13_799_275_926_493_068_613,
-                17_299_515_908_042_385_638,
-                14_066_239_811_268_707_862,
-                15_506_557_407_010_776_391,
+                15_031_301_406_181_041_675,
+                4_865_931_917_107_133_743,
+                15_642_408_912_939_561_496,
+                12_364_154_055_185_087_953,
+                8_288_241_310_337_659_808,
+                16_620_483_292_143_505_655,
             ],
             [
-                16_362_527_783_164_490_822,
-                10_339_770_751_650_844_978,
-                7_745_323_598_988_951_513,
-                12_921_833_252_336_354_826,
-                5_191_433_621_793_189_186,
-                15_064_146_538_247_429_787,
+                10_507_887_664_888_193_887,
+                7_972_046_481_146_137_035,
+                48_418_775_223_067_332,
+                9_519_166_218_506_624_621,
+                6_377_689_178_460_246_140,
+                14_361_221_358_384_919_491,
             ],
         ];
         let mut actual = [[0_u64; 6]; 5];
@@ -1963,7 +2201,7 @@ mod tests {
                         "{width}x{height} {tab:?}:\n{golden}"
                     );
                     assert!(golden.contains("ONLINE"));
-                    assert!(golden.contains("F1 help") || golden.contains("[1]Chat"));
+                    assert!(golden.contains("help") || golden.contains("[1]Chat"));
                 }
             }
         }
@@ -2015,9 +2253,9 @@ mod tests {
         assert_eq!(
             fingerprints,
             [
-                14_548_917_146_417_123_609,
-                8_988_964_665_087_750_412,
-                13_378_690_012_755_700_490,
+                12_798_691_881_099_513_966,
+                8_738_156_666_465_401_879,
+                14_357_062_234_359_601_905,
             ],
             "full-buffer theme golden changed"
         );
@@ -2033,26 +2271,22 @@ mod tests {
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
         let first = terminal_text(&terminal);
         assert!(first.contains("Alt+Enter"));
-        assert!(first.contains("PgUp/PgDn"));
+        assert!(first.contains("PageUp"));
         assert!(app.help_max_scroll.get() > 0);
+
+        let generated = app.help_entries();
+        for needle in ["Ctrl+K", "Ctrl+P", "Ctrl+C", "Ctrl+L", "F1", "?"] {
+            assert!(
+                generated.iter().any(|entry| entry.keys.contains(needle)),
+                "generated help omitted {needle:?}"
+            );
+        }
 
         app.help_scroll = app.help_max_scroll.get();
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
         let last = terminal_text(&terminal);
-        let reachable = format!("{first}\n{last}");
-        for needle in [
-            "Ctrl+K",
-            "Ctrl+P",
-            "Ctrl+C",
-            "Ctrl+L",
-            "F1 / ?",
-            "Esc/q close",
-        ] {
-            assert!(
-                reachable.contains(needle),
-                "help overlay never exposes {needle:?}:\n{reachable}"
-            );
-        }
+        assert!(last.contains("Command palette"));
+        assert!(last.contains("Esc/q/F1 close"));
     }
 
     #[test]
@@ -2070,8 +2304,11 @@ mod tests {
                 .draw(|frame| crate::ui::render(frame, &app))
                 .unwrap();
             let text = terminal_text(&terminal);
-            assert!(text.contains("F1 / ?"), "{width}x{height}:\n{text}");
-            assert!(text.contains("Esc/q close"), "{width}x{height}:\n{text}");
+            assert!(
+                text.contains("Command palette"),
+                "{width}x{height}:\n{text}"
+            );
+            assert!(text.contains("Esc/q/F1 close"), "{width}x{height}:\n{text}");
         }
     }
 
@@ -2088,9 +2325,9 @@ mod tests {
     #[test]
     fn command_palette_render_snapshots_are_responsive_at_60_80_120() {
         let mut entries = vec![
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::NewSession),
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop),
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::ToggleDetails),
+            CommandPaletteEntry::Builtin(ActionId::NewSession),
+            CommandPaletteEntry::Builtin(ActionId::StopRun),
+            CommandPaletteEntry::Builtin(ActionId::ToggleDetails),
         ];
         entries.extend((0..12).map(|index| {
             if index == 7 {
@@ -2125,6 +2362,8 @@ mod tests {
                 resolving: false,
                 error: None,
                 disabled_reasons: &disabled_reasons,
+                binding_hints: &[],
+                footer: None,
             };
             let backend = TestBackend::new(width, 24);
             let mut terminal = Terminal::new(backend).unwrap();
@@ -2172,6 +2411,8 @@ mod tests {
                     resolving: false,
                     error: None,
                     disabled_reasons: &disabled_reasons,
+                    binding_hints: &[],
+                    footer: None,
                 },
                 24,
                 row_width,
@@ -2200,6 +2441,8 @@ mod tests {
                 resolving: false,
                 error: Some("API unavailable — Ctrl+R to retry"),
                 disabled_reasons: &disabled_reasons,
+                binding_hints: &[],
+                footer: None,
             },
             24,
             72,
@@ -2221,6 +2464,8 @@ mod tests {
                 resolving: true,
                 error: None,
                 disabled_reasons: &disabled_reasons,
+                binding_hints: &[],
+                footer: None,
             },
             24,
             72,
@@ -2257,6 +2502,8 @@ mod tests {
                         resolving: true,
                         error: None,
                         disabled_reasons: &disabled_reasons,
+                        binding_hints: &[],
+                        footer: None,
                     },
                     Some(&hitboxes),
                 )
@@ -2275,6 +2522,8 @@ mod tests {
                 resolving: false,
                 error: None,
                 disabled_reasons: &[],
+                binding_hints: &[],
+                footer: None,
             },
             24,
             72,
@@ -2292,6 +2541,8 @@ mod tests {
                 resolving: false,
                 error: None,
                 disabled_reasons: &disabled_reasons,
+                binding_hints: &[],
+                footer: None,
             },
             24,
             72,
@@ -2302,8 +2553,8 @@ mod tests {
     #[test]
     fn disabled_reasons_match_runtime_availability_and_label_type_source() {
         let entries = vec![
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::NewSession),
-            CommandPaletteEntry::Builtin(BuiltinPaletteAction::Stop),
+            CommandPaletteEntry::Builtin(ActionId::NewSession),
+            CommandPaletteEntry::Builtin(ActionId::StopRun),
             command(
                 "Deploy production",
                 "workflow",
@@ -2328,6 +2579,8 @@ mod tests {
                 resolving: false,
                 error: None,
                 disabled_reasons: &disabled_reasons,
+                binding_hints: &[],
+                footer: None,
             },
             24,
             80,
@@ -2344,10 +2597,7 @@ mod tests {
         };
 
         assert!(description_for(0).contains("Disabled: Unavailable"));
-        assert_eq!(
-            description_for(1).trim(),
-            BuiltinPaletteAction::Stop.description()
-        );
+        assert_eq!(description_for(1).trim(), ActionId::StopRun.description());
         assert!(description_for(2).contains("Disabled: Composer commands"));
         assert!(description_for(2).contains("run is active"));
         assert!(palette_text(&rendered.lines).contains("workflow · workspace"));

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -135,7 +135,14 @@ pub fn render_status_info(f: &mut Frame, area: Rect, app: &App) {
             Style::default().fg(colors::tool_running()),
         ));
         items.push((
-            "draft editable; Enter sends after run".to_string(),
+            format!(
+                "draft editable; {}",
+                app.action_key_phrase(
+                    ActionContext::Chat,
+                    ActionId::SendMessage,
+                    "sends after run"
+                )
+            ),
             Style::default().fg(colors::inactive()),
         ));
     } else if app.pending_question.is_some() || app.dismissed_question.is_some() {
@@ -2287,6 +2294,43 @@ mod tests {
         let last = terminal_text(&terminal);
         assert!(last.contains("Command palette"));
         assert!(last.contains("Esc/q/F1 close"));
+    }
+
+    #[test]
+    fn help_overlay_full_buffer_goldens_cover_default_and_remapped_keymaps() {
+        let mut fingerprints = Vec::new();
+        for (index, keymap) in [
+            Keymap::default(),
+            Keymap::from_json(
+                r#"{"bindings":[
+                    {"context":"chat","action":"send-message","keys":["F12"]}
+                ]}"#,
+            )
+            .unwrap(),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+            app.set_keymap(keymap, None);
+            app.help_visible = true;
+            let mut terminal = Terminal::new(TestBackend::new(100, 36)).unwrap();
+            terminal
+                .draw(|frame| crate::ui::render(frame, &app))
+                .unwrap();
+            let text = terminal_text(&terminal);
+            if index == 0 {
+                assert!(text.contains("Enter"));
+            } else {
+                assert!(text.contains("F12"));
+            }
+            fingerprints.push(buffer_fingerprint(&terminal));
+        }
+        assert_eq!(
+            fingerprints,
+            [18_393_380_293_077_633_457, 11_493_634_725_320_844_945],
+            "complete help-overlay buffer golden changed"
+        );
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/ui/mcp.rs
+++ b/crates/app/bamboo-tui/src/ui/mcp.rs
@@ -5,6 +5,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
 use crate::app::App;
+use crate::keymap::{ActionContext, ActionId};
 use crate::theme::colors;
 use crate::ui::sessions::{truncate_cells, visible_window};
 
@@ -52,12 +53,27 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw("   "),
-            Span::styled("[r] Refresh", Style::default().fg(colors::inactive())),
-            Span::raw("  "),
-            Span::styled("[t] Tools", Style::default().fg(colors::inactive())),
+            Span::styled(
+                format!(
+                    "[{}] Refresh",
+                    app.key_hint(ActionContext::Mcp, ActionId::Refresh)
+                ),
+                Style::default().fg(colors::inactive()),
+            ),
             Span::raw("  "),
             Span::styled(
-                "[Enter] Connect/Disc",
+                format!(
+                    "[{}] Tools",
+                    app.key_hint(ActionContext::Mcp, ActionId::ShowTools)
+                ),
+                Style::default().fg(colors::inactive()),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!(
+                    "[{}] Connect/Disc",
+                    app.key_hint(ActionContext::Mcp, ActionId::Activate)
+                ),
                 Style::default().fg(colors::inactive()),
             ),
         ])
@@ -128,7 +144,10 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     } else {
         tool_lines.push(Line::from(Span::styled(
             truncate_cells(
-                " Select a server and press 't' for tools",
+                &format!(
+                    " Select a server and press {} for tools",
+                    app.key_hint(ActionContext::Mcp, ActionId::ShowTools)
+                ),
                 chunks[2].width as usize,
             ),
             Style::default().fg(colors::inactive()),
@@ -138,11 +157,12 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     f.render_widget(tools, chunks[2]);
 
     // Footer
-    let footer_text = if compact {
-        " Enter connect · t tools · r refresh"
-    } else {
-        " [Enter] Connect/Disconnect · [t] Refresh Tools · [r] Refresh"
-    };
+    let footer_text = format!(
+        " {} connect · {} tools · {} refresh",
+        app.key_hint(ActionContext::Mcp, ActionId::Activate),
+        app.key_hint(ActionContext::Mcp, ActionId::ShowTools),
+        app.key_hint(ActionContext::Mcp, ActionId::Refresh),
+    );
     let footer = Paragraph::new(footer_text).style(Style::default().fg(colors::inactive()));
     f.render_widget(footer, chunks[3]);
 }

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -19,7 +19,7 @@ pub fn render(f: &mut Frame, app: &App) {
 
 fn render_with_palette(f: &mut Frame, app: &App) {
     if f.area().width < MIN_TERMINAL_WIDTH || f.area().height < MIN_TERMINAL_HEIGHT {
-        layout::render_terminal_too_small(f);
+        layout::render_terminal_too_small(f, app);
         return;
     }
 

--- a/crates/app/bamboo-tui/src/ui/schedules.rs
+++ b/crates/app/bamboo-tui/src/ui/schedules.rs
@@ -5,6 +5,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
 use crate::app::App;
+use crate::keymap::{ActionContext, ActionId};
 use crate::theme::colors;
 use crate::ui::sessions::{truncate_cells, visible_window};
 
@@ -50,11 +51,29 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw("   "),
-            Span::styled("[n] New", Style::default().fg(colors::inactive())),
+            Span::styled(
+                format!(
+                    "[{}] New",
+                    app.key_hint(ActionContext::Schedules, ActionId::NewSchedule)
+                ),
+                Style::default().fg(colors::inactive()),
+            ),
             Span::raw("  "),
-            Span::styled("[d] Delete", Style::default().fg(colors::inactive())),
+            Span::styled(
+                format!(
+                    "[{}] Delete",
+                    app.key_hint(ActionContext::Schedules, ActionId::DeleteSelection)
+                ),
+                Style::default().fg(colors::inactive()),
+            ),
             Span::raw("  "),
-            Span::styled("[r] Run now", Style::default().fg(colors::inactive())),
+            Span::styled(
+                format!(
+                    "[{}] Run now",
+                    app.key_hint(ActionContext::Schedules, ActionId::RunSchedule)
+                ),
+                Style::default().fg(colors::inactive()),
+            ),
         ])
     };
     let header = Paragraph::new(header);
@@ -102,11 +121,12 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     f.render_widget(list, chunks[1]);
 
     // Footer
-    let footer_text = if compact {
-        " n new · d delete · r run now"
-    } else {
-        " [n] New · [d] Delete · [r] Run now"
-    };
+    let footer_text = format!(
+        " {} new · {} delete · {} run now",
+        app.key_hint(ActionContext::Schedules, ActionId::NewSchedule),
+        app.key_hint(ActionContext::Schedules, ActionId::DeleteSelection),
+        app.key_hint(ActionContext::Schedules, ActionId::RunSchedule),
+    );
     let footer = Paragraph::new(footer_text).style(Style::default().fg(colors::inactive()));
     f.render_widget(footer, chunks[2]);
 }

--- a/crates/app/bamboo-tui/src/ui/sessions.rs
+++ b/crates/app/bamboo-tui/src/ui/sessions.rs
@@ -6,6 +6,7 @@ use ratatui::Frame;
 
 use crate::api::types::SessionSummary;
 use crate::app::App;
+use crate::keymap::{ActionContext, ActionId};
 use crate::text;
 use crate::theme::colors;
 
@@ -25,8 +26,11 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     }
 
     if app.sessions.sessions.is_empty() {
-        let empty = Paragraph::new("No sessions found.\n\nPress 'r' to refresh.")
-            .style(Style::default().fg(colors::inactive()));
+        let empty = Paragraph::new(format!(
+            "No sessions found.\n\nPress {} to refresh.",
+            app.key_hint(ActionContext::Sessions, ActionId::Refresh)
+        ))
+        .style(Style::default().fg(colors::inactive()));
         f.render_widget(empty, area);
         return;
     }
@@ -58,11 +62,29 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw("   "),
-            Span::styled("[r] Refresh", Style::default().fg(colors::inactive())),
+            Span::styled(
+                format!(
+                    "[{}] Refresh",
+                    app.key_hint(ActionContext::Sessions, ActionId::Refresh)
+                ),
+                Style::default().fg(colors::inactive()),
+            ),
             Span::raw("  "),
-            Span::styled("[d] Delete", Style::default().fg(colors::inactive())),
+            Span::styled(
+                format!(
+                    "[{}] Delete",
+                    app.key_hint(ActionContext::Sessions, ActionId::DeleteSelection)
+                ),
+                Style::default().fg(colors::inactive()),
+            ),
             Span::raw("  "),
-            Span::styled("[Enter] Open", Style::default().fg(colors::inactive())),
+            Span::styled(
+                format!(
+                    "[{}] Open",
+                    app.key_hint(ActionContext::Sessions, ActionId::Activate)
+                ),
+                Style::default().fg(colors::inactive()),
+            ),
         ])
     };
     let header = Paragraph::new(header);
@@ -97,18 +119,23 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     let page = app.sessions.offset / limit + 1;
     let pages = app.sessions.total.saturating_sub(1) / limit + 1;
     let page_info = Paragraph::new(format!(
-        " page {}/{} · total {} · [ ] to page",
-        page, pages, app.sessions.total
+        " page {}/{} · total {} · {}/{} to page",
+        page,
+        pages,
+        app.sessions.total,
+        app.key_hint(ActionContext::Sessions, ActionId::PreviousPage),
+        app.key_hint(ActionContext::Sessions, ActionId::NextPage),
     ))
     .style(Style::default().fg(colors::subtle()));
     f.render_widget(page_info, chunks[2]);
 
     // Footer
-    let footer_text = if area.width < 80 {
-        " Enter open · d delete · r refresh"
-    } else {
-        " [Enter] Open in Chat · [d] Delete · [r] Refresh"
-    };
+    let footer_text = format!(
+        " {} open · {} delete · {} refresh",
+        app.key_hint(ActionContext::Sessions, ActionId::Activate),
+        app.key_hint(ActionContext::Sessions, ActionId::DeleteSelection),
+        app.key_hint(ActionContext::Sessions, ActionId::Refresh),
+    );
     let footer = Paragraph::new(footer_text).style(Style::default().fg(colors::inactive()));
     f.render_widget(footer, chunks[3]);
 }

--- a/crates/app/bamboo-tui/src/ui/skills.rs
+++ b/crates/app/bamboo-tui/src/ui/skills.rs
@@ -5,6 +5,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
 use crate::app::App;
+use crate::keymap::{ActionContext, ActionId};
 use crate::theme::colors;
 use crate::ui::sessions::{truncate_cells, visible_window};
 
@@ -119,11 +120,10 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     }
 
     // Footer
-    let footer_text = if compact {
-        " Enter details"
-    } else {
-        " [Enter] View details"
-    };
+    let footer_text = format!(
+        " {} details",
+        app.key_hint(ActionContext::Skills, ActionId::Activate)
+    );
     let footer = Paragraph::new(footer_text).style(Style::default().fg(colors::inactive()));
     f.render_widget(footer, chunks[3]);
 }

--- a/docs/tui-keybindings.md
+++ b/docs/tui-keybindings.md
@@ -1,0 +1,98 @@
+# TUI keybindings
+
+The Bamboo TUI resolves every key through one action registry. Press `F1` to
+see the bindings that are active after configuration; the same resolved labels
+are used in tab headers, dialog footers, and the command palette.
+
+## Load a keymap
+
+Pass a JSON file to either CLI surface:
+
+```console
+bamboo tui --keymap ./tui-keymap.json
+bamboo-tui --keymap ./tui-keymap.json
+```
+
+`BAMBOO_TUI_KEYMAP` supplies the path when `--keymap` is omitted. The flag has
+precedence over the environment variable.
+
+```json
+{
+  "version": 1,
+  "leader": "Ctrl+\\",
+  "leader_timeout_ms": 750,
+  "bindings": [
+    {
+      "context": "global",
+      "action": "show-help",
+      "keys": ["F6", "Leader h"]
+    },
+    {
+      "context": "chat",
+      "action": "insert-newline",
+      "keys": ["Alt+Enter"]
+    },
+    {
+      "context": "navigation",
+      "action": "switch-tab-6",
+      "unbind": true
+    }
+  ]
+}
+```
+
+An override replaces all defaults for that exact context/action pair. Use
+`unbind: true` instead of `keys` to remove it. A sequence is written with
+space-separated strokes, such as `"Leader h"`; alternatives are separate
+items in `keys`. Key names are case-insensitive and support `Ctrl`, `Alt`,
+`Shift`, arrows, `Home`, `End`, `PageUp`, `PageDown`, `Tab`, `Backspace`,
+`Delete`, `Esc`, `Enter`, and `F1` through `F24`.
+
+The leader timeout must be 200–5000 ms. `Esc` cancels a pending sequence, a
+focus change cancels it, and an unmatched continuation reports the exact
+sequence instead of falling through to another action.
+
+## Contexts and action IDs
+
+Action and context IDs are stable kebab-case strings:
+
+- `global`: `quit-or-stop`, `show-help`, `show-notifications`,
+  `open-command-palette`, `new-session`, `reopen-pending-question`,
+  `open-model-picker`, `open-session-picker`, `stop-run`, `open-config-tab`,
+  `open-schedules-tab`, `next-tab`, `previous-tab`
+- `navigation`: `show-help`, `switch-tab-1` through `switch-tab-6`
+- `chat`: `stop-run`, `toggle-details`, `open-slash-palette`, `send-message`,
+  `insert-newline`, transcript scrolling, and `focus-conversation-blocks`
+- `conversation-block`: focus/scroll/copy/activate actions and
+  `toggle-details`
+- `help`, `notifications`, `question-options`, `question-custom`,
+  `question-number`, `question-inspect`: their displayed navigation,
+  answer, inspect, copy, and cancel actions; numbered shortcuts use
+  `quick-answer-1` through `quick-answer-9`
+- `serve-offer`, `session-delete-confirm`, `schedule-delete-confirm`:
+  `confirm` and `reject`
+- `sessions`, `mcp`, `schedules`, `schedule-form`, `skills`, `config`,
+  `config-editor`: the actions shown in the corresponding F1 group
+- `session-picker-browse`, `session-picker-rename`,
+  `session-picker-pinning`, `model-picker`, `command-palette`: the actions
+  shown in each picker group
+
+Use the F1 reference to confirm the exact resolved action labels before
+distributing a keymap.
+
+## Validation and terminal safety
+
+The complete custom layer is applied atomically. Unknown fields, versions,
+contexts, actions, or key names; duplicate overrides; collisions; ambiguous
+prefixes; and unreachable required actions reject the file. The TUI reports
+the path and reason, then uses all built-in defaults—never a partially applied
+map.
+
+Global printable single keys are rejected so normal Chat text cannot trigger
+an application action. Custom `Ctrl+S`, `Ctrl+Q`, and `Ctrl+Z` bindings are
+rejected because terminal flow control, multiplexers, SSH, or signal handling
+can consume them. Built-in compatibility aliases for `Ctrl+S`/`Ctrl+Q` always
+have leader or function-key alternatives. `Alt+Enter` is the portable newline
+default; `Shift+Enter` remains an additional enhanced-keyboard alias. Release
+events are ignored, and held-key repeats cannot repeat confirmation,
+submission, deletion, or lifecycle actions.

--- a/docs/tui-keybindings.md
+++ b/docs/tui-keybindings.md
@@ -53,7 +53,10 @@ focus change cancels it, and an unmatched continuation reports the exact
 sequence instead of falling through to another action. If an input event wins
 the timer race after expiry, it is reprocessed as a fresh key instead of being
 discarded. A single-stroke global quit binding always preempts a pending
-sequence.
+sequence or a focused-context prefix; longer bindings that contain the same
+stroke anywhere are rejected as unreachable.
+Custom leaders that depend on enhanced terminal key reporting are rejected so
+every generated leader fallback remains portable.
 
 ## Contexts and action IDs
 

--- a/docs/tui-keybindings.md
+++ b/docs/tui-keybindings.md
@@ -50,7 +50,10 @@ items in `keys`. Key names are case-insensitive and support `Ctrl`, `Alt`,
 
 The leader timeout must be 200–5000 ms. `Esc` cancels a pending sequence, a
 focus change cancels it, and an unmatched continuation reports the exact
-sequence instead of falling through to another action.
+sequence instead of falling through to another action. If an input event wins
+the timer race after expiry, it is reprocessed as a fresh key instead of being
+discarded. A single-stroke global quit binding always preempts a pending
+sequence.
 
 ## Contexts and action IDs
 
@@ -88,8 +91,12 @@ prefixes; and unreachable required actions reject the file. The TUI reports
 the path and reason, then uses all built-in defaults—never a partially applied
 map.
 
-Global printable single keys are rejected so normal Chat text cannot trigger
-an application action. Custom `Ctrl+S`, `Ctrl+Q`, and `Ctrl+Z` bindings are
+Global sequences whose first stroke is printable are rejected so normal Chat
+text cannot be captured as the start of an application action. When bindings
+from several active contexts share a prefix, the focused/modal context has
+priority over a shorter binding from a lower context; compatible longer
+continuations remain available across the context stack. Custom `Ctrl+S`,
+`Ctrl+Q`, and `Ctrl+Z` bindings are
 rejected because terminal flow control, multiplexers, SSH, or signal handling
 can consume them. Built-in compatibility aliases for `Ctrl+S`/`Ctrl+Q` always
 have leader or function-key alternatives. `Alt+Enter` is the portable newline

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -225,6 +225,11 @@ enum Commands {
         #[arg(long)]
         theme: Option<bamboo_tui::ThemePalette>,
 
+        /// JSON keymap override with per-context bindings, leader sequences,
+        /// and unbind support. Invalid maps fall back to safe defaults.
+        #[arg(long, value_name = "PATH")]
+        keymap: Option<PathBuf>,
+
         /// If `--server-url` is unreachable and loopback, start a local
         /// `bamboo serve` automatically instead of asking (y/n). No effect for
         /// a remote (non-loopback) `--server-url` — that always just warns.
@@ -1523,6 +1528,7 @@ async fn run() {
             session_id,
             model,
             theme,
+            keymap,
             auto_serve,
             no_auto_serve,
         } => {
@@ -1542,6 +1548,7 @@ async fn run() {
                 model,
                 auto_serve,
                 theme,
+                keymap,
             })
             .await;
             if let Err(e) = result {


### PR DESCRIPTION
## Summary

- centralize Bamboo TUI keyboard behavior in a typed ActionId registry with deterministic context precedence
- add versioned JSON keymaps with per-context remaps, unbinds, leader sequences, timeout handling, collision checks, and safe fallback
- derive help, tab/footer hints, command-palette bindings, and Chat composer hints from the resolved keymap
- expose --keymap on both CLI surfaces, support BAMBOO_TUI_KEYMAP, and document the schema and terminal-safety rules

## Test Plan

- cargo fmt --all --check
- cargo clippy --locked -p bamboo-tui --all-targets -- -D warnings
- cargo test --locked -p bamboo-tui
- cargo check --locked --bin bamboo
- cargo test --locked
- cargo run --locked --quiet --bin bamboo -- tui --help
- cargo run --locked --quiet -p bamboo-tui --bin bamboo-tui -- --help

## Screenshots

Not included: this is a full-screen terminal interaction change. Deterministic full-buffer golden tests cover compact, standard, wide, modal, help, and palette layouts.

Closes #641