### PR TITLE
fix(config): preserve unknown tool and skill keys

### DIFF
--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -2591,11 +2591,15 @@ pub struct ToolsConfig {
     /// Tool names that are disabled globally.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disabled: Vec<String>,
+
+    /// Preserve tool configuration owned by newer Bamboo versions or plugins.
+    #[serde(default, flatten)]
+    pub extra: BTreeMap<String, Value>,
 }
 
 impl ToolsConfig {
     fn is_empty(&self) -> bool {
-        self.disabled.is_empty()
+        self.disabled.is_empty() && self.extra.is_empty()
     }
 }
 
@@ -2605,11 +2609,15 @@ pub struct SkillsConfig {
     /// Skill IDs that are disabled globally.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disabled: Vec<String>,
+
+    /// Preserve skill configuration owned by newer Bamboo versions or plugins.
+    #[serde(default, flatten)]
+    pub extra: BTreeMap<String, Value>,
 }
 
 impl SkillsConfig {
     fn is_empty(&self) -> bool {
-        self.disabled.is_empty()
+        self.disabled.is_empty() && self.extra.is_empty()
     }
 }
 
@@ -5268,6 +5276,76 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn tools_config_preserves_unknown_keys_across_roundtrip() {
+        let input = serde_json::json!({
+            "disabled": ["bash"],
+            "plugin_runtime": {
+                "timeout_ms": 5_000,
+                "sandbox": true
+            },
+            "future_flag": "enabled"
+        });
+
+        let config: ToolsConfig = serde_json::from_value(input.clone()).unwrap();
+        assert_eq!(config.disabled, vec!["bash"]);
+        assert_eq!(config.extra["plugin_runtime"]["timeout_ms"], 5_000);
+        assert_eq!(config.extra["future_flag"], "enabled");
+        assert_eq!(serde_json::to_value(config).unwrap(), input);
+    }
+
+    #[test]
+    fn tools_config_keeps_section_when_only_unknown_keys_present() {
+        let input = serde_json::json!({
+            "tool_extension": {
+                "mode": "strict",
+                "options": ["one", "two"]
+            }
+        });
+        let config: Config = serde_json::from_value(serde_json::json!({
+            "tools": input.clone()
+        }))
+        .unwrap();
+
+        assert!(config.tools.disabled.is_empty());
+        assert_eq!(config.tools.extra["tool_extension"]["mode"], "strict");
+        assert_eq!(serde_json::to_value(&config).unwrap()["tools"], input);
+
+        let temp_home = TempHome::new();
+        config.save_to_dir(temp_home.path.clone()).unwrap();
+        let persisted: Value =
+            serde_json::from_slice(&std::fs::read(temp_home.path.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(persisted["tools"], input);
+    }
+
+    #[test]
+    fn skills_config_preserves_unknown_keys_across_roundtrip() {
+        let input = serde_json::json!({
+            "external_catalog": {
+                "path": "/opt/bamboo/skills",
+                "refresh": false
+            },
+            "schema_version": 2
+        });
+
+        let config: Config = serde_json::from_value(serde_json::json!({
+            "skills": input.clone()
+        }))
+        .unwrap();
+        assert!(config.skills.disabled.is_empty());
+        assert_eq!(config.skills.extra["external_catalog"]["refresh"], false);
+        assert_eq!(config.skills.extra["schema_version"], 2);
+        assert_eq!(serde_json::to_value(&config).unwrap()["skills"], input);
+
+        let temp_home = TempHome::new();
+        config.save_to_dir(temp_home.path.clone()).unwrap();
+        let persisted: Value =
+            serde_json::from_slice(&std::fs::read(temp_home.path.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(persisted["skills"], input);
+    }
 
     #[test]
     fn lifecycle_hooks_round_trip_as_a_distinct_top_level_section() {

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -6266,8 +6266,14 @@ mod tests {
             "server": {"port": 9876},
             "provider": "gemini",
             "features": {"dynamic_model_routing": true},
-            "tools": {"disabled": ["bash"]},
-            "skills": {"disabled": ["private"]},
+            "tools": {
+                "disabled": ["bash"],
+                "future_tool_config": {"nested": true}
+            },
+            "skills": {
+                "disabled": ["private"],
+                "future_skill_config": {"nested": "kept"}
+            },
             "env_vars": [{"name": "VISIBLE", "value": "ok"}],
             "default_work_area": {"path": "/workspace"},
             "access_control": {"password_enabled": true, "password_hash": "hash"},
@@ -6312,6 +6318,8 @@ mod tests {
         assert_eq!(value["server"]["port"], 9876);
         assert_eq!(value["provider"], "gemini");
         assert_eq!(value["tools"]["disabled"][0], "bash");
+        assert_eq!(value["tools"]["future_tool_config"]["nested"], true);
+        assert_eq!(value["skills"]["future_skill_config"]["nested"], "kept");
         assert_eq!(value["default_work_area"]["path"], "/workspace");
         assert_eq!(value["run_budget"]["max_tool_calls"], 4);
         assert_eq!(value["plugin_trust"]["enforcement"], "off");


### PR DESCRIPTION
## Summary

- preserve unknown `tools` and `skills` keys in flattened maps during config load-save round trips
- keep extension-only sections serialized through both the root config and modular section projection paths
- add regression coverage for known-plus-unknown fields, extension-only sections, and persisted `config.json`

## Root Cause

`ToolsConfig` and `SkillsConfig` only modeled their known `disabled` field. Serde discarded every other sub-key during deserialization, so the next save silently removed forward-compatible or plugin-owned configuration.

## User Impact

Bamboo now retains unrecognized tool and skill configuration instead of deleting it when another settings section is saved.

## Test Plan

- `cargo fmt --check`
- `cargo clippy -p bamboo-config --all-targets -- -D warnings`
- `cargo test -p bamboo-config` (668 passed)
- `cargo clippy` (passed; only three pre-existing `too_many_arguments` warnings)
- `cargo test` (full workspace, including integration and doc tests)

Screenshots: not applicable (configuration serialization only).

Closes #655