### PR TITLE
feat(tui): add navigable unified diff viewer

### DIFF
--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -385,6 +385,11 @@ pub struct PendingQuestion {
     /// bounded resource rather than arbitrary argument payloads.
     #[serde(default)]
     pub tool_arguments: Option<serde_json::Value>,
+    /// Optional, bounded file-change payload computed and supplied separately
+    /// by the server for permission review. This must never be inferred from
+    /// model-authored `tool_arguments` or by reading `file_path` in the TUI.
+    #[serde(default)]
+    pub proposed_file_change: Option<serde_json::Value>,
     /// True when the server bounded a large raw argument payload before
     /// returning it. The exact authorization resource remains available on
     /// `permission_request.resource`; this flag prevents the preview from
@@ -1427,6 +1432,42 @@ mod tests {
                 "command": "git push origin dev",
                 "cwd": "/workspace/repo"
             }))
+        );
+    }
+
+    #[test]
+    fn pending_question_keeps_proposed_file_change_separate_from_model_arguments() {
+        let pending: PendingQuestion = serde_json::from_value(serde_json::json!({
+            "has_pending_question": true,
+            "question": "Allow edit?",
+            "tool_call_id": "edit-1",
+            "tool_name": "Edit",
+            "interaction_kind": "permission",
+            "tool_arguments": {
+                "file_path": "/workspace/demo.rs",
+                "patch": "model-authored patch"
+            },
+            "proposed_file_change": {
+                "operation": "Edit",
+                "file_path": "/workspace/demo.rs",
+                "diff": {"format": "unified", "unified": "bounded"}
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            pending
+                .tool_arguments
+                .as_ref()
+                .and_then(|value| value.get("patch")),
+            Some(&serde_json::json!("model-authored patch"))
+        );
+        assert_eq!(
+            pending
+                .proposed_file_change
+                .as_ref()
+                .and_then(|value| value.get("operation")),
+            Some(&serde_json::json!("Edit"))
         );
     }
 

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -2,6 +2,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -106,6 +107,7 @@ mod subagent_tree_navigation_tests {
             ConversationBlockUiState {
                 expanded: true,
                 scroll: 4,
+                diff_wrap: true,
             },
         );
 
@@ -143,7 +145,8 @@ mod subagent_tree_navigation_tests {
             app.chat.block_ui["parent:block"],
             ConversationBlockUiState {
                 expanded: true,
-                scroll: 4
+                scroll: 4,
+                diff_wrap: true,
             }
         );
     }
@@ -199,6 +202,7 @@ mod subagent_tree_navigation_tests {
             interaction_kind: Some(PendingInteractionKind::Clarification),
             permission_request: None,
             tool_arguments: None,
+            proposed_file_change: None,
             tool_arguments_truncated: false,
         };
         child_context.pending_question = Some(ActiveQuestion::from_pending(
@@ -243,6 +247,7 @@ mod subagent_tree_navigation_tests {
             interaction_kind: Some(PendingInteractionKind::Permission),
             permission_request: None,
             tool_arguments: None,
+            proposed_file_change: None,
             tool_arguments_truncated: false,
         };
         app.dismissed_question = Some(ActiveQuestion::from_pending(
@@ -588,6 +593,21 @@ impl ToolCallDisplay {
             self.result.as_deref().unwrap_or_default()
         }
     }
+
+    fn file_change_payload(&self) -> Option<&str> {
+        self.result
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .or_else(|| self.error.as_deref().filter(|value| !value.is_empty()))
+            .or_else(|| (!self.stream_output.is_empty()).then_some(self.stream_output.as_str()))
+    }
+
+    pub(crate) fn parse_file_change(&self) -> Option<crate::file_change::FileChangeView> {
+        crate::file_change::FileChangeView::from_tool_result(
+            &self.tool_name,
+            self.file_change_payload()?,
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -693,11 +713,24 @@ pub struct ChatMessage {
     pub terminal_status: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConversationBlockUiState {
     pub expanded: bool,
     /// First visible detail line for bounded tool/reasoning inspectors.
     pub scroll: usize,
+    /// File-change rows wrap by default. Toggling this clips long rows for a
+    /// dense overview without changing the authoritative copied diff.
+    pub diff_wrap: bool,
+}
+
+impl Default for ConversationBlockUiState {
+    fn default() -> Self {
+        Self {
+            expanded: false,
+            scroll: 0,
+            diff_wrap: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -761,6 +794,9 @@ impl ConversationBlock<'_> {
             ConversationBlockKind::AssistantMarkdown { content, .. }
             | ConversationBlockKind::Reasoning { content, .. } => (*content).to_string(),
             ConversationBlockKind::ToolCall { tool, .. } => {
+                if let Some(change) = tool.parse_file_change() {
+                    return change.unified().to_string();
+                }
                 let output = tool.display_output();
                 format!(
                     "{}\nargs: {}\n{}{}",
@@ -788,14 +824,19 @@ impl ConversationBlock<'_> {
         }
     }
 
-    fn detail_line_count(&self, width: u16) -> usize {
+    fn detail_line_count(&self, width: u16, diff_wrap: bool) -> usize {
         match &self.kind {
             ConversationBlockKind::Reasoning { content, .. } => {
                 inspector_lines(content, width.saturating_sub(1) as usize).len()
             }
-            ConversationBlockKind::ToolCall { tool, .. } => {
-                inspector_lines(tool.display_output(), width.saturating_sub(3) as usize).len()
-            }
+            ConversationBlockKind::ToolCall { tool, .. } => tool.parse_file_change().map_or_else(
+                || inspector_lines(tool.display_output(), width.saturating_sub(3) as usize).len(),
+                |change| {
+                    change
+                        .rendered_rows(width.saturating_sub(3) as usize, diff_wrap)
+                        .len()
+                },
+            ),
             _ => 0,
         }
     }
@@ -834,6 +875,14 @@ struct InspectorCacheEntry {
     source_len: usize,
     width: usize,
     lines: Vec<String>,
+}
+
+#[derive(Debug)]
+struct FileChangeCacheEntry {
+    source_ptr: usize,
+    source_len: usize,
+    tool_name: String,
+    view: Option<Arc<crate::file_change::FileChangeView>>,
 }
 
 pub struct ChatState {
@@ -915,6 +964,9 @@ pub struct ChatState {
     /// rows so the fixed redraw tick only clones the bounded visible window
     /// instead of re-walking every byte on every frame.
     inspector_cache: RefCell<HashMap<String, InspectorCacheEntry>>,
+    /// Parsing the bounded JSON/unified payload is still too expensive for
+    /// every redraw tick. Cache by stable block id and immutable result buffer.
+    file_change_cache: RefCell<HashMap<String, FileChangeCacheEntry>>,
     #[cfg(test)]
     inspector_cache_builds: Cell<usize>,
     /// IDs installed from a running session's history (or from an intermediate
@@ -997,6 +1049,7 @@ impl ChatState {
             content_height: Cell::new(0),
             content_width: Cell::new(0),
             inspector_cache: RefCell::new(HashMap::new()),
+            file_change_cache: RefCell::new(HashMap::new()),
             #[cfg(test)]
             inspector_cache_builds: Cell::new(0),
             replay_tool_ids: HashSet::new(),
@@ -1036,6 +1089,7 @@ impl ChatState {
         self.block_ui.entry(id).or_insert(ConversationBlockUiState {
             expanded: self.expand_tools,
             scroll: 0,
+            diff_wrap: true,
         });
     }
 
@@ -1086,6 +1140,34 @@ impl ChatState {
             .cloned()
             .collect();
         (total, lines)
+    }
+
+    pub(crate) fn file_change_view(
+        &self,
+        key: &str,
+        tool: &ToolCallDisplay,
+    ) -> Option<Arc<crate::file_change::FileChangeView>> {
+        let payload = tool.file_change_payload()?;
+        let source_ptr = payload.as_ptr() as usize;
+        let source_len = payload.len();
+        let mut cache = self.file_change_cache.borrow_mut();
+        let rebuild = cache.get(key).is_none_or(|entry| {
+            entry.source_ptr != source_ptr
+                || entry.source_len != source_len
+                || entry.tool_name != tool.tool_name
+        });
+        if rebuild {
+            cache.insert(
+                key.to_string(),
+                FileChangeCacheEntry {
+                    source_ptr,
+                    source_len,
+                    tool_name: tool.tool_name.clone(),
+                    view: tool.parse_file_change().map(Arc::new),
+                },
+            );
+        }
+        cache.get(key).and_then(|entry| entry.view.clone())
     }
 
     fn prepare_replay_reconciliation(&mut self) {
@@ -1255,6 +1337,7 @@ impl ChatState {
         self.content_height.set(0);
         self.content_width.set(0);
         self.inspector_cache.borrow_mut().clear();
+        self.file_change_cache.borrow_mut().clear();
         self.clear_replay_reconciliation();
         self.unseen_updates = 0;
         self.current_turn_id = None;
@@ -2269,6 +2352,7 @@ pub struct PermissionQuestion {
     /// rendering must never repeatedly pretty-print an attacker-sized value.
     pub tool_arguments_preview: String,
     pub tool_arguments_truncated: bool,
+    pub(crate) proposed_file_change: Option<Arc<crate::file_change::FileChangeView>>,
     pub stage: PermissionStage,
     pub matcher_selected: usize,
     pub inspect_target: Option<PermissionInspectTarget>,
@@ -2288,7 +2372,7 @@ impl PermissionQuestion {
         }
     }
 
-    pub fn inspector_text(&self) -> String {
+    pub(crate) fn base_inspector_text(&self) -> String {
         let request = &self.request;
         let mut lines = vec![
             format!("request id: {}", request.request_id),
@@ -2370,6 +2454,26 @@ impl PermissionQuestion {
             }
         }
         lines.join("\n")
+    }
+
+    pub(crate) fn proposed_file_change(&self) -> Option<&crate::file_change::FileChangeView> {
+        if !matches!(
+            self.inspect_target,
+            Some(PermissionInspectTarget::Request) | None
+        ) {
+            None
+        } else {
+            self.proposed_file_change.as_deref()
+        }
+    }
+
+    pub fn inspector_text(&self) -> String {
+        let mut text = self.base_inspector_text();
+        if let Some(change) = self.proposed_file_change() {
+            text.push_str("\n\nPROPOSED FILE CHANGE (server-supplied; not yet applied):\n");
+            text.push_str(change.unified());
+        }
+        text
     }
 }
 
@@ -2588,11 +2692,22 @@ impl ActiveQuestion {
                     preview = preview.chars().take(MAX_PREVIEW_CHARS).collect();
                     preview.push('…');
                 }
+                let proposed_file_change = pending
+                    .proposed_file_change
+                    .as_ref()
+                    .and_then(|value| {
+                        crate::file_change::FileChangeView::from_proposed_value(
+                            &request.tool_name,
+                            value,
+                        )
+                    })
+                    .map(Arc::new);
                 ActiveQuestionKind::Permission(PermissionQuestion {
                     request,
                     tool_arguments_preview: preview,
                     tool_arguments_truncated: pending.tool_arguments_truncated
                         || locally_truncated,
+                    proposed_file_change,
                     stage: PermissionStage::Decision,
                     matcher_selected: 0,
                     inspect_target: None,
@@ -7449,11 +7564,17 @@ impl App {
         let Some(id) = self.chat.focused_block.clone() else {
             return;
         };
+        let diff_wrap = self
+            .chat
+            .block_ui
+            .get(&id)
+            .map(|state| state.diff_wrap)
+            .unwrap_or(true);
         let total = self
             .conversation_blocks()
             .into_iter()
             .find(|block| block.id == id)
-            .map(|block| block.detail_line_count(self.chat.content_width.get()))
+            .map(|block| block.detail_line_count(self.chat.content_width.get(), diff_wrap))
             .unwrap_or(0);
         let state = self.chat.block_ui.entry(id).or_default();
         if !state.expanded || total <= CONVERSATION_DETAIL_VIEWPORT {
@@ -7461,6 +7582,75 @@ impl App {
         }
         let max_scroll = total.saturating_sub(CONVERSATION_DETAIL_VIEWPORT);
         state.scroll = (state.scroll as i64 + delta as i64).clamp(0, max_scroll as i64) as usize;
+    }
+
+    fn jump_focused_diff_hunk(&mut self, forward: bool) {
+        let Some(id) = self.chat.focused_block.clone() else {
+            return;
+        };
+        let width = self.chat.content_width.get().saturating_sub(3) as usize;
+        let state = self.chat.block_ui.get(&id).cloned().unwrap_or_default();
+        let hunk_offsets = self
+            .conversation_blocks()
+            .into_iter()
+            .find(|block| block.id == id)
+            .and_then(|block| match block.kind {
+                ConversationBlockKind::ToolCall { tool, .. } => tool.parse_file_change(),
+                _ => None,
+            })
+            .map(|change| change.hunk_offsets(width, state.diff_wrap));
+        let Some(offsets) = hunk_offsets.filter(|offsets| !offsets.is_empty()) else {
+            self.status_message = "Focused block has no navigable diff hunks".to_string();
+            return;
+        };
+        let (target_index, target) = if forward {
+            offsets
+                .iter()
+                .enumerate()
+                .find(|(_, offset)| **offset > state.scroll)
+                .or_else(|| offsets.last().map(|offset| (offsets.len() - 1, offset)))
+                .expect("non-empty hunk offsets")
+        } else {
+            offsets
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, offset)| **offset < state.scroll)
+                .or_else(|| offsets.first().map(|offset| (0, offset)))
+                .expect("non-empty hunk offsets")
+        };
+        let ui_state = self.chat.block_ui.entry(id).or_default();
+        ui_state.expanded = true;
+        // Keep the exact hunk offset even when the renderer clamps the last
+        // viewport. This preserves deterministic previous/next navigation.
+        ui_state.scroll = *target;
+        self.status_message = format!("Diff hunk {}/{}", target_index + 1, offsets.len());
+    }
+
+    fn toggle_focused_diff_wrap(&mut self) {
+        let Some(id) = self.chat.focused_block.clone() else {
+            return;
+        };
+        let is_diff = self
+            .conversation_blocks()
+            .into_iter()
+            .find(|block| block.id == id)
+            .is_some_and(|block| match block.kind {
+                ConversationBlockKind::ToolCall { tool, .. } => tool.parse_file_change().is_some(),
+                _ => false,
+            });
+        if !is_diff {
+            self.status_message = "Focused block has no unified diff".to_string();
+            return;
+        }
+        let state = self.chat.block_ui.entry(id).or_default();
+        state.diff_wrap = !state.diff_wrap;
+        state.scroll = 0;
+        self.status_message = if state.diff_wrap {
+            "Diff lines wrap; copied content remains exact".to_string()
+        } else {
+            "Diff lines clipped; press wrap again or copy for exact content".to_string()
+        };
     }
 
     fn activate_focused_conversation_block(&mut self) {
@@ -9697,6 +9887,9 @@ impl App {
             ActionId::ScrollBlockPageDown => {
                 self.scroll_focused_block(CONVERSATION_DETAIL_VIEWPORT as i32)
             }
+            ActionId::PreviousDiffHunk => self.jump_focused_diff_hunk(false),
+            ActionId::NextDiffHunk => self.jump_focused_diff_hunk(true),
+            ActionId::ToggleDiffWrap => self.toggle_focused_diff_wrap(),
             ActionId::ToggleDetails => self.toggle_conversation_details(),
             ActionId::Activate => self.activate_focused_conversation_block(),
             ActionId::CopyValue => self.copy_focused_conversation_block(),
@@ -11243,6 +11436,7 @@ impl App {
                     interaction_kind: Some(PendingInteractionKind::Clarification),
                     permission_request: None,
                     tool_arguments: None,
+                    proposed_file_change: None,
                     tool_arguments_truncated: false,
                 };
                 let mut incoming = self.question_from_pending(session_id, &pending);
@@ -15144,6 +15338,7 @@ mod question_tests {
                     "command": "cargo test --workspace",
                     "timeout_seconds": 120
                 })),
+                proposed_file_change: None,
                 tool_arguments_truncated: false,
             },
             "must-not-be-used".to_string(),
@@ -15756,6 +15951,7 @@ mod question_tests {
                 interaction_kind: Some(PendingInteractionKind::Permission),
                 permission_request: None,
                 tool_arguments: Some(serde_json::json!({"command": "git push"})),
+                proposed_file_change: None,
                 tool_arguments_truncated: false,
             },
             "never-submit".to_string(),
@@ -15793,6 +15989,7 @@ mod question_tests {
                 interaction_kind: None,
                 permission_request: None,
                 tool_arguments: None,
+                proposed_file_change: None,
                 tool_arguments_truncated: false,
             },
             "Approve".to_string(),
@@ -16171,6 +16368,7 @@ mod question_tests {
                     ],
                 )),
                 tool_arguments: Some(serde_json::json!({"command": "cargo test"})),
+                proposed_file_change: None,
                 tool_arguments_truncated: false,
             }),
         })
@@ -17473,7 +17671,7 @@ mod question_tests {
         assert_eq!(
             actual,
             vec![
-                18_250_622_092_155_643_324,
+                17_147_369_131_010_514_566,
                 1_057_473_937_556_339_135,
                 1_502_110_673_089_046_554,
                 14_484_161_115_671_232_577,
@@ -17708,6 +17906,7 @@ mod question_tests {
                 interaction_kind: Some(PendingInteractionKind::Permission),
                 permission_request: Some(current_request),
                 tool_arguments: Some(serde_json::json!({"command": "cargo test"})),
+                proposed_file_change: None,
                 tool_arguments_truncated: false,
             },
             String::new(),
@@ -25956,5 +26155,176 @@ mod auto_serve_tests {
         assert!(text.contains("Start a local"), "offer prompt missing");
         assert!(text.contains("y/Enter start"), "start action missing");
         assert!(text.contains("n/Esc skip"), "skip action missing");
+    }
+}
+
+#[cfg(test)]
+mod file_change_navigation_tests {
+    use super::*;
+
+    fn canonical_change() -> (String, String) {
+        let unified = "--- a/demo.rs\n+++ b/demo.rs\n@@ -1,1 +1,1 @@\n-old\n+new\n@@ -20,1 +20,2 @@\n tail\n+extra".to_string();
+        let payload = serde_json::json!({
+            "operation": "Edit",
+            "message": "Edited file",
+            "file_path": "/workspace/demo.rs",
+            "workspace": "/workspace",
+            "checkpoint": {
+                "created": true,
+                "id": "checkpoint",
+                "path": "/checkpoints/demo.rs",
+                "size_bytes": 4
+            },
+            "diff": {
+                "format": "unified",
+                "unified": unified,
+                "old_line_count": 20,
+                "new_line_count": 21,
+                "added_lines": 2,
+                "removed_lines": 1,
+                "old_trailing_newline": true,
+                "new_trailing_newline": true,
+                "truncated": false
+            }
+        })
+        .to_string();
+        (payload, unified)
+    }
+
+    fn focused_diff_app() -> (App, String, String) {
+        let (payload, unified) = canonical_change();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.current_turn_id = Some("turn".to_string());
+        app.chat.current_tool_calls.push(ToolCallDisplay {
+            id: "change".to_string(),
+            tool_name: "Edit".to_string(),
+            arguments: "{}".to_string(),
+            result: Some(payload),
+            stream_output: String::new(),
+            error: None,
+            phase: "complete".to_string(),
+        });
+        let block_id = tool_block_id("turn", "change");
+        app.chat.register_block(block_id.clone());
+        app.chat.focused_block = Some(block_id.clone());
+        app.chat.content_width.set(80);
+        (app, block_id, unified)
+    }
+
+    #[test]
+    fn focused_diff_hunks_wrap_and_exact_copy_are_independent() {
+        let (mut app, block_id, unified) = focused_diff_app();
+
+        app.jump_focused_diff_hunk(true);
+        let first = app.chat.block_ui[&block_id].scroll;
+        assert!(first > 0);
+        assert!(app.chat.block_ui[&block_id].expanded);
+        assert_eq!(app.status_message, "Diff hunk 1/2");
+
+        app.jump_focused_diff_hunk(true);
+        let second = app.chat.block_ui[&block_id].scroll;
+        assert!(second > first);
+        assert_eq!(app.status_message, "Diff hunk 2/2");
+
+        app.jump_focused_diff_hunk(false);
+        assert_eq!(app.chat.block_ui[&block_id].scroll, first);
+
+        app.toggle_focused_diff_wrap();
+        assert!(!app.chat.block_ui[&block_id].diff_wrap);
+        assert_eq!(app.chat.block_ui[&block_id].scroll, 0);
+        app.toggle_focused_diff_wrap();
+        assert!(app.chat.block_ui[&block_id].diff_wrap);
+
+        let copied = app
+            .conversation_blocks()
+            .into_iter()
+            .find(|block| block.id == block_id)
+            .unwrap()
+            .copy_text();
+        assert_eq!(copied, unified);
+    }
+
+    #[test]
+    fn permission_diff_requires_complete_server_supplied_payload_and_copies_exact_text() {
+        let (payload, unified) = canonical_change();
+        let canonical: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        let request = PermissionRequest {
+            request_id: "request".to_string(),
+            request_generation: "generation".to_string(),
+            session_id: "session".to_string(),
+            workspace_path: Some("/workspace".to_string()),
+            tool_name: "Edit".to_string(),
+            permission_type: PermissionType::WriteFile,
+            resource: "/workspace/demo.rs".to_string(),
+            operation_summary: "edit demo.rs".to_string(),
+            risk_level: RiskLevel::Medium,
+            reason_code: PermissionReasonCode::ConfiguredAlwaysAsk,
+            effective_mode: EffectivePermissionMode::Default,
+            bypass_requested: false,
+            auto_approve_requested: false,
+            policy_revision: 1,
+            matched_rule: None,
+            allowed_decisions: Vec::new(),
+            suggested_matchers: Vec::new(),
+        };
+        let pending = PendingQuestion {
+            has_pending_question: true,
+            question: "Allow edit?".to_string(),
+            options: Some(vec!["Approve".to_string(), "Deny".to_string()]),
+            allow_custom: false,
+            tool_call_id: Some("request".to_string()),
+            tool_name: Some("Edit".to_string()),
+            source: Some("permission".to_string()),
+            interaction_kind: Some(PendingInteractionKind::Permission),
+            permission_request: Some(request),
+            tool_arguments: Some(
+                serde_json::json!({"file_path": "/workspace/demo.rs", "patch": "model text"}),
+            ),
+            proposed_file_change: Some(canonical),
+            tool_arguments_truncated: false,
+        };
+        let mut active = ActiveQuestion::from_pending(
+            "permission:block".to_string(),
+            "session".to_string(),
+            &pending,
+            String::new(),
+        );
+        active.inspecting = true;
+        active.inspect_scroll = u16::MAX;
+        let ActiveQuestionKind::Permission(permission) = &mut active.kind else {
+            panic!("typed permission expected");
+        };
+        permission.inspect_target = Some(PermissionInspectTarget::Request);
+
+        assert!(permission.proposed_file_change().is_some());
+        let exact = permission.inspector_text();
+        assert!(exact.contains("PROPOSED FILE CHANGE"));
+        assert!(exact.ends_with(&unified));
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.pending_question = Some(active);
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &app))
+            .unwrap();
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("PROPOSED"));
+        assert!(rendered.contains("+ new"));
+
+        let ActiveQuestionKind::Permission(permission) =
+            &mut app.pending_question.as_mut().unwrap().kind
+        else {
+            unreachable!()
+        };
+        permission.proposed_file_change = None;
+        assert!(permission.proposed_file_change().is_none());
+        assert!(!permission.inspector_text().contains("PROPOSED FILE CHANGE"));
     }
 }

--- a/crates/app/bamboo-tui/src/file_change.rs
+++ b/crates/app/bamboo-tui/src/file_change.rs
@@ -1,0 +1,849 @@
+//! Pure parsing and terminal presentation for Bamboo's bounded file-change
+//! result contract. This module deliberately operates only on supplied JSON;
+//! rendering a tool result must never read a path or invoke source control.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use serde_json::Value;
+
+use crate::text;
+use crate::theme::colors;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FileChangeState {
+    Proposed,
+    Applied,
+    Failed,
+}
+
+impl FileChangeState {
+    pub(crate) fn from_phase(phase: &str) -> Self {
+        if phase.eq_ignore_ascii_case("complete") {
+            Self::Applied
+        } else if phase.eq_ignore_ascii_case("error") || phase.eq_ignore_ascii_case("failed") {
+            Self::Failed
+        } else {
+            Self::Proposed
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Proposed => "PROPOSED",
+            Self::Applied => "APPLIED",
+            Self::Failed => "FAILED",
+        }
+    }
+
+    fn style(self) -> Style {
+        let color = match self {
+            Self::Proposed => colors::warning(),
+            Self::Applied => colors::tool_done(),
+            Self::Failed => colors::tool_error(),
+        };
+        Style::default().fg(color).add_modifier(Modifier::BOLD)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiffLineKind {
+    OldFile,
+    NewFile,
+    Hunk,
+    Context,
+    Added,
+    Removed,
+    Marker,
+    Meta,
+}
+
+impl DiffLineKind {
+    fn style(self) -> Style {
+        match self {
+            Self::Added => Style::default().fg(colors::success()),
+            Self::Removed => Style::default().fg(colors::error()),
+            Self::Hunk | Self::Marker => Style::default().fg(colors::warning()),
+            Self::OldFile | Self::NewFile | Self::Meta => Style::default().fg(colors::subtle()),
+            Self::Context => Style::default().fg(colors::inactive()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedDiffLine {
+    kind: DiffLineKind,
+    old_line: Option<usize>,
+    new_line: Option<usize>,
+    content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RenderedDiffRow {
+    pub(crate) text: String,
+    pub(crate) kind: DiffLineKind,
+    pub(crate) starts_hunk: bool,
+}
+
+impl RenderedDiffRow {
+    pub(crate) fn styled_line(&self, indent: &str) -> Line<'static> {
+        Line::from(Span::styled(
+            format!("{indent}{}", self.text),
+            self.kind.style(),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CheckpointStatus {
+    Saved,
+    NotCreated(Option<String>),
+}
+
+impl CheckpointStatus {
+    fn label(&self) -> String {
+        match self {
+            Self::Saved => "checkpoint saved".to_string(),
+            Self::NotCreated(Some(reason)) => {
+                format!("checkpoint none ({})", visible_text(reason))
+            }
+            Self::NotCreated(None) => "checkpoint none".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DiagnosticStatus {
+    format: String,
+    valid: Option<bool>,
+}
+
+impl DiagnosticStatus {
+    fn label(&self) -> String {
+        let format = visible_text(&self.format);
+        match self.valid {
+            Some(true) => format!("diagnostics {format} valid"),
+            Some(false) => format!("diagnostics {format} INVALID"),
+            None => format!("diagnostics {format} reported"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileChangeView {
+    operation: String,
+    path: String,
+    unified: String,
+    old_line_count: usize,
+    new_line_count: usize,
+    added_lines: usize,
+    removed_lines: usize,
+    old_trailing_newline: bool,
+    new_trailing_newline: bool,
+    truncated: bool,
+    checkpoint: CheckpointStatus,
+    diagnostic: Option<DiagnosticStatus>,
+    parsed_lines: Vec<ParsedDiffLine>,
+    hunk_count: usize,
+    file_count: usize,
+    crlf_payload: bool,
+}
+
+impl FileChangeView {
+    /// Parse only a result emitted by the canonical Write/Edit tool family.
+    /// A payload from any other tool, unsupported diff format, or malformed
+    /// unified text returns `None` so the caller can retain the generic view.
+    pub(crate) fn from_tool_result(tool_name: &str, payload: &str) -> Option<Self> {
+        let expected_operation = expected_operation(tool_name)?;
+        let value: Value = serde_json::from_str(payload).ok()?;
+        Self::from_value(expected_operation, &value)
+    }
+
+    /// Permission responses may optionally carry a separate, server-computed
+    /// canonical file-change object. Raw tool arguments never enter this path:
+    /// they are model input, not authoritative proposed-diff metadata.
+    pub(crate) fn from_proposed_value(tool_name: &str, value: &Value) -> Option<Self> {
+        let expected_operation = expected_operation(tool_name)?;
+        Self::from_value(expected_operation, value)
+    }
+
+    fn from_value(expected_operation: &'static str, value: &Value) -> Option<Self> {
+        let object = value.as_object()?;
+        let operation = object.get("operation")?.as_str()?;
+        if operation != expected_operation {
+            return None;
+        }
+        let path = object.get("file_path")?.as_str()?.trim().to_string();
+        if path.is_empty() || path.contains('\0') {
+            return None;
+        }
+        object.get("message")?.as_str()?;
+        if object.get("workspace")?.as_str()?.trim().is_empty() {
+            return None;
+        }
+
+        let diff = object.get("diff")?.as_object()?;
+        if diff.get("format")?.as_str()? != "unified" {
+            return None;
+        }
+        match diff.get("binary") {
+            None | Some(Value::Bool(false)) => {}
+            Some(_) => return None,
+        }
+        let unified = diff.get("unified")?.as_str()?.to_string();
+        if unified.contains('\0') {
+            return None;
+        }
+        let old_line_count = value_as_usize(diff.get("old_line_count")?)?;
+        let new_line_count = value_as_usize(diff.get("new_line_count")?)?;
+        let added_lines = value_as_usize(diff.get("added_lines")?)?;
+        let removed_lines = value_as_usize(diff.get("removed_lines")?)?;
+        let old_trailing_newline = diff.get("old_trailing_newline")?.as_bool()?;
+        let new_trailing_newline = diff.get("new_trailing_newline")?.as_bool()?;
+        let truncated = diff.get("truncated")?.as_bool()?;
+        let parsed = parse_unified(&unified, truncated)?;
+
+        let checkpoint = match object.get("checkpoint")?.as_object()? {
+            checkpoint if checkpoint.get("created")?.as_bool()? => {
+                checkpoint.get("id")?.as_str()?;
+                checkpoint.get("path")?.as_str()?;
+                checkpoint.get("size_bytes")?.as_u64()?;
+                CheckpointStatus::Saved
+            }
+            checkpoint => {
+                CheckpointStatus::NotCreated(Some(checkpoint.get("reason")?.as_str()?.to_string()))
+            }
+        };
+        let diagnostic = match object.get("diagnostics") {
+            Some(value) => {
+                let diagnostics = value.as_object()?;
+                Some(DiagnosticStatus {
+                    format: diagnostics.get("format")?.as_str()?.to_string(),
+                    valid: Some(diagnostics.get("valid")?.as_bool()?),
+                })
+            }
+            None => None,
+        };
+
+        Some(Self {
+            operation: operation.to_string(),
+            path,
+            unified,
+            old_line_count,
+            new_line_count,
+            added_lines,
+            removed_lines,
+            old_trailing_newline,
+            new_trailing_newline,
+            truncated,
+            checkpoint,
+            diagnostic,
+            hunk_count: parsed.hunk_count,
+            file_count: parsed.file_count,
+            parsed_lines: parsed.lines,
+            crlf_payload: parsed.crlf_payload,
+        })
+    }
+
+    pub(crate) fn unified(&self) -> &str {
+        &self.unified
+    }
+
+    pub(crate) fn summary_lines(
+        &self,
+        state: FileChangeState,
+        indent: &str,
+        width: usize,
+    ) -> Vec<Line<'static>> {
+        let content_width = width.saturating_sub(text::display_width(indent)).max(1);
+        let primary = text::clip_cells(
+            &format!(
+                "{} · {} · {}",
+                state.label(),
+                self.operation,
+                visible_text(&self.path)
+            ),
+            content_width,
+        );
+        let scope = if self.file_count == 1 {
+            "1 file".to_string()
+        } else {
+            format!("{} files", self.file_count)
+        };
+        let hunks = if self.hunk_count == 1 {
+            "1 hunk".to_string()
+        } else {
+            format!("{} hunks", self.hunk_count)
+        };
+        let stats = text::clip_cells(
+            &format!(
+                "DIFF · +{} added · -{} removed · {}→{} lines · {scope} · {hunks}",
+                self.added_lines, self.removed_lines, self.old_line_count, self.new_line_count
+            ),
+            content_width,
+        );
+        let diagnostic = self
+            .diagnostic
+            .as_ref()
+            .map(DiagnosticStatus::label)
+            .unwrap_or_else(|| "diagnostics none".to_string());
+        let truncation = if self.truncated { "TRUNCATED · " } else { "" };
+        let line_endings = if self.old_trailing_newline == self.new_trailing_newline {
+            format!("trailing newline {}", yes_no(self.new_trailing_newline))
+        } else {
+            format!(
+                "trailing newline {}→{}",
+                yes_no(self.old_trailing_newline),
+                yes_no(self.new_trailing_newline)
+            )
+        };
+        let transport = if self.crlf_payload {
+            " · CRLF payload"
+        } else {
+            ""
+        };
+        let meta = text::clip_cells(
+            &format!(
+                "META · {truncation}{} · {diagnostic} · {line_endings}{transport}",
+                self.checkpoint.label()
+            ),
+            content_width,
+        );
+
+        vec![
+            Line::from(Span::styled(format!("{indent}{primary}"), state.style())),
+            Line::from(Span::styled(
+                format!("{indent}{stats}"),
+                Style::default().fg(colors::subtle()),
+            )),
+            Line::from(Span::styled(
+                format!("{indent}{meta}"),
+                Style::default().fg(if self.truncated {
+                    colors::warning()
+                } else {
+                    colors::subtle()
+                }),
+            )),
+        ]
+    }
+
+    pub(crate) fn rendered_rows(&self, width: usize, wrap: bool) -> Vec<RenderedDiffRow> {
+        let width = width.max(1);
+        let number_width = decimal_width(self.old_line_count.max(self.new_line_count)).min(8);
+        let gutter_width = number_width.saturating_mul(2).saturating_add(7);
+        let body_width = width.saturating_sub(gutter_width).max(1);
+        let mut rows = Vec::new();
+
+        for parsed in &self.parsed_lines {
+            let (old, new, marker) = match parsed.kind {
+                DiffLineKind::Context => (
+                    line_number(parsed.old_line, number_width),
+                    line_number(parsed.new_line, number_width),
+                    "  ",
+                ),
+                DiffLineKind::Added => (
+                    line_number(None, number_width),
+                    line_number(parsed.new_line, number_width),
+                    "+ ",
+                ),
+                DiffLineKind::Removed => (
+                    line_number(parsed.old_line, number_width),
+                    line_number(None, number_width),
+                    "- ",
+                ),
+                DiffLineKind::Hunk => ("@".repeat(number_width), "@".repeat(number_width), "  "),
+                DiffLineKind::OldFile => ("-".repeat(number_width), "·".repeat(number_width), "  "),
+                DiffLineKind::NewFile => ("·".repeat(number_width), "+".repeat(number_width), "  "),
+                DiffLineKind::Marker => ("!".repeat(number_width), "!".repeat(number_width), "  "),
+                DiffLineKind::Meta => ("·".repeat(number_width), "·".repeat(number_width), "  "),
+            };
+            let prefix = format!("{old} {new} │ {marker}");
+            let visible_content = visible_text(&parsed.content);
+            let chunks = if wrap {
+                text::hard_wrap(&visible_content, body_width)
+            } else {
+                vec![text::clip_cells(&visible_content, body_width)]
+            };
+            for (index, chunk) in chunks.into_iter().enumerate() {
+                let row_prefix = if index == 0 {
+                    prefix.clone()
+                } else {
+                    format!("{} │ ↳ ", " ".repeat(number_width * 2 + 1))
+                };
+                rows.push(RenderedDiffRow {
+                    text: format!("{row_prefix}{chunk}"),
+                    kind: parsed.kind,
+                    starts_hunk: index == 0 && parsed.kind == DiffLineKind::Hunk,
+                });
+            }
+        }
+        rows
+    }
+
+    pub(crate) fn hunk_offsets(&self, width: usize, wrap: bool) -> Vec<usize> {
+        self.rendered_rows(width, wrap)
+            .iter()
+            .enumerate()
+            .filter_map(|(index, row)| row.starts_hunk.then_some(index))
+            .collect()
+    }
+}
+
+fn expected_operation(tool_name: &str) -> Option<&'static str> {
+    let normalized = tool_name
+        .chars()
+        .filter(|character| !matches!(character, '_' | '-'))
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    match normalized.as_str() {
+        "write" | "writefile" => Some("Write"),
+        "edit" | "editfile" | "applypatch" => Some("Edit"),
+        _ => None,
+    }
+}
+
+fn value_as_usize(value: &Value) -> Option<usize> {
+    usize::try_from(value.as_u64()?).ok()
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn decimal_width(value: usize) -> usize {
+    value.max(1).to_string().len()
+}
+
+fn line_number(value: Option<usize>, width: usize) -> String {
+    match value {
+        Some(value) => format!("{value:>width$}"),
+        None => format!("{:>width$}", "·"),
+    }
+}
+
+fn visible_text(value: &str) -> String {
+    let mut visible = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\t' => visible.push('\t'),
+            '\r' => visible.push('␍'),
+            '\u{1b}' => visible.push('␛'),
+            character if character.is_control() => visible.push('�'),
+            character => visible.push(character),
+        }
+    }
+    visible
+}
+
+struct ParsedUnified {
+    lines: Vec<ParsedDiffLine>,
+    hunk_count: usize,
+    file_count: usize,
+    crlf_payload: bool,
+}
+
+fn parse_unified(unified: &str, truncated: bool) -> Option<ParsedUnified> {
+    let crlf_payload = unified.contains("\r\n");
+    let mut logical = unified.split('\n').collect::<Vec<_>>();
+    if unified.ends_with('\n') {
+        logical.pop();
+    }
+    if logical.is_empty() {
+        return None;
+    }
+    let has_truncation_marker = logical.last().is_some_and(|line| {
+        line.trim_end_matches('\r')
+            .starts_with("... diff truncated")
+    });
+    if truncated != has_truncation_marker {
+        return None;
+    }
+
+    let mut lines = Vec::with_capacity(logical.len());
+    let mut old_cursor = None;
+    let mut new_cursor = None;
+    let mut old_remaining = 0usize;
+    let mut new_remaining = 0usize;
+    let mut awaiting_new_header = false;
+    let mut have_file_header = false;
+    let mut old_headers = 0usize;
+    let mut new_headers = 0usize;
+    let mut hunk_count = 0usize;
+
+    let logical_len = logical.len();
+    for (index, raw) in logical.into_iter().enumerate() {
+        let line = raw.strip_suffix('\r').unwrap_or(raw);
+        let counts_exhausted = old_remaining == 0 && new_remaining == 0;
+        let (kind, old_line, new_line, content) = if let Some(header) = line.strip_prefix("@@") {
+            if awaiting_new_header || !have_file_header || !counts_exhausted {
+                return None;
+            }
+            let (old_start, old_count, new_start, new_count) = parse_hunk_header(line)?;
+            old_cursor = Some(old_start);
+            new_cursor = Some(new_start);
+            old_remaining = old_count;
+            new_remaining = new_count;
+            hunk_count += 1;
+            (DiffLineKind::Hunk, None, None, format!("@@{header}"))
+        } else if counts_exhausted && line.starts_with("--- ") {
+            let content = line.strip_prefix("--- ").expect("prefix was checked above");
+            if awaiting_new_header {
+                return None;
+            }
+            old_headers += 1;
+            awaiting_new_header = true;
+            have_file_header = false;
+            old_cursor = None;
+            new_cursor = None;
+            (DiffLineKind::OldFile, None, None, format!("--- {content}"))
+        } else if awaiting_new_header && line.starts_with("+++ ") {
+            let content = line.strip_prefix("+++ ").expect("prefix was checked above");
+            new_headers += 1;
+            awaiting_new_header = false;
+            have_file_header = true;
+            (DiffLineKind::NewFile, None, None, format!("+++ {content}"))
+        } else if let Some(content) = line.strip_prefix(' ') {
+            if old_remaining == 0 || new_remaining == 0 {
+                return None;
+            }
+            let old = old_cursor?;
+            let new = new_cursor?;
+            old_cursor = Some(old.saturating_add(1));
+            new_cursor = Some(new.saturating_add(1));
+            old_remaining -= 1;
+            new_remaining -= 1;
+            (
+                DiffLineKind::Context,
+                Some(old),
+                Some(new),
+                content.to_string(),
+            )
+        } else if let Some(content) = line.strip_prefix('-') {
+            if old_remaining == 0 {
+                if !is_trailing_newline_annotation(content) || new_remaining != 0 {
+                    return None;
+                }
+            } else {
+                old_remaining -= 1;
+            }
+            let old = old_cursor?;
+            old_cursor = Some(old.saturating_add(1));
+            (DiffLineKind::Removed, Some(old), None, content.to_string())
+        } else if let Some(content) = line.strip_prefix('+') {
+            if new_remaining == 0 {
+                if !is_trailing_newline_annotation(content) || old_remaining != 0 {
+                    return None;
+                }
+            } else {
+                new_remaining -= 1;
+            }
+            let new = new_cursor?;
+            new_cursor = Some(new.saturating_add(1));
+            (DiffLineKind::Added, None, Some(new), content.to_string())
+        } else if let Some(content) = line.strip_prefix("\\ ") {
+            (DiffLineKind::Marker, None, None, format!("! {content}"))
+        } else if line.starts_with("... diff truncated") {
+            (DiffLineKind::Meta, None, None, line.to_string())
+        } else if truncated && line.is_empty() && index + 2 == logical_len {
+            (
+                DiffLineKind::Meta,
+                None,
+                None,
+                "... diff truncated at line boundary".to_string(),
+            )
+        } else {
+            return None;
+        };
+        lines.push(ParsedDiffLine {
+            kind,
+            old_line,
+            new_line,
+            content,
+        });
+    }
+
+    if old_headers == 0
+        || old_headers != new_headers
+        || awaiting_new_header
+        || hunk_count == 0
+        || (!truncated && (old_remaining != 0 || new_remaining != 0))
+    {
+        return None;
+    }
+    Some(ParsedUnified {
+        lines,
+        hunk_count,
+        file_count: old_headers,
+        crlf_payload,
+    })
+}
+
+fn is_trailing_newline_annotation(content: &str) -> bool {
+    matches!(
+        content,
+        "[old had trailing newline]"
+            | "[new missing trailing newline]"
+            | "[old missing trailing newline]"
+            | "[new has trailing newline]"
+    )
+}
+
+fn parse_hunk_header(line: &str) -> Option<(usize, usize, usize, usize)> {
+    let mut parts = line.split_whitespace();
+    if parts.next()? != "@@" {
+        return None;
+    }
+    let (old_start, old_count) = parse_range(parts.next()?, '-')?;
+    let (new_start, new_count) = parse_range(parts.next()?, '+')?;
+    if parts.next()? != "@@" {
+        return None;
+    }
+    Some((old_start, old_count, new_start, new_count))
+}
+
+fn parse_range(value: &str, prefix: char) -> Option<(usize, usize)> {
+    let value = value.strip_prefix(prefix)?;
+    let (start, count) = value.split_once(',').map_or((value, "1"), |parts| parts);
+    Some((start.parse().ok()?, count.parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn payload(
+        operation: &str,
+        unified: &str,
+        old: usize,
+        new: usize,
+        added: usize,
+        removed: usize,
+    ) -> String {
+        let checkpoint = if old > 0 {
+            json!({
+                "created": true,
+                "id": "checkpoint-1",
+                "path": "/checkpoints/demo.txt",
+                "size_bytes": old
+            })
+        } else {
+            json!({"created": false, "reason": "file_did_not_exist"})
+        };
+        json!({
+            "operation": operation,
+            "message": "changed",
+            "file_path": "/workspace/demo.txt",
+            "workspace": "/workspace",
+            "checkpoint": checkpoint,
+            "diagnostics": {"format": "json", "valid": true},
+            "diff": {
+                "format": "unified",
+                "unified": unified,
+                "old_line_count": old,
+                "new_line_count": new,
+                "added_lines": added,
+                "removed_lines": removed,
+                "old_trailing_newline": old > 0,
+                "new_trailing_newline": new > 0,
+                "truncated": false
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn parses_create_edit_delete_and_empty_file_changes() {
+        let create = payload(
+            "Write",
+            "--- a/demo.txt\n+++ b/demo.txt\n@@ -1,0 +1,2 @@\n+alpha\n+beta",
+            0,
+            2,
+            2,
+            0,
+        );
+        let create = FileChangeView::from_tool_result("Write", &create).unwrap();
+        assert_eq!(create.added_lines, 2);
+        assert!(create
+            .rendered_rows(60, true)
+            .iter()
+            .any(|row| row.text.contains("+ alpha")));
+
+        let edit = payload(
+            "Edit",
+            "--- a/demo.txt\n+++ b/demo.txt\n@@ -1,2 +1,2 @@\n keep\n-old\n+new\n@@ -8,1 +8,2 @@\n tail\n+extra",
+            8,
+            9,
+            2,
+            1,
+        );
+        let edit = FileChangeView::from_tool_result("apply_patch", &edit).unwrap();
+        assert_eq!(edit.hunk_offsets(60, true).len(), 2);
+
+        let delete = payload(
+            "Edit",
+            "--- a/demo.txt\n+++ b/demo.txt\n@@ -1,2 +1,0 @@\n-alpha\n-beta",
+            2,
+            0,
+            0,
+            2,
+        );
+        assert_eq!(
+            FileChangeView::from_tool_result("Edit", &delete)
+                .unwrap()
+                .removed_lines,
+            2
+        );
+
+        let empty = payload(
+            "Write",
+            "--- a/demo.txt\n+++ b/demo.txt\n@@ -1,0 +1,0 @@",
+            0,
+            0,
+            0,
+            0,
+        );
+        assert!(FileChangeView::from_tool_result("Write", &empty).is_some());
+    }
+
+    #[test]
+    fn preserves_crlf_unicode_tabs_and_exact_copy_while_wrapping() {
+        let unified = "--- a/demo.txt\r\n+++ b/demo.txt\r\n@@ -1,1 +1,1 @@\r\n-\told界\u{1b}\r\n+\tnew👨‍👩‍👧‍👦\r\n-[old missing trailing newline]\r\n+[new has trailing newline]\r\n";
+        let mut value: Value =
+            serde_json::from_str(&payload("Edit", unified, 1, 1, 1, 1)).expect("test payload");
+        value["diff"]["old_trailing_newline"] = json!(false);
+        value["diff"]["new_trailing_newline"] = json!(true);
+        let view = FileChangeView::from_tool_result("Edit", &value.to_string()).unwrap();
+        assert_eq!(view.unified(), unified);
+        assert!(view.crlf_payload);
+        assert!(view
+            .rendered_rows(20, true)
+            .iter()
+            .any(|row| row.text.contains('\t')));
+        assert!(view
+            .rendered_rows(20, true)
+            .iter()
+            .any(|row| row.text.contains('界') || row.text.contains('👨')));
+        assert!(view
+            .rendered_rows(20, true)
+            .iter()
+            .all(|row| !row.text.contains('\u{1b}')));
+        let summary = view.summary_lines(FileChangeState::Applied, "", 120);
+        let summary = summary
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert!(summary.contains("trailing newline no→yes"));
+    }
+
+    #[test]
+    fn header_like_content_stays_inside_its_hunk_and_bad_counts_fall_back() {
+        let unified =
+            "--- a/demo.txt\n+++ b/demo.txt\n@@ -1,2 +1,2 @@\n--- removed heading\n+++ added heading\n tail";
+        let value = payload("Edit", unified, 2, 2, 1, 1);
+        let view = FileChangeView::from_tool_result("Edit", &value).unwrap();
+        assert_eq!(view.file_count, 1);
+        let rows = view.rendered_rows(80, true);
+        assert!(rows
+            .iter()
+            .any(|row| row.kind == DiffLineKind::Removed
+                && row.text.contains("- -- removed heading")));
+        assert!(rows
+            .iter()
+            .any(|row| row.kind == DiffLineKind::Added && row.text.contains("+ ++ added heading")));
+
+        let malformed = payload(
+            "Edit",
+            "--- a/demo.txt\n+++ b/demo.txt\n@@ -1,2 +1,2 @@\n-old\n+new",
+            2,
+            2,
+            1,
+            1,
+        );
+        assert!(FileChangeView::from_tool_result("Edit", &malformed).is_none());
+    }
+
+    #[test]
+    fn reports_truncation_and_navigates_multiple_files_at_supported_widths() {
+        let mut value: Value = serde_json::from_str(&payload(
+            "Edit",
+            "--- a/one\n+++ b/one\n@@ -1,1 +1,1 @@\n-a\n+b\n--- a/two\n+++ b/two\n@@ -4,1 +4,1 @@\n-c\n+d\n... diff truncated (9 more lines)",
+            4,
+            4,
+            2,
+            2,
+        ))
+        .unwrap();
+        value["diff"]["truncated"] = json!(true);
+        let view = FileChangeView::from_tool_result("Edit", &value.to_string()).unwrap();
+        assert_eq!(view.file_count, 2);
+        for width in [60, 80, 120] {
+            let rows = view.rendered_rows(width, true);
+            assert_eq!(rows.iter().filter(|row| row.starts_hunk).count(), 2);
+            assert_eq!(view.hunk_offsets(width, true).len(), 2);
+            assert!(rows
+                .iter()
+                .all(|row| text::display_width(&row.text) <= width));
+        }
+        let summary = view.summary_lines(FileChangeState::Applied, "", 120);
+        let summary_text = summary
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert!(summary_text.contains("TRUNCATED"));
+
+        value["diff"]["unified"] = json!(
+            "--- a/one\n+++ b/one\n@@ -1,1 +1,1 @@\n-a\n+b\n\n... diff truncated (content too long)"
+        );
+        assert!(
+            FileChangeView::from_tool_result("Edit", &value.to_string()).is_some(),
+            "a character cap landing exactly after a newline stays canonical"
+        );
+    }
+
+    #[test]
+    fn malformed_unknown_and_binary_payloads_fall_back() {
+        assert!(FileChangeView::from_tool_result("Write", "not json").is_none());
+        let valid = payload(
+            "Write",
+            "--- a/demo\n+++ b/demo\n@@ -1,0 +1,1 @@\n+x",
+            0,
+            1,
+            1,
+            0,
+        );
+        assert!(FileChangeView::from_tool_result("Bash", &valid).is_none());
+        assert!(FileChangeView::from_tool_result("Edit", &valid).is_none());
+
+        let mut binary: Value = serde_json::from_str(&valid).unwrap();
+        binary["diff"]["binary"] = json!(true);
+        assert!(FileChangeView::from_tool_result("Write", &binary.to_string()).is_none());
+        binary["diff"]["binary"] = json!("false");
+        assert!(FileChangeView::from_tool_result("Write", &binary.to_string()).is_none());
+
+        let mut malformed: Value = serde_json::from_str(&valid).unwrap();
+        malformed["diff"]["unified"] = json!("--- a/demo\n+++ b/demo\nnot a hunk");
+        assert!(FileChangeView::from_tool_result("Write", &malformed.to_string()).is_none());
+    }
+
+    #[test]
+    fn proposed_permission_diff_requires_a_separate_canonical_value() {
+        let canonical: Value = serde_json::from_str(&payload(
+            "Edit",
+            "--- a/demo\n+++ b/demo\n@@ -1,1 +1,1 @@\n-old\n+new",
+            1,
+            1,
+            1,
+            1,
+        ))
+        .unwrap();
+        let raw_arguments = json!({"file_path": "/workspace/demo", "patch": "raw model text"});
+        assert!(FileChangeView::from_proposed_value("Edit", &raw_arguments).is_none());
+        assert!(FileChangeView::from_proposed_value("Edit", &canonical).is_some());
+    }
+}

--- a/crates/app/bamboo-tui/src/keymap.rs
+++ b/crates/app/bamboo-tui/src/keymap.rs
@@ -179,6 +179,9 @@ pub(crate) enum ActionId {
     ScrollBlockDown,
     ScrollBlockPageUp,
     ScrollBlockPageDown,
+    PreviousDiffHunk,
+    NextDiffHunk,
+    ToggleDiffWrap,
     CopyValue,
     InspectValue,
     ToggleInspectorPane,
@@ -982,6 +985,30 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
         [(ConversationBlock, "PageDown")]
     ),
     spec!(
+        PreviousDiffHunk,
+        "Previous diff hunk",
+        "Jump to the previous hunk in the focused file change",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "[")]
+    ),
+    spec!(
+        NextDiffHunk,
+        "Next diff hunk",
+        "Jump to the next hunk in the focused file change",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "]")]
+    ),
+    spec!(
+        ToggleDiffWrap,
+        "Toggle diff wrapping",
+        "Wrap or clip long lines in the focused diff without changing copied content",
+        false,
+        [ConversationBlock],
+        [(ConversationBlock, "w")]
+    ),
+    spec!(
         CopyValue,
         "Copy exact value",
         "Copy the focused value through OSC 52",
@@ -1331,6 +1358,8 @@ impl ActionId {
                 | Self::ScrollBlockDown
                 | Self::ScrollBlockPageUp
                 | Self::ScrollBlockPageDown
+                | Self::PreviousDiffHunk
+                | Self::NextDiffHunk
                 | Self::Backspace
         )
     }

--- a/crates/app/bamboo-tui/src/lib.rs
+++ b/crates/app/bamboo-tui/src/lib.rs
@@ -22,6 +22,7 @@ mod api;
 mod app;
 mod components;
 mod event;
+mod file_change;
 mod history;
 mod keymap;
 mod search;

--- a/crates/app/bamboo-tui/src/ui/chat.rs
+++ b/crates/app/bamboo-tui/src/ui/chat.rs
@@ -9,10 +9,95 @@ use crate::app::{
     ToolCallDisplay, CONVERSATION_DETAIL_VIEWPORT,
 };
 use crate::components::markdown;
+use crate::file_change::FileChangeState;
 use crate::keymap::{ActionContext, ActionId};
 use crate::theme::{self, colors};
 
 const COLLAPSED_DETAIL_LINES: usize = 3;
+const COLLAPSED_DIFF_LINES: usize = 4;
+
+fn push_file_change_detail(
+    lines: &mut Vec<Line<'static>>,
+    app: &App,
+    block_id: &str,
+    tc: &ToolCallDisplay,
+    state: &ConversationBlockUiState,
+    focused: bool,
+    width: u16,
+) -> bool {
+    let Some(change) = app.chat.file_change_view(block_id, tc) else {
+        return false;
+    };
+    lines.extend(change.summary_lines(
+        FileChangeState::from_phase(&tc.phase),
+        "   ",
+        width as usize,
+    ));
+
+    let rows = change.rendered_rows(width.saturating_sub(3) as usize, state.diff_wrap);
+    let limit = if state.expanded {
+        CONVERSATION_DETAIL_VIEWPORT
+    } else {
+        COLLAPSED_DIFF_LINES
+    };
+    let max_start = rows.len().saturating_sub(limit);
+    let start = if state.expanded {
+        state.scroll.min(max_start)
+    } else {
+        0
+    };
+    if start > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("   ↑ {start} earlier diff rows"),
+            Style::default().fg(colors::subtle()),
+        )));
+    }
+    lines.extend(
+        rows.iter()
+            .skip(start)
+            .take(limit)
+            .map(|row| row.styled_line("   ")),
+    );
+    let hidden_after = rows.len().saturating_sub(start + limit);
+    if hidden_after > 0 {
+        lines.push(Line::from(Span::styled(
+            if state.expanded {
+                format!("   ↓ {hidden_after} later diff rows")
+            } else {
+                format!(
+                    "   … {hidden_after} more — focus then {} to inspect",
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::Activate)
+                )
+            },
+            Style::default().fg(colors::subtle()),
+        )));
+    }
+    if focused {
+        lines.push(Line::from(Span::styled(
+            if state.expanded {
+                format!(
+                    "   {} collapse · {}/{} scroll · {}/{} hunks · {} {} · {} copy exact diff",
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::ScrollBlockUp),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::ScrollBlockDown),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::PreviousDiffHunk),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::NextDiffHunk),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::ToggleDiffWrap),
+                    if state.diff_wrap { "clip" } else { "wrap" },
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+                )
+            } else {
+                format!(
+                    "   {} expand · {} copy exact diff",
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::Activate),
+                    app.key_hint(ActionContext::ConversationBlock, ActionId::CopyValue),
+                )
+            },
+            Style::default().fg(colors::subtle()),
+        )));
+    }
+    true
+}
 
 /// Render one tool block's bounded inspector. Expansion is per block, and an
 /// expanded block remains bounded; when focused, j/k or PgUp/PgDn changes its
@@ -26,6 +111,10 @@ fn push_tool_detail(
     focused: bool,
     width: u16,
 ) {
+    if push_file_change_detail(lines, app, block_id, tc, state, focused, width) {
+        return;
+    }
+
     // Arguments.
     let args = tc.arguments.trim();
     if !args.is_empty() && args != "null" && args != "{}" {
@@ -541,6 +630,7 @@ mod tests {
             &ConversationBlockUiState {
                 expanded: true,
                 scroll: 0,
+                diff_wrap: true,
             },
             false,
             100,
@@ -577,6 +667,190 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    fn file_change_payload(truncated: bool) -> String {
+        serde_json::json!({
+            "operation": "Edit",
+            "message": "Edited file",
+            "file_path": "/workspace/界/demo.rs",
+            "workspace": "/workspace/界",
+            "checkpoint": {
+                "created": true,
+                "id": "checkpoint-1",
+                "path": "/checkpoints/demo.rs",
+                "size_bytes": 4
+            },
+            "diagnostics": {"format": "rust", "valid": true},
+            "diff": {
+                "format": "unified",
+                "unified": if truncated {
+                    "--- a/demo.rs\n+++ b/demo.rs\n@@ -1,1 +1,1 @@\n-old\n+new\n... diff truncated (20 more lines)"
+                } else {
+                    "--- a/demo.rs\n+++ b/demo.rs\n@@ -1,1 +1,1 @@\n-old\n+new"
+                },
+                "old_line_count": 1,
+                "new_line_count": 1,
+                "added_lines": 1,
+                "removed_lines": 1,
+                "old_trailing_newline": true,
+                "new_trailing_newline": false,
+                "truncated": truncated
+            }
+        })
+        .to_string()
+    }
+
+    fn tool_detail_text(
+        tool: &ToolCallDisplay,
+        state: &ConversationBlockUiState,
+        width: u16,
+    ) -> String {
+        let app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let mut lines = Vec::new();
+        push_tool_detail(
+            &mut lines,
+            &app,
+            "test:file-change",
+            tool,
+            state,
+            false,
+            width,
+        );
+        lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn canonical_file_changes_render_specialized_states_and_raw_fallbacks() {
+        let base = ToolCallDisplay {
+            id: "change".to_string(),
+            tool_name: "Edit".to_string(),
+            arguments: r#"{"file_path":"/workspace/界/demo.rs"}"#.to_string(),
+            result: Some(file_change_payload(false)),
+            stream_output: String::new(),
+            error: None,
+            phase: "complete".to_string(),
+        };
+        let state = ConversationBlockUiState {
+            expanded: true,
+            ..Default::default()
+        };
+        let applied = tool_detail_text(&base, &state, 80);
+        for expected in [
+            "APPLIED · Edit · /workspace/界/demo.rs",
+            "+1 added · -1 removed",
+            "checkpoint saved",
+            "diagnostics rust valid",
+            "- old",
+            "+ new",
+        ] {
+            assert!(
+                applied.contains(expected),
+                "missing {expected:?}: {applied}"
+            );
+        }
+        assert!(!applied.contains("\"operation\""));
+
+        let mut proposed = base.clone();
+        proposed.phase = "running".to_string();
+        assert!(tool_detail_text(&proposed, &state, 80).contains("PROPOSED"));
+        let mut failed = base.clone();
+        failed.phase = "error".to_string();
+        assert!(tool_detail_text(&failed, &state, 80).contains("FAILED"));
+        let mut truncated = base.clone();
+        truncated.result = Some(file_change_payload(true));
+        assert!(tool_detail_text(&truncated, &state, 80).contains("TRUNCATED"));
+
+        let malformed = ToolCallDisplay {
+            result: Some("{malformed file result".to_string()),
+            ..base
+        };
+        let fallback = tool_detail_text(&malformed, &state, 80);
+        assert!(fallback.contains("{malformed file result"));
+        assert!(fallback.contains("args:"));
+    }
+
+    #[test]
+    fn file_change_rendering_is_equivalent_for_history_and_live_tools() {
+        use crate::api::types::{HistoryFunctionCall, HistoryMessage, HistoryToolCall};
+        use crate::history::map_history;
+
+        let payload = file_change_payload(false);
+        let mapped = map_history(vec![
+            HistoryMessage {
+                id: "assistant-history".to_string(),
+                role: "assistant".to_string(),
+                tool_calls: Some(vec![HistoryToolCall {
+                    id: "change-1".to_string(),
+                    function: HistoryFunctionCall {
+                        name: "Edit".to_string(),
+                        arguments: "{}".to_string(),
+                    },
+                }]),
+                ..Default::default()
+            },
+            HistoryMessage {
+                role: "tool".to_string(),
+                content: payload.clone(),
+                tool_call_id: Some("change-1".to_string()),
+                tool_success: Some(true),
+                ..Default::default()
+            },
+        ]);
+        let history = &mapped[0].tool_calls[0];
+        let live = ToolCallDisplay {
+            id: "change-1".to_string(),
+            tool_name: "Edit".to_string(),
+            arguments: "{}".to_string(),
+            result: Some(payload),
+            stream_output: String::new(),
+            error: None,
+            phase: "complete".to_string(),
+        };
+        let state = ConversationBlockUiState {
+            expanded: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            tool_detail_text(history, &state, 80),
+            tool_detail_text(&live, &state, 80)
+        );
+    }
+
+    #[test]
+    fn monochrome_diff_rows_stay_textually_distinct_at_supported_widths() {
+        let tool = ToolCallDisplay {
+            id: "change".to_string(),
+            tool_name: "Edit".to_string(),
+            arguments: "{}".to_string(),
+            result: Some(file_change_payload(false)),
+            stream_output: String::new(),
+            error: None,
+            phase: "complete".to_string(),
+        };
+        let state = ConversationBlockUiState {
+            expanded: true,
+            ..Default::default()
+        };
+        crate::theme::with_palette(crate::theme::ThemePalette::NoColor, || {
+            for width in [60, 80, 120] {
+                let rendered = tool_detail_text(&tool, &state, width);
+                assert!(rendered.contains("- old"));
+                assert!(rendered.contains("+ new"));
+                assert!(rendered
+                    .lines()
+                    .all(|line| crate::text::display_width(line) <= width as usize));
+            }
+        });
     }
 
     #[test]
@@ -618,6 +892,7 @@ mod tests {
             ConversationBlockUiState {
                 expanded: true,
                 scroll: 5,
+                diff_wrap: true,
             },
         );
         app.chat.block_ui.insert(
@@ -679,6 +954,7 @@ mod tests {
                 ConversationBlockUiState {
                     expanded: true,
                     scroll: 0,
+                    diff_wrap: true,
                 },
             );
         }

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -1343,7 +1343,25 @@ fn render_permission_inspector(
         ]),
         sections[0],
     );
-    let value = permission.inspector_text();
+    let mut value = permission
+        .base_inspector_text()
+        .lines()
+        .map(|line| Line::raw(line.to_string()))
+        .collect::<Vec<_>>();
+    if let Some(change) = permission.proposed_file_change() {
+        value.push(Line::raw(""));
+        value.extend(change.summary_lines(
+            crate::file_change::FileChangeState::Proposed,
+            "",
+            sections[1].width as usize,
+        ));
+        value.extend(
+            change
+                .rendered_rows(sections[1].width as usize, true)
+                .iter()
+                .map(|row| row.styled_line("")),
+        );
+    }
     let paragraph = Paragraph::new(value).wrap(Wrap { trim: false });
     let wrapped_count = paragraph.line_count(sections[1].width);
     let max_scroll = u16::try_from(wrapped_count.saturating_sub(sections[1].height as usize))
@@ -1428,6 +1446,12 @@ fn render_permission_question(f: &mut Frame, app: &App, q: &ActiveQuestion) {
         text_width,
         2,
     ));
+    if permission.proposed_file_change().is_some() {
+        details.push(one_line(
+            "file change",
+            "PROPOSED server-supplied unified diff available in inspector",
+        ));
+    }
     details.extend(labelled_preview(
         if permission.tool_arguments_truncated {
             "arguments (bounded, truncated)"
@@ -3656,7 +3680,7 @@ mod tests {
         }
         assert_eq!(
             fingerprints,
-            [16_377_252_346_594_077_601, 9_609_611_161_121_647_853,],
+            [9_023_054_049_185_338_977, 1_360_325_232_269_958_569,],
             "complete help-overlay buffer golden changed"
         );
     }


### PR DESCRIPTION
## Summary

- render canonical `Write`, `Edit`, and `apply_patch` results as bounded, navigable unified diffs
- show path, applied/proposed/failed state, line statistics, checkpoint/diagnostic metadata, and truncation while preserving a raw fallback for malformed payloads
- add previous/next hunk navigation, wrapping control, exact unified-diff copy, monochrome distinctions, and responsive 60/80/120-column rendering
- reuse the renderer for permission previews only when a separate trusted server payload supplies the proposed file change

Closes #648

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-tui --all-targets -- -D warnings`
- `cargo test -p bamboo-tui --no-fail-fast` — 416 passed
- `cargo test --no-fail-fast` — every affected and downstream suite passed; one unrelated `bamboo-engine` account-feed dedupe test failed once under whole-workspace concurrency, then passed 3/3 exact reruns
- exact rerun: `cargo test -p bamboo-engine 'events::account_sink::tests::config_health_state_dedupes_only_consecutive_same_kind_across_restart' -- --exact --nocapture`

## Screenshots

N/A — terminal rendering is covered by `TestBackend` assertions and goldens at 60, 80, and 120 columns.
