### PR TITLE
feat(tui): add persistent sub-agent inspector

### DIFF
--- a/crates/app/bamboo-client-core/src/lib.rs
+++ b/crates/app/bamboo-client-core/src/lib.rs
@@ -227,6 +227,13 @@ pub enum AgentEvent {
         #[serde(default)]
         content_summary: Option<String>,
     },
+    /// Current round for a session. Parent streams may carry this inside a
+    /// `SubAgentEvent`, allowing clients to update the exact child row without
+    /// interpreting display text.
+    RunnerProgress {
+        session_id: String,
+        round_count: u32,
+    },
     /// A per-run token/tool-call/subagent budget tripped and the run was
     /// gracefully stopped (issue #221).
     BudgetExceeded {
@@ -248,12 +255,18 @@ pub enum AgentEvent {
     },
 
     // ── Sub-agent lifecycle (forwarded from the parent session's stream) ──
-    // Minimal projections of the server's SubAgent* events; extra server fields
-    // (parent_session_id, timestamp, the nested `event`) are ignored on decode.
+    // Typed projections of the server's SubAgent* events. Extra envelope fields
+    // such as parent_session_id and timestamp are ignored on decode.
     SubAgentStarted {
         child_session_id: String,
         #[serde(default)]
         title: Option<String>,
+    },
+    /// Full-fidelity child event forwarded on the parent session stream.
+    /// Boxing keeps the recursively-shaped wire contract finite.
+    SubAgentEvent {
+        child_session_id: String,
+        event: Box<AgentEvent>,
     },
     SubAgentHeartbeat {
         child_session_id: String,
@@ -374,6 +387,32 @@ mod clarification_event_tests {
             } if child_session_id == "child-1"
                 && request_id == "request-7"
                 && resource == "/tmp/result.txt"
+        ));
+    }
+
+    #[test]
+    fn forwarded_child_progress_preserves_child_and_session_identity() {
+        let event: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "sub_agent_event",
+            "parent_session_id": "parent-1",
+            "child_session_id": "child-2",
+            "event": {
+                "type": "runner_progress",
+                "session_id": "child-2",
+                "round_count": 7
+            }
+        }))
+        .unwrap();
+
+        assert!(matches!(
+            event,
+            AgentEvent::SubAgentEvent { child_session_id, event }
+                if child_session_id == "child-2"
+                    && matches!(
+                        event.as_ref(),
+                        AgentEvent::RunnerProgress { session_id, round_count: 7 }
+                            if session_id == "child-2"
+                    )
         ));
     }
 

--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -561,6 +561,51 @@ impl BambooClient {
         Ok(envelope.session)
     }
 
+    /// Same paginated session endpoint as [`Self::list_sessions`], decoded
+    /// into the relationship-rich projection used by the child-session tree.
+    pub async fn list_session_tree(
+        &self,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> Result<ListSessionTreeEnvelope> {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        if let Some(offset) = offset {
+            query.push(("offset", offset.to_string()));
+        }
+        let resp = self
+            .client
+            .get(self.url("/api/v1/sessions"))
+            .query(&query)
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("list child-session tree failed ({status}): {body}");
+        }
+        Ok(resp.json().await?)
+    }
+
+    /// Relationship-rich detail lookup used to discover the active session's
+    /// durable root before the paginated tree is assembled.
+    pub async fn get_session_tree(&self, session_id: &str) -> Result<SessionTreeSummary> {
+        let resp = self
+            .client
+            .get(self.url(&format!("/api/v1/sessions/{session_id}")))
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("get child-session root failed ({status}): {body}");
+        }
+        let envelope: GetSessionTreeEnvelope = resp.json().await?;
+        Ok(envelope.session)
+    }
+
     /// Fetch a session together with its metadata ETag. Rename and pin flows
     /// retain this version while the operator edits, then send it back via
     /// `If-Match` so concurrent updates become a recoverable 412 instead of a
@@ -1347,6 +1392,47 @@ mod tests {
         assert_eq!(approval.version, 6);
         assert_eq!(approval.state, ChildApprovalState::DecisionRecorded);
         assert_eq!(approval.approved, Some(false));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn child_tree_uses_relationship_detail_and_paginated_session_contracts() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut detail_socket, _) = listener.accept().await.unwrap();
+            let detail = read_request(&mut detail_socket).await;
+            assert!(detail.starts_with("GET /api/v1/sessions/child-2 HTTP/1.1"));
+            respond(
+                &mut detail_socket,
+                "200 OK",
+                "\"1\"",
+                r#"{"session":{"id":"child-2","kind":"child","parent_session_id":"child-1","root_session_id":"root","spawn_depth":2,"placement":{"kind":"ssh","host":"worker"}}}"#,
+            )
+            .await;
+
+            let (mut page_socket, _) = listener.accept().await.unwrap();
+            let page = read_request(&mut page_socket).await;
+            assert!(page.starts_with("GET /api/v1/sessions?limit=2&offset=2 HTTP/1.1"));
+            respond(
+                &mut page_socket,
+                "200 OK",
+                "\"1\"",
+                r#"{"sessions":[{"id":"child-2","kind":"child","parent_session_id":"child-1","root_session_id":"root","spawn_depth":2,"placement":{"kind":"ssh","host":"worker"}}],"total":3,"limit":2,"offset":2}"#,
+            )
+            .await;
+        });
+
+        let client = BambooClient::new(&base_url);
+        let detail = client.get_session_tree("child-2").await.unwrap();
+        assert_eq!(detail.parent_session_id.as_deref(), Some("child-1"));
+        assert_eq!(detail.root_session_id, "root");
+        assert_eq!(detail.placement.host, "worker");
+
+        let page = client.list_session_tree(Some(2), Some(2)).await.unwrap();
+        assert_eq!(page.total, 3);
+        assert_eq!(page.offset, 2);
+        assert_eq!(page.sessions[0].spawn_depth, 2);
         server.await.unwrap();
     }
 

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -171,6 +171,111 @@ pub struct GetSessionEnvelope {
     pub session: SessionSummary,
 }
 
+/// Full session projection used by the Sub-agents inspector.  The ordinary
+/// session picker intentionally keeps a smaller DTO; the tree needs the
+/// durable relationship and placement metadata already emitted by the same
+/// server endpoints.
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionTreeKind {
+    Root,
+    Child,
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionTreePlacement {
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub host: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct SessionTreeSummary {
+    pub id: String,
+    #[serde(default)]
+    pub kind: SessionTreeKind,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub parent_session_id: Option<String>,
+    #[serde(default)]
+    pub root_session_id: String,
+    #[serde(default)]
+    pub spawn_depth: u32,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub is_running: bool,
+    #[serde(default)]
+    pub has_pending_question: bool,
+    #[serde(default)]
+    pub running_child_count: u32,
+    #[serde(default)]
+    pub last_run_status: Option<String>,
+    #[serde(default)]
+    pub last_run_error: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub last_activity_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub subagent_type: Option<String>,
+    #[serde(default)]
+    pub lifecycle: Option<String>,
+    #[serde(default)]
+    pub resident_name: Option<String>,
+    #[serde(default)]
+    pub placement: SessionTreePlacement,
+}
+
+impl SessionTreeSummary {
+    pub(crate) fn placeholder(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            kind: SessionTreeKind::Unknown,
+            title: String::new(),
+            parent_session_id: None,
+            root_session_id: String::new(),
+            spawn_depth: 0,
+            model: String::new(),
+            is_running: false,
+            has_pending_question: false,
+            running_child_count: 0,
+            last_run_status: None,
+            last_run_error: None,
+            updated_at: None,
+            last_activity_at: None,
+            subagent_type: None,
+            lifecycle: None,
+            resident_name: None,
+            placement: SessionTreePlacement::default(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct ListSessionTreeEnvelope {
+    #[serde(default)]
+    pub sessions: Vec<SessionTreeSummary>,
+    #[serde(default)]
+    pub total: usize,
+    #[serde(default)]
+    pub limit: usize,
+    #[serde(default)]
+    pub offset: usize,
+    #[serde(default)]
+    pub next_offset: Option<usize>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct GetSessionTreeEnvelope {
+    pub session: SessionTreeSummary,
+}
+
 // ── Session resume (history + pending question) ──
 
 /// `function` payload of a [`HistoryToolCall`] — mirrors the server's
@@ -1007,6 +1112,44 @@ mod tests {
         assert!(!s.pinned);
         assert_eq!(s.permission_mode, SessionPermissionMode::Default);
         assert!(!s.bypass_permissions);
+    }
+
+    #[test]
+    fn child_tree_projection_preserves_relationship_and_placement_metadata() {
+        let json = r#"{
+            "id":"child-2",
+            "kind":"child",
+            "title":"Review",
+            "parent_session_id":"child-1",
+            "root_session_id":"root",
+            "spawn_depth":2,
+            "model":"gpt-5",
+            "is_running":true,
+            "last_run_error":"old error",
+            "subagent_type":"reviewer",
+            "lifecycle":"resident",
+            "resident_name":"reviewer-a",
+            "placement":{"kind":"ssh","host":"worker.example"}
+        }"#;
+        let session: SessionTreeSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(session.kind, SessionTreeKind::Child);
+        assert_eq!(session.parent_session_id.as_deref(), Some("child-1"));
+        assert_eq!(session.root_session_id, "root");
+        assert_eq!(session.spawn_depth, 2);
+        assert_eq!(session.subagent_type.as_deref(), Some("reviewer"));
+        assert_eq!(session.lifecycle.as_deref(), Some("resident"));
+        assert_eq!(session.resident_name.as_deref(), Some("reviewer-a"));
+        assert_eq!(session.placement.kind, "ssh");
+        assert_eq!(session.placement.host, "worker.example");
+    }
+
+    #[test]
+    fn child_tree_projection_tolerates_missing_legacy_metadata() {
+        let session: SessionTreeSummary = serde_json::from_str(r#"{"id":"legacy"}"#).unwrap();
+        assert_eq!(session.kind, SessionTreeKind::Unknown);
+        assert!(session.parent_session_id.is_none());
+        assert!(session.root_session_id.is_empty());
+        assert!(session.placement.host.is_empty());
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -26,6 +26,7 @@ use crate::keymap::{
     HelpEntry, KeyResolution, Keymap, PendingSequence,
 };
 use crate::search::ranked_indices;
+use crate::subagents::{SubagentTreeState, SubagentTreeStatus, MAX_SUBAGENT_TREE_SESSIONS};
 use crate::ui;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -36,6 +37,284 @@ pub enum Tab {
     Schedules,
     Skills,
     Config,
+}
+
+#[cfg(test)]
+mod subagent_tree_navigation_tests {
+    use super::*;
+    use crate::api::types::{SessionTreeKind, SessionTreeSummary};
+
+    fn summary(id: &str, parent: Option<&str>, root: &str, depth: u32) -> SessionTreeSummary {
+        let mut value = SessionTreeSummary::placeholder(id);
+        value.kind = if parent.is_some() {
+            SessionTreeKind::Child
+        } else {
+            SessionTreeKind::Root
+        };
+        value.title = id.to_string();
+        value.parent_session_id = parent.map(str::to_string);
+        value.root_session_id = root.to_string();
+        value.spawn_depth = depth;
+        value
+    }
+
+    fn tree(active: &str, children: &[SessionTreeSummary]) -> SubagentTreeState {
+        let active_summary = children
+            .iter()
+            .find(|summary| summary.id == active)
+            .cloned()
+            .expect("active summary");
+        let mut tree = SubagentTreeState::new(1, active.to_string());
+        tree.install_root(active_summary);
+        tree.install_page(children.to_vec(), children.len(), 100, 0, None);
+        tree
+    }
+
+    fn child_approval(parent: &str, child: &str, request: &str) -> QueuedChildApproval {
+        QueuedChildApproval {
+            record: ChildApprovalRecord {
+                parent_session_id: parent.to_string(),
+                child_session_id: child.to_string(),
+                child_attempt: 1,
+                request_id: request.to_string(),
+                tool_name: "Write".to_string(),
+                permission: "write_file".to_string(),
+                resource: format!("/workspace/{child}.txt"),
+                created_at: "2026-08-15T00:00:00Z".to_string(),
+                updated_at: "2026-08-15T00:00:00Z".to_string(),
+                version: 2,
+                state: ChildApprovalState::Pending,
+                approved: None,
+                reason: None,
+            },
+            authoritative: true,
+        }
+    }
+
+    #[test]
+    fn child_open_and_parent_return_restore_exact_cached_ui_state() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("root".to_string());
+        app.chat.history_loaded = true;
+        app.chat.textarea = TextArea::from(["parent draft".to_string()]);
+        app.chat.textarea.move_cursor(CursorMove::Jump(0, 6));
+        app.chat.scroll_offset = 17;
+        app.chat.auto_scroll = false;
+        app.chat.focused_block = Some("parent:block".to_string());
+        app.chat.block_ui.insert(
+            "parent:block".to_string(),
+            ConversationBlockUiState {
+                expanded: true,
+                scroll: 4,
+            },
+        );
+
+        let child_context_id = app.allocate_context_id();
+        let mut child_context = SessionUiContext::blank(child_context_id);
+        child_context.chat.session_id = Some("child".to_string());
+        child_context.chat.history_loaded = true;
+        child_context.chat.textarea = TextArea::from(["child draft".to_string()]);
+        app.cache_context(child_context);
+
+        let graph = vec![
+            summary("root", None, "root", 0),
+            summary("child", Some("root"), "root", 1),
+        ];
+        let mut root_tree = tree("root", &graph);
+        root_tree.move_selection(1);
+        assert_eq!(root_tree.selected_id(), Some("child"));
+        app.subagent_tree = Some(root_tree);
+        app.open_selected_subagent_session();
+        assert_eq!(app.chat.session_id.as_deref(), Some("child"));
+
+        let mut child_tree = tree("child", &graph);
+        child_tree.select_first();
+        assert_eq!(child_tree.selected_id(), Some("root"));
+        app.subagent_tree = Some(child_tree);
+        app.open_selected_subagent_session();
+
+        assert_eq!(app.chat.session_id.as_deref(), Some("root"));
+        assert_eq!(app.chat.textarea.lines(), ["parent draft"]);
+        assert_eq!(app.chat.textarea.cursor(), (0, 6));
+        assert_eq!(app.chat.scroll_offset, 17);
+        assert!(!app.chat.auto_scroll);
+        assert_eq!(app.chat.focused_block.as_deref(), Some("parent:block"));
+        assert_eq!(
+            app.chat.block_ui["parent:block"],
+            ConversationBlockUiState {
+                expanded: true,
+                scroll: 4
+            }
+        );
+    }
+
+    #[test]
+    fn pending_permission_jump_selects_the_exact_child_request() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("root".to_string());
+        app.chat.history_loaded = true;
+        app.pending_child_approvals = VecDeque::from([
+            child_approval("root", "child-a", "request-a"),
+            child_approval("root", "child-b", "request-b"),
+        ]);
+        let graph = vec![
+            summary("root", None, "root", 0),
+            summary("child-a", Some("root"), "root", 1),
+            summary("child-b", Some("root"), "root", 1),
+        ];
+        let mut state = tree("root", &graph);
+        state.sync_pending_permissions([("root", "child-a"), ("root", "child-b")]);
+        state.move_selection(2);
+        assert_eq!(state.selected_id(), Some("child-b"));
+        app.subagent_tree = Some(state);
+
+        app.open_selected_subagent_pending();
+
+        let question = app.pending_question.as_ref().expect("child modal opened");
+        assert!(matches!(
+            &question.kind,
+            ActiveQuestionKind::ChildApproval(child)
+                if child.child_session_id == "child-b" && child.request_id == "request-b"
+        ));
+    }
+
+    #[test]
+    fn pending_clarification_jump_opens_the_selected_child_context() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("root".to_string());
+        app.chat.history_loaded = true;
+
+        let child_context_id = app.allocate_context_id();
+        let mut child_context = SessionUiContext::blank(child_context_id);
+        child_context.chat.session_id = Some("child".to_string());
+        child_context.chat.history_loaded = true;
+        let pending = PendingQuestion {
+            has_pending_question: true,
+            question: "Choose a target".to_string(),
+            options: Some(vec!["A".to_string(), "B".to_string()]),
+            allow_custom: false,
+            tool_call_id: Some("question-1".to_string()),
+            tool_name: Some("ask".to_string()),
+            source: Some("pause_tool".to_string()),
+            interaction_kind: Some(PendingInteractionKind::Clarification),
+            permission_request: None,
+            tool_arguments: None,
+            tool_arguments_truncated: false,
+        };
+        child_context.pending_question = Some(ActiveQuestion::from_pending(
+            "child-question".to_string(),
+            "child".to_string(),
+            &pending,
+            String::new(),
+        ));
+        app.cache_context(child_context);
+
+        let mut child = summary("child", Some("root"), "root", 1);
+        child.has_pending_question = true;
+        let graph = vec![summary("root", None, "root", 0), child];
+        let mut state = tree("root", &graph);
+        state.move_selection(1);
+        app.subagent_tree = Some(state);
+
+        app.open_selected_subagent_pending();
+
+        assert_eq!(app.chat.session_id.as_deref(), Some("child"));
+        assert_eq!(
+            app.pending_question
+                .as_ref()
+                .map(|question| question.session_id.as_str()),
+            Some("child")
+        );
+    }
+
+    #[test]
+    fn pending_permission_on_the_active_session_reopens_its_own_request() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("root".to_string());
+        app.chat.history_loaded = true;
+        let pending = PendingQuestion {
+            has_pending_question: true,
+            question: "Allow the command?".to_string(),
+            options: Some(vec!["Approve".to_string(), "Deny".to_string()]),
+            allow_custom: false,
+            tool_call_id: Some("permission-1".to_string()),
+            tool_name: Some("Bash".to_string()),
+            source: Some("permission_gate".to_string()),
+            interaction_kind: Some(PendingInteractionKind::Permission),
+            permission_request: None,
+            tool_arguments: None,
+            tool_arguments_truncated: false,
+        };
+        app.dismissed_question = Some(ActiveQuestion::from_pending(
+            "root-permission".to_string(),
+            "root".to_string(),
+            &pending,
+            String::new(),
+        ));
+
+        let graph = vec![summary("root", None, "root", 0)];
+        let mut state = tree("root", &graph);
+        state.mark_waiting_permission("root", "permission for Bash".to_string());
+        app.subagent_tree = Some(state);
+
+        app.open_selected_subagent_pending();
+
+        assert_eq!(app.chat.session_id.as_deref(), Some("root"));
+        assert_eq!(
+            app.pending_question
+                .as_ref()
+                .map(|question| question.session_id.as_str()),
+            Some("root")
+        );
+    }
+
+    #[test]
+    fn forwarded_progress_cannot_cross_update_a_sibling_row() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("root".to_string());
+        app.chat.current_execution_started = true;
+        let graph = vec![
+            summary("root", None, "root", 0),
+            summary("child-a", Some("root"), "root", 1),
+            summary("child-b", Some("root"), "root", 1),
+        ];
+        app.subagent_tree = Some(tree("root", &graph));
+
+        app.handle_sse_event(AgentEvent::SubAgentEvent {
+            child_session_id: "child-a".to_string(),
+            event: Box::new(AgentEvent::RunnerProgress {
+                session_id: "child-b".to_string(),
+                round_count: 9,
+            }),
+        })
+        .unwrap();
+        assert_eq!(
+            app.subagent_tree.as_ref().unwrap().nodes["child-a"].status(),
+            SubagentTreeStatus::Idle,
+            "a mismatched nested identity must not change the envelope row"
+        );
+        assert_eq!(
+            app.subagent_tree.as_ref().unwrap().nodes["child-a"].round_count,
+            None
+        );
+        assert_eq!(
+            app.subagent_tree.as_ref().unwrap().nodes["child-b"].round_count,
+            None
+        );
+
+        app.handle_sse_event(AgentEvent::SubAgentEvent {
+            child_session_id: "child-a".to_string(),
+            event: Box::new(AgentEvent::RunnerProgress {
+                session_id: "child-a".to_string(),
+                round_count: 3,
+            }),
+        })
+        .unwrap();
+        assert_eq!(
+            app.subagent_tree.as_ref().unwrap().nodes["child-a"].round_count,
+            Some(3)
+        );
+    }
 }
 
 #[cfg(test)]
@@ -3418,6 +3697,12 @@ pub struct App {
     /// Sessions management tab, closing this overlay leaves the transcript,
     /// composer draft/cursor, and scroll position untouched.
     pub session_picker: Option<SessionPicker>,
+    /// Focusable, relationship-aware view of the active root/child session
+    /// graph. It is global overlay state rather than part of a session view;
+    /// opening a row closes it before moving the exact cached Chat context.
+    pub(crate) subagent_tree: Option<SubagentTreeState>,
+    subagent_tree_epoch: u64,
+    subagent_tree_task: Option<tokio::task::JoinHandle<()>>,
     /// Combined built-in/server command palette (`Ctrl+K` globally or `/` as
     /// the first composer character). It never mutates the composer until a
     /// selection succeeds, so cancellation and every async failure preserve
@@ -3539,6 +3824,9 @@ impl Drop for App {
         if let Some(task) = self.opening_session_task.take() {
             task.abort();
         }
+        if let Some(task) = self.subagent_tree_task.take() {
+            task.abort();
+        }
         for context in self.session_views.values_mut() {
             context.abort_background_work();
         }
@@ -3639,6 +3927,9 @@ impl App {
             permission_mode_confirm: None,
             model_picker: None,
             session_picker: None,
+            subagent_tree: None,
+            subagent_tree_epoch: 0,
+            subagent_tree_task: None,
             command_palette: None,
             pending_delete: None,
             pending_schedule_delete: None,
@@ -3844,6 +4135,7 @@ impl App {
         if self.session_picker.is_some() {
             self.pending_delete = None;
         }
+        self.close_subagent_tree();
         self.close_session_picker();
         self.close_model_picker();
         self.close_command_palette();
@@ -5054,6 +5346,7 @@ impl App {
                                 authoritative: true,
                             })
                             .collect();
+                        self.sync_subagent_tree_permissions();
 
                         let active_match = self.pending_question.as_ref().and_then(|question| {
                             matches!(question.kind, ActiveQuestionKind::ChildApproval(_)).then(
@@ -6150,6 +6443,90 @@ impl App {
                     self.load_next_session_picker_page();
                 }
             }
+            AppEvent::SubagentTreeRootLoaded {
+                epoch,
+                active_session_id,
+                result,
+            } => {
+                let current_session_matches =
+                    self.chat.session_id.as_deref() == Some(active_session_id.as_str());
+                let Some(tree) = self.subagent_tree.as_mut().filter(|tree| {
+                    tree.epoch == epoch && tree.active_session_id == active_session_id
+                }) else {
+                    return Ok(());
+                };
+                self.subagent_tree_task = None;
+                tree.loading_root = false;
+                if !current_session_matches {
+                    tree.error =
+                        Some("Active session changed while the child tree was loading".to_string());
+                    return Ok(());
+                }
+                let mut load_first_page = false;
+                match result {
+                    Ok(summary) if summary.id == active_session_id => {
+                        tree.error = None;
+                        tree.install_root(summary);
+                        load_first_page = true;
+                    }
+                    Ok(summary) => {
+                        tree.error = Some(format!(
+                            "Session detail identity mismatch: requested {active_session_id}, received {}",
+                            summary.id
+                        ));
+                    }
+                    Err(error) => {
+                        tree.error = Some(format!(
+                            "Failed to discover the child-session root: {error}"
+                        ));
+                    }
+                }
+                if load_first_page {
+                    self.load_subagent_tree_page(epoch, 0);
+                }
+            }
+            AppEvent::SubagentTreePageLoaded {
+                epoch,
+                offset,
+                result,
+            } => {
+                let Some(tree) = self
+                    .subagent_tree
+                    .as_mut()
+                    .filter(|tree| tree.epoch == epoch)
+                else {
+                    return Ok(());
+                };
+                self.subagent_tree_task = None;
+                tree.loading_page = false;
+                match result {
+                    Ok(envelope) => {
+                        tree.error = None;
+                        tree.install_page(
+                            envelope.sessions,
+                            envelope.total,
+                            envelope.limit,
+                            envelope.offset,
+                            envelope.next_offset,
+                        );
+                    }
+                    Err(error) => {
+                        tree.error = Some(format!(
+                            "Failed to load child-session relationships: {error}"
+                        ));
+                    }
+                }
+                self.sync_subagent_tree_permissions();
+                let next_offset = self
+                    .subagent_tree
+                    .as_ref()
+                    .filter(|tree| tree.epoch == epoch && !tree.capped)
+                    .and_then(|tree| tree.next_offset)
+                    .filter(|next| *next > offset);
+                if let Some(next_offset) = next_offset {
+                    self.load_subagent_tree_page(epoch, next_offset);
+                }
+            }
             AppEvent::SessionPickerVersionLoaded {
                 epoch,
                 session_id,
@@ -6923,6 +7300,7 @@ impl App {
             || self.pending_question.is_some()
             || self.pending_delete.is_some()
             || self.pending_schedule_delete.is_some()
+            || self.subagent_tree.is_some()
             || self.session_picker.is_some()
             || self.model_picker.is_some()
             || self.command_palette.is_some()
@@ -6984,6 +7362,8 @@ impl App {
             ActionContext::SessionDeleteConfirm
         } else if self.pending_schedule_delete.is_some() {
             ActionContext::ScheduleDeleteConfirm
+        } else if self.subagent_tree.is_some() {
+            ActionContext::SubagentTree
         } else if self.session_picker.is_some() {
             self.session_picker_context()
         } else if self.model_picker.is_some() {
@@ -7090,6 +7470,8 @@ impl App {
             picker.error = Some(message.clone());
         } else if let Some(picker) = self.session_picker.as_mut() {
             picker.error = Some(message.clone());
+        } else if let Some(tree) = self.subagent_tree.as_mut() {
+            tree.error = Some(message.clone());
         }
         self.status_message = message;
     }
@@ -7162,6 +7544,7 @@ impl App {
             ActionId::ReopenPendingQuestion => self.reopen_pending_question(),
             ActionId::OpenModelPicker => self.open_model_picker(),
             ActionId::OpenSessionPicker => self.open_session_picker(),
+            ActionId::OpenSubagentTree => self.open_subagent_tree(),
             ActionId::StopRun => self.stop_streaming(),
             ActionId::ToggleDetails => self.toggle_conversation_details(),
             ActionId::OpenConfigTab => {
@@ -7229,6 +7612,7 @@ impl App {
             }
             ActionContext::PermissionRuleConfirm => self.handle_permission_rule_confirm_key(key),
             ActionContext::PermissionModeConfirm => self.handle_permission_mode_confirm_key(key),
+            ActionContext::SubagentTree => self.handle_subagent_tree_key(key),
             ActionContext::SessionPickerBrowse
             | ActionContext::SessionPickerRename
             | ActionContext::SessionPickerPinning => self.handle_session_picker_key(key).await?,
@@ -8490,6 +8874,7 @@ impl App {
         {
             Self::refresh_child_question(question, &queued);
         }
+        self.sync_subagent_tree_permissions();
         self.show_next_child_approval();
     }
 
@@ -8535,6 +8920,7 @@ impl App {
                 || queued.record.request_id != request_id
                 || queued.record.version > terminal_version
         });
+        self.sync_subagent_tree_permissions();
     }
 
     fn retire_parent_question_context(&mut self) {
@@ -10020,7 +10406,9 @@ impl App {
                 self.chat.note_update();
             }
             AgentEvent::ExecutionStarted {
-                run_id, started_at, ..
+                run_id,
+                session_id,
+                started_at,
             } => {
                 if !self
                     .chat
@@ -10051,6 +10439,28 @@ impl App {
                     self.pending_answer_run_started = true;
                 }
                 self.stream_disconnected = false;
+                if let Some(tree) = self
+                    .subagent_tree
+                    .as_mut()
+                    .filter(|tree| tree.contains_session(&session_id))
+                {
+                    tree.mark_running(&session_id, "execution started", true);
+                }
+            }
+            AgentEvent::RunnerProgress {
+                session_id,
+                round_count,
+            } => {
+                if self.chat.session_id.as_deref() != Some(session_id.as_str()) {
+                    return Ok(());
+                }
+                if let Some(tree) = self
+                    .subagent_tree
+                    .as_mut()
+                    .filter(|tree| tree.contains_session(&session_id))
+                {
+                    tree.apply_runner_progress(&session_id, round_count);
+                }
             }
             AgentEvent::ReasoningToken { content } => {
                 if self.chat.run_status.phase.is_terminal() {
@@ -10323,6 +10733,16 @@ impl App {
                     format!("Permission required for {tool_name}"),
                 );
                 if let Some(session_id) = self.chat.session_id.clone() {
+                    if let Some(tree) = self
+                        .subagent_tree
+                        .as_mut()
+                        .filter(|tree| tree.contains_session(&session_id))
+                    {
+                        tree.mark_waiting_permission(
+                            &session_id,
+                            format!("permission for {tool_name}"),
+                        );
+                    }
                     self.status_message = "Synchronizing typed permission request...".to_string();
                     self.reconcile_pending_question_after_stream_connect(session_id);
                 }
@@ -10404,6 +10824,20 @@ impl App {
                 // the compatibility sentinel: every durable registry record
                 // starts at a positive version.
                 let authoritative_identity = version > 0;
+                if status == "pending" || authoritative_identity {
+                    if let Some(tree) = self
+                        .subagent_tree
+                        .as_mut()
+                        .filter(|tree| tree.contains_session(&parent_session_id))
+                    {
+                        tree.apply_child_approval_changed(
+                            &parent_session_id,
+                            &child_session_id,
+                            &status,
+                            authoritative_identity,
+                        );
+                    }
+                }
                 if status == "pending" {
                     self.chat
                         .run_status
@@ -10524,6 +10958,13 @@ impl App {
                     );
                     return Ok(());
                 };
+                if let Some(tree) = self
+                    .subagent_tree
+                    .as_mut()
+                    .filter(|tree| tree.contains_session(&session_id))
+                {
+                    tree.mark_waiting_input(&session_id);
+                }
                 let pending = PendingQuestion {
                     has_pending_question: true,
                     question,
@@ -10607,6 +11048,15 @@ impl App {
                 if self.chat.run_status.phase.is_terminal() && !self.chat.streaming {
                     return Ok(());
                 }
+                if let Some(session_id) = self.chat.session_id.clone() {
+                    if let Some(tree) = self
+                        .subagent_tree
+                        .as_mut()
+                        .filter(|tree| tree.contains_session(&session_id))
+                    {
+                        tree.apply_completed(&session_id, "completed", None);
+                    }
+                }
                 self.handle_complete(usage);
             }
             AgentEvent::Cancelled { message } => {
@@ -10614,6 +11064,15 @@ impl App {
                     return Ok(());
                 }
                 let message = message.unwrap_or_else(|| "Cancelled".to_string());
+                if let Some(session_id) = self.chat.session_id.clone() {
+                    if let Some(tree) = self
+                        .subagent_tree
+                        .as_mut()
+                        .filter(|tree| tree.contains_session(&session_id))
+                    {
+                        tree.apply_completed(&session_id, "cancelled", Some(message.clone()));
+                    }
+                }
                 self.chat
                     .run_status
                     .finish(RunPhase::Cancelled, message.clone());
@@ -10644,6 +11103,15 @@ impl App {
             AgentEvent::Error { message } => {
                 if self.chat.run_status.phase.is_terminal() && !self.chat.streaming {
                     return Ok(());
+                }
+                if let Some(session_id) = self.chat.session_id.clone() {
+                    if let Some(tree) = self
+                        .subagent_tree
+                        .as_mut()
+                        .filter(|tree| tree.contains_session(&session_id))
+                    {
+                        tree.apply_completed(&session_id, "error", Some(message.clone()));
+                    }
                 }
                 self.chat
                     .run_status
@@ -10783,10 +11251,35 @@ impl App {
                 );
                 self.status_message = format!("Plan updated: {}", file_path);
             }
+            AgentEvent::SubAgentEvent {
+                child_session_id,
+                event,
+            } => {
+                let identity_matches = match event.as_ref() {
+                    AgentEvent::ExecutionStarted { session_id, .. }
+                    | AgentEvent::RunnerProgress { session_id, .. } => {
+                        session_id == &child_session_id
+                    }
+                    _ => true,
+                };
+                if !identity_matches {
+                    return Ok(());
+                }
+                let parent_session_id = self.chat.session_id.clone();
+                if let (Some(parent_session_id), Some(tree)) =
+                    (parent_session_id, self.subagent_tree.as_mut())
+                {
+                    if tree.contains_session(&parent_session_id) {
+                        tree.apply_started(&parent_session_id, &child_session_id, None, false);
+                        tree.apply_forwarded_event(&child_session_id, &event);
+                    }
+                }
+            }
             AgentEvent::SubAgentStarted {
                 child_session_id,
                 title,
             } => {
+                let tree_title = title.clone();
                 let replay_expected = self
                     .chat
                     .replay_expected_child_ids
@@ -10860,6 +11353,20 @@ impl App {
                     NoticeLevel::Info,
                     format!("Sub-agent {child_session_id} started"),
                 );
+                if let Some(parent_session_id) = self.chat.session_id.clone() {
+                    if let Some(tree) = self
+                        .subagent_tree
+                        .as_mut()
+                        .filter(|tree| tree.contains_session(&parent_session_id))
+                    {
+                        tree.apply_started(
+                            &parent_session_id,
+                            &child_session_id,
+                            tree_title,
+                            fresh_start || active_in_current_turn,
+                        );
+                    }
+                }
                 if active_in_current_turn {
                     self.chat
                         .current_turn_child_ids
@@ -10871,13 +11378,33 @@ impl App {
                 self.chat.note_update();
             }
             AgentEvent::SubAgentHeartbeat { child_session_id } => {
-                self.chat.run_status.subagent_heartbeat(child_session_id);
+                self.chat
+                    .run_status
+                    .subagent_heartbeat(child_session_id.clone());
+                if let Some(parent_session_id) = self.chat.session_id.as_deref() {
+                    if let Some(tree) = self
+                        .subagent_tree
+                        .as_mut()
+                        .filter(|tree| tree.contains_session(parent_session_id))
+                    {
+                        tree.apply_heartbeat(&child_session_id);
+                    }
+                }
             }
             AgentEvent::SubAgentCompleted {
                 child_session_id,
                 status,
                 error,
             } => {
+                if let Some(parent_session_id) = self.chat.session_id.as_deref() {
+                    if let Some(tree) = self
+                        .subagent_tree
+                        .as_mut()
+                        .filter(|tree| tree.contains_session(parent_session_id))
+                    {
+                        tree.apply_completed(&child_session_id, &status, error.clone());
+                    }
+                }
                 self.chat
                     .run_status
                     .subagent_finished(child_session_id.clone(), &status);
@@ -12077,6 +12604,276 @@ impl App {
                     });
                 });
             }
+            _ => {}
+        }
+    }
+
+    // ── Persistent child-session tree (Leader+A) ──
+
+    fn open_subagent_tree(&mut self) {
+        let Some(active_session_id) = self.chat.session_id.clone() else {
+            self.status_message =
+                "Start or open a session before inspecting sub-agents".to_string();
+            return;
+        };
+        if self.event_tx.is_none() {
+            self.status_message = "Sub-agent tree is not attached to the event loop".to_string();
+            return;
+        }
+        if let Some(task) = self.subagent_tree_task.take() {
+            task.abort();
+        }
+        self.subagent_tree_epoch = self.subagent_tree_epoch.wrapping_add(1).max(1);
+        let epoch = self.subagent_tree_epoch;
+        self.subagent_tree = Some(SubagentTreeState::new(epoch, active_session_id.clone()));
+        self.sync_subagent_tree_permissions();
+        self.load_subagent_tree_root(epoch, active_session_id);
+    }
+
+    fn close_subagent_tree(&mut self) {
+        if let Some(task) = self.subagent_tree_task.take() {
+            task.abort();
+        }
+        self.subagent_tree = None;
+    }
+
+    fn reload_subagent_tree(&mut self) {
+        let Some(active_session_id) = self
+            .subagent_tree
+            .as_ref()
+            .map(|tree| tree.active_session_id.clone())
+        else {
+            return;
+        };
+        if let Some(task) = self.subagent_tree_task.take() {
+            task.abort();
+        }
+        self.subagent_tree_epoch = self.subagent_tree_epoch.wrapping_add(1).max(1);
+        let epoch = self.subagent_tree_epoch;
+        self.subagent_tree = Some(SubagentTreeState::new(epoch, active_session_id.clone()));
+        self.sync_subagent_tree_permissions();
+        self.load_subagent_tree_root(epoch, active_session_id);
+    }
+
+    fn load_subagent_tree_root(&mut self, epoch: u64, active_session_id: String) {
+        let Some(tx) = self.event_tx.clone() else {
+            return;
+        };
+        let client = self.client.clone();
+        self.subagent_tree_task = Some(tokio::spawn(async move {
+            let result = client
+                .get_session_tree(&active_session_id)
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::SubagentTreeRootLoaded {
+                epoch,
+                active_session_id,
+                result,
+            });
+        }));
+    }
+
+    fn load_subagent_tree_page(&mut self, epoch: u64, offset: usize) {
+        let Some(tx) = self.event_tx.clone() else {
+            return;
+        };
+        let Some(tree) = self
+            .subagent_tree
+            .as_mut()
+            .filter(|tree| tree.epoch == epoch)
+        else {
+            return;
+        };
+        if tree.scanned >= MAX_SUBAGENT_TREE_SESSIONS {
+            tree.capped = tree.scanned < tree.total;
+            tree.loading_page = false;
+            return;
+        }
+        tree.loading_page = true;
+        let limit = (tree.page_limit > 0).then_some(tree.page_limit);
+        let client = self.client.clone();
+        self.subagent_tree_task = Some(tokio::spawn(async move {
+            let result = client
+                .list_session_tree(limit, (offset > 0).then_some(offset))
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(AppEvent::SubagentTreePageLoaded {
+                epoch,
+                offset,
+                result,
+            });
+        }));
+    }
+
+    fn sync_subagent_tree_permissions(&mut self) {
+        let pending = self
+            .pending_child_approvals
+            .iter()
+            .filter(|queued| queued.record.state == ChildApprovalState::Pending)
+            .map(|queued| {
+                (
+                    queued.record.parent_session_id.clone(),
+                    queued.record.child_session_id.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        if let Some(tree) = self.subagent_tree.as_mut() {
+            tree.sync_pending_permissions(
+                pending
+                    .iter()
+                    .map(|(parent, child)| (parent.as_str(), child.as_str())),
+            );
+        }
+    }
+
+    fn focus_child_approval(&mut self, child_session_id: &str) -> bool {
+        let active_matches = self.pending_question.as_ref().is_some_and(|question| {
+            matches!(
+                &question.kind,
+                ActiveQuestionKind::ChildApproval(child)
+                    if child.child_session_id == child_session_id
+            )
+        });
+        if active_matches {
+            return true;
+        }
+        let dismissed_matches = self.dismissed_question.as_ref().is_some_and(|question| {
+            matches!(
+                &question.kind,
+                ActiveQuestionKind::ChildApproval(child)
+                    if child.child_session_id == child_session_id
+            )
+        });
+        if dismissed_matches {
+            self.pending_question = self.dismissed_question.take();
+            self.status_message = format!("Child {child_session_id} approval reopened");
+            return true;
+        }
+        let Some(index) = self.pending_child_approvals.iter().position(|queued| {
+            queued.record.child_session_id == child_session_id
+                && queued.record.state == ChildApprovalState::Pending
+        }) else {
+            return false;
+        };
+        let Some(queued) = self.pending_child_approvals.remove(index) else {
+            return false;
+        };
+        self.pending_child_approvals.push_front(queued);
+        self.show_next_child_approval();
+        self.pending_question.is_some()
+    }
+
+    fn open_selected_subagent_session(&mut self) {
+        let selected = self
+            .subagent_tree
+            .as_ref()
+            .and_then(SubagentTreeState::selected_id)
+            .map(str::to_string);
+        let Some(session_id) = selected else {
+            return;
+        };
+        let already_active = self.chat.session_id.as_deref() == Some(session_id.as_str());
+        self.close_subagent_tree();
+        if already_active {
+            self.status_message = "Already viewing the selected session".to_string();
+        } else {
+            self.resume_session(session_id);
+        }
+    }
+
+    fn open_selected_subagent_pending(&mut self) {
+        let selected = self.subagent_tree.as_ref().and_then(|tree| {
+            tree.selected_node().map(|node| {
+                (
+                    node.summary.id.clone(),
+                    node.status(),
+                    node.summary.has_pending_question,
+                )
+            })
+        });
+        let Some((session_id, status, has_pending_question)) = selected else {
+            return;
+        };
+        if !status.is_pending() {
+            if let Some(tree) = self.subagent_tree.as_mut() {
+                tree.error = Some("The selected session has no pending request".to_string());
+            }
+            return;
+        }
+        self.close_subagent_tree();
+        match status {
+            SubagentTreeStatus::WaitingForPermission => {
+                if !self.focus_child_approval(&session_id) {
+                    if self.chat.session_id.as_deref() == Some(session_id.as_str()) {
+                        self.reopen_pending_question();
+                    } else if has_pending_question {
+                        self.resume_session(session_id);
+                    } else if let Some(parent_session_id) = self.chat.session_id.clone() {
+                        self.refresh_child_approvals(parent_session_id);
+                        self.status_message = format!(
+                            "Refreshing the exact pending permission for child {session_id}"
+                        );
+                    }
+                }
+            }
+            SubagentTreeStatus::WaitingForInput => {
+                if self.chat.session_id.as_deref() == Some(session_id.as_str()) {
+                    self.reopen_pending_question();
+                } else {
+                    self.resume_session(session_id);
+                }
+            }
+            _ => unreachable!("pending status checked above"),
+        }
+    }
+
+    fn handle_subagent_tree_key(&mut self, key: KeyEvent) {
+        let action = self.resolve_context_action(ActionContext::SubagentTree, key);
+        match action {
+            Some(ActionId::NavigateUp) => {
+                if let Some(tree) = self.subagent_tree.as_mut() {
+                    tree.move_selection(-1);
+                }
+            }
+            Some(ActionId::NavigateDown) => {
+                if let Some(tree) = self.subagent_tree.as_mut() {
+                    tree.move_selection(1);
+                }
+            }
+            Some(ActionId::PageUp) => {
+                if let Some(tree) = self.subagent_tree.as_mut() {
+                    tree.move_selection(-8);
+                }
+            }
+            Some(ActionId::PageDown) => {
+                if let Some(tree) = self.subagent_tree.as_mut() {
+                    tree.move_selection(8);
+                }
+            }
+            Some(ActionId::JumpFirst) => {
+                if let Some(tree) = self.subagent_tree.as_mut() {
+                    tree.select_first();
+                }
+            }
+            Some(ActionId::JumpLast) => {
+                if let Some(tree) = self.subagent_tree.as_mut() {
+                    tree.select_last();
+                }
+            }
+            Some(ActionId::ExpandTreeNode) => {
+                if let Some(tree) = self.subagent_tree.as_mut() {
+                    tree.expand_or_descend();
+                }
+            }
+            Some(ActionId::CollapseTreeNode) => {
+                if let Some(tree) = self.subagent_tree.as_mut() {
+                    tree.collapse_or_ascend();
+                }
+            }
+            Some(ActionId::Activate) => self.open_selected_subagent_session(),
+            Some(ActionId::OpenPendingRequest) => self.open_selected_subagent_pending(),
+            Some(ActionId::Refresh) => self.reload_subagent_tree(),
+            Some(ActionId::Cancel) => self.close_subagent_tree(),
             _ => {}
         }
     }
@@ -16313,6 +17110,25 @@ mod question_tests {
         commands.open_command_palette(CommandPaletteTrigger::Global);
         actual.push(minimum_modal_fingerprint(&commands));
 
+        let mut subagents = App::new(BambooClient::new("http://127.0.0.1:0"));
+        subagents.chat.session_id = Some("root".to_string());
+        let mut root = SessionTreeSummary::placeholder("root");
+        root.kind = SessionTreeKind::Root;
+        root.title = "root agent".to_string();
+        root.root_session_id = "root".to_string();
+        let mut child = SessionTreeSummary::placeholder("child");
+        child.kind = SessionTreeKind::Child;
+        child.title = "child agent".to_string();
+        child.parent_session_id = Some("root".to_string());
+        child.root_session_id = "root".to_string();
+        child.spawn_depth = 1;
+        child.has_pending_question = true;
+        let mut tree = SubagentTreeState::new(1, "root".to_string());
+        tree.install_root(root.clone());
+        tree.install_page(vec![root, child], 2, 100, 0, None);
+        subagents.subagent_tree = Some(tree);
+        actual.push(minimum_modal_fingerprint(&subagents));
+
         let mut serve = App::new(BambooClient::new("http://127.0.0.1:0"));
         serve.serve_offer = Some(ServeOffer {
             url: format!("http://127.0.0.1:9562/{}", "long-path-".repeat(12)),
@@ -16322,7 +17138,7 @@ mod question_tests {
         assert_eq!(
             actual,
             vec![
-                12_013_467_434_067_207_854,
+                2_521_080_266_750_332_561,
                 1_057_473_937_556_339_135,
                 1_502_110_673_089_046_554,
                 14_484_161_115_671_232_577,
@@ -16331,7 +17147,8 @@ mod question_tests {
                 10_493_202_686_479_633_261,
                 9_858_505_864_262_550_789,
                 8_710_182_394_295_884_107,
-                1_923_556_055_944_460_855,
+                15_353_719_274_755_616_638,
+                5_239_033_309_572_019_229,
                 3_245_283_921_451_133_623,
             ],
             "minimum-size modal golden changed"

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -1,9 +1,10 @@
 use crossterm::event::{KeyEvent, MouseEvent};
 
 use crate::api::types::{
-    CatalogModel, CommandDetail, CommandListResponse, ListSessionsEnvelope, McpServer,
-    PendingQuestion, PermissionDecisionResponse, PermissionPolicyResponse, ProviderCatalog,
-    Schedule, SessionSummary, Skill, SkillDetail, SubagentSnapshotResponse, ToolInfo,
+    CatalogModel, CommandDetail, CommandListResponse, ListSessionTreeEnvelope,
+    ListSessionsEnvelope, McpServer, PendingQuestion, PermissionDecisionResponse,
+    PermissionPolicyResponse, ProviderCatalog, Schedule, SessionSummary, SessionTreeSummary, Skill,
+    SkillDetail, SubagentSnapshotResponse, ToolInfo,
 };
 use crate::api::{
     PermissionMutationFailure, RespondFailure, SessionMutationFailure, VersionedSession,
@@ -218,6 +219,20 @@ pub enum AppEvent {
         offset: usize,
         observation_epoch: u64,
         result: Loaded<ListSessionsEnvelope>,
+    },
+    /// Relationship-rich detail for the session that opened the Sub-agents
+    /// inspector. It establishes the durable root before pages are reduced.
+    SubagentTreeRootLoaded {
+        epoch: u64,
+        active_session_id: String,
+        result: Loaded<SessionTreeSummary>,
+    },
+    /// One serialized page of the account session index. The tree scans the
+    /// bounded paginated source, then retains only the active root graph.
+    SubagentTreePageLoaded {
+        epoch: u64,
+        offset: usize,
+        result: Loaded<ListSessionTreeEnvelope>,
     },
     /// Fresh session summary + ETag loaded before a rename/pin mutation.
     SessionPickerVersionLoaded {

--- a/crates/app/bamboo-tui/src/keymap.rs
+++ b/crates/app/bamboo-tui/src/keymap.rs
@@ -39,6 +39,7 @@ pub(crate) enum ActionContext {
     PermissionRuleConfirm,
     PermissionDeleteConfirm,
     PermissionModeConfirm,
+    SubagentTree,
     SessionPickerBrowse,
     SessionPickerRename,
     SessionPickerPinning,
@@ -47,7 +48,7 @@ pub(crate) enum ActionContext {
 }
 
 impl ActionContext {
-    pub(crate) const ALL: [Self; 30] = [
+    pub(crate) const ALL: [Self; 31] = [
         Self::Chat,
         Self::ConversationBlock,
         Self::Global,
@@ -73,6 +74,7 @@ impl ActionContext {
         Self::PermissionRuleConfirm,
         Self::PermissionDeleteConfirm,
         Self::PermissionModeConfirm,
+        Self::SubagentTree,
         Self::SessionPickerBrowse,
         Self::SessionPickerRename,
         Self::SessionPickerPinning,
@@ -107,6 +109,7 @@ impl ActionContext {
             Self::PermissionRuleConfirm => "Global permission rule confirmation",
             Self::PermissionDeleteConfirm => "Permission delete",
             Self::PermissionModeConfirm => "Permission mode",
+            Self::SubagentTree => "Sub-agent tree",
             Self::SessionPickerBrowse => "Session picker",
             Self::SessionPickerRename => "Session rename",
             Self::SessionPickerPinning => "Session pin",
@@ -127,6 +130,7 @@ pub(crate) enum ActionId {
     ReopenPendingQuestion,
     OpenModelPicker,
     OpenSessionPicker,
+    OpenSubagentTree,
     StopRun,
     ToggleDetails,
     OpenConfigTab,
@@ -215,6 +219,9 @@ pub(crate) enum ActionId {
     RenameSession,
     ToggleSessionPin,
     LoadMore,
+    ExpandTreeNode,
+    CollapseTreeNode,
+    OpenPendingRequest,
 }
 
 #[derive(Clone, Copy)]
@@ -343,6 +350,15 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
         [(Global, "Ctrl+P; Leader p")]
     ),
     spec!(
+        OpenSubagentTree,
+        "Sub-agent tree",
+        "Inspect and navigate the active parent/child session graph",
+        true,
+        Chat,
+        [Global],
+        [(Global, "Leader a")]
+    ),
+    spec!(
         StopRun,
         "Stop active run",
         "Request cancellation of the active agent run",
@@ -460,6 +476,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             Skills,
             Config,
             Permissions,
+            SubagentTree,
             SessionPickerBrowse,
             ModelPicker,
             CommandPalette
@@ -476,6 +493,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (Skills, "Up"),
             (Config, "Up; k"),
             (Permissions, "Up; k"),
+            (SubagentTree, "Up; k"),
             (SessionPickerBrowse, "Up"),
             (ModelPicker, "Up"),
             (CommandPalette, "Up")
@@ -498,6 +516,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             Skills,
             Config,
             Permissions,
+            SubagentTree,
             SessionPickerBrowse,
             ModelPicker,
             CommandPalette
@@ -514,6 +533,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (Skills, "Down"),
             (Config, "Down; j"),
             (Permissions, "Down; j"),
+            (SubagentTree, "Down; j"),
             (SessionPickerBrowse, "Down"),
             (ModelPicker, "Down"),
             (CommandPalette, "Down")
@@ -531,6 +551,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             QuestionInspect,
             PermissionRuleConfirm,
             Config,
+            SubagentTree,
             ModelPicker,
             CommandPalette
         ],
@@ -541,6 +562,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (QuestionInspect, "PageUp"),
             (PermissionRuleConfirm, "PageUp"),
             (Config, "PageUp"),
+            (SubagentTree, "PageUp"),
             (ModelPicker, "PageUp"),
             (CommandPalette, "PageUp")
         ]
@@ -557,6 +579,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             QuestionInspect,
             PermissionRuleConfirm,
             Config,
+            SubagentTree,
             ModelPicker,
             CommandPalette
         ],
@@ -567,6 +590,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (QuestionInspect, "PageDown"),
             (PermissionRuleConfirm, "PageDown"),
             (Config, "PageDown"),
+            (SubagentTree, "PageDown"),
             (ModelPicker, "PageDown"),
             (CommandPalette, "PageDown")
         ]
@@ -583,6 +607,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             QuestionInspect,
             PermissionRuleConfirm,
             ConversationBlock,
+            SubagentTree,
             ModelPicker,
             CommandPalette
         ],
@@ -593,6 +618,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (QuestionInspect, "Home"),
             (PermissionRuleConfirm, "Home"),
             (ConversationBlock, "Home"),
+            (SubagentTree, "Home; g g"),
             (ModelPicker, "Home"),
             (CommandPalette, "Home")
         ]
@@ -609,6 +635,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             QuestionInspect,
             PermissionRuleConfirm,
             ConversationBlock,
+            SubagentTree,
             ModelPicker,
             CommandPalette
         ],
@@ -619,6 +646,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (QuestionInspect, "End"),
             (PermissionRuleConfirm, "End"),
             (ConversationBlock, "End"),
+            (SubagentTree, "End; Shift+G"),
             (ModelPicker, "End"),
             (CommandPalette, "End")
         ]
@@ -639,6 +667,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             ScheduleForm,
             Skills,
             Permissions,
+            SubagentTree,
             SessionPickerBrowse,
             SessionPickerRename,
             ModelPicker,
@@ -655,6 +684,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (ScheduleForm, "Enter"),
             (Skills, "Enter"),
             (Permissions, "Enter"),
+            (SubagentTree, "Enter"),
             (SessionPickerBrowse, "Enter"),
             (SessionPickerRename, "Enter"),
             (ModelPicker, "Enter"),
@@ -677,6 +707,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             ConfigEditor,
             Permissions,
             PermissionEditor,
+            SubagentTree,
             SessionPickerBrowse,
             SessionPickerRename,
             SessionPickerPinning,
@@ -694,6 +725,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (ConfigEditor, "Esc"),
             (Permissions, "Esc"),
             (PermissionEditor, "Esc"),
+            (SubagentTree, "Esc; q"),
             (SessionPickerBrowse, "Esc"),
             (SessionPickerRename, "Esc"),
             (SessionPickerPinning, "Esc"),
@@ -733,6 +765,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
         [
             Sessions,
             Mcp,
+            SubagentTree,
             SessionPickerBrowse,
             SessionPickerRename,
             SessionPickerPinning,
@@ -744,6 +777,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
         [
             (Sessions, "r"),
             (Mcp, "r"),
+            (SubagentTree, "r; Ctrl+R"),
             (SessionPickerBrowse, "Ctrl+R"),
             (SessionPickerRename, "Ctrl+R"),
             (SessionPickerPinning, "Ctrl+R"),
@@ -1201,6 +1235,30 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
         false,
         [SessionPickerBrowse],
         [(SessionPickerBrowse, "PageDown; ]")]
+    ),
+    spec!(
+        ExpandTreeNode,
+        "Expand tree node",
+        "Expand the selected child-session branch or enter its first child",
+        false,
+        [SubagentTree],
+        [(SubagentTree, "Right; l")]
+    ),
+    spec!(
+        CollapseTreeNode,
+        "Collapse tree node",
+        "Collapse the selected branch or move to its parent",
+        false,
+        [SubagentTree],
+        [(SubagentTree, "Left; h")]
+    ),
+    spec!(
+        OpenPendingRequest,
+        "Open pending child request",
+        "Jump to the exact selected child's clarification or permission request",
+        false,
+        [SubagentTree],
+        [(SubagentTree, "p")]
     ),
 ];
 

--- a/crates/app/bamboo-tui/src/lib.rs
+++ b/crates/app/bamboo-tui/src/lib.rs
@@ -25,6 +25,7 @@ mod event;
 mod history;
 mod keymap;
 mod search;
+mod subagents;
 mod text;
 mod theme;
 mod ui;

--- a/crates/app/bamboo-tui/src/subagents.rs
+++ b/crates/app/bamboo-tui/src/subagents.rs
@@ -1,0 +1,1023 @@
+use std::collections::{HashMap, HashSet};
+
+use chrono::{DateTime, Utc};
+
+use crate::api::types::{AgentEvent, SessionTreeKind, SessionTreeSummary};
+
+pub(crate) const MAX_SUBAGENT_TREE_SESSIONS: usize = 1_000;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum SubagentTreeStatus {
+    #[default]
+    Idle,
+    Running,
+    WaitingForInput,
+    WaitingForPermission,
+    Completed,
+    Cancelled,
+    Error,
+}
+
+impl SubagentTreeStatus {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Running => "running",
+            Self::WaitingForInput => "waiting for input",
+            Self::WaitingForPermission => "waiting for permission",
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+            Self::Error => "error",
+        }
+    }
+
+    pub(crate) fn glyph(self) -> &'static str {
+        match self {
+            Self::Idle => "·",
+            Self::Running => "▶",
+            Self::WaitingForInput => "?",
+            Self::WaitingForPermission => "!",
+            Self::Completed => "✓",
+            Self::Cancelled => "■",
+            Self::Error => "✗",
+        }
+    }
+
+    pub(crate) fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Cancelled | Self::Error)
+    }
+
+    pub(crate) fn is_pending(self) -> bool {
+        matches!(self, Self::WaitingForInput | Self::WaitingForPermission)
+    }
+
+    fn from_terminal_label(label: &str) -> Self {
+        let normalized = label.to_ascii_lowercase();
+        if normalized.contains("error") || normalized.contains("fail") {
+            Self::Error
+        } else if normalized.contains("cancel")
+            || normalized.contains("stop")
+            || normalized.contains("skip")
+        {
+            Self::Cancelled
+        } else if normalized.contains("wait") || normalized.contains("pause") {
+            Self::WaitingForInput
+        } else {
+            Self::Completed
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SubagentTreeNode {
+    pub(crate) summary: SessionTreeSummary,
+    live_status: Option<SubagentTreeStatus>,
+    pub(crate) round_count: Option<u32>,
+    pub(crate) activity: Option<String>,
+    pub(crate) live_error: Option<String>,
+    pub(crate) event_updated_at: Option<DateTime<Utc>>,
+    pub(crate) pending_permission: bool,
+    queued_permission: bool,
+}
+
+impl SubagentTreeNode {
+    fn new(summary: SessionTreeSummary) -> Self {
+        Self {
+            summary,
+            live_status: None,
+            round_count: None,
+            activity: None,
+            live_error: None,
+            event_updated_at: None,
+            pending_permission: false,
+            queued_permission: false,
+        }
+    }
+
+    pub(crate) fn status(&self) -> SubagentTreeStatus {
+        if self.pending_permission || self.queued_permission {
+            return SubagentTreeStatus::WaitingForPermission;
+        }
+        if let Some(status) = self.live_status {
+            return status;
+        }
+        if self.summary.has_pending_question {
+            return SubagentTreeStatus::WaitingForInput;
+        }
+        if self.summary.is_running {
+            return SubagentTreeStatus::Running;
+        }
+        self.summary
+            .last_run_status
+            .as_deref()
+            .map(SubagentTreeStatus::from_terminal_label)
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn title(&self) -> &str {
+        let title = self.summary.title.trim();
+        if title.is_empty() {
+            "sub-agent"
+        } else {
+            title
+        }
+    }
+
+    pub(crate) fn error(&self) -> Option<&str> {
+        self.live_error
+            .as_deref()
+            .or(self.summary.last_run_error.as_deref())
+    }
+
+    pub(crate) fn last_update(&self) -> Option<DateTime<Utc>> {
+        self.event_updated_at
+            .or(self.summary.last_activity_at)
+            .or(self.summary.updated_at)
+    }
+
+    pub(crate) fn metadata_incomplete(&self, root_session_id: &str) -> bool {
+        self.summary.id != root_session_id
+            && (self
+                .summary
+                .parent_session_id
+                .as_deref()
+                .is_none_or(str::is_empty)
+                || self.summary.root_session_id.is_empty()
+                || self.summary.kind == SessionTreeKind::Unknown)
+    }
+
+    fn set_live_status(&mut self, status: SubagentTreeStatus, activity: impl Into<String>) {
+        self.live_status = Some(status);
+        self.activity = Some(activity.into());
+        self.event_updated_at = Some(Utc::now());
+        if status != SubagentTreeStatus::Error {
+            self.live_error = None;
+        }
+    }
+
+    fn note_running(&mut self, activity: impl Into<String>, authoritative_successor: bool) {
+        let current = self.status();
+        if current.is_terminal() && !authoritative_successor {
+            return;
+        }
+        if current.is_pending() && !authoritative_successor {
+            self.activity = Some(activity.into());
+            self.event_updated_at = Some(Utc::now());
+            return;
+        }
+        self.pending_permission = false;
+        self.set_live_status(SubagentTreeStatus::Running, activity);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SubagentTreeRow {
+    pub(crate) session_id: String,
+    pub(crate) depth: usize,
+    pub(crate) has_children: bool,
+    pub(crate) expanded: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct SubagentTreeState {
+    pub(crate) epoch: u64,
+    pub(crate) active_session_id: String,
+    pub(crate) root_session_id: String,
+    pub(crate) nodes: HashMap<String, SubagentTreeNode>,
+    pub(crate) visible: Vec<SubagentTreeRow>,
+    pub(crate) selected: usize,
+    expanded: HashSet<String>,
+    explicitly_collapsed: HashSet<String>,
+    pub(crate) loading_root: bool,
+    pub(crate) loading_page: bool,
+    pub(crate) error: Option<String>,
+    pub(crate) scanned: usize,
+    pub(crate) total: usize,
+    pub(crate) page_limit: usize,
+    pub(crate) next_offset: Option<usize>,
+    pub(crate) capped: bool,
+}
+
+impl SubagentTreeState {
+    pub(crate) fn new(epoch: u64, active_session_id: String) -> Self {
+        Self {
+            epoch,
+            root_session_id: active_session_id.clone(),
+            active_session_id,
+            nodes: HashMap::new(),
+            visible: Vec::new(),
+            selected: 0,
+            expanded: HashSet::new(),
+            explicitly_collapsed: HashSet::new(),
+            loading_root: true,
+            loading_page: false,
+            error: None,
+            scanned: 0,
+            total: 0,
+            page_limit: 0,
+            next_offset: None,
+            capped: false,
+        }
+    }
+
+    pub(crate) fn selected_id(&self) -> Option<&str> {
+        self.visible
+            .get(self.selected)
+            .map(|row| row.session_id.as_str())
+    }
+
+    pub(crate) fn selected_node(&self) -> Option<&SubagentTreeNode> {
+        self.selected_id().and_then(|id| self.nodes.get(id))
+    }
+
+    pub(crate) fn install_root(&mut self, summary: SessionTreeSummary) {
+        self.loading_root = false;
+        self.upsert_summary(summary);
+        self.rebuild();
+    }
+
+    pub(crate) fn install_page(
+        &mut self,
+        sessions: Vec<SessionTreeSummary>,
+        total: usize,
+        limit: usize,
+        offset: usize,
+        next_offset: Option<usize>,
+    ) {
+        self.loading_page = false;
+        self.scanned = self.scanned.max(offset.saturating_add(sessions.len()));
+        self.total = total;
+        if limit > 0 {
+            self.page_limit = limit;
+        }
+        for session in sessions {
+            self.upsert_summary(session);
+        }
+        self.next_offset = next_offset.filter(|_| self.scanned < MAX_SUBAGENT_TREE_SESSIONS);
+        self.capped = self.scanned >= MAX_SUBAGENT_TREE_SESSIONS && self.scanned < total;
+        self.rebuild();
+    }
+
+    fn upsert_summary(&mut self, summary: SessionTreeSummary) {
+        if let Some(existing) = self.nodes.get_mut(&summary.id) {
+            // Live event state is intentionally retained: a page request may
+            // have been issued before the event and complete afterward.
+            existing.summary = summary;
+        } else {
+            self.nodes
+                .insert(summary.id.clone(), SubagentTreeNode::new(summary));
+        }
+    }
+
+    fn ensure_node(&mut self, id: &str) -> &mut SubagentTreeNode {
+        self.nodes
+            .entry(id.to_string())
+            .or_insert_with(|| SubagentTreeNode::new(SessionTreeSummary::placeholder(id)))
+    }
+
+    pub(crate) fn apply_started(
+        &mut self,
+        parent_session_id: &str,
+        child_session_id: &str,
+        title: Option<String>,
+        authoritative_successor: bool,
+    ) {
+        self.ensure_node(parent_session_id);
+        let root = self.root_session_id.clone();
+        let child = self.ensure_node(child_session_id);
+        if child
+            .summary
+            .parent_session_id
+            .as_deref()
+            .is_none_or(str::is_empty)
+        {
+            child.summary.parent_session_id = Some(parent_session_id.to_string());
+        }
+        if child.summary.root_session_id.is_empty() {
+            child.summary.root_session_id = root;
+        }
+        if let Some(title) = title.filter(|title| !title.trim().is_empty()) {
+            child.summary.title = title;
+        }
+        child.note_running("started", authoritative_successor);
+        if authoritative_successor {
+            child.round_count = None;
+        }
+        self.rebuild();
+    }
+
+    pub(crate) fn apply_heartbeat(&mut self, child_session_id: &str) {
+        let child = self.ensure_node(child_session_id);
+        child.note_running("heartbeat", false);
+        self.rebuild();
+    }
+
+    pub(crate) fn apply_completed(
+        &mut self,
+        child_session_id: &str,
+        status: &str,
+        error: Option<String>,
+    ) {
+        let child = self.ensure_node(child_session_id);
+        child.pending_permission = false;
+        child.queued_permission = false;
+        let next = SubagentTreeStatus::from_terminal_label(status);
+        child.set_live_status(next, status);
+        child.live_error = error;
+        self.rebuild();
+    }
+
+    pub(crate) fn apply_runner_progress(&mut self, session_id: &str, round_count: u32) {
+        let child = self.ensure_node(session_id);
+        if child.status().is_terminal() {
+            return;
+        }
+        child.round_count = Some(round_count);
+        // Unlike a heartbeat, exact runner progress proves that a previously
+        // blocked session resumed. Clear the transient pending signal while
+        // still refusing to reopen a terminal generation above.
+        child.pending_permission = false;
+        child.set_live_status(SubagentTreeStatus::Running, format!("round {round_count}"));
+        self.rebuild();
+    }
+
+    pub(crate) fn mark_running(
+        &mut self,
+        session_id: &str,
+        activity: impl Into<String>,
+        authoritative_successor: bool,
+    ) {
+        self.ensure_node(session_id)
+            .note_running(activity, authoritative_successor);
+        self.rebuild();
+    }
+
+    pub(crate) fn mark_waiting_input(&mut self, session_id: &str) {
+        self.ensure_node(session_id)
+            .set_live_status(SubagentTreeStatus::WaitingForInput, "clarification pending");
+        self.rebuild();
+    }
+
+    pub(crate) fn mark_waiting_permission(&mut self, session_id: &str, activity: String) {
+        let node = self.ensure_node(session_id);
+        node.pending_permission = true;
+        node.activity = Some(activity);
+        node.event_updated_at = Some(Utc::now());
+        self.rebuild();
+    }
+
+    pub(crate) fn apply_forwarded_event(&mut self, child_session_id: &str, event: &AgentEvent) {
+        match event {
+            AgentEvent::ExecutionStarted { session_id, .. } if session_id == child_session_id => {
+                self.ensure_node(child_session_id)
+                    .note_running("execution started", true);
+            }
+            AgentEvent::RunnerProgress {
+                session_id,
+                round_count,
+            } if session_id == child_session_id => {
+                self.apply_runner_progress(session_id, *round_count);
+                return;
+            }
+            AgentEvent::NeedClarification { .. } => {
+                self.ensure_node(child_session_id)
+                    .set_live_status(SubagentTreeStatus::WaitingForInput, "clarification pending");
+            }
+            AgentEvent::ToolApprovalRequested { tool_name, .. } => {
+                let child = self.ensure_node(child_session_id);
+                child.pending_permission = true;
+                child.activity = Some(format!("permission for {tool_name}"));
+                child.event_updated_at = Some(Utc::now());
+            }
+            AgentEvent::Complete { .. } => {
+                self.apply_completed(child_session_id, "completed", None);
+                return;
+            }
+            AgentEvent::Cancelled { message } => {
+                self.apply_completed(child_session_id, "cancelled", message.clone());
+                return;
+            }
+            AgentEvent::Error { message } => {
+                self.apply_completed(child_session_id, "error", Some(message.clone()));
+                return;
+            }
+            AgentEvent::SubAgentStarted {
+                child_session_id: descendant_id,
+                title,
+            } => {
+                self.apply_started(child_session_id, descendant_id, title.clone(), true);
+                return;
+            }
+            AgentEvent::SubAgentEvent {
+                child_session_id: descendant_id,
+                event,
+            } => {
+                self.apply_started(child_session_id, descendant_id, None, false);
+                self.apply_forwarded_event(descendant_id, event);
+                return;
+            }
+            AgentEvent::SubAgentHeartbeat {
+                child_session_id: descendant_id,
+            } => {
+                self.apply_heartbeat(descendant_id);
+                return;
+            }
+            AgentEvent::SubAgentCompleted {
+                child_session_id: descendant_id,
+                status,
+                error,
+            } => {
+                self.apply_completed(descendant_id, status, error.clone());
+                return;
+            }
+            AgentEvent::ChildApprovalRequested {
+                child_session_id: requested_child,
+                tool_name,
+                ..
+            } => {
+                let child = self.ensure_node(requested_child);
+                child.pending_permission = true;
+                child.activity = Some(format!("permission for {tool_name}"));
+                child.event_updated_at = Some(Utc::now());
+            }
+            AgentEvent::ChildApprovalChanged {
+                parent_session_id,
+                child_session_id: requested_child,
+                version,
+                status,
+                ..
+            } => {
+                if parent_session_id == child_session_id {
+                    self.apply_child_approval_changed(
+                        parent_session_id,
+                        requested_child,
+                        status,
+                        *version > 0,
+                    );
+                }
+                return;
+            }
+            AgentEvent::Token { .. }
+            | AgentEvent::ReasoningToken { .. }
+            | AgentEvent::ToolToken { .. }
+            | AgentEvent::ToolStart { .. }
+            | AgentEvent::ToolComplete { .. }
+            | AgentEvent::ToolError { .. }
+            | AgentEvent::ToolLifecycle { .. } => {
+                self.ensure_node(child_session_id)
+                    .note_running("active", false);
+            }
+            _ => {}
+        }
+        self.rebuild();
+    }
+
+    /// Apply the durable parent/child approval identity without allowing a
+    /// compatibility terminal frame (version 0) to clear a newer request.
+    pub(crate) fn apply_child_approval_changed(
+        &mut self,
+        parent_session_id: &str,
+        child_session_id: &str,
+        status: &str,
+        authoritative_identity: bool,
+    ) {
+        self.ensure_node(parent_session_id);
+        let root = self.root_session_id.clone();
+        let child = self.ensure_node(child_session_id);
+        if child
+            .summary
+            .parent_session_id
+            .as_deref()
+            .is_none_or(str::is_empty)
+        {
+            child.summary.parent_session_id = Some(parent_session_id.to_string());
+        }
+        if child.summary.root_session_id.is_empty() {
+            child.summary.root_session_id = root;
+        }
+
+        if status == "pending" {
+            child.pending_permission = true;
+            child.activity = Some("approval pending".to_string());
+            child.event_updated_at = Some(Utc::now());
+        } else if authoritative_identity {
+            child.pending_permission = false;
+            child.queued_permission = false;
+            if child.live_status == Some(SubagentTreeStatus::WaitingForPermission) {
+                child.live_status = None;
+            }
+            child.activity = Some(format!("approval {status}"));
+            child.event_updated_at = Some(Utc::now());
+        }
+        self.rebuild();
+    }
+
+    pub(crate) fn sync_pending_permissions<'a>(
+        &mut self,
+        approvals: impl IntoIterator<Item = (&'a str, &'a str)>,
+    ) {
+        let pending = approvals
+            .into_iter()
+            .map(|(parent, child)| (parent.to_string(), child.to_string()))
+            .collect::<Vec<_>>();
+        let pending_ids = pending
+            .iter()
+            .map(|(_, child)| child.clone())
+            .collect::<HashSet<_>>();
+        for node in self.nodes.values_mut() {
+            node.queued_permission = pending_ids.contains(&node.summary.id);
+        }
+        for (parent_id, child_id) in pending {
+            self.ensure_node(&parent_id);
+            let root = self.root_session_id.clone();
+            let child = self.ensure_node(&child_id);
+            if child
+                .summary
+                .parent_session_id
+                .as_deref()
+                .is_none_or(str::is_empty)
+            {
+                child.summary.parent_session_id = Some(parent_id);
+            }
+            if child.summary.root_session_id.is_empty() {
+                child.summary.root_session_id = root;
+            }
+            child.queued_permission = true;
+        }
+        self.rebuild();
+    }
+
+    pub(crate) fn move_selection(&mut self, delta: isize) {
+        if self.visible.is_empty() {
+            self.selected = 0;
+            return;
+        }
+        self.selected = (self.selected as isize + delta)
+            .clamp(0, self.visible.len().saturating_sub(1) as isize)
+            as usize;
+    }
+
+    pub(crate) fn select_first(&mut self) {
+        self.selected = 0;
+    }
+
+    pub(crate) fn select_last(&mut self) {
+        self.selected = self.visible.len().saturating_sub(1);
+    }
+
+    pub(crate) fn expand_or_descend(&mut self) {
+        let Some(row) = self.visible.get(self.selected).cloned() else {
+            return;
+        };
+        if row.has_children && !row.expanded {
+            self.explicitly_collapsed.remove(&row.session_id);
+            self.expanded.insert(row.session_id);
+            self.rebuild();
+            return;
+        }
+        if row.has_children {
+            self.move_selection(1);
+        }
+    }
+
+    pub(crate) fn collapse_or_ascend(&mut self) {
+        let Some(row) = self.visible.get(self.selected).cloned() else {
+            return;
+        };
+        if row.has_children && row.expanded {
+            self.expanded.remove(&row.session_id);
+            self.explicitly_collapsed.insert(row.session_id);
+            self.rebuild();
+            return;
+        }
+        if let Some(parent_id) = self.display_parent(&row.session_id) {
+            if let Some(index) = self
+                .visible
+                .iter()
+                .position(|candidate| candidate.session_id == parent_id)
+            {
+                self.selected = index;
+            }
+        }
+    }
+
+    pub(crate) fn breadcrumb(&self, session_id: &str) -> Vec<String> {
+        self.ancestry_ids(session_id)
+            .into_iter()
+            .filter_map(|id| self.nodes.get(&id))
+            .map(|node| {
+                let title = node.summary.title.trim();
+                if title.is_empty() {
+                    short_session_id(&node.summary.id)
+                } else {
+                    title.to_string()
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn graph_node_count(&self) -> usize {
+        self.graph_ids().len()
+    }
+
+    pub(crate) fn contains_session(&self, session_id: &str) -> bool {
+        self.graph_ids().contains(session_id)
+    }
+
+    fn rebuild(&mut self) {
+        let selected_id = self.selected_id().map(str::to_string);
+        self.root_session_id = self.resolve_root_id();
+        let root_session_id = self.root_session_id.clone();
+        self.nodes
+            .entry(root_session_id.clone())
+            .or_insert_with(|| {
+                SubagentTreeNode::new(SessionTreeSummary::placeholder(root_session_id))
+            });
+
+        if !self.explicitly_collapsed.contains(&self.root_session_id) {
+            self.expanded.insert(self.root_session_id.clone());
+        }
+        for ancestor in self.ancestry_ids(&self.active_session_id) {
+            if !self.explicitly_collapsed.contains(&ancestor) {
+                self.expanded.insert(ancestor);
+            }
+        }
+
+        let graph = self.graph_ids();
+        let mut children: HashMap<String, Vec<String>> = HashMap::new();
+        for id in &graph {
+            if id == &self.root_session_id {
+                continue;
+            }
+            if let Some(parent) = self.display_parent_in_graph(id, &graph) {
+                children.entry(parent).or_default().push(id.clone());
+            }
+        }
+        for siblings in children.values_mut() {
+            siblings.sort_by(|left, right| self.compare_nodes(left, right));
+        }
+
+        self.visible.clear();
+        let mut visited = HashSet::new();
+        self.push_visible(&self.root_session_id.clone(), 0, &children, &mut visited);
+
+        let desired = selected_id
+            .filter(|id| self.visible.iter().any(|row| &row.session_id == id))
+            .unwrap_or_else(|| self.active_session_id.clone());
+        self.selected = self
+            .visible
+            .iter()
+            .position(|row| row.session_id == desired)
+            .unwrap_or(0);
+    }
+
+    fn push_visible(
+        &mut self,
+        session_id: &str,
+        depth: usize,
+        children: &HashMap<String, Vec<String>>,
+        visited: &mut HashSet<String>,
+    ) {
+        if !visited.insert(session_id.to_string()) {
+            return;
+        }
+        let descendants = children.get(session_id);
+        let has_children = descendants.is_some_and(|children| !children.is_empty());
+        let expanded = has_children && self.expanded.contains(session_id);
+        self.visible.push(SubagentTreeRow {
+            session_id: session_id.to_string(),
+            depth,
+            has_children,
+            expanded,
+        });
+        if expanded {
+            for child in descendants.into_iter().flatten() {
+                self.push_visible(child, depth.saturating_add(1), children, visited);
+            }
+        }
+    }
+
+    fn compare_nodes(&self, left: &str, right: &str) -> std::cmp::Ordering {
+        let left_node = self.nodes.get(left);
+        let right_node = self.nodes.get(right);
+        left_node
+            .map(|node| node.summary.spawn_depth)
+            .cmp(&right_node.map(|node| node.summary.spawn_depth))
+            .then_with(|| {
+                left_node
+                    .map(SubagentTreeNode::title)
+                    .unwrap_or_default()
+                    .to_ascii_lowercase()
+                    .cmp(
+                        &right_node
+                            .map(SubagentTreeNode::title)
+                            .unwrap_or_default()
+                            .to_ascii_lowercase(),
+                    )
+            })
+            .then_with(|| left.cmp(right))
+    }
+
+    fn resolve_root_id(&self) -> String {
+        if let Some(active) = self.nodes.get(&self.active_session_id) {
+            if !active.summary.root_session_id.trim().is_empty() {
+                return active.summary.root_session_id.clone();
+            }
+        }
+        let mut current = self.active_session_id.clone();
+        let mut seen = HashSet::new();
+        while seen.insert(current.clone()) {
+            let Some(parent) = self
+                .nodes
+                .get(&current)
+                .and_then(|node| node.summary.parent_session_id.as_deref())
+                .filter(|parent| !parent.trim().is_empty() && *parent != current)
+            else {
+                break;
+            };
+            current = parent.to_string();
+        }
+        current
+    }
+
+    fn graph_ids(&self) -> HashSet<String> {
+        let mut graph = HashSet::from([self.root_session_id.clone()]);
+        for (id, node) in &self.nodes {
+            if node.summary.root_session_id == self.root_session_id {
+                graph.insert(id.clone());
+            }
+        }
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (id, node) in &self.nodes {
+                if graph.contains(id) {
+                    continue;
+                }
+                if node
+                    .summary
+                    .parent_session_id
+                    .as_ref()
+                    .is_some_and(|parent| graph.contains(parent))
+                {
+                    graph.insert(id.clone());
+                    changed = true;
+                }
+            }
+        }
+        for id in self.ancestry_ids(&self.active_session_id) {
+            graph.insert(id);
+        }
+        graph.insert(self.active_session_id.clone());
+        graph
+    }
+
+    fn display_parent(&self, session_id: &str) -> Option<String> {
+        self.display_parent_in_graph(session_id, &self.graph_ids())
+    }
+
+    fn display_parent_in_graph(&self, session_id: &str, graph: &HashSet<String>) -> Option<String> {
+        if session_id == self.root_session_id {
+            return None;
+        }
+        let node = self.nodes.get(session_id)?;
+        if let Some(parent) = node
+            .summary
+            .parent_session_id
+            .as_deref()
+            .filter(|parent| *parent != session_id && graph.contains(*parent))
+        {
+            return Some(parent.to_string());
+        }
+        graph
+            .contains(&self.root_session_id)
+            .then(|| self.root_session_id.clone())
+    }
+
+    fn ancestry_ids(&self, session_id: &str) -> Vec<String> {
+        let graph = self.graph_ids_without_ancestry();
+        let mut path = Vec::new();
+        let mut current = session_id.to_string();
+        let mut seen = HashSet::new();
+        while seen.insert(current.clone()) {
+            path.push(current.clone());
+            if current == self.root_session_id {
+                break;
+            }
+            let Some(parent) = self.display_parent_in_graph(&current, &graph) else {
+                break;
+            };
+            current = parent;
+        }
+        path.reverse();
+        path
+    }
+
+    /// Graph seed used while computing ancestry. Keeping it separate avoids a
+    /// graph_ids -> ancestry_ids recursion for malformed legacy metadata.
+    fn graph_ids_without_ancestry(&self) -> HashSet<String> {
+        let mut graph = HashSet::from([self.root_session_id.clone()]);
+        for (id, node) in &self.nodes {
+            if node.summary.root_session_id == self.root_session_id || id == &self.active_session_id
+            {
+                graph.insert(id.clone());
+            }
+        }
+        for id in self.nodes.keys() {
+            graph.insert(id.clone());
+        }
+        graph
+    }
+}
+
+pub(crate) fn short_session_id(id: &str) -> String {
+    const MAX: usize = 8;
+    let mut chars = id.chars();
+    let prefix = chars.by_ref().take(MAX).collect::<String>();
+    if chars.next().is_some() {
+        format!("{prefix}…")
+    } else {
+        prefix
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(id: &str, parent: Option<&str>, root: &str, depth: u32) -> SessionTreeSummary {
+        let mut summary = SessionTreeSummary::placeholder(id);
+        summary.kind = if parent.is_some() {
+            SessionTreeKind::Child
+        } else {
+            SessionTreeKind::Root
+        };
+        summary.title = id.to_string();
+        summary.parent_session_id = parent.map(str::to_string);
+        summary.root_session_id = root.to_string();
+        summary.spawn_depth = depth;
+        summary
+    }
+
+    fn populated_tree() -> SubagentTreeState {
+        let mut tree = SubagentTreeState::new(7, "child-b".to_string());
+        tree.install_root(summary("child-b", Some("root"), "root", 1));
+        tree.install_page(
+            vec![
+                summary("root", None, "root", 0),
+                summary("child-a", Some("root"), "root", 1),
+                summary("child-b", Some("root"), "root", 1),
+                summary("grandchild", Some("child-b"), "root", 2),
+                summary("unrelated", None, "unrelated", 0),
+            ],
+            5,
+            5,
+            0,
+            None,
+        );
+        tree
+    }
+
+    #[test]
+    fn concurrent_siblings_and_nested_descendants_build_one_unambiguous_tree() {
+        let tree = populated_tree();
+        assert_eq!(tree.root_session_id, "root");
+        assert_eq!(tree.graph_node_count(), 4);
+        let ids = tree
+            .visible
+            .iter()
+            .map(|row| (row.session_id.as_str(), row.depth))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ids,
+            vec![
+                ("root", 0),
+                ("child-a", 1),
+                ("child-b", 1),
+                ("grandchild", 2)
+            ]
+        );
+        assert_eq!(
+            tree.breadcrumb("grandchild"),
+            ["root", "child-b", "grandchild"]
+        );
+        assert!(
+            tree.nodes.contains_key("unrelated"),
+            "the bounded scan retains source rows"
+        );
+        assert!(tree.visible.iter().all(|row| row.session_id != "unrelated"));
+    }
+
+    #[test]
+    fn terminal_child_ignores_stale_start_heartbeat_and_wrong_progress_identity() {
+        let mut tree = populated_tree();
+        tree.apply_completed("child-b", "completed", None);
+        tree.apply_heartbeat("child-b");
+        tree.apply_started("root", "child-b", None, false);
+        tree.apply_forwarded_event(
+            "child-b",
+            &AgentEvent::RunnerProgress {
+                session_id: "child-a".to_string(),
+                round_count: 99,
+            },
+        );
+        let child = &tree.nodes["child-b"];
+        assert_eq!(child.status(), SubagentTreeStatus::Completed);
+        assert_eq!(child.round_count, None);
+
+        tree.apply_started("root", "child-b", Some("resident reused".into()), true);
+        assert_eq!(tree.nodes["child-b"].status(), SubagentTreeStatus::Running);
+        assert_eq!(tree.nodes["child-b"].title(), "resident reused");
+    }
+
+    #[test]
+    fn reconnect_replay_and_late_page_cannot_regress_terminal_child() {
+        let mut tree = populated_tree();
+        let completion = AgentEvent::Complete {
+            usage: crate::api::types::TokenUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            },
+        };
+
+        tree.apply_forwarded_event("child-b", &completion);
+        tree.apply_forwarded_event("child-b", &completion);
+        tree.apply_heartbeat("child-b");
+
+        let mut stale_page = summary("child-b", Some("root"), "root", 1);
+        stale_page.is_running = true;
+        stale_page.last_run_status = None;
+        tree.install_page(vec![stale_page], 5, 5, 0, None);
+
+        let child = &tree.nodes["child-b"];
+        assert_eq!(child.status(), SubagentTreeStatus::Completed);
+        assert_eq!(child.activity.as_deref(), Some("completed"));
+    }
+
+    #[test]
+    fn pending_permission_is_bound_to_the_exact_child() {
+        let mut tree = populated_tree();
+        tree.sync_pending_permissions([("root", "child-a")]);
+        assert_eq!(
+            tree.nodes["child-a"].status(),
+            SubagentTreeStatus::WaitingForPermission
+        );
+        assert_ne!(
+            tree.nodes["child-b"].status(),
+            SubagentTreeStatus::WaitingForPermission
+        );
+    }
+
+    #[test]
+    fn exact_progress_and_authoritative_approval_resolution_clear_pending_state() {
+        let mut tree = populated_tree();
+        tree.mark_waiting_input("child-a");
+        tree.apply_runner_progress("child-a", 4);
+        assert_eq!(tree.nodes["child-a"].status(), SubagentTreeStatus::Running);
+
+        tree.apply_child_approval_changed("root", "child-a", "pending", true);
+        assert_eq!(
+            tree.nodes["child-a"].status(),
+            SubagentTreeStatus::WaitingForPermission
+        );
+        tree.apply_child_approval_changed("root", "child-a", "approved", false);
+        assert_eq!(
+            tree.nodes["child-a"].status(),
+            SubagentTreeStatus::WaitingForPermission,
+            "a compatibility terminal frame cannot clear a concrete request"
+        );
+        tree.apply_child_approval_changed("root", "child-a", "approved", true);
+        assert_eq!(tree.nodes["child-a"].status(), SubagentTreeStatus::Running);
+    }
+
+    #[test]
+    fn resident_remote_and_error_metadata_survive_page_projection() {
+        let mut tree = SubagentTreeState::new(1, "root".into());
+        tree.install_root(summary("root", None, "root", 0));
+        let mut child = summary("resident", Some("root"), "root", 1);
+        child.lifecycle = Some("resident".into());
+        child.resident_name = Some("reviewer".into());
+        child.subagent_type = Some("guardian".into());
+        child.placement.kind = "ssh".into();
+        child.placement.host = "worker.example".into();
+        child.last_run_status = Some("error".into());
+        child.last_run_error = Some("boom".into());
+        tree.install_page(vec![child], 1, 1, 0, None);
+        let node = &tree.nodes["resident"];
+        assert_eq!(node.status(), SubagentTreeStatus::Error);
+        assert_eq!(node.error(), Some("boom"));
+        assert_eq!(node.summary.lifecycle.as_deref(), Some("resident"));
+        assert_eq!(node.summary.placement.host, "worker.example");
+    }
+
+    #[test]
+    fn legacy_active_session_without_relationship_metadata_degrades_to_one_root() {
+        let mut tree = SubagentTreeState::new(1, "legacy".into());
+        tree.install_root(SessionTreeSummary::placeholder("legacy"));
+        tree.install_page(Vec::new(), 0, 100, 0, None);
+        assert_eq!(tree.root_session_id, "legacy");
+        assert_eq!(tree.visible.len(), 1);
+        assert_eq!(tree.visible[0].session_id, "legacy");
+    }
+}

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -3327,6 +3327,12 @@ mod tests {
                 "generated help omitted {needle:?}"
             );
         }
+        assert!(
+            generated
+                .iter()
+                .any(|entry| entry.description.contains("Sub-agent tree")),
+            "generated help omitted the global sub-agent tree action"
+        );
 
         app.help_scroll = app.help_max_scroll.get();
         terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
@@ -3367,7 +3373,7 @@ mod tests {
         }
         assert_eq!(
             fingerprints,
-            [17_065_867_340_943_315_060, 12_487_818_554_989_084_324,],
+            [10_497_738_457_900_557_685, 4_621_970_272_475_212_681,],
             "complete help-overlay buffer golden changed"
         );
     }

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -6,6 +6,7 @@ pub mod permissions;
 pub mod schedules;
 pub mod sessions;
 pub mod skills;
+pub mod subagents;
 
 use ratatui::Frame;
 
@@ -81,6 +82,10 @@ fn render_with_palette(f: &mut Frame, app: &App) {
 
     if app.session_picker.is_some() {
         layout::render_session_picker(f, app);
+    }
+
+    if app.subagent_tree.is_some() {
+        subagents::render(f, app);
     }
 
     if app.pending_delete.is_some() || app.pending_schedule_delete.is_some() {

--- a/crates/app/bamboo-tui/src/ui/subagents.rs
+++ b/crates/app/bamboo-tui/src/ui/subagents.rs
@@ -1,0 +1,499 @@
+use chrono::{DateTime, Utc};
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+use crate::api::types::SessionTreeKind;
+use crate::app::App;
+use crate::keymap::{ActionContext, ActionId};
+use crate::subagents::{short_session_id, SubagentTreeNode, SubagentTreeState, SubagentTreeStatus};
+use crate::theme::colors;
+
+pub fn render(f: &mut Frame, app: &App) {
+    let Some(tree) = &app.subagent_tree else {
+        return;
+    };
+    let screen = f.area();
+    let area = centered_rect(96, screen.height.saturating_sub(2).max(1), screen);
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let footer = [
+        format!(
+            "{} / {} move · {} / {} branch · {} open",
+            app.primary_key_hint(ActionContext::SubagentTree, ActionId::NavigateUp),
+            app.primary_key_hint(ActionContext::SubagentTree, ActionId::NavigateDown),
+            app.primary_key_hint(ActionContext::SubagentTree, ActionId::CollapseTreeNode),
+            app.primary_key_hint(ActionContext::SubagentTree, ActionId::ExpandTreeNode),
+            app.primary_key_hint(ActionContext::SubagentTree, ActionId::Activate),
+        ),
+        format!(
+            "{} pending · {} refresh · {} close",
+            app.primary_key_hint(ActionContext::SubagentTree, ActionId::OpenPendingRequest),
+            app.primary_key_hint(ActionContext::SubagentTree, ActionId::Refresh),
+            app.primary_key_hint(ActionContext::SubagentTree, ActionId::Cancel),
+        ),
+    ];
+    let lines = tree_lines(
+        tree,
+        inner_width,
+        area.height.saturating_sub(2) as usize,
+        Utc::now(),
+        &footer,
+    );
+
+    f.render_widget(Clear, area);
+    f.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(colors::brand()))
+                .title(" Sub-agents "),
+        ),
+        area,
+    );
+}
+
+fn tree_lines<'a>(
+    tree: &SubagentTreeState,
+    width: usize,
+    height: usize,
+    now: DateTime<Utc>,
+    footer: &'a [String; 2],
+) -> Vec<Line<'a>> {
+    let compact = width < 76;
+    let selected_path = tree
+        .selected_id()
+        .map(|id| tree.breadcrumb(id).join(" › "))
+        .unwrap_or_else(|| "loading".to_string());
+    let active_path = tree.breadcrumb(&tree.active_session_id).join(" › ");
+    let mut lines = vec![Line::from(vec![
+        Span::styled(
+            " Session graph ",
+            Style::default()
+                .fg(colors::brand())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{} nodes", tree.graph_node_count()),
+            Style::default().fg(colors::subtle()),
+        ),
+    ])];
+    lines.push(Line::from(vec![
+        Span::styled(" Active path: ", Style::default().fg(colors::subtle())),
+        Span::styled(
+            truncate(&active_path, width.saturating_sub(14)),
+            Style::default().fg(colors::inactive()),
+        ),
+    ]));
+
+    if tree.loading_root {
+        lines.push(Line::raw(" Loading active session metadata..."));
+    } else if tree.loading_page {
+        lines.push(Line::raw(format!(
+            " Scanning session index: {} / {}...",
+            tree.scanned, tree.total
+        )));
+    } else {
+        lines.push(Line::raw(format!(
+            " Scanned {} / {}{}",
+            tree.scanned,
+            tree.total,
+            if tree.capped {
+                " · memory cap reached"
+            } else {
+                ""
+            }
+        )));
+    }
+    if let Some(error) = &tree.error {
+        lines.push(Line::from(Span::styled(
+            format!(" ! {}", truncate(error, width.saturating_sub(3))),
+            Style::default().fg(colors::error()),
+        )));
+    }
+
+    let detail_rows = tree
+        .selected_node()
+        .map(|node| 4 + usize::from(compact || node.error().is_some()))
+        .unwrap_or(1);
+    let fixed_rows = lines.len() + detail_rows + footer.len() + 1;
+    // Reserve both overflow indicators. Otherwise a long tree can push the
+    // selected details or keyboard footer below the viewport by two rows.
+    let list_capacity = height.saturating_sub(fixed_rows.saturating_add(2)).max(1);
+    let total = tree.visible.len();
+    let selected = tree.selected.min(total.saturating_sub(1));
+    let mut start = selected.saturating_sub(list_capacity / 2);
+    if start + list_capacity > total {
+        start = total.saturating_sub(list_capacity);
+    }
+    let end = (start + list_capacity).min(total);
+    if start > 0 {
+        lines.push(Line::from(Span::styled(
+            format!(" ↑ {start} hidden"),
+            Style::default().fg(colors::subtle()),
+        )));
+    }
+    for (index, row) in tree
+        .visible
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(end.saturating_sub(start))
+    {
+        let Some(node) = tree.nodes.get(&row.session_id) else {
+            continue;
+        };
+        lines.push(tree_row(
+            node,
+            row.depth,
+            row.has_children,
+            row.expanded,
+            row.session_id == tree.active_session_id,
+            index == selected,
+            width,
+            compact,
+        ));
+    }
+    if end < total {
+        lines.push(Line::from(Span::styled(
+            format!(" ↓ {} hidden", total - end),
+            Style::default().fg(colors::subtle()),
+        )));
+    }
+
+    lines.push(Line::raw(""));
+    if let Some(node) = tree.selected_node() {
+        lines.extend(selected_details(
+            node,
+            &tree.root_session_id,
+            &selected_path,
+            width,
+            compact,
+            now,
+        ));
+    } else {
+        lines.push(Line::raw(" No session rows loaded"));
+    }
+
+    for footer in footer {
+        lines.push(Line::from(Span::styled(
+            format!(" {}", truncate(footer, width.saturating_sub(1))),
+            Style::default().fg(colors::subtle()),
+        )));
+    }
+    lines
+}
+
+#[allow(clippy::too_many_arguments)]
+fn tree_row<'a>(
+    node: &SubagentTreeNode,
+    depth: usize,
+    has_children: bool,
+    expanded: bool,
+    active: bool,
+    selected: bool,
+    width: usize,
+    compact: bool,
+) -> Line<'a> {
+    let status = node.status();
+    let branch = if has_children {
+        if expanded {
+            "▾"
+        } else {
+            "▸"
+        }
+    } else {
+        "•"
+    };
+    let depth = depth.min(6);
+    let indent = if depth < 6 {
+        "  ".repeat(depth)
+    } else {
+        "… ".to_string() + &"  ".repeat(4)
+    };
+    let active = if active { "*" } else { " " };
+    let status_text = if compact {
+        format!("{} {}", status.glyph(), status.label())
+    } else {
+        format!("{} {:<22}", status.glyph(), status.label())
+    };
+    let prefix = format!(" {active}{indent}{branch} {status_text} ");
+    let id = short_session_id(&node.summary.id);
+    let suffix = format!("{} [{id}]", node.title());
+    let style = if selected {
+        Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    let status_style = style.fg(status_color(status));
+    Line::from(vec![
+        Span::styled(truncate(&prefix, width), status_style),
+        Span::styled(
+            truncate(&suffix, width.saturating_sub(display_width(&prefix))),
+            style,
+        ),
+    ])
+}
+
+fn selected_details<'a>(
+    node: &SubagentTreeNode,
+    root_session_id: &str,
+    selected_path: &str,
+    width: usize,
+    compact: bool,
+    now: DateTime<Utc>,
+) -> Vec<Line<'a>> {
+    let role = node
+        .summary
+        .subagent_type
+        .as_deref()
+        .unwrap_or(match node.summary.kind {
+            SessionTreeKind::Root => "root",
+            SessionTreeKind::Child => "child",
+            SessionTreeKind::Unknown => "unknown role",
+        });
+    let lifecycle = match (
+        node.summary.lifecycle.as_deref(),
+        node.summary.resident_name.as_deref(),
+    ) {
+        (Some("resident"), Some(name)) => format!("resident:{name}"),
+        (Some(value), _) => value.to_string(),
+        (None, _) if node.summary.kind == SessionTreeKind::Child => "one-shot".to_string(),
+        (None, _) => "root".to_string(),
+    };
+    let placement = match (
+        node.summary.placement.kind.trim(),
+        node.summary.placement.host.trim(),
+    ) {
+        ("", "") => "placement unknown".to_string(),
+        ("", host) => host.to_string(),
+        (kind, "") => kind.to_string(),
+        (kind, host) => format!("{kind}@{host}"),
+    };
+    let updated = node
+        .last_update()
+        .map(|at| relative_age(now, at))
+        .unwrap_or_else(|| "update unknown".to_string());
+    let round = node
+        .round_count
+        .map(|round| format!("round {round}"))
+        .or_else(|| node.activity.clone())
+        .unwrap_or_else(|| "no live activity".to_string());
+    let metadata = if node.metadata_incomplete(root_session_id) {
+        " · legacy metadata incomplete"
+    } else {
+        ""
+    };
+    let mut lines = vec![Line::from(vec![
+        Span::styled(" Selected path: ", Style::default().fg(colors::subtle())),
+        Span::raw(truncate(selected_path, width.saturating_sub(16))),
+    ])];
+    if compact {
+        lines.push(Line::raw(format!(
+            " {} · {}{}",
+            truncate(&format!("{role} · {lifecycle}"), width.saturating_sub(2)),
+            node.status().label(),
+            metadata,
+        )));
+        lines.push(Line::raw(format!(
+            " {}",
+            truncate(
+                &format!("{placement} · model {}", fallback(&node.summary.model)),
+                width.saturating_sub(1)
+            )
+        )));
+        lines.push(Line::raw(format!(
+            " {} · {updated}",
+            truncate(&round, width / 2)
+        )));
+    } else {
+        lines.push(Line::raw(format!(
+            " Role/lifecycle: {role} · {lifecycle}{metadata}"
+        )));
+        lines.push(Line::raw(format!(
+            " Placement/model: {}",
+            truncate(
+                &format!("{placement} · {}", fallback(&node.summary.model)),
+                width.saturating_sub(18)
+            )
+        )));
+        lines.push(Line::raw(format!(" Activity: {round} · {updated}")));
+    }
+    if let Some(error) = node.error() {
+        lines.push(Line::from(Span::styled(
+            format!(" Error: {}", truncate(error, width.saturating_sub(8))),
+            Style::default().fg(colors::error()),
+        )));
+    } else if compact {
+        lines.push(Line::raw(""));
+    }
+    lines
+}
+
+fn fallback(value: &str) -> &str {
+    if value.trim().is_empty() {
+        "unknown"
+    } else {
+        value
+    }
+}
+
+fn relative_age(now: DateTime<Utc>, at: DateTime<Utc>) -> String {
+    let seconds = now.signed_duration_since(at).num_seconds().max(0);
+    if seconds < 5 {
+        "updated now".to_string()
+    } else if seconds < 60 {
+        format!("updated {seconds}s ago")
+    } else if seconds < 3_600 {
+        format!("updated {}m ago", seconds / 60)
+    } else if seconds < 86_400 {
+        format!("updated {}h ago", seconds / 3_600)
+    } else {
+        format!("updated {}d ago", seconds / 86_400)
+    }
+}
+
+fn status_color(status: SubagentTreeStatus) -> ratatui::style::Color {
+    match status {
+        SubagentTreeStatus::Running => colors::tool_running(),
+        SubagentTreeStatus::WaitingForInput | SubagentTreeStatus::WaitingForPermission => {
+            colors::warning()
+        }
+        SubagentTreeStatus::Completed => colors::success(),
+        SubagentTreeStatus::Cancelled => colors::inactive(),
+        SubagentTreeStatus::Error => colors::error(),
+        SubagentTreeStatus::Idle => colors::subtle(),
+    }
+}
+
+fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let width = (area.width as u32 * percent_x as u32 / 100) as u16;
+    let x = area.width.saturating_sub(width) / 2;
+    let y = area.height.saturating_sub(height) / 2;
+    Rect::new(
+        area.x + x,
+        area.y + y,
+        width.min(area.width),
+        height.min(area.height),
+    )
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    crate::text::truncate_cells(value, width)
+}
+
+fn display_width(value: &str) -> usize {
+    crate::text::display_width(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::{SessionTreeKind, SessionTreeSummary};
+    use crate::api::BambooClient;
+    use crate::app::App;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn summary(id: &str, parent: Option<&str>, depth: u32) -> SessionTreeSummary {
+        let mut value = SessionTreeSummary::placeholder(id);
+        value.kind = if parent.is_some() {
+            SessionTreeKind::Child
+        } else {
+            SessionTreeKind::Root
+        };
+        value.title = match id {
+            "root" => "Root session",
+            "child" => "Research child",
+            _ => "Nested reviewer",
+        }
+        .to_string();
+        value.parent_session_id = parent.map(str::to_string);
+        value.root_session_id = "root".to_string();
+        value.spawn_depth = depth;
+        value.model = "gpt-5".to_string();
+        value
+    }
+
+    fn app_with_tree() -> App {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("child".to_string());
+        let mut tree = SubagentTreeState::new(1, "child".to_string());
+        tree.install_root(summary("child", Some("root"), 1));
+        let mut child = summary("child", Some("root"), 1);
+        child.subagent_type = Some("researcher".to_string());
+        child.lifecycle = Some("resident".to_string());
+        child.resident_name = Some("research".to_string());
+        child.placement.kind = "ssh".to_string();
+        child.placement.host = "worker.example".to_string();
+        child.has_pending_question = true;
+        tree.install_page(
+            vec![
+                summary("root", None, 0),
+                child,
+                summary("grandchild", Some("child"), 2),
+            ],
+            3,
+            100,
+            0,
+            None,
+        );
+        app.subagent_tree = Some(tree);
+        app
+    }
+
+    #[test]
+    fn tree_overlay_is_responsive_and_never_hides_identity_behind_color() {
+        for width in [60, 80, 120] {
+            let app = app_with_tree();
+            let mut terminal = Terminal::new(TestBackend::new(width, 24)).unwrap();
+            terminal
+                .draw(|frame| crate::ui::render(frame, &app))
+                .unwrap();
+            let text = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect::<String>();
+            assert!(text.contains("Active path"), "{width}: {text}");
+            assert!(text.contains("waiting for input"), "{width}: {text}");
+            assert!(text.contains("Research child"), "{width}: {text}");
+        }
+    }
+
+    #[test]
+    fn long_tree_keeps_details_and_keyboard_footer_inside_the_viewport() {
+        let mut tree = SubagentTreeState::new(1, "root".to_string());
+        tree.install_root(summary("root", None, 0));
+        let mut sessions = vec![summary("root", None, 0)];
+        sessions.extend((0..30).map(|index| {
+            let id = format!("child-{index:02}");
+            summary(&id, Some("root"), 1)
+        }));
+        tree.install_page(sessions, 31, 100, 0, None);
+        tree.select_last();
+        let footer = [
+            "move · branch · open".to_string(),
+            "pending · refresh · close".to_string(),
+        ];
+        let height = 18;
+
+        let lines = tree_lines(&tree, 58, height, Utc::now(), &footer);
+
+        assert!(
+            lines.len() <= height,
+            "{} lines exceeded {height}",
+            lines.len()
+        );
+        let text = lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Selected path"), "{text}");
+        assert!(text.contains("pending · refresh · close"), "{text}");
+    }
+}


### PR DESCRIPTION
## Summary

- add a persistent, focusable parent/child session tree to `bamboo-tui` behind `Leader a`
- reconstruct completed and nested child sessions from durable relationship metadata, then merge identity-safe live progress, approval, clarification, reconnect, and terminal events
- preserve cached parent/child transcript state while navigating, including scroll, expanded blocks, selection, composer draft, pending-request ownership, and explicit breadcrumbs
- render responsive compact/detail views with non-color-only lifecycle labels, placement/model/error metadata, and bounded long-tree scrolling

## Acceptance coverage

- concurrent siblings and nested descendants use stable session/run identity and keyboard tree navigation
- duplicate, stale, mismatched, and replayed events cannot mutate the wrong child row
- completed, errored, cancelled, resident-reused, remote, and legacy sessions remain reconstructable and inspectable
- child transcript navigation restores the exact parent UI context
- approval and clarification badges route to the request owned by the exact session
- responsive `TestBackend` coverage exercises 60-, 80-, and 120-column layouts, breadcrumbs, non-color-only status, and long-tree viewport bounds

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-tui --all-targets -- -D warnings`
- `cargo test -p bamboo-client-core`
- `cargo test -p bamboo-tui`
- `cargo test`

## Screenshots

The terminal UI is verified as rendered cells rather than a browser bitmap. Responsive `TestBackend` snapshots cover the compact and detailed layouts at 60, 80, and 120 columns, plus overflow behavior for long trees.

```text
Sub-agents  root / planner / researcher
▾ [running] planner      local   gpt-5
  ├─ [input] researcher remote  gpt-5
  └─ [done]  verifier   local   gpt-5
```

Closes #645
