### PR TITLE
feat(tui): add capability-aware model and reasoning controls

### DIFF
--- a/crates/app/bamboo-client-core/src/lib.rs
+++ b/crates/app/bamboo-client-core/src/lib.rs
@@ -13,6 +13,33 @@ fn default_allow_custom() -> bool {
     true
 }
 
+/// Provider-agnostic reasoning levels accepted by Bamboo's session and
+/// execute contracts. Keeping this wire enum in the shared client crate makes
+/// every front-end serialize the same canonical lowercase values.
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningEffort {
+    Low,
+    Medium,
+    High,
+    Xhigh,
+    Max,
+}
+
+impl ReasoningEffort {
+    pub const ALL: [Self; 5] = [Self::Low, Self::Medium, Self::High, Self::Xhigh, Self::Max];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Xhigh => "xhigh",
+            Self::Max => "max",
+        }
+    }
+}
+
 // ── Chat ──
 
 #[derive(Serialize, Clone, Debug)]
@@ -32,6 +59,10 @@ pub struct ChatRequest {
     /// provider was previously active for a same-named model.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+    /// Optional execution-profile override. Omission delegates to the
+    /// provider/session default instead of inventing a client-side level.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -53,10 +84,12 @@ mod chat_request_tests {
             project_id: Some("project-client".to_string()),
             model: Some("gpt-5".to_string()),
             provider: Some("openai".to_string()),
+            reasoning_effort: Some(super::ReasoningEffort::High),
         })
         .unwrap();
         assert_eq!(value["project_id"], "project-client");
         assert_eq!(value["provider"], "openai");
+        assert_eq!(value["reasoning_effort"], "high");
         assert!(value.get("session_id").is_none());
     }
 }
@@ -69,6 +102,8 @@ pub struct ExecuteRequest {
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
 }
 
 #[cfg(test)]
@@ -80,10 +115,12 @@ mod execute_request_tests {
         let value = serde_json::to_value(ExecuteRequest {
             model: Some("shared".to_string()),
             provider: Some("provider-b".to_string()),
+            reasoning_effort: Some(super::ReasoningEffort::Xhigh),
         })
         .unwrap();
         assert_eq!(value["model"], "shared");
         assert_eq!(value["provider"], "provider-b");
+        assert_eq!(value["reasoning_effort"], "xhigh");
     }
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -415,6 +415,7 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
         model: model.clone(),
         model_ref: req.model_ref.clone(),
         provider: req.provider.clone(),
+        reasoning_effort: req.reasoning_effort,
         message: req.message.clone(),
         system_prompt: request::optional_non_empty(req.system_prompt.as_deref()).map(String::from),
         enhance_prompt: request::optional_non_empty(req.enhance_prompt.as_deref())

--- a/crates/app/bamboo-server/src/handlers/agent/chat/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/tests.rs
@@ -73,6 +73,7 @@ fn chat_request_blank_model_trims_to_empty() {
         model: Some("   ".to_string()),
         provider: None,
         model_ref: None,
+        reasoning_effort: None,
     };
     // A whitespace-only model is treated the same as an absent one by the
     // handler's `request::resolve_model` (falls back to the server default).

--- a/crates/app/bamboo-server/src/handlers/agent/chat/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/types.rs
@@ -1,4 +1,4 @@
-use bamboo_domain::ProviderModelRef;
+use bamboo_domain::{reasoning::ReasoningEffort, ProviderModelRef};
 use serde::{Deserialize, Serialize};
 
 /// Request payload for creating a new chat message.
@@ -48,6 +48,11 @@ pub struct ChatRequest {
     pub provider: Option<String>,
     #[serde(default)]
     pub model_ref: Option<ProviderModelRef>,
+    /// Optional per-session execution-profile override for a newly-created
+    /// chat. Existing sessions retain their stored value unless changed via
+    /// the CAS-guarded session PATCH endpoint.
+    #[serde(default)]
+    pub reasoning_effort: Option<ReasoningEffort>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -173,10 +178,12 @@ mod tests {
             model: Some("gpt-4".to_string()),
             provider: None,
             model_ref: None,
+            reasoning_effort: Some(ReasoningEffort::High),
         };
         let debug_str = format!("{:?}", req);
         assert!(debug_str.contains("ChatRequest"));
         assert!(debug_str.contains("Test"));
+        assert!(debug_str.contains("High"));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -632,17 +632,17 @@ pub async fn patch_session(
             req.model.as_deref(),
         );
 
-        // A typed permission write is authoritative and CAS-guarded. The
-        // expected revision is the exact value produced by the preceding
-        // operations in this request, never a lock-free reload of whatever a
-        // third party may have committed in the gap.
+        // Every execution-profile/permission write honors an optional
+        // `If-Match`. The expected revision is the exact value produced by any
+        // preceding operations in this request, never a lock-free reload of
+        // whatever a third party may have committed in the gap.
         #[cfg(test)]
         let earlier_authoritative_field = req.project_id.is_some()
             || req.workspace_path.is_some()
             || req.title.is_some()
             || req.pinned.is_some()
             || req.gold_config.is_some();
-        let permission_expected_version = req.permission_mode.and(precondition);
+        let config_expected_version = precondition;
 
         #[cfg(test)]
         if req.permission_mode.is_some() && earlier_authoritative_field {
@@ -670,7 +670,7 @@ pub async fn patch_session(
                 "session_id": session_id
             })));
         };
-        if let Some(expected) = permission_expected_version {
+        if let Some(expected) = config_expected_version {
             if session.metadata_version != expected {
                 return Ok(precondition_failed(&session_id, session.metadata_version));
             }
@@ -736,11 +736,14 @@ pub async fn patch_session(
                     ))
                 })?;
             }
-            session.metadata_version = session.metadata_version.saturating_add(1);
         }
 
         let model_changed = session.model != prev_model || session.model_ref != prev_model_ref;
         let reasoning_changed = session.reasoning_effort != prev_reasoning;
+        let config_changed = model_changed || reasoning_changed || permission_transition.is_some();
+        if config_changed {
+            session.metadata_version = session.metadata_version.saturating_add(1);
+        }
         session.updated_at = chrono::Utc::now();
         state
             .persistence
@@ -932,6 +935,95 @@ mod tests {
         assert_eq!(
             indexed.permission_mode,
             bamboo_domain::SessionPermissionMode::Auto
+        );
+    }
+
+    #[actix_web::test]
+    async fn execution_profile_patch_is_atomic_versioned_and_rejects_stale_writes() {
+        let state = new_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let id = create_session!(app);
+        let initial_version = state
+            .storage
+            .load_session(&id)
+            .await
+            .expect("load")
+            .expect("session")
+            .metadata_version;
+        let initial_etag = format!("\"{initial_version}\"");
+
+        let updated = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/v1/sessions/{id}"))
+                .insert_header((header::IF_MATCH, initial_etag.as_str()))
+                .set_json(serde_json::json!({
+                    "model": "shared",
+                    "provider": "provider-b",
+                    "reasoning_effort": "xhigh"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(updated.status(), StatusCode::OK);
+        let updated_etag = format!("\"{}\"", initial_version.saturating_add(1));
+        assert_eq!(
+            updated
+                .headers()
+                .get(header::ETAG)
+                .and_then(|value| value.to_str().ok()),
+            Some(updated_etag.as_str())
+        );
+        let body: Value = test::read_body_json(updated).await;
+        assert_eq!(body["session"]["model"], "shared");
+        assert_eq!(body["session"]["model_ref"]["provider"], "provider-b");
+        assert_eq!(body["session"]["reasoning_effort"], "xhigh");
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/v1/sessions/{id}"))
+                .insert_header((header::IF_MATCH, initial_etag.as_str()))
+                .set_json(serde_json::json!({
+                    "model": "other",
+                    "provider": "provider-c",
+                    "clear_reasoning_effort": true
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), StatusCode::PRECONDITION_FAILED);
+        assert_eq!(
+            stale
+                .headers()
+                .get(header::ETAG)
+                .and_then(|value| value.to_str().ok()),
+            Some(updated_etag.as_str())
+        );
+
+        let persisted = state
+            .storage
+            .load_session(&id)
+            .await
+            .expect("load")
+            .expect("session");
+        assert_eq!(persisted.metadata_version, initial_version + 1);
+        assert_eq!(persisted.model, "shared");
+        assert_eq!(
+            persisted
+                .model_ref
+                .as_ref()
+                .map(|model| model.provider.as_str()),
+            Some("provider-b")
+        );
+        assert_eq!(
+            persisted.reasoning_effort,
+            Some(bamboo_domain::ReasoningEffort::Xhigh)
         );
     }
 

--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -32,7 +32,7 @@ impl SessionMutationFailure {
         }
     }
 
-    fn protocol(message: impl Into<String>) -> Self {
+    pub(crate) fn protocol(message: impl Into<String>) -> Self {
         Self {
             conflict: false,
             current_version: None,
@@ -312,6 +312,7 @@ impl BambooClient {
         session_id: &str,
         model: Option<&str>,
         provider: Option<&str>,
+        reasoning_effort: Option<ReasoningEffort>,
     ) -> Result<ExecuteResponse> {
         let resp = self
             .client
@@ -319,6 +320,7 @@ impl BambooClient {
             .json(&ExecuteRequest {
                 model: model.map(|m| m.to_string()),
                 provider: provider.map(str::to_string),
+                reasoning_effort,
             })
             .send()
             .await?;
@@ -742,29 +744,52 @@ impl BambooClient {
         Ok(catalog)
     }
 
-    /// PATCH the active session's model before the picker commits a selection
-    /// locally. The caller keeps the overlay open on failure so the visible
-    /// model badge can never drift from the persisted session record.
-    pub async fn patch_session_model(
+    /// PATCH the active session's model and reasoning choice as one CAS-guarded
+    /// operation before the picker commits either value locally. Returning the
+    /// authoritative summary + ETag lets the UI distinguish validation errors
+    /// from a stale-session conflict without guessing from display text.
+    pub async fn patch_session_execution_profile(
         &self,
         session_id: &str,
+        expected_version: u64,
         model_ref: &CatalogModelRef,
-    ) -> Result<()> {
+        reasoning_effort: Option<ReasoningEffort>,
+    ) -> std::result::Result<VersionedSession, SessionMutationFailure> {
         let resp = self
             .client
             .patch(self.url(&format!("/api/v1/sessions/{}", session_id)))
-            .json(&PatchSessionModelRequest {
-                model: model_ref.model.clone(),
-                provider: model_ref.provider.clone(),
-            })
+            .header(reqwest::header::IF_MATCH, format!("\"{expected_version}\""))
+            .json(&PatchSessionExecutionProfileRequest::new(
+                model_ref,
+                reasoning_effort,
+            ))
             .send()
-            .await?;
+            .await
+            .map_err(SessionMutationFailure::transport)?;
         let status = resp.status();
+        let metadata_version = parse_etag(resp.headers());
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("patch session model failed ({status}): {}", body.trim());
+            return Err(SessionMutationFailure::rejected(
+                status,
+                body,
+                metadata_version,
+            ));
         }
-        Ok(())
+        let metadata_version = metadata_version.ok_or_else(|| {
+            SessionMutationFailure::protocol(
+                "session execution-profile PATCH response omitted metadata ETag",
+            )
+        })?;
+        let envelope: GetSessionEnvelope = resp.json().await.map_err(|error| {
+            SessionMutationFailure::protocol(format!(
+                "session execution-profile PATCH returned an unreadable response: {error}"
+            ))
+        })?;
+        Ok(VersionedSession {
+            summary: envelope.session,
+            metadata_version,
+        })
     }
 
     // ── MCP ──
@@ -1792,27 +1817,86 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn model_patch_preserves_provider_model_identity() {
+    async fn execution_profile_patch_is_atomic_and_cas_guarded() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let base_url = format!("http://{}", listener.local_addr().unwrap());
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
             let patch = read_request(&mut socket).await;
             assert!(patch.starts_with("PATCH /api/v1/sessions/s1 HTTP/1.1"));
-            assert!(patch.ends_with(r#"{"model":"shared","provider":"provider-b"}"#));
-            respond(&mut socket, "200 OK", "\"1\"", "{}").await;
+            assert!(patch.to_ascii_lowercase().contains("if-match: \"7\""));
+            assert_eq!(
+                request_json(&patch),
+                serde_json::json!({
+                    "model": "shared",
+                    "provider": "provider-b",
+                    "reasoning_effort": "max"
+                })
+            );
+            respond(
+                &mut socket,
+                "200 OK",
+                "\"8\"",
+                r#"{"session":{"id":"s1","title":"Session","model":"shared","provider":"provider-b","reasoning_effort":"max"}}"#,
+            )
+            .await;
         });
 
-        BambooClient::new(&base_url)
-            .patch_session_model(
+        let updated = BambooClient::new(&base_url)
+            .patch_session_execution_profile(
                 "s1",
+                7,
                 &CatalogModelRef {
                     provider: "provider-b".to_string(),
                     model: "shared".to_string(),
                 },
+                Some(ReasoningEffort::Max),
             )
             .await
             .unwrap();
+        assert_eq!(updated.metadata_version, 8);
+        assert_eq!(updated.summary.reasoning_effort, Some(ReasoningEffort::Max));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn execution_profile_patch_reports_stale_session_conflict() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let patch = read_request(&mut socket).await;
+            assert_eq!(
+                request_json(&patch),
+                serde_json::json!({
+                    "model": "plain",
+                    "provider": "provider-b",
+                    "clear_reasoning_effort": true
+                })
+            );
+            respond(
+                &mut socket,
+                "412 Precondition Failed",
+                "\"11\"",
+                r#"{"error":{"message":"Version conflict"},"current_version":11}"#,
+            )
+            .await;
+        });
+
+        let error = BambooClient::new(&base_url)
+            .patch_session_execution_profile(
+                "s1",
+                7,
+                &CatalogModelRef {
+                    provider: "provider-b".to_string(),
+                    model: "plain".to_string(),
+                },
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(error.conflict);
+        assert_eq!(error.current_version, Some(11));
         server.await.unwrap();
     }
 }

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -22,7 +22,8 @@ fn default_title_generated() -> bool {
 // across the CLI and TUI front-ends); re-exported here so the rest of the TUI
 // can keep referring to `crate::api::types::{AgentEvent, ChatRequest, …}`.
 pub use bamboo_client_core::{
-    AgentEvent, ChatRequest, ChatResponse, ExecuteRequest, ExecuteResponse, TokenUsage,
+    AgentEvent, ChatRequest, ChatResponse, ExecuteRequest, ExecuteResponse, ReasoningEffort,
+    TokenUsage,
 };
 
 // ── Command catalog ──
@@ -93,6 +94,10 @@ pub struct SessionSummary {
     pub model_ref: Option<CatalogModelRef>,
     #[serde(default)]
     pub provider: Option<String>,
+    /// Stored per-session override. `None` means the provider default remains
+    /// authoritative; the TUI must not pretend a concrete level was stored.
+    #[serde(default)]
+    pub reasoning_effort: Option<ReasoningEffort>,
     #[serde(default)]
     pub is_running: bool,
     #[serde(default)]
@@ -929,11 +934,49 @@ pub struct CatalogModelRef {
     pub model: String,
 }
 
+/// Capability flags and limits declared for one catalog model. Every field is
+/// defaulted so an older server remains readable and unknown support is never
+/// presented as guaranteed support.
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct CatalogModelCapabilities {
+    #[serde(default)]
+    pub supports_tools: bool,
+    #[serde(default)]
+    pub supports_vision: bool,
+    #[serde(default)]
+    pub supports_reasoning: bool,
+    #[serde(default)]
+    pub supports_streaming: Option<bool>,
+    #[serde(default)]
+    pub max_context_tokens: Option<u32>,
+    #[serde(default)]
+    pub max_output_tokens: Option<u32>,
+}
+
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogModelSource {
+    Upstream,
+    Static,
+    Manual,
+    #[serde(other)]
+    Unknown,
+}
+
+impl CatalogModelSource {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Upstream => "upstream",
+            Self::Static => "static",
+            Self::Manual => "manual",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 /// One entry in `GET /v1/bamboo/provider-catalog`'s `models` array — a
-/// lenient subset of the server's `ProviderModelDescriptor`
-/// (`bamboo-domain::provider_catalog`). `capabilities`/`source`/
-/// `discovered_at` aren't rendered by the picker, so they're ignored on
-/// decode rather than modeled.
+/// lenient projection of the server's `ProviderModelDescriptor`
+/// (`bamboo-domain::provider_catalog`).
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct CatalogModel {
     #[serde(default)]
@@ -942,6 +985,10 @@ pub struct CatalogModel {
     pub display_name: String,
     #[serde(default)]
     pub provider_display_name: String,
+    #[serde(default)]
+    pub capabilities: CatalogModelCapabilities,
+    #[serde(default)]
+    pub source: Option<CatalogModelSource>,
 }
 
 /// Wire shape of `GET /v1/bamboo/provider-catalog`. `providers` isn't
@@ -953,13 +1000,32 @@ pub struct ProviderCatalog {
     pub models: Vec<CatalogModel>,
 }
 
-/// Body of `PATCH /api/v1/sessions/{id}` for the model-picker's exact
-/// provider/model update. The server derives and persists its typed
-/// `model_ref` when both legacy-compatible fields are present.
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+/// Body of `PATCH /api/v1/sessions/{id}` for one atomic execution-profile
+/// update. Exactly one of `reasoning_effort` and `clear_reasoning_effort` is
+/// emitted, so model and reasoning cannot become half-applied in the UI.
 #[derive(Serialize, Debug, Clone)]
-pub struct PatchSessionModelRequest {
+pub struct PatchSessionExecutionProfileRequest {
     pub model: String,
     pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_reasoning_effort: bool,
+}
+
+impl PatchSessionExecutionProfileRequest {
+    pub fn new(model: &CatalogModelRef, reasoning_effort: Option<ReasoningEffort>) -> Self {
+        Self {
+            model: model.model.clone(),
+            provider: model.provider.clone(),
+            reasoning_effort,
+            clear_reasoning_effort: reasoning_effort.is_none(),
+        }
+    }
 }
 
 /// Canonical metadata subset used by the session picker's rename/pin actions.
@@ -1456,10 +1522,21 @@ mod tests {
         assert_eq!(envelope.session.model, "claude-sonnet-5");
     }
 
+    #[test]
+    fn session_summary_distinguishes_stored_reasoning_override_from_default() {
+        let stored: SessionSummary =
+            serde_json::from_str(r#"{"id":"s1","model":"reasoner","reasoning_effort":"high"}"#)
+                .unwrap();
+        assert_eq!(stored.reasoning_effort, Some(ReasoningEffort::High));
+
+        let provider_default: SessionSummary =
+            serde_json::from_str(r#"{"id":"s2","model":"reasoner"}"#).unwrap();
+        assert_eq!(provider_default.reasoning_effort, None);
+    }
+
     /// Fixture mirroring the real `GET /v1/bamboo/provider-catalog` response
-    /// (`bamboo-domain::ProviderCatalog`), including fields the picker doesn't
-    /// model (`providers`, `capabilities`, `source`, `updated_at`) — those must
-    /// be ignored, not break deserialization.
+    /// (`bamboo-domain::ProviderCatalog`). Capability/source fields must remain
+    /// typed while unrelated envelope fields stay forward-compatible.
     #[test]
     fn provider_catalog_deserializes_lenient_model_shapes() {
         let json = r#"{
@@ -1471,7 +1548,14 @@ mod tests {
                     "reference": {"provider": "openai", "model": "gpt-4.1"},
                     "display_name": "GPT-4.1",
                     "provider_display_name": "OpenAI",
-                    "capabilities": {"supports_tools": true, "supports_vision": true},
+                    "capabilities": {
+                        "supports_tools": true,
+                        "supports_vision": true,
+                        "supports_reasoning": true,
+                        "supports_streaming": true,
+                        "max_context_tokens": 1048576,
+                        "max_output_tokens": 32768
+                    },
                     "source": "upstream",
                     "discovered_at": "2026-07-01T00:00:00Z"
                 },
@@ -1490,8 +1574,17 @@ mod tests {
         assert_eq!(m0.reference.model, "gpt-4.1");
         assert_eq!(m0.display_name, "GPT-4.1");
         assert_eq!(m0.provider_display_name, "OpenAI");
+        assert!(m0.capabilities.supports_tools);
+        assert!(m0.capabilities.supports_vision);
+        assert!(m0.capabilities.supports_reasoning);
+        assert_eq!(m0.capabilities.supports_streaming, Some(true));
+        assert_eq!(m0.capabilities.max_context_tokens, Some(1_048_576));
+        assert_eq!(m0.capabilities.max_output_tokens, Some(32_768));
+        assert_eq!(m0.source, Some(CatalogModelSource::Upstream));
         let m1 = &catalog.models[1];
         assert_eq!(m1.reference.model, "claude-sonnet-5");
+        assert_eq!(m1.capabilities, CatalogModelCapabilities::default());
+        assert_eq!(m1.source, None);
     }
 
     /// An empty catalog (no providers configured) must still deserialize —
@@ -1504,13 +1597,38 @@ mod tests {
     }
 
     #[test]
-    fn patch_session_model_request_serializes_model_field() {
-        let req = PatchSessionModelRequest {
+    fn patch_session_profile_serializes_override_and_default_distinctly() {
+        let model = CatalogModelRef {
             model: "gpt-4.1".to_string(),
             provider: "openai".to_string(),
         };
+        let req = PatchSessionExecutionProfileRequest::new(&model, Some(ReasoningEffort::Xhigh));
         let json = serde_json::to_string(&req).unwrap();
-        assert_eq!(json, r#"{"model":"gpt-4.1","provider":"openai"}"#);
+        assert_eq!(
+            json,
+            r#"{"model":"gpt-4.1","provider":"openai","reasoning_effort":"xhigh"}"#
+        );
+
+        let default = PatchSessionExecutionProfileRequest::new(&model, None);
+        assert_eq!(
+            serde_json::to_string(&default).unwrap(),
+            r#"{"model":"gpt-4.1","provider":"openai","clear_reasoning_effort":true}"#
+        );
+    }
+
+    #[test]
+    fn every_reasoning_effort_uses_the_canonical_wire_value() {
+        let values = ["low", "medium", "high", "xhigh", "max"];
+        for (effort, expected) in ReasoningEffort::ALL.into_iter().zip(values) {
+            assert_eq!(
+                serde_json::to_string(&effort).unwrap(),
+                format!("\"{expected}\"")
+            );
+            assert_eq!(
+                serde_json::from_str::<ReasoningEffort>(&format!("\"{expected}\"")).unwrap(),
+                effort
+            );
+        }
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -882,6 +882,9 @@ pub struct ChatState {
     pub current_turn_id: Option<String>,
     pub current_terminal_status: Option<String>,
     pub model: String,
+    /// Stored per-session override. `None` deliberately means provider
+    /// default rather than a client-assumed concrete effort.
+    pub reasoning_effort: Option<ReasoningEffort>,
     /// Requested/effective permission posture of the open session. These are
     /// persisted in the header even when no approval modal is visible.
     pub permission_mode: SessionPermissionMode,
@@ -979,6 +982,7 @@ impl ChatState {
             current_turn_id: None,
             current_terminal_status: None,
             model: String::new(),
+            reasoning_effort: None,
             permission_mode: SessionPermissionMode::Default,
             bypass_permissions: false,
             provider: None,
@@ -1280,6 +1284,7 @@ pub struct OpenedSession {
     pub messages: Vec<ChatMessage>,
     pub model: String,
     pub provider: Option<String>,
+    pub reasoning_effort: Option<ReasoningEffort>,
     pub project_id: Option<String>,
     pub permission_mode: SessionPermissionMode,
     pub bypass_permissions: bool,
@@ -2902,18 +2907,47 @@ pub struct PermissionModeConfirm {
     pub submitting: bool,
 }
 
-/// In-progress model picker (`Ctrl+O` on the Chat tab). Opens immediately with
-/// `loading: true` and an empty list; the provider-catalog fetch runs off the
-/// event loop and lands via `AppEvent::CatalogLoaded`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ModelPickerHitboxKind {
+    Model(usize),
+    Reasoning(Option<ReasoningEffort>),
+    Apply,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ModelPickerHitbox {
+    pub(crate) kind: ModelPickerHitboxKind,
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+    pub(crate) width: u16,
+}
+
+impl ModelPickerHitbox {
+    pub(crate) fn contains(&self, column: u16, row: u16) -> bool {
+        row == self.y && column >= self.x && column < self.x.saturating_add(self.width)
+    }
+}
+
+/// In-progress execution-profile picker (`Ctrl+O` on the Chat tab). Opens
+/// immediately with `loading: true`; catalog capabilities and the active
+/// session's versioned profile are fetched together off the event loop.
 pub struct ModelPicker {
     pub epoch: u64,
+    pub session_id: Option<String>,
+    pub metadata_version: Option<u64>,
     pub models: Vec<CatalogModel>,
     pub visible: Vec<usize>,
     pub query: String,
     pub selected: usize,
+    pub reasoning_effort: Option<ReasoningEffort>,
+    /// Preserve an explicit draft across a conflict-triggered catalog/session
+    /// refresh instead of replacing it with the newly-fetched stored value.
+    pub reasoning_touched: bool,
     pub loading: bool,
     pub applying: bool,
     pub error: Option<String>,
+    pub(crate) hitboxes: RefCell<Vec<ModelPickerHitbox>>,
+    pub(crate) mouse_pressed: Option<ModelPickerHitboxKind>,
 }
 
 impl ModelPicker {
@@ -2921,6 +2955,62 @@ impl ModelPicker {
         self.visible
             .get(self.selected)
             .and_then(|index| self.models.get(*index))
+    }
+
+    pub(crate) fn selected_supports_reasoning(&self) -> bool {
+        self.selected_model()
+            .is_some_and(|model| model.capabilities.supports_reasoning)
+    }
+
+    fn set_reasoning_effort(&mut self, effort: Option<ReasoningEffort>) {
+        if effort.is_none() || self.selected_supports_reasoning() {
+            self.reasoning_effort = effort;
+            self.reasoning_touched = true;
+            self.error = None;
+        }
+    }
+
+    fn cycle_reasoning_effort(&mut self, delta: i32) {
+        // An unsupported model can only resolve an existing override back to
+        // provider default. This is deliberate and visible; model navigation
+        // never clears the override behind the operator's back.
+        if !self.selected_supports_reasoning() {
+            self.set_reasoning_effort(None);
+            return;
+        }
+        let choices = [
+            None,
+            Some(ReasoningEffort::Low),
+            Some(ReasoningEffort::Medium),
+            Some(ReasoningEffort::High),
+            Some(ReasoningEffort::Xhigh),
+            Some(ReasoningEffort::Max),
+        ];
+        let current = choices
+            .iter()
+            .position(|candidate| *candidate == self.reasoning_effort)
+            .unwrap_or_default();
+        let next = if delta < 0 {
+            current.saturating_sub(1)
+        } else {
+            current.saturating_add(1).min(choices.len() - 1)
+        };
+        self.set_reasoning_effort(choices[next]);
+    }
+
+    pub(crate) fn reasoning_label(&self) -> String {
+        self.reasoning_effort
+            .map(ReasoningEffort::as_str)
+            .unwrap_or("provider default")
+            .to_string()
+    }
+
+    pub(crate) fn hitbox_at(&self, column: u16, row: u16) -> Option<ModelPickerHitboxKind> {
+        self.hitboxes
+            .borrow()
+            .iter()
+            .find(|hitbox| hitbox.contains(column, row))
+            .map(|hitbox| hitbox.kind.clone())
     }
 
     fn refresh_filter(&mut self, preserve: Option<(String, String)>) {
@@ -3290,11 +3380,35 @@ fn model_key(model: &CatalogModel) -> (String, String) {
 
 fn model_search_text(model: &CatalogModel) -> String {
     format!(
-        "{} {} {} {}",
+        "{} {} {} {} {} {} {} {} {}",
         model.display_name,
         model.provider_display_name,
         model.reference.provider,
-        model.reference.model
+        model.reference.model,
+        if model.capabilities.supports_tools {
+            "tools"
+        } else {
+            ""
+        },
+        if model.capabilities.supports_vision {
+            "vision"
+        } else {
+            ""
+        },
+        if model.capabilities.supports_reasoning {
+            "reasoning"
+        } else {
+            ""
+        },
+        if model.capabilities.supports_streaming == Some(true) {
+            "streaming"
+        } else {
+            ""
+        },
+        model
+            .source
+            .map(CatalogModelSource::label)
+            .unwrap_or_default(),
     )
 }
 
@@ -4290,6 +4404,7 @@ impl App {
             .as_ref()
             .map(|model_ref| model_ref.provider.clone())
             .or_else(|| summary.provider.clone());
+        context.chat.reasoning_effort = summary.reasoning_effort;
         context.chat.project_id.clone_from(&summary.project_id);
         context.chat.permission_mode = summary.permission_mode;
         context.chat.bypass_permissions = summary.bypass_permissions;
@@ -5731,6 +5846,7 @@ impl App {
                         self.chat.latest_summary_observation_epoch = epoch;
                         self.chat.model = opened.model;
                         self.chat.provider = opened.provider;
+                        self.chat.reasoning_effort = opened.reasoning_effort;
                         self.chat.project_id = opened.project_id;
                         self.chat.permission_mode = opened.permission_mode;
                         self.chat.bypass_permissions = opened.bypass_permissions;
@@ -6266,27 +6382,87 @@ impl App {
                     }
                 }
             }
-            AppEvent::CatalogLoaded { epoch, result } => {
+            AppEvent::CatalogLoaded {
+                epoch,
+                session_id,
+                result,
+                session,
+            } => {
                 let retry = self.action_key_phrase(
                     ActionContext::ModelPicker,
                     ActionId::Refresh,
                     "retries",
                 );
+                if self.chat.session_id != session_id {
+                    return Ok(());
+                }
+                if !self
+                    .model_picker
+                    .as_ref()
+                    .is_some_and(|picker| picker.epoch == epoch && picker.session_id == session_id)
+                {
+                    return Ok(());
+                }
                 let selected_key = self
                     .model_picker
                     .as_ref()
-                    .filter(|picker| picker.epoch == epoch)
+                    .filter(|picker| picker.epoch == epoch && picker.session_id == session_id)
                     .and_then(ModelPicker::selected_model)
                     .map(model_key);
+                let reasoning_touched = self
+                    .model_picker
+                    .as_ref()
+                    .is_some_and(|picker| picker.epoch == epoch && picker.reasoning_touched);
+
+                let (profile, profile_error) = match (session_id.as_deref(), session) {
+                    (None, None) => (None, None),
+                    (Some(expected), Some(Ok(versioned))) if versioned.summary.id == expected => {
+                        (Some(versioned), None)
+                    }
+                    (Some(_), Some(Ok(_))) => (
+                        None,
+                        Some(
+                            "Session profile response belonged to a different session".to_string(),
+                        ),
+                    ),
+                    (Some(_), Some(Err(error))) => (
+                        None,
+                        Some(format!("Failed to load session profile: {error} — {retry}")),
+                    ),
+                    (Some(_), None) => (
+                        None,
+                        Some(format!("Session profile was not loaded — {retry}")),
+                    ),
+                    (None, Some(_)) => (
+                        None,
+                        Some("Unexpected session profile for a new chat".to_string()),
+                    ),
+                };
+                if let Some(versioned) = profile.as_ref() {
+                    self.chat.model.clone_from(&versioned.summary.model);
+                    self.chat.provider = versioned
+                        .summary
+                        .model_ref
+                        .as_ref()
+                        .map(|model_ref| model_ref.provider.clone())
+                        .or_else(|| versioned.summary.provider.clone());
+                    self.chat.reasoning_effort = versioned.summary.reasoning_effort;
+                }
                 let Some(picker) = self
                     .model_picker
                     .as_mut()
-                    .filter(|picker| picker.epoch == epoch)
+                    .filter(|picker| picker.epoch == epoch && picker.session_id == session_id)
                 else {
                     return Ok(());
                 };
                 self.model_picker_task = None;
                 picker.loading = false;
+                picker.metadata_version = profile.as_ref().map(|value| value.metadata_version);
+                if !reasoning_touched {
+                    if let Some(versioned) = profile.as_ref() {
+                        picker.reasoning_effort = versioned.summary.reasoning_effort;
+                    }
+                }
                 match result {
                     Ok(mut catalog) => {
                         catalog.models.retain(|model| {
@@ -6316,11 +6492,18 @@ impl App {
                         ));
                     }
                 }
+                if let Some(profile_error) = profile_error {
+                    picker.error = Some(match picker.error.take() {
+                        Some(error) => format!("{error}; {profile_error}"),
+                        None => profile_error,
+                    });
+                }
             }
             AppEvent::ModelPatched {
                 epoch,
                 session_id,
                 model,
+                reasoning_effort,
                 result,
             } => {
                 let retry = self.action_key_phrase(
@@ -6330,11 +6513,10 @@ impl App {
                 );
                 let cancel =
                     self.action_key_phrase(ActionContext::ModelPicker, ActionId::Cancel, "cancels");
-                let Some(picker) = self
-                    .model_picker
-                    .as_mut()
-                    .filter(|picker| picker.epoch == epoch)
-                else {
+                let Some(picker) = self.model_picker.as_mut().filter(|picker| {
+                    picker.epoch == epoch
+                        && picker.session_id.as_deref() == Some(session_id.as_str())
+                }) else {
                     return Ok(());
                 };
                 self.model_picker_task = None;
@@ -6347,11 +6529,39 @@ impl App {
                     return Ok(());
                 }
                 match result {
-                    Ok(()) => self.commit_model_selection(model),
+                    Ok(updated) => {
+                        let provider = updated
+                            .summary
+                            .model_ref
+                            .as_ref()
+                            .map(|model_ref| model_ref.provider.as_str())
+                            .or(updated.summary.provider.as_deref());
+                        if updated.summary.id != session_id
+                            || updated.summary.model != model.reference.model
+                            || provider != Some(model.reference.provider.as_str())
+                            || updated.summary.reasoning_effort != reasoning_effort
+                        {
+                            picker.error = Some(
+                                "Server returned a different execution profile; refresh before retrying"
+                                    .to_string(),
+                            );
+                            picker.metadata_version = None;
+                            return Ok(());
+                        }
+                        picker.metadata_version = Some(updated.metadata_version);
+                        self.commit_model_selection(model, updated.summary.reasoning_effort);
+                    }
                     Err(error) => {
-                        picker.error = Some(format!(
-                            "Failed to update session model: {error} — {retry}; {cancel}"
-                        ));
+                        if error.conflict {
+                            picker.metadata_version = None;
+                            picker.error = Some(format!(
+                                "Session profile changed in another client: {error} — {retry}; {cancel}"
+                            ));
+                        } else {
+                            picker.error = Some(format!(
+                                "Failed to update execution profile: {error} — {retry}; {cancel}"
+                            ));
+                        }
                     }
                 }
             }
@@ -6931,14 +7141,57 @@ impl App {
             return;
         }
 
-        if let Some(picker) = self.model_picker.as_mut() {
-            let delta = match mouse.kind {
-                MouseEventKind::ScrollUp => -3,
-                MouseEventKind::ScrollDown => 3,
-                _ => return,
-            };
-            if !picker.loading && !picker.applying {
-                picker.selected = scroll_selection(picker.selected, picker.visible.len(), delta);
+        if self.model_picker.is_some() {
+            let mut apply = None;
+            {
+                let picker = self.model_picker.as_mut().unwrap();
+                if picker.loading || picker.applying {
+                    return;
+                }
+                match mouse.kind {
+                    MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+                        let delta = if matches!(mouse.kind, MouseEventKind::ScrollUp) {
+                            -3
+                        } else {
+                            3
+                        };
+                        picker.selected =
+                            scroll_selection(picker.selected, picker.visible.len(), delta);
+                        picker.mouse_pressed = None;
+                    }
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        picker.mouse_pressed = picker.hitbox_at(mouse.column, mouse.row);
+                    }
+                    MouseEventKind::Up(MouseButton::Left) => {
+                        let released = picker.hitbox_at(mouse.column, mouse.row);
+                        let pressed = picker.mouse_pressed.take();
+                        if pressed == released {
+                            match released {
+                                Some(ModelPickerHitboxKind::Model(model_index)) => {
+                                    if let Some(visible_index) = picker
+                                        .visible
+                                        .iter()
+                                        .position(|candidate| *candidate == model_index)
+                                    {
+                                        picker.selected = visible_index;
+                                        picker.error = None;
+                                    }
+                                }
+                                Some(ModelPickerHitboxKind::Reasoning(effort)) => {
+                                    picker.set_reasoning_effort(effort);
+                                }
+                                Some(ModelPickerHitboxKind::Apply) => {
+                                    apply = picker.selected_model().cloned();
+                                }
+                                None => {}
+                            }
+                        }
+                    }
+                    _ => picker.mouse_pressed = None,
+                }
+            }
+            if let Some(model) = apply {
+                self.apply_model(model);
             }
             return;
         }
@@ -9515,6 +9768,7 @@ impl App {
         let existing_session = self.chat.session_id.clone();
         let project_id = self.chat.project_id.clone();
         let provider = self.chat.provider.clone();
+        let reasoning_effort = self.chat.reasoning_effort;
         tokio::spawn(async move {
             let req = ChatRequest {
                 message,
@@ -9522,6 +9776,7 @@ impl App {
                 project_id,
                 model: Some(model),
                 provider,
+                reasoning_effort,
             };
             let result = client
                 .chat(req)
@@ -9643,6 +9898,7 @@ impl App {
         let client = self.client.clone();
         let model = self.chat.model.clone();
         let provider = self.chat.provider.clone();
+        let reasoning_effort = self.chat.reasoning_effort;
         tokio::spawn(async move {
             let execute_session_id = session_id.clone();
             let execute_turn_id = turn_id.clone();
@@ -9675,7 +9931,12 @@ impl App {
             // the handler can finalize `chat.streaming` instead of spinning
             // forever waiting for events behind a run that doesn't exist.
             if let Err(e) = client
-                .execute(&session_id, model.as_deref(), provider.as_deref())
+                .execute(
+                    &session_id,
+                    model.as_deref(),
+                    provider.as_deref(),
+                    reasoning_effort,
+                )
                 .await
             {
                 let _ = tx.send(AppEvent::ExecuteFailed {
@@ -9811,6 +10072,7 @@ impl App {
                 messages: map_history(history.messages),
                 model: summary.model,
                 provider,
+                reasoning_effort: summary.reasoning_effort,
                 project_id: summary.project_id,
                 permission_mode: if summary.permission_mode == SessionPermissionMode::Default
                     && summary.bypass_permissions
@@ -9847,6 +10109,7 @@ impl App {
         self.stash_question_drafts();
         let model = self.chat.model.clone();
         let provider = self.chat.provider.clone();
+        let reasoning_effort = self.chat.reasoning_effort;
         let project_id = self.chat.project_id.clone();
         let expand_tools = self.chat.expand_tools;
         self.prepare_visible_session_switch();
@@ -9867,6 +10130,7 @@ impl App {
         }
         self.chat.model = model;
         self.chat.provider = provider;
+        self.chat.reasoning_effort = reasoning_effort;
         self.chat.project_id = project_id;
         self.chat.expand_tools = expand_tools;
         self.opening_session_id = None;
@@ -13740,13 +14004,19 @@ impl App {
         let epoch = self.picker_epoch;
         self.model_picker = Some(ModelPicker {
             epoch,
+            session_id: self.chat.session_id.clone(),
+            metadata_version: None,
             models: Vec::new(),
             visible: Vec::new(),
             query: String::new(),
             selected: 0,
+            reasoning_effort: self.chat.reasoning_effort,
+            reasoning_touched: false,
             loading: true,
             applying: false,
             error: None,
+            hitboxes: RefCell::new(Vec::new()),
+            mouse_pressed: None,
         });
         self.load_model_catalog(epoch);
     }
@@ -13777,14 +14047,32 @@ impl App {
         if let Some(picker) = self.model_picker.as_mut() {
             picker.loading = true;
             picker.error = None;
+            picker.metadata_version = None;
+            picker.mouse_pressed = None;
         }
         let client = self.client.clone();
+        let session_id = self
+            .model_picker
+            .as_ref()
+            .and_then(|picker| picker.session_id.clone());
         self.model_picker_task = Some(tokio::spawn(async move {
-            let result = client
-                .get_provider_catalog()
-                .await
-                .map_err(|error| error.to_string());
-            let _ = tx.send(AppEvent::CatalogLoaded { epoch, result });
+            let catalog = client.get_provider_catalog();
+            let (result, session) = if let Some(id) = session_id.as_deref() {
+                let session = client.get_session_versioned(id);
+                let (catalog, session) = tokio::join!(catalog, session);
+                (
+                    catalog.map_err(|error| error.to_string()),
+                    Some(session.map_err(|error| error.to_string())),
+                )
+            } else {
+                (catalog.await.map_err(|error| error.to_string()), None)
+            };
+            let _ = tx.send(AppEvent::CatalogLoaded {
+                epoch,
+                session_id,
+                result,
+                session,
+            });
         }));
     }
 
@@ -13858,6 +14146,16 @@ impl App {
                     self.apply_model(model);
                 }
             }
+            Some(ActionId::PreviousReasoningEffort) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.cycle_reasoning_effort(-1);
+                }
+            }
+            Some(ActionId::NextReasoningEffort) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.cycle_reasoning_effort(1);
+                }
+            }
             Some(ActionId::Cancel) => self.close_model_picker(),
             Some(ActionId::Backspace) => {
                 if let Some(picker) = self.model_picker.as_mut() {
@@ -13866,12 +14164,7 @@ impl App {
                     picker.refresh_filter(preserve);
                 }
             }
-            Some(ActionId::Refresh)
-                if self
-                    .model_picker
-                    .as_ref()
-                    .is_some_and(|picker| !picker.loading && picker.visible.is_empty()) =>
-            {
+            Some(ActionId::Refresh) => {
                 self.reload_model_catalog();
             }
             None => {
@@ -13892,8 +14185,22 @@ impl App {
     /// avoids the old half-applied state where the local badge changed and the
     /// modal closed even though persistence failed.
     fn apply_model(&mut self, model: CatalogModel) {
+        let reasoning_effort = self
+            .model_picker
+            .as_ref()
+            .map(|picker| picker.reasoning_effort)
+            .unwrap_or(self.chat.reasoning_effort);
+        if !model.capabilities.supports_reasoning && reasoning_effort.is_some() {
+            if let Some(picker) = self.model_picker.as_mut() {
+                picker.error = Some(
+                    "Selected model does not support reasoning; choose provider default before applying"
+                        .to_string(),
+                );
+            }
+            return;
+        }
         let Some(session_id) = self.chat.session_id.clone() else {
-            self.commit_model_selection(model);
+            self.commit_model_selection(model, reasoning_effort);
             return;
         };
         let Some(tx) = self.event_tx.clone() else {
@@ -13905,6 +14212,12 @@ impl App {
         let Some(picker) = self.model_picker.as_mut() else {
             return;
         };
+        let Some(metadata_version) = picker.metadata_version else {
+            picker.error = Some(
+                "Session profile is not loaded; refresh before applying this change".to_string(),
+            );
+            return;
+        };
         picker.applying = true;
         picker.error = None;
         let epoch = picker.epoch;
@@ -13912,13 +14225,18 @@ impl App {
         let client = self.client.clone();
         self.model_picker_task = Some(tokio::spawn(async move {
             let result = client
-                .patch_session_model(&session_id, &model_ref)
-                .await
-                .map_err(|error| error.to_string());
+                .patch_session_execution_profile(
+                    &session_id,
+                    metadata_version,
+                    &model_ref,
+                    reasoning_effort,
+                )
+                .await;
             let _ = tx.send(AppEvent::ModelPatched {
                 epoch,
                 session_id,
                 model,
+                reasoning_effort,
                 result,
             });
         }));
@@ -13946,7 +14264,11 @@ impl App {
         }
     }
 
-    fn commit_model_selection(&mut self, model: CatalogModel) {
+    fn commit_model_selection(
+        &mut self,
+        model: CatalogModel,
+        reasoning_effort: Option<ReasoningEffort>,
+    ) {
         let key = model_key(&model);
         let provider_label = if model.provider_display_name.trim().is_empty() {
             model.reference.provider.clone()
@@ -13958,8 +14280,15 @@ impl App {
         self.recent_models.truncate(MAX_RECENT_MODELS);
         self.chat.model = model.reference.model.clone();
         self.chat.provider = Some(model.reference.provider.clone());
+        self.chat.reasoning_effort = reasoning_effort;
         self.model_picker = None;
-        self.status_message = format!("Model: {} ({provider_label})", model.display_name);
+        let reasoning = reasoning_effort
+            .map(ReasoningEffort::as_str)
+            .unwrap_or("provider default");
+        self.status_message = format!(
+            "Model: {} ({provider_label}) · reasoning {reasoning}",
+            model.display_name
+        );
     }
 }
 
@@ -16742,6 +17071,7 @@ mod question_tests {
                 messages: Vec::new(),
                 model: "model".to_string(),
                 provider: None,
+                reasoning_effort: None,
                 project_id: None,
                 permission_mode: SessionPermissionMode::Default,
                 bypass_permissions: false,
@@ -16763,6 +17093,7 @@ mod question_tests {
                 messages: Vec::new(),
                 model: "model".to_string(),
                 provider: None,
+                reasoning_effort: None,
                 project_id: None,
                 permission_mode: SessionPermissionMode::Default,
                 bypass_permissions: false,
@@ -16823,6 +17154,7 @@ mod question_tests {
                 messages: Vec::new(),
                 model: "model".to_string(),
                 provider: None,
+                reasoning_effort: None,
                 project_id: None,
                 permission_mode: SessionPermissionMode::Default,
                 bypass_permissions: false,
@@ -16845,6 +17177,7 @@ mod question_tests {
                 messages: Vec::new(),
                 model: "model".to_string(),
                 provider: None,
+                reasoning_effort: None,
                 project_id: None,
                 permission_mode: SessionPermissionMode::Default,
                 bypass_permissions: false,
@@ -16890,6 +17223,7 @@ mod question_tests {
                 messages: Vec::new(),
                 model: "model".to_string(),
                 provider: None,
+                reasoning_effort: None,
                 project_id: None,
                 permission_mode: SessionPermissionMode::Default,
                 bypass_permissions: false,
@@ -16912,6 +17246,7 @@ mod question_tests {
                 messages: Vec::new(),
                 model: "model".to_string(),
                 provider: None,
+                reasoning_effort: None,
                 project_id: None,
                 permission_mode: SessionPermissionMode::Default,
                 bypass_permissions: false,
@@ -17138,14 +17473,14 @@ mod question_tests {
         assert_eq!(
             actual,
             vec![
-                2_521_080_266_750_332_561,
+                18_250_622_092_155_643_324,
                 1_057_473_937_556_339_135,
                 1_502_110_673_089_046_554,
                 14_484_161_115_671_232_577,
                 4_091_854_584_326_177_690,
                 16_229_128_572_274_018_012,
                 10_493_202_686_479_633_261,
-                9_858_505_864_262_550_789,
+                10_935_873_232_087_006_812,
                 8_710_182_394_295_884_107,
                 15_353_719_274_755_616_638,
                 5_239_033_309_572_019_229,
@@ -17944,6 +18279,7 @@ mod question_tests {
             model: String::new(),
             model_ref: None,
             provider: None,
+            reasoning_effort: None,
             is_running: false,
             has_pending_question: false,
             running_child_count: 0,
@@ -20445,6 +20781,7 @@ mod question_tests {
             messages,
             model: "claude-sonnet-5".to_string(),
             provider: None,
+            reasoning_effort: None,
             project_id: None,
             permission_mode: SessionPermissionMode::Default,
             bypass_permissions: false,
@@ -23008,19 +23345,46 @@ mod question_tests {
             },
             display_name: display.to_string(),
             provider_display_name: provider_display.to_string(),
+            capabilities: CatalogModelCapabilities::default(),
+            source: None,
         }
+    }
+
+    fn reasoning_model(
+        provider: &str,
+        model: &str,
+        display: &str,
+        provider_display: &str,
+    ) -> CatalogModel {
+        let mut model = catalog_model(provider, model, display, provider_display);
+        model.capabilities = CatalogModelCapabilities {
+            supports_tools: true,
+            supports_vision: true,
+            supports_reasoning: true,
+            supports_streaming: Some(true),
+            max_context_tokens: Some(128_000),
+            max_output_tokens: Some(16_384),
+        };
+        model.source = Some(CatalogModelSource::Upstream);
+        model
     }
 
     fn model_picker(models: Vec<CatalogModel>) -> ModelPicker {
         ModelPicker {
             epoch: 1,
+            session_id: None,
+            metadata_version: None,
             visible: (0..models.len()).collect(),
             models,
             query: String::new(),
             selected: 0,
+            reasoning_effort: None,
+            reasoning_touched: false,
             loading: false,
             applying: false,
             error: None,
+            hitboxes: RefCell::new(Vec::new()),
+            mouse_pressed: None,
         }
     }
 
@@ -23117,6 +23481,7 @@ mod question_tests {
         ]));
         {
             let picker = app.model_picker.as_mut().unwrap();
+            picker.session_id = Some("s1".to_string());
             picker.query = "claude".to_string();
             picker.refresh_filter(None);
             picker.applying = true;
@@ -23132,7 +23497,8 @@ mod question_tests {
                 "Claude Sonnet 5",
                 "Anthropic",
             ),
-            result: Err("offline".to_string()),
+            reasoning_effort: None,
+            result: Err(crate::api::SessionMutationFailure::protocol("offline")),
         })
         .await
         .unwrap();
@@ -23147,11 +23513,95 @@ mod question_tests {
     }
 
     #[tokio::test]
+    async fn model_patch_conflict_preserves_full_draft_and_requires_refresh() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("s1".to_string());
+        app.chat.model = "old-model".to_string();
+        app.chat.provider = Some("old-provider".to_string());
+        app.chat.reasoning_effort = Some(ReasoningEffort::Low);
+        let selected = reasoning_model("openai", "reasoner", "Reasoner", "OpenAI");
+        app.model_picker = Some(model_picker(vec![selected.clone()]));
+        {
+            let picker = app.model_picker.as_mut().unwrap();
+            picker.session_id = Some("s1".to_string());
+            picker.metadata_version = Some(7);
+            picker.query = "reason".to_string();
+            picker.reasoning_effort = Some(ReasoningEffort::Max);
+            picker.reasoning_touched = true;
+            picker.applying = true;
+        }
+
+        app.handle_event(AppEvent::ModelPatched {
+            epoch: 1,
+            session_id: "s1".to_string(),
+            model: selected,
+            reasoning_effort: Some(ReasoningEffort::Max),
+            result: Err(crate::api::SessionMutationFailure::test_conflict(8)),
+        })
+        .await
+        .unwrap();
+
+        let picker = app.model_picker.as_ref().expect("conflict is recoverable");
+        assert_eq!(picker.query, "reason");
+        assert_eq!(picker.reasoning_effort, Some(ReasoningEffort::Max));
+        assert!(picker.reasoning_touched);
+        assert_eq!(picker.metadata_version, None, "stale ETag cannot be reused");
+        assert!(picker.error.as_deref().unwrap().contains("another client"));
+        assert_eq!(app.chat.model, "old-model");
+        assert_eq!(app.chat.provider.as_deref(), Some("old-provider"));
+        assert_eq!(app.chat.reasoning_effort, Some(ReasoningEffort::Low));
+    }
+
+    #[tokio::test]
+    async fn successful_profile_patch_commits_only_the_exact_server_profile() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("s1".to_string());
+        app.chat.model = "old-model".to_string();
+        let selected = reasoning_model("openai", "reasoner", "Reasoner", "OpenAI");
+        app.model_picker = Some(model_picker(vec![selected.clone()]));
+        {
+            let picker = app.model_picker.as_mut().unwrap();
+            picker.session_id = Some("s1".to_string());
+            picker.metadata_version = Some(3);
+            picker.reasoning_effort = Some(ReasoningEffort::High);
+            picker.applying = true;
+        }
+        let mut summary = bare_session("s1");
+        summary.model = "reasoner".to_string();
+        summary.provider = Some("openai".to_string());
+        summary.model_ref = Some(CatalogModelRef {
+            provider: "openai".to_string(),
+            model: "reasoner".to_string(),
+        });
+        summary.reasoning_effort = Some(ReasoningEffort::High);
+
+        app.handle_event(AppEvent::ModelPatched {
+            epoch: 1,
+            session_id: "s1".to_string(),
+            model: selected,
+            reasoning_effort: Some(ReasoningEffort::High),
+            result: Ok(crate::api::VersionedSession {
+                summary,
+                metadata_version: 4,
+            }),
+        })
+        .await
+        .unwrap();
+
+        assert!(app.model_picker.is_none());
+        assert_eq!(app.chat.model, "reasoner");
+        assert_eq!(app.chat.provider.as_deref(), Some("openai"));
+        assert_eq!(app.chat.reasoning_effort, Some(ReasoningEffort::High));
+        assert!(app.status_message.contains("reasoning high"));
+    }
+
+    #[tokio::test]
     async fn session_switch_invalidates_an_in_flight_model_patch() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.session_id = Some("session-a".to_string());
         app.chat.model = "model-a".to_string();
         app.chat.provider = Some("provider-a".to_string());
+        app.chat.reasoning_effort = Some(ReasoningEffort::Low);
         app.model_picker = Some(model_picker(vec![catalog_model(
             "provider-a",
             "selected-for-a",
@@ -23167,6 +23617,7 @@ mod question_tests {
             result: Ok(OpenedSession {
                 model: "model-b".to_string(),
                 provider: Some("provider-b".to_string()),
+                reasoning_effort: Some(ReasoningEffort::Xhigh),
                 ..opened(vec![])
             }),
         })
@@ -23183,7 +23634,11 @@ mod question_tests {
                 "Selected for A",
                 "Provider A",
             ),
-            result: Ok(()),
+            reasoning_effort: None,
+            result: Ok(crate::api::VersionedSession {
+                summary: bare_session("session-a"),
+                metadata_version: 2,
+            }),
         })
         .await
         .unwrap();
@@ -23191,6 +23646,7 @@ mod question_tests {
         assert_eq!(app.chat.session_id.as_deref(), Some("session-b"));
         assert_eq!(app.chat.model, "model-b");
         assert_eq!(app.chat.provider.as_deref(), Some("provider-b"));
+        assert_eq!(app.chat.reasoning_effort, Some(ReasoningEffort::Xhigh));
     }
 
     #[test]
@@ -23301,7 +23757,101 @@ mod question_tests {
             "chat.model gets the plain model id, not provider/model"
         );
         assert_eq!(app.chat.provider.as_deref(), Some("anthropic"));
-        assert_eq!(app.status_message, "Model: Claude Sonnet 5 (Anthropic)");
+        assert_eq!(
+            app.status_message,
+            "Model: Claude Sonnet 5 (Anthropic) · reasoning provider default"
+        );
+    }
+
+    #[tokio::test]
+    async fn reasoning_selector_visits_every_canonical_effort_and_clamps() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.model_picker = Some(model_picker(vec![reasoning_model(
+            "openai", "reasoner", "Reasoner", "OpenAI",
+        )]));
+
+        let expected = [
+            Some(ReasoningEffort::Low),
+            Some(ReasoningEffort::Medium),
+            Some(ReasoningEffort::High),
+            Some(ReasoningEffort::Xhigh),
+            Some(ReasoningEffort::Max),
+        ];
+        for effort in expected {
+            app.handle_model_picker_key(key(KeyCode::Right))
+                .await
+                .unwrap();
+            let picker = app.model_picker.as_ref().unwrap();
+            assert_eq!(picker.reasoning_effort, effort);
+            assert!(picker.reasoning_touched);
+        }
+        app.handle_model_picker_key(key(KeyCode::Right))
+            .await
+            .unwrap();
+        assert_eq!(
+            app.model_picker.as_ref().unwrap().reasoning_effort,
+            Some(ReasoningEffort::Max),
+            "selector clamps at max"
+        );
+        for effort in [
+            Some(ReasoningEffort::Xhigh),
+            Some(ReasoningEffort::High),
+            Some(ReasoningEffort::Medium),
+            Some(ReasoningEffort::Low),
+            None,
+        ] {
+            app.handle_model_picker_key(key(KeyCode::Left))
+                .await
+                .unwrap();
+            assert_eq!(app.model_picker.as_ref().unwrap().reasoning_effort, effort);
+        }
+    }
+
+    #[tokio::test]
+    async fn unsupported_model_requires_explicit_default_before_apply() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.model = "reasoner".to_string();
+        app.chat.provider = Some("openai".to_string());
+        app.chat.reasoning_effort = Some(ReasoningEffort::High);
+        app.model_picker = Some(model_picker(vec![catalog_model(
+            "local",
+            "plain-model",
+            "Plain Model",
+            "Local",
+        )]));
+        {
+            let picker = app.model_picker.as_mut().unwrap();
+            picker.reasoning_effort = Some(ReasoningEffort::High);
+        }
+
+        app.handle_model_picker_key(key(KeyCode::Enter))
+            .await
+            .unwrap();
+        let picker = app
+            .model_picker
+            .as_ref()
+            .expect("unsupported draft stays open");
+        assert_eq!(picker.reasoning_effort, Some(ReasoningEffort::High));
+        assert!(picker
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("does not support"));
+        assert_eq!(app.chat.model, "reasoner");
+
+        app.handle_model_picker_key(key(KeyCode::Left))
+            .await
+            .unwrap();
+        let picker = app.model_picker.as_ref().unwrap();
+        assert_eq!(picker.reasoning_effort, None);
+        assert!(picker.reasoning_touched, "default resolution is explicit");
+        app.handle_model_picker_key(key(KeyCode::Enter))
+            .await
+            .unwrap();
+        assert!(app.model_picker.is_none());
+        assert_eq!(app.chat.model, "plain-model");
+        assert_eq!(app.chat.provider.as_deref(), Some("local"));
+        assert_eq!(app.chat.reasoning_effort, None);
     }
 
     /// `Enter` while the catalog is still loading (empty list) is a no-op —
@@ -23388,12 +23938,14 @@ mod question_tests {
     async fn model_picker_esc_leaves_model_unchanged() {
         let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
         app.chat.model = "old-model".to_string();
+        app.chat.reasoning_effort = Some(ReasoningEffort::Medium);
         app.chat.textarea.input(key(KeyCode::Char('d')));
         app.chat.scroll_offset = 9;
         app.status_message = "Keep model status".to_string();
         app.model_picker = Some(model_picker(vec![catalog_model(
             "openai", "gpt-4.1", "GPT-4.1", "OpenAI",
         )]));
+        app.model_picker.as_mut().unwrap().reasoning_effort = Some(ReasoningEffort::Max);
 
         app.handle_model_picker_key(key(KeyCode::Esc))
             .await
@@ -23401,6 +23953,11 @@ mod question_tests {
 
         assert!(app.model_picker.is_none());
         assert_eq!(app.chat.model, "old-model", "Esc must not change the model");
+        assert_eq!(
+            app.chat.reasoning_effort,
+            Some(ReasoningEffort::Medium),
+            "Esc must not commit the reasoning draft"
+        );
         assert_eq!(app.chat.textarea.lines().join("\n"), "d");
         assert_eq!(app.chat.scroll_offset, 9);
         assert_eq!(app.status_message, "Keep model status");
@@ -23415,7 +23972,9 @@ mod question_tests {
 
         app.handle_event(AppEvent::CatalogLoaded {
             epoch: 1,
+            session_id: None,
             result: Err("connection refused".to_string()),
+            session: None,
         })
         .await
         .unwrap();
@@ -23438,7 +23997,9 @@ mod question_tests {
 
         app.handle_event(AppEvent::CatalogLoaded {
             epoch: 1,
+            session_id: None,
             result: Ok(ProviderCatalog { models: vec![] }),
+            session: None,
         })
         .await
         .unwrap();
@@ -23446,6 +24007,80 @@ mod question_tests {
         let picker = app.model_picker.as_ref().expect("recoverable picker");
         assert!(picker.models.is_empty());
         assert!(picker.error.as_deref().unwrap().contains("No models"));
+    }
+
+    #[tokio::test]
+    async fn catalog_reload_installs_the_versioned_stored_profile() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("s1".to_string());
+        app.chat.model = "stale".to_string();
+        app.model_picker = Some(model_picker(vec![]));
+        app.model_picker.as_mut().unwrap().session_id = Some("s1".to_string());
+        let mut summary = bare_session("s1");
+        summary.model = "reasoner".to_string();
+        summary.model_ref = Some(CatalogModelRef {
+            provider: "openai".to_string(),
+            model: "reasoner".to_string(),
+        });
+        summary.reasoning_effort = Some(ReasoningEffort::Xhigh);
+
+        app.handle_event(AppEvent::CatalogLoaded {
+            epoch: 1,
+            session_id: Some("s1".to_string()),
+            result: Ok(ProviderCatalog {
+                models: vec![reasoning_model("openai", "reasoner", "Reasoner", "OpenAI")],
+            }),
+            session: Some(Ok(crate::api::VersionedSession {
+                summary,
+                metadata_version: 11,
+            })),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(app.chat.model, "reasoner");
+        assert_eq!(app.chat.provider.as_deref(), Some("openai"));
+        assert_eq!(app.chat.reasoning_effort, Some(ReasoningEffort::Xhigh));
+        let picker = app.model_picker.as_ref().unwrap();
+        assert_eq!(picker.metadata_version, Some(11));
+        assert_eq!(picker.reasoning_effort, Some(ReasoningEffort::Xhigh));
+        assert_eq!(picker.reasoning_label(), "xhigh");
+    }
+
+    #[tokio::test]
+    async fn stale_catalog_epoch_cannot_overwrite_the_visible_session_profile() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("s1".to_string());
+        app.chat.model = "current".to_string();
+        app.chat.provider = Some("current-provider".to_string());
+        app.chat.reasoning_effort = Some(ReasoningEffort::Low);
+        app.model_picker = Some(model_picker(vec![]));
+        {
+            let picker = app.model_picker.as_mut().unwrap();
+            picker.epoch = 2;
+            picker.session_id = Some("s1".to_string());
+        }
+        let mut stale = bare_session("s1");
+        stale.model = "stale".to_string();
+        stale.provider = Some("stale-provider".to_string());
+        stale.reasoning_effort = Some(ReasoningEffort::Max);
+
+        app.handle_event(AppEvent::CatalogLoaded {
+            epoch: 1,
+            session_id: Some("s1".to_string()),
+            result: Ok(ProviderCatalog::default()),
+            session: Some(Ok(crate::api::VersionedSession {
+                summary: stale,
+                metadata_version: 99,
+            })),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(app.chat.model, "current");
+        assert_eq!(app.chat.provider.as_deref(), Some("current-provider"));
+        assert_eq!(app.chat.reasoning_effort, Some(ReasoningEffort::Low));
+        assert_eq!(app.model_picker.as_ref().unwrap().metadata_version, None);
     }
 
     /// A catalog fetch that lands after the picker was already dismissed
@@ -23457,9 +24092,11 @@ mod question_tests {
 
         app.handle_event(AppEvent::CatalogLoaded {
             epoch: 1,
+            session_id: None,
             result: Ok(ProviderCatalog {
                 models: vec![catalog_model("openai", "gpt-4.1", "GPT-4.1", "OpenAI")],
             }),
+            session: None,
         })
         .await
         .unwrap();
@@ -23486,10 +24123,189 @@ mod question_tests {
 
         let buf = terminal.backend().buffer().clone();
         let text: String = buf.content().iter().map(|c| c.symbol()).collect();
-        assert!(text.contains("GPT-4.1"), "model display name missing");
-        assert!(text.contains("OpenAI"), "provider display name missing");
         assert!(text.contains("openai/gpt-4.1"), "provider/model id missing");
+        assert!(
+            text.contains("capabilities unknown"),
+            "text capability badge missing"
+        );
         assert!(text.contains("Esc cancel"), "narrow footer was clipped");
+    }
+
+    #[test]
+    fn model_picker_exposes_text_capabilities_and_reasoning_at_common_widths() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        for width in [60, 80, 120] {
+            let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+            app.model_picker = Some(model_picker(vec![reasoning_model(
+                "oa",
+                "r",
+                "A deliberately very long friendly model name",
+                "A deliberately very long provider display name",
+            )]));
+            let backend = TestBackend::new(width, 28);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| crate::ui::render(frame, &app))
+                .unwrap();
+            let text = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect::<String>();
+
+            for needle in [
+                "oa/r",
+                "tools",
+                "vision",
+                "reasoning",
+                "Reasoning:",
+                "default",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max",
+                "Esc cancel",
+            ] {
+                assert!(
+                    text.contains(needle),
+                    "{width}-column picker omitted {needle:?}:\n{text}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn mouse_selects_model_reasoning_and_applies_the_profile() {
+        use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.model_picker = Some(model_picker(vec![
+            catalog_model("local", "plain", "Plain", "Local"),
+            reasoning_model("openai", "reasoner", "Reasoner", "OpenAI"),
+        ]));
+        let backend = TestBackend::new(100, 28);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+
+        let hitbox = |app: &App, kind: ModelPickerHitboxKind| {
+            app.model_picker
+                .as_ref()
+                .unwrap()
+                .hitboxes
+                .borrow()
+                .iter()
+                .find(|hitbox| hitbox.kind == kind)
+                .cloned()
+                .unwrap_or_else(|| panic!("missing hitbox {kind:?}"))
+        };
+        let click = |app: &mut App, hitbox: &ModelPickerHitbox| {
+            for kind in [
+                MouseEventKind::Down(MouseButton::Left),
+                MouseEventKind::Up(MouseButton::Left),
+            ] {
+                app.handle_mouse(MouseEvent {
+                    kind,
+                    column: hitbox.x,
+                    row: hitbox.y,
+                    modifiers: KeyModifiers::empty(),
+                });
+            }
+        };
+
+        let model_hitbox = hitbox(&app, ModelPickerHitboxKind::Model(1));
+        click(&mut app, &model_hitbox);
+        assert_eq!(app.model_picker.as_ref().unwrap().selected, 1);
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let reasoning_hitbox = hitbox(
+            &app,
+            ModelPickerHitboxKind::Reasoning(Some(ReasoningEffort::Max)),
+        );
+        click(&mut app, &reasoning_hitbox);
+        assert_eq!(
+            app.model_picker.as_ref().unwrap().reasoning_effort,
+            Some(ReasoningEffort::Max)
+        );
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let apply_hitbox = hitbox(&app, ModelPickerHitboxKind::Apply);
+        click(&mut app, &apply_hitbox);
+
+        assert!(app.model_picker.is_none());
+        assert_eq!(app.chat.model, "reasoner");
+        assert_eq!(app.chat.provider.as_deref(), Some("openai"));
+        assert_eq!(app.chat.reasoning_effort, Some(ReasoningEffort::Max));
+    }
+
+    #[test]
+    fn chat_hud_distinguishes_reasoning_override_from_provider_default() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.model = "reasoner".to_string();
+        app.chat.provider = Some("openai".to_string());
+        app.chat.reasoning_effort = Some(ReasoningEffort::High);
+        let mut terminal = Terminal::new(TestBackend::new(120, 1)).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                crate::ui::layout::render_status_info(frame, area, &app);
+            })
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("model openai/reasoner"));
+        assert!(text.contains("reasoning high (override)"));
+
+        app.chat.reasoning_effort = None;
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                crate::ui::layout::render_status_info(frame, area, &app);
+            })
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("reasoning provider default (default)"));
+
+        app.chat.provider = None;
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                crate::ui::layout::render_status_info(frame, area, &app);
+            })
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("model reasoner"));
+        assert!(text.contains("reasoning provider default (default)"));
     }
 
     #[test]

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -3,8 +3,8 @@ use crossterm::event::{KeyEvent, MouseEvent};
 use crate::api::types::{
     CatalogModel, CommandDetail, CommandListResponse, ListSessionTreeEnvelope,
     ListSessionsEnvelope, McpServer, PendingQuestion, PermissionDecisionResponse,
-    PermissionPolicyResponse, ProviderCatalog, Schedule, SessionSummary, SessionTreeSummary, Skill,
-    SkillDetail, SubagentSnapshotResponse, ToolInfo,
+    PermissionPolicyResponse, ProviderCatalog, ReasoningEffort, Schedule, SessionSummary,
+    SessionTreeSummary, Skill, SkillDetail, SubagentSnapshotResponse, ToolInfo,
 };
 use crate::api::{
     PermissionMutationFailure, RespondFailure, SessionMutationFailure, VersionedSession,
@@ -202,7 +202,11 @@ pub enum AppEvent {
     /// safe when an older HTTP response arrives after the new overlay opened.
     CatalogLoaded {
         epoch: u64,
+        session_id: Option<String>,
         result: Loaded<ProviderCatalog>,
+        /// Matching session snapshot + ETag when an existing session opened
+        /// the picker. `None` is the intentional new-session path.
+        session: Option<Loaded<VersionedSession>>,
     },
     /// Recoverable model PATCH result. The picker stays open until success so
     /// query/selection and the chat draft survive validation/network errors.
@@ -210,7 +214,8 @@ pub enum AppEvent {
         epoch: u64,
         session_id: String,
         model: CatalogModel,
-        result: Loaded<()>,
+        reasoning_effort: Option<ReasoningEffort>,
+        result: Result<VersionedSession, SessionMutationFailure>,
     },
     /// One lazily-loaded page for the contextual session picker. Pages are
     /// requested serially and capped in memory; stale epochs are discarded.

--- a/crates/app/bamboo-tui/src/keymap.rs
+++ b/crates/app/bamboo-tui/src/keymap.rs
@@ -160,6 +160,8 @@ pub(crate) enum ActionId {
     Backspace,
     Refresh,
     ClearInput,
+    PreviousReasoningEffort,
+    NextReasoningEffort,
     Confirm,
     Reject,
     OpenSlashPalette,
@@ -334,7 +336,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
     spec!(
         OpenModelPicker,
         "Select model",
-        "Choose a provider-qualified model",
+        "Choose a provider-qualified model and reasoning profile",
         true,
         Chat,
         [Global],
@@ -798,6 +800,22 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (ModelPicker, "Ctrl+U"),
             (CommandPalette, "Ctrl+U")
         ]
+    ),
+    spec!(
+        PreviousReasoningEffort,
+        "Previous reasoning effort",
+        "Select the previous canonical reasoning profile",
+        false,
+        [ModelPicker],
+        [(ModelPicker, "Left")]
+    ),
+    spec!(
+        NextReasoningEffort,
+        "Next reasoning effort",
+        "Select the next canonical reasoning profile",
+        false,
+        [ModelPicker],
+        [(ModelPicker, "Right")]
     ),
     spec!(
         Confirm,

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -7,15 +7,16 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 use unicode_width::UnicodeWidthChar;
 
-use crate::api::types::PermissionDecisionKind;
+use crate::api::types::{PermissionDecisionKind, ReasoningEffort};
 use crate::app::{
     ActiveQuestion, ActiveQuestionKind, ActivityKind, App, CommandPaletteEntry,
-    CommandPaletteHitbox, CommandPaletteTrigger, ConnectionStatus, NoticeLevel, PermissionStage,
-    QuestionOptionHitbox, RunPhase, SessionActivityStatus, SessionPickerMode, Tab,
+    CommandPaletteHitbox, CommandPaletteTrigger, ConnectionStatus, ModelPickerHitbox,
+    ModelPickerHitboxKind, NoticeLevel, PermissionStage, QuestionOptionHitbox, RunPhase,
+    SessionActivityStatus, SessionPickerMode, Tab,
 };
 use crate::keymap::{ActionContext, ActionId};
 use crate::theme::{self, colors};
-use crate::ui::sessions::{session_row_line_with_activity, truncate_cells};
+use crate::ui::sessions::session_row_line_with_activity;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LayoutMode {
@@ -415,8 +416,23 @@ pub fn render_status_info(f: &mut Frame, area: Rect, app: &App) {
     }
 
     if !app.chat.model.is_empty() {
+        let model = app
+            .chat
+            .provider
+            .as_deref()
+            .map(|provider| format!("{provider}/{}", app.chat.model))
+            .unwrap_or_else(|| app.chat.model.clone());
         items.push((
-            format!("model {}", app.chat.model),
+            format!("model {model}"),
+            Style::default().fg(colors::inactive()),
+        ));
+        let (reasoning, source) = app
+            .chat
+            .reasoning_effort
+            .map(|effort| (effort.as_str(), "override"))
+            .unwrap_or(("provider default", "default"));
+        items.push((
+            format!("reasoning {reasoning} ({source})"),
             Style::default().fg(colors::inactive()),
         ));
     }
@@ -666,6 +682,19 @@ pub fn render_notifications(f: &mut Frame, app: &App) {
         if let Some(provider) = app.chat.provider.as_deref() {
             push_full_value("model provider", provider, colors::inactive());
         }
+        if let Some(reasoning) = app.chat.reasoning_effort {
+            push_full_value(
+                "reasoning effort",
+                &format!("{} (session override)", reasoning.as_str()),
+                colors::inactive(),
+            );
+        } else if !app.chat.model.is_empty() {
+            push_full_value(
+                "reasoning effort",
+                "provider default (resolved at run time)",
+                colors::inactive(),
+            );
+        }
         push_full_value("status", &app.status_message, colors::inactive());
         if has_typed_run {
             push_full_value(
@@ -799,6 +828,36 @@ pub fn render_notifications(f: &mut Frame, app: &App) {
                 &format!("{}/{}", model.reference.provider, model.reference.model),
                 colors::inactive(),
             );
+            push_full_value(
+                "selected model capabilities",
+                &format!(
+                    "tools={} vision={} reasoning={} streaming={}",
+                    model.capabilities.supports_tools,
+                    model.capabilities.supports_vision,
+                    model.capabilities.supports_reasoning,
+                    model
+                        .capabilities
+                        .supports_streaming
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "unknown".to_string())
+                ),
+                colors::inactive(),
+            );
+            if let Some(picker) = app.model_picker.as_ref() {
+                push_full_value(
+                    "selected reasoning draft",
+                    &format!(
+                        "{} ({})",
+                        picker.reasoning_label(),
+                        if picker.reasoning_effort.is_some() {
+                            "session override"
+                        } else {
+                            "provider default"
+                        }
+                    ),
+                    colors::inactive(),
+                );
+            }
         }
         let current_error = match app.tab {
             Tab::Chat => None,
@@ -2494,6 +2553,8 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
     ];
 
     let mut body: Vec<Line> = Vec::new();
+    let mut hitbox_specs: Vec<(ModelPickerHitboxKind, usize, usize, usize)> = Vec::new();
+    picker.hitboxes.borrow_mut().clear();
     if picker.loading && picker.models.is_empty() {
         body.push(Line::raw("  Loading models..."));
         body.push(Line::raw(""));
@@ -2551,7 +2612,7 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
             }));
         }
     } else {
-        let max_h = screen.height.min(22);
+        let max_h = screen.height.min(28);
         let total = picker.visible.len();
         let groups = picker
             .visible
@@ -2565,9 +2626,14 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
         // border, indicators, action footer, and an optional error. This keeps
         // both the highlighted model and recovery action visible on a short
         // screen even with 100 providers.
+        let profile_rows = 9
+            + usize::from(row_width < 70)
+            + usize::from(
+                picker.reasoning_effort.is_some() && !picker.selected_supports_reasoning(),
+            )
+            + usize::from(picker.error.is_some());
         let line_budget = (max_h as usize)
-            .saturating_sub(2 + header.len() + 2 + usize::from(picker.error.is_some()))
-            .saturating_sub(2)
+            .saturating_sub(2 + header.len() + profile_rows)
             .max(2);
         let selected = picker.selected.min(total.saturating_sub(1));
         let mut start = selected;
@@ -2601,11 +2667,10 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
         }
         let mut previous_group: Option<&str> = None;
         for i in start..end {
-            let Some(m) = picker
-                .visible
-                .get(i)
-                .and_then(|index| picker.models.get(*index))
-            else {
+            let Some(&model_index) = picker.visible.get(i) else {
+                continue;
+            };
+            let Some(m) = picker.models.get(model_index) else {
                 continue;
             };
             let group = groups.get(i).map(String::as_str).unwrap_or("Provider");
@@ -2627,17 +2692,53 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
             } else {
                 Style::default()
             };
-            body.push(Line::from(Span::styled(
-                truncate_cells(
-                    &format!(
-                        "  {marker} {} · {} · {}/{}",
-                        m.display_name,
-                        m.provider_display_name,
-                        m.reference.provider,
-                        m.reference.model,
-                    ),
-                    row_width,
+            let mut badges = Vec::new();
+            if m.capabilities.supports_tools {
+                badges.push("tools");
+            }
+            if m.capabilities.supports_vision {
+                badges.push("vision");
+            }
+            if m.capabilities.supports_reasoning {
+                badges.push("reasoning");
+            }
+            if m.capabilities.supports_streaming == Some(true) {
+                badges.push("streaming");
+            }
+            let badges = if badges.is_empty() {
+                "capabilities unknown".to_string()
+            } else {
+                badges.join(",")
+            };
+            let badge = format!("[{badges}]");
+            let prefix = format!("  {marker} ");
+            // Keep the provider-qualified identity and textual capabilities at
+            // opposite ends of every row. Only the friendly display labels in
+            // the middle are sacrificed on a narrow terminal, so same-named
+            // models remain distinguishable and capability badges never rely
+            // on color or disappear behind a long label.
+            let reserved = display_width(&prefix)
+                .saturating_add(2)
+                .saturating_add(display_width(&badge));
+            let details_width = row_width.saturating_sub(reserved).max(1);
+            let details = clip_cells(
+                &format!(
+                    "{}/{} · {} · {}",
+                    m.reference.provider,
+                    m.reference.model,
+                    m.display_name,
+                    m.provider_display_name,
                 ),
+                details_width,
+            );
+            hitbox_specs.push((
+                ModelPickerHitboxKind::Model(model_index),
+                header.len() + body.len(),
+                0,
+                row_width,
+            ));
+            body.push(Line::from(Span::styled(
+                format!("{prefix}{details}  {badge}"),
                 style,
             )));
         }
@@ -2645,17 +2746,183 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
             body.push(Line::raw(format!("  \u{2193} {} more", total - end)));
         }
         body.push(Line::raw(""));
-        body.push(Line::raw(if picker.applying {
-            "  Applying model...".to_string()
+        if let Some(model) = picker.selected_model() {
+            body.push(Line::from(Span::styled(
+                clip_cells(
+                    &format!(
+                        "  Capabilities: tools {} · vision {} · reasoning {} · streaming {}",
+                        if model.capabilities.supports_tools {
+                            "yes"
+                        } else {
+                            "no"
+                        },
+                        if model.capabilities.supports_vision {
+                            "yes"
+                        } else {
+                            "no"
+                        },
+                        if model.capabilities.supports_reasoning {
+                            "yes"
+                        } else {
+                            "no"
+                        },
+                        match model.capabilities.supports_streaming {
+                            Some(true) => "yes",
+                            Some(false) => "no",
+                            None => "unknown",
+                        }
+                    ),
+                    row_width,
+                ),
+                Style::default().fg(colors::inactive()),
+            )));
+            let context = model
+                .capabilities
+                .max_context_tokens
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let output = model
+                .capabilities
+                .max_output_tokens
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let source = model
+                .source
+                .map(|source| source.label())
+                .unwrap_or("unknown");
+            body.push(Line::from(Span::styled(
+                clip_cells(
+                    &format!("  Limits: context {context} · output {output} · source {source}"),
+                    row_width,
+                ),
+                Style::default().fg(colors::subtle()),
+            )));
+        }
+        let reasoning_source = if picker.reasoning_effort.is_some() {
+            "session override"
         } else {
-            format!(
-                "  {}/{} or wheel select · {} apply · {} cancel",
-                app.key_hint(ActionContext::ModelPicker, ActionId::NavigateUp),
-                app.key_hint(ActionContext::ModelPicker, ActionId::NavigateDown),
-                app.key_hint(ActionContext::ModelPicker, ActionId::Activate),
-                app.key_hint(ActionContext::ModelPicker, ActionId::Cancel),
-            )
-        }));
+            "provider default"
+        };
+        body.push(Line::from(vec![
+            Span::styled("  Reasoning: ", Style::default().fg(colors::subtle())),
+            Span::styled(
+                format!("{} ({reasoning_source})", picker.reasoning_label()),
+                Style::default()
+                    .fg(colors::inactive())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+
+        let choices = [
+            ("default", None),
+            ("low", Some(ReasoningEffort::Low)),
+            ("medium", Some(ReasoningEffort::Medium)),
+            ("high", Some(ReasoningEffort::High)),
+            ("xhigh", Some(ReasoningEffort::Xhigh)),
+            ("max", Some(ReasoningEffort::Max)),
+        ];
+        let reasoning_line = header.len() + body.len();
+        let mut reasoning_spans = vec![Span::raw("  ")];
+        let mut reasoning_x = 2_usize;
+        for (index, (label, effort)) in choices.into_iter().enumerate() {
+            if index > 0 {
+                reasoning_spans.push(Span::raw("  "));
+                reasoning_x += 2;
+            }
+            let selected = picker.reasoning_effort == effort;
+            let text = if selected {
+                format!("[{label}]")
+            } else {
+                label.to_string()
+            };
+            let enabled = effort.is_none() || picker.selected_supports_reasoning();
+            hitbox_specs.push((
+                ModelPickerHitboxKind::Reasoning(effort),
+                reasoning_line,
+                reasoning_x,
+                display_width(&text),
+            ));
+            reasoning_x += display_width(&text);
+            let style = if selected {
+                Style::default()
+                    .fg(if enabled {
+                        colors::brand()
+                    } else {
+                        colors::error()
+                    })
+                    .add_modifier(Modifier::BOLD)
+            } else if enabled {
+                Style::default().fg(colors::inactive())
+            } else {
+                Style::default().fg(colors::subtle())
+            };
+            reasoning_spans.push(Span::styled(text, style));
+        }
+        body.push(Line::from(reasoning_spans));
+        if !picker.selected_supports_reasoning() {
+            body.push(Line::from(Span::styled(
+                clip_cells(
+                    if picker.reasoning_effort.is_some() {
+                        "  Unsupported override: choose default before applying"
+                    } else {
+                        "  Reasoning disabled: selected model does not advertise support"
+                    },
+                    row_width,
+                ),
+                Style::default().fg(if picker.reasoning_effort.is_some() {
+                    colors::error()
+                } else {
+                    colors::subtle()
+                }),
+            )));
+        }
+        body.push(Line::raw(""));
+        if picker.applying {
+            body.push(Line::raw("  Applying execution profile..."));
+            body.push(Line::raw(""));
+        } else {
+            let apply_line = header.len() + body.len();
+            hitbox_specs.push((ModelPickerHitboxKind::Apply, apply_line, 0, row_width));
+            body.push(Line::raw(clip_cells(
+                &format!(
+                    "  {}/{} or wheel/click select · {} or click apply",
+                    app.key_hint(ActionContext::ModelPicker, ActionId::NavigateUp),
+                    app.key_hint(ActionContext::ModelPicker, ActionId::NavigateDown),
+                    app.key_hint(ActionContext::ModelPicker, ActionId::Activate),
+                ),
+                row_width,
+            )));
+            body.push(Line::raw(clip_cells(
+                &format!(
+                    "  {}/{} reasoning{}",
+                    app.key_hint(
+                        ActionContext::ModelPicker,
+                        ActionId::PreviousReasoningEffort
+                    ),
+                    app.key_hint(ActionContext::ModelPicker, ActionId::NextReasoningEffort),
+                    if row_width < 70 {
+                        String::new()
+                    } else {
+                        format!(
+                            " · {} refresh · {} cancel",
+                            app.key_hint(ActionContext::ModelPicker, ActionId::Refresh),
+                            app.key_hint(ActionContext::ModelPicker, ActionId::Cancel),
+                        )
+                    },
+                ),
+                row_width,
+            )));
+            if row_width < 70 {
+                body.push(Line::raw(clip_cells(
+                    &format!(
+                        "  {} refresh · {} cancel",
+                        app.key_hint(ActionContext::ModelPicker, ActionId::Refresh),
+                        app.key_hint(ActionContext::ModelPicker, ActionId::Cancel),
+                    ),
+                    row_width,
+                )));
+            }
+        }
     }
     if let Some(error) = &picker.error {
         body.push(Line::from(Span::styled(
@@ -2668,6 +2935,22 @@ pub fn render_model_picker(f: &mut Frame, app: &App) {
     lines.extend(body);
     let height = (lines.len() as u16 + 2).min(screen.height);
     let area = centered_rect(92, height, screen);
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let inner_height = area.height.saturating_sub(2) as usize;
+    *picker.hitboxes.borrow_mut() = hitbox_specs
+        .into_iter()
+        .filter_map(|(kind, line, x, width)| {
+            if line >= inner_height || x >= inner_width {
+                return None;
+            }
+            Some(ModelPickerHitbox {
+                kind,
+                x: area.x.saturating_add(1).saturating_add(x as u16),
+                y: area.y.saturating_add(1).saturating_add(line as u16),
+                width: width.min(inner_width.saturating_sub(x)) as u16,
+            })
+        })
+        .collect();
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
@@ -3196,28 +3479,28 @@ mod tests {
                 3_944_301_344_853_503_540,
             ],
             [
-                6_353_706_855_117_373_427,
-                4_949_655_866_133_198_277,
-                10_134_078_088_138_427_242,
-                11_816_528_128_860_418_159,
-                5_878_254_985_531_855_646,
-                12_446_404_274_958_450_273,
+                24_781_587_750_329_806,
+                6_579_436_295_116_943_564,
+                12_089_640_381_617_969_713,
+                6_623_364_059_247_515_612,
+                10_379_221_866_905_049_683,
+                14_888_099_553_530_257_456,
             ],
             [
-                609_548_665_447_335_598,
-                15_455_926_307_789_286_752,
-                15_067_376_218_731_150_667,
-                3_277_314_811_073_656_778,
-                14_631_367_563_638_541_673,
-                11_436_591_821_112_263_934,
+                485_063_884_737_677_656,
+                15_174_020_356_754_305_078,
+                18_098_551_241_095_770_095,
+                2_039_143_840_007_286_998,
+                15_505_883_945_608_060_517,
+                12_608_770_992_754_079_606,
             ],
             [
-                9_618_507_591_432_411_738,
-                18_322_932_115_686_371_420,
-                13_335_556_050_296_598_231,
-                15_586_733_975_648_698_454,
-                14_233_158_507_239_728_005,
-                1_559_304_031_034_526_378,
+                8_481_799_100_690_155_604,
+                14_754_389_782_278_135_326,
+                3_040_738_245_384_578_895,
+                15_188_342_156_374_578_654,
+                16_521_044_070_106_085_221,
+                5_557_511_852_062_544_146,
             ],
         ];
         let mut actual = [[0_u64; 6]; 5];
@@ -3373,7 +3656,7 @@ mod tests {
         }
         assert_eq!(
             fingerprints,
-            [10_497_738_457_900_557_685, 4_621_970_272_475_212_681,],
+            [16_377_252_346_594_077_601, 9_609_611_161_121_647_853,],
             "complete help-overlay buffer golden changed"
         );
     }

--- a/crates/app/bamboo-tui/src/ui/sessions.rs
+++ b/crates/app/bamboo-tui/src/ui/sessions.rs
@@ -355,6 +355,7 @@ mod tests {
             model: String::new(),
             model_ref: None,
             provider: None,
+            reasoning_effort: None,
             is_running: false,
             has_pending_question: false,
             running_child_count: 0,

--- a/crates/engine/bamboo-engine/src/session_app/chat.rs
+++ b/crates/engine/bamboo-engine/src/session_app/chat.rs
@@ -168,6 +168,7 @@ pub fn prepare_chat_turn_from_authoritative_session_with_workspace_policy(
         if let Some(project_id) = input.project_id.as_ref() {
             session.set_project_id_meta(project_id.to_string());
         }
+        session.reasoning_effort = input.reasoning_effort;
     }
 
     // ---- Resolve base prompt ----
@@ -852,6 +853,7 @@ mod tests {
             model: "gpt-5".to_string(),
             model_ref: None,
             provider: None,
+            reasoning_effort: None,
             message: "hello".to_string(),
             system_prompt: Some("Base prompt".to_string()),
             enhance_prompt: enhance_prompt.map(ToString::to_string),
@@ -872,6 +874,25 @@ mod tests {
             .find(|message| matches!(message.role, Role::System))
             .map(|message| message.content.clone())
             .expect("session should have a system message")
+    }
+
+    #[test]
+    fn new_chat_session_persists_explicit_reasoning_profile() {
+        let mut input = chat_turn_input(None);
+        input.reasoning_effort = Some(bamboo_domain::ReasoningEffort::Xhigh);
+
+        let session = prepare_chat_turn_from_authoritative_session(
+            None,
+            input,
+            "Global prompt",
+            "Builtin prompt",
+        )
+        .expect("new chat session");
+
+        assert_eq!(
+            session.reasoning_effort,
+            Some(bamboo_domain::ReasoningEffort::Xhigh)
+        );
     }
 
     fn active_workflow(id: &str, revision: u64) -> ActiveWorkflow {

--- a/crates/engine/bamboo-engine/src/session_app/types.rs
+++ b/crates/engine/bamboo-engine/src/session_app/types.rs
@@ -62,6 +62,10 @@ pub struct ChatTurnInput {
     pub model: String,
     pub model_ref: Option<ProviderModelRef>,
     pub provider: Option<String>,
+    /// Explicit reasoning override used when this chat creates a session.
+    /// Existing sessions remain authoritative; later changes go through the
+    /// session PATCH contract.
+    pub reasoning_effort: Option<ReasoningEffort>,
     pub message: String,
     pub system_prompt: Option<String>,
     pub enhance_prompt: Option<String>,


### PR DESCRIPTION
## Summary

- decode provider-catalog capability, limit, and source metadata and expose it in provider-qualified model rows/details
- add keyboard and mouse controls for `provider default`, `low`, `medium`, `high`, `xhigh`, and `max`, including an explicit recovery path when a selected model does not support reasoning
- keep model/provider/reasoning visible in the chat HUD and preserve picker/chat drafts across cancel, validation failures, stale responses, session switches, and CAS conflicts
- apply model and reasoning together through one `If-Match`-guarded session PATCH and accept only the exact authoritative profile returned by the server
- carry an explicit reasoning profile through new-chat creation and subsequent execute requests

## Test Plan

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test -p bamboo-client-core`
- `cargo test -p bamboo-tui` (404 passed)
- `cargo test -p bamboo-engine` (1366 unit tests and 1 doctest passed)
- `cargo test -p bamboo-server` (1843 unit tests, integration suites, and doctests passed)
- `cargo clippy -p bamboo-client-core -p bamboo-tui --all-targets --no-deps -- -D warnings`
- `cargo clippy -p bamboo-engine -p bamboo-server --lib --no-deps -- -D warnings -A clippy::too_many_arguments`
- `git diff --check`

The repository-wide strict clippy command is currently blocked by pre-existing warnings in unchanged `bamboo-storage`, engine test, and server bridge files; the affected production crates and the complete client/TUI targets pass the scoped commands above.

## Screenshots

Terminal-only UI. Responsive 60/80/120-column rendering, monochrome-readable capability text, modal full-buffer goldens, and mouse hitboxes are covered by deterministic `ratatui::TestBackend` tests.

Closes #647
