### PR TITLE
feat(tui): add live task and plan progress view (#649)

### DIFF
--- a/crates/app/bamboo-client-core/src/lib.rs
+++ b/crates/app/bamboo-client-core/src/lib.rs
@@ -133,6 +133,207 @@ pub struct ExecuteResponse {
 
 // ── SSE events ──
 
+/// Canonical task lifecycle status shared by HTTP snapshots and SSE deltas.
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskItemStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Completed,
+    Blocked,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskPhase {
+    Planning,
+    #[default]
+    Execution,
+    Verification,
+    Handoff,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskPriority {
+    Low,
+    #[default]
+    Medium,
+    High,
+    Critical,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskEvidenceKind {
+    #[default]
+    Note,
+    ToolCall,
+    File,
+    Command,
+    Test,
+    Observation,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct TaskEvidence {
+    #[serde(default)]
+    pub kind: TaskEvidenceKind,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub reference: Option<String>,
+    #[serde(default)]
+    pub tool_name: Option<String>,
+    #[serde(default)]
+    pub tool_call_id: Option<String>,
+    #[serde(default)]
+    pub round: Option<u32>,
+    #[serde(default)]
+    pub success: Option<bool>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskBlockerKind {
+    UserInput,
+    Dependency,
+    ToolFailure,
+    External,
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct TaskBlocker {
+    #[serde(default)]
+    pub kind: TaskBlockerKind,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub waiting_on: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct TaskTransition {
+    #[serde(default)]
+    pub from_status: TaskItemStatus,
+    #[serde(default)]
+    pub to_status: TaskItemStatus,
+    #[serde(default)]
+    pub reason: Option<String>,
+    #[serde(default)]
+    pub round: Option<u32>,
+    #[serde(default)]
+    pub changed_at: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct TaskItem {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub status: TaskItemStatus,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default)]
+    pub notes: String,
+    #[serde(default, alias = "activeForm")]
+    pub active_form: Option<String>,
+    #[serde(default)]
+    pub parent_id: Option<String>,
+    #[serde(default)]
+    pub phase: TaskPhase,
+    #[serde(default)]
+    pub priority: TaskPriority,
+    #[serde(default)]
+    pub completion_criteria: Vec<String>,
+    #[serde(default)]
+    pub evidence: Vec<TaskEvidence>,
+    #[serde(default)]
+    pub blockers: Vec<TaskBlocker>,
+    #[serde(default)]
+    pub transitions: Vec<TaskTransition>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct TaskList {
+    #[serde(default)]
+    pub session_id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub items: Vec<TaskItem>,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct TaskProgress {
+    #[serde(default)]
+    pub completed: usize,
+    #[serde(default)]
+    pub total: usize,
+    #[serde(default)]
+    pub percentage: u8,
+}
+
+/// Read-only response from `GET /api/v1/sessions/{id}/task`.
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct TaskListResponse {
+    #[serde(default)]
+    pub session_id: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub items: Vec<TaskItem>,
+    #[serde(default)]
+    pub progress: TaskProgress,
+    #[serde(default)]
+    pub version: u64,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanModeStatus {
+    #[default]
+    Exploring,
+    Designing,
+    Reviewing,
+    Finalizing,
+    AwaitingApproval,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct PlanModeState {
+    pub entered_at: String,
+    pub pre_permission_mode: String,
+    #[serde(default)]
+    pub plan_file_path: Option<String>,
+    #[serde(default)]
+    pub status: PlanModeStatus,
+}
+
 /// Server-Sent Event payload streamed during an agent run.
 ///
 /// Tagged by a `type` field, snake_cased. This is the superset of variants
@@ -179,6 +380,51 @@ pub enum AgentEvent {
         allow_custom: bool,
         #[serde(default)]
         source: Option<String>,
+    },
+    TaskListUpdated {
+        task_list: TaskList,
+        /// Monotonic persisted task-list generation. Older servers omit it;
+        /// clients then fall back to the snapshot timestamp.
+        #[serde(default)]
+        version: Option<u64>,
+    },
+    TaskListItemProgress {
+        session_id: String,
+        item_id: String,
+        status: TaskItemStatus,
+        tool_calls_count: usize,
+        version: u64,
+        /// Rich item projection for blocker/evidence/transition rendering.
+        /// Optional so critical events persisted by older servers still replay.
+        #[serde(default)]
+        item: Option<TaskItem>,
+    },
+    TaskListCompleted {
+        session_id: String,
+        completed_at: String,
+        total_rounds: u32,
+        total_tool_calls: usize,
+        #[serde(default)]
+        version: Option<u64>,
+    },
+    TaskEvaluationStarted {
+        session_id: String,
+        items_count: usize,
+        #[serde(default)]
+        generation: Option<u64>,
+    },
+    TaskEvaluationCompleted {
+        session_id: String,
+        updates_count: usize,
+        reasoning: String,
+        #[serde(default)]
+        generation: Option<u64>,
+    },
+    TaskEvaluationCancelled {
+        session_id: String,
+        reason: String,
+        #[serde(default)]
+        generation: Option<u64>,
     },
     /// A parent-session tool was stopped at Bamboo's typed permission gate.
     /// The authoritative request contract is fetched from the pending endpoint;
@@ -246,7 +492,7 @@ pub enum AgentEvent {
         #[serde(default)]
         entered_at: Option<String>,
         #[serde(default)]
-        status: Option<String>,
+        status: Option<PlanModeStatus>,
         #[serde(default)]
         plan_file_path: Option<String>,
     },
@@ -263,6 +509,8 @@ pub enum AgentEvent {
         file_path: String,
         #[serde(default)]
         content_summary: Option<String>,
+        #[serde(default)]
+        status: Option<PlanModeStatus>,
     },
     /// Current round for a session. Parent streams may carry this inside a
     /// `SubAgentEvent`, allowing clients to update the exact child row without
@@ -470,6 +718,93 @@ mod clarification_event_tests {
                 version: 0,
                 reason: None,
                 resolved_at: None,
+                ..
+            }
+        ));
+    }
+}
+
+#[cfg(test)]
+mod task_plan_event_tests {
+    use super::{AgentEvent, PlanModeStatus, TaskItemStatus};
+
+    #[test]
+    fn legacy_task_events_default_new_projection_fields() {
+        let updated: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "task_list_updated",
+            "task_list": {
+                "session_id": "root-1",
+                "title": "Tasks",
+                "items": [],
+                "created_at": "2026-08-16T00:00:00Z",
+                "updated_at": "2026-08-16T00:00:01Z"
+            }
+        }))
+        .unwrap();
+        assert!(matches!(
+            updated,
+            AgentEvent::TaskListUpdated { version: None, .. }
+        ));
+
+        let progress: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "task_list_item_progress",
+            "session_id": "root-1",
+            "item_id": "task-1",
+            "status": "blocked",
+            "tool_calls_count": 2,
+            "version": 4
+        }))
+        .unwrap();
+        assert!(matches!(
+            progress,
+            AgentEvent::TaskListItemProgress {
+                status: TaskItemStatus::Blocked,
+                item: None,
+                version: 4,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rich_task_and_plan_events_preserve_live_details() {
+        let progress: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "task_list_item_progress",
+            "session_id": "root-1",
+            "item_id": "task-1",
+            "status": "blocked",
+            "tool_calls_count": 2,
+            "version": 5,
+            "item": {
+                "id": "task-1",
+                "description": "Deploy",
+                "status": "blocked",
+                "blockers": [{
+                    "kind": "external",
+                    "summary": "release gate",
+                    "waiting_on": "human approval"
+                }]
+            }
+        }))
+        .unwrap();
+        assert!(matches!(
+            progress,
+            AgentEvent::TaskListItemProgress { item: Some(item), .. }
+                if item.blockers[0].waiting_on.as_deref() == Some("human approval")
+        ));
+
+        let plan: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "plan_file_updated",
+            "session_id": "root-1",
+            "file_path": "/tmp/plan.md",
+            "content_summary": "Ready for review",
+            "status": "awaiting_approval"
+        }))
+        .unwrap();
+        assert!(matches!(
+            plan,
+            AgentEvent::PlanFileUpdated {
+                status: Some(PlanModeStatus::AwaitingApproval),
                 ..
             }
         ));

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
@@ -219,6 +219,7 @@ mod tests {
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             },
+            version: Some(1),
         }
     }
 
@@ -488,6 +489,7 @@ mod tests {
             completed_at: Utc::now(),
             total_rounds: 3,
             total_tool_calls: 10,
+            version: Some(2),
         };
         assert!(is_critical_event(&event));
     }

--- a/crates/app/bamboo-server/src/handlers/agent/task/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/task/handlers.rs
@@ -25,20 +25,27 @@ pub async fn get_task_list(
         session.clone()
     };
 
+    let version = shared_session
+        .task_list_version_meta()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(0);
     let Some(task_list) = shared_session.task_list.as_ref() else {
-        return Ok(HttpResponse::Ok().json(serde_json::json!({
-            "session_id": shared_session.id,
-            "title": null,
-            "items": [],
-            "progress": {
-                "completed": 0,
-                "total": 0,
-                "percentage": 0
-            }
-        })));
+        return Ok(HttpResponse::Ok().json(super::types::TaskListResponse {
+            session_id: shared_session.id.clone(),
+            title: None,
+            items: Vec::new(),
+            progress: super::types::TaskProgress {
+                completed: 0,
+                total: 0,
+                percentage: 0,
+            },
+            version,
+            created_at: None,
+            updated_at: None,
+        }));
     };
 
-    Ok(HttpResponse::Ok().json(to_task_list_response(task_list)))
+    Ok(HttpResponse::Ok().json(to_task_list_response(task_list, version)))
 }
 
 /// Check if a session has a task list.

--- a/crates/app/bamboo-server/src/handlers/agent/task/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/task/types.rs
@@ -1,26 +1,18 @@
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 use bamboo_domain::{TaskItem, TaskItemStatus, TaskList};
-
-/// Task item response for frontend
-#[derive(Serialize)]
-pub struct TaskItemResponse {
-    pub id: String,
-    pub description: String,
-    pub status: String,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub depends_on: Vec<String>,
-    #[serde(skip_serializing_if = "String::is_empty")]
-    pub notes: String,
-}
 
 /// Task list response for frontend
 #[derive(Serialize)]
 pub struct TaskListResponse {
     pub session_id: String,
-    pub title: String,
-    pub items: Vec<TaskItemResponse>,
+    pub title: Option<String>,
+    pub items: Vec<TaskItem>,
     pub progress: TaskProgress,
+    pub version: u64,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
 }
 
 /// Progress information
@@ -31,12 +23,7 @@ pub struct TaskProgress {
     pub percentage: u8,
 }
 
-pub(super) fn to_task_list_response(task_list: &TaskList) -> TaskListResponse {
-    let items = task_list
-        .items
-        .iter()
-        .map(TaskItemResponse::from_item)
-        .collect();
+pub(super) fn to_task_list_response(task_list: &TaskList, version: u64) -> TaskListResponse {
     let completed = task_list
         .items
         .iter()
@@ -46,13 +33,16 @@ pub(super) fn to_task_list_response(task_list: &TaskList) -> TaskListResponse {
 
     TaskListResponse {
         session_id: task_list.session_id.clone(),
-        title: task_list.title.clone(),
-        items,
+        title: Some(task_list.title.clone()),
+        items: task_list.items.clone(),
         progress: TaskProgress {
             completed,
             total,
             percentage: completion_percentage(completed, total),
         },
+        version,
+        created_at: Some(task_list.created_at),
+        updated_at: Some(task_list.updated_at),
     }
 }
 
@@ -63,6 +53,7 @@ pub(super) fn completion_percentage(completed: usize, total: usize) -> u8 {
     ((completed as f32 / total as f32) * 100.0) as u8
 }
 
+#[cfg(test)]
 pub(super) fn task_status_label(status: &TaskItemStatus) -> &'static str {
     match status {
         TaskItemStatus::Pending => "pending",
@@ -72,31 +63,18 @@ pub(super) fn task_status_label(status: &TaskItemStatus) -> &'static str {
     }
 }
 
-impl TaskItemResponse {
-    fn from_item(item: &TaskItem) -> Self {
-        Self {
-            id: item.id.clone(),
-            description: item.description.clone(),
-            status: task_status_label(&item.status).to_string(),
-            depends_on: item.depends_on.clone(),
-            notes: item.notes.clone(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bamboo_domain::TaskItemStatus;
+    use bamboo_domain::{TaskBlocker, TaskBlockerKind, TaskItemStatus};
 
     #[test]
     fn test_task_item_response_serialization() {
-        let item = TaskItemResponse {
+        let item = TaskItem {
             id: "task-1".to_string(),
             description: "Test task".to_string(),
-            status: "pending".to_string(),
-            depends_on: vec![],
-            notes: String::new(),
+            status: TaskItemStatus::Pending,
+            ..TaskItem::default()
         };
 
         let json = serde_json::to_string(&item).unwrap();
@@ -106,12 +84,12 @@ mod tests {
 
     #[test]
     fn test_task_item_response_with_dependencies() {
-        let item = TaskItemResponse {
+        let item = TaskItem {
             id: "task-2".to_string(),
             description: "Dependent task".to_string(),
-            status: "pending".to_string(),
+            status: TaskItemStatus::Pending,
             depends_on: vec!["task-1".to_string()],
-            notes: String::new(),
+            ..TaskItem::default()
         };
 
         let json = serde_json::to_string(&item).unwrap();
@@ -120,59 +98,65 @@ mod tests {
 
     #[test]
     fn test_task_item_response_with_notes() {
-        let item = TaskItemResponse {
+        let item = TaskItem {
             id: "task-3".to_string(),
             description: "Task with notes".to_string(),
-            status: "in_progress".to_string(),
-            depends_on: vec![],
+            status: TaskItemStatus::InProgress,
             notes: "This is a note".to_string(),
+            blockers: vec![TaskBlocker {
+                kind: TaskBlockerKind::External,
+                summary: "Waiting for CI".to_string(),
+                waiting_on: Some("build #42".to_string()),
+            }],
+            ..TaskItem::default()
         };
 
         let json = serde_json::to_string(&item).unwrap();
         assert!(json.contains("\"This is a note\""));
+        assert!(json.contains("\"waiting_on\":\"build #42\""));
     }
 
     #[test]
     fn test_task_item_response_skips_empty_fields() {
-        let item = TaskItemResponse {
+        let item = TaskItem {
             id: "task-4".to_string(),
             description: "Clean task".to_string(),
-            status: "completed".to_string(),
-            depends_on: vec![],
-            notes: String::new(),
+            status: TaskItemStatus::Completed,
+            ..TaskItem::default()
         };
 
         let json = serde_json::to_string(&item).unwrap();
-        // Should not serialize empty depends_on or notes
-        assert!(!json.contains("\"depends_on\""));
-        assert!(!json.contains("\"notes\""));
+        assert!(json.contains("\"status\":\"completed\""));
     }
 
     #[test]
     fn test_task_list_response_serialization() {
-        let item = TaskItemResponse {
+        let item = TaskItem {
             id: "item-1".to_string(),
             description: "Task 1".to_string(),
-            status: "completed".to_string(),
-            depends_on: vec![],
-            notes: String::new(),
+            status: TaskItemStatus::Completed,
+            ..TaskItem::default()
         };
 
         let response = TaskListResponse {
             session_id: "session-1".to_string(),
-            title: "My Task List".to_string(),
+            title: Some("My Task List".to_string()),
             items: vec![item],
             progress: TaskProgress {
                 completed: 1,
                 total: 1,
                 percentage: 100,
             },
+            version: 3,
+            created_at: None,
+            updated_at: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"session_id\":\"session-1\""));
         assert!(json.contains("\"My Task List\""));
         assert!(json.contains("\"percentage\":100"));
+        assert!(json.contains("\"version\":3"));
     }
 
     #[test]
@@ -210,29 +194,5 @@ mod tests {
     fn test_completion_percentage_rounding() {
         let percentage = completion_percentage(1, 3);
         assert_eq!(percentage, 33);
-    }
-
-    #[test]
-    fn test_task_status_label_pending() {
-        let label = task_status_label(&TaskItemStatus::Pending);
-        assert_eq!(label, "pending");
-    }
-
-    #[test]
-    fn test_task_status_label_in_progress() {
-        let label = task_status_label(&TaskItemStatus::InProgress);
-        assert_eq!(label, "in_progress");
-    }
-
-    #[test]
-    fn test_task_status_label_completed() {
-        let label = task_status_label(&TaskItemStatus::Completed);
-        assert_eq!(label, "completed");
-    }
-
-    #[test]
-    fn test_task_status_label_blocked() {
-        let label = task_status_label(&TaskItemStatus::Blocked);
-        assert_eq!(label, "blocked");
     }
 }

--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -563,6 +563,23 @@ impl BambooClient {
         Ok(envelope.session)
     }
 
+    /// Authoritative read-only task snapshot used on open, reconnect, and
+    /// explicit refresh. Child session IDs are resolved to their shared root
+    /// list by the server.
+    pub async fn get_task_list(&self, session_id: &str) -> Result<TaskListResponse> {
+        let resp = self
+            .client
+            .get(self.url(&format!("/api/v1/sessions/{session_id}/task")))
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("get task list failed ({status}): {body}");
+        }
+        Ok(resp.json().await?)
+    }
+
     /// Same paginated session endpoint as [`Self::list_sessions`], decoded
     /// into the relationship-rich projection used by the child-session tree.
     pub async fn list_session_tree(
@@ -1458,6 +1475,37 @@ mod tests {
         assert_eq!(page.total, 3);
         assert_eq!(page.offset, 2);
         assert_eq!(page.sessions[0].spawn_depth, 2);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn task_snapshot_preserves_version_hierarchy_and_blockers() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_request(&mut socket).await;
+            assert!(request.starts_with("GET /api/v1/sessions/child-2/task HTTP/1.1"));
+            respond(
+                &mut socket,
+                "200 OK",
+                "\"1\"",
+                r#"{"session_id":"root","title":"Release","items":[{"id":"child","description":"Deploy","status":"blocked","parent_id":"parent","depends_on":["build"],"blockers":[{"kind":"dependency","summary":"Build pending","waiting_on":"build"}]}],"progress":{"completed":0,"total":1,"percentage":0},"version":7,"created_at":"2026-08-16T00:00:00Z","updated_at":"2026-08-16T00:00:01Z"}"#,
+            )
+            .await;
+        });
+
+        let snapshot = BambooClient::new(&base_url)
+            .get_task_list("child-2")
+            .await
+            .unwrap();
+        assert_eq!(snapshot.session_id, "root");
+        assert_eq!(snapshot.version, 7);
+        assert_eq!(snapshot.items[0].parent_id.as_deref(), Some("parent"));
+        assert_eq!(
+            snapshot.items[0].blockers[0].waiting_on.as_deref(),
+            Some("build")
+        );
         server.await.unwrap();
     }
 

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -22,8 +22,9 @@ fn default_title_generated() -> bool {
 // across the CLI and TUI front-ends); re-exported here so the rest of the TUI
 // can keep referring to `crate::api::types::{AgentEvent, ChatRequest, …}`.
 pub use bamboo_client_core::{
-    AgentEvent, ChatRequest, ChatResponse, ExecuteRequest, ExecuteResponse, ReasoningEffort,
-    TokenUsage,
+    AgentEvent, ChatRequest, ChatResponse, ExecuteRequest, ExecuteResponse, PlanModeState,
+    PlanModeStatus, ReasoningEffort, TaskItem, TaskItemStatus, TaskList, TaskListResponse,
+    TaskProgress, TokenUsage,
 };
 
 // ── Command catalog ──
@@ -123,6 +124,9 @@ pub struct SessionSummary {
     /// rendered as bypass even if an older server omitted `permission_mode`.
     #[serde(default)]
     pub bypass_permissions: bool,
+    /// Durable Plan Mode lifecycle, when the session is currently planning.
+    #[serde(default)]
+    pub plan_mode: Option<PlanModeState>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -28,6 +28,7 @@ use crate::keymap::{
 };
 use crate::search::ranked_indices;
 use crate::subagents::{SubagentTreeState, SubagentTreeStatus, MAX_SUBAGENT_TREE_SESSIONS};
+use crate::task_plan::{TaskPlanOverlayState, TaskPlanPane, TaskProgressState};
 use crate::ui;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -318,6 +319,200 @@ mod subagent_tree_navigation_tests {
         assert_eq!(
             app.subagent_tree.as_ref().unwrap().nodes["child-a"].round_count,
             Some(3)
+        );
+    }
+}
+
+#[cfg(test)]
+mod task_plan_integration_tests {
+    use super::*;
+
+    fn snapshot(status: TaskItemStatus, version: u64) -> TaskListResponse {
+        TaskListResponse {
+            session_id: "root".to_string(),
+            title: Some("Tasks".to_string()),
+            items: vec![TaskItem {
+                id: "one".to_string(),
+                description: "Ship".to_string(),
+                status,
+                ..TaskItem::default()
+            }],
+            progress: TaskProgress {
+                completed: usize::from(status == TaskItemStatus::Completed),
+                total: 1,
+                percentage: if status == TaskItemStatus::Completed {
+                    100
+                } else {
+                    0
+                },
+            },
+            version,
+            ..TaskListResponse::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn cold_snapshot_is_bound_to_the_exact_session_and_refresh_epoch() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("child".to_string());
+        app.chat.task_progress.begin_refresh("child");
+        app.task_plan_epoch = 4;
+
+        app.handle_event(AppEvent::TaskPlanSnapshotLoaded {
+            epoch: 3,
+            session_id: "child".to_string(),
+            plan_revision: 0,
+            result: Ok((snapshot(TaskItemStatus::Blocked, 6), None)),
+        })
+        .await
+        .unwrap();
+        app.handle_event(AppEvent::TaskPlanSnapshotLoaded {
+            epoch: 4,
+            session_id: "other".to_string(),
+            plan_revision: 0,
+            result: Ok((snapshot(TaskItemStatus::Blocked, 6), None)),
+        })
+        .await
+        .unwrap();
+        assert!(app.chat.task_progress.task_list.is_none());
+
+        app.handle_event(AppEvent::TaskPlanSnapshotLoaded {
+            epoch: 4,
+            session_id: "child".to_string(),
+            plan_revision: 0,
+            result: Ok((
+                snapshot(TaskItemStatus::Blocked, 6),
+                Some(PlanModeState {
+                    entered_at: "2026-08-16T00:00:00Z".to_string(),
+                    pre_permission_mode: "default".to_string(),
+                    plan_file_path: Some("plans/child.md".to_string()),
+                    status: PlanModeStatus::Reviewing,
+                }),
+            )),
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            app.chat.task_progress.owner_session_id.as_deref(),
+            Some("root")
+        );
+        assert_eq!(app.chat.task_progress.version, 6);
+        assert_eq!(
+            app.chat.run_status.plan.status,
+            Some(PlanModeStatus::Reviewing)
+        );
+    }
+
+    #[tokio::test]
+    async fn late_http_plan_snapshot_cannot_reopen_a_plan_closed_by_live_event() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("child".to_string());
+        app.chat.task_progress.begin_refresh("child");
+        app.task_plan_epoch = 4;
+
+        app.handle_sse_event(AgentEvent::PlanModeExited {
+            session_id: "child".to_string(),
+            approved: true,
+            plan: Some("# Approved".to_string()),
+            restored_mode: Some("default".to_string()),
+        })
+        .unwrap();
+        assert_eq!(app.chat.run_status.plan_revision, 1);
+
+        app.handle_event(AppEvent::TaskPlanSnapshotLoaded {
+            epoch: 4,
+            session_id: "child".to_string(),
+            plan_revision: 0,
+            result: Ok((
+                snapshot(TaskItemStatus::Pending, 4),
+                Some(PlanModeState {
+                    entered_at: "2026-08-16T00:00:00Z".to_string(),
+                    pre_permission_mode: "default".to_string(),
+                    plan_file_path: Some("plans/child.md".to_string()),
+                    status: PlanModeStatus::Reviewing,
+                }),
+            )),
+        })
+        .await
+        .unwrap();
+
+        assert!(!app.chat.run_status.plan.active);
+        assert_eq!(
+            app.chat.run_status.plan.last_outcome.as_deref(),
+            Some("approved")
+        );
+        assert_eq!(app.chat.task_progress.version, 4);
+    }
+
+    #[test]
+    fn nested_child_task_delta_updates_only_its_shared_parent_list() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.session_id = Some("root".to_string());
+        app.chat.task_progress.begin_refresh("root");
+        app.chat
+            .task_progress
+            .install_snapshot("root", snapshot(TaskItemStatus::Pending, 1));
+
+        app.handle_sse_event(AgentEvent::SubAgentEvent {
+            child_session_id: "child-a".to_string(),
+            event: Box::new(AgentEvent::TaskListItemProgress {
+                session_id: "child-a".to_string(),
+                item_id: "one".to_string(),
+                status: TaskItemStatus::Completed,
+                tool_calls_count: 1,
+                version: 2,
+                item: None,
+            }),
+        })
+        .unwrap();
+        assert_eq!(
+            app.chat.task_progress.task_list.as_ref().unwrap().items[0].status,
+            TaskItemStatus::Completed
+        );
+
+        app.handle_sse_event(AgentEvent::SubAgentEvent {
+            child_session_id: "child-a".to_string(),
+            event: Box::new(AgentEvent::TaskListItemProgress {
+                session_id: "child-b".to_string(),
+                item_id: "one".to_string(),
+                status: TaskItemStatus::Blocked,
+                tool_calls_count: 2,
+                version: 3,
+                item: None,
+            }),
+        })
+        .unwrap();
+        assert_eq!(
+            app.chat.task_progress.task_list.as_ref().unwrap().items[0].status,
+            TaskItemStatus::Completed
+        );
+    }
+
+    #[test]
+    fn plan_exit_events_distinguish_approval_from_rejection() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.handle_sse_event(AgentEvent::PlanModeExited {
+            session_id: "root".to_string(),
+            approved: false,
+            plan: Some("# Plan".to_string()),
+            restored_mode: Some("default".to_string()),
+        })
+        .unwrap();
+        assert_eq!(
+            app.chat.run_status.plan.last_outcome.as_deref(),
+            Some("rejected or exited")
+        );
+
+        app.handle_sse_event(AgentEvent::PlanModeExited {
+            session_id: "root".to_string(),
+            approved: true,
+            plan: Some("# Approved".to_string()),
+            restored_mode: Some("default".to_string()),
+        })
+        .unwrap();
+        assert_eq!(
+            app.chat.run_status.plan.last_outcome.as_deref(),
+            Some("approved")
         );
     }
 }
@@ -944,6 +1139,8 @@ pub struct ChatState {
     pub provider: Option<String>,
     pub token_usage: Option<TokenUsage>,
     pub plan_mode: bool,
+    /// Authoritative task snapshot plus monotonic live-event reducer state.
+    pub(crate) task_progress: TaskProgressState,
     /// Typed, durable execution state for this exact session context. It moves
     /// with the rest of `ChatState`, so background events can never overwrite
     /// whichever session happens to be visible.
@@ -1040,6 +1237,7 @@ impl ChatState {
             provider: None,
             token_usage: None,
             plan_mode: false,
+            task_progress: TaskProgressState::default(),
             run_status: RunStatusState::default(),
             expand_tools: false,
             sub_agents: Vec::new(),
@@ -1742,6 +1940,11 @@ pub(crate) struct PlanRunStatus {
     pub(crate) active: bool,
     pub(crate) reason: Option<String>,
     pub(crate) file_path: Option<String>,
+    pub(crate) status: Option<PlanModeStatus>,
+    pub(crate) entered_at: Option<String>,
+    pub(crate) pre_permission_mode: Option<String>,
+    pub(crate) content_summary: Option<String>,
+    pub(crate) plan: Option<String>,
     pub(crate) last_outcome: Option<String>,
 }
 
@@ -1780,6 +1983,9 @@ pub(crate) struct RunStatusState {
     pub(crate) tools: VecDeque<RunToolStatus>,
     pub(crate) compression: Option<CompressionRunStatus>,
     pub(crate) plan: PlanRunStatus,
+    /// Increments for every live plan lifecycle event observed by this exact
+    /// session view, guarding it from late HTTP refresh responses.
+    pub(crate) plan_revision: u64,
     pub(crate) budget: Option<BudgetRunStatus>,
     sub_agents: VecDeque<SubAgentRunStatus>,
     /// Recently observed server run ids for this session. A delayed
@@ -2114,26 +2320,69 @@ impl RunStatusState {
         });
     }
 
-    fn enter_plan(&mut self, reason: Option<String>, file_path: Option<String>) {
+    fn enter_plan(
+        &mut self,
+        reason: Option<String>,
+        file_path: Option<String>,
+        status: Option<PlanModeStatus>,
+        entered_at: Option<String>,
+        pre_permission_mode: Option<String>,
+    ) {
+        self.plan_revision = self.plan_revision.wrapping_add(1).max(1);
         self.plan.active = true;
         self.plan.reason = reason;
-        if file_path.is_some() {
-            self.plan.file_path = file_path;
-        }
+        self.plan.file_path = file_path;
+        self.plan.status = status;
+        self.plan.entered_at = entered_at;
+        self.plan.pre_permission_mode = pre_permission_mode;
+        self.plan.content_summary = None;
+        self.plan.plan = None;
         self.plan.last_outcome = None;
     }
 
-    fn exit_plan(&mut self, approved: bool) {
+    fn restore_plan(&mut self, plan: Option<PlanModeState>) {
+        match plan {
+            Some(plan) => {
+                self.plan = PlanRunStatus {
+                    active: true,
+                    file_path: plan.plan_file_path,
+                    status: Some(plan.status),
+                    entered_at: Some(plan.entered_at),
+                    pre_permission_mode: Some(plan.pre_permission_mode),
+                    ..PlanRunStatus::default()
+                };
+            }
+            None => self.plan = PlanRunStatus::default(),
+        }
+    }
+
+    fn exit_plan(&mut self, approved: bool, plan: Option<String>) {
+        self.plan_revision = self.plan_revision.wrapping_add(1).max(1);
         self.plan.active = false;
+        self.plan.status = None;
+        if plan.is_some() {
+            self.plan.plan = plan;
+        }
         self.plan.last_outcome = Some(if approved {
             "approved".to_string()
         } else {
-            "exited".to_string()
+            "rejected or exited".to_string()
         });
     }
 
-    fn update_plan_file(&mut self, file_path: String) {
+    fn update_plan_file(
+        &mut self,
+        file_path: String,
+        content_summary: Option<String>,
+        status: Option<PlanModeStatus>,
+    ) {
+        self.plan_revision = self.plan_revision.wrapping_add(1).max(1);
         self.plan.file_path = Some(file_path);
+        self.plan.content_summary = content_summary;
+        if status.is_some() {
+            self.plan.active = true;
+            self.plan.status = status;
+        }
     }
 
     fn exceed_budget(&mut self, kind: String, limit: u64, actual: u64) -> bool {
@@ -3932,6 +4181,10 @@ pub struct App {
     pub(crate) subagent_tree: Option<SubagentTreeState>,
     subagent_tree_epoch: u64,
     subagent_tree_task: Option<tokio::task::JoinHandle<()>>,
+    /// Read-only task/plan inspector for the active Chat session.
+    pub(crate) task_plan: Option<TaskPlanOverlayState>,
+    task_plan_epoch: u64,
+    task_plan_task: Option<tokio::task::JoinHandle<()>>,
     /// Combined built-in/server command palette (`Ctrl+K` globally or `/` as
     /// the first composer character). It never mutates the composer until a
     /// selection succeeds, so cancellation and every async failure preserve
@@ -4056,6 +4309,9 @@ impl Drop for App {
         if let Some(task) = self.subagent_tree_task.take() {
             task.abort();
         }
+        if let Some(task) = self.task_plan_task.take() {
+            task.abort();
+        }
         for context in self.session_views.values_mut() {
             context.abort_background_work();
         }
@@ -4159,6 +4415,9 @@ impl App {
             subagent_tree: None,
             subagent_tree_epoch: 0,
             subagent_tree_task: None,
+            task_plan: None,
+            task_plan_epoch: 0,
+            task_plan_task: None,
             command_palette: None,
             pending_delete: None,
             pending_schedule_delete: None,
@@ -4365,6 +4624,8 @@ impl App {
             self.pending_delete = None;
         }
         self.close_subagent_tree();
+        self.close_task_plan();
+        self.cancel_task_plan_refresh();
         self.close_session_picker();
         self.close_model_picker();
         self.close_command_palette();
@@ -6040,10 +6301,41 @@ impl App {
                             let question = self.question_from_pending(session_id.clone(), pending);
                             self.pending_question = Some(question);
                         }
+                        self.refresh_task_plan_snapshot(session_id.clone());
                         self.refresh_child_approvals(session_id);
                     }
                     Err(e) => {
                         self.notify(NoticeLevel::Error, format!("Failed to open session: {e}"));
+                    }
+                }
+            }
+            AppEvent::TaskPlanSnapshotLoaded {
+                epoch,
+                session_id,
+                plan_revision,
+                result,
+            } => {
+                if epoch != self.task_plan_epoch
+                    || self.chat.session_id.as_deref() != Some(session_id.as_str())
+                {
+                    return Ok(());
+                }
+                self.task_plan_task = None;
+                match result {
+                    Ok((tasks, plan_mode)) => {
+                        self.chat.task_progress.install_snapshot(&session_id, tasks);
+                        if self.chat.run_status.plan_revision == plan_revision {
+                            self.chat.plan_mode = plan_mode.is_some();
+                            self.chat.run_status.restore_plan(plan_mode);
+                        }
+                    }
+                    Err(error) => {
+                        self.chat
+                            .task_progress
+                            .fail_refresh(&session_id, error.clone());
+                        if self.task_plan.is_some() {
+                            self.status_message = format!("Task/plan refresh failed: {error}");
+                        }
                     }
                 }
             }
@@ -7744,6 +8036,7 @@ impl App {
             || self.pending_delete.is_some()
             || self.pending_schedule_delete.is_some()
             || self.subagent_tree.is_some()
+            || self.task_plan.is_some()
             || self.session_picker.is_some()
             || self.model_picker.is_some()
             || self.command_palette.is_some()
@@ -7807,6 +8100,8 @@ impl App {
             ActionContext::ScheduleDeleteConfirm
         } else if self.subagent_tree.is_some() {
             ActionContext::SubagentTree
+        } else if self.task_plan.is_some() {
+            ActionContext::TaskPlan
         } else if self.session_picker.is_some() {
             self.session_picker_context()
         } else if self.model_picker.is_some() {
@@ -7915,6 +8210,8 @@ impl App {
             picker.error = Some(message.clone());
         } else if let Some(tree) = self.subagent_tree.as_mut() {
             tree.error = Some(message.clone());
+        } else if self.task_plan.is_some() {
+            self.chat.task_progress.error = Some(message.clone());
         }
         self.status_message = message;
     }
@@ -7988,6 +8285,7 @@ impl App {
             ActionId::OpenModelPicker => self.open_model_picker(),
             ActionId::OpenSessionPicker => self.open_session_picker(),
             ActionId::OpenSubagentTree => self.open_subagent_tree(),
+            ActionId::OpenTaskPlan => self.open_task_plan(),
             ActionId::StopRun => self.stop_streaming(),
             ActionId::ToggleDetails => self.toggle_conversation_details(),
             ActionId::OpenConfigTab => {
@@ -8056,6 +8354,7 @@ impl App {
             ActionContext::PermissionRuleConfirm => self.handle_permission_rule_confirm_key(key),
             ActionContext::PermissionModeConfirm => self.handle_permission_mode_confirm_key(key),
             ActionContext::SubagentTree => self.handle_subagent_tree_key(key),
+            ActionContext::TaskPlan => self.handle_task_plan_key(key),
             ActionContext::SessionPickerBrowse
             | ActionContext::SessionPickerRename
             | ActionContext::SessionPickerPinning => self.handle_session_picker_key(key).await?,
@@ -10815,7 +11114,10 @@ impl App {
                     .is_none_or(|question| !question.submitting)
                 {
                     self.reconcile_pending_question_after_stream_connect(session_id.clone());
-                    self.refresh_child_approvals(session_id);
+                    self.refresh_child_approvals(session_id.clone());
+                }
+                if reconnecting && self.routing_background_session.is_none() {
+                    self.refresh_task_plan_snapshot(session_id);
                 }
                 Ok(())
             }
@@ -10850,7 +11152,124 @@ impl App {
         }
     }
 
+    fn reduce_task_event(
+        &mut self,
+        event: &AgentEvent,
+        envelope_session_id: Option<&str>,
+        shared_source: bool,
+    ) -> bool {
+        let Some(active_session_id) = self.chat.session_id.clone() else {
+            return false;
+        };
+        if self.chat.task_progress.requested_session_id.is_none() {
+            self.chat.task_progress.begin_refresh(&active_session_id);
+        }
+        let applied = match event {
+            AgentEvent::TaskListUpdated { task_list, version } => {
+                let source = envelope_session_id.unwrap_or(active_session_id.as_str());
+                self.chat.task_progress.apply_list(
+                    source,
+                    task_list.clone(),
+                    *version,
+                    shared_source,
+                )
+            }
+            AgentEvent::TaskListItemProgress {
+                session_id,
+                item_id,
+                status,
+                version,
+                item,
+                ..
+            } => {
+                if envelope_session_id.is_some_and(|envelope| envelope != session_id) {
+                    return true;
+                }
+                self.chat.task_progress.apply_item(
+                    session_id,
+                    item_id.clone(),
+                    *status,
+                    *version,
+                    item.clone(),
+                    shared_source,
+                )
+            }
+            AgentEvent::TaskListCompleted {
+                session_id,
+                total_rounds,
+                total_tool_calls,
+                version,
+                ..
+            } => {
+                if envelope_session_id.is_some_and(|envelope| envelope != session_id) {
+                    return true;
+                }
+                self.chat.task_progress.apply_completed(
+                    session_id,
+                    *version,
+                    *total_rounds,
+                    *total_tool_calls,
+                    shared_source,
+                )
+            }
+            AgentEvent::TaskEvaluationStarted {
+                session_id,
+                items_count,
+                generation,
+            } => {
+                if envelope_session_id.is_some_and(|envelope| envelope != session_id) {
+                    return true;
+                }
+                self.chat.task_progress.evaluation_started(
+                    session_id,
+                    *items_count,
+                    *generation,
+                    shared_source,
+                )
+            }
+            AgentEvent::TaskEvaluationCompleted {
+                session_id,
+                updates_count,
+                reasoning,
+                generation,
+            } => {
+                if envelope_session_id.is_some_and(|envelope| envelope != session_id) {
+                    return true;
+                }
+                self.chat.task_progress.evaluation_finished(
+                    session_id,
+                    format!("evaluation applied {updates_count} updates · {reasoning}"),
+                    *generation,
+                    shared_source,
+                )
+            }
+            AgentEvent::TaskEvaluationCancelled {
+                session_id,
+                reason,
+                generation,
+            } => {
+                if envelope_session_id.is_some_and(|envelope| envelope != session_id) {
+                    return true;
+                }
+                self.chat.task_progress.evaluation_finished(
+                    session_id,
+                    format!("evaluation cancelled · {reason}"),
+                    *generation,
+                    shared_source,
+                )
+            }
+            _ => return false,
+        };
+        if matches!(applied, crate::task_plan::ApplyResult::Applied) {
+            self.chat.note_update();
+        }
+        true
+    }
+
     fn handle_sse_event(&mut self, event: AgentEvent) -> Result<()> {
+        if self.reduce_task_event(&event, None, false) {
+            return Ok(());
+        }
         match event {
             AgentEvent::Token { content } => {
                 if self.chat.run_status.phase.is_terminal() {
@@ -11666,12 +12085,19 @@ impl App {
             }
             AgentEvent::PlanModeEntered {
                 reason,
+                pre_permission_mode,
+                entered_at,
+                status,
                 plan_file_path,
                 ..
             } => {
-                self.chat
-                    .run_status
-                    .enter_plan(reason.clone(), plan_file_path);
+                self.chat.run_status.enter_plan(
+                    reason.clone(),
+                    plan_file_path,
+                    status,
+                    entered_at,
+                    pre_permission_mode,
+                );
                 self.record_activity(ActivityKind::Plan, NoticeLevel::Info, "Plan mode entered");
                 self.chat.plan_mode = true;
                 self.status_message = format!(
@@ -11682,8 +12108,8 @@ impl App {
                         .unwrap_or_default()
                 );
             }
-            AgentEvent::PlanModeExited { approved, .. } => {
-                self.chat.run_status.exit_plan(approved);
+            AgentEvent::PlanModeExited { approved, plan, .. } => {
+                self.chat.run_status.exit_plan(approved, plan);
                 self.record_activity(
                     ActivityKind::Plan,
                     NoticeLevel::Info,
@@ -11700,8 +12126,15 @@ impl App {
                     "Plan mode exited".to_string()
                 };
             }
-            AgentEvent::PlanFileUpdated { file_path, .. } => {
-                self.chat.run_status.update_plan_file(file_path.clone());
+            AgentEvent::PlanFileUpdated {
+                file_path,
+                content_summary,
+                status,
+                ..
+            } => {
+                self.chat
+                    .run_status
+                    .update_plan_file(file_path.clone(), content_summary, status);
                 self.record_activity(
                     ActivityKind::Plan,
                     NoticeLevel::Info,
@@ -11723,6 +12156,7 @@ impl App {
                 if !identity_matches {
                     return Ok(());
                 }
+                self.reduce_task_event(&event, Some(&child_session_id), true);
                 let parent_session_id = self.chat.session_id.clone();
                 if let (Some(parent_session_id), Some(tree)) =
                     (parent_session_id, self.subagent_tree.as_mut())
@@ -11732,6 +12166,14 @@ impl App {
                         tree.apply_forwarded_event(&child_session_id, &event);
                     }
                 }
+            }
+            AgentEvent::TaskListUpdated { .. }
+            | AgentEvent::TaskListItemProgress { .. }
+            | AgentEvent::TaskListCompleted { .. }
+            | AgentEvent::TaskEvaluationStarted { .. }
+            | AgentEvent::TaskEvaluationCompleted { .. }
+            | AgentEvent::TaskEvaluationCancelled { .. } => {
+                unreachable!("task events are reduced before the main event match")
             }
             AgentEvent::SubAgentStarted {
                 child_session_id,
@@ -13062,6 +13504,135 @@ impl App {
                     });
                 });
             }
+            _ => {}
+        }
+    }
+
+    // ── Task and plan progress (Leader+T) ──
+
+    fn open_task_plan(&mut self) {
+        let Some(session_id) = self.chat.session_id.clone() else {
+            self.status_message =
+                "Start or open a session before inspecting task progress".to_string();
+            return;
+        };
+        self.task_plan = Some(TaskPlanOverlayState::default());
+        self.refresh_task_plan_snapshot(session_id);
+    }
+
+    fn close_task_plan(&mut self) {
+        self.task_plan = None;
+    }
+
+    fn cancel_task_plan_refresh(&mut self) {
+        self.task_plan_epoch = self.task_plan_epoch.wrapping_add(1);
+        if let Some(task) = self.task_plan_task.take() {
+            task.abort();
+        }
+    }
+
+    fn refresh_task_plan_snapshot(&mut self, session_id: String) {
+        if self.chat.session_id.as_deref() != Some(session_id.as_str()) {
+            return;
+        }
+        self.cancel_task_plan_refresh();
+        self.task_plan_epoch = self.task_plan_epoch.wrapping_add(1).max(1);
+        let epoch = self.task_plan_epoch;
+        let plan_revision = self.chat.run_status.plan_revision;
+        self.chat.task_progress.begin_refresh(&session_id);
+        let Some(tx) = self.event_tx.clone() else {
+            self.chat.task_progress.fail_refresh(
+                &session_id,
+                "Task refresh is not attached to the event loop".to_string(),
+            );
+            return;
+        };
+        let client = self.client.clone();
+        self.task_plan_task = Some(tokio::spawn(async move {
+            let (tasks, summary) = tokio::join!(
+                client.get_task_list(&session_id),
+                client.get_session(&session_id)
+            );
+            let result = match (tasks, summary) {
+                (Ok(tasks), Ok(summary)) => Ok((tasks, summary.plan_mode)),
+                (Err(error), _) => Err(error.to_string()),
+                (_, Err(error)) => Err(error.to_string()),
+            };
+            let _ = tx.send(AppEvent::TaskPlanSnapshotLoaded {
+                epoch,
+                session_id,
+                plan_revision,
+                result,
+            });
+        }));
+    }
+
+    fn handle_task_plan_key(&mut self, key: KeyEvent) {
+        let action = self.resolve_context_action(ActionContext::TaskPlan, key);
+        let item_count = self.chat.task_progress.ordered_items().len();
+        match action {
+            Some(ActionId::NavigateUp) => {
+                if let Some(overlay) = self.task_plan.as_mut() {
+                    if overlay.pane == TaskPlanPane::Tasks {
+                        overlay.move_selection(-1, item_count);
+                    } else {
+                        overlay.detail_scroll = overlay.detail_scroll.saturating_sub(1);
+                    }
+                }
+            }
+            Some(ActionId::NavigateDown) => {
+                if let Some(overlay) = self.task_plan.as_mut() {
+                    if overlay.pane == TaskPlanPane::Tasks {
+                        overlay.move_selection(1, item_count);
+                    } else {
+                        overlay.detail_scroll = overlay.detail_scroll.saturating_add(1);
+                    }
+                }
+            }
+            Some(ActionId::PageUp) => {
+                if let Some(overlay) = self.task_plan.as_mut() {
+                    if overlay.pane == TaskPlanPane::Tasks {
+                        overlay.move_selection(-8, item_count);
+                    } else {
+                        overlay.detail_scroll = overlay.detail_scroll.saturating_sub(8);
+                    }
+                }
+            }
+            Some(ActionId::PageDown) => {
+                if let Some(overlay) = self.task_plan.as_mut() {
+                    if overlay.pane == TaskPlanPane::Tasks {
+                        overlay.move_selection(8, item_count);
+                    } else {
+                        overlay.detail_scroll = overlay.detail_scroll.saturating_add(8);
+                    }
+                }
+            }
+            Some(ActionId::JumpFirst) => {
+                if let Some(overlay) = self.task_plan.as_mut() {
+                    overlay.selected = 0;
+                    overlay.detail_scroll = 0;
+                }
+            }
+            Some(ActionId::JumpLast) => {
+                if let Some(overlay) = self.task_plan.as_mut() {
+                    if overlay.pane == TaskPlanPane::Tasks {
+                        overlay.selected = item_count.saturating_sub(1);
+                    } else {
+                        overlay.detail_scroll = usize::MAX / 2;
+                    }
+                }
+            }
+            Some(ActionId::ToggleInspectorPane) => {
+                if let Some(overlay) = self.task_plan.as_mut() {
+                    overlay.toggle_pane();
+                }
+            }
+            Some(ActionId::Refresh) => {
+                if let Some(session_id) = self.chat.session_id.clone() {
+                    self.refresh_task_plan_snapshot(session_id);
+                }
+            }
+            Some(ActionId::Cancel) => self.close_task_plan(),
             _ => {}
         }
     }
@@ -17643,6 +18214,12 @@ mod question_tests {
         commands.open_command_palette(CommandPaletteTrigger::Global);
         actual.push(minimum_modal_fingerprint(&commands));
 
+        let mut task_plan = App::new(BambooClient::new("http://127.0.0.1:0"));
+        task_plan.chat.session_id = Some("root".to_string());
+        task_plan.chat.task_progress.begin_refresh("root");
+        task_plan.task_plan = Some(TaskPlanOverlayState::default());
+        actual.push(minimum_modal_fingerprint(&task_plan));
+
         let mut subagents = App::new(BambooClient::new("http://127.0.0.1:0"));
         subagents.chat.session_id = Some("root".to_string());
         let mut root = SessionTreeSummary::placeholder("root");
@@ -17671,7 +18248,7 @@ mod question_tests {
         assert_eq!(
             actual,
             vec![
-                17_147_369_131_010_514_566,
+                8_245_894_359_903_651_780,
                 1_057_473_937_556_339_135,
                 1_502_110_673_089_046_554,
                 14_484_161_115_671_232_577,
@@ -17680,7 +18257,8 @@ mod question_tests {
                 10_493_202_686_479_633_261,
                 10_935_873_232_087_006_812,
                 8_710_182_394_295_884_107,
-                15_353_719_274_755_616_638,
+                3_584_340_785_452_026_141,
+                199_111_197_660_670_885,
                 5_239_033_309_572_019_229,
                 3_245_283_921_451_133_623,
             ],
@@ -18488,6 +19066,7 @@ mod question_tests {
             pinned: false,
             permission_mode: SessionPermissionMode::Default,
             bypass_permissions: false,
+            plan_mode: None,
         }
     }
 
@@ -25503,6 +26082,7 @@ mod run_status_tests {
             session_id: "session-life".to_string(),
             file_path: "plan-v2.md".to_string(),
             content_summary: None,
+            status: Some(PlanModeStatus::AwaitingApproval),
         })
         .unwrap();
         app.handle_sse_event(AgentEvent::PlanModeExited {
@@ -25774,6 +26354,9 @@ mod run_status_tests {
         app.chat.run_status.enter_plan(
             Some("review the implementation".to_string()),
             Some("plans/644.md".to_string()),
+            Some(PlanModeStatus::Reviewing),
+            Some("2026-08-16T00:00:00Z".to_string()),
+            Some("default".to_string()),
         );
         app.chat
             .run_status

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -3,8 +3,9 @@ use crossterm::event::{KeyEvent, MouseEvent};
 use crate::api::types::{
     CatalogModel, CommandDetail, CommandListResponse, ListSessionTreeEnvelope,
     ListSessionsEnvelope, McpServer, PendingQuestion, PermissionDecisionResponse,
-    PermissionPolicyResponse, ProviderCatalog, ReasoningEffort, Schedule, SessionSummary,
-    SessionTreeSummary, Skill, SkillDetail, SubagentSnapshotResponse, ToolInfo,
+    PermissionPolicyResponse, PlanModeState, ProviderCatalog, ReasoningEffort, Schedule,
+    SessionSummary, SessionTreeSummary, Skill, SkillDetail, SubagentSnapshotResponse,
+    TaskListResponse, ToolInfo,
 };
 use crate::api::{
     PermissionMutationFailure, RespondFailure, SessionMutationFailure, VersionedSession,
@@ -133,6 +134,16 @@ pub enum AppEvent {
         session_id: String,
         epoch: u64,
         result: Result<OpenedSession, String>,
+    },
+    /// Authoritative task and plan snapshot for the active session. A single
+    /// epoch binds both reads so late responses cannot cross a session switch.
+    TaskPlanSnapshotLoaded {
+        epoch: u64,
+        session_id: String,
+        /// Plan event revision observed when the request started. A late HTTP
+        /// response cannot overwrite a newer live plan event.
+        plan_revision: u64,
+        result: Loaded<(TaskListResponse, Option<PlanModeState>)>,
     },
     /// One bounded, periodic status pass for cached sessions whose full SSE
     /// subscription was evicted. Context id + stream epoch prevent an older

--- a/crates/app/bamboo-tui/src/keymap.rs
+++ b/crates/app/bamboo-tui/src/keymap.rs
@@ -40,6 +40,7 @@ pub(crate) enum ActionContext {
     PermissionDeleteConfirm,
     PermissionModeConfirm,
     SubagentTree,
+    TaskPlan,
     SessionPickerBrowse,
     SessionPickerRename,
     SessionPickerPinning,
@@ -48,7 +49,7 @@ pub(crate) enum ActionContext {
 }
 
 impl ActionContext {
-    pub(crate) const ALL: [Self; 31] = [
+    pub(crate) const ALL: [Self; 32] = [
         Self::Chat,
         Self::ConversationBlock,
         Self::Global,
@@ -75,6 +76,7 @@ impl ActionContext {
         Self::PermissionDeleteConfirm,
         Self::PermissionModeConfirm,
         Self::SubagentTree,
+        Self::TaskPlan,
         Self::SessionPickerBrowse,
         Self::SessionPickerRename,
         Self::SessionPickerPinning,
@@ -110,6 +112,7 @@ impl ActionContext {
             Self::PermissionDeleteConfirm => "Permission delete",
             Self::PermissionModeConfirm => "Permission mode",
             Self::SubagentTree => "Sub-agent tree",
+            Self::TaskPlan => "Task and plan progress",
             Self::SessionPickerBrowse => "Session picker",
             Self::SessionPickerRename => "Session rename",
             Self::SessionPickerPinning => "Session pin",
@@ -131,6 +134,7 @@ pub(crate) enum ActionId {
     OpenModelPicker,
     OpenSessionPicker,
     OpenSubagentTree,
+    OpenTaskPlan,
     StopRun,
     ToggleDetails,
     OpenConfigTab,
@@ -364,6 +368,15 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
         [(Global, "Leader a")]
     ),
     spec!(
+        OpenTaskPlan,
+        "Task and plan progress",
+        "Inspect the active session's live task tree and plan lifecycle",
+        true,
+        Chat,
+        [Global],
+        [(Global, "Leader t")]
+    ),
+    spec!(
         StopRun,
         "Stop active run",
         "Request cancellation of the active agent run",
@@ -482,6 +495,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             Config,
             Permissions,
             SubagentTree,
+            TaskPlan,
             SessionPickerBrowse,
             ModelPicker,
             CommandPalette
@@ -499,6 +513,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (Config, "Up; k"),
             (Permissions, "Up; k"),
             (SubagentTree, "Up; k"),
+            (TaskPlan, "Up; k"),
             (SessionPickerBrowse, "Up"),
             (ModelPicker, "Up"),
             (CommandPalette, "Up")
@@ -522,6 +537,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             Config,
             Permissions,
             SubagentTree,
+            TaskPlan,
             SessionPickerBrowse,
             ModelPicker,
             CommandPalette
@@ -539,6 +555,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (Config, "Down; j"),
             (Permissions, "Down; j"),
             (SubagentTree, "Down; j"),
+            (TaskPlan, "Down; j"),
             (SessionPickerBrowse, "Down"),
             (ModelPicker, "Down"),
             (CommandPalette, "Down")
@@ -557,6 +574,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             PermissionRuleConfirm,
             Config,
             SubagentTree,
+            TaskPlan,
             ModelPicker,
             CommandPalette
         ],
@@ -568,6 +586,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (PermissionRuleConfirm, "PageUp"),
             (Config, "PageUp"),
             (SubagentTree, "PageUp"),
+            (TaskPlan, "PageUp"),
             (ModelPicker, "PageUp"),
             (CommandPalette, "PageUp")
         ]
@@ -585,6 +604,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             PermissionRuleConfirm,
             Config,
             SubagentTree,
+            TaskPlan,
             ModelPicker,
             CommandPalette
         ],
@@ -596,6 +616,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (PermissionRuleConfirm, "PageDown"),
             (Config, "PageDown"),
             (SubagentTree, "PageDown"),
+            (TaskPlan, "PageDown"),
             (ModelPicker, "PageDown"),
             (CommandPalette, "PageDown")
         ]
@@ -613,6 +634,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             PermissionRuleConfirm,
             ConversationBlock,
             SubagentTree,
+            TaskPlan,
             ModelPicker,
             CommandPalette
         ],
@@ -624,6 +646,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (PermissionRuleConfirm, "Home"),
             (ConversationBlock, "Home"),
             (SubagentTree, "Home; g g"),
+            (TaskPlan, "Home; g g"),
             (ModelPicker, "Home"),
             (CommandPalette, "Home")
         ]
@@ -641,6 +664,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             PermissionRuleConfirm,
             ConversationBlock,
             SubagentTree,
+            TaskPlan,
             ModelPicker,
             CommandPalette
         ],
@@ -652,6 +676,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (PermissionRuleConfirm, "End"),
             (ConversationBlock, "End"),
             (SubagentTree, "End; Shift+G"),
+            (TaskPlan, "End; Shift+G"),
             (ModelPicker, "End"),
             (CommandPalette, "End")
         ]
@@ -713,6 +738,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             Permissions,
             PermissionEditor,
             SubagentTree,
+            TaskPlan,
             SessionPickerBrowse,
             SessionPickerRename,
             SessionPickerPinning,
@@ -731,6 +757,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (Permissions, "Esc"),
             (PermissionEditor, "Esc"),
             (SubagentTree, "Esc; q"),
+            (TaskPlan, "Esc; q"),
             (SessionPickerBrowse, "Esc"),
             (SessionPickerRename, "Esc"),
             (SessionPickerPinning, "Esc"),
@@ -771,6 +798,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             Sessions,
             Mcp,
             SubagentTree,
+            TaskPlan,
             SessionPickerBrowse,
             SessionPickerRename,
             SessionPickerPinning,
@@ -783,6 +811,7 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
             (Sessions, "r"),
             (Mcp, "r"),
             (SubagentTree, "r; Ctrl+R"),
+            (TaskPlan, "r; Ctrl+R"),
             (SessionPickerBrowse, "Ctrl+R"),
             (SessionPickerRename, "Ctrl+R"),
             (SessionPickerPinning, "Ctrl+R"),
@@ -1033,8 +1062,8 @@ pub(crate) static ACTION_SPECS: &[ActionSpec] = &[
         "Toggle inspected value",
         "Switch between the question and selected option",
         false,
-        [QuestionInspect],
-        [(QuestionInspect, "Tab")]
+        [QuestionInspect, TaskPlan],
+        [(QuestionInspect, "Tab"), (TaskPlan, "Tab")]
     ),
     spec!(
         CustomAnswer,

--- a/crates/app/bamboo-tui/src/lib.rs
+++ b/crates/app/bamboo-tui/src/lib.rs
@@ -27,6 +27,7 @@ mod history;
 mod keymap;
 mod search;
 mod subagents;
+mod task_plan;
 mod text;
 mod theme;
 mod ui;

--- a/crates/app/bamboo-tui/src/task_plan.rs
+++ b/crates/app/bamboo-tui/src/task_plan.rs
@@ -76,6 +76,7 @@ impl TaskProgressState {
             .map(|item| (item.id.clone(), version))
             .collect();
         self.completed = self.progress.total > 0 && self.progress.completed == self.progress.total;
+        self.completion_summary = None;
         self.task_list = Some(task_list);
         self.loading = false;
         self.error = None;
@@ -130,6 +131,7 @@ impl TaskProgressState {
             .collect();
         self.progress = calculate_progress(&task_list.items);
         self.completed = self.progress.total > 0 && self.progress.completed == self.progress.total;
+        self.completion_summary = None;
         self.task_list = Some(task_list);
         self.loading = false;
         self.error = None;
@@ -170,25 +172,36 @@ impl TaskProgressState {
             title: "Agent Tasks".to_string(),
             ..TaskList::default()
         });
-        let mut incoming = item.unwrap_or_else(|| TaskItem {
-            id: item_id.clone(),
-            description: item_id.clone(),
-            ..TaskItem::default()
-        });
-        incoming.status = status;
         if let Some(existing) = list
             .items
             .iter_mut()
             .find(|existing| existing.id == item_id)
         {
-            *existing = incoming;
+            if let Some(mut incoming) = item {
+                incoming.status = status;
+                *existing = incoming;
+            } else {
+                // Legacy persisted progress frames have no rich item
+                // projection. Preserve the authoritative snapshot details
+                // and apply only the delta fields they actually carry.
+                existing.status = status;
+            }
         } else {
+            let mut incoming = item.unwrap_or_else(|| TaskItem {
+                id: item_id.clone(),
+                description: item_id.clone(),
+                ..TaskItem::default()
+            });
+            incoming.status = status;
             list.items.push(incoming);
         }
         self.version = self.version.max(version);
         self.item_versions.insert(item_id, version);
         self.progress = calculate_progress(&list.items);
         self.completed = self.progress.total > 0 && self.progress.completed == self.progress.total;
+        if !self.completed {
+            self.completion_summary = None;
+        }
         self.loading = false;
         self.error = None;
         ApplyResult::Applied
@@ -210,6 +223,15 @@ impl TaskProgressState {
         }
         if let Some(version) = version {
             self.version = self.version.max(version);
+        }
+        if let Some(list) = self.task_list.as_mut() {
+            for item in &mut list.items {
+                item.status = TaskItemStatus::Completed;
+                if let Some(version) = version {
+                    self.item_versions.insert(item.id.clone(), version);
+                }
+            }
+            self.progress = calculate_progress(&list.items);
         }
         self.completed = true;
         self.completion_summary = Some(format!(
@@ -472,6 +494,34 @@ mod tests {
     }
 
     #[test]
+    fn legacy_progress_delta_preserves_existing_task_details() {
+        let mut state = state();
+        let task = &mut state.task_list.as_mut().unwrap().items[0];
+        task.depends_on = vec!["setup".to_string()];
+        task.blockers.push(TaskBlocker {
+            kind: TaskBlockerKind::Dependency,
+            summary: "Waiting for setup".to_string(),
+            waiting_on: Some("setup".to_string()),
+        });
+
+        assert_eq!(
+            state.apply_item(
+                "session-a",
+                "one".to_string(),
+                TaskItemStatus::Blocked,
+                5,
+                None,
+                false,
+            ),
+            ApplyResult::Applied
+        );
+        let task = &state.task_list.as_ref().unwrap().items[0];
+        assert_eq!(task.description, "Task one");
+        assert_eq!(task.depends_on, ["setup"]);
+        assert_eq!(task.blockers[0].waiting_on.as_deref(), Some("setup"));
+    }
+
+    #[test]
     fn nested_and_cyclic_items_are_all_visible() {
         let mut parent = item("parent", TaskItemStatus::InProgress);
         let mut child = item("child", TaskItemStatus::Pending);
@@ -539,6 +589,25 @@ mod tests {
         assert_eq!(
             state.task_list.as_ref().unwrap().items[0].status,
             TaskItemStatus::Completed
+        );
+    }
+
+    #[test]
+    fn completion_event_converges_known_items_and_aggregate_progress() {
+        let mut state = state();
+        assert_eq!(
+            state.apply_completed("session-a", Some(5), 3, 7, false),
+            ApplyResult::Applied
+        );
+        assert_eq!(
+            state.task_list.as_ref().unwrap().items[0].status,
+            TaskItemStatus::Completed
+        );
+        assert_eq!(state.progress.completed, 1);
+        assert_eq!(state.progress.percentage, 100);
+        assert_eq!(
+            state.completion_summary.as_deref(),
+            Some("completed in 3 rounds · 7 tool calls")
         );
     }
 

--- a/crates/app/bamboo-tui/src/task_plan.rs
+++ b/crates/app/bamboo-tui/src/task_plan.rs
@@ -1,0 +1,562 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::api::types::{TaskItem, TaskItemStatus, TaskList, TaskListResponse, TaskProgress};
+
+/// Session-owned task state. This lives inside `ChatState`, so a background
+/// stream can update only its own cached conversation instead of whichever
+/// tab happens to be visible.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct TaskProgressState {
+    pub(crate) requested_session_id: Option<String>,
+    pub(crate) owner_session_id: Option<String>,
+    pub(crate) task_list: Option<TaskList>,
+    pub(crate) progress: TaskProgress,
+    pub(crate) version: u64,
+    item_versions: HashMap<String, u64>,
+    pub(crate) loading: bool,
+    pub(crate) error: Option<String>,
+    pub(crate) completed: bool,
+    pub(crate) completion_summary: Option<String>,
+    pub(crate) evaluation: Option<String>,
+    evaluation_generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApplyResult {
+    Applied,
+    Stale,
+    WrongSession,
+}
+
+impl TaskProgressState {
+    pub(crate) fn begin_refresh(&mut self, requested_session_id: &str) {
+        if self.requested_session_id.as_deref() != Some(requested_session_id) {
+            *self = Self {
+                requested_session_id: Some(requested_session_id.to_string()),
+                loading: true,
+                ..Self::default()
+            };
+        } else {
+            self.loading = true;
+            self.error = None;
+        }
+    }
+
+    pub(crate) fn install_snapshot(
+        &mut self,
+        requested_session_id: &str,
+        snapshot: TaskListResponse,
+    ) -> ApplyResult {
+        if self.requested_session_id.as_deref() != Some(requested_session_id) {
+            return ApplyResult::WrongSession;
+        }
+        if self.task_list.is_some() && snapshot.version < self.version {
+            self.loading = false;
+            return ApplyResult::Stale;
+        }
+        let owner = if snapshot.session_id.is_empty() {
+            requested_session_id.to_string()
+        } else {
+            snapshot.session_id
+        };
+        let version = snapshot.version;
+        let task_list = TaskList {
+            session_id: owner.clone(),
+            title: snapshot.title.unwrap_or_else(|| "Agent Tasks".to_string()),
+            items: snapshot.items,
+            created_at: snapshot.created_at.unwrap_or_default(),
+            updated_at: snapshot.updated_at.unwrap_or_default(),
+        };
+        self.owner_session_id = Some(owner);
+        self.progress = snapshot.progress;
+        self.version = version;
+        self.item_versions = task_list
+            .items
+            .iter()
+            .map(|item| (item.id.clone(), version))
+            .collect();
+        self.completed = self.progress.total > 0 && self.progress.completed == self.progress.total;
+        self.task_list = Some(task_list);
+        self.loading = false;
+        self.error = None;
+        ApplyResult::Applied
+    }
+
+    pub(crate) fn fail_refresh(&mut self, requested_session_id: &str, error: String) {
+        if self.requested_session_id.as_deref() == Some(requested_session_id) {
+            self.loading = false;
+            self.error = Some(error);
+        }
+    }
+
+    fn accepts_source(&self, source_session_id: &str, shared_source: bool) -> bool {
+        self.requested_session_id.as_deref() == Some(source_session_id)
+            || self.owner_session_id.as_deref() == Some(source_session_id)
+            || (shared_source && self.requested_session_id.is_some())
+    }
+
+    pub(crate) fn apply_list(
+        &mut self,
+        source_session_id: &str,
+        task_list: TaskList,
+        version: Option<u64>,
+        _shared_source: bool,
+    ) -> ApplyResult {
+        let belongs_to_view = self.accepts_source(source_session_id, false)
+            || self.requested_session_id.as_deref() == Some(task_list.session_id.as_str())
+            || self.owner_session_id.as_deref() == Some(task_list.session_id.as_str());
+        if !belongs_to_view {
+            return ApplyResult::WrongSession;
+        }
+        if let Some(incoming) = version {
+            if incoming <= self.version && self.task_list.is_some() {
+                return ApplyResult::Stale;
+            }
+        } else if self.task_list.as_ref().is_some_and(|current| {
+            !task_list.updated_at.is_empty()
+                && !current.updated_at.is_empty()
+                && task_list.updated_at <= current.updated_at
+        }) {
+            return ApplyResult::Stale;
+        }
+
+        let incoming_version = version.unwrap_or(self.version.saturating_add(1));
+        self.owner_session_id = Some(task_list.session_id.clone());
+        self.version = incoming_version;
+        self.item_versions = task_list
+            .items
+            .iter()
+            .map(|item| (item.id.clone(), incoming_version))
+            .collect();
+        self.progress = calculate_progress(&task_list.items);
+        self.completed = self.progress.total > 0 && self.progress.completed == self.progress.total;
+        self.task_list = Some(task_list);
+        self.loading = false;
+        self.error = None;
+        ApplyResult::Applied
+    }
+
+    pub(crate) fn apply_item(
+        &mut self,
+        source_session_id: &str,
+        item_id: String,
+        status: TaskItemStatus,
+        version: u64,
+        item: Option<TaskItem>,
+        shared_source: bool,
+    ) -> ApplyResult {
+        if !self.accepts_source(source_session_id, shared_source) {
+            return ApplyResult::WrongSession;
+        }
+        if version < self.version
+            || self
+                .item_versions
+                .get(&item_id)
+                .is_some_and(|current| version <= *current)
+        {
+            return ApplyResult::Stale;
+        }
+        if item.as_ref().is_some_and(|rich| rich.id != item_id) {
+            return ApplyResult::WrongSession;
+        }
+
+        let owner = self
+            .owner_session_id
+            .clone()
+            .or_else(|| self.requested_session_id.clone())
+            .unwrap_or_else(|| source_session_id.to_string());
+        let list = self.task_list.get_or_insert_with(|| TaskList {
+            session_id: owner,
+            title: "Agent Tasks".to_string(),
+            ..TaskList::default()
+        });
+        let mut incoming = item.unwrap_or_else(|| TaskItem {
+            id: item_id.clone(),
+            description: item_id.clone(),
+            ..TaskItem::default()
+        });
+        incoming.status = status;
+        if let Some(existing) = list
+            .items
+            .iter_mut()
+            .find(|existing| existing.id == item_id)
+        {
+            *existing = incoming;
+        } else {
+            list.items.push(incoming);
+        }
+        self.version = self.version.max(version);
+        self.item_versions.insert(item_id, version);
+        self.progress = calculate_progress(&list.items);
+        self.completed = self.progress.total > 0 && self.progress.completed == self.progress.total;
+        self.loading = false;
+        self.error = None;
+        ApplyResult::Applied
+    }
+
+    pub(crate) fn apply_completed(
+        &mut self,
+        source_session_id: &str,
+        version: Option<u64>,
+        total_rounds: u32,
+        total_tool_calls: usize,
+        shared_source: bool,
+    ) -> ApplyResult {
+        if !self.accepts_source(source_session_id, shared_source) {
+            return ApplyResult::WrongSession;
+        }
+        if version.is_some_and(|incoming| incoming < self.version) {
+            return ApplyResult::Stale;
+        }
+        if let Some(version) = version {
+            self.version = self.version.max(version);
+        }
+        self.completed = true;
+        self.completion_summary = Some(format!(
+            "completed in {total_rounds} rounds · {total_tool_calls} tool calls"
+        ));
+        ApplyResult::Applied
+    }
+
+    pub(crate) fn evaluation_started(
+        &mut self,
+        source_session_id: &str,
+        items_count: usize,
+        generation: Option<u64>,
+        shared_source: bool,
+    ) -> ApplyResult {
+        if !self.accepts_source(source_session_id, shared_source) {
+            return ApplyResult::WrongSession;
+        }
+        if generation.is_some_and(|incoming| incoming < self.evaluation_generation) {
+            return ApplyResult::Stale;
+        }
+        self.evaluation_generation = generation.unwrap_or(self.evaluation_generation);
+        self.evaluation = Some(format!("evaluating {items_count} tasks"));
+        ApplyResult::Applied
+    }
+
+    pub(crate) fn evaluation_finished(
+        &mut self,
+        source_session_id: &str,
+        message: String,
+        generation: Option<u64>,
+        shared_source: bool,
+    ) -> ApplyResult {
+        if !self.accepts_source(source_session_id, shared_source) {
+            return ApplyResult::WrongSession;
+        }
+        if generation.is_some_and(|incoming| incoming < self.evaluation_generation) {
+            return ApplyResult::Stale;
+        }
+        self.evaluation_generation = generation.unwrap_or(self.evaluation_generation);
+        self.evaluation = Some(message);
+        ApplyResult::Applied
+    }
+
+    pub(crate) fn ordered_items(&self) -> Vec<(usize, &TaskItem)> {
+        let Some(list) = &self.task_list else {
+            return Vec::new();
+        };
+        ordered_items(&list.items)
+    }
+}
+
+fn calculate_progress(items: &[TaskItem]) -> TaskProgress {
+    let completed = items
+        .iter()
+        .filter(|item| item.status == TaskItemStatus::Completed)
+        .count();
+    let total = items.len();
+    TaskProgress {
+        completed,
+        total,
+        percentage: completed
+            .saturating_mul(100)
+            .checked_div(total)
+            .unwrap_or(0) as u8,
+    }
+}
+
+fn ordered_items(items: &[TaskItem]) -> Vec<(usize, &TaskItem)> {
+    let ids = items
+        .iter()
+        .map(|item| item.id.as_str())
+        .collect::<HashSet<_>>();
+    let mut children: HashMap<&str, Vec<usize>> = HashMap::new();
+    let mut roots = Vec::new();
+    for (index, item) in items.iter().enumerate() {
+        match item
+            .parent_id
+            .as_deref()
+            .filter(|parent| ids.contains(parent))
+        {
+            Some(parent) if parent != item.id => children.entry(parent).or_default().push(index),
+            _ => roots.push(index),
+        }
+    }
+    let mut result = Vec::with_capacity(items.len());
+    let mut visited = HashSet::new();
+    fn walk<'a>(
+        index: usize,
+        depth: usize,
+        items: &'a [TaskItem],
+        children: &HashMap<&str, Vec<usize>>,
+        visited: &mut HashSet<usize>,
+        result: &mut Vec<(usize, &'a TaskItem)>,
+    ) {
+        if !visited.insert(index) {
+            return;
+        }
+        let item = &items[index];
+        result.push((depth, item));
+        if let Some(child_indices) = children.get(item.id.as_str()) {
+            for child in child_indices {
+                walk(
+                    *child,
+                    depth.saturating_add(1),
+                    items,
+                    children,
+                    visited,
+                    result,
+                );
+            }
+        }
+    }
+    for root in roots {
+        walk(root, 0, items, &children, &mut visited, &mut result);
+    }
+    // Cycles and malformed parent links remain visible instead of vanishing.
+    for index in 0..items.len() {
+        walk(index, 0, items, &children, &mut visited, &mut result);
+    }
+    result
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum TaskPlanPane {
+    #[default]
+    Tasks,
+    Plan,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct TaskPlanOverlayState {
+    pub(crate) pane: TaskPlanPane,
+    pub(crate) selected: usize,
+    pub(crate) detail_scroll: usize,
+}
+
+impl TaskPlanOverlayState {
+    pub(crate) fn toggle_pane(&mut self) {
+        self.pane = match self.pane {
+            TaskPlanPane::Tasks => TaskPlanPane::Plan,
+            TaskPlanPane::Plan => TaskPlanPane::Tasks,
+        };
+        self.detail_scroll = 0;
+    }
+
+    pub(crate) fn move_selection(&mut self, delta: isize, item_count: usize) {
+        if item_count == 0 {
+            self.selected = 0;
+            return;
+        }
+        self.selected = self
+            .selected
+            .saturating_add_signed(delta)
+            .min(item_count.saturating_sub(1));
+        self.detail_scroll = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_client_core::{TaskBlocker, TaskBlockerKind};
+
+    fn item(id: &str, status: TaskItemStatus) -> TaskItem {
+        TaskItem {
+            id: id.to_string(),
+            description: format!("Task {id}"),
+            status,
+            ..TaskItem::default()
+        }
+    }
+
+    fn state() -> TaskProgressState {
+        let mut state = TaskProgressState::default();
+        state.begin_refresh("session-a");
+        state.install_snapshot(
+            "session-a",
+            TaskListResponse {
+                session_id: "root-a".to_string(),
+                title: Some("Tasks".to_string()),
+                items: vec![item("one", TaskItemStatus::Pending)],
+                progress: TaskProgress {
+                    completed: 0,
+                    total: 1,
+                    percentage: 0,
+                },
+                version: 4,
+                ..TaskListResponse::default()
+            },
+        );
+        state
+    }
+
+    #[test]
+    fn stale_duplicate_and_cross_session_deltas_do_not_regress() {
+        let mut state = state();
+        assert_eq!(
+            state.apply_item(
+                "session-a",
+                "one".to_string(),
+                TaskItemStatus::Completed,
+                5,
+                None,
+                false,
+            ),
+            ApplyResult::Applied
+        );
+        assert_eq!(
+            state.apply_item(
+                "session-a",
+                "one".to_string(),
+                TaskItemStatus::Pending,
+                4,
+                None,
+                false,
+            ),
+            ApplyResult::Stale
+        );
+        assert_eq!(
+            state.apply_item(
+                "session-b",
+                "one".to_string(),
+                TaskItemStatus::Blocked,
+                6,
+                None,
+                false,
+            ),
+            ApplyResult::WrongSession
+        );
+        assert_eq!(
+            state.task_list.as_ref().unwrap().items[0].status,
+            TaskItemStatus::Completed
+        );
+    }
+
+    #[test]
+    fn rich_progress_preserves_blocker_reason_and_wait_target() {
+        let mut state = state();
+        let mut blocked = item("one", TaskItemStatus::Blocked);
+        blocked.blockers.push(TaskBlocker {
+            kind: TaskBlockerKind::Dependency,
+            summary: "API schema is not ready".to_string(),
+            waiting_on: Some("task-two".to_string()),
+        });
+        assert_eq!(
+            state.apply_item(
+                "session-a",
+                "one".to_string(),
+                TaskItemStatus::Blocked,
+                5,
+                Some(blocked),
+                false,
+            ),
+            ApplyResult::Applied
+        );
+        let blocker = &state.task_list.as_ref().unwrap().items[0].blockers[0];
+        assert_eq!(blocker.summary, "API schema is not ready");
+        assert_eq!(blocker.waiting_on.as_deref(), Some("task-two"));
+    }
+
+    #[test]
+    fn nested_and_cyclic_items_are_all_visible() {
+        let mut parent = item("parent", TaskItemStatus::InProgress);
+        let mut child = item("child", TaskItemStatus::Pending);
+        child.parent_id = Some(parent.id.clone());
+        let mut cycle_a = item("cycle-a", TaskItemStatus::Blocked);
+        let mut cycle_b = item("cycle-b", TaskItemStatus::Pending);
+        cycle_a.parent_id = Some("cycle-b".to_string());
+        cycle_b.parent_id = Some("cycle-a".to_string());
+        parent.depends_on = vec!["setup".to_string()];
+        let items = [parent, child, cycle_a, cycle_b];
+        let ordered = ordered_items(&items);
+        assert_eq!(ordered.len(), 4);
+        assert_eq!(ordered[0].1.id, "parent");
+        assert_eq!(ordered[1].0, 1);
+    }
+
+    #[test]
+    fn authoritative_reconnect_snapshot_converges_at_same_version() {
+        let mut state = state();
+        state.begin_refresh("session-a");
+        let result = state.install_snapshot(
+            "session-a",
+            TaskListResponse {
+                session_id: "root-a".to_string(),
+                items: vec![item("one", TaskItemStatus::Blocked)],
+                version: 4,
+                ..TaskListResponse::default()
+            },
+        );
+        assert_eq!(result, ApplyResult::Applied);
+        assert_eq!(
+            state.task_list.as_ref().unwrap().items[0].status,
+            TaskItemStatus::Blocked
+        );
+    }
+
+    #[test]
+    fn late_older_http_snapshot_cannot_regress_a_live_delta() {
+        let mut state = state();
+        assert_eq!(
+            state.apply_item(
+                "session-a",
+                "one".to_string(),
+                TaskItemStatus::Completed,
+                6,
+                None,
+                false,
+            ),
+            ApplyResult::Applied
+        );
+        state.begin_refresh("session-a");
+        assert_eq!(
+            state.install_snapshot(
+                "session-a",
+                TaskListResponse {
+                    session_id: "root-a".to_string(),
+                    items: vec![item("one", TaskItemStatus::Pending)],
+                    version: 5,
+                    ..TaskListResponse::default()
+                },
+            ),
+            ApplyResult::Stale
+        );
+        assert!(!state.loading);
+        assert_eq!(
+            state.task_list.as_ref().unwrap().items[0].status,
+            TaskItemStatus::Completed
+        );
+    }
+
+    #[test]
+    fn switching_sessions_clears_stale_rows_and_keeps_refresh_error_visible() {
+        let mut state = state();
+        state.begin_refresh("session-b");
+        assert!(state.task_list.is_none());
+        assert_eq!(state.requested_session_id.as_deref(), Some("session-b"));
+        state.fail_refresh("session-b", "server offline".to_string());
+        assert!(!state.loading);
+        assert_eq!(state.error.as_deref(), Some("server offline"));
+
+        // A late response for the previous session cannot repopulate the view.
+        assert_eq!(
+            state.install_snapshot("session-a", TaskListResponse::default()),
+            ApplyResult::WrongSession
+        );
+        assert!(state.task_list.is_none());
+    }
+}

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -3680,7 +3680,7 @@ mod tests {
         }
         assert_eq!(
             fingerprints,
-            [9_023_054_049_185_338_977, 1_360_325_232_269_958_569,],
+            [8_643_330_157_882_708_308, 7_772_966_265_523_513_716,],
             "complete help-overlay buffer golden changed"
         );
     }

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub mod schedules;
 pub mod sessions;
 pub mod skills;
 pub mod subagents;
+pub mod task_plan;
 
 use ratatui::Frame;
 
@@ -86,6 +87,10 @@ fn render_with_palette(f: &mut Frame, app: &App) {
 
     if app.subagent_tree.is_some() {
         subagents::render(f, app);
+    }
+
+    if app.task_plan.is_some() {
+        task_plan::render(f, app);
     }
 
     if app.pending_delete.is_some() || app.pending_schedule_delete.is_some() {

--- a/crates/app/bamboo-tui/src/ui/sessions.rs
+++ b/crates/app/bamboo-tui/src/ui/sessions.rs
@@ -365,6 +365,7 @@ mod tests {
             pinned: false,
             permission_mode: crate::api::types::SessionPermissionMode::Default,
             bypass_permissions: false,
+            plan_mode: None,
         }
     }
 

--- a/crates/app/bamboo-tui/src/ui/task_plan.rs
+++ b/crates/app/bamboo-tui/src/ui/task_plan.rs
@@ -158,6 +158,15 @@ fn task_lines(
             clip_cells(evaluation, width.saturating_sub(13))
         )));
     }
+    if let Some(completion) = &state.completion_summary {
+        lines.push(Line::from(Span::styled(
+            format!(
+                " Completion: {}",
+                clip_cells(completion, width.saturating_sub(13))
+            ),
+            Style::default().fg(colors::success()),
+        )));
+    }
     if ordered.is_empty() {
         lines.push(Line::from(Span::styled(
             " No task list has been created for this session.",
@@ -185,9 +194,10 @@ fn task_lines(
             format!(" · deps {}", item.depends_on.join(","))
         };
         let prefix = format!(
-            " {}{} {} ",
+            " {}{} {:<11} {}",
             if selected_row { "›" } else { " " },
             status_icon(item.status),
+            task_status_label(item.status),
             indent
         );
         let available = width.saturating_sub(crate::text::display_width(&prefix));
@@ -483,6 +493,7 @@ mod tests {
                 .map(|cell| cell.symbol())
                 .collect();
             assert!(rendered.contains("Tasks / Plan"));
+            assert!(rendered.contains("blocked"));
             assert!(rendered.contains("waiting on backend contract"));
         }
     }

--- a/crates/app/bamboo-tui/src/ui/task_plan.rs
+++ b/crates/app/bamboo-tui/src/ui/task_plan.rs
@@ -1,0 +1,532 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+use crate::api::types::{PlanModeStatus, TaskItem, TaskItemStatus};
+use crate::app::{App, ConnectionStatus, PlanRunStatus};
+use crate::keymap::{ActionContext, ActionId};
+use crate::task_plan::{TaskPlanPane, TaskProgressState};
+use crate::text::{clip_cells, hard_wrap};
+use crate::theme::colors;
+
+pub fn render(f: &mut Frame, app: &App) {
+    let Some(overlay) = &app.task_plan else {
+        return;
+    };
+    let screen = f.area();
+    let area = centered_rect(96, screen.height.saturating_sub(2).max(1), screen);
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let inner_height = area.height.saturating_sub(2) as usize;
+    let lines = task_plan_lines(app, inner_width, inner_height);
+
+    f.render_widget(Clear, area);
+    f.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(colors::brand()))
+                .title(match overlay.pane {
+                    TaskPlanPane::Tasks => " Tasks / Plan · Tasks ",
+                    TaskPlanPane::Plan => " Tasks / Plan · Plan ",
+                }),
+        ),
+        area,
+    );
+}
+
+fn task_plan_lines(app: &App, width: usize, height: usize) -> Vec<Line<'static>> {
+    let Some(overlay) = &app.task_plan else {
+        return Vec::new();
+    };
+    let footer = [
+        format!(
+            "{} / {} move · {} switch pane · {} refresh",
+            app.primary_key_hint(ActionContext::TaskPlan, ActionId::NavigateUp),
+            app.primary_key_hint(ActionContext::TaskPlan, ActionId::NavigateDown),
+            app.primary_key_hint(ActionContext::TaskPlan, ActionId::ToggleInspectorPane),
+            app.primary_key_hint(ActionContext::TaskPlan, ActionId::Refresh),
+        ),
+        format!(
+            "{} / {} page · {} close",
+            app.primary_key_hint(ActionContext::TaskPlan, ActionId::PageUp),
+            app.primary_key_hint(ActionContext::TaskPlan, ActionId::PageDown),
+            app.primary_key_hint(ActionContext::TaskPlan, ActionId::Cancel),
+        ),
+    ];
+    let mut lines = vec![Line::from(vec![
+        Span::styled(
+            if overlay.pane == TaskPlanPane::Tasks {
+                " [Tasks] "
+            } else {
+                "  Tasks  "
+            },
+            pane_style(overlay.pane == TaskPlanPane::Tasks),
+        ),
+        Span::styled(
+            if overlay.pane == TaskPlanPane::Plan {
+                " [Plan] "
+            } else {
+                "  Plan  "
+            },
+            pane_style(overlay.pane == TaskPlanPane::Plan),
+        ),
+        Span::styled(
+            format!(
+                "  session {}",
+                short_session(app.chat.session_id.as_deref())
+            ),
+            Style::default().fg(colors::subtle()),
+        ),
+    ])];
+
+    let connection = app.active_connection_status();
+    if connection == ConnectionStatus::Offline {
+        lines.push(Line::from(Span::styled(
+            " ○ Offline — showing the last authoritative snapshot; refresh will retry",
+            Style::default().fg(colors::warning()),
+        )));
+    }
+    if app.chat.task_progress.loading {
+        lines.push(Line::from(Span::styled(
+            " ◌ Synchronizing task and plan state...",
+            Style::default().fg(colors::inactive()),
+        )));
+    }
+    if let Some(error) = &app.chat.task_progress.error {
+        lines.push(Line::from(Span::styled(
+            format!(" ! {}", clip_cells(error, width.saturating_sub(3))),
+            Style::default().fg(colors::error()),
+        )));
+    }
+
+    let content_height = height.saturating_sub(lines.len() + footer.len());
+    match overlay.pane {
+        TaskPlanPane::Tasks => lines.extend(task_lines(
+            &app.chat.task_progress,
+            overlay.selected,
+            width,
+            content_height,
+        )),
+        TaskPlanPane::Plan => lines.extend(plan_lines(
+            &app.chat.run_status.plan,
+            overlay.detail_scroll,
+            width,
+            content_height,
+        )),
+    }
+    while lines.len() + footer.len() < height {
+        lines.push(Line::raw(""));
+    }
+    lines.extend(
+        footer
+            .into_iter()
+            .map(|line| Line::from(Span::styled(clip_cells(&line, width), footer_style()))),
+    );
+    lines.truncate(height);
+    lines
+}
+
+fn task_lines(
+    state: &TaskProgressState,
+    selected: usize,
+    width: usize,
+    height: usize,
+) -> Vec<Line<'static>> {
+    let ordered = state.ordered_items();
+    let mut lines = vec![Line::from(vec![
+        Span::styled(" Progress ", Style::default().fg(colors::subtle())),
+        Span::styled(
+            format!(
+                "{}/{} · {}% · version {}",
+                state.progress.completed,
+                state.progress.total,
+                state.progress.percentage,
+                state.version
+            ),
+            Style::default().fg(if state.completed {
+                colors::success()
+            } else {
+                colors::inactive()
+            }),
+        ),
+    ])];
+    if let Some(evaluation) = &state.evaluation {
+        lines.push(Line::raw(format!(
+            " Evaluation: {}",
+            clip_cells(evaluation, width.saturating_sub(13))
+        )));
+    }
+    if ordered.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " No task list has been created for this session.",
+            Style::default().fg(colors::inactive()),
+        )));
+        return lines;
+    }
+
+    let selected = selected.min(ordered.len().saturating_sub(1));
+    let compact = width < 78;
+    let detail_budget = if compact { 7 } else { 9 }.min(height.saturating_sub(lines.len() + 2));
+    let list_budget = height
+        .saturating_sub(lines.len() + detail_budget + 1)
+        .max(1);
+    let mut start = selected.saturating_sub(list_budget / 2);
+    if start + list_budget > ordered.len() {
+        start = ordered.len().saturating_sub(list_budget);
+    }
+    for (row, (depth, item)) in ordered.iter().enumerate().skip(start).take(list_budget) {
+        let selected_row = row == selected;
+        let indent = "  ".repeat((*depth).min(5));
+        let dependency = if compact || item.depends_on.is_empty() {
+            String::new()
+        } else {
+            format!(" · deps {}", item.depends_on.join(","))
+        };
+        let prefix = format!(
+            " {}{} {} ",
+            if selected_row { "›" } else { " " },
+            status_icon(item.status),
+            indent
+        );
+        let available = width.saturating_sub(crate::text::display_width(&prefix));
+        let label = clip_cells(&format!("{}{}", task_label(item), dependency), available);
+        lines.push(Line::from(vec![
+            Span::styled(prefix, status_style(item.status, selected_row)),
+            Span::styled(
+                label,
+                if selected_row {
+                    Style::default().add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default()
+                },
+            ),
+        ]));
+    }
+    lines.push(Line::from(Span::styled(
+        " ─ Selected task ─",
+        Style::default().fg(colors::subtle()),
+    )));
+    lines.extend(task_detail_lines(ordered[selected].1, width, detail_budget));
+    lines
+}
+
+fn task_detail_lines(item: &TaskItem, width: usize, budget: usize) -> Vec<Line<'static>> {
+    let mut values = Vec::new();
+    values.push(format!(
+        " ID: {} · phase {:?} · priority {:?}",
+        item.id, item.phase, item.priority
+    ));
+    if !item.depends_on.is_empty() {
+        values.push(format!(" Depends on: {}", item.depends_on.join(", ")));
+    }
+    if let Some(parent) = &item.parent_id {
+        values.push(format!(" Parent: {parent}"));
+    }
+    if !item.completion_criteria.is_empty() {
+        values.push(format!(
+            " Completion criteria: {}",
+            item.completion_criteria.join(" · ")
+        ));
+    }
+    for blocker in &item.blockers {
+        values.push(format!(
+            " BLOCKED: {}{}",
+            blocker.summary,
+            blocker
+                .waiting_on
+                .as_ref()
+                .map(|target| format!(" · waiting on {target}"))
+                .unwrap_or_default()
+        ));
+    }
+    if !item.notes.trim().is_empty() {
+        values.push(format!(" Notes: {}", item.notes.trim()));
+    }
+    if let Some(evidence) = item.evidence.last() {
+        values.push(format!(" Evidence: {}", evidence.summary));
+    }
+    if let Some(transition) = item.transitions.last() {
+        let reason = transition
+            .reason
+            .as_ref()
+            .map(|reason| format!(" · {reason}"))
+            .unwrap_or_default();
+        let round = transition
+            .round
+            .map(|round| format!(" · round {round}"))
+            .unwrap_or_default();
+        let changed_at = if transition.changed_at.is_empty() {
+            String::new()
+        } else {
+            format!(" · {}", transition.changed_at)
+        };
+        values.push(format!(
+            " Transition: {} → {}{reason}{round}{changed_at}",
+            task_status_label(transition.from_status),
+            task_status_label(transition.to_status),
+        ));
+    }
+    if values.len() == 1 {
+        values.push(" No blockers, notes, or evidence recorded.".to_string());
+    }
+    values
+        .into_iter()
+        .flat_map(|value| hard_wrap(&value, width.max(1)))
+        .take(budget)
+        .map(Line::raw)
+        .collect()
+}
+
+fn plan_lines(
+    plan: &PlanRunStatus,
+    scroll: usize,
+    width: usize,
+    height: usize,
+) -> Vec<Line<'static>> {
+    let phase = plan
+        .status
+        .map(plan_status_label)
+        .unwrap_or(if plan.active { "active" } else { "inactive" });
+    let mut values = vec![format!(
+        " {} Plan mode · {phase}",
+        if plan.active { "●" } else { "○" }
+    )];
+    if let Some(outcome) = &plan.last_outcome {
+        values.push(format!(" Outcome: {outcome}"));
+    }
+    if let Some(reason) = &plan.reason {
+        values.push(format!(" Reason: {reason}"));
+    }
+    if let Some(path) = &plan.file_path {
+        values.push(format!(" File: {path}"));
+    }
+    if let Some(entered_at) = &plan.entered_at {
+        values.push(format!(" Entered: {entered_at}"));
+    }
+    if let Some(mode) = &plan.pre_permission_mode {
+        values.push(format!(" Restores permission mode: {mode}"));
+    }
+    if let Some(summary) = &plan.content_summary {
+        values.push(format!(" Summary: {summary}"));
+    }
+    if let Some(content) = &plan.plan {
+        values.push(" ─ Reviewed plan ─".to_string());
+        values.extend(content.lines().map(|line| format!(" {line}")));
+    }
+    if values.len() == 1 && !plan.active {
+        values.push(" No plan lifecycle has been recorded for this session.".to_string());
+    }
+    let wrapped = values
+        .into_iter()
+        .flat_map(|value| hard_wrap(&value, width.max(1)))
+        .collect::<Vec<_>>();
+    let max_start = wrapped.len().saturating_sub(height);
+    let start = scroll.min(max_start);
+    wrapped
+        .into_iter()
+        .skip(start)
+        .take(height)
+        .map(Line::raw)
+        .collect()
+}
+
+fn task_label(item: &TaskItem) -> &str {
+    item.active_form
+        .as_deref()
+        .filter(|_| item.status == TaskItemStatus::InProgress)
+        .unwrap_or(&item.description)
+}
+
+fn status_icon(status: TaskItemStatus) -> &'static str {
+    match status {
+        TaskItemStatus::Pending => "○",
+        TaskItemStatus::InProgress => "●",
+        TaskItemStatus::Completed => "✓",
+        TaskItemStatus::Blocked => "!",
+        TaskItemStatus::Unknown => "?",
+    }
+}
+
+fn task_status_label(status: TaskItemStatus) -> &'static str {
+    match status {
+        TaskItemStatus::Pending => "pending",
+        TaskItemStatus::InProgress => "in progress",
+        TaskItemStatus::Completed => "completed",
+        TaskItemStatus::Blocked => "blocked",
+        TaskItemStatus::Unknown => "unknown",
+    }
+}
+
+fn status_style(status: TaskItemStatus, selected: bool) -> Style {
+    let color = match status {
+        TaskItemStatus::Completed => colors::success(),
+        TaskItemStatus::Blocked => colors::error(),
+        TaskItemStatus::InProgress => colors::brand(),
+        TaskItemStatus::Pending | TaskItemStatus::Unknown => colors::inactive(),
+    };
+    let style = Style::default().fg(color);
+    if selected {
+        style.add_modifier(Modifier::BOLD)
+    } else {
+        style
+    }
+}
+
+fn plan_status_label(status: PlanModeStatus) -> &'static str {
+    match status {
+        PlanModeStatus::Exploring => "exploring",
+        PlanModeStatus::Designing => "designing",
+        PlanModeStatus::Reviewing => "reviewing",
+        PlanModeStatus::Finalizing => "finalizing",
+        PlanModeStatus::AwaitingApproval => "awaiting approval",
+        PlanModeStatus::Unknown => "unknown",
+    }
+}
+
+fn pane_style(active: bool) -> Style {
+    if active {
+        Style::default()
+            .fg(colors::brand())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(colors::inactive())
+    }
+}
+
+fn footer_style() -> Style {
+    Style::default().fg(colors::subtle())
+}
+
+fn short_session(session_id: Option<&str>) -> String {
+    session_id
+        .map(|id| id.chars().take(12).collect())
+        .unwrap_or_else(|| "not started".to_string())
+}
+
+fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let width = area.width.saturating_mul(percent_x).saturating_div(100);
+    let height = height.min(area.height);
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::TaskList;
+    use crate::api::BambooClient;
+    use crate::task_plan::TaskPlanOverlayState;
+    use bamboo_client_core::{TaskBlocker, TaskBlockerKind, TaskTransition};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn app_with_tasks() -> App {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:1"));
+        app.connected = true;
+        app.chat.session_id = Some("session-unicode".to_string());
+        app.chat.task_progress.requested_session_id = app.chat.session_id.clone();
+        app.chat.task_progress.owner_session_id = app.chat.session_id.clone();
+        app.chat.task_progress.task_list = Some(TaskList {
+            session_id: "session-unicode".to_string(),
+            title: "Release".to_string(),
+            items: vec![
+                TaskItem {
+                    id: "root".to_string(),
+                    description: "实现非常长的 Unicode 任务 👨‍👩‍👧‍👦，并验证不会破坏终端布局".repeat(3),
+                    status: TaskItemStatus::InProgress,
+                    active_form: Some("正在验证任务进度视图".to_string()),
+                    depends_on: vec!["setup".to_string()],
+                    ..TaskItem::default()
+                },
+                TaskItem {
+                    id: "child".to_string(),
+                    description: "等待 API".to_string(),
+                    status: TaskItemStatus::Blocked,
+                    parent_id: Some("root".to_string()),
+                    blockers: vec![TaskBlocker {
+                        kind: TaskBlockerKind::Dependency,
+                        summary: "schema review".to_string(),
+                        waiting_on: Some("backend contract".to_string()),
+                    }],
+                    ..TaskItem::default()
+                },
+            ],
+            ..TaskList::default()
+        });
+        app.chat.task_progress.progress.total = 2;
+        app.chat.task_progress.version = 9;
+        app.task_plan = Some(TaskPlanOverlayState {
+            selected: 1,
+            ..TaskPlanOverlayState::default()
+        });
+        app
+    }
+
+    #[test]
+    fn task_overlay_renders_at_minimum_and_wide_widths() {
+        for width in [60, 80, 120] {
+            let app = app_with_tasks();
+            let backend = TestBackend::new(width, 20);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|frame| render(frame, &app)).unwrap();
+            let rendered: String = terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect();
+            assert!(rendered.contains("Tasks / Plan"));
+            assert!(rendered.contains("waiting on backend contract"));
+        }
+    }
+
+    #[test]
+    fn plan_pane_distinguishes_approval_and_rejection() {
+        let mut app = app_with_tasks();
+        app.task_plan.as_mut().unwrap().pane = TaskPlanPane::Plan;
+        app.chat.run_status.plan.last_outcome = Some("rejected or exited".to_string());
+        app.chat.run_status.plan.status = Some(PlanModeStatus::AwaitingApproval);
+        let lines = task_plan_lines(&app, 58, 18);
+        let text = lines
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("awaiting approval"));
+        assert!(text.contains("rejected or exited"));
+    }
+
+    #[test]
+    fn task_details_render_completion_criteria_and_latest_transition() {
+        let mut task = TaskItem {
+            id: "verify".to_string(),
+            description: "Verify release".to_string(),
+            status: TaskItemStatus::Completed,
+            completion_criteria: vec!["all checks pass".to_string()],
+            ..TaskItem::default()
+        };
+        task.transitions.push(TaskTransition {
+            from_status: TaskItemStatus::InProgress,
+            to_status: TaskItemStatus::Completed,
+            reason: Some("CI succeeded".to_string()),
+            round: Some(4),
+            changed_at: "2026-08-16T00:00:00Z".to_string(),
+        });
+
+        let text = task_detail_lines(&task, 120, 10)
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Completion criteria: all checks pass"));
+        assert!(text.contains("Transition: in progress → completed"));
+        assert!(text.contains("CI succeeded · round 4"));
+    }
+}

--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -36,7 +36,9 @@
 //! ```
 
 use crate::tools::ToolResult;
-use bamboo_domain::{AgentHookPoint, HookResult, PendingQuestionSource, TaskItemStatus, TaskList};
+use bamboo_domain::{
+    AgentHookPoint, HookResult, PendingQuestionSource, TaskItem, TaskItemStatus, TaskList,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -221,6 +223,9 @@ pub enum AgentEvent {
     TaskListUpdated {
         /// Current task list state.
         task_list: TaskList,
+        /// Monotonic persisted task-list generation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<u64>,
     },
 
     /// Emitted when a task item makes progress (delta update).
@@ -235,6 +240,9 @@ pub enum AgentEvent {
         tool_calls_count: usize,
         /// Item version (for optimistic concurrency)
         version: u64,
+        /// Rich item projection for blocker/evidence/transition rendering.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        item: Option<TaskItem>,
     },
 
     /// Emitted when all task items are completed.
@@ -247,6 +255,9 @@ pub enum AgentEvent {
         total_rounds: u32,
         /// Total tool calls made
         total_tool_calls: usize,
+        /// Monotonic persisted task-list generation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<u64>,
     },
 
     /// Emitted when task evaluation starts.
@@ -469,6 +480,9 @@ pub enum AgentEvent {
         file_path: String,
         /// Summary of the plan content (truncated)
         content_summary: String,
+        /// Status after persisting the plan file.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<bamboo_domain::PlanModeStatus>,
     },
 
     /// Runner progress update emitted at the start of each agent turn.
@@ -782,7 +796,7 @@ impl AgentEvent {
     /// per-session forwarder instead.
     pub fn session_id(&self) -> Option<&str> {
         match self {
-            AgentEvent::TaskListUpdated { task_list } => Some(task_list.session_id.as_str()),
+            AgentEvent::TaskListUpdated { task_list, .. } => Some(task_list.session_id.as_str()),
             AgentEvent::TaskListItemProgress { session_id, .. }
             | AgentEvent::TaskListCompleted { session_id, .. }
             | AgentEvent::TaskEvaluationStarted { session_id, .. }
@@ -1029,11 +1043,13 @@ mod tests {
     fn task_list_updated_serializes_with_task_names() {
         let event = AgentEvent::TaskListUpdated {
             task_list: sample_task_list(),
+            version: Some(7),
         };
 
         let value = serde_json::to_value(event).expect("event should serialize");
         assert_eq!(value["type"], "task_list_updated");
         assert!(value.get("task_list").is_some());
+        assert_eq!(value["version"], 7);
         assert!(value.get("todo_list").is_none());
     }
 
@@ -1342,6 +1358,7 @@ mod tests {
             session_id: "sess-1".to_string(),
             file_path: "/tmp/plans/sess-1.md".to_string(),
             content_summary: "Implementation plan for feature X".to_string(),
+            status: Some(bamboo_domain::PlanModeStatus::AwaitingApproval),
         };
 
         let value = serde_json::to_value(event).expect("event should serialize");

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -935,10 +935,14 @@ async fn apply_completed_task_evaluation(
 
             if persisted {
                 state.task_context = staged_task_context;
+                let event_version = new_version.parse::<u64>().ok();
                 session.set_task_list_version_meta(new_version);
                 session.set_task_list(task_list.clone());
                 let _ = event_tx
-                    .send(AgentEvent::TaskListUpdated { task_list })
+                    .send(AgentEvent::TaskListUpdated {
+                        task_list,
+                        version: event_version,
+                    })
                     .await;
             } else {
                 apply_outcome.stale = true;
@@ -6153,7 +6157,7 @@ mod tests {
             .await
             .expect("task update event should be emitted");
         match event {
-            AgentEvent::TaskListUpdated { task_list } => {
+            AgentEvent::TaskListUpdated { task_list, .. } => {
                 assert_eq!(
                     task_list.items[0].status,
                     bamboo_domain::TaskItemStatus::Completed

--- a/crates/engine/bamboo-engine/src/runtime/runner/task_lifecycle/finalize.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/task_lifecycle/finalize.rs
@@ -25,6 +25,7 @@ pub(super) async fn finalize_task_context(
                 completed_at: Utc::now(),
                 total_rounds: ctx.current_round + 1, // Convert 0-indexed to 1-indexed for display.
                 total_tool_calls: ctx.items.iter().map(|item| item.tool_calls.len()).sum(),
+                version: Some(ctx.version),
             })
             .await;
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
@@ -382,6 +382,7 @@ pub(super) async fn maybe_handle_user_question_tool(context: UserQuestionToolCon
                 file_path,
                 content_summary: plan_content_summary(&result.result)
                     .unwrap_or_else(|| "Plan file updated".to_string()),
+                status: Some(PlanModeStatus::AwaitingApproval),
             })
             .await;
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/tests.rs
@@ -416,10 +416,15 @@ async fn maybe_handle_user_question_tool_persists_exit_plan_file_and_emits_updat
             session_id,
             file_path,
             content_summary,
+            status,
         } => {
             assert_eq!(session_id, "session-exit-plan");
             assert_eq!(file_path, *plan_file_path);
             assert!(content_summary.contains("# Plan") || content_summary.contains("Plan"));
+            assert_eq!(
+                status,
+                Some(bamboo_domain::PlanModeStatus::AwaitingApproval)
+            );
         }
         other => panic!("unexpected second event: {other:?}"),
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/progress.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/progress.rs
@@ -42,5 +42,52 @@ fn build_progress_event(ctx: &TaskLoopContext, session_id: &str) -> Option<Agent
         status: target_item.status.clone(),
         tool_calls_count: target_item.tool_calls.len(),
         version: ctx.version,
+        item: ctx.task_item_snapshot(&target_item.id),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::task_context::TaskLoopItem;
+    use bamboo_domain::{TaskBlocker, TaskBlockerKind};
+    use chrono::Utc;
+
+    #[test]
+    fn progress_event_carries_the_rich_item_and_monotonic_version() {
+        let now = Utc::now();
+        let ctx = TaskLoopContext {
+            session_id: "root".to_string(),
+            items: vec![TaskLoopItem {
+                id: "deploy".to_string(),
+                description: "Deploy release".to_string(),
+                status: TaskItemStatus::Blocked,
+                blockers: vec![TaskBlocker {
+                    kind: TaskBlockerKind::External,
+                    summary: "Release approval pending".to_string(),
+                    waiting_on: Some("operator".to_string()),
+                }],
+                ..TaskLoopItem::default()
+            }],
+            active_item_id: Some("deploy".to_string()),
+            current_round: 3,
+            max_rounds: 20,
+            created_at: now,
+            updated_at: now,
+            version: 8,
+            task_list_dirty: false,
+        };
+
+        let event = build_progress_event(&ctx, "child").expect("progress event");
+        assert!(matches!(
+            event,
+            AgentEvent::TaskListItemProgress {
+                session_id,
+                version: 8,
+                item: Some(item),
+                ..
+            } if session_id == "child"
+                && item.blockers[0].waiting_on.as_deref() == Some("operator")
+        ));
+    }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/taskwrite.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/taskwrite.rs
@@ -84,9 +84,17 @@ pub(super) async fn maybe_handle_taskwrite(
 
     match persist_shared_task_list(config, session, &shared_session_id, session_id).await {
         TaskPersistenceOutcome::Publish(authoritative_task_list) => {
+            // Persistence may rebase a stale child candidate onto a newer
+            // shared-root generation. Publish the generation paired with the
+            // authoritative snapshot, not the pre-save candidate version.
+            let authoritative_version = session
+                .task_list_version_meta()
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or(next_version);
             let _ = event_tx
                 .send(AgentEvent::TaskListUpdated {
                     task_list: authoritative_task_list,
+                    version: Some(authoritative_version),
                 })
                 .await;
             reinitialize_task_context(task_context, session, session_id, true);

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
@@ -335,7 +335,7 @@ async fn root_taskwrite_uses_control_plane_save_and_preserves_event_and_context_
 
     let event = rx.recv().await.expect("task update event");
     match event {
-        AgentEvent::TaskListUpdated { task_list } => {
+        AgentEvent::TaskListUpdated { task_list, .. } => {
             assert_eq!(task_list.items.len(), 1);
         }
         other => panic!("unexpected event: {other:?}"),
@@ -502,7 +502,10 @@ async fn child_taskwrite_publishes_snapshot_rebased_by_local_save_everywhere() {
         serde_json::to_value(&authoritative_task_list).expect("serialize authority")
     );
     let event_task_list = match rx.recv().await.expect("rebased Task event") {
-        AgentEvent::TaskListUpdated { task_list } => task_list,
+        AgentEvent::TaskListUpdated { task_list, version } => {
+            assert_eq!(version, Some(2));
+            task_list
+        }
         other => panic!("unexpected event: {other:?}"),
     };
     assert_eq!(
@@ -707,7 +710,7 @@ async fn child_taskwrite_root_cas_conflict_refreshes_repository_without_full_sav
         serde_json::to_value(winner_task_list).expect("serialize winner task list")
     );
     let event_task_list = match rx.recv().await.expect("authoritative Task event") {
-        AgentEvent::TaskListUpdated { task_list } => task_list,
+        AgentEvent::TaskListUpdated { task_list, .. } => task_list,
         other => panic!("unexpected event: {other:?}"),
     };
     assert_eq!(

--- a/crates/engine/bamboo-engine/src/runtime/task_context/conversion.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_context/conversion.rs
@@ -39,6 +39,16 @@ fn into_task_item(loop_item: TaskLoopItem) -> TaskItem {
 }
 
 impl TaskLoopContext {
+    /// Clone one loop item into the durable task projection used by SSE
+    /// progress events. Keeping the conversion here prevents the live view
+    /// from drifting from the snapshot representation.
+    pub(crate) fn task_item_snapshot(&self, item_id: &str) -> Option<TaskItem> {
+        self.items
+            .iter()
+            .find(|item| item.id == item_id)
+            .map(clone_loop_item_into_task_item)
+    }
+
     /// Create `TaskLoopContext` from the session's task list.
     pub fn from_session(session: &bamboo_agent_core::Session) -> Option<Self> {
         session.task_list.as_ref().map(|task_list| {

--- a/examples/stream_events.rs
+++ b/examples/stream_events.rs
@@ -95,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
             }
 
             // -- Progress tracking --------------------------------------------
-            AgentEvent::TaskListUpdated { task_list } => {
+            AgentEvent::TaskListUpdated { task_list, .. } => {
                 println!("\n[task list updated] {} item(s)", task_list.items.len());
             }
 


### PR DESCRIPTION
## Summary

- add a read-only `Leader+t` / command-palette Task & Plan inspector for the active TUI session
- render hierarchical tasks, dependencies, progress, blockers, waiting targets, completion criteria, evidence, transitions, and plan approval lifecycle in compact and wide terminals
- expose the existing rich task state through backward-compatible HTTP/SSE projections, including monotonic versions and authoritative reconnect snapshots
- guard the per-session reducer against stale, duplicate, out-of-order, cross-session, and late HTTP responses

## Test Plan

- `cargo test --workspace --quiet`
- `cargo test -p bamboo-client-core --quiet`
- `cargo test -p bamboo-tui --quiet` (432 passed)
- `cargo test -p bamboo-engine task --quiet` (92 passed)
- `cargo test -p bamboo-server handlers::agent::task --quiet` (14 passed)
- `cargo clippy -p bamboo-client-core -p bamboo-tui --all-targets --no-deps -- -D warnings`
- `cargo clippy -p bamboo-agent-core -p bamboo-engine --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Screenshots

Not attached: this is a terminal UI. Ratatui `TestBackend` coverage verifies the overlay at 60, 80, and 120 columns, including long Unicode content.

Closes #649
