### PR TITLE
feat(server): deduplicate chat and execute retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,15 +211,20 @@ Once the server is running, driving the **full agent loop** — the LLM plans, c
 # 1. Create a turn. This PERSISTS the message and returns immediately — it does
 #    NOT run the loop yet. Response includes the session id and events URL:
 #    { "session_id": "...", "stream_url": "/api/v1/events/<id>", "status": "streaming" }
+CHAT_KEY=$(uuidgen)
 SID=$(curl -s http://127.0.0.1:9562/api/v1/chat \
   -H 'Content-Type: application/json' \
+  -H "Idempotency-Key: $CHAT_KEY" \
   -d '{"message":"List the files here and tell me what this project does.","model":"claude-sonnet-4-6"}' \
   | jq -r .session_id)
 
 # 2. Start the agent loop for that session. The body may be empty ({}) — every
 #    field (model/provider/skill_mode/reasoning_effort/…) is an optional override.
+EXECUTE_KEY=$(uuidgen)
 curl -s -X POST "http://127.0.0.1:9562/api/v1/execute/$SID" \
-  -H 'Content-Type: application/json' -d '{}'
+  -H 'Content-Type: application/json' \
+  -H "Idempotency-Key: $EXECUTE_KEY" \
+  -d '{}'
 
 # 3. Watch the loop in real time (SSE): assistant text, tool calls, tool results,
 #    token usage, and completion arrive as they happen.
@@ -227,6 +232,15 @@ curl -N "http://127.0.0.1:9562/api/v1/events/$SID"
 ```
 
 On `POST /api/v1/chat`, `message` and `model` are the only required fields; useful optionals are `session_id` (continue a conversation), `system_prompt`, `selected_skill_ids`, `workspace_path`, `provider`, `images`. Note that `chat` only **persists** the turn — you must then `POST /api/v1/execute/{session_id}` to actually run the loop. Besides the per-session `GET /api/v1/events/{session_id}` feed, there is an account-wide, resumable change feed `GET /api/v1/stream` (SSE, resumable via `?since=<seq>` or the `Last-Event-ID` header) that streams events across **all** sessions — handy for multi-session sync.
+
+`POST /api/v1/chat` and `POST /api/v1/execute/{session_id}` accept an optional
+`Idempotency-Key` header. Bamboo keeps up to 1,024 completed responses in memory
+for 10 minutes: an equivalent retry replays the first response without
+duplicating the message or run, while the same key with a different payload
+returns `409`. Keys are scoped independently to chat and execute, and a server
+restart clears these short-lived receipts. `POST /api/v1/sessions` has a
+separate durable recovery contract documented in
+[`docs/session-create-idempotency.md`](docs/session-create-idempotency.md).
 
 ### Use it as a Rust SDK (in-process)
 

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -174,6 +174,8 @@ impl AppState {
         let (session_store, storage) = init_storage(&data_dir).await?;
         let session_create_operations =
             Arc::new(super::session_create_operations::SessionCreateOperationStore::new(&data_dir));
+        let mutation_idempotency =
+            Arc::new(super::mutation_idempotency::MutationIdempotencyStore::default());
         match session_create_operations.prune_expired().await {
             Ok(0) => {}
             Ok(deleted) => tracing::info!(
@@ -1020,6 +1022,7 @@ impl AppState {
             storage,
             session_store,
             session_create_operations,
+            mutation_idempotency,
             project_store,
             project_context_resolver,
             workspace_resolver,

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -241,6 +241,10 @@ pub struct AppState {
     pub(crate) session_create_operations:
         Arc<session_create_operations::SessionCreateOperationStore>,
 
+    /// Short-lived, process-local response receipts for `POST /chat` and
+    /// `POST /execute`. Raw caller keys and request payloads are never stored.
+    pub(crate) mutation_idempotency: Arc<mutation_idempotency::MutationIdempotencyStore>,
+
     /// Authoritative first-class Project registry and shared-resource paths.
     pub project_store: Arc<bamboo_projects::ProjectStore>,
 
@@ -515,6 +519,7 @@ pub mod runner_lifecycle;
 // field of the public `schedule_app::ScheduleContext`) is typed
 // `session_events::NotificationRelayDeps`, so external callers that build a
 // `ScheduleContext` by hand (e.g. integration tests) need to name it.
+pub(crate) mod mutation_idempotency;
 pub(crate) mod session_create_operations;
 pub mod session_events;
 mod session_loader;

--- a/crates/app/bamboo-server/src/app_state/mutation_idempotency.rs
+++ b/crates/app/bamboo-server/src/app_state/mutation_idempotency.rs
@@ -1,0 +1,461 @@
+//! Process-local idempotency for short-lived mutating HTTP requests.
+//!
+//! `POST /chat` and `POST /execute` have durable side effects but return small,
+//! self-contained JSON responses. A client can therefore safely retry an
+//! ambiguous request when it supplies an `Idempotency-Key`: the first request
+//! owns the key, concurrent duplicates wait for it, and completed responses
+//! are replayed for a bounded window. Only digests are retained; raw keys and
+//! request payloads never enter the cache or logs.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use actix_web::body::to_bytes;
+use actix_web::http::header::{HeaderMap, CONTENT_LENGTH, TRANSFER_ENCODING};
+use actix_web::http::StatusCode;
+use actix_web::{HttpRequest, HttpResponse};
+use dashmap::DashMap;
+use serde::Serialize;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+use super::session_create_operations::{key_digest, payload_fingerprint, validate_key};
+
+pub(crate) const IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
+const DEFAULT_TTL: Duration = Duration::from_secs(10 * 60);
+const DEFAULT_CAPACITY: usize = 1_024;
+const MAX_CACHED_RESPONSE_BYTES: usize = 256 * 1_024;
+
+#[derive(Clone)]
+pub(crate) struct PreparedMutationIdempotency {
+    key_digest: String,
+    payload_fingerprint: String,
+}
+
+#[derive(Serialize)]
+struct FingerprintEnvelope<'a, T: ?Sized> {
+    target: &'a str,
+    payload: &'a T,
+}
+
+/// Parse and fingerprint an optional idempotency request.
+///
+/// `scope` separates independent mutation families (for example, chat and
+/// execute). `target` is included in the payload fingerprint, so reusing one
+/// execute key for another session fails closed instead of starting work.
+pub(crate) fn prepare<T: Serialize + ?Sized>(
+    request: &HttpRequest,
+    scope: &str,
+    target: &str,
+    payload: &T,
+) -> Result<Option<PreparedMutationIdempotency>, HttpResponse> {
+    let Some(value) = request.headers().get(IDEMPOTENCY_KEY_HEADER) else {
+        return Ok(None);
+    };
+    let raw_key = value.to_str().map_err(|_| {
+        invalid_key_response("Idempotency-Key must contain only visible ASCII characters")
+    })?;
+    validate_key(raw_key).map_err(invalid_key_response)?;
+
+    // Domain-separate mutation families while retaining the existing key
+    // validation and SHA-256 implementation shared with POST /sessions.
+    let digest = key_digest(&format!("mutation-idempotency:v1:{scope}\0{raw_key}"));
+    let fingerprint =
+        payload_fingerprint(&FingerprintEnvelope { target, payload }).map_err(|error| {
+            tracing::error!(
+                target: "bamboo.mutation_idempotency",
+                phase = "fingerprint",
+                error = %error,
+                "failed to fingerprint idempotent mutation request"
+            );
+            HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": crate::error::error_value(
+                    "Failed to fingerprint idempotent mutation request"
+                )
+            }))
+        })?;
+
+    Ok(Some(PreparedMutationIdempotency {
+        key_digest: digest,
+        payload_fingerprint: fingerprint,
+    }))
+}
+
+fn invalid_key_response(message: &str) -> HttpResponse {
+    HttpResponse::BadRequest().json(serde_json::json!({
+        "error": {
+            "type": "api_error",
+            "code": "invalid_idempotency_key",
+            "message": message,
+        }
+    }))
+}
+
+fn conflict_response() -> HttpResponse {
+    HttpResponse::Conflict().json(serde_json::json!({
+        "error": {
+            "type": "api_error",
+            "code": "idempotency_key_conflict",
+            "message": "Idempotency-Key was already used with a different request payload",
+        }
+    }))
+}
+
+#[derive(Clone)]
+struct CachedHttpResponse {
+    status: StatusCode,
+    headers: HeaderMap,
+    body: actix_web::web::Bytes,
+}
+
+impl CachedHttpResponse {
+    async fn capture(response: HttpResponse) -> Result<Self, String> {
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = to_bytes(response.into_body())
+            .await
+            .map_err(|error| format!("failed to buffer idempotent response: {error}"))?;
+        Ok(Self {
+            status,
+            headers,
+            body,
+        })
+    }
+
+    fn to_response(&self) -> HttpResponse {
+        let mut builder = HttpResponse::build(self.status);
+        for (name, value) in &self.headers {
+            if name != CONTENT_LENGTH && name != TRANSFER_ENCODING {
+                builder.append_header((name.clone(), value.clone()));
+            }
+        }
+        builder.body(self.body.clone())
+    }
+}
+
+struct CachedEntry {
+    payload_fingerprint: String,
+    response: CachedHttpResponse,
+    expires_at: Instant,
+    sequence: u64,
+}
+
+#[derive(Default)]
+struct CacheState {
+    entries: HashMap<String, CachedEntry>,
+    next_sequence: u64,
+}
+
+impl CacheState {
+    fn prune_expired(&mut self, now: Instant) {
+        self.entries.retain(|_, entry| entry.expires_at > now);
+    }
+
+    fn insert_bounded(
+        &mut self,
+        capacity: usize,
+        key_digest: String,
+        payload_fingerprint: String,
+        response: CachedHttpResponse,
+        expires_at: Instant,
+    ) {
+        while self.entries.len() >= capacity {
+            let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.sequence)
+                .map(|(key, _)| key.clone())
+            else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+        let sequence = self.next_sequence;
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        self.entries.insert(
+            key_digest,
+            CachedEntry {
+                payload_fingerprint,
+                response,
+                expires_at,
+                sequence,
+            },
+        );
+    }
+}
+
+/// Bounded, process-ephemeral response receipts for chat/execute mutations.
+pub(crate) struct MutationIdempotencyStore {
+    ttl: Duration,
+    capacity: usize,
+    entries: Mutex<CacheState>,
+    /// Strong entries exist only while at least one request owns or waits for
+    /// the key. [`KeyLockGuard`] removes the last idle lock on release.
+    key_locks: DashMap<String, Arc<Mutex<()>>>,
+}
+
+impl Default for MutationIdempotencyStore {
+    fn default() -> Self {
+        Self::new(DEFAULT_TTL, DEFAULT_CAPACITY)
+    }
+}
+
+impl MutationIdempotencyStore {
+    fn new(ttl: Duration, capacity: usize) -> Self {
+        Self {
+            ttl,
+            capacity: capacity.max(1),
+            entries: Mutex::new(CacheState::default()),
+            key_locks: DashMap::new(),
+        }
+    }
+
+    async fn lock_key(self: &Arc<Self>, key_digest: &str) -> KeyLockGuard {
+        let lock = self
+            .key_locks
+            .entry(key_digest.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        let guard = lock.lock_owned().await;
+        KeyLockGuard {
+            store: self.clone(),
+            key_digest: key_digest.to_string(),
+            guard: Some(guard),
+        }
+    }
+
+    /// Run an idempotent mutation or replay the first completed response.
+    ///
+    /// The per-key mutex remains held through the operation and cache commit.
+    /// Cancellation drops the guard without writing a receipt, allowing the
+    /// next retry to become the owner instead of waiting forever.
+    pub(crate) async fn execute<F, Fut>(
+        self: &Arc<Self>,
+        prepared: PreparedMutationIdempotency,
+        operation: F,
+    ) -> HttpResponse
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = HttpResponse>,
+    {
+        let _key_guard = self.lock_key(&prepared.key_digest).await;
+        let now = Instant::now();
+        {
+            let mut cache = self.entries.lock().await;
+            cache.prune_expired(now);
+            if let Some(entry) = cache.entries.get(&prepared.key_digest) {
+                if entry.payload_fingerprint != prepared.payload_fingerprint {
+                    return conflict_response();
+                }
+                tracing::debug!(
+                    target: "bamboo.mutation_idempotency",
+                    correlation_id = %correlation_id(&prepared.key_digest),
+                    outcome = "replayed",
+                    "replayed idempotent mutation response"
+                );
+                return entry.response.to_response();
+            }
+        }
+
+        let response = operation().await;
+        let captured = match CachedHttpResponse::capture(response).await {
+            Ok(captured) => captured,
+            Err(error) => {
+                tracing::error!(
+                    target: "bamboo.mutation_idempotency",
+                    correlation_id = %correlation_id(&prepared.key_digest),
+                    error = %error,
+                    "failed to capture idempotent mutation response"
+                );
+                return HttpResponse::InternalServerError().json(serde_json::json!({
+                    "error": crate::error::error_value(
+                        "Failed to capture idempotent mutation response"
+                    )
+                }));
+            }
+        };
+
+        if captured.body.len() <= MAX_CACHED_RESPONSE_BYTES {
+            let mut cache = self.entries.lock().await;
+            cache.prune_expired(Instant::now());
+            cache.insert_bounded(
+                self.capacity,
+                prepared.key_digest.clone(),
+                prepared.payload_fingerprint,
+                captured.clone(),
+                Instant::now() + self.ttl,
+            );
+            tracing::debug!(
+                target: "bamboo.mutation_idempotency",
+                correlation_id = %correlation_id(&prepared.key_digest),
+                outcome = "stored",
+                "stored idempotent mutation response"
+            );
+        } else {
+            tracing::warn!(
+                target: "bamboo.mutation_idempotency",
+                correlation_id = %correlation_id(&prepared.key_digest),
+                response_bytes = captured.body.len(),
+                max_response_bytes = MAX_CACHED_RESPONSE_BYTES,
+                outcome = "too_large",
+                "idempotent mutation response exceeded the cache limit"
+            );
+        }
+
+        captured.to_response()
+    }
+
+    #[cfg(test)]
+    async fn entry_count(&self) -> usize {
+        self.entries.lock().await.entries.len()
+    }
+}
+
+fn correlation_id(key_digest: &str) -> &str {
+    key_digest.get(..16).unwrap_or(key_digest)
+}
+
+struct KeyLockGuard {
+    store: Arc<MutationIdempotencyStore>,
+    key_digest: String,
+    guard: Option<OwnedMutexGuard<()>>,
+}
+
+impl Drop for KeyLockGuard {
+    fn drop(&mut self) {
+        // Release ownership before checking the map's strong count. If no
+        // waiter captured the lock concurrently, only the map entry remains.
+        self.guard.take();
+        self.store
+            .key_locks
+            .remove_if(&self.key_digest, |_, lock| Arc::strong_count(lock) == 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Notify;
+
+    fn prepared(key: &str, fingerprint: &str) -> PreparedMutationIdempotency {
+        PreparedMutationIdempotency {
+            key_digest: key_digest(key),
+            payload_fingerprint: fingerprint.to_string(),
+        }
+    }
+
+    async fn body(response: HttpResponse) -> (StatusCode, actix_web::web::Bytes) {
+        let status = response.status();
+        let body = to_bytes(response.into_body()).await.expect("response body");
+        (status, body)
+    }
+
+    #[actix_web::test]
+    async fn completed_response_is_replayed_without_running_again() {
+        let store = Arc::new(MutationIdempotencyStore::default());
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let first_calls = calls.clone();
+        let first = store
+            .execute(prepared("same-key", "same-payload"), || async move {
+                first_calls.fetch_add(1, Ordering::SeqCst);
+                HttpResponse::Created().json(serde_json::json!({"result": "first"}))
+            })
+            .await;
+        let replay_calls = calls.clone();
+        let replay = store
+            .execute(prepared("same-key", "same-payload"), || async move {
+                replay_calls.fetch_add(1, Ordering::SeqCst);
+                HttpResponse::Ok().finish()
+            })
+            .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(body(first).await, body(replay).await);
+        assert_eq!(store.entry_count().await, 1);
+        assert!(store.key_locks.is_empty(), "idle key locks must self-clean");
+    }
+
+    #[actix_web::test]
+    async fn same_key_with_different_payload_fails_closed() {
+        let store = Arc::new(MutationIdempotencyStore::default());
+        let _ = store
+            .execute(prepared("same-key", "payload-a"), || async {
+                HttpResponse::Created().finish()
+            })
+            .await;
+
+        let conflict = store
+            .execute(prepared("same-key", "payload-b"), || async {
+                panic!("conflicting request must not execute")
+            })
+            .await;
+        let (status, bytes) = body(conflict).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        let value: serde_json::Value = serde_json::from_slice(&bytes).expect("json response");
+        assert_eq!(value["error"]["code"], "idempotency_key_conflict");
+    }
+
+    #[actix_web::test]
+    async fn concurrent_duplicate_waits_and_executes_only_once() {
+        let store = Arc::new(MutationIdempotencyStore::default());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+
+        let first_store = store.clone();
+        let first_calls = calls.clone();
+        let first_started = started.clone();
+        let first = async move {
+            first_store
+                .execute(prepared("racing-key", "payload"), || async move {
+                    first_calls.fetch_add(1, Ordering::SeqCst);
+                    first_started.notify_one();
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    HttpResponse::Accepted().json(serde_json::json!({"run_id": "one"}))
+                })
+                .await
+        };
+
+        let second_store = store.clone();
+        let second_calls = calls.clone();
+        let second = async move {
+            started.notified().await;
+            second_store
+                .execute(prepared("racing-key", "payload"), || async move {
+                    second_calls.fetch_add(1, Ordering::SeqCst);
+                    HttpResponse::Ok().finish()
+                })
+                .await
+        };
+
+        let (first, second) = tokio::join!(first, second);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(body(first).await, body(second).await);
+        assert!(store.key_locks.is_empty(), "idle key locks must self-clean");
+    }
+
+    #[actix_web::test]
+    async fn ttl_and_capacity_bound_replay_state() {
+        let store = Arc::new(MutationIdempotencyStore::new(Duration::from_millis(20), 2));
+        for key in ["one", "two", "three"] {
+            let _ = store
+                .execute(prepared(key, key), || async { HttpResponse::Ok().finish() })
+                .await;
+        }
+        assert_eq!(store.entry_count().await, 2);
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let rerun_calls = calls.clone();
+        let _ = store
+            .execute(prepared("three", "three"), || async move {
+                rerun_calls.fetch_add(1, Ordering::SeqCst);
+                HttpResponse::Ok().finish()
+            })
+            .await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "expired entry must rerun");
+        assert_eq!(store.entry_count().await, 1);
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -1,4 +1,4 @@
-use actix_web::{web, HttpResponse, Responder};
+use actix_web::{web, HttpRequest, HttpResponse};
 
 use super::{ChatRequest, ChatResponse};
 use crate::app_state::AppState;
@@ -170,7 +170,28 @@ mod tests;
 /// This endpoint accepts a user message and creates or updates a chat session.
 /// After calling this endpoint, use the returned `stream_url` to execute
 /// the agent and receive events.
-pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) -> impl Responder {
+pub async fn handler(
+    state: web::Data<AppState>,
+    http_request: HttpRequest,
+    req: web::Json<ChatRequest>,
+) -> HttpResponse {
+    let prepared = match crate::app_state::mutation_idempotency::prepare(
+        &http_request,
+        "chat",
+        "POST /api/v1/chat",
+        &*req,
+    ) {
+        Ok(prepared) => prepared,
+        Err(response) => return response,
+    };
+    let Some(prepared) = prepared else {
+        return handle_chat(state, req).await;
+    };
+    let store = state.mutation_idempotency.clone();
+    store.execute(prepared, || handle_chat(state, req)).await
+}
+
+async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) -> HttpResponse {
     let session_id = request::resolve_session_id(req.session_id.as_deref());
     let (
         existing_session_found,

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -638,6 +638,77 @@ mod optional_model_e2e {
         assert_eq!(session.model, "gpt-explicit-override");
     }
 
+    /// #733: a retry after the first response is lost must receive the exact
+    /// first response without appending the user message a second time.
+    #[actix_web::test]
+    async fn idempotency_key_replays_chat_without_duplicate_message() {
+        use bamboo_agent_core::Role;
+
+        let state = new_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let request = || {
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .insert_header(("Idempotency-Key", "chat-retry-733"))
+                .set_json(serde_json::json!({
+                    "message": "persist exactly once",
+                    "model": "chat-model"
+                }))
+                .to_request()
+        };
+
+        let first = test::call_service(&app, request()).await;
+        assert_eq!(first.status(), StatusCode::CREATED);
+        let first_body = test::read_body(first).await;
+        let replay = test::call_service(&app, request()).await;
+        assert_eq!(replay.status(), StatusCode::CREATED);
+        let replay_body = test::read_body(replay).await;
+        assert_eq!(
+            replay_body, first_body,
+            "retry must replay exact JSON bytes"
+        );
+
+        let response: Value = serde_json::from_slice(&first_body).expect("chat response JSON");
+        let session_id = response["session_id"].as_str().expect("session_id");
+        let session = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load session")
+            .expect("session exists");
+        assert_eq!(
+            session
+                .messages
+                .iter()
+                .filter(|message| message.role == Role::User)
+                .count(),
+            1,
+            "replay must not append a second user message"
+        );
+
+        let conflict = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .insert_header(("Idempotency-Key", "chat-retry-733"))
+                .set_json(serde_json::json!({
+                    "message": "different payload",
+                    "model": "chat-model"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(conflict.status(), StatusCode::CONFLICT);
+        let conflict: Value = test::read_body_json(conflict).await;
+        assert_eq!(conflict["error"]["code"], "idempotency_key_conflict");
+    }
+
     /// No request model AND no server default configured → 400, not a silent
     /// empty-model session.
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/agent/chat/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/types.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// * `model` - Optional model identifier (e.g., "gpt-4o-mini", "claude-3-opus").
 ///   When absent or empty, the server falls back to its resolved default model
 ///   (issue #480) — the same resolution `GET /api/v1/execute/defaults` reports.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ChatRequest {
     pub message: String,
     pub session_id: Option<String>,
@@ -55,7 +55,7 @@ pub struct ChatRequest {
     pub reasoning_effort: Option<ReasoningEffort>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ChatImage {
     pub base64: String,
     #[serde(default)]

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -1,4 +1,4 @@
-use actix_web::{web, HttpResponse};
+use actix_web::{web, HttpRequest, HttpResponse};
 
 use super::image_fallback::resolve_image_fallback;
 use super::{ExecuteRequest, ExecuteSyncInfo, ExecuteSyncReason};
@@ -23,10 +23,37 @@ mod validation;
 /// Execute the AI agent on a chat session.
 pub async fn handler(
     state: web::Data<AppState>,
+    http_request: HttpRequest,
     path: web::Path<String>,
     req: web::Json<ExecuteRequest>,
 ) -> HttpResponse {
     let session_id = path.into_inner();
+    let prepared = match crate::app_state::mutation_idempotency::prepare(
+        &http_request,
+        "execute",
+        &format!("POST /api/v1/execute/{session_id}"),
+        &*req,
+    ) {
+        Ok(prepared) => prepared,
+        Err(response) => return response,
+    };
+    let Some(prepared) = prepared else {
+        return handle_execute(state, session_id, req).await;
+    };
+    let store = state.mutation_idempotency.clone();
+    store
+        .execute(prepared, || handle_execute(state, session_id, req))
+        .await
+}
+
+/// Execute a session for in-process callers that do not cross the HTTP
+/// boundary. HTTP callers should use [`handler`] so an `Idempotency-Key` can
+/// be honored before any durable work starts.
+pub async fn handle_execute(
+    state: web::Data<AppState>,
+    session_id: String,
+    req: web::Json<ExecuteRequest>,
+) -> HttpResponse {
     // Linearize startup ownership against an abandoned-turn reconciliation.
     // Reconciliation holds the same persistence lock through its durable CAS
     // and broadcast; whichever acquires it first becomes the authoritative

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
@@ -175,6 +175,162 @@ fn evaluate_client_sync_allows_missing_pending_question_tool_call_id() {
     );
 }
 
+mod idempotency_e2e {
+    use actix_web::{http::StatusCode, test, web, App};
+    use async_trait::async_trait;
+    use bamboo_agent_core::{Message, Session};
+    use bamboo_llm::{
+        LLMChunk, LLMError, LLMProvider, LLMRequestOptions, LLMStream, ProviderModelRouter,
+        ProviderRegistry,
+    };
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use tokio::sync::Semaphore;
+
+    use crate::routes::configure_routes;
+    use crate::AppState;
+
+    struct BlockingProvider {
+        calls: AtomicUsize,
+        started: Semaphore,
+        release: Semaphore,
+    }
+
+    impl BlockingProvider {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+                started: Semaphore::new(0),
+                release: Semaphore::new(0),
+            })
+        }
+
+        async fn response(&self) -> Result<LLMStream, LLMError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.started.add_permits(1);
+            let _permit = self
+                .release
+                .acquire()
+                .await
+                .expect("release semaphore remains open");
+            Ok(Box::pin(futures::stream::iter(vec![
+                Ok(LLMChunk::Token("completed once".to_string())),
+                Ok(LLMChunk::Done),
+            ])))
+        }
+    }
+
+    #[async_trait]
+    impl LLMProvider for BlockingProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[bamboo_agent_core::Message],
+            _tools: &[bamboo_agent_core::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            self.response().await
+        }
+
+        async fn chat_stream_with_options(
+            &self,
+            _messages: &[bamboo_agent_core::Message],
+            _tools: &[bamboo_agent_core::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+            _options: Option<&LLMRequestOptions>,
+        ) -> Result<LLMStream, LLMError> {
+            self.response().await
+        }
+    }
+
+    async fn state_with_provider(provider: Arc<BlockingProvider>) -> web::Data<AppState> {
+        let data_dir = tempdir().expect("tempdir").keep();
+        bamboo_config::paths::init_bamboo_dir(data_dir.clone());
+        let mut config = bamboo_llm::Config::from_data_dir(Some(data_dir.clone()));
+        config.provider = "openai".to_string();
+        config.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
+            model: Some("execute-model".to_string()),
+            ..Default::default()
+        });
+
+        let provider_trait: Arc<dyn LLMProvider> = provider.clone();
+        let mut state = AppState::new_with_provider(data_dir, config, provider_trait)
+            .await
+            .expect("app state");
+        let mut providers = HashMap::new();
+        providers.insert("openai".to_string(), provider as Arc<dyn LLMProvider>);
+        state.provider_registry = Arc::new(ProviderRegistry::new(providers, "openai".to_string()));
+        state.provider_router = Arc::new(ProviderModelRouter::new(state.provider_registry.clone()));
+        web::Data::new(state)
+    }
+
+    /// #733: execute retries replay the original Accepted response (including
+    /// run_id) instead of entering preparation or spawning another agent loop.
+    #[actix_web::test]
+    async fn idempotency_key_replays_execute_without_duplicate_run() {
+        let provider = BlockingProvider::new();
+        let state = state_with_provider(provider.clone()).await;
+        let session_id = "execute-idempotency-733";
+        let mut session = Session::new(session_id, "execute-model");
+        session.title_generated = true;
+        session.add_message(Message::user("run exactly once"));
+        crate::handlers::agent::events::mark_pending_turn(&mut session);
+        state.save_and_cache_session(&mut session).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let request = || {
+            test::TestRequest::post()
+                .uri(&format!("/api/v1/execute/{session_id}"))
+                .insert_header(("Idempotency-Key", "execute-retry-733"))
+                .set_json(serde_json::json!({}))
+                .to_request()
+        };
+
+        let first = test::call_service(&app, request()).await;
+        assert_eq!(first.status(), StatusCode::ACCEPTED);
+        let first_body = test::read_body(first).await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            provider.started.acquire(),
+        )
+        .await
+        .expect("agent provider started")
+        .expect("started semaphore remains open")
+        .forget();
+
+        let replay = test::call_service(&app, request()).await;
+        assert_eq!(replay.status(), StatusCode::ACCEPTED);
+        let replay_body = test::read_body(replay).await;
+        assert_eq!(
+            replay_body, first_body,
+            "retry must replay the first run_id"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(state.agent_runners.read().await.len(), 1);
+
+        let cancel = state
+            .agent_runners
+            .read()
+            .await
+            .get(session_id)
+            .expect("runner remains registered")
+            .cancel_token
+            .clone();
+        cancel.cancel();
+        provider.release.add_permits(1);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
 #[actix_web::test]
 async fn startup_failure_persists_and_broadcasts_for_owned_turn() {
     use actix_web::web;

--- a/crates/app/bamboo-server/src/handlers/agent/execute/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod runtime;
 mod types;
 
 pub use defaults::handler as defaults_handler;
-pub use handler::handler;
+pub use handler::{handle_execute, handler};
 pub(crate) use runtime::{spawn_agent_execution, spawn_event_forwarder};
 pub use types::{
     ExecuteClientSync, ExecuteRequest, ExecuteResponse, ExecuteSyncInfo, ExecuteSyncReason,

--- a/crates/app/bamboo-server/src/handlers/agent/execute/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/types.rs
@@ -105,7 +105,7 @@ pub struct ExecuteResponse {
 ///   "model": "claude-3-opus"
 /// }
 /// ```
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ExecuteRequest {
     /// Optional model compatibility fallback for execution.
     #[serde(default)]

--- a/docs/guides/API.md
+++ b/docs/guides/API.md
@@ -24,6 +24,12 @@ POST /api/v1/chat
 
 Create a new chat session or add a message to an existing session.
 
+Supply an optional `Idempotency-Key` header when a client may retry after an
+ambiguous timeout. For 10 minutes, an equivalent retry returns the first
+response without appending the message again. Reusing the key with another
+payload returns `409 idempotency_key_conflict`. Receipts are process-local and
+bounded; omitting the header preserves the normal behavior.
+
 **Request Body:**
 
 ```json
@@ -60,6 +66,11 @@ POST /api/v1/execute/{session_id}
 ```
 
 Start the agent execution loop for a session.
+
+`Idempotency-Key` has the same optional 10-minute replay contract as chat. An
+equivalent retry returns the original status, body, and `run_id` without
+starting another run. The canonical nested route
+`POST /api/v1/sessions/{session_id}/execute` shares the same receipt.
 
 **Path Parameters:**
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -15,7 +15,7 @@ use actix_web::web;
 use bamboo_agent_core::storage::Storage as _;
 use bamboo_agent_core::{Message, Role, Session, SessionKind};
 use bamboo_server::app_state::AppState;
-use bamboo_server::handlers::agent::execute::{handler as execute_handler, ExecuteRequest};
+use bamboo_server::handlers::agent::execute::{handle_execute, ExecuteRequest};
 use bamboo_server::handlers::agent::respond::{submit_response, RespondRequest};
 use bamboo_tools::permission::PermissionMode;
 
@@ -483,9 +483,9 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
     // inventing behavior the API doesn't back. `--timeout` IS added, but as a
     // client-side wall-clock cutoff (reuses the Ctrl-C cancellation path
     // below) rather than a request field, for the same reason.
-    let response = execute_handler(
+    let response = handle_execute(
         data.clone(),
-        web::Path::from(session_id.clone()),
+        session_id.clone(),
         web::Json(ExecuteRequest {
             model: model_selection.model.clone(),
             provider: model_selection.provider.clone(),


### PR DESCRIPTION
## Summary

- add optional `Idempotency-Key` handling to `POST /api/v1/chat` and both execute route forms
- replay the exact first response for 10 minutes without repeating message persistence or runner startup
- reject key reuse with a different typed payload using `409 idempotency_key_conflict`
- bound process-local receipts to 1,024 entries while storing only SHA-256 digests, never raw keys or payloads
- preserve the existing durable idempotency contract for `POST /api/v1/sessions`
- keep the in-process headless execution path independent of HTTP-only idempotency

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code`
- `cargo test -p bamboo-server --lib app_state::mutation_idempotency::tests::`
- `cargo test -p bamboo-server --lib idempotency_key_replays`
- `cargo test --all-features --lib --tests`
- `cargo build --examples`

## Screenshots

Not applicable; server/API behavior only.

Closes #733