### PR TITLE
refactor(config): make provider instances authoritative

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/builder.rs
+++ b/crates/app/bamboo-sdk/src/agent/builder.rs
@@ -257,18 +257,21 @@ impl AgentBuilder {
         self
     }
 
-    /// Select the provider by name (`anthropic`, `openai`, `gemini`, `copilot`,
-    /// `bodhi`) for [`with_defaults_for_data_dir`](Self::with_defaults_for_data_dir),
-    /// overriding `config.json`'s `provider`. A following [`api_key`](Self::api_key)
-    /// applies to *this* provider. The name is lower-cased (config matching is
-    /// case-sensitive).
+    /// Select the provider by instance id or built-in type (`anthropic`,
+    /// `openai`, `gemini`, `copilot`, `bodhi`) for
+    /// [`with_defaults_for_data_dir`](Self::with_defaults_for_data_dir). An exact
+    /// instance id wins; a type deterministically selects the first enabled
+    /// instance of that type, falling back to the legacy slot only when none
+    /// exists. A following [`api_key`](Self::api_key) applies to this effective
+    /// target. Instance ids are matched exactly; built-in type names are
+    /// normalized to lowercase.
     ///
     /// Note: this drives provider creation inside `with_defaults_for_data_dir`
     /// and can fail there (e.g. missing key). A [`provider`](Self::provider)
     /// injected before defaults skips that creation entirely; one injected
     /// afterwards replaces the already-created provider at build time.
     pub fn provider_name(mut self, provider: impl Into<String>) -> Self {
-        self.provider_name = Some(provider.into().trim().to_ascii_lowercase());
+        self.provider_name = Some(provider.into().trim().to_string());
         self
     }
 
@@ -563,7 +566,7 @@ impl AgentBuilder {
         // Select the provider first, so `api_key` and provider creation both act
         // on the chosen provider rather than config.json's default.
         if let Some(provider) = self.provider_name.clone() {
-            config.provider = provider;
+            select_provider_override(&mut config, &provider);
         }
         if let Some(api_key) = self.api_key.clone() {
             apply_api_key(&mut config, &api_key)?;
@@ -835,7 +838,7 @@ impl Default for AgentBuilder {
     }
 }
 
-/// Apply `api_key` to the active provider's in-memory config slot.
+/// Apply `api_key` to the effective provider's in-memory config slot.
 ///
 /// If the provider stanza already exists, its key is overwritten. If it is
 /// absent (the common default-config / no-`config.json` case), a minimal stanza
@@ -845,12 +848,26 @@ impl Default for AgentBuilder {
 /// `gemini`) are fabricated; other providers (e.g. `copilot`, which authenticates
 /// via cached OAuth rather than a plain key) return a typed error.
 fn apply_api_key(config: &mut Config, api_key: &str) -> Result<(), SdkError> {
+    let provider_key = config.effective_default_provider().to_string();
+    if let Some(instance) = config.provider_instances.get_mut(&provider_key) {
+        let provider = instance.provider_type.clone();
+        if !matches!(provider.as_str(), "openai" | "anthropic" | "gemini") {
+            return Err(SdkError::UnsupportedApiKeyProvider { provider });
+        }
+        instance.api_key = api_key.to_string();
+        instance.api_key_encrypted = None;
+        instance
+            .extra
+            .remove(bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY);
+        return Ok(());
+    }
+
     // A minimal `{"api_key": …}` stanza; every other provider-config field
     // deserializes to its serde default, so the target type is inferred from
     // the assignment below (no `serde` trait import needed).
     let stanza = || serde_json::json!({ "api_key": api_key });
 
-    let provider = config.provider.clone();
+    let provider = provider_key;
     let providers = config.providers_mut();
     match provider.as_str() {
         "openai" => match providers.openai.as_mut() {
@@ -899,6 +916,34 @@ fn apply_api_key(config: &mut Config, api_key: &str) -> Result<(), SdkError> {
     }
 }
 
+/// Apply an SDK provider override without bypassing provider-instance
+/// authority. Exact ids win (including disabled ids, which the factory then
+/// rejects); a built-in type selects the lexicographically first enabled
+/// instance of that type. Only when no instance matches do we deliberately
+/// fall back to the legacy single-provider slot.
+fn select_provider_override(config: &mut Config, requested: &str) {
+    if config.provider_instances.contains_key(requested) {
+        config.default_provider_instance = Some(requested.to_string());
+        return;
+    }
+
+    let requested_type = requested.to_ascii_lowercase();
+    let mut matching = config
+        .provider_instances
+        .iter()
+        .filter(|(_, instance)| instance.enabled && instance.provider_type == requested_type)
+        .map(|(id, _)| id.clone())
+        .collect::<Vec<_>>();
+    matching.sort();
+    if let Some(instance_id) = matching.into_iter().next() {
+        config.default_provider_instance = Some(instance_id);
+        return;
+    }
+
+    config.default_provider_instance = None;
+    config.provider = requested_type;
+}
+
 fn permission_checker_for_mode(mode: PermissionMode) -> Option<Arc<dyn PermissionChecker>> {
     let config = Arc::new(PermissionConfig::new());
     config.set_mode(mode);
@@ -908,7 +953,9 @@ fn permission_checker_for_mode(mode: PermissionMode) -> Option<Arc<dyn Permissio
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_api_key, permission_checker_for_mode, AgentBuilder};
+    use super::{
+        apply_api_key, permission_checker_for_mode, select_provider_override, AgentBuilder,
+    };
     use async_trait::async_trait;
     use bamboo_agent_core::tools::{
         FunctionCall, Tool, ToolCall, ToolCtx, ToolError, ToolExecutionContext, ToolExecutor,
@@ -1011,6 +1058,92 @@ mod tests {
         assert!(
             config.providers().anthropic.is_none(),
             "the default provider must not receive the key"
+        );
+    }
+
+    #[test]
+    fn provider_override_prefers_exact_instance_then_deterministic_type_match() {
+        let mut config = Config::default();
+        for (id, provider_type, enabled) in [
+            ("Work-Exact", "openai", false),
+            ("z-enabled", "openai", true),
+            ("a-enabled", "openai", true),
+            ("anthropic-work", "anthropic", true),
+        ] {
+            config.provider_instances.insert(
+                id.to_string(),
+                serde_json::from_value(serde_json::json!({
+                    "provider_type": provider_type,
+                    "enabled": enabled
+                }))
+                .unwrap(),
+            );
+        }
+
+        select_provider_override(&mut config, "Work-Exact");
+        assert_eq!(
+            config.default_provider_instance.as_deref(),
+            Some("Work-Exact"),
+            "exact id wins even when disabled so factory validation stays fail-closed"
+        );
+
+        select_provider_override(&mut config, "OPENAI");
+        assert_eq!(
+            config.default_provider_instance.as_deref(),
+            Some("a-enabled")
+        );
+    }
+
+    #[test]
+    fn api_key_updates_effective_instance_and_clears_environment_marker() {
+        let mut config = Config::default();
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "enabled": true,
+                "api_key_from_env": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        apply_api_key(&mut config, "sk-sdk-override").unwrap();
+        let instance = &config.provider_instances["work"];
+        assert_eq!(instance.api_key, "sk-sdk-override");
+        assert!(instance.api_key_encrypted.is_none());
+        assert!(!bamboo_config::provider_instance_api_key_from_env(instance));
+        assert!(
+            config.providers().openai.is_none(),
+            "instance override must not fabricate a legacy slot"
+        );
+    }
+
+    #[test]
+    fn provider_override_falls_back_to_legacy_slot_only_without_matching_instance() {
+        let mut config = Config::default();
+        config.provider_instances.insert(
+            "anthropic-work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "anthropic",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("anthropic-work".to_string());
+        config.providers_mut().gemini = None;
+
+        select_provider_override(&mut config, "GEMINI");
+        assert!(config.default_provider_instance.is_none());
+        assert_eq!(config.provider, "gemini");
+        apply_api_key(&mut config, "gemini-sdk-key").unwrap();
+        assert_eq!(
+            config
+                .providers()
+                .gemini
+                .as_ref()
+                .map(|provider| provider.api_key.as_str()),
+            Some("gemini-sdk-key")
         );
     }
 

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -11,7 +11,8 @@ use bamboo_agent_core::AgentEvent;
 use bamboo_engine::execution::{reserve_session_execution, SessionExecutionReserveOutcome};
 use bamboo_engine::model_areas::resolve_global_area_models;
 use bamboo_engine::model_config_helper::{
-    resolve_gold_config, resolve_provider_type, GOLD_CONFIG_METADATA_KEY,
+    resolve_gold_config, resolve_provider_routing_key, resolve_provider_type,
+    GOLD_CONFIG_METADATA_KEY,
 };
 use bamboo_engine::session_app::approval_replay::{
     apply_permission_replay_result, find_permission_replay_target, refresh_approval_replay_posture,
@@ -19,7 +20,7 @@ use bamboo_engine::session_app::approval_replay::{
     PermissionReplayTarget,
 };
 use bamboo_engine::session_app::execute::consume_pending_clarification_resume;
-use bamboo_engine::session_app::provider_model::session_effective_model_ref;
+use bamboo_engine::session_app::provider_model::{persist_model_ref, session_effective_model_ref};
 use bamboo_engine::session_app::respond::{
     PERMISSION_REEXECUTE_GENERATION_METADATA_KEY, PERMISSION_REEXECUTE_METADATA_KEY,
 };
@@ -96,11 +97,46 @@ impl ResumeExecutionPort for AppStateResumeRef {
             return;
         }
 
-        let model = session.model.clone();
-        let resolved_provider_name = session_effective_model_ref(&session)
-            .map(|model_ref| model_ref.provider)
-            .unwrap_or(config.provider_name);
         let config_snapshot = self.0.config.read().await.clone();
+        let model = session.model.clone();
+        let session_model_ref = session_effective_model_ref(&session);
+        let requested_provider = session_model_ref
+            .as_ref()
+            .map(|model_ref| model_ref.provider.as_str())
+            .unwrap_or(config.provider_name.as_str());
+        let resolved_provider_name = match resolve_provider_routing_key(
+            &config_snapshot,
+            requested_provider,
+            &self.0.provider_registry,
+        ) {
+            Ok(provider) => provider,
+            Err(error) => {
+                tracing::error!(
+                    %session_id,
+                    provider = requested_provider,
+                    %error,
+                    "resume provider target is unavailable; refusing to fall back"
+                );
+                execution_reservation.abandon().await;
+                return;
+            }
+        };
+        if let Some(mut model_ref) = session_model_ref {
+            model_ref.provider = resolved_provider_name.clone();
+            persist_model_ref(&mut session, &model_ref);
+        }
+        let provider_override = match self.0.provider_registry.get(&resolved_provider_name) {
+            Some(provider) => provider,
+            None => {
+                tracing::error!(
+                    %session_id,
+                    provider = %resolved_provider_name,
+                    "resume provider disappeared after resolution; refusing to fall back"
+                );
+                execution_reservation.abandon().await;
+                return;
+            }
+        };
         let resolved_provider_type = resolve_provider_type(
             &config_snapshot,
             &resolved_provider_name,
@@ -215,7 +251,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                     execution_reservation,
                     is_child_session,
                     provider_name: resolved_provider_name,
-                    provider_override: None,
+                    provider_override: Some(provider_override.clone()),
                     model_roster,
                     reasoning_effort,
                     reasoning_effort_source,
@@ -470,7 +506,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                 execution_reservation,
                 is_child_session,
                 provider_name: resolved_provider_name,
-                provider_override: None,
+                provider_override: Some(provider_override),
                 model_roster,
                 reasoning_effort,
                 reasoning_effort_source,

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -105,12 +105,12 @@ pub async fn handle_execute(
         config_snapshot.disabled_tool_names().into_iter().collect();
     let disabled_skill_ids_vec: Vec<String> =
         config_snapshot.disabled_skill_ids().into_iter().collect();
-    let requested_provider = req
+    let explicit_provider = req
         .model_ref
         .as_ref()
         .map(|model_ref| model_ref.provider.as_str())
-        .or(req.provider.as_deref())
-        .unwrap_or(config_snapshot.provider.as_str());
+        .or(req.provider.as_deref());
+    let requested_provider = resolve_requested_provider(&config_snapshot, explicit_provider);
 
     let requested_provider_type = resolve_provider_type(
         &config_snapshot,
@@ -301,6 +301,13 @@ pub async fn handle_execute(
             bad_request_error_response(error)
         }
     }
+}
+
+fn resolve_requested_provider<'a>(
+    config: &'a bamboo_config::Config,
+    explicit_provider: Option<&'a str>,
+) -> &'a str {
+    explicit_provider.unwrap_or_else(|| config.effective_default_provider())
 }
 
 async fn fail_pending_startup(

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -6,7 +6,7 @@ use crate::app_state::AppState;
 use bamboo_engine::model_areas::resolve_global_area_models;
 use bamboo_engine::model_config_helper::{
     get_default_model_for_provider, get_reasoning_effort_for_provider, resolve_gold_config,
-    resolve_provider_type,
+    resolve_provider_routing_key, resolve_provider_type,
 };
 
 use self::response::{
@@ -110,11 +110,34 @@ pub async fn handle_execute(
         .as_ref()
         .map(|model_ref| model_ref.provider.as_str())
         .or(req.provider.as_deref());
-    let requested_provider = resolve_requested_provider(&config_snapshot, explicit_provider);
+    let requested_provider_alias = resolve_requested_provider(&config_snapshot, explicit_provider);
+    let requested_provider = match resolve_provider_routing_key(
+        &config_snapshot,
+        requested_provider_alias,
+        &state.provider_registry,
+    ) {
+        Ok(provider) => provider,
+        Err(error) => {
+            let detail = format!("provider routing failed: {error}");
+            fail_pending_startup(
+                &state,
+                &session_id,
+                startup_turn_id.as_deref(),
+                &detail,
+                &mut startup_guard,
+            )
+            .await;
+            return if explicit_provider.is_some() {
+                bad_request_error_response(detail)
+            } else {
+                internal_server_error_response(detail)
+            };
+        }
+    };
 
     let requested_provider_type = resolve_provider_type(
         &config_snapshot,
-        requested_provider,
+        &requested_provider,
         &state.provider_registry,
     );
     // Auxiliary (non-chat) models are global: resolved from config for the
@@ -122,20 +145,20 @@ pub async fn handle_execute(
     // fast/background/summarization trio.
     let areas = resolve_global_area_models(
         &config_snapshot,
-        requested_provider,
+        &requested_provider,
         &state.provider_registry,
     );
 
     let config = bamboo_engine::session_app::types::ExecutionConfigSnapshot {
-        default_model: get_default_model_for_provider(&config_snapshot, requested_provider).ok(),
+        default_model: get_default_model_for_provider(&config_snapshot, &requested_provider).ok(),
         default_model_ref: config_snapshot.defaults.as_ref().map(|d| d.chat.clone()),
         default_reasoning_effort: get_reasoning_effort_for_provider(
             &config_snapshot,
-            requested_provider,
+            &requested_provider,
         ),
         disabled_tools: disabled_tools_vec.clone(),
         disabled_skill_ids: disabled_skill_ids_vec.clone(),
-        provider_name: requested_provider.to_string(),
+        provider_name: requested_provider.clone(),
         provider_type: requested_provider_type.clone(),
         fast_model: areas.fast.as_ref().map(|m| m.model_name.clone()),
         fast_model_ref: areas.fast_ref.clone(),
@@ -148,11 +171,16 @@ pub async fn handle_execute(
         provider_model_ref_enabled: config_snapshot.features.provider_model_ref,
     };
 
+    let mut request_model_ref = req.model_ref.clone();
+    if let Some(model_ref) = &mut request_model_ref {
+        model_ref.provider = requested_provider.clone();
+    }
+    let request_provider = req.provider.as_ref().map(|_| requested_provider.clone());
     let input = bamboo_engine::session_app::types::ExecuteInput {
         session_id: session_id.clone(),
         request_model: req.model.clone(),
-        request_model_ref: req.model_ref.clone(),
-        request_provider: req.provider.clone(),
+        request_model_ref,
+        request_provider,
         request_reasoning_effort: req.reasoning_effort,
         request_skill_mode: req.skill_mode.clone(),
         client_sync: req.client_sync.as_ref().map(|cs| {

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -13,15 +13,20 @@ use std::collections::BTreeSet;
 use tokio::sync::mpsc;
 
 use super::build_sync_info_from_session;
-use super::response::{already_running_response, internal_server_error_response, started_response};
+use super::response::{
+    already_running_response, bad_request_error_response, internal_server_error_response,
+    started_response,
+};
 use crate::app_state::AppState;
 use crate::handlers::agent::execute::runtime::{
     reserve_runner, spawn_agent_execution, spawn_event_forwarder, RunnerReservation,
     SpawnAgentExecution,
 };
 use bamboo_engine::model_areas::resolve_global_area_models;
-use bamboo_engine::model_config_helper::{resolve_gold_config, GOLD_CONFIG_METADATA_KEY};
-use bamboo_engine::session_app::provider_model::session_effective_model_ref;
+use bamboo_engine::model_config_helper::{
+    resolve_gold_config, resolve_provider_routing_key, GOLD_CONFIG_METADATA_KEY,
+};
+use bamboo_engine::session_app::provider_model::{persist_model_ref, session_effective_model_ref};
 use bamboo_engine::session_app::types::ExecutionConfigSnapshot;
 use bamboo_engine::ImageFallbackConfig;
 use bamboo_llm::Config;
@@ -69,6 +74,52 @@ pub(super) async fn handle_execute_ready(context: ExecuteReadyContext<'_>) -> Ht
         disabled_skill_ids,
     } = context;
     let mut session = ready.session;
+
+    // Old sessions and compatibility clients may still persist a built-in
+    // provider type (for example `openai`) while the registry is keyed by a
+    // custom instance id. Canonicalize before reserving or saving the run, and
+    // require the exact target to be live. An unresolved explicit/session
+    // target must never fall through to the process-wide default provider.
+    let provider_override = if let Some(mut model_ref) = session_effective_model_ref(&session) {
+        let routing_key = match resolve_provider_routing_key(
+            config_snapshot,
+            &model_ref.provider,
+            &state.provider_registry,
+        ) {
+            Ok(routing_key) => routing_key,
+            Err(error) => {
+                let detail = format!("provider routing failed: {error}");
+                super::fail_pending_startup(
+                    state,
+                    session_id,
+                    ready.startup_turn_id.as_deref(),
+                    &detail,
+                    &mut *ready.startup_guard,
+                )
+                .await;
+                return bad_request_error_response(detail);
+            }
+        };
+        model_ref.provider = routing_key;
+        persist_model_ref(&mut session, &model_ref);
+        match state.provider_router.route(&model_ref) {
+            Ok(provider) => Some(provider),
+            Err(error) => {
+                let detail = format!("provider routing failed: {error}");
+                super::fail_pending_startup(
+                    state,
+                    session_id,
+                    ready.startup_turn_id.as_deref(),
+                    &detail,
+                    &mut *ready.startup_guard,
+                )
+                .await;
+                return bad_request_error_response(detail);
+            }
+        }
+    } else {
+        None
+    };
 
     // #74: re-derive the "no interactive human approver" posture per
     // user-initiated execute, OVERWRITING the session's persisted flag (see
@@ -195,7 +246,7 @@ pub(super) async fn handle_execute_ready(context: ExecuteReadyContext<'_>) -> Ht
         execution_reservation,
         is_child_session: ready.is_child_session,
         provider_name: resolved_provider_name,
-        provider_override: None,
+        provider_override,
         model_roster,
         reasoning_effort: ready.effective_reasoning_effort,
         reasoning_effort_source: ready.reasoning_source.to_string(),

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
@@ -4,6 +4,8 @@ use crate::handlers::agent::execute::{ExecuteClientSync, ExecuteSyncInfo, Execut
 
 use bamboo_engine::session_app::types::ServerExecuteSnapshot;
 
+use super::resolve_requested_provider;
+
 fn evaluate_client_sync_adapter(
     client_sync: Option<&ExecuteClientSync>,
     server_snapshot: &ServerExecuteSnapshot,
@@ -34,6 +36,27 @@ fn validate_and_normalize_model_treats_empty_value_as_absent() {
     assert_eq!(
         validate_and_normalize_model(Some("   ")).expect("empty model should normalize"),
         None
+    );
+}
+
+#[test]
+fn requested_provider_fallback_uses_default_provider_instance() {
+    let mut config = bamboo_config::Config::default();
+    let instance = serde_json::from_value(serde_json::json!({
+        "provider_type": "openai",
+        "enabled": true
+    }))
+    .unwrap();
+    config.provider = "anthropic".to_string();
+    config
+        .provider_instances
+        .insert("execute-openai".to_string(), instance);
+    config.default_provider_instance = Some("execute-openai".to_string());
+
+    assert_eq!(resolve_requested_provider(&config, None), "execute-openai");
+    assert_eq!(
+        resolve_requested_provider(&config, Some("explicit")),
+        "explicit"
     );
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
@@ -290,6 +290,55 @@ mod idempotency_e2e {
         web::Data::new(state)
     }
 
+    async fn state_with_instance_providers(
+        default_provider: Arc<BlockingProvider>,
+        openai_provider: Arc<BlockingProvider>,
+    ) -> web::Data<AppState> {
+        let data_dir = tempdir().expect("tempdir").keep();
+        bamboo_config::paths::init_bamboo_dir(data_dir.clone());
+        let mut config = bamboo_llm::Config::from_data_dir(Some(data_dir.clone()));
+        config.provider_instances.insert(
+            "main-anthropic".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "anthropic",
+                "model": "claude-main",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.provider_instances.insert(
+            "work-openai".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "model": "gpt-work",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("main-anthropic".to_string());
+        config.features.provider_model_ref = true;
+
+        let runtime_default: Arc<dyn LLMProvider> = default_provider.clone();
+        let mut state = AppState::new_with_provider(data_dir, config, runtime_default)
+            .await
+            .expect("app state");
+        let mut providers = HashMap::new();
+        providers.insert(
+            "main-anthropic".to_string(),
+            default_provider as Arc<dyn LLMProvider>,
+        );
+        providers.insert(
+            "work-openai".to_string(),
+            openai_provider as Arc<dyn LLMProvider>,
+        );
+        state.provider_registry = Arc::new(ProviderRegistry::new(
+            providers,
+            "main-anthropic".to_string(),
+        ));
+        state.provider_router = Arc::new(ProviderModelRouter::new(state.provider_registry.clone()));
+        web::Data::new(state)
+    }
+
     /// #733: execute retries replay the original Accepted response (including
     /// run_id) instead of entering preparation or spawning another agent loop.
     #[actix_web::test]
@@ -351,6 +400,177 @@ mod idempotency_e2e {
         cancel.cancel();
         provider.release.add_permits(1);
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+
+    #[actix_web::test]
+    async fn execute_builtin_provider_type_routes_to_custom_instance_not_runtime_default() {
+        let default_provider = BlockingProvider::new();
+        let openai_provider = BlockingProvider::new();
+        let state =
+            state_with_instance_providers(default_provider.clone(), openai_provider.clone()).await;
+        let session_id = "execute-provider-type-alias";
+        let mut session = Session::new(session_id, "gpt-work");
+        session.title_generated = true;
+        session.add_message(Message::user("route to the OpenAI instance"));
+        crate::handlers::agent::events::mark_pending_turn(&mut session);
+        state.save_and_cache_session(&mut session).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/api/v1/execute/{session_id}"))
+                .set_json(serde_json::json!({
+                    "model_ref": {"provider": "openai", "model": "gpt-work"}
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            openai_provider.started.acquire(),
+        )
+        .await
+        .expect("OpenAI instance started")
+        .expect("started semaphore remains open")
+        .forget();
+        assert_eq!(openai_provider.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(default_provider.calls.load(Ordering::SeqCst), 0);
+
+        let persisted = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("session load")
+            .expect("session exists");
+        assert_eq!(
+            persisted
+                .model_ref
+                .as_ref()
+                .map(|model_ref| model_ref.provider.as_str()),
+            Some("work-openai")
+        );
+
+        let cancel = state
+            .agent_runners
+            .read()
+            .await
+            .get(session_id)
+            .expect("runner remains registered")
+            .cancel_token
+            .clone();
+        cancel.cancel();
+        openai_provider.release.add_permits(1);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+
+    #[actix_web::test]
+    async fn execute_canonicalizes_legacy_session_provider_ref_before_resume() {
+        let default_provider = BlockingProvider::new();
+        let openai_provider = BlockingProvider::new();
+        let state =
+            state_with_instance_providers(default_provider.clone(), openai_provider.clone()).await;
+        let session_id = "execute-legacy-session-provider-ref";
+        let mut session = Session::new(session_id, "gpt-work");
+        session.model_ref = Some(bamboo_domain::ProviderModelRef::new("openai", "gpt-work"));
+        session.set_provider_name("openai");
+        session.title_generated = true;
+        session.add_message(Message::user("resume the migrated session"));
+        crate::handlers::agent::events::mark_pending_turn(&mut session);
+        state.save_and_cache_session(&mut session).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/api/v1/execute/{session_id}"))
+                .set_json(serde_json::json!({}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            openai_provider.started.acquire(),
+        )
+        .await
+        .expect("migrated OpenAI instance started")
+        .expect("started semaphore remains open")
+        .forget();
+        assert_eq!(openai_provider.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(default_provider.calls.load(Ordering::SeqCst), 0);
+
+        let persisted = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("session load")
+            .expect("session exists");
+        assert_eq!(
+            persisted
+                .model_ref
+                .as_ref()
+                .map(|model_ref| model_ref.provider.as_str()),
+            Some("work-openai")
+        );
+
+        let cancel = state
+            .agent_runners
+            .read()
+            .await
+            .get(session_id)
+            .expect("runner remains registered")
+            .cancel_token
+            .clone();
+        cancel.cancel();
+        openai_provider.release.add_permits(1);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+
+    #[actix_web::test]
+    async fn execute_unknown_explicit_provider_fails_before_runner_reservation() {
+        let default_provider = BlockingProvider::new();
+        let openai_provider = BlockingProvider::new();
+        let state =
+            state_with_instance_providers(default_provider.clone(), openai_provider.clone()).await;
+        let session_id = "execute-unknown-provider";
+        let mut session = Session::new(session_id, "unknown-model");
+        session.title_generated = true;
+        session.add_message(Message::user("must fail closed"));
+        crate::handlers::agent::events::mark_pending_turn(&mut session);
+        state.save_and_cache_session(&mut session).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/api/v1/execute/{session_id}"))
+                .set_json(serde_json::json!({
+                    "model_ref": {"provider": "missing-instance", "model": "unknown-model"}
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(default_provider.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(openai_provider.calls.load(Ordering::SeqCst), 0);
+        assert!(!state.agent_runners.read().await.contains_key(session_id));
     }
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
@@ -1008,16 +1008,21 @@ mod tests {
     async fn event_forwarder_triggers_gold_auto_answer_when_mpsc_closes() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let mut config = Config::from_data_dir(Some(temp_dir.path().to_path_buf()));
-        config.provider = String::new();
+        config.provider = "test-provider".to_string();
         config.features.provider_model_ref = true;
         let provider = ScriptedProvider::new("ok.");
         let provider_trait: Arc<dyn LLMProvider> = provider.clone();
-        let mut app_state =
-            AppState::new_with_provider(temp_dir.path().to_path_buf(), config, provider_trait)
-                .await
-                .expect("app state");
-        app_state.provider_registry =
-            Arc::new(ProviderRegistry::new(HashMap::new(), String::new()));
+        let mut app_state = AppState::new_with_provider(
+            temp_dir.path().to_path_buf(),
+            config,
+            provider_trait.clone(),
+        )
+        .await
+        .expect("app state");
+        app_state.provider_registry = Arc::new(ProviderRegistry::new(
+            HashMap::from([("test-provider".to_string(), provider_trait)]),
+            "test-provider".to_string(),
+        ));
         app_state.provider_router = Arc::new(ProviderModelRouter::new(
             app_state.provider_registry.clone(),
         ));
@@ -1139,16 +1144,21 @@ mod tests {
     async fn event_forwarder_does_not_auto_continue_after_auto_answer_applies() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let mut config = Config::from_data_dir(Some(temp_dir.path().to_path_buf()));
-        config.provider = String::new();
+        config.provider = "test-provider".to_string();
         config.features.provider_model_ref = true;
         let provider = ScriptedProvider::new("ok.");
         let provider_trait: Arc<dyn LLMProvider> = provider.clone();
-        let mut app_state =
-            AppState::new_with_provider(temp_dir.path().to_path_buf(), config, provider_trait)
-                .await
-                .expect("app state");
-        app_state.provider_registry =
-            Arc::new(ProviderRegistry::new(HashMap::new(), String::new()));
+        let mut app_state = AppState::new_with_provider(
+            temp_dir.path().to_path_buf(),
+            config,
+            provider_trait.clone(),
+        )
+        .await
+        .expect("app state");
+        app_state.provider_registry = Arc::new(ProviderRegistry::new(
+            HashMap::from([("test-provider".to_string(), provider_trait)]),
+            "test-provider".to_string(),
+        ));
         app_state.provider_router = Arc::new(ProviderModelRouter::new(
             app_state.provider_registry.clone(),
         ));

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
@@ -152,6 +152,21 @@ pub(crate) fn make_disabled_filter_resolver(
 }
 
 pub(crate) fn spawn_agent_execution(mut args: SpawnAgentExecution) {
+    let session_model_ref = session_effective_model_ref(&args.session);
+    let provider_override = match (session_model_ref.as_ref(), args.provider_override.take()) {
+        (Some(_), Some(provider)) => Some(provider),
+        (Some(model_ref), None) => {
+            tracing::error!(
+                session_id = %args.session_id,
+                provider = %model_ref.provider,
+                model = %model_ref.model,
+                "session has an explicit provider target without a pre-resolved provider; refusing to fall back"
+            );
+            return;
+        }
+        (None, provider) => provider,
+    };
+
     if let Some(config) = args.state.permission_checker.permission_config() {
         config.set_session_workspace(args.session_id.clone(), args.session.workspace.clone());
         if let Err(error) =
@@ -168,22 +183,6 @@ pub(crate) fn spawn_agent_execution(mut args: SpawnAgentExecution) {
 
     let selected_skill_ids = session_state::selected_skill_ids_for_session(&args.session);
     let selected_skill_mode = session_state::selected_skill_mode_for_session(&args.session);
-    let provider_override = session_effective_model_ref(&args.session)
-        .and_then(|model_ref| match args.state.provider_router.route(&model_ref) {
-            Ok(provider) => Some(provider),
-            Err(error) => {
-                tracing::warn!(
-                    session_id = %args.session_id,
-                    provider = %model_ref.provider,
-                    model = %model_ref.model,
-                    error = %error,
-                    "failed to resolve provider override for session execution; falling back to runtime provider"
-                );
-                None
-            }
-        })
-        .or(args.provider_override);
-
     let auxiliary_model_resolver = make_auxiliary_model_resolver(&args.state, &args.provider_name);
 
     // The resolved provider name is the authoritative routing key; thread it into

--- a/crates/app/bamboo-server/src/handlers/copilot_auth/client.rs
+++ b/crates/app/bamboo-server/src/handlers/copilot_auth/client.rs
@@ -8,6 +8,17 @@ use bamboo_llm::providers::{copilot::auth::CopilotAuthHandler, CopilotProvider};
 use bamboo_llm::Config;
 
 pub(super) fn resolve_headless_auth(config: &Config) -> bool {
+    if let Some(instance) = config
+        .provider_instances
+        .get(config.effective_default_provider())
+        .filter(|instance| instance.provider_type == "copilot")
+    {
+        return instance
+            .extra
+            .get("headless_auth")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(config.headless_auth);
+    }
     config
         .providers()
         .copilot

--- a/crates/app/bamboo-server/src/handlers/copilot_auth/legacy.rs
+++ b/crates/app/bamboo-server/src/handlers/copilot_auth/legacy.rs
@@ -10,7 +10,12 @@ pub async fn authenticate_copilot(
     let config = app_state.config.read().await.clone();
     let app_data_dir = app_state.app_data_dir.clone();
 
-    if config.provider != "copilot" {
+    let effective_type = config
+        .provider_instances
+        .get(config.effective_default_provider())
+        .map(|instance| instance.provider_type.as_str())
+        .unwrap_or_else(|| config.effective_default_provider());
+    if effective_type != "copilot" {
         return Ok(HttpResponse::BadRequest().json(serde_json::json!({
             "success": false,
             "error": crate::error::error_value("Current provider is not Copilot")

--- a/crates/app/bamboo-server/src/handlers/copilot_auth/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/copilot_auth/tests.rs
@@ -1,5 +1,5 @@
 use actix_web::http::StatusCode;
-use bamboo_config::{CopilotConfig, ProviderConfigs};
+use bamboo_config::{CopilotConfig, ProviderConfigs, ProviderInstanceConfig};
 use bamboo_llm::Config;
 
 use super::{client::resolve_headless_auth, status_logout::auth_status_from_token_content};
@@ -31,6 +31,24 @@ fn resolve_headless_auth_falls_back_to_legacy_root_field() {
     let mut config = Config::default();
     config.providers_mut().copilot = None;
     config.headless_auth = true;
+
+    assert!(resolve_headless_auth(&config));
+}
+
+#[test]
+fn resolve_headless_auth_prefers_effective_copilot_instance() {
+    let mut config = Config::default();
+    config.headless_auth = false;
+    let instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+        "provider_type": "copilot",
+        "enabled": true,
+        "headless_auth": true
+    }))
+    .unwrap();
+    config
+        .provider_instances
+        .insert("work".to_string(), instance);
+    config.default_provider_instance = Some("work".to_string());
 
     assert!(resolve_headless_auth(&config));
 }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
@@ -24,6 +24,7 @@ pub use credentials::{
 };
 pub use notifications::{get_notification_config, put_notification_config};
 pub use proxy_auth::{get_proxy_auth_status, set_proxy_auth};
+pub(crate) use sections::scrub_unsafe_request_override_literals;
 pub use sections::{
     get_mcp_section, get_provider_section, get_provider_settings_section, get_typed_section,
     put_mcp_section, put_provider_section, put_provider_settings_section, put_typed_section,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -858,7 +858,7 @@ fn provider_credential_status(
     if let Some(reference) = credential_ref {
         let status = app_state
             .credential_store
-            .status(reference)
+            .status_with_crypto_validation(reference)
             .map_err(|error| map_mutation_error(ConfigSectionMutationError::Store(error)))?;
         let source = status.configured.then_some(match status.source {
             bamboo_config::CredentialSource::User => "user",
@@ -2187,7 +2187,8 @@ mod tests {
                                     "Authorization": "override-header-secret",
                                     "X-Access-Key": "override-access-key-secret",
                                     "X-Private-Key": "override-private-key-secret",
-                                    "X-Device-Key": "override-device-key-secret"
+                                    "X-Device-Key": "override-device-key-secret",
+                                    "X-Client-Tokens": "override-client-tokens-secret"
                                 },
                                 "body_patch": [
                                     {
@@ -2197,6 +2198,10 @@ mod tests {
                                     {
                                         "path": "/secrets/primary",
                                         "value": "override-plural-secret"
+                                    },
+                                    {
+                                        "path": "/client_tokens/0",
+                                        "value": "override-client-token-body-secret"
                                     }
                                 ]
                             }
@@ -2215,6 +2220,10 @@ mod tests {
                         (
                             "api_keys".to_string(),
                             json!({"primary": "unknown-provider-api-keys-secret"}),
+                        ),
+                        (
+                            "client_tokens".to_string(),
+                            json!(["unknown-provider-client-token-secret"]),
                         ),
                     ]),
                     ..OpenAIConfig::default()
@@ -2311,11 +2320,14 @@ mod tests {
             "override-access-key-secret",
             "override-private-key-secret",
             "override-device-key-secret",
+            "override-client-tokens-secret",
+            "override-client-token-body-secret",
             "override-credential-secret",
             "override-plural-secret",
             "unknown-provider-secret",
             "unknown-provider-plural-secret",
             "unknown-provider-api-keys-secret",
+            "unknown-provider-client-token-secret",
             "provider-url-secret",
             "query-secret",
             "****...****",
@@ -2362,11 +2374,14 @@ mod tests {
             "override-access-key-secret",
             "override-private-key-secret",
             "override-device-key-secret",
+            "override-client-tokens-secret",
+            "override-client-token-body-secret",
             "override-credential-secret",
             "override-plural-secret",
             "unknown-provider-secret",
             "unknown-provider-plural-secret",
             "unknown-provider-api-keys-secret",
+            "unknown-provider-client-token-secret",
             "provider-url-secret",
             "query-secret",
             "****...****",
@@ -2675,7 +2690,6 @@ mod tests {
 
     #[actix_web::test]
     async fn provider_settings_round_trip_is_full_cas_and_credentials_are_explicit_and_redacted() {
-        let _key = bamboo_config::encryption::set_test_encryption_key([0x70; 32]);
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
         let app = test::init_service(

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -154,6 +154,14 @@ pub struct ProviderInstanceSettingsData {
     /// Anthropic-compatible upstream opt-in introduced by #520.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_replay_always: Option<bool>,
+    /// Anthropic maximum output tokens retained from the legacy provider
+    /// contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// Copilot device-flow browser behavior retained from the legacy provider
+    /// contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub headless_auth: Option<bool>,
 }
 
 fn provider_instance_enabled_default() -> bool {
@@ -199,6 +207,13 @@ impl ProviderInstanceSettingsData {
                         .and_then(Value::as_bool)
                 })
                 .flatten(),
+            max_tokens: (instance.provider_type == "anthropic")
+                .then(|| instance.extra.get("max_tokens").and_then(Value::as_u64))
+                .flatten()
+                .and_then(|value| u32::try_from(value).ok()),
+            headless_auth: (instance.provider_type == "copilot")
+                .then(|| instance.extra.get("headless_auth").and_then(Value::as_bool))
+                .flatten(),
         }
     }
 
@@ -218,6 +233,12 @@ impl ProviderInstanceSettingsData {
                 bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY.to_string(),
                 json!(explicit_prompt_cache),
             );
+        }
+        if let Some(max_tokens) = self.max_tokens {
+            extra.insert("max_tokens".to_string(), json!(max_tokens));
+        }
+        if let Some(headless_auth) = self.headless_auth {
+            extra.insert("headless_auth".to_string(), json!(headless_auth));
         }
         ProviderInstanceConfig {
             provider_type: self.provider_type,
@@ -272,7 +293,7 @@ pub async fn get_provider_section(
     let _io = app_state.config_io_lock.lock().await;
     let config = app_state.config.read().await.clone();
     let data = json!({
-        "active_provider": config.provider,
+        "active_provider": config.effective_default_provider(),
         "providers": provider_diagnostics(&config),
         "defaults": config.defaults,
         "features": config.features,
@@ -300,13 +321,17 @@ pub async fn get_provider_settings_section(
     macro_rules! builtin_status {
         ($name:literal, $field:ident, $from_env:expr) => {
             if let Some(provider) = config.providers().$field.as_ref() {
+                let environment_bound = $from_env;
+                let runtime_configured =
+                    !provider.api_key.trim().is_empty() || provider.api_key_encrypted.is_some();
                 builtin_status.insert(
                     $name.to_string(),
                     serde_json::to_value(provider_credential_status(
                         &app_state,
                         provider.credential_ref.as_ref(),
-                        $from_env,
-                        !provider.api_key.trim().is_empty() || provider.api_key_encrypted.is_some(),
+                        environment_bound,
+                        environment_bound && !provider.api_key.trim().is_empty(),
+                        runtime_configured,
                     )?)?,
                 );
             }
@@ -343,12 +368,14 @@ pub async fn get_provider_settings_section(
 
     let mut instance_status = Map::new();
     for (id, instance) in &config.provider_instances {
+        let environment_bound = bamboo_config::provider_instance_api_key_from_env(instance);
         instance_status.insert(
             id.clone(),
             serde_json::to_value(provider_credential_status(
                 &app_state,
                 instance.credential_ref.as_ref(),
-                false,
+                environment_bound,
+                bamboo_config::provider_instance_environment_override_active(instance),
                 !instance.api_key.trim().is_empty() || instance.api_key_encrypted.is_some(),
             )?)?,
         );
@@ -446,6 +473,7 @@ pub async fn put_provider_settings_section(
                 candidate,
                 &credential_changes.provider_instances,
             )?;
+            validate_provider_settings_default(candidate)?;
             bamboo_llm::validate_provider_config(candidate).map_err(|error| {
                 ConfigSectionMutationError::Invalid(format!("invalid provider settings: {error}"))
             })?;
@@ -762,7 +790,7 @@ fn sanitized_provider_instance_metadata(
     Ok(value)
 }
 
-fn scrub_unsafe_request_override_literals(value: &mut Value) {
+pub(crate) fn scrub_unsafe_request_override_literals(value: &mut Value) {
     match value {
         Value::Object(object) => {
             if let Some(headers) = object.get_mut("headers").and_then(Value::as_object_mut) {
@@ -800,9 +828,18 @@ fn scrub_unsafe_request_override_literals(value: &mut Value) {
 fn provider_credential_status(
     app_state: &AppState,
     credential_ref: Option<&bamboo_config::CredentialRef>,
-    from_environment: bool,
+    environment_bound: bool,
+    environment_active: bool,
     runtime_configured: bool,
 ) -> Result<ProviderCredentialStatusView, AppError> {
+    if environment_active {
+        return Ok(ProviderCredentialStatusView {
+            credential_ref: credential_ref.map(|reference| reference.as_str().to_string()),
+            configured: true,
+            source: Some("environment".to_string()),
+            updated_at: None,
+        });
+    }
     if let Some(reference) = credential_ref {
         let status = app_state
             .credential_store
@@ -823,8 +860,11 @@ fn provider_credential_status(
     }
     Ok(ProviderCredentialStatusView {
         credential_ref: None,
-        configured: from_environment || runtime_configured,
-        source: if from_environment {
+        // An env marker records a binding, not availability. Without an active
+        // variable or a stored fallback, stale in-memory plaintext cannot make
+        // the instance appear configured.
+        configured: !environment_bound && runtime_configured,
+        source: if environment_bound {
             Some("environment".to_string())
         } else if runtime_configured {
             Some("migrated".to_string())
@@ -844,6 +884,30 @@ fn provider_exists(providers: &ProviderConfigs, name: &str) -> bool {
         "bodhi" => providers.bodhi.is_some(),
         _ => false,
     }
+}
+
+fn validate_provider_settings_default(
+    candidate: &bamboo_config::Config,
+) -> Result<(), ConfigSectionMutationError> {
+    let Some(default_id) = candidate.default_provider_instance.as_deref() else {
+        if candidate.provider_instances.is_empty()
+            || provider_exists(candidate.providers(), &candidate.provider)
+        {
+            return Ok(());
+        }
+        return Err(ConfigSectionMutationError::Invalid(format!(
+            "provider instances require a default_provider_instance_id when legacy provider '{}' is not configured",
+            candidate.provider
+        )));
+    };
+    if candidate.provider_instances.contains_key(default_id)
+        || provider_exists(candidate.providers(), default_id)
+    {
+        return Ok(());
+    }
+    Err(ConfigSectionMutationError::Invalid(format!(
+        "default provider instance '{default_id}' has no matching provider instance or legacy provider configuration"
+    )))
 }
 
 fn retain_provider_settings_server_owned_fields(
@@ -900,6 +964,8 @@ fn retain_provider_settings_server_owned_fields(
                         key.as_str(),
                         "target_provider"
                             | "thinking_replay_always"
+                            | "max_tokens"
+                            | "headless_auth"
                             | bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY
                     )
                 })
@@ -996,6 +1062,9 @@ fn apply_provider_instance_credential_changes(
                 ProviderCredentialChange::Replace { value } if !value.trim().is_empty() => {
                     instance.api_key = value.clone();
                     instance.api_key_encrypted = None;
+                    instance
+                        .extra
+                        .remove(bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY);
                 }
                 ProviderCredentialChange::Replace { .. } => {
                     return Err(ConfigSectionMutationError::Invalid(format!(
@@ -1005,6 +1074,9 @@ fn apply_provider_instance_credential_changes(
                 ProviderCredentialChange::Clear => {
                     instance.api_key.clear();
                     instance.api_key_encrypted = None;
+                    instance
+                        .extra
+                        .remove(bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY);
                 }
             },
             None if matches!(change, ProviderCredentialChange::Clear) => {}
@@ -1049,6 +1121,16 @@ fn validate_provider_instance_shape(
         if instance.thinking_replay_always.is_some() && instance.provider_type != "anthropic" {
             return Err(format!(
                 "thinking_replay_always is only accepted for anthropic provider instance '{id}'"
+            ));
+        }
+        if instance.max_tokens.is_some() && instance.provider_type != "anthropic" {
+            return Err(format!(
+                "max_tokens is only accepted for anthropic provider instance '{id}'"
+            ));
+        }
+        if instance.headless_auth.is_some() && instance.provider_type != "copilot" {
+            return Err(format!(
+                "headless_auth is only accepted for copilot provider instance '{id}'"
             ));
         }
         if instance.explicit_prompt_cache.is_some() && instance.provider_type != "openai" {
@@ -1880,6 +1962,31 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
     use std::time::Duration;
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let previous = std::env::var_os(key);
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     fn server(id: &str, transport: TransportConfig) -> McpServerConfig {
         McpServerConfig {
             id: id.to_string(),
@@ -1892,6 +1999,83 @@ mod tests {
             allowed_tools: vec!["read".to_string()],
             denied_tools: vec!["delete".to_string()],
         }
+    }
+
+    #[actix_web::test]
+    async fn provider_instance_credential_intent_clears_environment_marker() {
+        let mut config = bamboo_config::Config::default();
+        let mut instance: ProviderInstanceConfig = serde_json::from_value(json!({
+            "provider_type": "openai",
+            "enabled": true,
+            "api_key_from_env": true
+        }))
+        .unwrap();
+        instance.api_key = "sk-runtime-env".to_string();
+        config
+            .provider_instances
+            .insert("work".to_string(), instance);
+
+        apply_provider_instance_credential_changes(
+            &mut config,
+            &BTreeMap::from([(
+                "work".to_string(),
+                ProviderCredentialChange::Replace {
+                    value: "sk-user".to_string(),
+                },
+            )]),
+        )
+        .unwrap();
+        assert!(!bamboo_config::provider_instance_api_key_from_env(
+            &config.provider_instances["work"]
+        ));
+
+        config
+            .provider_instances
+            .get_mut("work")
+            .unwrap()
+            .extra
+            .insert(
+                bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY.to_string(),
+                json!(true),
+            );
+        apply_provider_instance_credential_changes(
+            &mut config,
+            &BTreeMap::from([("work".to_string(), ProviderCredentialChange::Clear)]),
+        )
+        .unwrap();
+        assert!(!bamboo_config::provider_instance_api_key_from_env(
+            &config.provider_instances["work"]
+        ));
+    }
+
+    #[actix_web::test]
+    async fn provider_settings_default_rejects_dangling_builtin_alias() {
+        let mut config = bamboo_config::Config::default();
+        *config.providers_mut() = ProviderConfigs::default();
+        config.default_provider_instance = Some("copilot".to_string());
+        assert!(matches!(
+            validate_provider_settings_default(&config),
+            Err(ConfigSectionMutationError::Invalid(_))
+        ));
+
+        config.providers_mut().copilot = Some(Default::default());
+        validate_provider_settings_default(&config)
+            .expect("an actual legacy stanza keeps the hybrid alias valid");
+
+        config.default_provider_instance = None;
+        config.provider = "anthropic".to_string();
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(json!({
+                "provider_type": "copilot",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        assert!(matches!(
+            validate_provider_settings_default(&config),
+            Err(ConfigSectionMutationError::Invalid(_))
+        ));
     }
 
     fn editable_provider_settings() -> Value {
@@ -3119,6 +3303,144 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn provider_settings_environment_status_tracks_runtime_availability() {
+        let _lock = bamboo_config::test_support::env_cache_lock_acquire();
+        let _openai = EnvVarGuard::set(
+            "BAMBOO_OPENAI_API_KEY",
+            Some("sk-runtime-openai-environment"),
+        );
+        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", None);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        {
+            let mut config = state.config.write().await;
+            for (id, provider_type, api_key) in [
+                ("available", "openai", "sk-runtime-openai-environment"),
+                ("missing", "gemini", "stale-runtime-value"),
+            ] {
+                let mut instance: ProviderInstanceConfig = serde_json::from_value(json!({
+                    "provider_type": provider_type,
+                    "enabled": true,
+                    "api_key_from_env": true
+                }))
+                .unwrap();
+                instance.api_key = api_key.to_string();
+                config.provider_instances.insert(id.to_string(), instance);
+            }
+        }
+        let app = test::init_service(App::new().app_data(state).route(
+            "/provider-settings",
+            web::get().to(get_provider_settings_section),
+        ))
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/provider-settings")
+                .to_request(),
+        )
+        .await;
+        assert!(response.status().is_success());
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(
+            body["data"]["credential_status"]["provider_instances"]["available"]["configured"],
+            true
+        );
+        assert_eq!(
+            body["data"]["credential_status"]["provider_instances"]["missing"]["configured"],
+            false
+        );
+        for id in ["available", "missing"] {
+            assert_eq!(
+                body["data"]["credential_status"]["provider_instances"][id]["source"],
+                "environment"
+            );
+            assert!(body["data"]["provider_instances"][id]
+                .get("api_key_from_env")
+                .is_none());
+        }
+    }
+
+    #[actix_web::test]
+    async fn provider_settings_environment_override_precedes_and_falls_back_to_stored_ref() {
+        let _lock = bamboo_config::test_support::env_cache_lock_acquire();
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x6a; 32]);
+        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", Some("sk-runtime-openai-override"));
+        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", None);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let credential_ref =
+            CredentialRef::parse("provider.work.api_key").expect("valid credential ref");
+        state
+            .credential_store
+            .replace(
+                credential_ref.clone(),
+                "sk-stored-fallback",
+                bamboo_config::CredentialSource::Migrated,
+                0,
+            )
+            .unwrap();
+        {
+            let mut instance: ProviderInstanceConfig = serde_json::from_value(json!({
+                "provider_type": "openai",
+                "enabled": true,
+                "api_key_from_env": true,
+                "credential_ref": credential_ref.as_str()
+            }))
+            .unwrap();
+            instance.api_key = "sk-runtime-openai-override".to_string();
+            let mut config = state.config.write().await;
+            config
+                .provider_instances
+                .insert("work".to_string(), instance);
+            config.default_provider_instance = Some("work".to_string());
+        }
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/provider-settings",
+            web::get().to(get_provider_settings_section),
+        ))
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/provider-settings")
+                .to_request(),
+        )
+        .await;
+        let body: Value = test::read_body_json(response).await;
+        let active = &body["data"]["credential_status"]["provider_instances"]["work"];
+        assert_eq!(active["configured"], true);
+        assert_eq!(active["source"], "environment");
+        assert_eq!(active["credential_ref"], credential_ref.as_str());
+
+        std::env::remove_var("BAMBOO_OPENAI_API_KEY");
+        state
+            .config
+            .write()
+            .await
+            .provider_instances
+            .get_mut("work")
+            .unwrap()
+            .api_key = "sk-stored-fallback".to_string();
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/provider-settings")
+                .to_request(),
+        )
+        .await;
+        let body: Value = test::read_body_json(response).await;
+        let fallback = &body["data"]["credential_status"]["provider_instances"]["work"];
+        assert_eq!(fallback["configured"], true);
+        assert_eq!(fallback["source"], "migrated");
+        assert!(fallback["updated_at"].is_string());
+    }
+
+    #[actix_web::test]
     async fn provider_instance_runtime_fields_are_explicit_editable_and_preserve_unknown_metadata()
     {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x71; 32]);
@@ -3152,6 +3474,13 @@ mod tests {
                     "provider_type": "anthropic",
                     "label": "GLM compatible",
                     "thinking_replay_always": true,
+                    "max_tokens": 8192,
+                    "enabled": false
+                },
+                "copilot-cli": {
+                    "provider_type": "copilot",
+                    "label": "Copilot CLI",
+                    "headless_auth": true,
                     "enabled": false
                 },
                 "openai-proxy": {
@@ -3200,6 +3529,14 @@ mod tests {
             true
         );
         assert_eq!(
+            created["data"]["provider_instances"]["glm-compat"]["max_tokens"],
+            8192
+        );
+        assert_eq!(
+            created["data"]["provider_instances"]["copilot-cli"]["headless_auth"],
+            true
+        );
+        assert_eq!(
             created["data"]["provider_instances"]["openai-proxy"]["explicit_prompt_cache"],
             false
         );
@@ -3218,6 +3555,8 @@ mod tests {
         let mut updated = created["data"].clone();
         updated["provider_instances"]["bodhi-proxy"]["target_provider"] = json!("anthropic");
         updated["provider_instances"]["glm-compat"]["thinking_replay_always"] = json!(false);
+        updated["provider_instances"]["glm-compat"]["max_tokens"] = json!(4096);
+        updated["provider_instances"]["copilot-cli"]["headless_auth"] = json!(false);
         updated["provider_instances"]["openai-proxy"]["explicit_prompt_cache"] = json!(true);
         let updated = test::call_service(
             &app,
@@ -3241,6 +3580,14 @@ mod tests {
             false
         );
         assert_eq!(
+            updated["data"]["provider_instances"]["glm-compat"]["max_tokens"],
+            4096
+        );
+        assert_eq!(
+            updated["data"]["provider_instances"]["copilot-cli"]["headless_auth"],
+            false
+        );
+        assert_eq!(
             updated["data"]["provider_instances"]["openai-proxy"]["explicit_prompt_cache"],
             true
         );
@@ -3259,6 +3606,14 @@ mod tests {
                 false
             );
             assert_eq!(
+                config.provider_instances["glm-compat"].extra["max_tokens"],
+                4096
+            );
+            assert_eq!(
+                config.provider_instances["copilot-cli"].extra["headless_auth"],
+                false
+            );
+            assert_eq!(
                 config.provider_instances["openai-proxy"].extra
                     [bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY],
                 true
@@ -3274,6 +3629,14 @@ mod tests {
             .as_object_mut()
             .unwrap()
             .remove("thinking_replay_always");
+        removed["provider_instances"]["glm-compat"]
+            .as_object_mut()
+            .unwrap()
+            .remove("max_tokens");
+        removed["provider_instances"]["copilot-cli"]
+            .as_object_mut()
+            .unwrap()
+            .remove("headless_auth");
         removed["provider_instances"]["openai-proxy"]
             .as_object_mut()
             .unwrap()
@@ -3293,6 +3656,8 @@ mod tests {
         assert!(
             removed["data"]["provider_instances"]["glm-compat"]["thinking_replay_always"].is_null()
         );
+        assert!(removed["data"]["provider_instances"]["glm-compat"]["max_tokens"].is_null());
+        assert!(removed["data"]["provider_instances"]["copilot-cli"]["headless_auth"].is_null());
         assert!(
             removed["data"]["provider_instances"]["openai-proxy"]["explicit_prompt_cache"]
                 .is_null()
@@ -3309,6 +3674,12 @@ mod tests {
             assert!(!config.provider_instances["glm-compat"]
                 .extra
                 .contains_key("thinking_replay_always"));
+            assert!(!config.provider_instances["glm-compat"]
+                .extra
+                .contains_key("max_tokens"));
+            assert!(!config.provider_instances["copilot-cli"]
+                .extra
+                .contains_key("headless_auth"));
             assert!(!config.provider_instances["openai-proxy"]
                 .extra
                 .contains_key(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY));
@@ -3320,6 +3691,8 @@ mod tests {
             ("bodhi-proxy", "target_provider", json!("copilot")),
             ("glm-compat", "target_provider", json!("openai")),
             ("glm-compat", "explicit_prompt_cache", json!(false)),
+            ("openai-proxy", "max_tokens", json!(4096)),
+            ("openai-proxy", "headless_auth", json!(true)),
         ] {
             let mut invalid = removed["data"].clone();
             invalid["provider_instances"][id][field] = value;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -437,6 +437,18 @@ pub async fn put_provider_settings_section(
                 credential_status: _,
             } = data;
 
+            for (id, instance) in &provider_instances {
+                let Some(existing) = current.provider_instances.get(id) else {
+                    continue;
+                };
+                if existing.provider_type != instance.provider_type {
+                    return Err(ConfigSectionMutationError::Invalid(format!(
+                        "provider_type for existing provider instance '{id}' cannot be changed from '{}' to '{}'; create a new provider instance instead",
+                        existing.provider_type, instance.provider_type
+                    )));
+                }
+            }
+
             let instance_native = default_provider_instance_id
                 .as_ref()
                 .is_some_and(|id| provider_instances.contains_key(id));
@@ -795,7 +807,10 @@ pub(crate) fn scrub_unsafe_request_override_literals(value: &mut Value) {
         Value::Object(object) => {
             if let Some(headers) = object.get_mut("headers").and_then(Value::as_object_mut) {
                 headers.retain(|name, expression| {
-                    !is_sensitive_header_name(name) || is_external_template_reference(expression)
+                    !bamboo_config::request_override_header_is_credential(name)
+                        || bamboo_config::request_override_value_is_nonliteral_runtime_template(
+                            expression,
+                        )
                 });
             }
             if let Some(patches) = object.get_mut("body_patch").and_then(Value::as_array_mut) {
@@ -806,10 +821,10 @@ pub(crate) fn scrub_unsafe_request_override_literals(value: &mut Value) {
                     !patch
                         .get("path")
                         .and_then(Value::as_str)
-                        .is_some_and(is_sensitive_override_path)
-                        || patch
-                            .get("value")
-                            .is_none_or(is_external_template_reference)
+                        .is_some_and(bamboo_config::request_override_body_patch_targets_credential)
+                        || patch.get("value").is_none_or(
+                            bamboo_config::request_override_value_is_nonliteral_runtime_template,
+                        )
                 });
             }
             for value in object.values_mut() {
@@ -917,7 +932,7 @@ fn retain_provider_settings_server_owned_fields(
     // Unknown forward-compatible metadata is intentionally not exposed by the
     // network DTO because its contents cannot be classified as non-secret.
     // Preserve it from the process-owned snapshot just like credential refs.
-    candidate.providers_mut().extra = current.providers().extra.clone();
+    candidate.providers_mut().extra = secret_free_provider_extra(&current.providers().extra);
     macro_rules! retain_env_provider {
         ($field:ident) => {
             if let (Some(current), Some(candidate)) = (
@@ -928,7 +943,7 @@ fn retain_provider_settings_server_owned_fields(
                 candidate.api_key_encrypted = current.api_key_encrypted.clone();
                 candidate.credential_ref = current.credential_ref.clone();
                 candidate.api_key_from_env = current.api_key_from_env;
-                candidate.extra = current.extra.clone();
+                candidate.extra = secret_free_provider_extra(&current.extra);
             }
         };
     }
@@ -942,13 +957,13 @@ fn retain_provider_settings_server_owned_fields(
         candidate.api_key = current.api_key.clone();
         candidate.api_key_encrypted = current.api_key_encrypted.clone();
         candidate.credential_ref = current.credential_ref.clone();
-        candidate.extra = current.extra.clone();
+        candidate.extra = secret_free_provider_extra(&current.extra);
     }
     if let (Some(current), Some(candidate)) = (
         current.providers().copilot.as_ref(),
         candidate.providers_mut().copilot.as_mut(),
     ) {
-        candidate.extra = current.extra.clone();
+        candidate.extra = secret_free_provider_extra(&current.extra);
     }
     for (id, instance) in &mut candidate.provider_instances {
         if let Some(current) = current.provider_instances.get(id) {
@@ -969,10 +984,29 @@ fn retain_provider_settings_server_owned_fields(
                             | bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY
                     )
                 })
+                .filter(|(key, value)| {
+                    bamboo_config::provider_metadata_is_secret_free(&Value::Object(
+                        std::iter::once(((*key).clone(), (*value).clone())).collect(),
+                    ))
+                })
                 .map(|(key, value)| (key.clone(), value.clone()))
                 .collect();
             instance.extra.extend(editable_extra);
         }
+    }
+}
+
+fn secret_free_provider_extra(extra: &BTreeMap<String, Value>) -> BTreeMap<String, Value> {
+    let mut value = Value::Object(
+        extra
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    );
+    bamboo_config::scrub_provider_metadata_credentials(&mut value);
+    match value {
+        Value::Object(extra) => extra.into_iter().collect(),
+        _ => BTreeMap::new(),
     }
 }
 
@@ -1199,7 +1233,9 @@ fn reject_sensitive_header_literals(value: &Value) -> Result<(), String> {
         return Ok(());
     };
     for (name, expression) in headers {
-        if is_sensitive_header_name(name) && !is_external_template_reference(expression) {
+        if bamboo_config::request_override_header_is_credential(name)
+            && !bamboo_config::request_override_value_is_nonliteral_runtime_template(expression)
+        {
             return Err(format!(
                 "sensitive request override header '{name}' must use an env_ref or generated value"
             ));
@@ -1216,11 +1252,11 @@ fn reject_sensitive_body_patch_literals(value: &Value) -> Result<(), String> {
         let sensitive_path = patch
             .get("path")
             .and_then(Value::as_str)
-            .is_some_and(is_sensitive_override_path);
+            .is_some_and(bamboo_config::request_override_body_patch_targets_credential);
         if sensitive_path
-            && patch
-                .get("value")
-                .is_some_and(|value| !is_external_template_reference(value))
+            && patch.get("value").is_some_and(|value| {
+                !bamboo_config::request_override_value_is_nonliteral_runtime_template(value)
+            })
         {
             return Err(
                 "sensitive request override body values must use an env_ref or generated value"
@@ -1229,47 +1265,6 @@ fn reject_sensitive_body_patch_literals(value: &Value) -> Result<(), String> {
         }
     }
     Ok(())
-}
-
-fn is_sensitive_header_name(name: &str) -> bool {
-    let normalized = name.to_ascii_lowercase().replace('_', "-");
-    [
-        "authorization",
-        "api-key",
-        "apikey",
-        "token",
-        "secret",
-        "password",
-        "cookie",
-    ]
-    .iter()
-    .any(|needle| normalized.contains(needle))
-}
-
-fn is_sensitive_override_path(path: &str) -> bool {
-    let normalized = path.to_ascii_lowercase();
-    [
-        "api_key",
-        "api-key",
-        "apikey",
-        "token",
-        "secret",
-        "password",
-        "authorization",
-        "cookie",
-    ]
-    .iter()
-    .any(|needle| normalized.contains(needle))
-}
-
-fn is_external_template_reference(value: &Value) -> bool {
-    let Some(object) = value.as_object() else {
-        return false;
-    };
-    matches!(
-        object.get("type").and_then(Value::as_str),
-        Some("env_ref") | Some("generated")
-    ) && object.get("fallback").is_none_or(Value::is_null)
 }
 
 fn deserialize_provider_candidate<'de, D>(deserializer: D) -> Result<ProviderConfigs, D::Error>
@@ -1962,31 +1957,6 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
     use std::time::Duration;
 
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: Option<&str>) -> Self {
-            let previous = std::env::var_os(key);
-            match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
-            }
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-
     fn server(id: &str, transport: TransportConfig) -> McpServerConfig {
         McpServerConfig {
             id: id.to_string(),
@@ -2212,7 +2182,16 @@ mod tests {
                     model: Some("diagnostic-model".to_string()),
                     request_overrides: Some(
                         serde_json::from_value(json!({
-                            "common": {"headers": {"Authorization": "override-header-secret"}}
+                            "common": {
+                                "headers": {
+                                    "Authorization": "override-header-secret",
+                                    "X-Access-Key": "override-access-key-secret"
+                                },
+                                "body_patch": [{
+                                    "path": "/credential",
+                                    "value": "override-credential-secret"
+                                }]
+                            }
                         }))
                         .unwrap(),
                     ),
@@ -2311,6 +2290,8 @@ mod tests {
             "provider-plaintext-secret",
             "provider-ciphertext-secret",
             "override-header-secret",
+            "override-access-key-secret",
+            "override-credential-secret",
             "unknown-provider-secret",
             "provider-url-secret",
             "query-secret",
@@ -2355,6 +2336,8 @@ mod tests {
             "provider-plaintext-secret",
             "provider-ciphertext-secret",
             "override-header-secret",
+            "override-access-key-secret",
+            "override-credential-secret",
             "unknown-provider-secret",
             "provider-url-secret",
             "query-secret",
@@ -3209,7 +3192,119 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn hybrid_legacy_default_provider_settings_preserve_builtin_alias() {
+    async fn provider_settings_rejects_provider_type_change_for_existing_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new().app_data(state.clone()).service(
+                web::resource("/provider-settings")
+                    .route(web::get().to(get_provider_settings_section))
+                    .route(web::put().to(put_provider_settings_section)),
+            ),
+        )
+        .await;
+        let secret = "immutable-provider-type-secret";
+
+        let created = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 0,
+                    "data": {
+                        "provider": "openai",
+                        "providers": {},
+                        "defaults": null,
+                        "features": {},
+                        "provider_instances": {
+                            "work": {
+                                "provider_type": "openai",
+                                "model": "gpt-instance",
+                                "enabled": true
+                            }
+                        },
+                        "default_provider_instance_id": "work"
+                    },
+                    "credential_changes": {
+                        "provider_instances": {
+                            "work": {"action": "replace", "value": secret}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = created.status();
+        let body = String::from_utf8(test::read_body(created).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "unexpected provider settings response {status}: {body}"
+        );
+        let created: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(created["revision"], 1);
+        let credential_ref = created["data"]["credential_status"]["provider_instances"]["work"]
+            ["credential_ref"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let providers_before = std::fs::read(dir.path().join("providers.json")).unwrap();
+        let credentials_before = std::fs::read(dir.path().join("credentials.json")).unwrap();
+
+        let mut changed = created["data"].clone();
+        changed["provider_instances"]["work"]["provider_type"] = json!("anthropic");
+        let rejected = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": changed
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(rejected.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        let rejected_body = String::from_utf8(test::read_body(rejected).await.to_vec()).unwrap();
+        assert!(rejected_body.contains(
+            "provider_type for existing provider instance 'work' cannot be changed from 'openai' to 'anthropic'"
+        ));
+
+        let current = state.config.read().await;
+        let work = &current.provider_instances["work"];
+        assert_eq!(work.provider_type, "openai");
+        assert_eq!(work.api_key, secret);
+        assert_eq!(
+            work.credential_ref.as_ref().map(|value| value.as_str()),
+            Some(credential_ref.as_str())
+        );
+        drop(current);
+        assert_eq!(
+            std::fs::read(dir.path().join("providers.json")).unwrap(),
+            providers_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("credentials.json")).unwrap(),
+            credentials_before
+        );
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/provider-settings")
+                .to_request(),
+        )
+        .await;
+        let response: Value = test::read_body_json(response).await;
+        assert_eq!(response["revision"], 1);
+        assert_eq!(
+            response["data"]["provider_instances"]["work"]["provider_type"],
+            "openai"
+        );
+    }
+
+    #[actix_web::test]
+    async fn hybrid_legacy_default_provider_settings_preserves_alias_until_restart_migration() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
@@ -3291,26 +3386,32 @@ mod tests {
             Some("openai")
         );
         assert!(restarted_config.provider_instances.contains_key("work"));
+        assert_eq!(restarted_config.provider_instances.len(), 2);
         assert_eq!(
             restarted_config
-                .providers()
-                .openai
-                .as_ref()
-                .unwrap()
+                .provider_instances
+                .get("openai")
+                .expect("restart materializes the legacy default")
                 .api_key,
             legacy_secret
         );
+        assert_eq!(
+            restarted_config.provider_instances["openai"].provider_type,
+            "openai"
+        );
+        assert!(restarted_config.providers().openai.is_none());
     }
 
     #[actix_web::test]
     async fn provider_settings_environment_status_tracks_runtime_availability() {
-        let _lock = bamboo_config::test_support::env_cache_lock_acquire();
-        let _openai = EnvVarGuard::set(
+        let _openai = bamboo_config::test_support::override_runtime_env_var(
             "BAMBOO_OPENAI_API_KEY",
             Some("sk-runtime-openai-environment"),
         );
-        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", None);
-        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", None);
+        let _anthropic =
+            bamboo_config::test_support::override_runtime_env_var("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini =
+            bamboo_config::test_support::override_runtime_env_var("BAMBOO_GEMINI_API_KEY", None);
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
         {
@@ -3365,17 +3466,20 @@ mod tests {
 
     #[actix_web::test]
     async fn provider_settings_environment_override_precedes_and_falls_back_to_stored_ref() {
-        let _lock = bamboo_config::test_support::env_cache_lock_acquire();
         let _key = bamboo_config::encryption::set_test_encryption_key([0x6a; 32]);
-        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", Some("sk-runtime-openai-override"));
-        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", None);
-        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", None);
+        let openai = bamboo_config::test_support::override_runtime_env_var(
+            "BAMBOO_OPENAI_API_KEY",
+            Some("sk-runtime-openai-override"),
+        );
+        let _anthropic =
+            bamboo_config::test_support::override_runtime_env_var("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini =
+            bamboo_config::test_support::override_runtime_env_var("BAMBOO_GEMINI_API_KEY", None);
         let dir = tempfile::tempdir().unwrap();
-        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let facade = bamboo_config::ConfigFacade::open_or_migrate(dir.path()).unwrap();
         let credential_ref =
             CredentialRef::parse("provider.work.api_key").expect("valid credential ref");
-        state
-            .credential_store
+        bamboo_config::CredentialStore::open(dir.path())
             .replace(
                 credential_ref.clone(),
                 "sk-stored-fallback",
@@ -3383,21 +3487,32 @@ mod tests {
                 0,
             )
             .unwrap();
-        {
-            let mut instance: ProviderInstanceConfig = serde_json::from_value(json!({
-                "provider_type": "openai",
-                "enabled": true,
-                "api_key_from_env": true,
-                "credential_ref": credential_ref.as_str()
-            }))
+        let snapshot = facade.registry().providers.snapshot();
+        let mut providers = snapshot.data.as_ref().clone();
+        let instance: ProviderInstanceConfig = serde_json::from_value(json!({
+            "provider_type": "openai",
+            "model": "gpt-env-restart",
+            "enabled": true,
+            "api_key_from_env": true,
+            "credential_ref": credential_ref.as_str()
+        }))
+        .unwrap();
+        providers
+            .provider_instances
+            .insert("work".to_string(), instance);
+        providers.default_provider_instance = Some("work".to_string());
+        facade
+            .registry()
+            .providers
+            .commit(snapshot.revision, providers)
             .unwrap();
-            instance.api_key = "sk-runtime-openai-override".to_string();
-            let mut config = state.config.write().await;
-            config
-                .provider_instances
-                .insert("work".to_string(), instance);
-            config.default_provider_instance = Some("work".to_string());
-        }
+        drop(facade);
+
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        assert_eq!(
+            state.config.read().await.provider_instances["work"].api_key,
+            "sk-runtime-openai-override"
+        );
         let app = test::init_service(App::new().app_data(state.clone()).route(
             "/provider-settings",
             web::get().to(get_provider_settings_section),
@@ -3417,15 +3532,19 @@ mod tests {
         assert_eq!(active["source"], "environment");
         assert_eq!(active["credential_ref"], credential_ref.as_str());
 
-        std::env::remove_var("BAMBOO_OPENAI_API_KEY");
-        state
-            .config
-            .write()
-            .await
-            .provider_instances
-            .get_mut("work")
-            .unwrap()
-            .api_key = "sk-stored-fallback".to_string();
+        drop(app);
+        drop(state);
+        openai.replace(None);
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        assert_eq!(
+            state.config.read().await.provider_instances["work"].api_key,
+            "sk-stored-fallback"
+        );
+        let app = test::init_service(App::new().app_data(state).route(
+            "/provider-settings",
+            web::get().to(get_provider_settings_section),
+        ))
+        .await;
         let response = test::call_service(
             &app,
             test::TestRequest::get()
@@ -3551,6 +3670,16 @@ mod tests {
             .unwrap()
             .extra
             .insert("future_server_field".to_string(), json!(hidden_value));
+        let recovered_secret = "recovered-provider-extra-secret";
+        state
+            .config
+            .write()
+            .await
+            .provider_instances
+            .get_mut("bodhi-proxy")
+            .unwrap()
+            .extra
+            .insert("client_secret".to_string(), json!(recovered_secret));
 
         let mut updated = created["data"].clone();
         updated["provider_instances"]["bodhi-proxy"]["target_provider"] = json!("anthropic");
@@ -3569,6 +3698,7 @@ mod tests {
         assert!(updated.status().is_success());
         let updated_body = String::from_utf8(test::read_body(updated).await.to_vec()).unwrap();
         assert!(!updated_body.contains(hidden_value));
+        assert!(!updated_body.contains(recovered_secret));
         let updated: Value = serde_json::from_str(&updated_body).unwrap();
         assert_eq!(updated["revision"], 2);
         assert_eq!(
@@ -3597,6 +3727,9 @@ mod tests {
                 config.provider_instances["bodhi-proxy"].extra["future_server_field"],
                 hidden_value
             );
+            assert!(!config.provider_instances["bodhi-proxy"]
+                .extra
+                .contains_key("client_secret"));
             assert_eq!(
                 config.provider_instances["bodhi-proxy"].extra["target_provider"],
                 "anthropic"

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -2185,20 +2185,38 @@ mod tests {
                             "common": {
                                 "headers": {
                                     "Authorization": "override-header-secret",
-                                    "X-Access-Key": "override-access-key-secret"
+                                    "X-Access-Key": "override-access-key-secret",
+                                    "X-Private-Key": "override-private-key-secret",
+                                    "X-Device-Key": "override-device-key-secret"
                                 },
-                                "body_patch": [{
-                                    "path": "/credential",
-                                    "value": "override-credential-secret"
-                                }]
+                                "body_patch": [
+                                    {
+                                        "path": "/credential",
+                                        "value": "override-credential-secret"
+                                    },
+                                    {
+                                        "path": "/secrets/primary",
+                                        "value": "override-plural-secret"
+                                    }
+                                ]
                             }
                         }))
                         .unwrap(),
                     ),
-                    extra: BTreeMap::from([(
-                        "future_secret".to_string(),
-                        json!("unknown-provider-secret"),
-                    )]),
+                    extra: BTreeMap::from([
+                        (
+                            "future_secret".to_string(),
+                            json!("unknown-provider-secret"),
+                        ),
+                        (
+                            "secrets".to_string(),
+                            json!({"primary": "unknown-provider-plural-secret"}),
+                        ),
+                        (
+                            "api_keys".to_string(),
+                            json!({"primary": "unknown-provider-api-keys-secret"}),
+                        ),
+                    ]),
                     ..OpenAIConfig::default()
                 }),
                 ..ProviderConfigs::default()
@@ -2291,8 +2309,13 @@ mod tests {
             "provider-ciphertext-secret",
             "override-header-secret",
             "override-access-key-secret",
+            "override-private-key-secret",
+            "override-device-key-secret",
             "override-credential-secret",
+            "override-plural-secret",
             "unknown-provider-secret",
+            "unknown-provider-plural-secret",
+            "unknown-provider-api-keys-secret",
             "provider-url-secret",
             "query-secret",
             "****...****",
@@ -2337,8 +2360,13 @@ mod tests {
             "provider-ciphertext-secret",
             "override-header-secret",
             "override-access-key-secret",
+            "override-private-key-secret",
+            "override-device-key-secret",
             "override-credential-secret",
+            "override-plural-secret",
             "unknown-provider-secret",
+            "unknown-provider-plural-secret",
+            "unknown-provider-api-keys-secret",
             "provider-url-secret",
             "query-secret",
             "****...****",

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
@@ -474,7 +474,31 @@ pub(super) fn provider_validation_issue(
     config: &Config,
     fallback_error: String,
 ) -> (&'static str, String) {
-    match config.provider.as_str() {
+    let effective = config.effective_default_provider();
+    if let Some(instance) = config.provider_instances.get(effective) {
+        let configured = instance.provider_type == "copilot"
+            || !instance.api_key.trim().is_empty()
+            || instance.api_key_encrypted.is_some()
+            || instance.credential_ref.is_some()
+            || bamboo_config::provider_instance_environment_override_active(instance);
+        let message = format!(
+            "{} API key is required for provider instance '{effective}'",
+            match instance.provider_type.as_str() {
+                "openai" => "OpenAI",
+                "anthropic" => "Anthropic",
+                "gemini" => "Gemini",
+                "bodhi" => "Bodhi",
+                _ => "Provider",
+            }
+        );
+        return if configured {
+            ("provider_instances", fallback_error)
+        } else {
+            ("provider_instances", message)
+        };
+    }
+
+    match effective {
         "openai" => provider_issue(
             config
                 .providers()

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
@@ -169,6 +169,9 @@ mod tests {
             "enabled": true,
             "api_key_from_env": true,
             "private_key": "instance-private-extra",
+            "secrets": {"primary": "instance-plural-extra"},
+            "api_keys": {"primary": "instance-api-keys-extra"},
+            "tokens": ["instance-tokens-extra"],
             "oauth": {
                 "client_id": "public-client-id",
                 "value": "instance-oauth-extra"
@@ -178,12 +181,15 @@ mod tests {
                     "headers": {
                         "Authorization": "Bearer override-header-secret",
                         "X-Access-Key": "override-access-key-secret",
+                        "X-Private-Key": "override-private-key-secret",
+                        "X-Device-Key": "override-device-key-secret",
                         "X-Api-Key": {"type": "env_ref", "name": "PROJECTED_API_KEY"},
                         "X-Trace": "public-trace"
                     },
                     "body_patch": [
                         {"path": "/api_key", "value": "override-body-secret"},
                         {"path": "/credential", "value": "override-credential-secret"},
+                        {"path": "/secrets/primary", "value": "override-plural-secret"},
                         {"path": "/api_key", "value": {"type": "env_ref", "name": "PROJECTED_API_KEY"}},
                         {"path": "/temperature", "value": 0.2}
                     ]
@@ -251,9 +257,15 @@ mod tests {
             "api_key_from_env",
             "override-header-secret",
             "override-access-key-secret",
+            "override-private-key-secret",
+            "override-device-key-secret",
             "override-body-secret",
             "override-credential-secret",
+            "override-plural-secret",
             "instance-private-extra",
+            "instance-plural-extra",
+            "instance-api-keys-extra",
+            "instance-tokens-extra",
             "instance-oauth-extra",
             "future-client-extra",
         ] {

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
@@ -1,19 +1,21 @@
 use actix_web::{web, HttpResponse};
+use serde_json::Value;
 
-use crate::{app_state::AppState, error::AppError};
+use crate::{
+    app_state::AppState, error::AppError,
+    handlers::settings::bamboo_config::scrub_unsafe_request_override_literals,
+};
+use bamboo_config::{Config, ProviderConfigs};
 use bamboo_llm::AVAILABLE_PROVIDERS;
 
-use super::super::super::redaction::redact_providers_for_api;
 use super::super::types::ProviderConfigResponse;
 
 pub(super) async fn handle_get_provider_config(
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, AppError> {
-    let mut config = app_state.config.read().await.clone();
-    let provider = config.provider.clone();
-    config.refresh_provider_api_keys_encrypted()?;
-    let providers = serde_json::to_value(config.providers())?;
-    let masked_providers = redact_providers_for_api(providers, &config);
+    let config = app_state.config.read().await.clone();
+    let provider = legacy_active_provider_type(&config);
+    let masked_providers = legacy_provider_response_view(&config)?;
 
     let response = ProviderConfigResponse {
         provider,
@@ -27,4 +29,242 @@ pub(super) async fn handle_get_provider_config(
     };
 
     Ok(HttpResponse::Ok().json(response))
+}
+
+fn legacy_active_provider_type(config: &Config) -> String {
+    let effective = config.effective_default_provider();
+    config
+        .provider_instances
+        .get(effective)
+        .map(|instance| instance.provider_type.clone())
+        .unwrap_or_else(|| effective.to_string())
+}
+
+/// Build the deprecated type-keyed provider response from the instance-native
+/// authority. This boundary intentionally owns its masking instead of using
+/// the generic config redactor: the projected provider may be ref-backed even
+/// though the durable legacy slot no longer exists, and a credential reference
+/// is itself server-owned metadata that old clients must never receive.
+fn legacy_provider_response_view(config: &Config) -> Result<Value, AppError> {
+    let mut view = bamboo_config::legacy_provider_compatibility_view(config);
+    let configured = legacy_provider_configured(&view);
+    clear_legacy_provider_credentials(&mut view);
+    let mut value = serde_json::to_value(view)?;
+    scrub_unsafe_request_override_literals(&mut value);
+    scrub_legacy_credential_metadata(&mut value);
+    let Some(object) = value.as_object_mut() else {
+        return Ok(value);
+    };
+
+    for (name, is_configured) in configured {
+        let Some(provider) = object.get_mut(name).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        // `extra` is flattened, so remove these keys even after the typed
+        // fields above have been cleared. Only the compatibility mask crosses
+        // this endpoint.
+        provider.remove("api_key");
+        provider.remove("api_key_encrypted");
+        provider.remove("credential_ref");
+        provider.remove(bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY);
+        if is_configured {
+            provider.insert(
+                "api_key".to_string(),
+                Value::String("****...****".to_string()),
+            );
+        }
+    }
+
+    Ok(value)
+}
+
+/// Unknown provider metadata is forward-compatible and therefore flattened at
+/// several levels. Treat credential-shaped keys as secret at every depth so a
+/// future provider cannot accidentally expose its credential authority through
+/// this deprecated compatibility endpoint.
+fn scrub_legacy_credential_metadata(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            object.retain(|key, _| {
+                !matches!(
+                    key.as_str(),
+                    "api_key"
+                        | "api_key_encrypted"
+                        | "credential_ref"
+                        | bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY
+                )
+            });
+            for value in object.values_mut() {
+                scrub_legacy_credential_metadata(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                scrub_legacy_credential_metadata(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn legacy_provider_configured(providers: &ProviderConfigs) -> Vec<(&'static str, bool)> {
+    macro_rules! configured {
+        ($provider:expr) => {
+            $provider.as_ref().is_some_and(|provider| {
+                // This endpoint reports the live compatibility view. A
+                // durable ref or env binding without a successfully hydrated
+                // runtime value must not be rendered as a configured mask.
+                !provider.api_key.trim().is_empty()
+            })
+        };
+    }
+
+    vec![
+        ("openai", configured!(providers.openai)),
+        ("anthropic", configured!(providers.anthropic)),
+        ("gemini", configured!(providers.gemini)),
+        (
+            "bodhi",
+            providers
+                .bodhi
+                .as_ref()
+                .is_some_and(|provider| !provider.api_key.trim().is_empty()),
+        ),
+    ]
+}
+
+fn clear_legacy_provider_credentials(providers: &mut ProviderConfigs) {
+    macro_rules! clear {
+        ($field:ident) => {
+            if let Some(provider) = providers.$field.as_mut() {
+                provider.api_key.clear();
+                provider.api_key_encrypted = None;
+                provider.credential_ref = None;
+            }
+        };
+    }
+    clear!(openai);
+    clear!(anthropic);
+    clear!(gemini);
+    clear!(bodhi);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{legacy_active_provider_type, legacy_provider_response_view};
+    use bamboo_config::{Config, CredentialRef, ProviderInstanceConfig};
+
+    fn ref_backed_instance() -> ProviderInstanceConfig {
+        let mut instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "label": "Work",
+            "api_key_encrypted": "runtime-ciphertext",
+            "credential_ref": "provider.work.api_key",
+            "base_url": "https://work.example/v1",
+            "model": "gpt-work",
+            "enabled": true,
+            "api_key_from_env": true,
+            "request_overrides": {
+                "common": {
+                    "headers": {
+                        "Authorization": "Bearer override-header-secret",
+                        "X-Api-Key": {"type": "env_ref", "name": "PROJECTED_API_KEY"},
+                        "X-Trace": "public-trace"
+                    },
+                    "body_patch": [
+                        {"path": "/api_key", "value": "override-body-secret"},
+                        {"path": "/api_key", "value": {"type": "env_ref", "name": "PROJECTED_API_KEY"}},
+                        {"path": "/temperature", "value": 0.2}
+                    ]
+                }
+            }
+        }))
+        .expect("valid instance");
+        instance.api_key = "sk-runtime-plaintext".to_string();
+        instance.credential_ref = Some(
+            CredentialRef::parse("provider.work.api_key").expect("valid credential reference"),
+        );
+        instance
+    }
+
+    #[test]
+    fn legacy_get_projection_uses_default_instance_type_and_leaks_no_credential_metadata() {
+        let mut config = Config::default();
+        config.provider = "anthropic".to_string();
+        config
+            .provider_instances
+            .insert("work".to_string(), ref_backed_instance());
+        config.default_provider_instance = Some("work".to_string());
+        config.providers_mut().extra.insert(
+            "future-provider".to_string(),
+            serde_json::json!({
+                "api_key": "future-plaintext",
+                "nested": {
+                    "api_key_encrypted": "future-ciphertext",
+                    "credential_ref": "provider.future.api_key",
+                    "api_key_from_env": true
+                }
+            }),
+        );
+
+        assert_eq!(legacy_active_provider_type(&config), "openai");
+        let value = legacy_provider_response_view(&config).expect("projection");
+        assert_eq!(value["openai"]["api_key"], "****...****");
+        assert_eq!(value["openai"]["model"], "gpt-work");
+        assert!(value["openai"]["request_overrides"]["common"]["headers"]
+            .get("Authorization")
+            .is_none());
+        assert_eq!(
+            value["openai"]["request_overrides"]["common"]["headers"]["X-Api-Key"]["type"],
+            "env_ref"
+        );
+        assert_eq!(
+            value["openai"]["request_overrides"]["common"]["body_patch"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        let serialized = serde_json::to_string(&value).unwrap();
+        for forbidden in [
+            "sk-runtime-plaintext",
+            "runtime-ciphertext",
+            "provider.work.api_key",
+            "credential_ref",
+            "api_key_encrypted",
+            "future-plaintext",
+            "future-ciphertext",
+            "provider.future.api_key",
+            "api_key_from_env",
+            "override-header-secret",
+            "override-body-secret",
+        ] {
+            assert!(
+                !serialized.contains(forbidden),
+                "legacy response leaked {forbidden}: {serialized}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_get_projection_does_not_mask_an_unavailable_environment_binding() {
+        let mut config = Config::default();
+        let instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "enabled": true,
+            "api_key_from_env": true,
+            "credential_ref": "provider.missing.api_key"
+        }))
+        .expect("valid instance");
+        config
+            .provider_instances
+            .insert("missing".to_string(), instance);
+        config.default_provider_instance = Some("missing".to_string());
+
+        let value = legacy_provider_response_view(&config).expect("projection");
+        assert!(value["openai"].get("api_key").is_none());
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert!(!serialized.contains("****...****"));
+        assert!(!serialized.contains("provider.missing.api_key"));
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
@@ -15,7 +15,8 @@ pub(super) async fn handle_get_provider_config(
 ) -> Result<HttpResponse, AppError> {
     let config = app_state.config.read().await.clone();
     let provider = legacy_active_provider_type(&config);
-    let masked_providers = legacy_provider_response_view(&config)?;
+    let masked_providers =
+        legacy_provider_response_view(&config, Some(&app_state.credential_store))?;
 
     let response = ProviderConfigResponse {
         provider,
@@ -45,9 +46,12 @@ fn legacy_active_provider_type(config: &Config) -> String {
 /// the generic config redactor: the projected provider may be ref-backed even
 /// though the durable legacy slot no longer exists, and a credential reference
 /// is itself server-owned metadata that old clients must never receive.
-fn legacy_provider_response_view(config: &Config) -> Result<Value, AppError> {
+fn legacy_provider_response_view(
+    config: &Config,
+    credential_store: Option<&bamboo_config::CredentialStore>,
+) -> Result<Value, AppError> {
     let mut view = bamboo_config::legacy_provider_compatibility_view(config);
-    let configured = legacy_provider_configured(&view);
+    let configured = legacy_provider_configured(&view, credential_store);
     clear_legacy_provider_credentials(&mut view);
     let mut value = serde_json::to_value(view)?;
     scrub_unsafe_request_override_literals(&mut value);
@@ -111,28 +115,53 @@ fn scrub_legacy_credential_metadata(value: &mut Value) {
     }
 }
 
-fn legacy_provider_configured(providers: &ProviderConfigs) -> Vec<(&'static str, bool)> {
+fn legacy_provider_configured(
+    providers: &ProviderConfigs,
+    credential_store: Option<&bamboo_config::CredentialStore>,
+) -> Vec<(&'static str, bool)> {
     macro_rules! configured {
-        ($provider:expr) => {
+        ($provider_type:literal, $provider:expr) => {
             $provider.as_ref().is_some_and(|provider| {
                 // This endpoint reports the live compatibility view. A
                 // durable ref or env binding without a successfully hydrated
                 // runtime value must not be rendered as a configured mask.
-                !provider.api_key.trim().is_empty()
+                if provider.api_key_from_env
+                    && bamboo_config::provider_api_key_environment_override_active(
+                        $provider_type,
+                        &provider.api_key,
+                    )
+                {
+                    true
+                } else if let (Some(store), Some(reference)) =
+                    (credential_store, provider.credential_ref.as_ref())
+                {
+                    store
+                        .status_with_crypto_validation(reference)
+                        .is_ok_and(|status| status.configured)
+                } else {
+                    !provider.api_key_from_env && !provider.api_key.trim().is_empty()
+                }
             })
         };
     }
 
     vec![
-        ("openai", configured!(providers.openai)),
-        ("anthropic", configured!(providers.anthropic)),
-        ("gemini", configured!(providers.gemini)),
+        ("openai", configured!("openai", providers.openai)),
+        ("anthropic", configured!("anthropic", providers.anthropic)),
+        ("gemini", configured!("gemini", providers.gemini)),
         (
             "bodhi",
-            providers
-                .bodhi
-                .as_ref()
-                .is_some_and(|provider| !provider.api_key.trim().is_empty()),
+            providers.bodhi.as_ref().is_some_and(|provider| {
+                if let (Some(store), Some(reference)) =
+                    (credential_store, provider.credential_ref.as_ref())
+                {
+                    store
+                        .status_with_crypto_validation(reference)
+                        .is_ok_and(|status| status.configured)
+                } else {
+                    !provider.api_key.trim().is_empty()
+                }
+            }),
         ),
     ]
 }
@@ -172,6 +201,7 @@ mod tests {
             "secrets": {"primary": "instance-plural-extra"},
             "api_keys": {"primary": "instance-api-keys-extra"},
             "tokens": ["instance-tokens-extra"],
+            "client_tokens": ["instance-client-tokens-extra"],
             "oauth": {
                 "client_id": "public-client-id",
                 "value": "instance-oauth-extra"
@@ -183,6 +213,7 @@ mod tests {
                         "X-Access-Key": "override-access-key-secret",
                         "X-Private-Key": "override-private-key-secret",
                         "X-Device-Key": "override-device-key-secret",
+                        "X-Client-Tokens": "override-client-tokens-secret",
                         "X-Api-Key": {"type": "env_ref", "name": "PROJECTED_API_KEY"},
                         "X-Trace": "public-trace"
                     },
@@ -190,6 +221,7 @@ mod tests {
                         {"path": "/api_key", "value": "override-body-secret"},
                         {"path": "/credential", "value": "override-credential-secret"},
                         {"path": "/secrets/primary", "value": "override-plural-secret"},
+                        {"path": "/client_tokens/0", "value": "override-client-token-body-secret"},
                         {"path": "/api_key", "value": {"type": "env_ref", "name": "PROJECTED_API_KEY"}},
                         {"path": "/temperature", "value": 0.2}
                     ]
@@ -206,6 +238,17 @@ mod tests {
 
     #[test]
     fn legacy_get_projection_uses_default_instance_type_and_leaks_no_credential_metadata() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x6f; 32]);
+        let credential_dir = tempfile::tempdir().expect("credential tempdir");
+        let credential_store = bamboo_config::CredentialStore::open(credential_dir.path());
+        credential_store
+            .replace(
+                CredentialRef::parse("provider.work.api_key").expect("valid credential reference"),
+                "stored-provider-secret",
+                bamboo_config::CredentialSource::Migrated,
+                0,
+            )
+            .expect("store provider credential");
         let mut config = Config::default();
         config.provider = "anthropic".to_string();
         config
@@ -226,7 +269,8 @@ mod tests {
         );
 
         assert_eq!(legacy_active_provider_type(&config), "openai");
-        let value = legacy_provider_response_view(&config).expect("projection");
+        let value =
+            legacy_provider_response_view(&config, Some(&credential_store)).expect("projection");
         assert_eq!(value["openai"]["api_key"], "****...****");
         assert_eq!(value["openai"]["model"], "gpt-work");
         assert_eq!(value["openai"]["oauth"]["client_id"], "public-client-id");
@@ -247,6 +291,7 @@ mod tests {
         let serialized = serde_json::to_string(&value).unwrap();
         for forbidden in [
             "sk-runtime-plaintext",
+            "stored-provider-secret",
             "runtime-ciphertext",
             "provider.work.api_key",
             "credential_ref",
@@ -259,6 +304,8 @@ mod tests {
             "override-access-key-secret",
             "override-private-key-secret",
             "override-device-key-secret",
+            "override-client-tokens-secret",
+            "override-client-token-body-secret",
             "override-body-secret",
             "override-credential-secret",
             "override-plural-secret",
@@ -266,6 +313,7 @@ mod tests {
             "instance-plural-extra",
             "instance-api-keys-extra",
             "instance-tokens-extra",
+            "instance-client-tokens-extra",
             "instance-oauth-extra",
             "future-client-extra",
         ] {
@@ -278,10 +326,13 @@ mod tests {
 
     #[test]
     fn legacy_get_projection_does_not_mask_an_unavailable_environment_binding() {
+        let _openai_env =
+            bamboo_config::test_support::override_runtime_env_var("BAMBOO_OPENAI_API_KEY", None);
         let mut config = Config::default();
         let instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
             "provider_type": "openai",
             "enabled": true,
+            "api_key": "stale-runtime-environment-key",
             "api_key_from_env": true,
             "credential_ref": "provider.missing.api_key"
         }))
@@ -291,10 +342,11 @@ mod tests {
             .insert("missing".to_string(), instance);
         config.default_provider_instance = Some("missing".to_string());
 
-        let value = legacy_provider_response_view(&config).expect("projection");
+        let value = legacy_provider_response_view(&config, None).expect("projection");
         assert!(value["openai"].get("api_key").is_none());
         let serialized = serde_json::to_string(&value).unwrap();
         assert!(!serialized.contains("****...****"));
         assert!(!serialized.contains("provider.missing.api_key"));
+        assert!(!serialized.contains("stale-runtime-environment-key"));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
@@ -83,6 +83,10 @@ fn legacy_provider_response_view(config: &Config) -> Result<Value, AppError> {
 /// future provider cannot accidentally expose its credential authority through
 /// this deprecated compatibility endpoint.
 fn scrub_legacy_credential_metadata(value: &mut Value) {
+    // `ProviderConfigs` flattens unknown metadata. Reuse the same conservative
+    // classifier as durable config validation so recovered legacy/LKG values
+    // cannot expose private_key/client_secret or nested credential payloads.
+    bamboo_config::scrub_provider_metadata_credentials(value);
     match value {
         Value::Object(object) => {
             object.retain(|key, _| {
@@ -164,15 +168,22 @@ mod tests {
             "model": "gpt-work",
             "enabled": true,
             "api_key_from_env": true,
+            "private_key": "instance-private-extra",
+            "oauth": {
+                "client_id": "public-client-id",
+                "value": "instance-oauth-extra"
+            },
             "request_overrides": {
                 "common": {
                     "headers": {
                         "Authorization": "Bearer override-header-secret",
+                        "X-Access-Key": "override-access-key-secret",
                         "X-Api-Key": {"type": "env_ref", "name": "PROJECTED_API_KEY"},
                         "X-Trace": "public-trace"
                     },
                     "body_patch": [
                         {"path": "/api_key", "value": "override-body-secret"},
+                        {"path": "/credential", "value": "override-credential-secret"},
                         {"path": "/api_key", "value": {"type": "env_ref", "name": "PROJECTED_API_KEY"}},
                         {"path": "/temperature", "value": 0.2}
                     ]
@@ -202,7 +213,8 @@ mod tests {
                 "nested": {
                     "api_key_encrypted": "future-ciphertext",
                     "credential_ref": "provider.future.api_key",
-                    "api_key_from_env": true
+                    "api_key_from_env": true,
+                    "client_secret": "future-client-extra"
                 }
             }),
         );
@@ -211,6 +223,7 @@ mod tests {
         let value = legacy_provider_response_view(&config).expect("projection");
         assert_eq!(value["openai"]["api_key"], "****...****");
         assert_eq!(value["openai"]["model"], "gpt-work");
+        assert_eq!(value["openai"]["oauth"]["client_id"], "public-client-id");
         assert!(value["openai"]["request_overrides"]["common"]["headers"]
             .get("Authorization")
             .is_none());
@@ -237,7 +250,12 @@ mod tests {
             "provider.future.api_key",
             "api_key_from_env",
             "override-header-secret",
+            "override-access-key-secret",
             "override-body-secret",
+            "override-credential-secret",
+            "instance-private-extra",
+            "instance-oauth-extra",
+            "future-client-extra",
         ] {
             assert!(
                 !serialized.contains(forbidden),

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/reload.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/reload.rs
@@ -6,11 +6,12 @@ pub(super) async fn handle_reload_provider_config(
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, AppError> {
     let new_config = app_state.reload_config_and_runtime().await?;
+    let provider = new_config.effective_default_provider().to_string();
 
-    tracing::info!("Provider reloaded successfully: {}", new_config.provider);
+    tracing::info!("Provider reloaded successfully: {}", provider);
 
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "success": true,
-        "provider": new_config.provider
+        "provider": provider
     })))
 }

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/update.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/update.rs
@@ -110,6 +110,69 @@ fn apply_provider_patch(
 }
 
 fn validate_provider_config(config: &Config) -> Result<(), AppError> {
+    let providers = config.providers();
+    let request_overrides = [
+        providers
+            .openai
+            .as_ref()
+            .and_then(|provider| provider.request_overrides.as_ref()),
+        providers
+            .anthropic
+            .as_ref()
+            .and_then(|provider| provider.request_overrides.as_ref()),
+        providers
+            .gemini
+            .as_ref()
+            .and_then(|provider| provider.request_overrides.as_ref()),
+        providers
+            .copilot
+            .as_ref()
+            .and_then(|provider| provider.request_overrides.as_ref()),
+    ];
+    for request_overrides in request_overrides.into_iter().flatten() {
+        let original = serde_json::to_value(request_overrides).map_err(|error| {
+            AppError::BadRequest(format!("Invalid provider request_overrides: {error}"))
+        })?;
+        let mut sanitized = original.clone();
+        crate::handlers::settings::bamboo_config::scrub_unsafe_request_override_literals(
+            &mut sanitized,
+        );
+        if sanitized != original {
+            return Err(AppError::BadRequest(
+                "Invalid configuration: provider request_overrides contain literal credential material"
+                    .to_string(),
+            ));
+        }
+    }
+    let mut extra_maps = vec![&providers.extra];
+    if let Some(provider) = &providers.openai {
+        extra_maps.push(&provider.extra);
+    }
+    if let Some(provider) = &providers.anthropic {
+        extra_maps.push(&provider.extra);
+    }
+    if let Some(provider) = &providers.gemini {
+        extra_maps.push(&provider.extra);
+    }
+    if let Some(provider) = &providers.copilot {
+        extra_maps.push(&provider.extra);
+    }
+    if let Some(provider) = &providers.bodhi {
+        extra_maps.push(&provider.extra);
+    }
+    if extra_maps.into_iter().any(|extra| {
+        !bamboo_config::provider_metadata_is_secret_free(&Value::Object(
+            extra
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        ))
+    }) {
+        return Err(AppError::BadRequest(
+            "Invalid configuration: provider metadata contains credential material outside api_key"
+                .to_string(),
+        ));
+    }
     if let Err(error) = bamboo_llm::validate_provider_config(config) {
         return Err(AppError::BadRequest(format!(
             "Invalid configuration: {error}"
@@ -127,7 +190,7 @@ fn bad_request_response(message: String) -> HttpResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_provider_patch, is_instance_native};
+    use super::{build_provider_patch, is_instance_native, validate_provider_config, AppError};
     use crate::app_state::AppState;
     use crate::handlers::settings::provider::types::UpdateProviderRequest;
     use actix_web::{test as actix_test, web, App};
@@ -156,6 +219,52 @@ mod tests {
             !is_instance_native(&hybrid),
             "a real legacy-default hybrid remains writable during the compatibility window"
         );
+    }
+
+    #[test]
+    fn legacy_provider_write_rejects_credential_shaped_extra() {
+        let mut config = Config::default();
+        let mut openai = bamboo_config::OpenAIConfig {
+            api_key: "sk-provider".to_string(),
+            model: Some("gpt-test".to_string()),
+            ..Default::default()
+        };
+        openai.extra.insert(
+            "client_secret".to_string(),
+            serde_json::json!("must-not-enter-extra"),
+        );
+        config.providers_mut().openai = Some(openai);
+
+        assert!(matches!(
+            validate_provider_config(&config),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn legacy_provider_write_rejects_literal_request_override_credentials() {
+        let mut config = Config::default();
+        config.providers_mut().openai = Some(
+            serde_json::from_value(serde_json::json!({
+                "api_key": "sk-provider",
+                "model": "gpt-test",
+                "request_overrides": {
+                    "common": {
+                        "headers": {"X-Access-Key": "must-not-enter-overrides"},
+                        "body_patch": [{
+                            "path": "/credential",
+                            "value": "must-not-enter-overrides"
+                        }]
+                    }
+                }
+            }))
+            .unwrap(),
+        );
+
+        assert!(matches!(
+            validate_provider_config(&config),
+            Err(AppError::BadRequest(_))
+        ));
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/update.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/update.rs
@@ -23,6 +23,16 @@ pub(super) async fn handle_update_provider_config(
     let new_config = match app_state
         .update_config_with_provider_credentials(
             move |config| {
+                // This guard must run against the transaction-current snapshot,
+                // not a lock released before the mutation begins: a concurrent
+                // canonical migration must never leave a window where this
+                // legacy write is acknowledged and then discarded.
+                if is_instance_native(config) {
+                    return Err(AppError::BadRequest(
+                        "The legacy provider endpoint is read-only after provider-instance migration; use /v1/bamboo/config/provider-settings (revisioned) or /v1/bamboo/settings/provider-instances"
+                            .to_string(),
+                    ));
+                }
                 let current = config.clone();
                 let new_config = apply_provider_patch(&current, patch_obj, &api_key_intents)?;
                 validate_provider_config(&new_config)?;
@@ -53,6 +63,13 @@ pub(super) async fn handle_update_provider_config(
         "success": true,
         "provider": new_config.provider
     })))
+}
+
+fn is_instance_native(config: &Config) -> bool {
+    config
+        .default_provider_instance
+        .as_ref()
+        .is_some_and(|id| config.provider_instances.contains_key(id))
 }
 
 fn build_provider_patch(payload: &UpdateProviderRequest) -> serde_json::Map<String, Value> {
@@ -110,8 +127,76 @@ fn bad_request_response(message: String) -> HttpResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::build_provider_patch;
+    use super::{build_provider_patch, is_instance_native};
+    use crate::app_state::AppState;
     use crate::handlers::settings::provider::types::UpdateProviderRequest;
+    use actix_web::{test as actix_test, web, App};
+    use bamboo_config::{Config, ProviderInstanceConfig};
+
+    fn instance(provider_type: &str) -> ProviderInstanceConfig {
+        serde_json::from_value(serde_json::json!({
+            "provider_type": provider_type,
+            "enabled": true
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn legacy_update_is_rejected_only_for_resolved_instance_authority() {
+        let mut native = Config::default();
+        native
+            .provider_instances
+            .insert("work".to_string(), instance("openai"));
+        native.default_provider_instance = Some("work".to_string());
+        assert!(is_instance_native(&native));
+
+        let mut hybrid = native;
+        hybrid.default_provider_instance = Some("anthropic".to_string());
+        assert!(
+            !is_instance_native(&hybrid),
+            "a real legacy-default hybrid remains writable during the compatibility window"
+        );
+    }
+
+    #[actix_web::test]
+    async fn legacy_post_returns_bad_request_without_mutating_instance_native_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        {
+            let mut config = state.config.write().await;
+            let mut work = instance("openai");
+            work.api_key = "sk-work".to_string();
+            work.model = Some("instance-model".to_string());
+            config.provider_instances.insert("work".to_string(), work);
+            config.default_provider_instance = Some("work".to_string());
+        }
+        let app = actix_test::init_service(App::new().app_data(state.clone()).route(
+            "/provider",
+            web::post().to(super::handle_update_provider_config),
+        ))
+        .await;
+
+        let response = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::post()
+                .uri("/provider")
+                .set_json(serde_json::json!({
+                    "provider": "openai",
+                    "providers": {"openai": {"model": "legacy-write"}}
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        let body = String::from_utf8(actix_test::read_body(response).await.to_vec()).unwrap();
+        assert!(body.contains("provider-settings"));
+        assert_eq!(
+            state.config.read().await.provider_instances["work"]
+                .model
+                .as_deref(),
+            Some("instance-model")
+        );
+    }
 
     #[test]
     fn build_provider_patch_sets_provider_and_providers_fields() {

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/update.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/update.rs
@@ -230,8 +230,8 @@ mod tests {
             ..Default::default()
         };
         openai.extra.insert(
-            "client_secret".to_string(),
-            serde_json::json!("must-not-enter-extra"),
+            "secrets".to_string(),
+            serde_json::json!({"primary": "must-not-enter-extra"}),
         );
         config.providers_mut().openai = Some(openai);
 
@@ -250,9 +250,9 @@ mod tests {
                 "model": "gpt-test",
                 "request_overrides": {
                     "common": {
-                        "headers": {"X-Access-Key": "must-not-enter-overrides"},
+                        "headers": {"X-Private-Key": "must-not-enter-overrides"},
                         "body_patch": [{
-                            "path": "/credential",
+                            "path": "/secrets/primary",
                             "value": "must-not-enter-overrides"
                         }]
                     }

--- a/crates/app/bamboo-server/src/handlers/settings/provider/models/dispatch.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/models/dispatch.rs
@@ -1,14 +1,166 @@
 use crate::{app_state::AppState, error::AppError};
+use bamboo_config::{ProviderInstanceConfig, RequestOverridesConfig};
 use bamboo_llm::Config;
 use serde_json::Value;
 
 use super::upstream::fetch_models_from_api;
 
-pub(super) fn provider_type_from_payload<'a>(payload: &'a Value, fallback: &'a str) -> &'a str {
+/// Fully resolved model-discovery target. `routing_key` stays distinct from
+/// `provider_type`: two OpenAI-compatible instances may have different keys,
+/// credentials, base URLs and overrides, while using the same wire protocol.
+pub(super) struct ModelFetchTarget {
+    pub(super) routing_key: String,
+    pub(super) provider_type: String,
+    pub(super) api_key: Option<String>,
+    pub(super) base_url: Option<String>,
+    pub(super) request_overrides: Option<RequestOverridesConfig>,
+}
+
+pub(super) fn provider_key_from_payload(payload: &Value, config: &Config) -> String {
     payload
-        .get("provider")
-        .and_then(|value| value.as_str())
-        .unwrap_or(fallback)
+        .get("provider_instance_id")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("provider").and_then(Value::as_str))
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| config.effective_default_provider())
+        .to_string()
+}
+
+pub(super) fn resolve_model_fetch_target(
+    config: &Config,
+    requested_key: &str,
+) -> Result<ModelFetchTarget, AppError> {
+    // An exact instance id is always authoritative, including the disabled
+    // state. Never fall back to a stale legacy alias with the same id.
+    if let Some(instance) = config.provider_instances.get(requested_key) {
+        return target_from_instance(requested_key, instance);
+    }
+
+    if !bamboo_llm::AVAILABLE_PROVIDERS.contains(&requested_key) {
+        return Err(AppError::BadRequest(format!(
+            "Unknown provider instance or type: {requested_key}"
+        )));
+    }
+
+    // Narrow hybrid seam: a missing effective default may still be a real
+    // legacy alias while materialization is deferred. It wins over another
+    // explicit instance of the same type because it is the selected provider.
+    if requested_key == config.effective_default_provider() {
+        if let Some(target) = target_from_legacy(config, requested_key) {
+            return Ok(target);
+        }
+    }
+
+    // Legacy clients send a built-in type, not an instance id. Map that type
+    // deterministically to the selected instance of that type, then the
+    // lexicographically first enabled instance. This seam is response/request
+    // compatibility only; the returned target remains instance-native.
+    if let Some(default_id) = config.default_provider_instance.as_deref() {
+        if let Some(instance) = config.provider_instances.get(default_id) {
+            if instance.provider_type == requested_key {
+                return target_from_instance(default_id, instance);
+            }
+        }
+    }
+    let mut matching_ids = config
+        .provider_instances
+        .iter()
+        .filter(|(_, instance)| instance.provider_type == requested_key && instance.enabled)
+        .map(|(id, _)| id.as_str())
+        .collect::<Vec<_>>();
+    matching_ids.sort_unstable();
+    if let Some(id) = matching_ids.first() {
+        return target_from_instance(id, &config.provider_instances[*id]);
+    }
+
+    target_from_legacy(config, requested_key).ok_or_else(|| {
+        AppError::BadRequest(format!(
+            "{} configuration required",
+            provider_display_name(requested_key)
+        ))
+    })
+}
+
+fn target_from_instance(
+    id: &str,
+    instance: &ProviderInstanceConfig,
+) -> Result<ModelFetchTarget, AppError> {
+    if !instance.enabled {
+        return Err(AppError::BadRequest(format!(
+            "Provider instance '{id}' is disabled"
+        )));
+    }
+    Ok(ModelFetchTarget {
+        routing_key: id.to_string(),
+        provider_type: instance.provider_type.clone(),
+        api_key: (instance.provider_type != "copilot").then(|| instance.api_key.clone()),
+        base_url: instance.base_url.clone(),
+        request_overrides: instance.request_overrides.clone(),
+    })
+}
+
+fn target_from_legacy(config: &Config, provider_type: &str) -> Option<ModelFetchTarget> {
+    let (api_key, base_url, request_overrides) = match provider_type {
+        "openai" => {
+            let provider = config.providers().openai.as_ref()?;
+            (
+                Some(provider.api_key.clone()),
+                provider.base_url.clone(),
+                provider.request_overrides.clone(),
+            )
+        }
+        "anthropic" => {
+            let provider = config.providers().anthropic.as_ref()?;
+            (
+                Some(provider.api_key.clone()),
+                provider.base_url.clone(),
+                provider.request_overrides.clone(),
+            )
+        }
+        "gemini" => {
+            let provider = config.providers().gemini.as_ref()?;
+            (
+                Some(provider.api_key.clone()),
+                provider.base_url.clone(),
+                provider.request_overrides.clone(),
+            )
+        }
+        "copilot" => {
+            if config.providers().copilot.is_none()
+                && config.effective_default_provider() != "copilot"
+            {
+                return None;
+            }
+            (None, None, None)
+        }
+        "bodhi" => {
+            let provider = config.providers().bodhi.as_ref()?;
+            (
+                Some(provider.api_key.clone()),
+                provider.base_url.clone(),
+                None,
+            )
+        }
+        _ => return None,
+    };
+    Some(ModelFetchTarget {
+        routing_key: provider_type.to_string(),
+        provider_type: provider_type.to_string(),
+        api_key,
+        base_url,
+        request_overrides,
+    })
+}
+
+fn provider_display_name(provider_type: &str) -> &str {
+    match provider_type {
+        "openai" => "OpenAI",
+        "anthropic" => "Anthropic",
+        "gemini" => "Gemini",
+        "copilot" => "Copilot",
+        "bodhi" => "Bodhi",
+        other => other,
+    }
 }
 
 pub(super) fn build_proxy_aware_http_client(config: &Config) -> Result<reqwest::Client, AppError> {
@@ -19,64 +171,36 @@ pub(super) fn build_proxy_aware_http_client(config: &Config) -> Result<reqwest::
 
 pub(super) async fn fetch_models_for_provider(
     app_state: &AppState,
-    config: &Config,
-    provider_type: &str,
+    target: &ModelFetchTarget,
     client: &reqwest::Client,
 ) -> Result<Vec<String>, AppError> {
-    match provider_type {
-        "copilot" => fetch_copilot_models(app_state).await,
-        "openai" => {
-            let openai =
-                config.providers().openai.as_ref().ok_or_else(|| {
-                    AppError::BadRequest("OpenAI configuration required".to_string())
-                })?;
-            ensure_api_key(openai.api_key.as_str())?;
-            fetch_models_from_api(
-                client,
-                "openai",
-                &openai.api_key,
-                openai.base_url.as_deref(),
-                openai.request_overrides.as_ref(),
-            )
-            .await
-        }
-        "anthropic" => {
-            let anthropic = config.providers().anthropic.as_ref().ok_or_else(|| {
-                AppError::BadRequest("Anthropic configuration required".to_string())
-            })?;
-            ensure_api_key(anthropic.api_key.as_str())?;
-            fetch_models_from_api(
-                client,
-                "anthropic",
-                &anthropic.api_key,
-                anthropic.base_url.as_deref(),
-                anthropic.request_overrides.as_ref(),
-            )
-            .await
-        }
-        "gemini" => {
-            let gemini =
-                config.providers().gemini.as_ref().ok_or_else(|| {
-                    AppError::BadRequest("Gemini configuration required".to_string())
-                })?;
-            ensure_api_key(gemini.api_key.as_str())?;
-            fetch_models_from_api(
-                client,
-                "gemini",
-                &gemini.api_key,
-                gemini.base_url.as_deref(),
-                gemini.request_overrides.as_ref(),
-            )
-            .await
-        }
-        other => Err(AppError::BadRequest(format!(
-            "Unsupported provider: {other}"
-        ))),
+    if target.provider_type == "copilot" {
+        return fetch_copilot_models(app_state, &target.routing_key).await;
     }
+    let api_key = target.api_key.as_deref().unwrap_or_default();
+    ensure_api_key(api_key)?;
+    fetch_models_from_api(
+        client,
+        &target.provider_type,
+        api_key,
+        target.base_url.as_deref(),
+        target.request_overrides.as_ref(),
+    )
+    .await
 }
 
-async fn fetch_copilot_models(app_state: &AppState) -> Result<Vec<String>, AppError> {
-    let provider = app_state.get_provider().await;
+async fn fetch_copilot_models(
+    app_state: &AppState,
+    routing_key: &str,
+) -> Result<Vec<String>, AppError> {
+    let provider = app_state
+        .provider_registry
+        .get(routing_key)
+        .ok_or_else(|| {
+            AppError::BadRequest(format!(
+                "Copilot provider instance '{routing_key}' is not available"
+            ))
+        })?;
     provider.list_models().await.map_err(|error| {
         let message = error.to_string();
         if message.contains("proxy") || message.contains("407") {
@@ -92,4 +216,142 @@ fn ensure_api_key(api_key: &str) -> Result<(), AppError> {
         return Err(AppError::BadRequest("API key not configured".to_string()));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{provider_key_from_payload, resolve_model_fetch_target};
+    use bamboo_config::{Config, OpenAIConfig, ProviderInstanceConfig};
+
+    fn instance(key: &str, base_url: &str) -> ProviderInstanceConfig {
+        let mut instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "base_url": base_url,
+            "enabled": true
+        }))
+        .unwrap();
+        instance.api_key = key.to_string();
+        instance
+    }
+
+    #[test]
+    fn exact_instance_selection_keeps_per_instance_key_and_base_url() {
+        let mut config = Config::default();
+        config.provider_instances.insert(
+            "work".to_string(),
+            instance("sk-work", "https://work.example/v1"),
+        );
+        config.provider_instances.insert(
+            "personal".to_string(),
+            instance("sk-personal", "https://personal.example/v1"),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        let personal = resolve_model_fetch_target(&config, "personal").unwrap();
+        assert_eq!(personal.routing_key, "personal");
+        assert_eq!(personal.api_key.as_deref(), Some("sk-personal"));
+        assert_eq!(
+            personal.base_url.as_deref(),
+            Some("https://personal.example/v1")
+        );
+
+        let legacy_type = resolve_model_fetch_target(&config, "openai").unwrap();
+        assert_eq!(legacy_type.routing_key, "work");
+        assert_eq!(legacy_type.api_key.as_deref(), Some("sk-work"));
+    }
+
+    #[test]
+    fn explicit_default_instance_beats_stale_legacy_type_config() {
+        let mut config = Config::default();
+        config.providers_mut().openai = Some(OpenAIConfig {
+            api_key: "sk-stale".to_string(),
+            base_url: Some("https://stale.example/v1".to_string()),
+            ..OpenAIConfig::default()
+        });
+        config.provider_instances.insert(
+            "work".to_string(),
+            instance("sk-work", "https://work.example/v1"),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        let target = resolve_model_fetch_target(&config, "openai").unwrap();
+        assert_eq!(target.routing_key, "work");
+        assert_eq!(target.api_key.as_deref(), Some("sk-work"));
+    }
+
+    #[test]
+    fn missing_effective_hybrid_default_uses_real_legacy_alias() {
+        let mut config = Config::default();
+        config.provider = "openai".to_string();
+        config.providers_mut().openai = Some(OpenAIConfig {
+            api_key: "sk-legacy-default".to_string(),
+            base_url: Some("https://legacy.example/v1".to_string()),
+            ..OpenAIConfig::default()
+        });
+        config.provider_instances.insert(
+            "work".to_string(),
+            instance("sk-work", "https://work.example/v1"),
+        );
+
+        let target = resolve_model_fetch_target(&config, "openai").unwrap();
+        assert_eq!(target.routing_key, "openai");
+        assert_eq!(target.api_key.as_deref(), Some("sk-legacy-default"));
+    }
+
+    #[test]
+    fn payload_instance_id_has_precedence_and_default_is_instance_aware() {
+        let mut config = Config::default();
+        config.provider_instances.insert(
+            "work".to_string(),
+            instance("sk-work", "https://work.example/v1"),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        assert_eq!(
+            provider_key_from_payload(
+                &serde_json::json!({
+                    "provider": "openai",
+                    "provider_instance_id": "work"
+                }),
+                &config
+            ),
+            "work"
+        );
+        assert_eq!(
+            provider_key_from_payload(&serde_json::json!({}), &config),
+            "work"
+        );
+    }
+
+    #[test]
+    fn selected_legacy_copilot_needs_no_provider_stanza() {
+        let mut config = Config::default();
+        config.provider = "copilot".to_string();
+        *config.providers_mut() = bamboo_config::ProviderConfigs::default();
+
+        let target = resolve_model_fetch_target(&config, "copilot").unwrap();
+        assert_eq!(target.routing_key, "copilot");
+        assert_eq!(target.provider_type, "copilot");
+        assert!(target.api_key.is_none());
+    }
+
+    #[test]
+    fn exact_copilot_instance_keeps_its_registry_routing_key() {
+        let mut config = Config::default();
+        for id in ["copilot-work", "copilot-personal"] {
+            config.provider_instances.insert(
+                id.to_string(),
+                serde_json::from_value(serde_json::json!({
+                    "provider_type": "copilot",
+                    "enabled": true
+                }))
+                .unwrap(),
+            );
+        }
+        config.default_provider_instance = Some("copilot-work".to_string());
+
+        let target = resolve_model_fetch_target(&config, "copilot-personal").unwrap();
+        assert_eq!(target.routing_key, "copilot-personal");
+        assert_eq!(target.provider_type, "copilot");
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/provider/models/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/models/mod.rs
@@ -14,11 +14,10 @@ pub async fn fetch_provider_models(
     payload: web::Json<serde_json::Value>,
 ) -> Result<HttpResponse, AppError> {
     let config = app_state.config.read().await.clone();
-    let provider_type = dispatch::provider_type_from_payload(&payload, &config.provider);
+    let provider_key = dispatch::provider_key_from_payload(&payload, &config);
+    let target = dispatch::resolve_model_fetch_target(&config, &provider_key)?;
     let client = dispatch::build_proxy_aware_http_client(&config)?;
-    let models =
-        dispatch::fetch_models_for_provider(app_state.get_ref(), &config, provider_type, &client)
-            .await?;
+    let models = dispatch::fetch_models_for_provider(app_state.get_ref(), &target, &client).await?;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "models": models })))
 }

--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -136,11 +136,16 @@ fn instance_config_to_api(instance: &ProviderInstanceConfig) -> Map<String, Valu
         config.insert("request_overrides".to_string(), value);
     }
 
-    for (key, value) in &instance.extra {
-        if key == "api_key_encrypted" {
-            continue;
-        }
-        config.insert(key.clone(), value.clone());
+    let mut public_extra = Value::Object(
+        instance
+            .extra
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    );
+    bamboo_config::scrub_provider_metadata_credentials(&mut public_extra);
+    if let Value::Object(public_extra) = public_extra {
+        config.extend(public_extra);
     }
 
     config
@@ -187,6 +192,21 @@ fn validate_provider_type(provider_type: &str) -> Result<(), AppError> {
 fn validate_instance_config(instance: &ProviderInstanceConfig) -> Result<(), AppError> {
     validate_provider_type(&instance.provider_type)?;
 
+    if let Some(request_overrides) = &instance.request_overrides {
+        let original = serde_json::to_value(request_overrides).map_err(|error| {
+            AppError::BadRequest(format!("Invalid provider request_overrides: {error}"))
+        })?;
+        let mut sanitized = original.clone();
+        crate::handlers::settings::bamboo_config::scrub_unsafe_request_override_literals(
+            &mut sanitized,
+        );
+        if sanitized != original {
+            return Err(AppError::BadRequest(
+                "provider request_overrides contain literal credential material".to_string(),
+            ));
+        }
+    }
+
     if let Some(value) = instance
         .extra
         .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY)
@@ -214,6 +234,19 @@ fn validate_instance_config(instance: &ProviderInstanceConfig) -> Result<(), App
     {
         return Err(AppError::BadRequest(
             "api_key is required for non-copilot providers".to_string(),
+        ));
+    }
+
+    let extra = Value::Object(
+        instance
+            .extra
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    );
+    if !bamboo_config::provider_metadata_is_secret_free(&extra) {
+        return Err(AppError::BadRequest(
+            "provider instance config contains credential material outside api_key".to_string(),
         ));
     }
 
@@ -285,7 +318,23 @@ fn apply_instance_update(
     existing: &ProviderInstanceConfig,
     payload: &UpdateInstanceRequest,
 ) -> Result<ProviderInstanceConfig, AppError> {
-    let mut merged = instance_to_patchable_value(existing)?;
+    // Never preserve a credential-shaped field from a recovered legacy/LKG
+    // `extra` map. It is not part of the credential authority and old clients
+    // cannot safely round-trip it.
+    let mut sanitized_existing = existing.clone();
+    let mut public_extra = Value::Object(
+        sanitized_existing
+            .extra
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    );
+    bamboo_config::scrub_provider_metadata_credentials(&mut public_extra);
+    sanitized_existing.extra = match public_extra {
+        Value::Object(extra) => extra.into_iter().collect(),
+        _ => Default::default(),
+    };
+    let mut merged = instance_to_patchable_value(&sanitized_existing)?;
     let Some(obj) = merged.as_object_mut() else {
         return Err(AppError::InternalError(anyhow::anyhow!(
             "Serialized provider instance was not a JSON object"
@@ -708,6 +757,36 @@ mod tests {
     }
 
     #[test]
+    fn arbitrary_extra_cannot_write_or_echo_credential_material() {
+        let mut request = create_request("sk-real");
+        request.config["private_key"] = Value::String("private-extra-literal".to_string());
+        request.config["nested"] = serde_json::json!({
+            "client_secret": "client-extra-literal"
+        });
+        let error = build_instance_from_create(&request)
+            .expect_err("credential-shaped extra must be rejected");
+        assert!(matches!(error, AppError::BadRequest(_)));
+
+        let mut recovered = build_instance_from_create(&create_request("sk-real")).unwrap();
+        recovered.extra.insert(
+            "private_key".to_string(),
+            Value::String("recovered-private-literal".to_string()),
+        );
+        recovered.extra.insert(
+            "oauth".to_string(),
+            serde_json::json!({
+                "client_id": "public-client-id",
+                "value": "recovered-oauth-literal"
+            }),
+        );
+        let response = Value::Object(instance_config_to_api(&recovered));
+        let serialized = serde_json::to_string(&response).unwrap();
+        assert!(!serialized.contains("recovered-private-literal"));
+        assert!(!serialized.contains("recovered-oauth-literal"));
+        assert_eq!(response["oauth"]["client_id"], "public-client-id");
+    }
+
+    #[test]
     fn api_reports_ref_backed_instance_as_configured_without_exposing_ref() {
         let mut instance = build_instance_from_create(&create_request("sk-real")).unwrap();
         instance.api_key.clear();
@@ -748,10 +827,12 @@ mod tests {
                 "common": {
                     "headers": {
                         "Authorization": "Bearer response-secret",
+                        "X-Access-Key": "access-key-response-secret",
                         "X-Api-Key": {"type": "env_ref", "name": "SAFE_API_KEY"}
                     },
                     "body_patch": [
                         {"path": "/api_key", "value": "body-response-secret"},
+                        {"path": "/credential", "value": "credential-response-secret"},
                         {"path": "/api_key", "value": {"type": "env_ref", "name": "SAFE_API_KEY"}}
                     ]
                 }
@@ -762,7 +843,9 @@ mod tests {
         let api = Value::Object(instance_config_to_api(&instance));
         let serialized = serde_json::to_string(&api).unwrap();
         assert!(!serialized.contains("response-secret"));
+        assert!(!serialized.contains("access-key-response-secret"));
         assert!(!serialized.contains("body-response-secret"));
+        assert!(!serialized.contains("credential-response-secret"));
         assert_eq!(
             api["request_overrides"]["common"]["headers"]["X-Api-Key"]["type"],
             "env_ref"
@@ -774,6 +857,31 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn create_rejects_literal_request_override_credentials() {
+        let mut literal = create_request("sk-real");
+        literal.config["request_overrides"] = serde_json::json!({
+            "common": {
+                "headers": {"X-Access-Key": "literal-access-key"},
+                "body_patch": [{"path": "/credential", "value": "literal-body-key"}]
+            }
+        });
+        assert!(matches!(
+            build_instance_from_create(&literal),
+            Err(AppError::BadRequest(_))
+        ));
+
+        let mut runtime = create_request("sk-real");
+        runtime.config["request_overrides"] = serde_json::json!({
+            "common": {
+                "headers": {
+                    "X-Access-Key": {"type": "env_ref", "name": "UPSTREAM_ACCESS_KEY"}
+                }
+            }
+        });
+        build_instance_from_create(&runtime).expect("runtime credential reference is secret-free");
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -767,6 +767,16 @@ mod tests {
             .expect_err("credential-shaped extra must be rejected");
         assert!(matches!(error, AppError::BadRequest(_)));
 
+        for field in ["secrets", "tokens", "passwords", "api_keys"] {
+            let mut plural = create_request("sk-real");
+            plural.config[field] = serde_json::json!({
+                "primary": format!("plural-{field}-literal")
+            });
+            let error = build_instance_from_create(&plural)
+                .expect_err("plural credential container must be rejected");
+            assert!(matches!(error, AppError::BadRequest(_)), "field: {field}");
+        }
+
         let mut recovered = build_instance_from_create(&create_request("sk-real")).unwrap();
         recovered.extra.insert(
             "private_key".to_string(),
@@ -779,10 +789,20 @@ mod tests {
                 "value": "recovered-oauth-literal"
             }),
         );
+        recovered.extra.insert(
+            "secrets".to_string(),
+            serde_json::json!({"primary": "recovered-plural-literal"}),
+        );
+        recovered.extra.insert(
+            "api_keys".to_string(),
+            serde_json::json!({"primary": "recovered-api-keys-literal"}),
+        );
         let response = Value::Object(instance_config_to_api(&recovered));
         let serialized = serde_json::to_string(&response).unwrap();
         assert!(!serialized.contains("recovered-private-literal"));
         assert!(!serialized.contains("recovered-oauth-literal"));
+        assert!(!serialized.contains("recovered-plural-literal"));
+        assert!(!serialized.contains("recovered-api-keys-literal"));
         assert_eq!(response["oauth"]["client_id"], "public-client-id");
     }
 
@@ -828,11 +848,14 @@ mod tests {
                     "headers": {
                         "Authorization": "Bearer response-secret",
                         "X-Access-Key": "access-key-response-secret",
+                        "X-Private-Key": "private-key-response-secret",
+                        "X-Device-Key": "device-key-response-secret",
                         "X-Api-Key": {"type": "env_ref", "name": "SAFE_API_KEY"}
                     },
                     "body_patch": [
                         {"path": "/api_key", "value": "body-response-secret"},
                         {"path": "/credential", "value": "credential-response-secret"},
+                        {"path": "/secrets/primary", "value": "plural-response-secret"},
                         {"path": "/api_key", "value": {"type": "env_ref", "name": "SAFE_API_KEY"}}
                     ]
                 }
@@ -844,8 +867,11 @@ mod tests {
         let serialized = serde_json::to_string(&api).unwrap();
         assert!(!serialized.contains("response-secret"));
         assert!(!serialized.contains("access-key-response-secret"));
+        assert!(!serialized.contains("private-key-response-secret"));
+        assert!(!serialized.contains("device-key-response-secret"));
         assert!(!serialized.contains("body-response-secret"));
         assert!(!serialized.contains("credential-response-secret"));
+        assert!(!serialized.contains("plural-response-secret"));
         assert_eq!(
             api["request_overrides"]["common"]["headers"]["X-Api-Key"]["type"],
             "env_ref"
@@ -864,8 +890,8 @@ mod tests {
         let mut literal = create_request("sk-real");
         literal.config["request_overrides"] = serde_json::json!({
             "common": {
-                "headers": {"X-Access-Key": "literal-access-key"},
-                "body_patch": [{"path": "/credential", "value": "literal-body-key"}]
+                "headers": {"X-Private-Key": "literal-private-key"},
+                "body_patch": [{"path": "/secrets/primary", "value": "literal-body-key"}]
             }
         });
         assert!(matches!(
@@ -882,6 +908,119 @@ mod tests {
             }
         });
         build_instance_from_create(&runtime).expect("runtime credential reference is secret-free");
+    }
+
+    #[actix_web::test]
+    async fn credential_shaped_writes_stay_rejected_after_real_restart_and_read() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("initial app state"),
+        );
+        let app = actix_web::test::init_service(
+            actix_web::App::new()
+                .app_data(state.clone())
+                .route("/instances", web::post().to(create_provider_instance))
+                .route("/instances", web::get().to(list_provider_instances)),
+        )
+        .await;
+
+        let attempts = [
+            serde_json::json!({
+                "type": "openai",
+                "config": {
+                    "api_key": "valid-provider-key",
+                    "secrets": {"value": "restart-extra-secret"}
+                }
+            }),
+            serde_json::json!({
+                "type": "openai",
+                "config": {
+                    "api_key": "valid-provider-key",
+                    "request_overrides": {"common": {
+                        "headers": {"X-Private-Key": "restart-header-secret"}
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "type": "openai",
+                "config": {
+                    "api_key": "valid-provider-key",
+                    "request_overrides": {"common": {
+                        "body_patch": [{
+                            "path": "/secrets/primary",
+                            "value": "restart-body-secret"
+                        }]
+                    }}
+                }
+            }),
+        ];
+        for payload in attempts {
+            let response = actix_web::test::call_service(
+                &app,
+                actix_web::test::TestRequest::post()
+                    .uri("/instances")
+                    .set_json(payload)
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        }
+        drop(app);
+        drop(state);
+
+        for name in ["config.json", "providers.json", "credentials.json"] {
+            let path = temp_dir.path().join(name);
+            if let Ok(contents) = std::fs::read_to_string(path) {
+                for forbidden in [
+                    "restart-extra-secret",
+                    "restart-header-secret",
+                    "restart-body-secret",
+                    "valid-provider-key",
+                ] {
+                    assert!(
+                        !contents.contains(forbidden),
+                        "{name} retained rejected credential material"
+                    );
+                }
+            }
+        }
+
+        let restarted = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("restarted app state"),
+        );
+        let app = actix_web::test::init_service(
+            actix_web::App::new()
+                .app_data(restarted)
+                .route("/instances", web::get().to(list_provider_instances)),
+        )
+        .await;
+        let response = actix_web::test::call_service(
+            &app,
+            actix_web::test::TestRequest::get()
+                .uri("/instances")
+                .to_request(),
+        )
+        .await;
+        assert!(response.status().is_success());
+        let body = String::from_utf8(actix_web::test::read_body(response).await.to_vec())
+            .expect("UTF-8 response");
+        for forbidden in [
+            "restart-extra-secret",
+            "restart-header-secret",
+            "restart-body-secret",
+            "valid-provider-key",
+        ] {
+            assert!(
+                !body.contains(forbidden),
+                "restart response leaked {forbidden}"
+            );
+        }
+        let body: Value = serde_json::from_str(&body).expect("valid response JSON");
+        assert_eq!(body["instances"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -128,10 +128,12 @@ fn instance_config_to_api(instance: &ProviderInstanceConfig) -> Map<String, Valu
         );
     }
     if let Some(request_overrides) = &instance.request_overrides {
-        config.insert(
-            "request_overrides".to_string(),
-            serde_json::to_value(request_overrides).expect("request_overrides should serialize"),
+        let mut value =
+            serde_json::to_value(request_overrides).expect("request_overrides should serialize");
+        crate::handlers::settings::bamboo_config::scrub_unsafe_request_override_literals(
+            &mut value,
         );
+        config.insert("request_overrides".to_string(), value);
     }
 
     for (key, value) in &instance.extra {
@@ -203,7 +205,13 @@ fn validate_instance_config(instance: &ProviderInstanceConfig) -> Result<(), App
         }
     }
 
-    if instance.provider_type != "copilot" && instance.api_key.trim().is_empty() {
+    if instance.enabled
+        && instance.provider_type != "copilot"
+        && instance.api_key.trim().is_empty()
+        && instance.api_key_encrypted.is_none()
+        && instance.credential_ref.is_none()
+        && !bamboo_config::provider_instance_api_key_from_env(instance)
+    {
         return Err(AppError::BadRequest(
             "api_key is required for non-copilot providers".to_string(),
         ));
@@ -224,6 +232,7 @@ fn build_instance_from_create(
     let mut obj = config_value_as_object(payload.config.clone())?;
     obj.remove("api_key_encrypted");
     obj.remove("credential_ref");
+    obj.remove(bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY);
     obj.insert(
         "provider_type".to_string(),
         Value::String(payload.provider_type.clone()),
@@ -293,8 +302,12 @@ fn apply_instance_update(
     if let Some(config_patch) = payload.config.clone() {
         let mut patch_obj = config_value_as_object(config_patch)?;
 
-        if let Some(api_key) = patch_obj.get("api_key").and_then(|v| v.as_str()) {
-            if config_manager::is_masked_api_key(api_key) {
+        let clear_runtime_env_marker = match patch_obj.get("api_key") {
+            Some(Value::Null) => {
+                patch_obj.insert("api_key".to_string(), Value::String(String::new()));
+                true
+            }
+            Some(Value::String(api_key)) if config_manager::is_masked_api_key(api_key) => {
                 if existing.api_key.trim().is_empty() {
                     patch_obj.remove("api_key");
                 } else {
@@ -303,14 +316,27 @@ fn apply_instance_update(
                         Value::String(existing.api_key.clone()),
                     );
                 }
+                false
             }
-        }
+            Some(Value::String(_)) => true,
+            Some(_) => {
+                return Err(AppError::BadRequest(
+                    "api_key must be a string, null, or the masked placeholder".to_string(),
+                ));
+            }
+            None => false,
+        };
 
         patch_obj.remove("provider_type");
         patch_obj.remove("label");
         patch_obj.remove("enabled");
         patch_obj.remove("api_key_encrypted");
         patch_obj.remove("credential_ref");
+        patch_obj.remove(bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY);
+
+        if clear_runtime_env_marker {
+            obj.remove(bamboo_config::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY);
+        }
 
         for (key, value) in patch_obj {
             obj.insert(key, value);
@@ -326,6 +352,47 @@ fn apply_instance_update(
         .map_err(|e| AppError::BadRequest(format!("Invalid provider instance config: {e}")))?;
     validate_instance_config(&updated)?;
     Ok(updated)
+}
+
+fn legacy_provider_alias_exists(config: &bamboo_config::Config, target_id: &str) -> bool {
+    match target_id {
+        "openai" => config.providers().openai.is_some(),
+        "anthropic" => config.providers().anthropic.is_some(),
+        "gemini" => config.providers().gemini.is_some(),
+        "copilot" => config.providers().copilot.is_some(),
+        "bodhi" => config.providers().bodhi.is_some(),
+        _ => false,
+    }
+}
+
+fn validate_default_target(
+    config: &bamboo_config::Config,
+    target_id: &str,
+) -> Result<(), AppError> {
+    if let Some(instance) = config.provider_instances.get(target_id) {
+        if !instance.enabled {
+            return Err(AppError::BadRequest(format!(
+                "Cannot set '{target_id}' as default: provider instance is disabled"
+            )));
+        }
+        return Ok(());
+    }
+    if legacy_provider_alias_exists(config, target_id) {
+        return Ok(());
+    }
+    Err(AppError::BadRequest(format!(
+        "Cannot set '{target_id}' as default: no provider instance or legacy provider configuration exists"
+    )))
+}
+
+fn next_enabled_instance_id(config: &bamboo_config::Config) -> Option<String> {
+    config
+        .provider_instances
+        .iter()
+        .filter(|(_, instance)| instance.enabled)
+        .map(|(id, _)| id)
+        .min()
+        .cloned()
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────
@@ -370,7 +437,8 @@ pub async fn create_provider_instance(
                         instance_id
                     )));
                 }
-                let should_set_default = config.default_provider_instance.is_none();
+                let should_set_default =
+                    config.default_provider_instance.is_none() && instance_config.enabled;
                 config
                     .provider_instances
                     .insert(instance_id.clone(), instance_config.clone());
@@ -499,7 +567,7 @@ pub async fn delete_provider_instance(
                     )));
                 }
                 if config.default_provider_instance.as_deref() == Some(&instance_id_for_closure) {
-                    config.default_provider_instance = None;
+                    config.default_provider_instance = next_enabled_instance_id(config);
                 }
                 Ok(())
             },
@@ -529,14 +597,7 @@ pub async fn set_default_provider_instance(
     let new_config = app_state
         .update_config(
             move |config| {
-                let is_instance = config.provider_instances.contains_key(&target_id);
-                let is_legacy_type = AVAILABLE_PROVIDERS.contains(&target_id.as_str());
-                if !is_instance && !is_legacy_type {
-                    return Err(AppError::BadRequest(format!(
-                        "Cannot set '{}' as default: not a known provider instance or type",
-                        target_id
-                    )));
-                }
+                validate_default_target(config, &target_id)?;
                 config.default_provider_instance = Some(target_id.clone());
                 Ok(())
             },
@@ -656,6 +717,178 @@ mod tests {
         assert_eq!(api["api_key"], "****...****");
         assert!(!api.contains_key("credential_ref"));
         assert!(!api.contains_key("api_key_encrypted"));
+    }
+
+    #[test]
+    fn api_reports_environment_binding_as_configured_only_when_runtime_key_is_available() {
+        let mut instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "enabled": true,
+            "api_key_from_env": true
+        }))
+        .unwrap();
+        instance.api_key.clear();
+
+        let api = instance_config_to_api(&instance);
+        assert!(!api.contains_key("api_key"));
+        assert_eq!(api["api_key_from_env"], true);
+        validate_instance_config(&instance).expect("env marker satisfies runtime credential shape");
+
+        instance.api_key = "sk-runtime-env".to_string();
+        let api = instance_config_to_api(&instance);
+        assert_eq!(api["api_key"], "****...****");
+    }
+
+    #[test]
+    fn api_scrubs_sensitive_request_override_literals() {
+        let instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "enabled": true,
+            "request_overrides": {
+                "common": {
+                    "headers": {
+                        "Authorization": "Bearer response-secret",
+                        "X-Api-Key": {"type": "env_ref", "name": "SAFE_API_KEY"}
+                    },
+                    "body_patch": [
+                        {"path": "/api_key", "value": "body-response-secret"},
+                        {"path": "/api_key", "value": {"type": "env_ref", "name": "SAFE_API_KEY"}}
+                    ]
+                }
+            }
+        }))
+        .unwrap();
+
+        let api = Value::Object(instance_config_to_api(&instance));
+        let serialized = serde_json::to_string(&api).unwrap();
+        assert!(!serialized.contains("response-secret"));
+        assert!(!serialized.contains("body-response-secret"));
+        assert_eq!(
+            api["request_overrides"]["common"]["headers"]["X-Api-Key"]["type"],
+            "env_ref"
+        );
+        assert_eq!(
+            api["request_overrides"]["common"]["body_patch"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn api_key_intent_clears_environment_ownership_but_mask_retains_it() {
+        let mut instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "enabled": true,
+            "api_key_from_env": true
+        }))
+        .unwrap();
+        instance.api_key = "sk-from-runtime-env".to_string();
+
+        let masked = apply_instance_update(
+            &instance,
+            &UpdateInstanceRequest {
+                label: Some("Renamed".to_string()),
+                enabled: None,
+                config: Some(serde_json::json!({"api_key": "****...****"})),
+            },
+        )
+        .unwrap();
+        assert!(bamboo_config::provider_instance_api_key_from_env(&masked));
+        assert_eq!(masked.api_key, "sk-from-runtime-env");
+
+        let replaced = apply_instance_update(
+            &instance,
+            &UpdateInstanceRequest {
+                label: None,
+                enabled: None,
+                config: Some(serde_json::json!({"api_key": "sk-user-owned"})),
+            },
+        )
+        .unwrap();
+        assert!(!bamboo_config::provider_instance_api_key_from_env(
+            &replaced
+        ));
+        assert_eq!(replaced.api_key, "sk-user-owned");
+
+        let cleared = apply_instance_update(
+            &instance,
+            &UpdateInstanceRequest {
+                label: None,
+                enabled: Some(false),
+                config: Some(serde_json::json!({"api_key": null})),
+            },
+        )
+        .unwrap();
+        assert!(!bamboo_config::provider_instance_api_key_from_env(&cleared));
+        assert!(cleared.api_key.is_empty());
+    }
+
+    #[test]
+    fn create_does_not_accept_client_owned_environment_marker() {
+        let request = CreateInstanceRequest {
+            provider_type: "openai".to_string(),
+            label: None,
+            enabled: None,
+            config: serde_json::json!({
+                "api_key": "sk-user-owned",
+                "api_key_from_env": true
+            }),
+        };
+        let instance = build_instance_from_create(&request).unwrap();
+        assert!(!bamboo_config::provider_instance_api_key_from_env(
+            &instance
+        ));
+    }
+
+    #[test]
+    fn default_target_requires_real_enabled_instance_or_real_legacy_alias() {
+        let mut config = bamboo_config::Config::default();
+        *config.providers_mut() = bamboo_config::ProviderConfigs::default();
+        assert!(matches!(
+            validate_default_target(&config, "openai"),
+            Err(AppError::BadRequest(_))
+        ));
+
+        config.providers_mut().openai = Some(Default::default());
+        validate_default_target(&config, "openai").expect("real hybrid alias remains compatible");
+
+        let mut disabled: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "enabled": false
+        }))
+        .unwrap();
+        disabled.api_key = "sk-disabled".to_string();
+        config
+            .provider_instances
+            .insert("disabled".to_string(), disabled);
+        assert!(matches!(
+            validate_default_target(&config, "disabled"),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn deleting_default_selects_next_enabled_instance_deterministically() {
+        let mut config = bamboo_config::Config::default();
+        for (id, enabled) in [("z-last", true), ("a-first", true), ("disabled", false)] {
+            let mut instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+                "provider_type": "copilot",
+                "enabled": enabled
+            }))
+            .unwrap();
+            instance.enabled = enabled;
+            config.provider_instances.insert(id.to_string(), instance);
+        }
+        assert_eq!(
+            next_enabled_instance_id(&config).as_deref(),
+            Some("a-first")
+        );
+        config.provider_instances.remove("a-first");
+        assert_eq!(next_enabled_instance_id(&config).as_deref(), Some("z-last"));
+        config.provider_instances.remove("z-last");
+        assert!(next_enabled_instance_id(&config).is_none());
     }
 
     // A provider-instance secret is committed to credentials.json before its

--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -86,13 +86,13 @@ fn default_label_for_provider_type(provider_type: &str) -> String {
     }
 }
 
-fn instance_config_to_api(instance: &ProviderInstanceConfig) -> Map<String, Value> {
+fn instance_config_to_api(
+    instance: &ProviderInstanceConfig,
+    credential_configured: bool,
+) -> Map<String, Value> {
     let mut config = Map::new();
 
-    if !instance.api_key.trim().is_empty()
-        || instance.api_key_encrypted.is_some()
-        || instance.credential_ref.is_some()
-    {
+    if credential_configured {
         config.insert(
             "api_key".to_string(),
             Value::String("****...****".to_string()),
@@ -151,7 +151,11 @@ fn instance_config_to_api(instance: &ProviderInstanceConfig) -> Map<String, Valu
     config
 }
 
-fn instance_to_api(id: &str, instance: &ProviderInstanceConfig) -> ProviderInstanceResponse {
+fn instance_to_api(
+    id: &str,
+    instance: &ProviderInstanceConfig,
+    credential_configured: bool,
+) -> ProviderInstanceResponse {
     ProviderInstanceResponse {
         id: id.to_string(),
         r#type: instance.provider_type.clone(),
@@ -160,8 +164,21 @@ fn instance_to_api(id: &str, instance: &ProviderInstanceConfig) -> ProviderInsta
             .clone()
             .unwrap_or_else(|| default_label_for_provider_type(&instance.provider_type)),
         enabled: instance.enabled,
-        config: instance_config_to_api(instance),
+        config: instance_config_to_api(instance, credential_configured),
     }
+}
+
+fn instance_credential_configured(app_state: &AppState, instance: &ProviderInstanceConfig) -> bool {
+    if bamboo_config::provider_instance_environment_override_active(instance) {
+        return true;
+    }
+    if let Some(reference) = instance.credential_ref.as_ref() {
+        return app_state
+            .credential_store
+            .status_with_crypto_validation(reference)
+            .is_ok_and(|status| status.configured);
+    }
+    !instance.api_key.trim().is_empty()
 }
 
 fn validate_instance_id(id: &str) -> Result<(), AppError> {
@@ -454,7 +471,13 @@ pub async fn list_provider_instances(
     let instances: Vec<ProviderInstanceResponse> = config
         .provider_instances
         .iter()
-        .map(|(id, instance)| instance_to_api(id, instance))
+        .map(|(id, instance)| {
+            instance_to_api(
+                id,
+                instance,
+                instance_credential_configured(&app_state, instance),
+            )
+        })
         .collect();
 
     Ok(HttpResponse::Ok().json(ListInstancesResponse {
@@ -519,7 +542,11 @@ pub async fn create_provider_instance(
             ))
         })?;
 
-    Ok(HttpResponse::Created().json(instance_to_api(&instance_id_for_response, created)))
+    Ok(HttpResponse::Created().json(instance_to_api(
+        &instance_id_for_response,
+        created,
+        instance_credential_configured(&app_state, created),
+    )))
 }
 
 /// PUT /bamboo/settings/provider-instances/{instance_id}
@@ -589,7 +616,11 @@ pub async fn update_provider_instance(
             ))
         })?;
 
-    Ok(HttpResponse::Ok().json(instance_to_api(&instance_id_for_response, updated)))
+    Ok(HttpResponse::Ok().json(instance_to_api(
+        &instance_id_for_response,
+        updated,
+        instance_credential_configured(&app_state, updated),
+    )))
 }
 
 /// DELETE /bamboo/settings/provider-instances/{instance_id}
@@ -705,7 +736,7 @@ mod tests {
             Some(&Value::Bool(false))
         );
         assert_eq!(
-            instance_config_to_api(&instance)
+            instance_config_to_api(&instance, true)
                 .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY),
             Some(&Value::Bool(false))
         );
@@ -767,7 +798,15 @@ mod tests {
             .expect_err("credential-shaped extra must be rejected");
         assert!(matches!(error, AppError::BadRequest(_)));
 
-        for field in ["secrets", "tokens", "passwords", "api_keys"] {
+        for field in [
+            "secrets",
+            "tokens",
+            "client_tokens",
+            "service_tokens",
+            "provider_tokens",
+            "passwords",
+            "api_keys",
+        ] {
             let mut plural = create_request("sk-real");
             plural.config[field] = serde_json::json!({
                 "primary": format!("plural-{field}-literal")
@@ -797,25 +836,34 @@ mod tests {
             "api_keys".to_string(),
             serde_json::json!({"primary": "recovered-api-keys-literal"}),
         );
-        let response = Value::Object(instance_config_to_api(&recovered));
+        recovered.extra.insert(
+            "client_tokens".to_string(),
+            serde_json::json!(["recovered-client-token-literal"]),
+        );
+        let response = Value::Object(instance_config_to_api(&recovered, true));
         let serialized = serde_json::to_string(&response).unwrap();
         assert!(!serialized.contains("recovered-private-literal"));
         assert!(!serialized.contains("recovered-oauth-literal"));
         assert!(!serialized.contains("recovered-plural-literal"));
         assert!(!serialized.contains("recovered-api-keys-literal"));
+        assert!(!serialized.contains("recovered-client-token-literal"));
         assert_eq!(response["oauth"]["client_id"], "public-client-id");
     }
 
     #[test]
-    fn api_reports_ref_backed_instance_as_configured_without_exposing_ref() {
+    fn api_masks_ref_backed_instance_only_after_credential_validation() {
         let mut instance = build_instance_from_create(&create_request("sk-real")).unwrap();
         instance.api_key.clear();
         instance.credential_ref =
             Some(bamboo_config::credential_ref("provider_instance", "work", "api_key").unwrap());
-        let api = instance_config_to_api(&instance);
+        let api = instance_config_to_api(&instance, true);
         assert_eq!(api["api_key"], "****...****");
         assert!(!api.contains_key("credential_ref"));
         assert!(!api.contains_key("api_key_encrypted"));
+
+        let unavailable = instance_config_to_api(&instance, false);
+        assert!(!unavailable.contains_key("api_key"));
+        assert!(!unavailable.contains_key("credential_ref"));
     }
 
     #[test]
@@ -828,13 +876,13 @@ mod tests {
         .unwrap();
         instance.api_key.clear();
 
-        let api = instance_config_to_api(&instance);
+        let api = instance_config_to_api(&instance, false);
         assert!(!api.contains_key("api_key"));
         assert_eq!(api["api_key_from_env"], true);
         validate_instance_config(&instance).expect("env marker satisfies runtime credential shape");
 
         instance.api_key = "sk-runtime-env".to_string();
-        let api = instance_config_to_api(&instance);
+        let api = instance_config_to_api(&instance, true);
         assert_eq!(api["api_key"], "****...****");
     }
 
@@ -850,12 +898,14 @@ mod tests {
                         "X-Access-Key": "access-key-response-secret",
                         "X-Private-Key": "private-key-response-secret",
                         "X-Device-Key": "device-key-response-secret",
+                        "X-Client-Tokens": "client-tokens-response-secret",
                         "X-Api-Key": {"type": "env_ref", "name": "SAFE_API_KEY"}
                     },
                     "body_patch": [
                         {"path": "/api_key", "value": "body-response-secret"},
                         {"path": "/credential", "value": "credential-response-secret"},
                         {"path": "/secrets/primary", "value": "plural-response-secret"},
+                        {"path": "/client_tokens/0", "value": "client-token-body-secret"},
                         {"path": "/api_key", "value": {"type": "env_ref", "name": "SAFE_API_KEY"}}
                     ]
                 }
@@ -863,15 +913,17 @@ mod tests {
         }))
         .unwrap();
 
-        let api = Value::Object(instance_config_to_api(&instance));
+        let api = Value::Object(instance_config_to_api(&instance, false));
         let serialized = serde_json::to_string(&api).unwrap();
         assert!(!serialized.contains("response-secret"));
         assert!(!serialized.contains("access-key-response-secret"));
         assert!(!serialized.contains("private-key-response-secret"));
         assert!(!serialized.contains("device-key-response-secret"));
+        assert!(!serialized.contains("client-tokens-response-secret"));
         assert!(!serialized.contains("body-response-secret"));
         assert!(!serialized.contains("credential-response-secret"));
         assert!(!serialized.contains("plural-response-secret"));
+        assert!(!serialized.contains("client-token-body-secret"));
         assert_eq!(
             api["request_overrides"]["common"]["headers"]["X-Api-Key"]["type"],
             "env_ref"
@@ -890,8 +942,14 @@ mod tests {
         let mut literal = create_request("sk-real");
         literal.config["request_overrides"] = serde_json::json!({
             "common": {
-                "headers": {"X-Private-Key": "literal-private-key"},
-                "body_patch": [{"path": "/secrets/primary", "value": "literal-body-key"}]
+                "headers": {
+                    "X-Private-Key": "literal-private-key",
+                    "X-Client-Tokens": "literal-client-tokens"
+                },
+                "body_patch": [
+                    {"path": "/secrets/primary", "value": "literal-body-key"},
+                    {"path": "/client_tokens/0", "value": "literal-client-token-body"}
+                ]
             }
         });
         assert!(matches!(
@@ -938,8 +996,24 @@ mod tests {
                 "type": "openai",
                 "config": {
                     "api_key": "valid-provider-key",
+                    "client_tokens": ["restart-client-token-secret"]
+                }
+            }),
+            serde_json::json!({
+                "type": "openai",
+                "config": {
+                    "api_key": "valid-provider-key",
                     "request_overrides": {"common": {
                         "headers": {"X-Private-Key": "restart-header-secret"}
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "type": "openai",
+                "config": {
+                    "api_key": "valid-provider-key",
+                    "request_overrides": {"common": {
+                        "headers": {"X-Client-Tokens": "restart-client-header-secret"}
                     }}
                 }
             }),
@@ -951,6 +1025,18 @@ mod tests {
                         "body_patch": [{
                             "path": "/secrets/primary",
                             "value": "restart-body-secret"
+                        }]
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "type": "openai",
+                "config": {
+                    "api_key": "valid-provider-key",
+                    "request_overrides": {"common": {
+                        "body_patch": [{
+                            "path": "/client_tokens/0",
+                            "value": "restart-client-body-secret"
                         }]
                     }}
                 }
@@ -975,8 +1061,11 @@ mod tests {
             if let Ok(contents) = std::fs::read_to_string(path) {
                 for forbidden in [
                     "restart-extra-secret",
+                    "restart-client-token-secret",
                     "restart-header-secret",
+                    "restart-client-header-secret",
                     "restart-body-secret",
+                    "restart-client-body-secret",
                     "valid-provider-key",
                 ] {
                     assert!(
@@ -1010,8 +1099,11 @@ mod tests {
             .expect("UTF-8 response");
         for forbidden in [
             "restart-extra-secret",
+            "restart-client-token-secret",
             "restart-header-secret",
+            "restart-client-header-secret",
             "restart-body-secret",
+            "restart-client-body-secret",
             "valid-provider-key",
         ] {
             assert!(
@@ -1021,6 +1113,129 @@ mod tests {
         }
         let body: Value = serde_json::from_str(&body).expect("valid response JSON");
         assert_eq!(body["instances"], serde_json::json!([]));
+    }
+
+    #[actix_web::test]
+    async fn credential_recovery_failures_are_unconfigured_across_provider_apis() {
+        let _openai_env =
+            bamboo_config::test_support::override_runtime_env_var("BAMBOO_OPENAI_API_KEY", None);
+        let encryption_key = bamboo_config::encryption::set_test_encryption_key([0x7c; 32]);
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let configured_ref =
+            bamboo_config::credential_ref("provider_instance", "corrupt", "api_key").unwrap();
+        let missing_ref =
+            bamboo_config::credential_ref("provider_instance", "missing", "api_key").unwrap();
+        bamboo_config::CredentialStore::open(temp_dir.path())
+            .replace(
+                configured_ref.clone(),
+                "sk-encrypted-with-old-machine-key",
+                bamboo_config::CredentialSource::Migrated,
+                0,
+            )
+            .unwrap();
+
+        let facade = bamboo_config::ConfigFacade::open_or_migrate(temp_dir.path()).unwrap();
+        let snapshot = facade.registry().providers.snapshot();
+        let mut providers = snapshot.data.as_ref().clone();
+        for (id, reference) in [
+            ("corrupt", configured_ref.clone()),
+            ("missing", missing_ref.clone()),
+        ] {
+            providers.provider_instances.insert(
+                id.to_string(),
+                serde_json::from_value(serde_json::json!({
+                    "provider_type": "openai",
+                    "enabled": true,
+                    "model": format!("gpt-{id}"),
+                    "credential_ref": reference.as_str()
+                }))
+                .unwrap(),
+            );
+        }
+        providers.default_provider_instance = Some("corrupt".to_string());
+        facade
+            .registry()
+            .providers
+            .commit(snapshot.revision, providers)
+            .unwrap();
+        drop(facade);
+        drop(encryption_key);
+
+        let _wrong_key = bamboo_config::encryption::set_test_encryption_key([0x7d; 32]);
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("credential recovery failure must leave settings available"),
+        );
+        for instance in state.config.read().await.provider_instances.values() {
+            assert!(instance.api_key.is_empty());
+        }
+
+        let app = actix_web::test::init_service(
+            actix_web::App::new()
+                .app_data(state)
+                .route(
+                    "/provider-settings",
+                    web::get().to(
+                        crate::handlers::settings::bamboo_config::get_provider_settings_section,
+                    ),
+                )
+                .route("/instances", web::get().to(list_provider_instances))
+                .route(
+                    "/legacy",
+                    web::get().to(crate::handlers::settings::provider::get_provider_config),
+                ),
+        )
+        .await;
+
+        let canonical = actix_web::test::call_service(
+            &app,
+            actix_web::test::TestRequest::get()
+                .uri("/provider-settings")
+                .to_request(),
+        )
+        .await;
+        assert!(canonical.status().is_success());
+        let canonical: Value = actix_web::test::read_body_json(canonical).await;
+        for id in ["corrupt", "missing"] {
+            assert_eq!(
+                canonical["data"]["credential_status"]["provider_instances"][id]["configured"],
+                false
+            );
+            assert!(
+                canonical["data"]["credential_status"]["provider_instances"][id]["source"]
+                    .is_null()
+            );
+        }
+
+        let instances = actix_web::test::call_service(
+            &app,
+            actix_web::test::TestRequest::get()
+                .uri("/instances")
+                .to_request(),
+        )
+        .await;
+        assert!(instances.status().is_success());
+        let instances: Value = actix_web::test::read_body_json(instances).await;
+        for instance in instances["instances"].as_array().unwrap() {
+            assert!(instance["config"].get("api_key").is_none());
+            assert!(instance["config"].get("credential_ref").is_none());
+        }
+
+        let legacy = actix_web::test::call_service(
+            &app,
+            actix_web::test::TestRequest::get()
+                .uri("/legacy")
+                .to_request(),
+        )
+        .await;
+        assert!(legacy.status().is_success());
+        let legacy: Value = actix_web::test::read_body_json(legacy).await;
+        assert!(legacy["providers"]["openai"].get("api_key").is_none());
+        assert!(serde_json::to_string(&legacy)
+            .unwrap()
+            .find("****...****")
+            .is_none());
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/services/gold_auto_answer/tests.rs
+++ b/crates/app/bamboo-server/src/services/gold_auto_answer/tests.rs
@@ -221,15 +221,21 @@ fn build_pending_session(
 async fn gold_auto_answer_conclusion_with_options_full_loop() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let mut config = Config::from_data_dir(Some(temp_dir.path().to_path_buf()));
-    config.provider = String::new();
+    config.provider = "test-provider".to_string();
     config.features.provider_model_ref = true;
     let provider = ScriptedProvider::new("ok.");
     let provider_trait: Arc<dyn LLMProvider> = provider.clone();
-    let mut app_state =
-        AppState::new_with_provider(temp_dir.path().to_path_buf(), config, provider_trait)
-            .await
-            .expect("app state");
-    app_state.provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), String::new()));
+    let mut app_state = AppState::new_with_provider(
+        temp_dir.path().to_path_buf(),
+        config,
+        provider_trait.clone(),
+    )
+    .await
+    .expect("app state");
+    app_state.provider_registry = Arc::new(ProviderRegistry::new(
+        HashMap::from([("test-provider".to_string(), provider_trait)]),
+        "test-provider".to_string(),
+    ));
     app_state.provider_router = Arc::new(ProviderModelRouter::new(
         app_state.provider_registry.clone(),
     ));
@@ -319,15 +325,21 @@ async fn gold_auto_answer_exit_plan_mode_full_loop() {
 
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let mut config = Config::from_data_dir(Some(temp_dir.path().to_path_buf()));
-    config.provider = String::new();
+    config.provider = "test-provider".to_string();
     config.features.provider_model_ref = true;
     let provider = ScriptedProvider::new("Approve (Default mode)");
     let provider_trait: Arc<dyn LLMProvider> = provider.clone();
-    let mut app_state =
-        AppState::new_with_provider(temp_dir.path().to_path_buf(), config, provider_trait)
-            .await
-            .expect("app state");
-    app_state.provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), String::new()));
+    let mut app_state = AppState::new_with_provider(
+        temp_dir.path().to_path_buf(),
+        config,
+        provider_trait.clone(),
+    )
+    .await
+    .expect("app state");
+    app_state.provider_registry = Arc::new(ProviderRegistry::new(
+        HashMap::from([("test-provider".to_string(), provider_trait)]),
+        "test-provider".to_string(),
+    ));
     app_state.provider_router = Arc::new(ProviderModelRouter::new(
         app_state.provider_registry.clone(),
     ));

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -275,7 +275,7 @@ pub fn build_external_child_runner_with_codex_tokens(
                 fabric_dir,
                 executor,
                 extract_provider_credentials(config),
-                config.provider.clone(),
+                config.effective_default_provider().to_string(),
                 config
                     .subagents()
                     .max_concurrent
@@ -393,7 +393,7 @@ fn build_local_actor_runner(
         fabric_dir,
         executor,
         extract_provider_credentials(config),
-        config.provider.clone(),
+        config.effective_default_provider().to_string(),
         sub.max_concurrent
             .unwrap_or(super::actor_adapter::DEFAULT_MAX_CONCURRENT_ACTORS),
     )
@@ -633,6 +633,52 @@ pub fn extract_provider_credentials(
 ) -> Vec<bamboo_subagent::provision::ScopedCredential> {
     let mut out = Vec::new();
 
+    fn push_instance(
+        out: &mut Vec<bamboo_subagent::provision::ScopedCredential>,
+        id: &str,
+        instance: &bamboo_config::ProviderInstanceConfig,
+    ) {
+        if !instance.enabled {
+            return;
+        }
+        let api_key = instance.api_key.trim().to_string();
+        if api_key.is_empty() {
+            return;
+        }
+        out.push(bamboo_subagent::provision::ScopedCredential {
+            provider: id.to_string(),
+            api_key,
+            base_url: instance.base_url.clone(),
+            provider_type: Some(instance.provider_type.clone()),
+            credential_ref: instance
+                .credential_ref
+                .as_ref()
+                .map(|reference| reference.as_str().to_string()),
+        });
+    }
+
+    if !config.provider_instances.is_empty() {
+        // Native instances are authoritative. Export enabled explicit
+        // instances only; stale legacy slots must not leak into child workers.
+        for (id, instance) in &config.provider_instances {
+            push_instance(&mut out, id, instance);
+        }
+
+        // Narrow #780 compatibility seam: a hybrid default may still name a
+        // real legacy alias not yet materialized. Mirror the registry's exact
+        // rule and add only that default, never every legacy credential.
+        let default_id = config.effective_default_provider();
+        if !config.provider_instances.contains_key(default_id) {
+            if let Some((_, instance)) = bamboo_config::synthesize_legacy_instances(config)
+                .into_iter()
+                .find(|(id, _)| id == default_id)
+            {
+                push_instance(&mut out, default_id, &instance);
+            }
+        }
+        return out;
+    }
+
     // Legacy single-instance slots: providers.anthropic / openai / gemini /
     // bodhi. `copilot` is intentionally omitted — it authenticates via device
     // flow and has no `api_key` field to extract.
@@ -690,27 +736,6 @@ pub fn extract_provider_credentials(
                 .map(|reference| reference.as_str().to_string()),
         );
     }
-
-    // Multi-instance providers: provider_instances keyed by instance id; the
-    // child routes by instance id, the worker constructs by provider_type.
-    // Read the typed struct directly — `api_key` is hydrated in memory but
-    // deliberately `skip_serializing`, so a serde projection would miss it.
-    out.extend(config.provider_instances.iter().filter_map(|(id, inst)| {
-        let api_key = inst.api_key.trim().to_string();
-        if api_key.is_empty() {
-            return None;
-        }
-        Some(bamboo_subagent::provision::ScopedCredential {
-            provider: id.clone(),
-            api_key,
-            base_url: inst.base_url.clone(),
-            provider_type: Some(inst.provider_type.clone()),
-            credential_ref: inst
-                .credential_ref
-                .as_ref()
-                .map(|reference| reference.as_str().to_string()),
-        })
-    }));
 
     out
 }
@@ -903,10 +928,10 @@ mod extract_provider_credentials_tests {
         assert!(extract_provider_credentials(&config).is_empty());
     }
 
-    /// Legacy + `provider_instances` coexisting: both must surface, with no
-    /// duplication/clobbering between the two sources.
+    /// Explicit instances are authoritative: unrelated stale legacy slots do
+    /// not cross the actor provisioning boundary.
     #[test]
-    fn legacy_and_instances_both_present_no_duplicates() {
+    fn instance_mode_omits_unrelated_legacy_credentials() {
         let mut config = Config::default();
         config.providers_mut().anthropic = Some(AnthropicConfig {
             api_key: "sk-ant-legacy".to_string(),
@@ -920,20 +945,79 @@ mod extract_provider_credentials_tests {
         config
             .provider_instances
             .insert("openai-work".to_string(), openai_work);
+        config.default_provider_instance = Some("openai-work".to_string());
+
+        let creds = extract_provider_credentials(&config);
+
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].provider, "openai-work");
+        assert_eq!(creds[0].api_key, "sk-oai-work");
+        assert_eq!(creds[0].provider_type.as_deref(), Some("openai"));
+        assert_eq!(
+            creds[0].credential_ref.as_deref(),
+            Some("provider.openai-work.api_key")
+        );
+    }
+
+    #[test]
+    fn hybrid_legacy_default_is_the_only_legacy_credential_exported() {
+        let mut config = Config::default();
+        config.providers_mut().anthropic = Some(AnthropicConfig {
+            api_key: "sk-ant-default".to_string(),
+            ..Default::default()
+        });
+        config.providers_mut().openai = Some(OpenAIConfig {
+            api_key: "sk-oai-stale".to_string(),
+            ..Default::default()
+        });
+        config
+            .provider_instances
+            .insert("work".to_string(), instance("openai", "sk-oai-work"));
+        config.default_provider_instance = Some("anthropic".to_string());
 
         let mut creds = extract_provider_credentials(&config);
         creds.sort_by(|a, b| a.provider.cmp(&b.provider));
 
         assert_eq!(creds.len(), 2);
         assert_eq!(creds[0].provider, "anthropic");
-        assert_eq!(creds[0].api_key, "sk-ant-legacy");
-        assert_eq!(creds[1].provider, "openai-work");
+        assert_eq!(creds[0].api_key, "sk-ant-default");
+        assert_eq!(creds[1].provider, "work");
         assert_eq!(creds[1].api_key, "sk-oai-work");
-        assert_eq!(creds[1].provider_type.as_deref(), Some("openai"));
-        assert_eq!(
-            creds[1].credential_ref.as_deref(),
-            Some("provider.openai-work.api_key")
-        );
+        assert!(creds
+            .iter()
+            .all(|credential| credential.api_key != "sk-oai-stale"));
+    }
+
+    #[test]
+    fn hybrid_legacy_provider_fallback_without_explicit_default_remains_exportable() {
+        let mut config = Config::default();
+        config.provider = "anthropic".to_string();
+        config.providers_mut().anthropic = Some(AnthropicConfig {
+            api_key: "sk-ant-effective-default".to_string(),
+            ..Default::default()
+        });
+        config
+            .provider_instances
+            .insert("work".to_string(), instance("openai", "sk-oai-work"));
+
+        let mut creds = extract_provider_credentials(&config);
+        creds.sort_by(|a, b| a.provider.cmp(&b.provider));
+
+        assert_eq!(creds.len(), 2);
+        assert_eq!(creds[0].provider, "anthropic");
+        assert_eq!(creds[1].provider, "work");
+    }
+
+    #[test]
+    fn disabled_instance_credential_is_not_exported() {
+        let mut config = Config::default();
+        let mut disabled = instance("openai", "sk-disabled");
+        disabled.enabled = false;
+        config
+            .provider_instances
+            .insert("disabled".to_string(), disabled);
+
+        assert!(extract_provider_credentials(&config).is_empty());
     }
 }
 

--- a/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
+++ b/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
@@ -202,9 +202,7 @@ async fn resolve_gold_provider_and_model(
 ) -> Result<GoldAuxiliaryTarget, String> {
     // Resolve fast model eagerly for the fallback chain.
     let config_snapshot = state.config().read().await.clone();
-    let provider_name = session_effective_model_ref(session)
-        .map(|r| r.provider.clone())
-        .unwrap_or_else(|| config_snapshot.provider.clone());
+    let provider_name = gold_provider_name(&config_snapshot, session);
     let stream_timeout = config_snapshot.stream_timeout;
     let configured_limit = crate::runtime::config::normalize_auxiliary_evaluation_max_concurrency(
         config_snapshot
@@ -317,6 +315,12 @@ async fn resolve_gold_provider_and_model(
     ))
 }
 
+fn gold_provider_name(config: &bamboo_config::Config, session: &Session) -> String {
+    session_effective_model_ref(session)
+        .map(|r| r.provider.clone())
+        .unwrap_or_else(|| config.effective_default_provider().to_string())
+}
+
 fn gold_auxiliary_target(
     provider: Arc<dyn LLMProvider>,
     model: String,
@@ -344,4 +348,28 @@ fn normalize_lightweight_reasoning_effort(
         ReasoningEffort::Xhigh | ReasoningEffort::Max => ReasoningEffort::High,
         other => other,
     })
+}
+
+#[cfg(test)]
+mod provider_selection_tests {
+    use super::gold_provider_name;
+    use bamboo_agent_core::Session;
+
+    #[test]
+    fn gold_provider_fallback_uses_default_provider_instance() {
+        let mut config = bamboo_config::Config::default();
+        let instance = serde_json::from_value(serde_json::json!({
+            "provider_type": "anthropic",
+            "enabled": true
+        }))
+        .unwrap();
+        config.provider = "openai".to_string();
+        config
+            .provider_instances
+            .insert("gold-anthropic".to_string(), instance);
+        config.default_provider_instance = Some("gold-anthropic".to_string());
+        let session = Session::new("gold-provider-instance", "model");
+
+        assert_eq!(gold_provider_name(&config, &session), "gold-anthropic");
+    }
 }

--- a/crates/engine/bamboo-engine/src/model_config_helper.rs
+++ b/crates/engine/bamboo-engine/src/model_config_helper.rs
@@ -114,7 +114,30 @@ pub fn get_default_model_for_provider(
     config: &Config,
     provider_name: &str,
 ) -> Result<String, LLMError> {
-    match provider_name.trim() {
+    let provider_name = provider_name.trim();
+    if let Some(instance) = config.provider_instances.get(provider_name) {
+        if !instance.enabled {
+            return Err(LLMError::Auth(format!(
+                "Provider instance '{provider_name}' is disabled"
+            )));
+        }
+        if let Some(model) = instance
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+        {
+            return Ok(model.to_string());
+        }
+        if instance.provider_type == "copilot" {
+            return Ok("gpt-4o".to_string());
+        }
+        return Err(LLMError::Auth(format!(
+            "Model must be specified for provider instance '{provider_name}'"
+        )));
+    }
+
+    match provider_name {
         "copilot" => {
             let provider_model = config
                 .providers()
@@ -163,7 +186,7 @@ pub fn get_default_model_for_provider(
 /// Get the default model for the current provider from config.
 /// Returns an error if no model is configured.
 pub fn get_default_model_from_config(config: &Config) -> Result<String, LLMError> {
-    get_default_model_for_provider(config, config.provider.as_str())
+    get_default_model_for_provider(config, config.effective_default_provider())
 }
 
 /// Get the schedule auto-execute model for the current provider from config.
@@ -178,13 +201,26 @@ pub fn get_schedule_model_from_config(config: &Config) -> Result<String, LLMErro
         .ok_or_else(|| {
             LLMError::Auth(format!(
                 "No fast/default model configured for provider '{}'",
-                config.provider
+                config.effective_default_provider()
             ))
         })
 }
 
 /// Get the fast/cheap model for a specific provider from config.
 pub fn get_fast_model_for_provider(config: &Config, provider_name: &str) -> Option<String> {
+    if let Some(instance) = config.provider_instances.get(provider_name.trim()) {
+        if !instance.enabled {
+            return None;
+        }
+        return instance
+            .fast_model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .map(ToString::to_string)
+            .or_else(|| get_default_model_for_provider(config, provider_name).ok());
+    }
+
     let fast = match provider_name.trim() {
         "openai" => config
             .providers()
@@ -252,7 +288,7 @@ pub fn get_task_summary_model_from_config(config: &Config) -> Result<String, LLM
     config.get_task_summary_model().ok_or_else(|| {
         LLMError::Auth(format!(
             "No task summary model configured for provider '{}'",
-            config.provider
+            config.effective_default_provider()
         ))
     })
 }
@@ -265,7 +301,7 @@ pub fn get_memory_background_model_from_config(config: &Config) -> Result<String
     config.get_memory_background_model().ok_or_else(|| {
         LLMError::Auth(format!(
             "No background memory model configured for provider '{}'",
-            config.provider
+            config.effective_default_provider()
         ))
     })
 }
@@ -278,7 +314,7 @@ pub fn get_vision_model_from_config(config: &Config) -> Result<String, LLMError>
     config.get_vision_model().ok_or_else(|| {
         LLMError::Auth(format!(
             "No model configured for provider '{}'",
-            config.provider
+            config.effective_default_provider()
         ))
     })
 }
@@ -396,7 +432,20 @@ pub fn resolve_vision_model(
             }
         }
     }
-    let model_name = config.get_vision_model()?;
+    let model_name = if let Some(instance) = config.provider_instances.get(provider_name) {
+        if !instance.enabled {
+            return None;
+        }
+        instance
+            .vision_model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .map(ToString::to_string)
+            .or_else(|| get_default_model_for_provider(config, provider_name).ok())?
+    } else {
+        config.get_vision_model()?
+    };
     let provider = provider_registry.get(provider_name)?;
     Some(ResolvedModel {
         provider,
@@ -685,6 +734,82 @@ mod tests {
         let result = get_default_model_from_config(&config);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "gpt-4o");
+    }
+
+    #[test]
+    fn instance_models_are_authoritative_over_stale_legacy_slot() {
+        let mut config = test_config! {
+            provider: "openai".to_string(),
+            providers: ProviderConfigs {
+                openai: Some(OpenAIConfig {
+                    api_key: "legacy".to_string(),
+                    model: Some("gpt-stale".to_string()),
+                    fast_model: Some("gpt-stale-fast".to_string()),
+                    vision_model: Some("gpt-stale-vision".to_string()),
+                    ..OpenAIConfig::default()
+                }),
+                ..ProviderConfigs::default()
+            },
+        };
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "model": "gpt-instance",
+                "fast_model": "gpt-instance-fast",
+                "vision_model": "gpt-instance-vision",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        assert_eq!(
+            get_default_model_from_config(&config).unwrap(),
+            "gpt-instance"
+        );
+        assert_eq!(
+            get_fast_model_for_provider(&config, "work").as_deref(),
+            Some("gpt-instance-fast")
+        );
+        assert_eq!(
+            get_schedule_model_from_config(&config).unwrap(),
+            "gpt-instance-fast"
+        );
+        assert_eq!(
+            get_vision_model_from_config(&config).unwrap(),
+            "gpt-instance-vision"
+        );
+    }
+
+    #[test]
+    fn disabled_instance_model_does_not_fall_back_to_legacy_provider() {
+        let mut config = test_config! {
+            provider: "openai".to_string(),
+            providers: ProviderConfigs {
+                openai: Some(OpenAIConfig {
+                    model: Some("gpt-stale".to_string()),
+                    ..OpenAIConfig::default()
+                }),
+                ..ProviderConfigs::default()
+            },
+        };
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "model": "gpt-instance",
+                "enabled": false
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        let error = get_default_model_from_config(&config)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("disabled"));
+        assert!(get_fast_model_for_provider(&config, "work").is_none());
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/model_config_helper.rs
+++ b/crates/engine/bamboo-engine/src/model_config_helper.rs
@@ -78,6 +78,86 @@ pub fn resolve_provider_type(
         .or_else(|| Some(trimmed.to_string()))
 }
 
+/// Resolve an exact runtime routing key from either an instance id or a
+/// built-in provider type used by legacy clients/sessions.
+///
+/// Exact instance ids always win, including disabled or failed instances: in
+/// those cases resolution fails closed instead of silently selecting another
+/// account. A built-in type selects the enabled default instance of that type,
+/// then the lexicographically first enabled instance, matching the model-fetch
+/// compatibility contract. The selected instance must exist in the live
+/// registry; constructor/auth failures are never replaced by the process-wide
+/// default provider.
+pub fn resolve_provider_routing_key(
+    config: &Config,
+    requested_provider: &str,
+    provider_registry: &Arc<ProviderRegistry>,
+) -> Result<String, LLMError> {
+    let requested = requested_provider.trim();
+    if requested.is_empty() {
+        return Err(LLMError::Auth("provider routing key is empty".to_string()));
+    }
+
+    let require_live = |routing_key: &str| {
+        provider_registry
+            .get(routing_key)
+            .map(|_| routing_key.to_string())
+            .ok_or_else(|| {
+                LLMError::Auth(format!(
+                    "Provider '{routing_key}' is configured but unavailable"
+                ))
+            })
+    };
+
+    if let Some(instance) = config.provider_instances.get(requested) {
+        if !instance.enabled {
+            return Err(LLMError::Auth(format!(
+                "Provider instance '{requested}' is disabled"
+            )));
+        }
+        return require_live(requested);
+    }
+
+    // Legacy and hybrid aliases are registered under their exact type key.
+    if provider_registry.get(requested).is_some() {
+        return Ok(requested.to_string());
+    }
+
+    if !bamboo_llm::AVAILABLE_PROVIDERS.contains(&requested) {
+        return Err(LLMError::Auth(format!(
+            "Unknown provider instance or type '{requested}'"
+        )));
+    }
+
+    if let Some(default_id) = config.default_provider_instance.as_deref() {
+        if let Some(instance) = config.provider_instances.get(default_id) {
+            if instance.provider_type == requested {
+                if !instance.enabled {
+                    return Err(LLMError::Auth(format!(
+                        "Default provider instance '{default_id}' is disabled"
+                    )));
+                }
+                return require_live(default_id);
+            }
+        }
+    }
+
+    let mut matching_ids = config
+        .provider_instances
+        .iter()
+        .filter(|(_, instance)| instance.enabled && instance.provider_type == requested)
+        .map(|(id, _)| id.as_str())
+        .collect::<Vec<_>>();
+    matching_ids.sort_unstable();
+    if let Some(instance_id) = matching_ids.first() {
+        return require_live(instance_id);
+    }
+
+    Err(LLMError::Auth(format!(
+        "No enabled provider instance is available for type '{requested}'"
+    )))
+}
+
 pub fn parse_session_gold_config(session_gold_config_json: Option<&str>) -> Option<GoldConfig> {
     let raw = session_gold_config_json?.trim();
     if raw.is_empty() {
@@ -706,6 +786,88 @@ mod tests {
         let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
         providers.insert("openai".to_string(), Arc::new(NoopProvider));
         Arc::new(ProviderRegistry::new(providers, "openai".to_string()))
+    }
+
+    fn registry_with_provider_ids(ids: &[&str], default: &str) -> Arc<ProviderRegistry> {
+        let providers = ids
+            .iter()
+            .map(|id| {
+                (
+                    (*id).to_string(),
+                    Arc::new(NoopProvider) as Arc<dyn LLMProvider>,
+                )
+            })
+            .collect();
+        Arc::new(ProviderRegistry::new(providers, default.to_string()))
+    }
+
+    #[test]
+    fn provider_type_alias_resolves_to_matching_default_instance() {
+        let mut config = Config::default();
+        config.provider_instances.insert(
+            "work-openai".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.provider_instances.insert(
+            "main-anthropic".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "anthropic",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("main-anthropic".to_string());
+        let registry =
+            registry_with_provider_ids(&["main-anthropic", "work-openai"], "main-anthropic");
+
+        assert_eq!(
+            resolve_provider_routing_key(&config, "openai", &registry).unwrap(),
+            "work-openai"
+        );
+        assert_eq!(
+            resolve_provider_routing_key(&config, "anthropic", &registry).unwrap(),
+            "main-anthropic"
+        );
+    }
+
+    #[test]
+    fn provider_type_alias_uses_lexical_instance_but_exact_unavailable_id_fails_closed() {
+        let mut config = Config::default();
+        for id in ["z-openai", "a-openai"] {
+            config.provider_instances.insert(
+                id.to_string(),
+                serde_json::from_value(serde_json::json!({
+                    "provider_type": "openai",
+                    "enabled": true
+                }))
+                .unwrap(),
+            );
+        }
+        config.provider_instances.insert(
+            "openai".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "enabled": false
+            }))
+            .unwrap(),
+        );
+        let registry = registry_with_provider_ids(&["a-openai", "z-openai"], "a-openai");
+
+        let error = resolve_provider_routing_key(&config, "openai", &registry)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("disabled"));
+
+        config.provider_instances.remove("openai");
+        assert_eq!(
+            resolve_provider_routing_key(&config, "openai", &registry).unwrap(),
+            "a-openai"
+        );
+        assert!(resolve_provider_routing_key(&config, "typo", &registry).is_err());
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -801,7 +801,9 @@ impl AgentRuntime {
                 .or_else(|| config.get_task_summary_model()),
             background_model_provider,
             summarization_model_provider,
-            provider_name: Some(provider_name.unwrap_or_else(|| config.provider.clone())),
+            provider_name: Some(
+                provider_name.unwrap_or_else(|| config.effective_default_provider().to_string()),
+            ),
             provider_type,
             reasoning_effort,
             auxiliary_model_resolver,

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -44,13 +44,13 @@ use tokio::sync::{broadcast, RwLock};
 
 use crate::model_areas::resolve_global_area_models;
 use crate::model_config_helper::{
-    resolve_fast_model, resolve_gold_config, GOLD_CONFIG_METADATA_KEY,
+    resolve_fast_model, resolve_gold_config, resolve_provider_routing_key, GOLD_CONFIG_METADATA_KEY,
 };
 use crate::session_activation::{
     SessionActivationLaunch, SessionActivationReserveOutcome, SessionActivationSpawner,
 };
 use crate::session_app::execute::consume_pending_clarification_resume;
-use crate::session_app::provider_model::session_effective_model_ref;
+use crate::session_app::provider_model::{persist_model_ref, session_effective_model_ref};
 use crate::session_app::resume::{
     resume_session_execution, ResumeExecutionPort, ResumeSpawnRequest,
 };
@@ -988,25 +988,61 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
             return;
         };
 
+        let config_snapshot = self.config.read().await.clone();
         let model = session.model.clone();
-        let resolved_provider_name = session_effective_model_ref(&session)
-            .map(|model_ref| model_ref.provider)
-            .unwrap_or(config.provider_name);
-        let provider_override = session_effective_model_ref(&session)
-            .and_then(|model_ref| match self.provider_router.route(&model_ref) {
+        let session_model_ref = session_effective_model_ref(&session);
+        let requested_provider = session_model_ref
+            .as_ref()
+            .map(|model_ref| model_ref.provider.as_str())
+            .unwrap_or(config.provider_name.as_str());
+        let resolved_provider_name = match resolve_provider_routing_key(
+            &config_snapshot,
+            requested_provider,
+            &self.provider_registry,
+        ) {
+            Ok(provider) => provider,
+            Err(error) => {
+                tracing::error!(
+                    session_id = %session_id,
+                    provider = requested_provider,
+                    %error,
+                    "child-completion resume provider is unavailable; refusing to fall back"
+                );
+                execution_reservation.abandon().await;
+                return;
+            }
+        };
+        let provider_override = if let Some(mut model_ref) = session_model_ref {
+            model_ref.provider = resolved_provider_name.clone();
+            persist_model_ref(&mut session, &model_ref);
+            match self.provider_router.route(&model_ref) {
                 Ok(provider) => Some(provider),
                 Err(error) => {
-                    tracing::warn!(
+                    tracing::error!(
                         session_id = %session_id,
                         provider = %model_ref.provider,
                         model = %model_ref.model,
-                        error = %error,
-                        "failed to resolve provider override for child-completion parent resume; falling back to runtime provider"
+                        %error,
+                        "child-completion resume provider routing failed closed"
                     );
-                    None
+                    execution_reservation.abandon().await;
+                    return;
                 }
-            });
-        let config_snapshot = self.config.read().await.clone();
+            }
+        } else {
+            match self.provider_registry.get(&resolved_provider_name) {
+                Some(provider) => Some(provider),
+                None => {
+                    tracing::error!(
+                        session_id = %session_id,
+                        provider = %resolved_provider_name,
+                        "child-completion resume provider disappeared after resolution; refusing to fall back"
+                    );
+                    execution_reservation.abandon().await;
+                    return;
+                }
+            }
+        };
         let resolved_fast_provider = resolve_fast_model(
             &config_snapshot,
             &resolved_provider_name,

--- a/crates/engine/bamboo-engine/src/session_app/resolution.rs
+++ b/crates/engine/bamboo-engine/src/session_app/resolution.rs
@@ -3,7 +3,7 @@
 //! gold config, mapped into the snapshot structs the agent loop consumes.
 //!
 //! These resolution rules are load-bearing invariants — the resolved provider
-//! name (session model ref, falling back to `config.provider`) and the global
+//! name (session model ref, falling back to the effective default provider) and the global
 //! (never session-bound) auxiliary model fallback. They were previously
 //! hand-rolled at every spawn/resume site; centralizing them here keeps the
 //! rules consistent by construction. The builder is pure orchestration over the
@@ -40,7 +40,7 @@ pub fn resolve_resume_config_snapshot(
 ) -> ResumeConfigSnapshot {
     let resolved_provider_name = session_effective_model_ref(session)
         .map(|model_ref| model_ref.provider)
-        .unwrap_or_else(|| config.provider.clone());
+        .unwrap_or_else(|| config.effective_default_provider().to_string());
     let resolved_provider_type = resolve_provider_type(config, &resolved_provider_name, registry);
     // Auxiliary models are global (config-derived), never session-bound.
     let areas = resolve_global_area_models(config, &resolved_provider_name, registry);
@@ -74,5 +74,34 @@ pub fn resolve_resume_config_snapshot(
                     .map(String::as_str),
             )
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn session_without_model_ref_resumes_on_effective_default_instance() {
+        let mut config = Config::default();
+        config.provider = "openai".to_string();
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "anthropic",
+                "model": "claude-instance",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("work".to_string());
+        let registry = Arc::new(ProviderRegistry::new(HashMap::new(), "work".to_string()));
+        let session = Session::new("resume-instance-default", "claude-instance");
+
+        let resolved = resolve_resume_config_snapshot(&config, &registry, &session, None);
+
+        assert_eq!(resolved.provider_name, "work");
+        assert_eq!(resolved.provider_type.as_deref(), Some("anthropic"));
     }
 }

--- a/crates/engine/bamboo-engine/src/title_gen/mod.rs
+++ b/crates/engine/bamboo-engine/src/title_gen/mod.rs
@@ -208,13 +208,7 @@ async fn try_llm_title(
 ) -> Result<String, String> {
     // Determine provider name (session-aware, with global config fallback) and resolve fast model.
     let config_snapshot = { state.config().read().await.clone() };
-    let provider_name = if let Some(ref m) = session.model_ref {
-        m.provider.clone()
-    } else if let Some(p) = session.provider_name() {
-        p
-    } else {
-        config_snapshot.provider.clone()
-    };
+    let provider_name = title_provider_name(&config_snapshot, session);
 
     let resolved = crate::model_config_helper::resolve_fast_model(
         &config_snapshot,
@@ -268,6 +262,16 @@ async fn try_llm_title(
     timeout(Duration::from_secs(TITLE_GEN_TIMEOUT_SECS), fut)
         .await
         .map_err(|_| "title-gen LLM timeout".to_string())?
+}
+
+fn title_provider_name(config: &bamboo_config::Config, session: &Session) -> String {
+    if let Some(ref m) = session.model_ref {
+        m.provider.clone()
+    } else if let Some(p) = session.provider_name() {
+        p
+    } else {
+        config.effective_default_provider().to_string()
+    }
 }
 
 /// Trim, take first line, strip leading/trailing quotes/punctuation,

--- a/crates/engine/bamboo-engine/src/title_gen/tests.rs
+++ b/crates/engine/bamboo-engine/src/title_gen/tests.rs
@@ -85,3 +85,25 @@ fn first_user_text_stays_empty_until_a_text_turn_exists() {
 
     assert!(first_user_text(&session).is_none());
 }
+
+#[test]
+fn title_provider_fallback_uses_default_provider_instance() {
+    let mut config = bamboo_config::Config::default();
+    let instance = serde_json::from_value(serde_json::json!({
+        "provider_type": "openai",
+        "enabled": true
+    }))
+    .unwrap();
+    config.provider = "anthropic".to_string();
+    config
+        .provider_instances
+        .insert("work-openai".to_string(), instance);
+    config.default_provider_instance = Some("work-openai".to_string());
+    let session = Session::new("title-provider-instance", "model");
+
+    assert_eq!(
+        title_provider_name(&config, &session),
+        "work-openai",
+        "title generation must route through the instance authority"
+    );
+}

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -3681,7 +3681,7 @@ impl Config {
         // mode the override may name either an exact instance id or a provider
         // type. Type matches are ordered by instance id so the result is
         // deterministic even for a multi-account configuration.
-        if let Ok(provider) = std::env::var("BAMBOO_PROVIDER") {
+        if let Ok(provider) = crate::runtime_env_var("BAMBOO_PROVIDER") {
             let provider = provider.trim().to_string();
             if !provider.is_empty() {
                 self.provider = provider.clone();
@@ -3739,7 +3739,7 @@ impl Config {
         // config.json. The `api_key_from_env` flag keeps `refresh_provider_api_keys_encrypted`
         // from re-encrypting these keys into `api_key_encrypted` on a later save,
         // so an env key is never persisted to disk. (#253)
-        if let Ok(key) = std::env::var("BAMBOO_OPENAI_API_KEY") {
+        if let Ok(key) = crate::runtime_env_var("BAMBOO_OPENAI_API_KEY") {
             let key = key.trim();
             if !key.is_empty() {
                 if self.provider_instances.is_empty() {
@@ -3754,7 +3754,7 @@ impl Config {
                 }
             }
         }
-        if let Ok(key) = std::env::var("BAMBOO_ANTHROPIC_API_KEY") {
+        if let Ok(key) = crate::runtime_env_var("BAMBOO_ANTHROPIC_API_KEY") {
             let key = key.trim();
             if !key.is_empty() {
                 if self.provider_instances.is_empty() {
@@ -3769,7 +3769,7 @@ impl Config {
                 }
             }
         }
-        if let Ok(key) = std::env::var("BAMBOO_GEMINI_API_KEY") {
+        if let Ok(key) = crate::runtime_env_var("BAMBOO_GEMINI_API_KEY") {
             let key = key.trim();
             if !key.is_empty() {
                 if self.provider_instances.is_empty() {
@@ -8141,11 +8141,16 @@ mod tests {
 
     #[test]
     fn runtime_env_overrides_select_and_hydrate_only_marked_instances() {
-        let _lock = env_lock_acquire();
-        let _provider = EnvVarGuard::set("BAMBOO_PROVIDER", "openai");
-        let _openai_key = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", "sk-runtime-env-instance");
-        let _anthropic_key = EnvVarGuard::unset("BAMBOO_ANTHROPIC_API_KEY");
-        let _gemini_key = EnvVarGuard::unset("BAMBOO_GEMINI_API_KEY");
+        let _provider =
+            crate::test_support::override_runtime_env_var("BAMBOO_PROVIDER", Some("openai"));
+        let _openai_key = crate::test_support::override_runtime_env_var(
+            "BAMBOO_OPENAI_API_KEY",
+            Some("sk-runtime-env-instance"),
+        );
+        let _anthropic_key =
+            crate::test_support::override_runtime_env_var("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini_key =
+            crate::test_support::override_runtime_env_var("BAMBOO_GEMINI_API_KEY", None);
 
         let mut config = Config::default();
         *config.providers_mut() = ProviderConfigs::default();
@@ -8192,11 +8197,14 @@ mod tests {
 
     #[test]
     fn runtime_provider_override_prefers_exact_instance_id() {
-        let _lock = env_lock_acquire();
-        let _provider = EnvVarGuard::set("BAMBOO_PROVIDER", "personal");
-        let _openai_key = EnvVarGuard::unset("BAMBOO_OPENAI_API_KEY");
-        let _anthropic_key = EnvVarGuard::unset("BAMBOO_ANTHROPIC_API_KEY");
-        let _gemini_key = EnvVarGuard::unset("BAMBOO_GEMINI_API_KEY");
+        let _provider =
+            crate::test_support::override_runtime_env_var("BAMBOO_PROVIDER", Some("personal"));
+        let _openai_key =
+            crate::test_support::override_runtime_env_var("BAMBOO_OPENAI_API_KEY", None);
+        let _anthropic_key =
+            crate::test_support::override_runtime_env_var("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini_key =
+            crate::test_support::override_runtime_env_var("BAMBOO_GEMINI_API_KEY", None);
         let mut config = Config::default();
         for id in ["work", "personal"] {
             config.provider_instances.insert(
@@ -8381,8 +8389,15 @@ mod tests {
         let _lock = env_lock_acquire();
         let temp_home = TempHome::new();
         let _home = EnvVarGuard::set("HOME", temp_home.path.to_string_lossy().as_ref());
-        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", "sk-ant-from-env");
-        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", "sk-oai-from-env");
+        let _anthropic = crate::test_support::override_runtime_env_var(
+            "BAMBOO_ANTHROPIC_API_KEY",
+            Some("sk-ant-from-env"),
+        );
+        let _openai = crate::test_support::override_runtime_env_var(
+            "BAMBOO_OPENAI_API_KEY",
+            Some("sk-oai-from-env"),
+        );
+        let _gemini = crate::test_support::override_runtime_env_var("BAMBOO_GEMINI_API_KEY", None);
 
         // No config.json on disk → the providers are created from the env keys
         // alone (#253: deploy without a plaintext api_key in a mounted file).
@@ -8580,7 +8595,8 @@ mod tests {
 
         let _port = EnvVarGuard::set("BAMBOO_PORT", "9999");
         let _bind = EnvVarGuard::set("BAMBOO_BIND", "192.168.1.1");
-        let _provider = EnvVarGuard::set("BAMBOO_PROVIDER", "openai");
+        let _provider =
+            crate::test_support::override_runtime_env_var("BAMBOO_PROVIDER", Some("openai"));
 
         let config = Config::from_data_dir(Some(temp_home.path.clone()));
         assert_eq!(config.server.port, 9999);

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -3677,9 +3677,34 @@ impl Config {
             self.server.bind = bind;
         }
 
-        // Note: BAMBOO_DATA_DIR already handled by the caller.
+        // Note: BAMBOO_DATA_DIR already handled by the caller. In instance
+        // mode the override may name either an exact instance id or a provider
+        // type. Type matches are ordered by instance id so the result is
+        // deterministic even for a multi-account configuration.
         if let Ok(provider) = std::env::var("BAMBOO_PROVIDER") {
-            self.provider = provider;
+            let provider = provider.trim().to_string();
+            if !provider.is_empty() {
+                self.provider = provider.clone();
+                if !self.provider_instances.is_empty() {
+                    let selected = self
+                        .provider_instances
+                        .contains_key(&provider)
+                        .then_some(provider.clone())
+                        .or_else(|| {
+                            let mut matching = self
+                                .provider_instances
+                                .iter()
+                                .filter(|(_, instance)| {
+                                    instance.enabled && instance.provider_type == provider
+                                })
+                                .map(|(id, _)| id.clone())
+                                .collect::<Vec<_>>();
+                            matching.sort();
+                            matching.into_iter().next()
+                        });
+                    self.default_provider_instance = selected;
+                }
+            }
         }
 
         if let Ok(headless) = std::env::var("BAMBOO_HEADLESS") {
@@ -3717,35 +3742,57 @@ impl Config {
         if let Ok(key) = std::env::var("BAMBOO_OPENAI_API_KEY") {
             let key = key.trim();
             if !key.is_empty() {
-                let openai = self
-                    .providers
-                    .openai
-                    .get_or_insert_with(OpenAIConfig::default);
-                openai.api_key = key.to_string();
-                openai.api_key_from_env = true;
+                if self.provider_instances.is_empty() {
+                    let openai = self
+                        .providers
+                        .openai
+                        .get_or_insert_with(OpenAIConfig::default);
+                    openai.api_key = key.to_string();
+                    openai.api_key_from_env = true;
+                } else {
+                    self.apply_provider_instance_env_key("openai", key);
+                }
             }
         }
         if let Ok(key) = std::env::var("BAMBOO_ANTHROPIC_API_KEY") {
             let key = key.trim();
             if !key.is_empty() {
-                let anthropic = self
-                    .providers
-                    .anthropic
-                    .get_or_insert_with(AnthropicConfig::default);
-                anthropic.api_key = key.to_string();
-                anthropic.api_key_from_env = true;
+                if self.provider_instances.is_empty() {
+                    let anthropic = self
+                        .providers
+                        .anthropic
+                        .get_or_insert_with(AnthropicConfig::default);
+                    anthropic.api_key = key.to_string();
+                    anthropic.api_key_from_env = true;
+                } else {
+                    self.apply_provider_instance_env_key("anthropic", key);
+                }
             }
         }
         if let Ok(key) = std::env::var("BAMBOO_GEMINI_API_KEY") {
             let key = key.trim();
             if !key.is_empty() {
-                let gemini = self
-                    .providers
-                    .gemini
-                    .get_or_insert_with(GeminiConfig::default);
-                gemini.api_key = key.to_string();
-                gemini.api_key_from_env = true;
+                if self.provider_instances.is_empty() {
+                    let gemini = self
+                        .providers
+                        .gemini
+                        .get_or_insert_with(GeminiConfig::default);
+                    gemini.api_key = key.to_string();
+                    gemini.api_key_from_env = true;
+                } else {
+                    self.apply_provider_instance_env_key("gemini", key);
+                }
             }
+        }
+    }
+
+    fn apply_provider_instance_env_key(&mut self, provider_type: &str, key: &str) {
+        for instance in self.provider_instances.values_mut().filter(|instance| {
+            instance.provider_type == provider_type
+                && crate::provider_instance_api_key_from_env(instance)
+        }) {
+            instance.api_key = key.to_string();
+            instance.api_key_encrypted = None;
         }
     }
 
@@ -4017,7 +4064,14 @@ impl Config {
                 return Some(model_ref.model.clone());
             }
         }
-        match self.provider.as_str() {
+        let provider = self.effective_default_provider();
+        if let Some(instance) = self.provider_instances.get(provider) {
+            return instance
+                .model
+                .clone()
+                .or_else(|| (instance.provider_type == "copilot").then(|| "gpt-4o".to_string()));
+        }
+        match provider {
             "openai" => self.providers.openai.as_ref().and_then(|c| c.model.clone()),
             "anthropic" => self
                 .providers
@@ -4049,28 +4103,33 @@ impl Config {
                 return Some(model_ref.model.clone());
             }
         }
-        let fast = match self.provider.as_str() {
-            "openai" => self
-                .providers
-                .openai
-                .as_ref()
-                .and_then(|c| c.fast_model.clone()),
-            "anthropic" => self
-                .providers
-                .anthropic
-                .as_ref()
-                .and_then(|c| c.fast_model.clone()),
-            "gemini" => self
-                .providers
-                .gemini
-                .as_ref()
-                .and_then(|c| c.fast_model.clone()),
-            "copilot" => self
-                .providers
-                .copilot
-                .as_ref()
-                .and_then(|c| c.fast_model.clone()),
-            _ => None,
+        let provider = self.effective_default_provider();
+        let fast = if let Some(instance) = self.provider_instances.get(provider) {
+            instance.fast_model.clone()
+        } else {
+            match provider {
+                "openai" => self
+                    .providers
+                    .openai
+                    .as_ref()
+                    .and_then(|c| c.fast_model.clone()),
+                "anthropic" => self
+                    .providers
+                    .anthropic
+                    .as_ref()
+                    .and_then(|c| c.fast_model.clone()),
+                "gemini" => self
+                    .providers
+                    .gemini
+                    .as_ref()
+                    .and_then(|c| c.fast_model.clone()),
+                "copilot" => self
+                    .providers
+                    .copilot
+                    .as_ref()
+                    .and_then(|c| c.fast_model.clone()),
+                _ => None,
+            }
         };
         fast.or_else(|| self.get_model())
     }
@@ -4135,28 +4194,34 @@ impl Config {
             .map(|value| value.trim())
             .filter(|value| !value.is_empty())
             .map(ToString::to_string);
-        configured.or_else(|| match self.provider.as_str() {
-            "openai" => self
-                .providers
-                .openai
-                .as_ref()
-                .and_then(|c| c.fast_model.clone()),
-            "anthropic" => self
-                .providers
-                .anthropic
-                .as_ref()
-                .and_then(|c| c.fast_model.clone()),
-            "gemini" => self
-                .providers
-                .gemini
-                .as_ref()
-                .and_then(|c| c.fast_model.clone()),
-            "copilot" => self
-                .providers
-                .copilot
-                .as_ref()
-                .and_then(|c| c.fast_model.clone()),
-            _ => None,
+        configured.or_else(|| {
+            let provider = self.effective_default_provider();
+            if let Some(instance) = self.provider_instances.get(provider) {
+                return instance.fast_model.clone();
+            }
+            match provider {
+                "openai" => self
+                    .providers
+                    .openai
+                    .as_ref()
+                    .and_then(|c| c.fast_model.clone()),
+                "anthropic" => self
+                    .providers
+                    .anthropic
+                    .as_ref()
+                    .and_then(|c| c.fast_model.clone()),
+                "gemini" => self
+                    .providers
+                    .gemini
+                    .as_ref()
+                    .and_then(|c| c.fast_model.clone()),
+                "copilot" => self
+                    .providers
+                    .copilot
+                    .as_ref()
+                    .and_then(|c| c.fast_model.clone()),
+                _ => None,
+            }
         })
     }
 
@@ -4200,35 +4265,40 @@ impl Config {
     /// Used for image understanding tasks.
     /// Falls back to `get_model()` when no vision_model is configured.
     pub fn get_vision_model(&self) -> Option<String> {
-        let vision = match self.provider.as_str() {
-            "openai" => self
-                .providers
-                .openai
-                .as_ref()
-                .and_then(|c| c.vision_model.clone()),
-            "anthropic" => self
-                .providers
-                .anthropic
-                .as_ref()
-                .and_then(|c| c.vision_model.clone()),
-            "gemini" => self
-                .providers
-                .gemini
-                .as_ref()
-                .and_then(|c| c.vision_model.clone()),
-            "copilot" => self
-                .providers
-                .copilot
-                .as_ref()
-                .and_then(|c| c.vision_model.clone()),
-            _ => None,
+        let provider = self.effective_default_provider();
+        let vision = if let Some(instance) = self.provider_instances.get(provider) {
+            instance.vision_model.clone()
+        } else {
+            match provider {
+                "openai" => self
+                    .providers
+                    .openai
+                    .as_ref()
+                    .and_then(|c| c.vision_model.clone()),
+                "anthropic" => self
+                    .providers
+                    .anthropic
+                    .as_ref()
+                    .and_then(|c| c.vision_model.clone()),
+                "gemini" => self
+                    .providers
+                    .gemini
+                    .as_ref()
+                    .and_then(|c| c.vision_model.clone()),
+                "copilot" => self
+                    .providers
+                    .copilot
+                    .as_ref()
+                    .and_then(|c| c.vision_model.clone()),
+                _ => None,
+            }
         };
         vision.or_else(|| self.get_model())
     }
 
     /// Get the default reasoning effort for the currently active provider.
     pub fn get_reasoning_effort(&self) -> Option<ReasoningEffort> {
-        self.reasoning_effort_for_key(&self.provider)
+        self.reasoning_effort_for_key(self.effective_default_provider())
     }
 
     /// Resolve the configured default reasoning effort for a provider routing key.
@@ -8021,6 +8091,128 @@ mod tests {
         assert_eq!(
             config.get_memory_background_model().as_deref(),
             Some("gpt-fast")
+        );
+    }
+
+    #[test]
+    fn effective_instance_models_and_reasoning_override_stale_legacy_provider() {
+        let mut config = Config::default();
+        config.features.provider_model_ref = false;
+        config.provider = "openai".to_string();
+        config.providers.openai = Some(OpenAIConfig {
+            api_key: "sk-stale".to_string(),
+            model: Some("legacy-main".to_string()),
+            fast_model: Some("legacy-fast".to_string()),
+            vision_model: Some("legacy-vision".to_string()),
+            reasoning_effort: Some(ReasoningEffort::Low),
+            ..OpenAIConfig::default()
+        });
+        let mut instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "model": "instance-main",
+            "fast_model": "instance-fast",
+            "vision_model": "instance-vision",
+            "reasoning_effort": "high",
+            "enabled": true
+        }))
+        .unwrap();
+        instance.api_key = "sk-instance".to_string();
+        config
+            .provider_instances
+            .insert("work".to_string(), instance);
+        config.default_provider_instance = Some("work".to_string());
+
+        assert_eq!(config.get_model().as_deref(), Some("instance-main"));
+        assert_eq!(config.get_fast_model().as_deref(), Some("instance-fast"));
+        assert_eq!(
+            config.get_memory_background_model().as_deref(),
+            Some("instance-fast")
+        );
+        assert_eq!(
+            config.get_task_summary_model().as_deref(),
+            Some("instance-fast")
+        );
+        assert_eq!(
+            config.get_vision_model().as_deref(),
+            Some("instance-vision")
+        );
+        assert_eq!(config.get_reasoning_effort(), Some(ReasoningEffort::High));
+    }
+
+    #[test]
+    fn runtime_env_overrides_select_and_hydrate_only_marked_instances() {
+        let _lock = env_lock_acquire();
+        let _provider = EnvVarGuard::set("BAMBOO_PROVIDER", "openai");
+        let _openai_key = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", "sk-runtime-env-instance");
+        let _anthropic_key = EnvVarGuard::unset("BAMBOO_ANTHROPIC_API_KEY");
+        let _gemini_key = EnvVarGuard::unset("BAMBOO_GEMINI_API_KEY");
+
+        let mut config = Config::default();
+        *config.providers_mut() = ProviderConfigs::default();
+        for (id, from_environment) in [("z-unmarked", false), ("a-marked", true)] {
+            let mut extra = serde_json::Map::new();
+            if from_environment {
+                extra.insert("api_key_from_env".to_string(), serde_json::json!(true));
+            }
+            extra.insert("provider_type".to_string(), serde_json::json!("openai"));
+            extra.insert("enabled".to_string(), serde_json::json!(true));
+            config.provider_instances.insert(
+                id.to_string(),
+                serde_json::from_value(serde_json::Value::Object(extra)).unwrap(),
+            );
+        }
+
+        config.apply_runtime_env_overrides();
+
+        assert_eq!(
+            config.default_provider_instance.as_deref(),
+            Some("a-marked"),
+            "type override selects the lexicographically first enabled instance"
+        );
+        assert_eq!(
+            config.provider_instances["a-marked"].api_key,
+            "sk-runtime-env-instance"
+        );
+        assert!(config.provider_instances["z-unmarked"].api_key.is_empty());
+        assert!(
+            config.providers().openai.is_none(),
+            "instance-mode env hydration must not recreate a legacy alias"
+        );
+
+        config.refresh_encrypted_secrets().unwrap();
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(!serialized.contains("sk-runtime-env-instance"));
+        assert!(
+            config.provider_instances["a-marked"]
+                .api_key_encrypted
+                .is_none(),
+            "runtime env plaintext must not be encrypted into ordinary config"
+        );
+    }
+
+    #[test]
+    fn runtime_provider_override_prefers_exact_instance_id() {
+        let _lock = env_lock_acquire();
+        let _provider = EnvVarGuard::set("BAMBOO_PROVIDER", "personal");
+        let _openai_key = EnvVarGuard::unset("BAMBOO_OPENAI_API_KEY");
+        let _anthropic_key = EnvVarGuard::unset("BAMBOO_ANTHROPIC_API_KEY");
+        let _gemini_key = EnvVarGuard::unset("BAMBOO_GEMINI_API_KEY");
+        let mut config = Config::default();
+        for id in ["work", "personal"] {
+            config.provider_instances.insert(
+                id.to_string(),
+                serde_json::from_value(serde_json::json!({
+                    "provider_type": "openai",
+                    "enabled": true
+                }))
+                .unwrap(),
+            );
+        }
+
+        config.apply_runtime_env_overrides();
+        assert_eq!(
+            config.default_provider_instance.as_deref(),
+            Some("personal")
         );
     }
 

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -477,6 +477,13 @@ impl Config {
                 instance.api_key_encrypted = None;
                 continue;
             }
+            if crate::provider_instance_api_key_from_env(instance) {
+                // Runtime environment keys are never converted into durable
+                // ciphertext. The metadata marker is enough to re-inject the
+                // standard provider env var after the next restart.
+                instance.api_key_encrypted = None;
+                continue;
+            }
             let api_key = instance.api_key.trim();
             // Empty plaintext → preserve existing ciphertext (see
             // refresh_provider_api_keys_encrypted). #268.
@@ -495,6 +502,10 @@ impl Config {
     pub fn ensure_provider_instance_credentials_isolated(&mut self) -> Result<()> {
         for (id, instance) in &mut self.provider_instances {
             if instance.credential_ref.is_some() {
+                instance.api_key_encrypted = None;
+                continue;
+            }
+            if crate::provider_instance_api_key_from_env(instance) {
                 instance.api_key_encrypted = None;
                 continue;
             }

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -250,9 +250,38 @@ fn credential_refs_for_scope(
                     }))
             })
             .collect(),
-        ExactTransactionScope::Providers
-        | ExactTransactionScope::Mcp
-        | ExactTransactionScope::ClusterFabric => BTreeSet::new(),
+        ExactTransactionScope::Providers => [
+            config
+                .providers()
+                .openai
+                .as_ref()
+                .and_then(|provider| provider.credential_ref.clone()),
+            config
+                .providers()
+                .anthropic
+                .as_ref()
+                .and_then(|provider| provider.credential_ref.clone()),
+            config
+                .providers()
+                .gemini
+                .as_ref()
+                .and_then(|provider| provider.credential_ref.clone()),
+            config
+                .providers()
+                .bodhi
+                .as_ref()
+                .and_then(|provider| provider.credential_ref.clone()),
+        ]
+        .into_iter()
+        .flatten()
+        .chain(
+            config
+                .provider_instances
+                .values()
+                .filter_map(|instance| instance.credential_ref.clone()),
+        )
+        .collect(),
+        ExactTransactionScope::Mcp | ExactTransactionScope::ClusterFabric => BTreeSet::new(),
     }
 }
 
@@ -315,6 +344,18 @@ pub(crate) fn validate_active_section_credential_values(
     let scope = non_cluster_credential_scope(section)?;
     let (active_refs, statuses) =
         semantic_credential_statuses_for_scope(config, scope, credential_lkg);
+    ensure_active_credential_statuses(&active_refs, &statuses)
+}
+
+pub(crate) fn validate_provider_credential_values(
+    config: &crate::Config,
+    credential_lkg: &crate::credential_store::CredentialDocumentLkg,
+) -> ConfigStoreResult<()> {
+    let (active_refs, statuses) = semantic_credential_statuses_for_scope(
+        config,
+        ExactTransactionScope::Providers,
+        credential_lkg,
+    );
     ensure_active_credential_statuses(&active_refs, &statuses)
 }
 

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -382,6 +382,39 @@ impl CredentialStore {
         Ok((health.revision, status))
     }
 
+    /// Return secret-free status while proving that an active credential can
+    /// be decrypted with the current runtime key.
+    ///
+    /// Ordinary status/list APIs intentionally describe durable metadata and
+    /// therefore report a present entry as configured without decrypting it.
+    /// Runtime-facing provider projections need a stronger contract: a stale
+    /// ciphertext left by a machine/key change must not be advertised as a
+    /// usable credential. Decryption happens under the same document lock and
+    /// the plaintext is dropped before this method returns.
+    pub fn status_with_crypto_validation(
+        &self,
+        credential_ref: &CredentialRef,
+    ) -> ConfigStoreResult<CredentialStatus> {
+        reject_internal_recovery_ref(credential_ref)?;
+        self.with_transaction_lock(|| {
+            let document = self.load_document()?;
+            Ok(match document.entries.get(credential_ref) {
+                Some(entry) => CredentialStatus {
+                    credential_ref: credential_ref.clone(),
+                    configured: crate::encryption::decrypt(&entry.ciphertext).is_ok(),
+                    source: entry.source,
+                    updated_at: Some(entry.updated_at),
+                },
+                None => CredentialStatus {
+                    credential_ref: credential_ref.clone(),
+                    configured: false,
+                    source: CredentialSource::User,
+                    updated_at: None,
+                },
+            })
+        })
+    }
+
     pub fn status_with_health(
         &self,
         credential_ref: &CredentialRef,
@@ -3236,6 +3269,39 @@ mod tests {
         assert_eq!(revision, 2);
         assert!(!status.configured);
         assert!(store.resolve(&reference).unwrap().is_none());
+    }
+
+    #[test]
+    fn crypto_validated_status_rejects_missing_and_undecryptable_entries() {
+        let key = crate::encryption::set_test_encryption_key([0x7a; 32]);
+        let dir = TempDir::new().unwrap();
+        let store = CredentialStore::open(dir.path());
+        let configured = credential_ref("provider_instance", "work", "api_key").unwrap();
+        let missing = credential_ref("provider_instance", "missing", "api_key").unwrap();
+        store
+            .replace(
+                configured.clone(),
+                "sk-runtime-valid",
+                CredentialSource::Migrated,
+                0,
+            )
+            .unwrap();
+
+        let status = store.status_with_crypto_validation(&configured).unwrap();
+        assert!(status.configured);
+        assert_eq!(status.source, CredentialSource::Migrated);
+        assert!(
+            !store
+                .status_with_crypto_validation(&missing)
+                .unwrap()
+                .configured
+        );
+
+        drop(key);
+        let _wrong_key = crate::encryption::set_test_encryption_key([0x7b; 32]);
+        let status = store.status_with_crypto_validation(&configured).unwrap();
+        assert!(!status.configured);
+        assert_eq!(status.source, CredentialSource::Migrated);
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/lib.rs
+++ b/crates/infra/bamboo-config/src/lib.rs
@@ -46,8 +46,9 @@ pub use paths::*;
 pub use provider_configs::ProviderConfigsModule;
 pub use provider_instance::{
     legacy_provider_compatibility_view, materialize_legacy_provider_instances,
-    provider_instance_api_key_from_env, provider_instance_environment_override_active,
-    synthesize_legacy_instances, PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY,
+    provider_api_key_environment_override_active, provider_instance_api_key_from_env,
+    provider_instance_environment_override_active, synthesize_legacy_instances,
+    PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY,
 };
 pub use section_facade::*;
 pub use settings::PermissionMode;

--- a/crates/infra/bamboo-config/src/lib.rs
+++ b/crates/infra/bamboo-config/src/lib.rs
@@ -80,6 +80,70 @@ pub mod test_support {
         /// own snapshot without racing unrelated server `AppState` publishers.
         static ENV_VARS_CACHE_OVERRIDE_FOR_TESTS:
             RefCell<Option<EnvVarsCacheSnapshot>> = const { RefCell::new(None) };
+
+        /// Scoped runtime environment overrides for tests that exercise config
+        /// loading. Process-wide `set_var` would otherwise leak transient
+        /// provider credentials and selectors into unrelated parallel tests.
+        static RUNTIME_ENV_OVERRIDES_FOR_TESTS:
+            RefCell<HashMap<&'static str, Option<String>>> = RefCell::new(HashMap::new());
+    }
+
+    /// Restores the previous thread-local runtime environment override when
+    /// its scope ends.
+    #[must_use = "keep the guard alive for the full runtime-env test scope"]
+    pub struct RuntimeEnvOverrideGuard {
+        key: &'static str,
+        previous: Option<Option<String>>,
+        _same_thread: PhantomData<Rc<()>>,
+    }
+
+    impl RuntimeEnvOverrideGuard {
+        /// Replace the in-scope value without exposing it process-wide.
+        pub fn replace(&self, value: Option<&str>) {
+            RUNTIME_ENV_OVERRIDES_FOR_TESTS.with(|overrides| {
+                overrides
+                    .borrow_mut()
+                    .insert(self.key, value.map(str::to_string));
+            });
+        }
+    }
+
+    impl Drop for RuntimeEnvOverrideGuard {
+        fn drop(&mut self) {
+            RUNTIME_ENV_OVERRIDES_FOR_TESTS.with(|overrides| {
+                let mut overrides = overrides.borrow_mut();
+                match self.previous.take() {
+                    Some(previous) => {
+                        overrides.insert(self.key, previous);
+                    }
+                    None => {
+                        overrides.remove(self.key);
+                    }
+                }
+            });
+        }
+    }
+
+    /// Override one runtime environment variable only for the current test
+    /// thread. `None` explicitly hides a real process environment value.
+    pub fn override_runtime_env_var(
+        key: &'static str,
+        value: Option<&str>,
+    ) -> RuntimeEnvOverrideGuard {
+        let previous = RUNTIME_ENV_OVERRIDES_FOR_TESTS.with(|overrides| {
+            overrides
+                .borrow_mut()
+                .insert(key, value.map(str::to_string))
+        });
+        RuntimeEnvOverrideGuard {
+            key,
+            previous,
+            _same_thread: PhantomData,
+        }
+    }
+
+    pub(crate) fn current_runtime_env_override(key: &str) -> Option<Option<String>> {
+        RUNTIME_ENV_OVERRIDES_FOR_TESTS.with(|overrides| overrides.borrow().get(key).cloned())
     }
 
     /// Restores the previous test-only env snapshot when its scope ends.
@@ -166,4 +230,12 @@ pub mod test_support {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
+}
+
+pub(crate) fn runtime_env_var(name: &str) -> Result<String, std::env::VarError> {
+    #[cfg(any(test, feature = "test-utils"))]
+    if let Some(value) = test_support::current_runtime_env_override(name) {
+        return value.ok_or(std::env::VarError::NotPresent);
+    }
+    std::env::var(name)
 }

--- a/crates/infra/bamboo-config/src/lib.rs
+++ b/crates/infra/bamboo-config/src/lib.rs
@@ -44,7 +44,11 @@ pub use memory_config::MemoryConfigModule;
 pub use model_mapping::*;
 pub use paths::*;
 pub use provider_configs::ProviderConfigsModule;
-pub use provider_instance::synthesize_legacy_instances;
+pub use provider_instance::{
+    legacy_provider_compatibility_view, materialize_legacy_provider_instances,
+    provider_instance_api_key_from_env, provider_instance_environment_override_active,
+    synthesize_legacy_instances, PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY,
+};
 pub use section_facade::*;
 pub use settings::PermissionMode;
 pub use subagents_config::SubagentsConfigModule;

--- a/crates/infra/bamboo-config/src/provider_instance.rs
+++ b/crates/infra/bamboo-config/src/provider_instance.rs
@@ -1,6 +1,83 @@
-//! Synthesize legacy provider config into the new instance-keyed format.
+//! Legacy-provider compatibility at the provider-instance boundary.
+//!
+//! Runtime code consumes [`ProviderInstanceConfig`] directly.  The helpers in
+//! this module are deliberately limited to the two compatibility directions:
+//!
+//! - materialize a legacy-only configuration into durable provider instances;
+//! - project instances into a temporary legacy view for the deprecated settings
+//!   response.
+//!
+//! The latter must never be used as a provider-construction substrate.
 
-use super::config::{Config, ProviderInstanceConfig};
+use super::config::{
+    AnthropicConfig, BodhiConfig, Config, CopilotConfig, GeminiConfig, OpenAIConfig,
+    ProviderConfigs, ProviderInstanceConfig,
+};
+use serde_json::Value;
+
+/// Marker stored in an instance's forward-compatible fields when its API key
+/// may be overridden by the provider type's standard `BAMBOO_*_API_KEY`
+/// environment variable. The marker is metadata only; plaintext is injected at
+/// runtime and is never encrypted or persisted by ordinary config saves.
+///
+/// Legacy materialization keeps this binding even when a stable
+/// [`crate::CredentialRef`] exists. That preserves the historical precedence
+/// contract: an environment key wins while present and the stored credential is
+/// the fallback after the variable is removed.
+pub const PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY: &str = "api_key_from_env";
+
+/// Whether a provider instance accepts its provider type's standard runtime
+/// environment-variable override.
+pub fn provider_instance_api_key_from_env(instance: &ProviderInstanceConfig) -> bool {
+    instance
+        .extra
+        .get(PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Whether a marked provider instance is currently using its standard runtime
+/// environment-variable override.
+///
+/// Merely persisting the binding is not enough: the variable must be non-empty
+/// and the live instance must have been hydrated with that exact value. This
+/// keeps credential-status projections honest when an environment variable is
+/// added after startup but before the next configuration reload.
+pub fn provider_instance_environment_override_active(instance: &ProviderInstanceConfig) -> bool {
+    if !provider_instance_api_key_from_env(instance) {
+        return false;
+    }
+    let Some(env_var) = standard_provider_api_key_env(&instance.provider_type) else {
+        return false;
+    };
+    let Ok(value) = std::env::var(env_var) else {
+        return false;
+    };
+    let value = value.trim();
+    !value.is_empty() && instance.api_key.trim() == value
+}
+
+fn copy_runtime_env_marker(
+    extra: &mut std::collections::BTreeMap<String, Value>,
+    from_environment: bool,
+) {
+    if from_environment {
+        extra.insert(
+            PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY.to_string(),
+            Value::Bool(true),
+        );
+    }
+}
+
+fn insert_optional_extra(
+    extra: &mut std::collections::BTreeMap<String, Value>,
+    key: &str,
+    value: Option<Value>,
+) {
+    if let Some(value) = value {
+        extra.entry(key.to_string()).or_insert(value);
+    }
+}
 
 /// Create synthetic provider instances from legacy `providers` config.
 ///
@@ -15,6 +92,8 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
     if let Some(openai) = &config.providers.openai {
         let id = "openai".to_string();
         if !config.provider_instances.contains_key(&id) {
+            let mut extra = openai.extra.clone();
+            copy_runtime_env_marker(&mut extra, openai.api_key_from_env);
             result.push((
                 id,
                 ProviderInstanceConfig {
@@ -22,7 +101,7 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     label: Some("OpenAI".to_string()),
                     api_key: openai.api_key.clone(),
                     api_key_encrypted: openai.api_key_encrypted.clone(),
-                    credential_ref: None,
+                    credential_ref: openai.credential_ref.clone(),
                     base_url: openai.base_url.clone(),
                     model: openai.model.clone(),
                     fast_model: openai.fast_model.clone(),
@@ -31,7 +110,7 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     responses_only_models: openai.responses_only_models.clone(),
                     request_overrides: openai.request_overrides.clone(),
                     enabled: true,
-                    extra: openai.extra.clone(),
+                    extra,
                 },
             ));
         }
@@ -40,6 +119,18 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
     if let Some(anthropic) = &config.providers.anthropic {
         let id = "anthropic".to_string();
         if !config.provider_instances.contains_key(&id) {
+            let mut extra = anthropic.extra.clone();
+            copy_runtime_env_marker(&mut extra, anthropic.api_key_from_env);
+            insert_optional_extra(
+                &mut extra,
+                "max_tokens",
+                anthropic.max_tokens.map(Value::from),
+            );
+            insert_optional_extra(
+                &mut extra,
+                "thinking_replay_always",
+                anthropic.thinking_replay_always.map(Value::Bool),
+            );
             result.push((
                 id,
                 ProviderInstanceConfig {
@@ -47,7 +138,7 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     label: Some("Anthropic".to_string()),
                     api_key: anthropic.api_key.clone(),
                     api_key_encrypted: anthropic.api_key_encrypted.clone(),
-                    credential_ref: None,
+                    credential_ref: anthropic.credential_ref.clone(),
                     base_url: anthropic.base_url.clone(),
                     model: anthropic.model.clone(),
                     fast_model: anthropic.fast_model.clone(),
@@ -56,7 +147,7 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     responses_only_models: vec![],
                     request_overrides: anthropic.request_overrides.clone(),
                     enabled: true,
-                    extra: Default::default(),
+                    extra,
                 },
             ));
         }
@@ -65,6 +156,8 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
     if let Some(gemini) = &config.providers.gemini {
         let id = "gemini".to_string();
         if !config.provider_instances.contains_key(&id) {
+            let mut extra = gemini.extra.clone();
+            copy_runtime_env_marker(&mut extra, gemini.api_key_from_env);
             result.push((
                 id,
                 ProviderInstanceConfig {
@@ -72,7 +165,7 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     label: Some("Gemini".to_string()),
                     api_key: gemini.api_key.clone(),
                     api_key_encrypted: gemini.api_key_encrypted.clone(),
-                    credential_ref: None,
+                    credential_ref: gemini.credential_ref.clone(),
                     base_url: gemini.base_url.clone(),
                     model: gemini.model.clone(),
                     fast_model: gemini.fast_model.clone(),
@@ -81,16 +174,20 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     responses_only_models: vec![],
                     request_overrides: gemini.request_overrides.clone(),
                     enabled: true,
-                    extra: Default::default(),
+                    extra,
                 },
             ));
         }
     }
 
-    if config.providers.copilot.is_some() {
+    if let Some(copilot) = &config.providers.copilot {
         let id = "copilot".to_string();
         if !config.provider_instances.contains_key(&id) {
             // Copilot doesn't have a traditional api_key; it uses device auth.
+            let mut extra = copilot.extra.clone();
+            extra
+                .entry("headless_auth".to_string())
+                .or_insert(Value::Bool(copilot.headless_auth));
             result.push((
                 id,
                 ProviderInstanceConfig {
@@ -100,39 +197,14 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     api_key_encrypted: None,
                     credential_ref: None,
                     base_url: None,
-                    model: config
-                        .providers
-                        .copilot
-                        .as_ref()
-                        .and_then(|c| c.model.clone()),
-                    fast_model: config
-                        .providers
-                        .copilot
-                        .as_ref()
-                        .and_then(|c| c.fast_model.clone()),
-                    vision_model: config
-                        .providers
-                        .copilot
-                        .as_ref()
-                        .and_then(|c| c.vision_model.clone()),
-                    reasoning_effort: config
-                        .providers
-                        .copilot
-                        .as_ref()
-                        .and_then(|c| c.reasoning_effort),
-                    responses_only_models: config
-                        .providers
-                        .copilot
-                        .as_ref()
-                        .map(|c| c.responses_only_models.clone())
-                        .unwrap_or_default(),
-                    request_overrides: config
-                        .providers
-                        .copilot
-                        .as_ref()
-                        .and_then(|c| c.request_overrides.clone()),
-                    enabled: true,
-                    extra: Default::default(),
+                    model: copilot.model.clone(),
+                    fast_model: copilot.fast_model.clone(),
+                    vision_model: copilot.vision_model.clone(),
+                    reasoning_effort: copilot.reasoning_effort,
+                    responses_only_models: copilot.responses_only_models.clone(),
+                    request_overrides: copilot.request_overrides.clone(),
+                    enabled: copilot.enabled || config.provider == "copilot",
+                    extra,
                 },
             ));
         }
@@ -141,6 +213,12 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
     if let Some(bodhi) = &config.providers.bodhi {
         let id = "bodhi".to_string();
         if !config.provider_instances.contains_key(&id) {
+            let mut extra = bodhi.extra.clone();
+            insert_optional_extra(
+                &mut extra,
+                "target_provider",
+                bodhi.target_provider.clone().map(Value::String),
+            );
             result.push((
                 id,
                 ProviderInstanceConfig {
@@ -148,7 +226,7 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     label: Some("Bodhi".to_string()),
                     api_key: bodhi.api_key.clone(),
                     api_key_encrypted: bodhi.api_key_encrypted.clone(),
-                    credential_ref: None,
+                    credential_ref: bodhi.credential_ref.clone(),
                     base_url: bodhi.base_url.clone(),
                     model: None,
                     fast_model: None,
@@ -157,7 +235,7 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
                     responses_only_models: vec![],
                     request_overrides: None,
                     enabled: true,
-                    extra: Default::default(),
+                    extra,
                 },
             ));
         }
@@ -166,10 +244,370 @@ pub fn synthesize_legacy_instances(config: &Config) -> Vec<(String, ProviderInst
     result
 }
 
+/// Idempotently materialize legacy provider configuration.
+///
+/// The provider type is retained as the instance id so existing routing keys,
+/// `BAMBOO_PROVIDER`, and old clients remain deterministic. An explicitly
+/// configured instance matching the selected routing key always wins. Hybrid
+/// configs may materialize a missing legacy default without changing any
+/// explicit instance.
+///
+/// Every non-conflicting legacy alias is preserved, even when the selected
+/// default already resolves to an explicit instance. Stored credentials reuse
+/// the legacy provider's stable `credential_ref`. Materialized
+/// OpenAI/Anthropic/Gemini aliases retain their standard environment override
+/// binding while keeping the stored credential as a fallback; environment-only
+/// aliases carry only the marker and never persist plaintext.
+pub fn materialize_legacy_provider_instances(config: &mut Config) -> bool {
+    let selected = config.effective_default_provider().trim().to_string();
+    if selected.is_empty() {
+        return false;
+    }
+    let selected_is_explicit = config.provider_instances.contains_key(&selected);
+
+    let mut candidates = synthesize_legacy_instances(config);
+
+    if !selected_is_explicit
+        && selected == "copilot"
+        && !candidates.iter().any(|(id, _)| id == &selected)
+    {
+        candidates.push((
+            selected.clone(),
+            default_copilot_instance(config.headless_auth),
+        ));
+    }
+
+    // Preserve every standard legacy env-only provider, not just the selected
+    // one. A custom explicit instance id must not absorb a type-wide legacy
+    // override, so the compatibility alias keeps the provider type as its id.
+    for provider_type in ["openai", "anthropic", "gemini"] {
+        if standard_provider_api_key_env_is_available(provider_type)
+            && !config.provider_instances.contains_key(provider_type)
+            && !candidates.iter().any(|(id, _)| id == provider_type)
+        {
+            let mut instance = empty_provider_instance(provider_type);
+            instance.label = Some(provider_display_label(provider_type).to_string());
+            copy_runtime_env_marker(&mut instance.extra, true);
+            candidates.push((provider_type.to_string(), instance));
+        }
+    }
+
+    // Credential migration must isolate ordinary legacy plaintext/ciphertext
+    // before provider metadata can be materialized. Refuse to turn an
+    // unisolated secret into an env-bound instance, which would otherwise make
+    // an ordinary save omit the plaintext and silently lose it.
+    if candidates.iter().any(|(_, instance)| {
+        instance.credential_ref.is_none()
+            && !provider_instance_api_key_from_env(instance)
+            && (!instance.api_key.trim().is_empty() || instance.api_key_encrypted.is_some())
+    }) {
+        return false;
+    }
+
+    for (_, instance) in &mut candidates {
+        if standard_provider_api_key_env(&instance.provider_type).is_some() {
+            copy_runtime_env_marker(&mut instance.extra, true);
+            if instance.credential_ref.is_none() {
+                // The only possible plaintext at this point is a runtime env
+                // value already identified by the legacy flag above.
+                instance.api_key.clear();
+                instance.api_key_encrypted = None;
+            }
+        }
+    }
+
+    if let Some((_, selected_instance)) = candidates
+        .iter_mut()
+        .find(|(id, _)| id == &selected && selected == "copilot")
+    {
+        selected_instance.enabled = true;
+    }
+
+    let selected_is_usable = selected_is_explicit
+        || candidates.iter().any(|(id, instance)| {
+            id == &selected
+                && instance.enabled
+                && (instance.provider_type == "copilot"
+                    || instance.credential_ref.is_some()
+                    || (provider_instance_api_key_from_env(instance)
+                        && standard_provider_api_key_env_is_available(&instance.provider_type)))
+        });
+    if !selected_is_usable {
+        return false;
+    }
+
+    let mut changed = !candidates.is_empty();
+    config.provider_instances.extend(candidates);
+    if config.default_provider_instance.as_deref() != Some(&selected) {
+        config.default_provider_instance = Some(selected);
+        changed = true;
+    }
+    changed
+}
+
+fn standard_provider_api_key_env(provider_type: &str) -> Option<&'static str> {
+    match provider_type {
+        "openai" => Some("BAMBOO_OPENAI_API_KEY"),
+        "anthropic" => Some("BAMBOO_ANTHROPIC_API_KEY"),
+        "gemini" => Some("BAMBOO_GEMINI_API_KEY"),
+        _ => None,
+    }
+}
+
+fn standard_provider_api_key_env_is_available(provider_type: &str) -> bool {
+    standard_provider_api_key_env(provider_type)
+        .and_then(|env_var| std::env::var(env_var).ok())
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn provider_display_label(provider_type: &str) -> &str {
+    match provider_type {
+        "openai" => "OpenAI",
+        "anthropic" => "Anthropic",
+        "gemini" => "Gemini",
+        "copilot" => "GitHub Copilot",
+        "bodhi" => "Bodhi",
+        other => other,
+    }
+}
+
+fn empty_provider_instance(provider_type: &str) -> ProviderInstanceConfig {
+    ProviderInstanceConfig {
+        provider_type: provider_type.to_string(),
+        label: None,
+        api_key: String::new(),
+        api_key_encrypted: None,
+        credential_ref: None,
+        base_url: None,
+        model: None,
+        fast_model: None,
+        vision_model: None,
+        reasoning_effort: None,
+        responses_only_models: Vec::new(),
+        request_overrides: None,
+        enabled: true,
+        extra: Default::default(),
+    }
+}
+
+fn default_copilot_instance(headless_auth: bool) -> ProviderInstanceConfig {
+    let mut instance = empty_provider_instance("copilot");
+    instance.label = Some("GitHub Copilot".to_string());
+    instance
+        .extra
+        .insert("headless_auth".to_string(), Value::Bool(headless_auth));
+    instance
+}
+
+/// Build the deprecated provider-settings view from instance-native state.
+///
+/// The durable and runtime authorities remain `provider_instances`. This is a
+/// response-only projection for old clients during the Lotus #177 migration
+/// window. The default instance is considered first; remaining instances are
+/// ordered by id so two identical configs always produce the same legacy view.
+pub fn legacy_provider_compatibility_view(config: &Config) -> ProviderConfigs {
+    if config.provider_instances.is_empty() {
+        return config.providers().clone();
+    }
+
+    // In instance mode, never let a stale legacy slot mask the authoritative
+    // instance selected below. Retain provider-section extension metadata and
+    // use legacy builtins only to fill provider types that no instance can
+    // represent for the old type-keyed DTO.
+    let legacy = config.providers().clone();
+    let mut providers = ProviderConfigs {
+        extra: legacy.extra.clone(),
+        ..ProviderConfigs::default()
+    };
+
+    // The narrow hybrid seam is ordered first: while a degraded facade defers
+    // materialization, the effective default may still name a real legacy
+    // alias. It must beat a non-default explicit instance of the same type.
+    let effective_default = config.effective_default_provider();
+    if !config.provider_instances.contains_key(effective_default) {
+        if let Some((_, instance)) = synthesize_legacy_instances(config)
+            .into_iter()
+            .find(|(id, _)| id == effective_default)
+        {
+            project_instance_for_legacy_api(&mut providers, &instance);
+        }
+    }
+
+    let mut ids = config
+        .provider_instances
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    ids.sort();
+    if let Some(default) = config.default_provider_instance.as_deref() {
+        if let Some(index) = ids.iter().position(|id| id == default) {
+            let default = ids.remove(index);
+            ids.insert(0, default);
+        }
+    }
+    for id in ids {
+        let Some(instance) = config.provider_instances.get(&id) else {
+            continue;
+        };
+        if instance.enabled {
+            project_instance_for_legacy_api(&mut providers, instance);
+        }
+    }
+
+    // Fill provider types absent from the authoritative instance projection so
+    // legacy clients keep their read-only catalog during the Lotus #177
+    // migration window. `project_instance_for_legacy_api` never overwrites a
+    // type already selected above.
+    let represented_types = config
+        .provider_instances
+        .values()
+        .map(|instance| instance.provider_type.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    for (_, instance) in synthesize_legacy_instances(config) {
+        if !represented_types.contains(instance.provider_type.as_str()) {
+            project_instance_for_legacy_api(&mut providers, &instance);
+        }
+    }
+    providers
+}
+
+fn project_instance_for_legacy_api(
+    providers: &mut ProviderConfigs,
+    instance: &ProviderInstanceConfig,
+) {
+    match instance.provider_type.as_str() {
+        "openai" if providers.openai.is_none() => {
+            providers.openai = Some(OpenAIConfig {
+                api_key: instance.api_key.clone(),
+                api_key_encrypted: instance.api_key_encrypted.clone(),
+                credential_ref: instance.credential_ref.clone(),
+                api_key_from_env: provider_instance_api_key_from_env(instance),
+                base_url: instance.base_url.clone(),
+                model: instance.model.clone(),
+                fast_model: instance.fast_model.clone(),
+                vision_model: instance.vision_model.clone(),
+                reasoning_effort: instance.reasoning_effort,
+                responses_only_models: instance.responses_only_models.clone(),
+                request_overrides: instance.request_overrides.clone(),
+                extra: compatibility_extra(instance, &[]),
+            });
+        }
+        "anthropic" if providers.anthropic.is_none() => {
+            providers.anthropic = Some(AnthropicConfig {
+                api_key: instance.api_key.clone(),
+                api_key_encrypted: instance.api_key_encrypted.clone(),
+                credential_ref: instance.credential_ref.clone(),
+                api_key_from_env: provider_instance_api_key_from_env(instance),
+                base_url: instance.base_url.clone(),
+                model: instance.model.clone(),
+                fast_model: instance.fast_model.clone(),
+                vision_model: instance.vision_model.clone(),
+                max_tokens: instance
+                    .extra
+                    .get("max_tokens")
+                    .and_then(Value::as_u64)
+                    .and_then(|value| u32::try_from(value).ok()),
+                reasoning_effort: instance.reasoning_effort,
+                request_overrides: instance.request_overrides.clone(),
+                thinking_replay_always: instance
+                    .extra
+                    .get("thinking_replay_always")
+                    .and_then(Value::as_bool),
+                extra: compatibility_extra(instance, &["max_tokens", "thinking_replay_always"]),
+            });
+        }
+        "gemini" if providers.gemini.is_none() => {
+            providers.gemini = Some(GeminiConfig {
+                api_key: instance.api_key.clone(),
+                api_key_encrypted: instance.api_key_encrypted.clone(),
+                credential_ref: instance.credential_ref.clone(),
+                api_key_from_env: provider_instance_api_key_from_env(instance),
+                base_url: instance.base_url.clone(),
+                model: instance.model.clone(),
+                fast_model: instance.fast_model.clone(),
+                vision_model: instance.vision_model.clone(),
+                reasoning_effort: instance.reasoning_effort,
+                request_overrides: instance.request_overrides.clone(),
+                extra: compatibility_extra(instance, &[]),
+            });
+        }
+        "copilot" if providers.copilot.is_none() => {
+            providers.copilot = Some(CopilotConfig {
+                enabled: instance.enabled,
+                headless_auth: instance
+                    .extra
+                    .get("headless_auth")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                model: instance.model.clone(),
+                fast_model: instance.fast_model.clone(),
+                vision_model: instance.vision_model.clone(),
+                reasoning_effort: instance.reasoning_effort,
+                responses_only_models: instance.responses_only_models.clone(),
+                request_overrides: instance.request_overrides.clone(),
+                extra: compatibility_extra(instance, &["headless_auth"]),
+            });
+        }
+        "bodhi" if providers.bodhi.is_none() => {
+            providers.bodhi = Some(BodhiConfig {
+                api_key: instance.api_key.clone(),
+                api_key_encrypted: instance.api_key_encrypted.clone(),
+                credential_ref: instance.credential_ref.clone(),
+                base_url: instance.base_url.clone(),
+                target_provider: instance
+                    .extra
+                    .get("target_provider")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string),
+                reasoning_effort: instance.reasoning_effort,
+                extra: compatibility_extra(instance, &["target_provider"]),
+            });
+        }
+        _ => {}
+    }
+}
+
+fn compatibility_extra(
+    instance: &ProviderInstanceConfig,
+    consumed_fields: &[&str],
+) -> std::collections::BTreeMap<String, Value> {
+    let mut extra = instance.extra.clone();
+    extra.remove(PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY);
+    for field in consumed_fields {
+        extra.remove(*field);
+    }
+    extra
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::Config;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let previous = std::env::var_os(key);
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     /// Build a test config with explicit empty providers/instances. (Since #38,
     /// `Config::default()` is in-memory only — no filesystem/env bleed — so the
@@ -278,5 +716,489 @@ mod tests {
 
         let instances = synthesize_legacy_instances(&config);
         assert!(instances.is_empty());
+    }
+
+    #[test]
+    fn synthesize_preserves_credential_reference_and_provider_specific_fields() {
+        let mut config = clean_test_config();
+        config.providers.openai = None;
+        config.providers.gemini = None;
+        config.providers.copilot = Some(CopilotConfig {
+            enabled: true,
+            headless_auth: true,
+            extra: [(
+                "copilot_extension".to_string(),
+                Value::String("kept".into()),
+            )]
+            .into_iter()
+            .collect(),
+            ..CopilotConfig::default()
+        });
+        config.providers.bodhi = Some(BodhiConfig {
+            api_key: String::new(),
+            api_key_encrypted: None,
+            credential_ref: Some(crate::CredentialRef::parse("provider.bodhi.api_key").unwrap()),
+            base_url: None,
+            target_provider: Some("anthropic".to_string()),
+            reasoning_effort: None,
+            extra: [("bodhi_extension".to_string(), Value::Bool(true))]
+                .into_iter()
+                .collect(),
+        });
+        config.providers.anthropic = Some(AnthropicConfig {
+            credential_ref: Some(
+                crate::CredentialRef::parse("provider.anthropic.api_key").unwrap(),
+            ),
+            max_tokens: Some(8192),
+            thinking_replay_always: Some(true),
+            extra: [(
+                "anthropic_extension".to_string(),
+                Value::String("kept".into()),
+            )]
+            .into_iter()
+            .collect(),
+            ..AnthropicConfig::default()
+        });
+
+        let instances = synthesize_legacy_instances(&config)
+            .into_iter()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let anthropic = &instances["anthropic"];
+        assert_eq!(
+            anthropic
+                .credential_ref
+                .as_ref()
+                .map(|value| value.as_str()),
+            Some("provider.anthropic.api_key")
+        );
+        assert_eq!(anthropic.extra["max_tokens"], serde_json::json!(8192));
+        assert_eq!(anthropic.extra["thinking_replay_always"], Value::Bool(true));
+        assert_eq!(
+            anthropic.extra["anthropic_extension"],
+            Value::String("kept".into())
+        );
+        assert_eq!(instances["copilot"].extra["headless_auth"], true);
+        assert_eq!(instances["copilot"].extra["copilot_extension"], "kept");
+        assert_eq!(instances["bodhi"].extra["target_provider"], "anthropic");
+        assert_eq!(instances["bodhi"].extra["bodhi_extension"], true);
+    }
+
+    #[test]
+    fn materialization_is_idempotent_and_reuses_stable_credential_reference() {
+        let mut config = clean_test_config();
+        config.provider = "openai".to_string();
+        config.providers.anthropic = None;
+        config.providers.gemini = None;
+        config.providers.copilot = None;
+        config.providers.bodhi = None;
+        config.providers.openai = Some(OpenAIConfig {
+            credential_ref: Some(crate::CredentialRef::parse("provider.openai.api_key").unwrap()),
+            model: Some("gpt-4.1".to_string()),
+            ..OpenAIConfig::default()
+        });
+
+        assert!(materialize_legacy_provider_instances(&mut config));
+        let first = serde_json::to_value(&config.provider_instances).unwrap();
+        assert!(!materialize_legacy_provider_instances(&mut config));
+        assert_eq!(
+            serde_json::to_value(&config.provider_instances).unwrap(),
+            first
+        );
+        assert_eq!(config.default_provider_instance.as_deref(), Some("openai"));
+        assert_eq!(
+            config.provider_instances["openai"]
+                .credential_ref
+                .as_ref()
+                .map(|value| value.as_str()),
+            Some("provider.openai.api_key")
+        );
+        assert!(provider_instance_api_key_from_env(
+            &config.provider_instances["openai"]
+        ));
+        assert!(!first.to_string().contains("api_key_encrypted"));
+    }
+
+    #[test]
+    fn explicit_disabled_default_is_never_rewritten_from_stale_legacy_config() {
+        let mut config = clean_test_config();
+        config.provider = "openai".to_string();
+        config.providers.openai = Some(OpenAIConfig {
+            credential_ref: Some(crate::CredentialRef::parse("provider.openai.api_key").unwrap()),
+            ..OpenAIConfig::default()
+        });
+        let mut explicit = empty_provider_instance("openai");
+        explicit.enabled = false;
+        config
+            .provider_instances
+            .insert("openai".to_string(), explicit);
+        config.default_provider_instance = Some("openai".to_string());
+
+        assert!(!materialize_legacy_provider_instances(&mut config));
+        assert!(!config.provider_instances["openai"].enabled);
+    }
+
+    #[test]
+    fn hybrid_missing_legacy_default_is_materialized_with_all_missing_aliases() {
+        let mut config = clean_test_config();
+        config
+            .provider_instances
+            .insert("work".to_string(), empty_provider_instance("openai"));
+        config.providers.openai = Some(OpenAIConfig {
+            credential_ref: Some(crate::CredentialRef::parse("provider.openai.api_key").unwrap()),
+            ..OpenAIConfig::default()
+        });
+        config.providers.anthropic = Some(AnthropicConfig {
+            credential_ref: Some(
+                crate::CredentialRef::parse("provider.anthropic.api_key").unwrap(),
+            ),
+            ..AnthropicConfig::default()
+        });
+        config.default_provider_instance = Some("openai".to_string());
+
+        assert!(materialize_legacy_provider_instances(&mut config));
+        assert!(config.provider_instances.contains_key("work"));
+        assert!(config.provider_instances.contains_key("openai"));
+        assert!(config.provider_instances.contains_key("anthropic"));
+        assert_eq!(config.default_provider_instance.as_deref(), Some("openai"));
+    }
+
+    #[test]
+    fn explicit_default_materializes_noncolliding_legacy_aliases_without_changing_default() {
+        let mut config = clean_test_config();
+        config.provider = "work".to_string();
+        config
+            .provider_instances
+            .insert("work".to_string(), empty_provider_instance("openai"));
+        config.default_provider_instance = Some("work".to_string());
+        config.providers.openai = Some(OpenAIConfig {
+            credential_ref: Some(crate::CredentialRef::parse("provider.openai.api_key").unwrap()),
+            model: Some("gpt-legacy".to_string()),
+            ..OpenAIConfig::default()
+        });
+        config.providers.anthropic = Some(AnthropicConfig {
+            credential_ref: Some(
+                crate::CredentialRef::parse("provider.anthropic.api_key").unwrap(),
+            ),
+            model: Some("claude-legacy".to_string()),
+            ..AnthropicConfig::default()
+        });
+
+        assert!(materialize_legacy_provider_instances(&mut config));
+        assert_eq!(config.default_provider_instance.as_deref(), Some("work"));
+        assert_eq!(
+            config.provider_instances["openai"].model.as_deref(),
+            Some("gpt-legacy")
+        );
+        assert_eq!(
+            config.provider_instances["anthropic"].model.as_deref(),
+            Some("claude-legacy")
+        );
+        assert!(provider_instance_api_key_from_env(
+            &config.provider_instances["openai"]
+        ));
+        assert!(provider_instance_api_key_from_env(
+            &config.provider_instances["anthropic"]
+        ));
+    }
+
+    #[test]
+    fn ordinary_missing_key_does_not_gain_an_environment_marker() {
+        let mut config = clean_test_config();
+        config.providers.anthropic = None;
+        config.providers.gemini = None;
+        config.providers.copilot = None;
+        config.providers.bodhi = None;
+        config.providers.openai = Some(OpenAIConfig::default());
+
+        let synthesized = synthesize_legacy_instances(&config);
+        assert_eq!(synthesized.len(), 1);
+        assert!(!provider_instance_api_key_from_env(&synthesized[0].1));
+    }
+
+    #[test]
+    fn missing_unusable_default_does_not_create_dangling_instance() {
+        let mut config = clean_test_config();
+        config.provider = "bodhi".to_string();
+        *config.providers_mut() = ProviderConfigs {
+            bodhi: Some(BodhiConfig {
+                api_key: String::new(),
+                api_key_encrypted: None,
+                credential_ref: None,
+                base_url: None,
+                target_provider: None,
+                reasoning_effort: None,
+                extra: Default::default(),
+            }),
+            ..ProviderConfigs::default()
+        };
+
+        assert!(!materialize_legacy_provider_instances(&mut config));
+        assert!(config.provider_instances.is_empty());
+        assert!(config.default_provider_instance.is_none());
+    }
+
+    #[test]
+    fn env_owned_legacy_key_migrates_as_marker_without_secret_material() {
+        let _lock = crate::test_support::env_cache_lock_acquire();
+        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", None);
+        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", Some("runtime-only"));
+        let mut config = clean_test_config();
+        config.provider = "gemini".to_string();
+        *config.providers_mut() = ProviderConfigs {
+            gemini: Some(GeminiConfig {
+                api_key: "runtime-only".to_string(),
+                api_key_from_env: true,
+                ..GeminiConfig::default()
+            }),
+            ..ProviderConfigs::default()
+        };
+
+        assert!(materialize_legacy_provider_instances(&mut config));
+        let instance = &config.provider_instances["gemini"];
+        assert!(provider_instance_api_key_from_env(instance));
+        let disk = serde_json::to_value(instance).unwrap();
+        assert_eq!(disk[PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY], true);
+        assert!(disk.get("api_key").is_none());
+        assert!(disk.get("api_key_encrypted").is_none());
+    }
+
+    #[test]
+    fn materialized_legacy_ref_keeps_environment_override_and_stored_fallback() {
+        let _lock = crate::test_support::env_cache_lock_acquire();
+        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", None);
+        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", None);
+        let mut config = clean_test_config();
+        config.provider = "openai".to_string();
+        config.providers.openai = Some(OpenAIConfig {
+            api_key: "sk-stored-fallback".to_string(),
+            credential_ref: Some(crate::CredentialRef::parse("provider.openai.api_key").unwrap()),
+            ..OpenAIConfig::default()
+        });
+
+        assert!(materialize_legacy_provider_instances(&mut config));
+        assert!(provider_instance_api_key_from_env(
+            &config.provider_instances["openai"]
+        ));
+        config.apply_runtime_env_overrides();
+        assert_eq!(
+            config.provider_instances["openai"].api_key,
+            "sk-stored-fallback"
+        );
+        assert!(!provider_instance_environment_override_active(
+            &config.provider_instances["openai"]
+        ));
+
+        std::env::set_var("BAMBOO_OPENAI_API_KEY", "sk-runtime-override");
+        config.apply_runtime_env_overrides();
+        assert_eq!(
+            config.provider_instances["openai"].api_key,
+            "sk-runtime-override"
+        );
+        assert!(provider_instance_environment_override_active(
+            &config.provider_instances["openai"]
+        ));
+
+        std::env::remove_var("BAMBOO_OPENAI_API_KEY");
+        config.provider_instances.get_mut("openai").unwrap().api_key =
+            "sk-stored-fallback".to_string();
+        config.apply_runtime_env_overrides();
+        assert_eq!(
+            config.provider_instances["openai"].api_key,
+            "sk-stored-fallback"
+        );
+        assert!(!provider_instance_environment_override_active(
+            &config.provider_instances["openai"]
+        ));
+    }
+
+    #[test]
+    fn nonselected_environment_only_provider_is_materialized_and_hydrated() {
+        let _lock = crate::test_support::env_cache_lock_acquire();
+        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", None);
+        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", Some("sk-ant-runtime"));
+        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", None);
+        let mut config = clean_test_config();
+        config.provider = "openai".to_string();
+        config.providers.openai = Some(OpenAIConfig {
+            api_key: "sk-openai-stored".to_string(),
+            credential_ref: Some(crate::CredentialRef::parse("provider.openai.api_key").unwrap()),
+            ..OpenAIConfig::default()
+        });
+
+        assert!(materialize_legacy_provider_instances(&mut config));
+        assert_eq!(config.default_provider_instance.as_deref(), Some("openai"));
+        let anthropic = &config.provider_instances["anthropic"];
+        assert!(provider_instance_api_key_from_env(anthropic));
+        assert!(anthropic.credential_ref.is_none());
+        assert!(anthropic.api_key.is_empty());
+
+        config.apply_runtime_env_overrides();
+        assert_eq!(
+            config.provider_instances["anthropic"].api_key,
+            "sk-ant-runtime"
+        );
+        assert!(provider_instance_environment_override_active(
+            &config.provider_instances["anthropic"]
+        ));
+    }
+
+    #[test]
+    fn selected_copilot_without_legacy_stanza_gets_a_default_instance() {
+        let mut config = clean_test_config();
+        config.provider = "copilot".to_string();
+        *config.providers_mut() = ProviderConfigs::default();
+
+        assert!(materialize_legacy_provider_instances(&mut config));
+        assert_eq!(config.default_provider_instance.as_deref(), Some("copilot"));
+        assert!(config.provider_instances["copilot"].enabled);
+    }
+
+    #[test]
+    fn legacy_view_prefers_authoritative_instance_over_stale_same_type_slot() {
+        let mut config = clean_test_config();
+        config.providers.openai = Some(OpenAIConfig {
+            api_key: "sk-stale".to_string(),
+            model: Some("stale-model".to_string()),
+            ..OpenAIConfig::default()
+        });
+        config.provider_instances.insert(
+            "work".to_string(),
+            ProviderInstanceConfig {
+                provider_type: "openai".to_string(),
+                label: Some("Work".to_string()),
+                api_key: "sk-instance".to_string(),
+                api_key_encrypted: None,
+                credential_ref: None,
+                base_url: Some("https://work.example/v1".to_string()),
+                model: Some("instance-model".to_string()),
+                fast_model: None,
+                vision_model: None,
+                reasoning_effort: None,
+                responses_only_models: Vec::new(),
+                request_overrides: None,
+                enabled: true,
+                extra: Default::default(),
+            },
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        let view = legacy_provider_compatibility_view(&config);
+        let openai = view.openai.expect("instance should be projected");
+        assert_eq!(openai.api_key, "sk-instance");
+        assert_eq!(openai.model.as_deref(), Some("instance-model"));
+        assert_eq!(openai.base_url.as_deref(), Some("https://work.example/v1"));
+    }
+
+    #[test]
+    fn legacy_view_prioritizes_effective_hybrid_alias_and_fills_missing_legacy_types() {
+        let mut config = clean_test_config();
+        config.provider = "anthropic".to_string();
+        config.providers.anthropic = Some(AnthropicConfig {
+            api_key: "sk-effective".to_string(),
+            model: Some("claude-effective".to_string()),
+            ..AnthropicConfig::default()
+        });
+        config.providers.gemini = Some(GeminiConfig {
+            api_key: "stale-gemini".to_string(),
+            ..GeminiConfig::default()
+        });
+        config.provider_instances.insert(
+            "work".to_string(),
+            ProviderInstanceConfig {
+                provider_type: "openai".to_string(),
+                label: None,
+                api_key: "sk-work".to_string(),
+                api_key_encrypted: None,
+                credential_ref: None,
+                base_url: None,
+                model: Some("gpt-work".to_string()),
+                fast_model: None,
+                vision_model: None,
+                reasoning_effort: None,
+                responses_only_models: Vec::new(),
+                request_overrides: None,
+                enabled: true,
+                extra: Default::default(),
+            },
+        );
+
+        let view = legacy_provider_compatibility_view(&config);
+        assert_eq!(
+            view.anthropic.and_then(|provider| provider.model),
+            Some("claude-effective".to_string())
+        );
+        assert!(view.openai.is_some());
+        assert!(
+            view.gemini.is_some(),
+            "legacy-only provider types remain visible to the deprecated read API"
+        );
+    }
+
+    #[test]
+    fn legacy_projection_serializes_consumed_extra_fields_exactly_once() {
+        let mut config = clean_test_config();
+        *config.providers_mut() = ProviderConfigs::default();
+        for (id, provider_type, extra) in [
+            (
+                "anthropic-work",
+                "anthropic",
+                serde_json::json!({
+                    "max_tokens": 6144,
+                    "thinking_replay_always": true,
+                    "api_key_from_env": true,
+                    "anthropic_extension": "kept"
+                }),
+            ),
+            (
+                "copilot-work",
+                "copilot",
+                serde_json::json!({
+                    "headless_auth": true,
+                    "copilot_extension": "kept"
+                }),
+            ),
+            (
+                "bodhi-work",
+                "bodhi",
+                serde_json::json!({
+                    "target_provider": "gemini",
+                    "bodhi_extension": "kept"
+                }),
+            ),
+        ] {
+            let mut value = extra.as_object().unwrap().clone();
+            value.insert(
+                "provider_type".to_string(),
+                Value::String(provider_type.to_string()),
+            );
+            value.insert("enabled".to_string(), Value::Bool(true));
+            let mut instance: ProviderInstanceConfig =
+                serde_json::from_value(Value::Object(value)).unwrap();
+            if provider_type != "copilot" {
+                instance.api_key = format!("secret-{id}");
+            }
+            config.provider_instances.insert(id.to_string(), instance);
+        }
+        config.default_provider_instance = Some("anthropic-work".to_string());
+
+        let value = serde_json::to_value(legacy_provider_compatibility_view(&config)).unwrap();
+        assert_eq!(value["anthropic"]["max_tokens"], 6144);
+        assert_eq!(value["anthropic"]["thinking_replay_always"], true);
+        assert_eq!(value["anthropic"]["anthropic_extension"], "kept");
+        assert!(value["anthropic"].get("api_key_from_env").is_none());
+        assert_eq!(value["copilot"]["headless_auth"], true);
+        assert_eq!(value["copilot"]["copilot_extension"], "kept");
+        assert_eq!(value["bodhi"]["target_provider"], "gemini");
+        assert_eq!(value["bodhi"]["bodhi_extension"], "kept");
+
+        let round_trip: ProviderConfigs = serde_json::from_value(value).unwrap();
+        assert_eq!(round_trip.anthropic.unwrap().max_tokens, Some(6144));
+        assert!(round_trip.copilot.unwrap().headless_auth);
+        assert_eq!(
+            round_trip.bodhi.unwrap().target_provider.as_deref(),
+            Some("gemini")
+        );
     }
 }

--- a/crates/infra/bamboo-config/src/provider_instance.rs
+++ b/crates/infra/bamboo-config/src/provider_instance.rs
@@ -47,14 +47,24 @@ pub fn provider_instance_environment_override_active(instance: &ProviderInstance
     if !provider_instance_api_key_from_env(instance) {
         return false;
     }
-    let Some(env_var) = standard_provider_api_key_env(&instance.provider_type) else {
+    provider_api_key_environment_override_active(&instance.provider_type, &instance.api_key)
+}
+
+/// Whether a provider key currently matches its standard environment override.
+///
+/// Compatibility projections use this without fabricating a temporary
+/// [`ProviderInstanceConfig`]. A persisted environment binding alone is not
+/// active: the variable must still be present and equal the hydrated runtime
+/// value.
+pub fn provider_api_key_environment_override_active(provider_type: &str, api_key: &str) -> bool {
+    let Some(env_var) = standard_provider_api_key_env(provider_type) else {
         return false;
     };
     let Ok(value) = crate::runtime_env_var(env_var) else {
         return false;
     };
     let value = value.trim();
-    !value.is_empty() && instance.api_key.trim() == value
+    !value.is_empty() && api_key.trim() == value
 }
 
 fn copy_runtime_env_marker(

--- a/crates/infra/bamboo-config/src/provider_instance.rs
+++ b/crates/infra/bamboo-config/src/provider_instance.rs
@@ -50,7 +50,7 @@ pub fn provider_instance_environment_override_active(instance: &ProviderInstance
     let Some(env_var) = standard_provider_api_key_env(&instance.provider_type) else {
         return false;
     };
-    let Ok(value) = std::env::var(env_var) else {
+    let Ok(value) = crate::runtime_env_var(env_var) else {
         return false;
     };
     let value = value.trim();
@@ -356,7 +356,7 @@ fn standard_provider_api_key_env(provider_type: &str) -> Option<&'static str> {
 
 fn standard_provider_api_key_env_is_available(provider_type: &str) -> bool {
     standard_provider_api_key_env(provider_type)
-        .and_then(|env_var| std::env::var(env_var).ok())
+        .and_then(|env_var| crate::runtime_env_var(env_var).ok())
         .is_some_and(|value| !value.trim().is_empty())
 }
 
@@ -583,31 +583,6 @@ fn compatibility_extra(
 mod tests {
     use super::*;
     use crate::config::Config;
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: Option<&str>) -> Self {
-            let previous = std::env::var_os(key);
-            match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
-            }
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
 
     /// Build a test config with explicit empty providers/instances. (Since #38,
     /// `Config::default()` is in-memory only — no filesystem/env bleed — so the
@@ -939,10 +914,13 @@ mod tests {
 
     #[test]
     fn env_owned_legacy_key_migrates_as_marker_without_secret_material() {
-        let _lock = crate::test_support::env_cache_lock_acquire();
-        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", None);
-        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", None);
-        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", Some("runtime-only"));
+        let _openai = crate::test_support::override_runtime_env_var("BAMBOO_OPENAI_API_KEY", None);
+        let _anthropic =
+            crate::test_support::override_runtime_env_var("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini = crate::test_support::override_runtime_env_var(
+            "BAMBOO_GEMINI_API_KEY",
+            Some("runtime-only"),
+        );
         let mut config = clean_test_config();
         config.provider = "gemini".to_string();
         *config.providers_mut() = ProviderConfigs {
@@ -965,10 +943,10 @@ mod tests {
 
     #[test]
     fn materialized_legacy_ref_keeps_environment_override_and_stored_fallback() {
-        let _lock = crate::test_support::env_cache_lock_acquire();
-        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", None);
-        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", None);
-        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", None);
+        let openai = crate::test_support::override_runtime_env_var("BAMBOO_OPENAI_API_KEY", None);
+        let _anthropic =
+            crate::test_support::override_runtime_env_var("BAMBOO_ANTHROPIC_API_KEY", None);
+        let _gemini = crate::test_support::override_runtime_env_var("BAMBOO_GEMINI_API_KEY", None);
         let mut config = clean_test_config();
         config.provider = "openai".to_string();
         config.providers.openai = Some(OpenAIConfig {
@@ -990,7 +968,7 @@ mod tests {
             &config.provider_instances["openai"]
         ));
 
-        std::env::set_var("BAMBOO_OPENAI_API_KEY", "sk-runtime-override");
+        openai.replace(Some("sk-runtime-override"));
         config.apply_runtime_env_overrides();
         assert_eq!(
             config.provider_instances["openai"].api_key,
@@ -1000,7 +978,7 @@ mod tests {
             &config.provider_instances["openai"]
         ));
 
-        std::env::remove_var("BAMBOO_OPENAI_API_KEY");
+        openai.replace(None);
         config.provider_instances.get_mut("openai").unwrap().api_key =
             "sk-stored-fallback".to_string();
         config.apply_runtime_env_overrides();
@@ -1015,10 +993,12 @@ mod tests {
 
     #[test]
     fn nonselected_environment_only_provider_is_materialized_and_hydrated() {
-        let _lock = crate::test_support::env_cache_lock_acquire();
-        let _openai = EnvVarGuard::set("BAMBOO_OPENAI_API_KEY", None);
-        let _anthropic = EnvVarGuard::set("BAMBOO_ANTHROPIC_API_KEY", Some("sk-ant-runtime"));
-        let _gemini = EnvVarGuard::set("BAMBOO_GEMINI_API_KEY", None);
+        let _openai = crate::test_support::override_runtime_env_var("BAMBOO_OPENAI_API_KEY", None);
+        let _anthropic = crate::test_support::override_runtime_env_var(
+            "BAMBOO_ANTHROPIC_API_KEY",
+            Some("sk-ant-runtime"),
+        );
+        let _gemini = crate::test_support::override_runtime_env_var("BAMBOO_GEMINI_API_KEY", None);
         let mut config = clean_test_config();
         config.provider = "openai".to_string();
         config.providers.openai = Some(OpenAIConfig {

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -964,7 +964,7 @@ fn validate_ordinary_section_json(value: &Value) -> ConfigStoreResult<()> {
         credential_context: CredentialScanContext,
     ) -> Result<(), String> {
         if credential_context != CredentialScanContext::None
-            && is_nonliteral_runtime_template(value)
+            && request_override_value_is_nonliteral_runtime_template(value)
         {
             return Ok(());
         }
@@ -1065,9 +1065,11 @@ fn validate_ordinary_section_json(value: &Value) -> ConfigStoreResult<()> {
                         if normalized_key == "headers" {
                             if let Some(headers) = value.as_object() {
                                 for (name, expression) in headers {
-                                    if is_credential_header(name)
+                                    if request_override_header_is_credential(name)
                                         && !value_is_empty(expression)
-                                        && !is_nonliteral_runtime_template(expression)
+                                        && !request_override_value_is_nonliteral_runtime_template(
+                                            expression,
+                                        )
                                     {
                                         return Err(format!(
                                             "credential header {name} must not contain a literal"
@@ -1481,6 +1483,157 @@ fn key_contains_literal_credential_material(key: &str, value: &Value) -> bool {
         && !value_is_empty(value)
 }
 
+/// Remove credential authority and literal credential material from provider
+/// metadata before it crosses a compatibility API boundary.
+///
+/// Provider `extra` maps are intentionally forward compatible, so older
+/// binaries can carry fields they do not understand. That also means an API
+/// response cannot assume an unknown field is public metadata. This scrubber
+/// mirrors the durable section classifier, including credential contexts such
+/// as `{ "oauth": { "value": ... } }`, while retaining explicit runtime
+/// templates and public metadata such as OAuth URLs, client ids, modes, and
+/// status booleans.
+///
+/// Credential references are server-owned authority and are removed even
+/// though they are safe to persist in the modular config.
+pub fn scrub_provider_metadata_credentials(value: &mut Value) {
+    fn walk(value: &mut Value, credential_context: CredentialScanContext) -> bool {
+        if credential_context != CredentialScanContext::None
+            && request_override_value_is_nonliteral_runtime_template(value)
+        {
+            return false;
+        }
+
+        match value {
+            Value::Object(object) => {
+                let keys = object.keys().cloned().collect::<Vec<_>>();
+                for key in keys {
+                    let Some(child) = object.get_mut(&key) else {
+                        continue;
+                    };
+                    let normalized = normalized_credential_key(&key);
+                    let reference_metadata = credential_reference_metadata_key(&key);
+
+                    if reference_metadata
+                        || key_contains_literal_credential_material(&key, child)
+                        || (credential_context != CredentialScanContext::None
+                            && NORMALIZED_CREDENTIAL_PAYLOAD_SUFFIXES
+                                .contains(&normalized.as_str())
+                            && !value_is_empty(child))
+                    {
+                        object.remove(&key);
+                        continue;
+                    }
+
+                    let child_keys_are_identifiers = matches!(
+                        normalized.as_str(),
+                        "headers" | "providerinstances" | "credentialrefs"
+                    ) || normalized.ends_with("credentialrefs");
+                    let key_context = if child.is_object() || child.is_array() {
+                        credential_context_key(&key)
+                    } else {
+                        credential_literal_key(&key)
+                    };
+                    let key_metadata_context = (child.is_object() || child.is_array())
+                        && credential_metadata_container_key(&key);
+                    let child_context = if credential_context == CredentialScanContext::Strong
+                        && credential_public_metadata_key(&key)
+                    {
+                        CredentialScanContext::Adjacent
+                    } else if credential_context == CredentialScanContext::Strong || key_context {
+                        CredentialScanContext::Strong
+                    } else if credential_context == CredentialScanContext::Adjacent
+                        || key_metadata_context
+                    {
+                        CredentialScanContext::Adjacent
+                    } else {
+                        CredentialScanContext::None
+                    };
+
+                    if child_keys_are_identifiers {
+                        match child {
+                            Value::Object(entries) if normalized == "headers" => {
+                                let names = entries.keys().cloned().collect::<Vec<_>>();
+                                for name in names {
+                                    let remove = entries.get_mut(&name).is_some_and(|expression| {
+                                        (request_override_header_is_credential(&name)
+                                            && !value_is_empty(expression)
+                                            && !request_override_value_is_nonliteral_runtime_template(
+                                                expression,
+                                            ))
+                                            || walk(expression, credential_context)
+                                    });
+                                    if remove {
+                                        entries.remove(&name);
+                                    }
+                                }
+                            }
+                            Value::Object(entries) => {
+                                let names = entries.keys().cloned().collect::<Vec<_>>();
+                                for name in names {
+                                    let remove = entries
+                                        .get_mut(&name)
+                                        .is_some_and(|entry| walk(entry, child_context));
+                                    if remove {
+                                        entries.remove(&name);
+                                    }
+                                }
+                            }
+                            Value::Array(entries) => {
+                                let mut index = 0;
+                                while index < entries.len() {
+                                    if walk(&mut entries[index], child_context) {
+                                        entries.remove(index);
+                                    } else {
+                                        index += 1;
+                                    }
+                                }
+                            }
+                            _ => {
+                                if walk(child, child_context) {
+                                    object.remove(&key);
+                                }
+                            }
+                        }
+                    } else if walk(child, child_context) {
+                        object.remove(&key);
+                    }
+                }
+                false
+            }
+            Value::Array(values) => {
+                let mut index = 0;
+                while index < values.len() {
+                    if walk(&mut values[index], credential_context) {
+                        values.remove(index);
+                    } else {
+                        index += 1;
+                    }
+                }
+                false
+            }
+            Value::String(value) => {
+                (credential_context == CredentialScanContext::Strong && !value.trim().is_empty())
+                    || url::Url::parse(value)
+                        .ok()
+                        .is_some_and(|url| !url.username().is_empty() || url.password().is_some())
+            }
+            Value::Number(_) => credential_context == CredentialScanContext::Strong,
+            Value::Bool(_) | Value::Null => false,
+        }
+    }
+
+    let _ = walk(value, CredentialScanContext::None);
+}
+
+/// Return whether provider metadata contains no API-visible credential
+/// authority or literal credential material.
+pub fn provider_metadata_is_secret_free(value: &Value) -> bool {
+    let mut sanitized = value.clone();
+    scrub_provider_metadata_credentials(&mut sanitized);
+    sanitized == *value
+}
+
 fn validate_configured_reference_coherence(
     object: &serde_json::Map<String, Value>,
 ) -> Result<(), String> {
@@ -1802,7 +1955,9 @@ fn validate_request_scope_override(value: &Value) -> Result<(), String> {
             .ok_or_else(|| "provider request override headers must be an object".to_string())?;
         for (name, expression) in headers {
             validate_template_expression_shape(expression)?;
-            if is_credential_header(name) && !is_nonliteral_runtime_template(expression) {
+            if request_override_header_is_credential(name)
+                && !request_override_value_is_nonliteral_runtime_template(expression)
+            {
                 return Err(format!(
                     "provider request override {name} must not contain a literal credential"
                 ));
@@ -1887,13 +2042,13 @@ fn validate_provider_body_patch(value: &Value) -> Result<(), String> {
             return Err("provider request body patch operation is invalid".to_string());
         }
     }
-    if !body_patch_targets_credential(path) {
+    if !request_override_body_patch_targets_credential(path) {
         return Ok(());
     }
     let Some(value) = patch.get("value") else {
         return Ok(());
     };
-    if !is_nonliteral_runtime_template(value) {
+    if !request_override_value_is_nonliteral_runtime_template(value) {
         return Err(format!(
             "provider request body patch {path} must not contain literal credential material"
         ));
@@ -1901,7 +2056,11 @@ fn validate_provider_body_patch(value: &Value) -> Result<(), String> {
     Ok(())
 }
 
-fn body_patch_targets_credential(path: &str) -> bool {
+/// Whether a request-override body path targets credential-shaped material.
+///
+/// API projections use the same classifier as the durable validator so legacy
+/// values that predate strict validation cannot be returned as plaintext.
+pub fn request_override_body_patch_targets_credential(path: &str) -> bool {
     fn credential_token(segment: &str) -> bool {
         matches!(
             segment,
@@ -1947,7 +2106,9 @@ fn body_patch_targets_credential(path: &str) -> bool {
             .any(|pair| credential_token(&format!("{}{}", pair[0], pair[1])))
 }
 
-fn is_nonliteral_runtime_template(value: &Value) -> bool {
+/// Whether a request-override expression resolves only from a validated
+/// runtime source and contains no literal fallback credential.
+pub fn request_override_value_is_nonliteral_runtime_template(value: &Value) -> bool {
     let Some(object) = value.as_object() else {
         return false;
     };
@@ -2037,7 +2198,10 @@ fn runtime_format_has_no_secret_literal(template: &str) -> bool {
     found_runtime_value && safe_literal
 }
 
-fn is_credential_header(name: &str) -> bool {
+/// Whether a request-override header name is credential-shaped.
+///
+/// Kept public so API response redaction and durable validation cannot drift.
+pub fn request_override_header_is_credential(name: &str) -> bool {
     let compact = name
         .chars()
         .filter(|ch| ch.is_ascii_alphanumeric())
@@ -5278,6 +5442,12 @@ impl ConfigFacade {
                         SectionId::Providers,
                     )?;
                 if !crate::materialize_legacy_provider_instances(&mut durable_config) {
+                    // Another facade/process may have published the migration
+                    // after this facade opened but before it acquired the
+                    // shared lock. The durable no-op is authoritative; adopt
+                    // that exact winner before returning so startup never
+                    // exposes the stale legacy generation until a watcher tick.
+                    let _ = self.registry.reload_if_changed(SectionId::Providers);
                     return Ok(false);
                 }
                 if durable_envelope.status != SectionStatus::Healthy
@@ -6194,6 +6364,48 @@ mod tests {
         std::fs::write(path, serde_json::to_vec_pretty(value).unwrap()).unwrap();
     }
 
+    #[test]
+    fn provider_api_metadata_scrubber_matches_durable_credential_contexts() {
+        let original = json!({
+            "headless_auth": true,
+            "oauth": {
+                "client_id": "public-client",
+                "authorization_url": "https://auth.example.test/authorize",
+                "value": "oauth-literal"
+            },
+            "private_key": "private-literal",
+            "nested": {"client_secret": "client-literal"},
+            "credential_ref": "provider.work.api_key",
+            "headers": {
+                "X-Trace": "public-trace",
+                "X-Access-Key": "header-literal",
+                "Authorization": {"type": "env_ref", "name": "UPSTREAM_TOKEN"}
+            }
+        });
+        assert!(!provider_metadata_is_secret_free(&original));
+
+        let mut sanitized = original;
+        scrub_provider_metadata_credentials(&mut sanitized);
+
+        assert_eq!(sanitized["headless_auth"], true);
+        assert_eq!(sanitized["oauth"]["client_id"], "public-client");
+        assert_eq!(
+            sanitized["oauth"]["authorization_url"],
+            "https://auth.example.test/authorize"
+        );
+        assert!(sanitized["oauth"].get("value").is_none());
+        assert!(sanitized.get("private_key").is_none());
+        assert!(sanitized["nested"].get("client_secret").is_none());
+        assert!(sanitized.get("credential_ref").is_none());
+        assert_eq!(sanitized["headers"]["X-Trace"], "public-trace");
+        assert!(sanitized["headers"].get("X-Access-Key").is_none());
+        assert_eq!(
+            sanitized["headers"]["Authorization"]["name"],
+            "UPSTREAM_TOKEN"
+        );
+        assert!(provider_metadata_is_secret_free(&sanitized));
+    }
+
     fn install_completed_legacy_openai(data_dir: &Path, secret: &str) -> (CredentialRef, u64) {
         let facade = ConfigFacade::open_or_migrate(data_dir).unwrap();
         let reference = CredentialRef::parse("provider.openai.api_key").unwrap();
@@ -6325,6 +6537,65 @@ mod tests {
                 .expose(),
             "completed-facade-secret"
         );
+    }
+
+    #[test]
+    fn concurrent_facades_publish_one_legacy_provider_migration_generation() {
+        let _key = crate::encryption::set_test_encryption_key([213; 32]);
+        let dir = TempDir::new().unwrap();
+        let (reference, legacy_revision) =
+            install_completed_legacy_openai(dir.path(), "concurrent-facade-secret");
+        let facades = [
+            std::sync::Arc::new(ConfigFacade::open(dir.path()).unwrap()),
+            std::sync::Arc::new(ConfigFacade::open(dir.path()).unwrap()),
+        ];
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let handles = facades
+            .into_iter()
+            .map(|facade| {
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    let _thread_key = crate::encryption::set_test_encryption_key([213; 32]);
+                    barrier.wait();
+                    facade.materialize_legacy_provider_authority().unwrap();
+                    let snapshot = facade.registry().providers.snapshot();
+                    (
+                        snapshot.revision,
+                        snapshot.status,
+                        snapshot.source_kind,
+                        snapshot.last_error.clone(),
+                        snapshot.data.default_provider_instance.clone(),
+                        snapshot.data.provider_instances.contains_key("openai"),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let results = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("facade thread"))
+            .collect::<Vec<_>>();
+        for (revision, status, source, last_error, default_id, has_instance) in &results {
+            assert_eq!(
+                *revision,
+                legacy_revision + 1,
+                "concurrent facade results: {results:?}"
+            );
+            assert_eq!(*status, SectionStatus::Healthy);
+            assert_eq!(*source, SectionSourceKind::File);
+            assert!(last_error.is_none());
+            assert_eq!(default_id.as_deref(), Some("openai"));
+            assert!(*has_instance);
+        }
+        assert_eq!(
+            CredentialStore::open(dir.path())
+                .resolve(&reference)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "concurrent-facade-secret"
+        );
+        assert_no_plaintext_in_persistent_files(dir.path(), &["concurrent-facade-secret"]);
     }
 
     #[test]
@@ -14143,7 +14414,7 @@ fn raw_reconciliation_secret_material_is_forbidden_with_context(
         path: &mut Vec<String>,
     ) -> bool {
         if credential_context != CredentialScanContext::None
-            && is_nonliteral_runtime_template(value)
+            && request_override_value_is_nonliteral_runtime_template(value)
         {
             return false;
         }
@@ -14179,9 +14450,11 @@ fn raw_reconciliation_secret_material_is_forbidden_with_context(
                                 let mut forbidden = false;
                                 for (name, expression) in entries {
                                     path.push(name.clone());
-                                    forbidden = if is_credential_header(name) {
+                                    forbidden = if request_override_header_is_credential(name) {
                                         !value_is_empty(expression)
-                                            && !is_nonliteral_runtime_template(expression)
+                                            && !request_override_value_is_nonliteral_runtime_template(
+                                                expression,
+                                            )
                                     } else {
                                         walk(section, expression, identifier_context, path)
                                     };

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -1301,14 +1301,19 @@ fn credential_token_is_sensitive(token: &str) -> bool {
             | "credential"
             | "credentials"
             | "secret"
+            | "secrets"
             | "token"
             | "password"
+            | "passwords"
             | "private"
             | "access"
             | "ciphertext"
+            | "ciphertexts"
             | "encrypted"
             | "cookie"
+            | "cookies"
             | "passphrase"
+            | "passphrases"
     )
 }
 
@@ -1317,13 +1322,21 @@ fn credential_key_compound_is_sensitive(tokens: &[String]) -> bool {
         matches!(
             (tokens[0].as_str(), tokens[1].as_str()),
             ("api", "key")
+                | ("api", "keys")
                 | ("auth", "key")
+                | ("auth", "keys")
                 | ("access", "key")
+                | ("access", "keys")
                 | ("private", "key")
+                | ("private", "keys")
                 | ("device", "key")
+                | ("device", "keys")
                 | ("secret", "key")
+                | ("secret", "keys")
                 | ("signing", "key")
+                | ("signing", "keys")
                 | ("encryption", "key")
+                | ("encryption", "keys")
         )
     })
 }
@@ -1342,6 +1355,53 @@ fn credential_name_has_terminal_sensitive_tokens(tokens: &[String]) -> bool {
         || (tokens.len() >= 2 && credential_key_compound_is_sensitive(&tokens[tokens.len() - 2..]))
 }
 
+fn normalized_terminal_token_collection(normalized: &str) -> bool {
+    normalized == "tokens"
+        || normalized.ends_with("apitokens")
+        || normalized.ends_with("authtokens")
+        || normalized.ends_with("accesstokens")
+        || normalized.ends_with("bearertokens")
+        || normalized.ends_with("idtokens")
+        || normalized.ends_with("refreshtokens")
+        || normalized.ends_with("sessiontokens")
+}
+
+fn normalized_request_override_credential_name(normalized: &str) -> bool {
+    matches!(
+        normalized,
+        "cookie" | "setcookie" | "authentication" | "secret" | "secrets" | "password" | "passwords"
+    ) || normalized.ends_with("authorization")
+        || normalized.ends_with("authkey")
+        || normalized.ends_with("authkeys")
+        || normalized.ends_with("auth")
+        || normalized.contains("apikey")
+        || normalized.ends_with("token")
+        || normalized_terminal_token_collection(normalized)
+        || normalized.ends_with("secret")
+        || normalized.ends_with("secrets")
+        || normalized.ends_with("password")
+        || normalized.ends_with("passwords")
+        || normalized.ends_with("accesskey")
+        || normalized.ends_with("accesskeys")
+        || normalized.ends_with("privatekey")
+        || normalized.ends_with("privatekeys")
+        || normalized.ends_with("devicekey")
+        || normalized.ends_with("devicekeys")
+        || normalized.ends_with("secretkey")
+        || normalized.ends_with("secretkeys")
+        || normalized.ends_with("signingkey")
+        || normalized.ends_with("signingkeys")
+        || normalized.ends_with("encryptionkey")
+        || normalized.ends_with("encryptionkeys")
+        || normalized.ends_with("credential")
+        || normalized.ends_with("credentials")
+        || normalized.ends_with("ciphertext")
+        || normalized.ends_with("ciphertexts")
+        || normalized.ends_with("encrypted")
+        || normalized.ends_with("passphrase")
+        || normalized.ends_with("passphrases")
+}
+
 fn normalized_terminal_credential_name(normalized: &str) -> bool {
     normalized.ends_with("auth")
         || normalized.ends_with("authentication")
@@ -1352,22 +1412,36 @@ fn normalized_terminal_credential_name(normalized: &str) -> bool {
         || normalized.ends_with("credential")
         || normalized.ends_with("credentials")
         || normalized.ends_with("secret")
+        || normalized.ends_with("secrets")
         || normalized.ends_with("token")
+        || normalized_terminal_token_collection(normalized)
         || normalized.ends_with("password")
+        || normalized.ends_with("passwords")
         || normalized.ends_with("private")
         || normalized.ends_with("access")
         || normalized.ends_with("ciphertext")
+        || normalized.ends_with("ciphertexts")
         || normalized.ends_with("encrypted")
         || normalized.ends_with("cookie")
+        || normalized.ends_with("cookies")
         || normalized.ends_with("passphrase")
+        || normalized.ends_with("passphrases")
         || normalized.ends_with("apikey")
+        || normalized.ends_with("apikeys")
         || normalized.ends_with("accesskey")
+        || normalized.ends_with("accesskeys")
         || normalized.ends_with("authkey")
+        || normalized.ends_with("authkeys")
         || normalized.ends_with("privatekey")
+        || normalized.ends_with("privatekeys")
         || normalized.ends_with("devicekey")
+        || normalized.ends_with("devicekeys")
         || normalized.ends_with("secretkey")
+        || normalized.ends_with("secretkeys")
         || normalized.ends_with("signingkey")
+        || normalized.ends_with("signingkeys")
         || normalized.ends_with("encryptionkey")
+        || normalized.ends_with("encryptionkeys")
         || normalized.ends_with("passwordhash")
         || normalized.ends_with("passwordsalt")
         || normalized.ends_with("tokenhash")
@@ -1459,8 +1533,21 @@ fn key_contains_literal_credential_material(key: &str, value: &Value) -> bool {
     let credential_owned = key.to_ascii_lowercase().ends_with("_encrypted")
         || normalized.ends_with("encrypted")
         || normalized.ends_with("token")
+        || normalized_terminal_token_collection(&normalized)
         || normalized.ends_with("password")
+        || normalized.ends_with("passwords")
         || normalized.ends_with("secret")
+        || normalized.ends_with("secrets")
+        || normalized.ends_with("credential")
+        || normalized.ends_with("credentials")
+        || normalized.ends_with("apikeys")
+        || normalized.ends_with("accesskeys")
+        || normalized.ends_with("authkeys")
+        || normalized.ends_with("privatekeys")
+        || normalized.ends_with("devicekeys")
+        || normalized.ends_with("secretkeys")
+        || normalized.ends_with("signingkeys")
+        || normalized.ends_with("encryptionkeys")
         || matches!(
             normalized.as_str(),
             "apikey"
@@ -2062,30 +2149,7 @@ fn validate_provider_body_patch(value: &Value) -> Result<(), String> {
 /// values that predate strict validation cannot be returned as plaintext.
 pub fn request_override_body_patch_targets_credential(path: &str) -> bool {
     fn credential_token(segment: &str) -> bool {
-        matches!(
-            segment,
-            "apikey"
-                | "token"
-                | "password"
-                | "secret"
-                | "appsecret"
-                | "clientsecret"
-                | "devicekey"
-                | "privatekey"
-                | "passphrase"
-                | "authorization"
-                | "cookie"
-                | "accesskey"
-                | "authkey"
-                | "credential"
-                | "credentials"
-        ) || segment.ends_with("token")
-            || segment.ends_with("password")
-            || segment.ends_with("secret")
-            || segment.ends_with("accesskey")
-            || segment.ends_with("authkey")
-            || segment.ends_with("credential")
-            || segment.ends_with("credentials")
+        normalized_request_override_credential_name(segment)
     }
 
     let decoded = path.replace("~1", "/").replace("~0", "~");
@@ -2207,20 +2271,7 @@ pub fn request_override_header_is_credential(name: &str) -> bool {
         .filter(|ch| ch.is_ascii_alphanumeric())
         .flat_map(char::to_lowercase)
         .collect::<String>();
-    matches!(compact.as_str(), "cookie" | "setcookie" | "authentication")
-        || compact.ends_with("authorization")
-        || compact.ends_with("authkey")
-        || compact.ends_with("auth")
-        || compact.contains("apikey")
-        || compact.ends_with("token")
-        || compact.ends_with("sessiontoken")
-        || compact == "secret"
-        || compact.ends_with("secret")
-        || compact == "password"
-        || compact.ends_with("password")
-        || compact.ends_with("accesskey")
-        || compact.ends_with("credential")
-        || compact.ends_with("credentials")
+    normalized_request_override_credential_name(&compact)
 }
 
 fn validate_mcp_headers(headers: &[bamboo_domain::mcp_config::HeaderConfig]) -> Result<(), String> {
@@ -6368,6 +6419,7 @@ mod tests {
     fn provider_api_metadata_scrubber_matches_durable_credential_contexts() {
         let original = json!({
             "headless_auth": true,
+            "max_tokens": 8192,
             "oauth": {
                 "client_id": "public-client",
                 "authorization_url": "https://auth.example.test/authorize",
@@ -6375,10 +6427,16 @@ mod tests {
             },
             "private_key": "private-literal",
             "nested": {"client_secret": "client-literal"},
+            "secrets": {"primary": "plural-container-literal"},
+            "tokens": ["plural-token-literal"],
+            "passwords": {"primary": "plural-password-literal"},
+            "api_keys": {"primary": "plural-api-key-literal"},
             "credential_ref": "provider.work.api_key",
             "headers": {
                 "X-Trace": "public-trace",
                 "X-Access-Key": "header-literal",
+                "X-Private-Key": "private-header-literal",
+                "X-Device-Key": "device-header-literal",
                 "Authorization": {"type": "env_ref", "name": "UPSTREAM_TOKEN"}
             }
         });
@@ -6388,6 +6446,7 @@ mod tests {
         scrub_provider_metadata_credentials(&mut sanitized);
 
         assert_eq!(sanitized["headless_auth"], true);
+        assert_eq!(sanitized["max_tokens"], 8192);
         assert_eq!(sanitized["oauth"]["client_id"], "public-client");
         assert_eq!(
             sanitized["oauth"]["authorization_url"],
@@ -6396,14 +6455,59 @@ mod tests {
         assert!(sanitized["oauth"].get("value").is_none());
         assert!(sanitized.get("private_key").is_none());
         assert!(sanitized["nested"].get("client_secret").is_none());
+        assert!(sanitized.get("secrets").is_none());
+        assert!(sanitized.get("tokens").is_none());
+        assert!(sanitized.get("passwords").is_none());
+        assert!(sanitized.get("api_keys").is_none());
         assert!(sanitized.get("credential_ref").is_none());
         assert_eq!(sanitized["headers"]["X-Trace"], "public-trace");
         assert!(sanitized["headers"].get("X-Access-Key").is_none());
+        assert!(sanitized["headers"].get("X-Private-Key").is_none());
+        assert!(sanitized["headers"].get("X-Device-Key").is_none());
         assert_eq!(
             sanitized["headers"]["Authorization"]["name"],
             "UPSTREAM_TOKEN"
         );
         assert!(provider_metadata_is_secret_free(&sanitized));
+    }
+
+    #[test]
+    fn request_override_credential_classifiers_cover_key_and_plural_forms() {
+        for header in [
+            "X-Private-Key",
+            "X-Device-Key",
+            "X-Secret-Keys",
+            "X-Api-Key-Version",
+        ] {
+            assert!(
+                request_override_header_is_credential(header),
+                "credential header was not classified: {header}"
+            );
+        }
+        for path in [
+            "/secrets/primary",
+            "/private/keys/primary",
+            "/device_keys/0",
+            "/accessKeys/current",
+            "/tokens/0",
+            "/passwords/primary",
+            "/api_keys/primary",
+        ] {
+            assert!(
+                request_override_body_patch_targets_credential(path),
+                "credential body path was not classified: {path}"
+            );
+        }
+        assert!(!request_override_header_is_credential("X-Trace-Id"));
+        assert!(!request_override_body_patch_targets_credential(
+            "/metadata/public_id"
+        ));
+        assert!(!request_override_body_patch_targets_credential(
+            "/max_tokens"
+        ));
+        assert!(!request_override_body_patch_targets_credential(
+            "/metadata/public_access"
+        ));
     }
 
     fn install_completed_legacy_openai(data_dir: &Path, secret: &str) -> (CredentialRef, u64) {

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -1303,6 +1303,7 @@ fn credential_token_is_sensitive(token: &str) -> bool {
             | "secret"
             | "secrets"
             | "token"
+            | "tokens"
             | "password"
             | "passwords"
             | "private"
@@ -1314,6 +1315,25 @@ fn credential_token_is_sensitive(token: &str) -> bool {
             | "cookies"
             | "passphrase"
             | "passphrases"
+    )
+}
+
+/// Token-count and token-budget fields are ordinary request metadata, not
+/// credential containers. Keep this an exact allowlist: an unknown plural
+/// `*_tokens` name is fail-closed because providers commonly use such fields
+/// for bearer/session credential collections.
+fn normalized_public_token_metadata_name(normalized: &str) -> bool {
+    matches!(
+        normalized,
+        "budgettokens"
+            | "contextwindowtokens"
+            | "maxcompletiontokens"
+            | "maxcontexttokens"
+            | "maxinputtokens"
+            | "maxoutputtokens"
+            | "maxprompttokens"
+            | "maxtokens"
+            | "maxtotaltokens"
     )
 }
 
@@ -1356,14 +1376,7 @@ fn credential_name_has_terminal_sensitive_tokens(tokens: &[String]) -> bool {
 }
 
 fn normalized_terminal_token_collection(normalized: &str) -> bool {
-    normalized == "tokens"
-        || normalized.ends_with("apitokens")
-        || normalized.ends_with("authtokens")
-        || normalized.ends_with("accesstokens")
-        || normalized.ends_with("bearertokens")
-        || normalized.ends_with("idtokens")
-        || normalized.ends_with("refreshtokens")
-        || normalized.ends_with("sessiontokens")
+    normalized.ends_with("tokens") && !normalized_public_token_metadata_name(normalized)
 }
 
 fn normalized_request_override_credential_name(normalized: &str) -> bool {
@@ -1472,12 +1485,15 @@ fn credential_metadata_container_key(key: &str) -> bool {
     if credential_reference_metadata_key(key) {
         return false;
     }
+    let normalized = normalized_credential_key(key);
+    if normalized_public_token_metadata_name(&normalized) {
+        return false;
+    }
     let tokens = credential_key_tokens(key);
     let tokenized_metadata = credential_name_has_sensitive_tokens(&tokens)
         && tokens
             .last()
             .is_some_and(|suffix| SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&suffix.as_str()));
-    let normalized = normalized_credential_key(key);
     let normalized_metadata = SAFE_CREDENTIAL_METADATA_SUFFIXES.iter().any(|suffix| {
         normalized
             .strip_suffix(suffix)
@@ -1488,7 +1504,8 @@ fn credential_metadata_container_key(key: &str) -> bool {
 
 fn credential_public_metadata_key(key: &str) -> bool {
     let normalized = normalized_credential_key(key);
-    SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&normalized.as_str())
+    normalized_public_token_metadata_name(&normalized)
+        || SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&normalized.as_str())
         || credential_key_tokens(key)
             .last()
             .is_some_and(|token| SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&token.as_str()))
@@ -1498,16 +1515,24 @@ fn credential_context_key(key: &str) -> bool {
     if credential_reference_metadata_key(key) {
         return false;
     }
+    let normalized = normalized_credential_key(key);
+    if normalized_public_token_metadata_name(&normalized) {
+        return false;
+    }
     let tokens = credential_key_tokens(key);
     let tokenized_context = credential_name_has_sensitive_tokens(&tokens)
         && !tokens
             .last()
             .is_some_and(|suffix| SAFE_CREDENTIAL_METADATA_SUFFIXES.contains(&suffix.as_str()));
-    tokenized_context || normalized_credential_context_name(&normalized_credential_key(key))
+    tokenized_context || normalized_credential_context_name(&normalized)
 }
 
 fn credential_literal_key(key: &str) -> bool {
     if credential_reference_metadata_key(key) {
+        return false;
+    }
+    let normalized = normalized_credential_key(key);
+    if normalized_public_token_metadata_name(&normalized) {
         return false;
     }
     let tokens = credential_key_tokens(key);
@@ -1522,7 +1547,7 @@ fn credential_literal_key(key: &str) -> bool {
             NORMALIZED_CREDENTIAL_PAYLOAD_SUFFIXES.contains(&suffix.as_str())
                 && credential_name_has_sensitive_tokens(&tokens[..tokens.len().saturating_sub(1)])
         });
-    tokenized_literal || normalized_credential_context_name(&normalized_credential_key(key))
+    tokenized_literal || normalized_credential_context_name(&normalized)
 }
 
 fn key_contains_literal_credential_material(key: &str, value: &Value) -> bool {
@@ -6420,6 +6445,7 @@ mod tests {
         let original = json!({
             "headless_auth": true,
             "max_tokens": 8192,
+            "max_output_tokens": 4096,
             "oauth": {
                 "client_id": "public-client",
                 "authorization_url": "https://auth.example.test/authorize",
@@ -6429,6 +6455,7 @@ mod tests {
             "nested": {"client_secret": "client-literal"},
             "secrets": {"primary": "plural-container-literal"},
             "tokens": ["plural-token-literal"],
+            "client_tokens": ["client-token-literal"],
             "passwords": {"primary": "plural-password-literal"},
             "api_keys": {"primary": "plural-api-key-literal"},
             "credential_ref": "provider.work.api_key",
@@ -6447,6 +6474,7 @@ mod tests {
 
         assert_eq!(sanitized["headless_auth"], true);
         assert_eq!(sanitized["max_tokens"], 8192);
+        assert_eq!(sanitized["max_output_tokens"], 4096);
         assert_eq!(sanitized["oauth"]["client_id"], "public-client");
         assert_eq!(
             sanitized["oauth"]["authorization_url"],
@@ -6457,6 +6485,7 @@ mod tests {
         assert!(sanitized["nested"].get("client_secret").is_none());
         assert!(sanitized.get("secrets").is_none());
         assert!(sanitized.get("tokens").is_none());
+        assert!(sanitized.get("client_tokens").is_none());
         assert!(sanitized.get("passwords").is_none());
         assert!(sanitized.get("api_keys").is_none());
         assert!(sanitized.get("credential_ref").is_none());
@@ -6477,6 +6506,9 @@ mod tests {
             "X-Private-Key",
             "X-Device-Key",
             "X-Secret-Keys",
+            "X-Client-Tokens",
+            "X-Service-Tokens",
+            "X-Provider-Tokens",
             "X-Api-Key-Version",
         ] {
             assert!(
@@ -6490,6 +6522,9 @@ mod tests {
             "/device_keys/0",
             "/accessKeys/current",
             "/tokens/0",
+            "/client_tokens/0",
+            "/service_tokens/current",
+            "/provider_tokens/primary",
             "/passwords/primary",
             "/api_keys/primary",
         ] {
@@ -6504,6 +6539,9 @@ mod tests {
         ));
         assert!(!request_override_body_patch_targets_credential(
             "/max_tokens"
+        ));
+        assert!(!request_override_body_patch_targets_credential(
+            "/max_output_tokens"
         ));
         assert!(!request_override_body_patch_targets_credential(
             "/metadata/public_access"

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -1567,11 +1567,28 @@ fn validate_providers(value: &ProvidersSection) -> Result<(), String> {
         )?;
     }
     for instance in value.provider_instances.values() {
+        let from_environment = match instance
+            .extra
+            .get(crate::PROVIDER_INSTANCE_API_KEY_FROM_ENV_CONFIG_KEY)
+        {
+            Some(Value::Bool(true))
+                if matches!(instance.provider_type.as_str(), "openai" | "anthropic" | "gemini") =>
+            {
+                true
+            }
+            Some(Value::Bool(false)) | None => false,
+            Some(_) => {
+                return Err(
+                    "provider instance api_key_from_env must be a boolean and is only supported for openai, anthropic, or gemini"
+                        .to_string(),
+                )
+            }
+        };
         validate_provider_credential(
             &instance.api_key,
             instance.api_key_encrypted.as_deref(),
             instance.credential_ref.as_ref(),
-            false,
+            from_environment,
         )?;
     }
     let serialized = serde_json::to_value(value)
@@ -2999,7 +3016,8 @@ fn preflight_legacy_root_sections(
     input: &StrictPlanningInput,
     overrides: Option<&StrictSourceOverrides>,
 ) -> ConfigStoreResult<()> {
-    let sanitized_config = scrub_preflight_config_secrets(&input.config)?;
+    let mut sanitized_config = scrub_preflight_config_secrets(&input.config)?;
+    crate::materialize_legacy_provider_instances(&mut sanitized_config);
     let projection = SectionProjection::from_config(&sanitized_config, input.model_limits.clone())?;
     let mut sections =
         project_legacy_raw_sections(&input.root_raw, None, &input.authoritative_sidecars)?;
@@ -3715,12 +3733,13 @@ fn plan_config_facade_layout_with_broker(
             continue;
         }
         let StrictPlanningInput {
-            config,
+            mut config,
             root_raw,
             model_limits,
             broker,
             authoritative_sidecars,
         } = input;
+        crate::materialize_legacy_provider_instances(&mut config);
         let mut projection = SectionProjection::from_config(&config, model_limits)?;
         let mut broker_raw = None;
         if include_broker {
@@ -3751,12 +3770,13 @@ fn plan_config_facade_compound_layout(
     let source_hashes = migration_source_hashes(data_dir)?;
     let overrides = &credential_plan.source_overrides;
     let StrictPlanningInput {
-        config,
+        mut config,
         root_raw,
         model_limits,
         broker,
         authoritative_sidecars,
     } = load_strict_planning_input_with_overrides(data_dir, Some(overrides))?;
+    crate::materialize_legacy_provider_instances(&mut config);
     let mut projection = SectionProjection::from_config(&config, model_limits)?;
     let mut broker_raw = None;
     if include_broker {
@@ -5042,6 +5062,39 @@ pub struct ConfigFacade {
     startup_legacy_root: Mutex<Option<LegacyRootReconciliationOutcome>>,
 }
 
+#[cfg(test)]
+type ProviderAuthorityMigrationTestHook = Box<dyn FnOnce() + Send + 'static>;
+
+#[cfg(test)]
+fn provider_authority_migration_test_hooks(
+) -> &'static Mutex<HashMap<PathBuf, ProviderAuthorityMigrationTestHook>> {
+    static HOOKS: std::sync::OnceLock<Mutex<HashMap<PathBuf, ProviderAuthorityMigrationTestHook>>> =
+        std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_provider_authority_migration_test_hook(
+    data_dir: &Path,
+    hook: impl FnOnce() + Send + 'static,
+) {
+    provider_authority_migration_test_hooks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(data_dir.to_path_buf(), Box::new(hook));
+}
+
+#[cfg(test)]
+fn run_provider_authority_migration_test_hook(data_dir: &Path) {
+    if let Some(hook) = provider_authority_migration_test_hooks()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(data_dir)
+    {
+        hook();
+    }
+}
+
 impl ConfigFacade {
     pub fn open(data_dir: impl AsRef<Path>) -> ConfigStoreResult<Self> {
         Self::open_stable(data_dir.as_ref(), |_| {})
@@ -5188,7 +5241,110 @@ impl ConfigFacade {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(outcome);
         }
+        facade.materialize_legacy_provider_authority()?;
         Ok(facade)
+    }
+
+    /// Adopt a legacy or hybrid provider selection into the authoritative
+    /// provider-instance representation after the modular facade exists.
+    ///
+    /// The fresh durable envelope is the only mutation base: degraded LKG or
+    /// backup reads cannot authorize a repair write, and the content-aware CAS
+    /// catches raw-file races that do not advance the revision. Initial section
+    /// splitting uses the compound journal instead and normally makes this an
+    /// idempotent no-op on first open.
+    fn materialize_legacy_provider_authority(&self) -> ConfigStoreResult<bool> {
+        crate::credential_migration::with_provider_mcp_migration_lock(&self.data_dir, || {
+            crate::ensure_provider_mcp_migration_ready(&self.data_dir)?;
+            if !section_layout_is_active(&self.data_dir)? {
+                return Err(layout_not_committed());
+            }
+            if read_legacy_reconciliation_record(&self.data_dir)?.is_some_and(|record| {
+                !record.committed.is_empty()
+                    || !record.planned.is_empty()
+                    || !record.rejected.is_empty()
+            }) {
+                // Preserve exact legacy-root publication events. Advancing the
+                // provider revision before those events are acknowledged would
+                // turn a valid rN handoff into an apparent stale conflict. The
+                // next open after acknowledgement retries this idempotently.
+                return Ok(false);
+            }
+
+            for attempt in 0..2 {
+                let (mut durable_config, durable_envelope) =
+                    load_durable_effective_section_snapshot_under_migration_lock(
+                        &self.data_dir,
+                        SectionId::Providers,
+                    )?;
+                if !crate::materialize_legacy_provider_instances(&mut durable_config) {
+                    return Ok(false);
+                }
+                if durable_envelope.status != SectionStatus::Healthy
+                    || durable_envelope.source_kind != SectionSourceKind::File
+                {
+                    tracing::warn!(
+                        status = ?durable_envelope.status,
+                        source = ?durable_envelope.source_kind,
+                        "provider-instance authority migration deferred: durable provider base is unavailable"
+                    );
+                    return Ok(false);
+                }
+
+                let store = CredentialStore::open(&self.data_dir);
+                let (credential_lkg, _, credential_health) =
+                    store.snapshot_with_health_unchecked()?;
+                if credential_health.status != SectionStatus::Healthy
+                    || credential_health.source != SectionSourceKind::File
+                {
+                    tracing::warn!(
+                        status = ?credential_health.status,
+                        source = ?credential_health.source,
+                        "provider-instance authority migration deferred: credential base is unavailable"
+                    );
+                    return Ok(false);
+                }
+                if let Err(error) = crate::credential_migration::validate_provider_credential_values(
+                    &durable_config,
+                    &credential_lkg,
+                ) {
+                    tracing::warn!(
+                        error = %error,
+                        "provider-instance authority migration deferred: active credential is unavailable"
+                    );
+                    return Ok(false);
+                }
+
+                let durable: ProvidersSection = serde_json::from_value(durable_envelope.data)?;
+                let candidate =
+                    SectionProjection::from_config(&durable_config, ModelLimitsSection::default())?
+                        .providers;
+                validate_providers(&candidate).map_err(crate::ConfigStoreError::Validation)?;
+
+                #[cfg(test)]
+                run_provider_authority_migration_test_hook(&self.data_dir);
+
+                match self
+                    .registry
+                    .providers
+                    .commit_from_durable_base_with_envelope(
+                        durable_envelope.revision,
+                        &durable,
+                        candidate,
+                    ) {
+                    Ok(_) => return Ok(true),
+                    Err(crate::ConfigStoreError::Conflict { .. }) if attempt == 0 => {
+                        // A raw editor may win without advancing the envelope
+                        // revision. Normalize/adopt that exact winner, then
+                        // recompute migration once from the fresh bytes. A
+                        // second conflict remains fail-closed.
+                        let _ = self.registry.reload_if_changed(SectionId::Providers);
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            unreachable!("bounded provider authority migration loop always returns")
+        })
     }
 
     pub fn registry(&self) -> &Arc<SectionRegistry> {
@@ -6036,6 +6192,435 @@ mod tests {
 
     fn write_json(path: &Path, value: &Value) {
         std::fs::write(path, serde_json::to_vec_pretty(value).unwrap()).unwrap();
+    }
+
+    fn install_completed_legacy_openai(data_dir: &Path, secret: &str) -> (CredentialRef, u64) {
+        let facade = ConfigFacade::open_or_migrate(data_dir).unwrap();
+        let reference = CredentialRef::parse("provider.openai.api_key").unwrap();
+        let store = CredentialStore::open(data_dir);
+        let credential_revision = store.revision().unwrap();
+        store
+            .replace(
+                reference.clone(),
+                secret,
+                CredentialSource::Migrated,
+                credential_revision,
+            )
+            .unwrap();
+
+        let expected_revision = facade.registry().providers.snapshot().revision;
+        let mut providers = ProvidersSection {
+            provider: Some("openai".to_string()),
+            ..ProvidersSection::default()
+        };
+        providers.providers.openai = Some(crate::OpenAIConfig {
+            credential_ref: Some(reference.clone()),
+            model: Some("gpt-legacy".to_string()),
+            ..crate::OpenAIConfig::default()
+        });
+        let event = facade
+            .registry()
+            .providers
+            .commit(expected_revision, providers)
+            .unwrap();
+        let ConfigSectionEvent::Changed { revision, .. } = event else {
+            panic!("provider commit should advance the revision")
+        };
+        (reference, revision)
+    }
+
+    #[test]
+    fn initial_split_materializes_provider_instance_without_copying_plaintext() {
+        let _key = crate::encryption::set_test_encryption_key([201; 32]);
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "provider": "openai",
+                "providers": {
+                    "openai": {
+                        "api_key": "initial-split-secret",
+                        "model": "gpt-legacy"
+                    }
+                }
+            }),
+        );
+
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let envelope = facade
+            .registry()
+            .envelope_value(SectionId::Providers)
+            .unwrap();
+        assert_eq!(envelope.data["default_provider_instance"], json!("openai"));
+        assert_eq!(
+            envelope.data["provider_instances"]["openai"]["credential_ref"],
+            json!("provider.openai.api_key")
+        );
+        assert!(envelope.data.get("provider").is_none());
+        assert!(envelope.data.get("openai").is_none());
+        assert_no_plaintext_in_persistent_files(dir.path(), &["initial-split-secret"]);
+
+        let reference = CredentialRef::parse("provider.openai.api_key").unwrap();
+        assert_eq!(
+            CredentialStore::open(dir.path())
+                .resolve(&reference)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "initial-split-secret"
+        );
+        let revision = envelope.revision;
+        drop(facade);
+
+        let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let after = restarted
+            .registry()
+            .envelope_value(SectionId::Providers)
+            .unwrap();
+        assert_eq!(after.revision, revision, "restart must be idempotent");
+        assert_eq!(
+            after.data["provider_instances"]["openai"]["model"],
+            json!("gpt-legacy")
+        );
+        let runtime = Config::from_data_dir_without_publish(Some(dir.path().to_path_buf()));
+        assert_eq!(
+            runtime.provider_instances["openai"].api_key,
+            "initial-split-secret"
+        );
+    }
+
+    #[test]
+    fn completed_facade_materializes_legacy_provider_with_exact_revision_and_restart() {
+        let _key = crate::encryption::set_test_encryption_key([202; 32]);
+        let dir = TempDir::new().unwrap();
+        let (reference, legacy_revision) =
+            install_completed_legacy_openai(dir.path(), "completed-facade-secret");
+
+        let migrated = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let envelope = migrated
+            .registry()
+            .envelope_value(SectionId::Providers)
+            .unwrap();
+        assert_eq!(envelope.revision, legacy_revision + 1);
+        assert_eq!(envelope.data["default_provider_instance"], json!("openai"));
+        assert_eq!(
+            envelope.data["provider_instances"]["openai"]["credential_ref"],
+            json!(reference.as_str())
+        );
+        assert!(envelope.data.get("provider").is_none());
+        assert!(envelope.data.get("openai").is_none());
+        assert_no_plaintext_in_persistent_files(dir.path(), &["completed-facade-secret"]);
+        drop(migrated);
+
+        let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(
+            restarted.registry().providers.snapshot().revision,
+            legacy_revision + 1
+        );
+        assert_eq!(
+            CredentialStore::open(dir.path())
+                .resolve(&reference)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "completed-facade-secret"
+        );
+    }
+
+    #[test]
+    fn completed_facade_preserves_nondefault_legacy_aliases_with_explicit_default() {
+        let _key = crate::encryption::set_test_encryption_key([212; 32]);
+        let dir = TempDir::new().unwrap();
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let store = CredentialStore::open(dir.path());
+        let openai_ref = CredentialRef::parse("provider.openai.api_key").unwrap();
+        let anthropic_ref = CredentialRef::parse("provider.anthropic.api_key").unwrap();
+        let (credential_revision, _) = store
+            .replace(
+                openai_ref.clone(),
+                "hybrid-openai-secret",
+                CredentialSource::Migrated,
+                store.revision().unwrap(),
+            )
+            .unwrap();
+        store
+            .replace(
+                anthropic_ref.clone(),
+                "hybrid-anthropic-secret",
+                CredentialSource::Migrated,
+                credential_revision,
+            )
+            .unwrap();
+
+        let expected_revision = facade.registry().providers.snapshot().revision;
+        let mut providers = ProvidersSection {
+            provider: Some("work".to_string()),
+            default_provider_instance: Some("work".to_string()),
+            ..ProvidersSection::default()
+        };
+        providers.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(json!({
+                "provider_type": "copilot",
+                "enabled": true,
+                "model": "gpt-work"
+            }))
+            .unwrap(),
+        );
+        providers.providers.openai = Some(crate::OpenAIConfig {
+            credential_ref: Some(openai_ref.clone()),
+            model: Some("gpt-legacy".to_string()),
+            ..crate::OpenAIConfig::default()
+        });
+        providers.providers.anthropic = Some(crate::AnthropicConfig {
+            credential_ref: Some(anthropic_ref.clone()),
+            model: Some("claude-legacy".to_string()),
+            ..crate::AnthropicConfig::default()
+        });
+        let event = facade
+            .registry()
+            .providers
+            .commit(expected_revision, providers)
+            .unwrap();
+        let ConfigSectionEvent::Changed {
+            revision: hybrid_revision,
+            ..
+        } = event
+        else {
+            panic!("hybrid provider commit should advance the revision")
+        };
+        drop(facade);
+
+        let migrated = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let envelope = migrated
+            .registry()
+            .envelope_value(SectionId::Providers)
+            .unwrap();
+        assert_eq!(envelope.revision, hybrid_revision + 1);
+        assert_eq!(envelope.data["default_provider_instance"], "work");
+        assert_eq!(
+            envelope.data["provider_instances"]["work"]["model"],
+            "gpt-work"
+        );
+        assert_eq!(
+            envelope.data["provider_instances"]["openai"]["credential_ref"],
+            openai_ref.as_str()
+        );
+        assert_eq!(
+            envelope.data["provider_instances"]["anthropic"]["credential_ref"],
+            anthropic_ref.as_str()
+        );
+        assert!(envelope.data.get("provider").is_none());
+        assert!(envelope.data.get("openai").is_none());
+        assert!(envelope.data.get("anthropic").is_none());
+        assert_no_plaintext_in_persistent_files(
+            dir.path(),
+            &["hybrid-openai-secret", "hybrid-anthropic-secret"],
+        );
+        let migrated_revision = envelope.revision;
+        drop(migrated);
+
+        let restarted = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(
+            restarted.registry().providers.snapshot().revision,
+            migrated_revision,
+            "the explicit-default hybrid migration must be idempotent"
+        );
+        assert_eq!(
+            store.resolve(&openai_ref).unwrap().unwrap().expose(),
+            "hybrid-openai-secret"
+        );
+        assert_eq!(
+            store.resolve(&anthropic_ref).unwrap().unwrap().expose(),
+            "hybrid-anthropic-secret"
+        );
+    }
+
+    #[test]
+    fn completed_migration_rebases_once_on_same_revision_editor_winner() {
+        let _key = crate::encryption::set_test_encryption_key([203; 32]);
+        let dir = TempDir::new().unwrap();
+        let (_, legacy_revision) = install_completed_legacy_openai(dir.path(), "cas-race-secret");
+        let providers_path = dir.path().join("providers.json");
+        let hook_path = providers_path.clone();
+        set_provider_authority_migration_test_hook(dir.path(), move || {
+            let mut document: Value =
+                serde_json::from_slice(&std::fs::read(&hook_path).unwrap()).unwrap();
+            document["data"]["openai"]["model"] = json!("editor-same-revision");
+            write_json(&hook_path, &document);
+        });
+
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let document: Value =
+            serde_json::from_slice(&std::fs::read(&providers_path).unwrap()).unwrap();
+        assert_eq!(
+            document["data"]["provider_instances"]["openai"]["model"],
+            json!("editor-same-revision")
+        );
+        assert_eq!(document["revision"], legacy_revision + 2);
+        assert!(document["data"].get("openai").is_none());
+        assert_eq!(
+            facade.registry().providers.snapshot().revision,
+            legacy_revision + 2
+        );
+    }
+
+    #[test]
+    fn degraded_instance_native_provider_lkg_remains_readable() {
+        let _key = crate::encryption::set_test_encryption_key([204; 32]);
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "provider": "openai",
+                "providers": {"openai": {"api_key": "native-lkg-secret"}}
+            }),
+        );
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let snapshot = facade.registry().providers.snapshot();
+        let mut candidate = snapshot.data.as_ref().clone();
+        candidate
+            .provider_instances
+            .get_mut("openai")
+            .unwrap()
+            .model = Some("gpt-native-lkg".to_string());
+        facade
+            .registry()
+            .providers
+            .commit(snapshot.revision, candidate)
+            .unwrap();
+        std::fs::write(
+            dir.path().join("providers.json"),
+            b"corrupt provider authority",
+        )
+        .unwrap();
+        drop(facade);
+
+        let reopened = ConfigFacade::open(dir.path()).unwrap();
+        assert!(!reopened.materialize_legacy_provider_authority().unwrap());
+        let snapshot = reopened.registry().providers.snapshot();
+        assert_eq!(snapshot.status, SectionStatus::Degraded);
+        assert!(snapshot.data.provider_instances.contains_key("openai"));
+        assert_eq!(
+            reopened
+                .effective_config()
+                .default_provider_instance
+                .as_deref(),
+            Some("openai")
+        );
+    }
+
+    #[test]
+    fn degraded_legacy_provider_lkg_defers_migration_without_losing_readability() {
+        let _key = crate::encryption::set_test_encryption_key([205; 32]);
+        let dir = TempDir::new().unwrap();
+        install_completed_legacy_openai(dir.path(), "legacy-lkg-secret");
+        let facade = ConfigFacade::open(dir.path()).unwrap();
+        let snapshot = facade.registry().providers.snapshot();
+        let mut candidate = snapshot.data.as_ref().clone();
+        candidate.providers.openai.as_mut().unwrap().model = Some("gpt-newer".to_string());
+        facade
+            .registry()
+            .providers
+            .commit(snapshot.revision, candidate)
+            .unwrap();
+        std::fs::write(
+            dir.path().join("providers.json"),
+            b"corrupt provider authority",
+        )
+        .unwrap();
+        drop(facade);
+
+        let reopened = ConfigFacade::open(dir.path()).unwrap();
+        assert!(!reopened.materialize_legacy_provider_authority().unwrap());
+        let snapshot = reopened.registry().providers.snapshot();
+        assert_eq!(snapshot.status, SectionStatus::Degraded);
+        assert!(snapshot.data.provider_instances.is_empty());
+        assert_eq!(snapshot.data.provider.as_deref(), Some("openai"));
+        assert!(snapshot.data.providers.openai.is_some());
+    }
+
+    #[test]
+    fn degraded_credential_lkg_defers_completed_provider_migration() {
+        let _key = crate::encryption::set_test_encryption_key([207; 32]);
+        let dir = TempDir::new().unwrap();
+        let (reference, legacy_revision) =
+            install_completed_legacy_openai(dir.path(), "credential-lkg-one");
+        let store = CredentialStore::open(dir.path());
+        let credential_revision = store.revision().unwrap();
+        store
+            .replace(
+                reference,
+                "credential-lkg-two",
+                CredentialSource::User,
+                credential_revision,
+            )
+            .unwrap();
+        std::fs::write(
+            dir.path().join("credentials.json"),
+            b"corrupt credential authority",
+        )
+        .unwrap();
+
+        let facade = ConfigFacade::open(dir.path()).unwrap();
+        assert!(!facade.materialize_legacy_provider_authority().unwrap());
+        assert_eq!(
+            facade.registry().providers.snapshot().revision,
+            legacy_revision
+        );
+        assert!(facade
+            .registry()
+            .providers
+            .snapshot()
+            .data
+            .provider_instances
+            .is_empty());
+        assert_eq!(
+            facade.registry().credentials.health().status,
+            SectionStatus::Degraded
+        );
+    }
+
+    #[test]
+    fn pending_legacy_publication_defers_provider_authority_revision() {
+        let _key = crate::encryption::set_test_encryption_key([206; 32]);
+        let dir = TempDir::new().unwrap();
+        let (_, legacy_revision) =
+            install_completed_legacy_openai(dir.path(), "pending-publication-secret");
+        let facade = ConfigFacade::open(dir.path()).unwrap();
+        let record = LegacyRootReconciliationRecord {
+            version: LEGACY_ROOT_RECONCILIATION_VERSION,
+            root_sha256: "1".repeat(64),
+            complete: true,
+            committed: BTreeMap::from([(
+                "providers".to_string(),
+                LegacyRootCommittedPublication {
+                    revision: legacy_revision,
+                    candidate_sha256: "2".repeat(64),
+                    runtime_degraded: false,
+                },
+            )]),
+            planned: BTreeMap::new(),
+            rejected: Vec::new(),
+            unknown_fields: 0,
+        };
+        crate::credential_migration::with_provider_mcp_migration_lock(dir.path(), || {
+            write_legacy_reconciliation_record(dir.path(), &record)
+        })
+        .unwrap();
+
+        assert!(!facade.materialize_legacy_provider_authority().unwrap());
+        assert_eq!(
+            facade.registry().providers.snapshot().revision,
+            legacy_revision
+        );
+        assert!(facade
+            .registry()
+            .providers
+            .snapshot()
+            .data
+            .provider_instances
+            .is_empty());
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -7,7 +7,7 @@ use crate::providers::{
     AnthropicProvider, BodhiProvider, CopilotProvider, GeminiProvider, OpenAIProvider,
 };
 use bamboo_config::paths::bamboo_dir;
-use bamboo_config::Config;
+use bamboo_config::{Config, ProviderInstanceConfig};
 use reqwest::Client;
 use std::sync::Arc;
 
@@ -29,7 +29,12 @@ pub async fn create_provider_with_dir(
     config: &Config,
     app_data_dir: std::path::PathBuf,
 ) -> Result<Arc<dyn LLMProvider>, LLMError> {
-    create_provider_by_name(config, &config.provider, app_data_dir).await
+    let provider_key = config.effective_default_provider();
+    if let Some(instance) = config.provider_instances.get(provider_key) {
+        create_provider_from_instance(config, instance, app_data_dir).await
+    } else {
+        create_provider_by_name(config, provider_key, app_data_dir).await
+    }
 }
 
 /// Create a single named provider.
@@ -40,17 +45,76 @@ pub async fn create_provider_by_name(
     provider_name: &str,
     app_data_dir: std::path::PathBuf,
 ) -> Result<Arc<dyn LLMProvider>, LLMError> {
+    if !AVAILABLE_PROVIDERS.contains(&provider_name) {
+        return Err(LLMError::Auth(format!(
+            "Unknown provider: {provider_name}. Available providers: {}",
+            AVAILABLE_PROVIDERS.join(", ")
+        )));
+    }
+
+    // Legacy compatibility seam. Runtime instance paths call
+    // `create_provider_from_instance` directly and never project an instance
+    // back into `Config.providers`.
+    let mut legacy = config.clone();
+    legacy.provider_instances.clear();
+    let mut instance = bamboo_config::synthesize_legacy_instances(&legacy)
+        .into_iter()
+        .find_map(|(_, instance)| (instance.provider_type == provider_name).then_some(instance))
+        .or_else(|| {
+            (provider_name == "copilot").then(|| ProviderInstanceConfig {
+                provider_type: "copilot".to_string(),
+                label: None,
+                api_key: String::new(),
+                api_key_encrypted: None,
+                credential_ref: None,
+                base_url: None,
+                model: None,
+                fast_model: None,
+                vision_model: None,
+                reasoning_effort: None,
+                responses_only_models: Vec::new(),
+                request_overrides: None,
+                enabled: true,
+                extra: Default::default(),
+            })
+        })
+        .ok_or_else(|| {
+            LLMError::Auth(format!(
+                "{} configuration required",
+                provider_display_name(provider_name)
+            ))
+        })?;
+    // Legacy callers historically selected a provider independently of its
+    // optional discovery flag. Instance-native callers must honor `enabled`.
+    instance.enabled = true;
+    create_provider_from_instance(config, &instance, app_data_dir).await
+}
+
+/// Create a provider directly from the authoritative instance configuration.
+///
+/// This is intentionally the only factory used by the instance registry. It
+/// must not mutate or populate legacy `Config.providers` slots.
+pub async fn create_provider_from_instance(
+    config: &Config,
+    instance: &ProviderInstanceConfig,
+    app_data_dir: std::path::PathBuf,
+) -> Result<Arc<dyn LLMProvider>, LLMError> {
+    if !instance.enabled {
+        return Err(LLMError::Auth(format!(
+            "Provider instance of type '{}' is disabled",
+            instance.provider_type
+        )));
+    }
+
     let masking_config = config.keyword_masking.clone();
     let http_client = build_http_client(config)?;
 
-    match provider_name {
+    match instance.provider_type.as_str() {
         "copilot" => {
-            // Get headless_auth from providers.copilot config, with fallback to deprecated root field
-            let headless_auth = config
-                .providers()
-                .copilot
-                .as_ref()
-                .map(|c| c.headless_auth)
+            let headless_auth = instance
+                .extra
+                .get("headless_auth")
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(config.headless_auth);
 
             let mut provider = CopilotProvider::with_auth_handler(
@@ -59,14 +123,12 @@ pub async fn create_provider_by_name(
                 headless_auth,
             );
 
-            if let Some(copilot_cfg) = config.providers().copilot.as_ref() {
-                if !copilot_cfg.responses_only_models.is_empty() {
-                    provider = provider
-                        .with_responses_only_models(copilot_cfg.responses_only_models.clone());
-                }
-                provider = provider.with_reasoning_effort(copilot_cfg.reasoning_effort);
-                provider = provider.with_request_overrides(copilot_cfg.request_overrides.clone());
+            if !instance.responses_only_models.is_empty() {
+                provider =
+                    provider.with_responses_only_models(instance.responses_only_models.clone());
             }
+            provider = provider.with_reasoning_effort(instance.reasoning_effort);
+            provider = provider.with_request_overrides(instance.request_overrides.clone());
 
             // Try to authenticate (using cache if available)
             match provider.try_authenticate_silent().await {
@@ -86,113 +148,108 @@ pub async fn create_provider_by_name(
         }
 
         "openai" => {
-            let openai_config = config
-                .providers()
-                .openai
-                .as_ref()
-                .ok_or_else(|| LLMError::Auth("OpenAI configuration required".to_string()))?;
-
-            if openai_config.api_key.is_empty() {
+            if instance.api_key.is_empty() {
                 return Err(LLMError::Auth("OpenAI API key is required".to_string()));
             }
 
             let mut provider =
-                OpenAIProvider::new(&openai_config.api_key).with_client(http_client.clone());
+                OpenAIProvider::new(&instance.api_key).with_client(http_client.clone());
 
-            if let Some(base_url) = &openai_config.base_url {
+            if let Some(base_url) = &instance.base_url {
                 if !base_url.is_empty() {
                     provider = provider.with_base_url(base_url);
                 }
             }
 
-            if !openai_config.responses_only_models.is_empty() {
-                provider = provider
-                    .with_responses_only_models(openai_config.responses_only_models.clone());
+            if !instance.responses_only_models.is_empty() {
+                provider =
+                    provider.with_responses_only_models(instance.responses_only_models.clone());
             }
 
-            provider = provider.with_reasoning_effort(openai_config.reasoning_effort);
-            provider =
-                provider.with_explicit_prompt_cache(openai_config.explicit_prompt_cache_enabled());
-            provider = provider.with_request_overrides(openai_config.request_overrides.clone());
+            provider = provider.with_reasoning_effort(instance.reasoning_effort);
+            provider = provider.with_explicit_prompt_cache(
+                instance
+                    .extra
+                    .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY)
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(true),
+            );
+            provider = provider.with_request_overrides(instance.request_overrides.clone());
 
             Ok(Arc::new(provider.with_masking(masking_config.clone())))
         }
 
         "anthropic" => {
-            let anthropic_config =
-                config.providers().anthropic.as_ref().ok_or_else(|| {
-                    LLMError::Auth("Anthropic configuration required".to_string())
-                })?;
-
-            if anthropic_config.api_key.is_empty() {
+            if instance.api_key.is_empty() {
                 return Err(LLMError::Auth("Anthropic API key is required".to_string()));
             }
 
             let mut provider =
-                AnthropicProvider::new(&anthropic_config.api_key).with_client(http_client.clone());
+                AnthropicProvider::new(&instance.api_key).with_client(http_client.clone());
 
-            if let Some(base_url) = &anthropic_config.base_url {
+            if let Some(base_url) = &instance.base_url {
                 if !base_url.is_empty() {
                     provider = provider.with_base_url(base_url);
                 }
             }
 
-            if let Some(max_tokens) = anthropic_config.max_tokens {
+            if let Some(max_tokens) = instance
+                .extra
+                .get("max_tokens")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|value| u32::try_from(value).ok())
+            {
                 provider = provider.with_max_tokens(max_tokens);
             }
 
-            provider = provider.with_reasoning_effort(anthropic_config.reasoning_effort);
-            provider = provider.with_request_overrides(anthropic_config.request_overrides.clone());
+            provider = provider.with_reasoning_effort(instance.reasoning_effort);
+            provider = provider.with_request_overrides(instance.request_overrides.clone());
             provider = provider.with_thinking_replay_always(
-                anthropic_config.thinking_replay_always.unwrap_or(false),
+                instance
+                    .extra
+                    .get("thinking_replay_always")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false),
             );
 
             Ok(Arc::new(provider.with_masking(masking_config.clone())))
         }
 
         "gemini" => {
-            let gemini_config = config
-                .providers()
-                .gemini
-                .as_ref()
-                .ok_or_else(|| LLMError::Auth("Gemini configuration required".to_string()))?;
-
-            if gemini_config.api_key.is_empty() {
+            if instance.api_key.is_empty() {
                 return Err(LLMError::Auth("Gemini API key is required".to_string()));
             }
 
             let mut provider =
-                GeminiProvider::new(&gemini_config.api_key).with_client(http_client.clone());
+                GeminiProvider::new(&instance.api_key).with_client(http_client.clone());
 
-            if let Some(base_url) = &gemini_config.base_url {
+            if let Some(base_url) = &instance.base_url {
                 if !base_url.is_empty() {
                     provider = provider.with_base_url(base_url);
                 }
             }
 
-            provider = provider.with_reasoning_effort(gemini_config.reasoning_effort);
-            provider = provider.with_request_overrides(gemini_config.request_overrides.clone());
+            provider = provider.with_reasoning_effort(instance.reasoning_effort);
+            provider = provider.with_request_overrides(instance.request_overrides.clone());
 
             Ok(Arc::new(provider.with_masking(masking_config.clone())))
         }
 
         "bodhi" => {
-            let bodhi_config = config
-                .providers()
-                .bodhi
-                .as_ref()
-                .ok_or_else(|| LLMError::Auth("Bodhi configuration required".to_string()))?;
-
-            if bodhi_config.api_key.is_empty() {
+            if instance.api_key.is_empty() {
                 return Err(LLMError::Auth("Bodhi API key is required".to_string()));
             }
 
-            let target_provider = bodhi_config.target_provider.as_deref().unwrap_or("openai");
+            let target_provider = instance
+                .extra
+                .get("target_provider")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("openai");
 
             let mut provider =
-                BodhiProvider::new(&bodhi_config.api_key).with_client(http_client.clone());
+                BodhiProvider::new(&instance.api_key).with_client(http_client.clone());
 
-            if let Some(base_url) = &bodhi_config.base_url {
+            if let Some(base_url) = &instance.base_url {
                 if !base_url.is_empty() {
                     provider = provider.with_base_url(base_url);
                 }
@@ -200,14 +257,14 @@ pub async fn create_provider_by_name(
 
             provider = provider
                 .with_target_provider(target_provider)
-                .with_reasoning_effort(bodhi_config.reasoning_effort);
+                .with_reasoning_effort(instance.reasoning_effort);
 
             Ok(Arc::new(provider.with_masking(masking_config.clone())))
         }
 
         _ => Err(LLMError::Auth(format!(
             "Unknown provider: {}. Available providers: {}",
-            provider_name,
+            instance.provider_type,
             AVAILABLE_PROVIDERS.join(", ")
         ))),
     }
@@ -414,6 +471,29 @@ mod tests {
 
         let result = create_provider(&config).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sdk_factory_rejects_disabled_default_instance() {
+        let mut config = config_with_provider("openai", ProviderConfigs::default());
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "api_key": "sk-instance",
+                "enabled": false
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("work".to_string());
+
+        let error = create_provider_with_dir(&config, std::env::temp_dir())
+            .await
+            .err()
+            .expect("disabled instance should fail")
+            .to_string();
+
+        assert!(error.contains("disabled"));
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-llm/src/provider_registry.rs
+++ b/crates/infra/bamboo-llm/src/provider_registry.rs
@@ -2,15 +2,18 @@
 //!
 //! Supports two modes:
 //! 1. **Legacy** — keyed by provider type name (e.g. `"openai"`, `"anthropic"`).
-//! 2. **Instance-keyed** — keyed by instance id (e.g. `"openai-work"`, `"anthropic-personal"`),
-//!    with legacy providers automatically synthesized as default instances.
+//! 2. **Instance-keyed** — keyed by instance id (e.g. `"openai-work"`, `"anthropic-personal"`).
+//!
+//! Instance configuration is authoritative in the second mode. A narrow
+//! synthesized-legacy branch remains only for hybrid configurations whose
+//! default still names a legacy alias during the Lotus migration window.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use crate::provider::{LLMError, LLMProvider};
-use crate::provider_factory::create_provider_by_name;
+use crate::provider_factory::{create_provider_by_name, create_provider_from_instance};
 use bamboo_config::Config;
 use bamboo_config::ProviderInstanceConfig;
 use bamboo_domain::poison::PoisonRecover;
@@ -67,9 +70,8 @@ impl ProviderRegistry {
     /// Create a registry by initializing every configured provider.
     ///
     /// When `config.provider_instances` is non-empty, each instance is initialized
-    /// by translating the instance config into the shape expected by
-    /// [`create_provider_by_name`]. Legacy providers are also included as
-    /// synthesized instances (via [`bamboo_config::synthesize_legacy_instances`]).
+    /// directly from its native configuration. Legacy providers are included only
+    /// as a compatibility seam for non-overlapping hybrid aliases.
     ///
     /// Providers that fail to initialize (missing API key, auth failure, etc.)
     /// are skipped with a warning log rather than aborting the entire startup.
@@ -178,7 +180,6 @@ impl ProviderRegistry {
         let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
         let mut metadata: HashMap<String, ProviderMetadata> = HashMap::new();
 
-        // Build a synthetic config per instance and create the provider.
         for (instance_id, instance) in &config.provider_instances {
             if !instance.enabled {
                 tracing::info!(instance_id, "Provider instance disabled, skipping");
@@ -219,46 +220,54 @@ impl ProviderRegistry {
             }
         }
 
-        // Also synthesize legacy providers that don't overlap with explicit instances.
-        let legacy = bamboo_config::synthesize_legacy_instances(config);
-        for (instance_id, instance_cfg) in legacy {
-            if !instance_cfg.enabled {
-                continue;
-            }
-            if providers.contains_key(&instance_id) {
-                continue; // explicit instance takes precedence
-            }
+        // Narrow compatibility seam for #780-era hybrid configs: the effective
+        // default may still name a legacy alias while other native instances
+        // exist. Never synthesize unrelated stale aliases, and never shadow an
+        // explicit instance with the same id.
+        {
+            let legacy_default_id = config.effective_default_provider();
+            let instance_cfg = (!config.provider_instances.contains_key(legacy_default_id))
+                .then(|| {
+                    bamboo_config::synthesize_legacy_instances(config)
+                        .into_iter()
+                        .find_map(|(id, instance)| (id == legacy_default_id).then_some(instance))
+                })
+                .flatten()
+                .filter(|instance| instance.enabled);
 
-            match Self::create_instance_provider(config, &instance_cfg, app_data_dir.clone()).await
-            {
-                Ok(provider) => {
-                    tracing::info!(
-                        instance_id,
-                        provider_type = &instance_cfg.provider_type,
-                        "Legacy provider instance synthesized"
-                    );
-                    providers.insert(instance_id.clone(), provider);
-                    metadata.insert(
-                        instance_id.clone(),
-                        ProviderMetadata {
-                            id: instance_id,
-                            provider_type: instance_cfg.provider_type.clone(),
-                            display_name: instance_cfg
-                                .label
-                                .clone()
-                                .filter(|label| !label.trim().is_empty())
-                                .unwrap_or_else(|| {
-                                    display_name_for_provider_type(&instance_cfg.provider_type)
-                                }),
-                        },
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        instance_id,
-                        error = %e,
-                        "Legacy provider instance failed to initialize"
-                    );
+            if let Some(instance_cfg) = instance_cfg {
+                match Self::create_instance_provider(config, &instance_cfg, app_data_dir.clone())
+                    .await
+                {
+                    Ok(provider) => {
+                        tracing::info!(
+                            instance_id = legacy_default_id,
+                            provider_type = &instance_cfg.provider_type,
+                            "Legacy default alias synthesized for hybrid compatibility"
+                        );
+                        providers.insert(legacy_default_id.to_string(), provider);
+                        metadata.insert(
+                            legacy_default_id.to_string(),
+                            ProviderMetadata {
+                                id: legacy_default_id.to_string(),
+                                provider_type: instance_cfg.provider_type.clone(),
+                                display_name: instance_cfg
+                                    .label
+                                    .clone()
+                                    .filter(|label| !label.trim().is_empty())
+                                    .unwrap_or_else(|| {
+                                        display_name_for_provider_type(&instance_cfg.provider_type)
+                                    }),
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            instance_id = legacy_default_id,
+                            error = %e,
+                            "Hybrid legacy default alias failed to initialize"
+                        );
+                    }
                 }
             }
         }
@@ -272,18 +281,14 @@ impl ProviderRegistry {
 
     /// Create a single provider from a [`ProviderInstanceConfig`].
     ///
-    /// This works by building a temporary [`Config`] that has the instance's
-    /// credentials projected into the legacy provider slot, then delegating
-    /// to [`create_provider_by_name`].
+    /// The instance remains the runtime authority; no legacy config slot is
+    /// populated as an intermediate representation.
     async fn create_instance_provider(
         base_config: &Config,
         instance: &ProviderInstanceConfig,
         app_data_dir: PathBuf,
     ) -> Result<Arc<dyn LLMProvider>, LLMError> {
-        let mut temp_config = base_config.clone();
-        // Project the instance's credentials into the legacy provider slots.
-        apply_instance_to_config(&mut temp_config, instance);
-        create_provider_by_name(&temp_config, &instance.provider_type, app_data_dir).await
+        create_provider_from_instance(base_config, instance, app_data_dir).await
     }
 
     /// Get a provider by name or instance id.
@@ -361,119 +366,6 @@ impl ProviderRegistry {
     pub fn set_default(&self, key: String) {
         *self.default_provider.write().recover_poison() = key;
     }
-}
-
-/// Project an instance's credentials into the legacy `Config` provider slots
-/// so that `create_provider_by_name` can consume them.
-fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConfig) {
-    let providers = config.providers_mut();
-    match instance.provider_type.as_str() {
-        "openai" => {
-            let extra = instance
-                .extra
-                .get(bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY)
-                .map(|value| {
-                    std::iter::once((
-                        bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY.to_string(),
-                        value.clone(),
-                    ))
-                    .collect()
-                })
-                .unwrap_or_default();
-            providers.openai = Some(bamboo_config::OpenAIConfig {
-                api_key: instance.api_key.clone(),
-                // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
-                // override, so it may be persisted normally. #253.
-                api_key_from_env: false,
-                api_key_encrypted: instance.api_key_encrypted.clone(),
-                credential_ref: None,
-                base_url: instance.base_url.clone(),
-                model: instance.model.clone(),
-                fast_model: instance.fast_model.clone(),
-                vision_model: instance.vision_model.clone(),
-                reasoning_effort: instance.reasoning_effort,
-                responses_only_models: instance.responses_only_models.clone(),
-                request_overrides: instance.request_overrides.clone(),
-                extra,
-            });
-        }
-        "anthropic" => {
-            providers.anthropic = Some(bamboo_config::AnthropicConfig {
-                api_key: instance.api_key.clone(),
-                // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
-                // override, so it may be persisted normally. #253.
-                api_key_from_env: false,
-                api_key_encrypted: instance.api_key_encrypted.clone(),
-                credential_ref: None,
-                base_url: instance.base_url.clone(),
-                model: instance.model.clone(),
-                fast_model: instance.fast_model.clone(),
-                vision_model: instance.vision_model.clone(),
-                max_tokens: None,
-                reasoning_effort: instance.reasoning_effort,
-                request_overrides: instance.request_overrides.clone(),
-                // Anthropic-compatible upstreams (e.g. GLM) that require
-                // unconditional `thinking`-block presence opt in via this
-                // instance's `extra.thinking_replay_always` (#520); real
-                // Anthropic must never set it.
-                thinking_replay_always: instance
-                    .extra
-                    .get("thinking_replay_always")
-                    .and_then(|v| v.as_bool()),
-                extra: Default::default(),
-            });
-        }
-        "gemini" => {
-            providers.gemini = Some(bamboo_config::GeminiConfig {
-                api_key: instance.api_key.clone(),
-                // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
-                // override, so it may be persisted normally. #253.
-                api_key_from_env: false,
-                api_key_encrypted: instance.api_key_encrypted.clone(),
-                credential_ref: None,
-                base_url: instance.base_url.clone(),
-                model: instance.model.clone(),
-                fast_model: instance.fast_model.clone(),
-                vision_model: instance.vision_model.clone(),
-                reasoning_effort: instance.reasoning_effort,
-                request_overrides: instance.request_overrides.clone(),
-                extra: Default::default(),
-            });
-        }
-        "copilot" => {
-            // Copilot uses device auth; just set the model overrides.
-            let existing = providers.copilot.take();
-            providers.copilot = Some(bamboo_config::CopilotConfig {
-                enabled: true,
-                headless_auth: existing.as_ref().map(|c| c.headless_auth).unwrap_or(false),
-                model: instance.model.clone(),
-                fast_model: instance.fast_model.clone(),
-                vision_model: instance.vision_model.clone(),
-                reasoning_effort: instance.reasoning_effort,
-                responses_only_models: instance.responses_only_models.clone(),
-                request_overrides: instance.request_overrides.clone(),
-                extra: Default::default(),
-            });
-        }
-        "bodhi" => {
-            providers.bodhi = Some(bamboo_config::BodhiConfig {
-                api_key: instance.api_key.clone(),
-                api_key_encrypted: instance.api_key_encrypted.clone(),
-                credential_ref: None,
-                base_url: instance.base_url.clone(),
-                target_provider: instance
-                    .extra
-                    .get("target_provider")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
-                reasoning_effort: instance.reasoning_effort,
-                extra: Default::default(),
-            });
-        }
-        _ => {}
-    }
-    // Set provider type so create_provider_by_name targets the right one.
-    config.provider = instance.provider_type.clone();
 }
 
 fn display_name_for_provider_type(id: &str) -> String {
@@ -614,117 +506,101 @@ mod tests {
         assert_eq!(registry.default_provider_name(), "new-default");
     }
 
-    #[test]
-    fn test_apply_instance_to_config_openai() {
+    #[tokio::test]
+    async fn explicit_instance_failure_does_not_fall_back_to_stale_legacy_alias() {
+        let temp = tempfile::tempdir().unwrap();
         let mut config = Config::default();
-        let mut extra = std::collections::BTreeMap::new();
-        extra.insert(
-            bamboo_config::OPENAI_EXPLICIT_PROMPT_CACHE_CONFIG_KEY.to_string(),
-            serde_json::json!(false),
-        );
-        let instance = ProviderInstanceConfig {
-            provider_type: "openai".to_string(),
-            label: Some("Test OpenAI".to_string()),
-            api_key: "sk-instance-key".to_string(),
-            api_key_encrypted: None,
-            credential_ref: None,
-            base_url: Some("https://custom.api.com/v1".to_string()),
-            model: Some("gpt-4o".to_string()),
-            fast_model: Some("gpt-4o-mini".to_string()),
-            vision_model: None,
-            reasoning_effort: None,
-            responses_only_models: vec![],
-            request_overrides: None,
-            enabled: true,
-            extra,
+        *config.providers_mut() = bamboo_config::ProviderConfigs {
+            openai: Some(OpenAIConfig {
+                api_key: "sk-stale-legacy".to_string(),
+                ..OpenAIConfig::default()
+            }),
+            ..Default::default()
         };
-
-        apply_instance_to_config(&mut config, &instance);
-
-        let openai = config
-            .providers()
-            .openai
-            .as_ref()
-            .expect("openai should be set");
-        assert_eq!(openai.api_key, "sk-instance-key");
-        assert_eq!(
-            openai.base_url.as_deref(),
-            Some("https://custom.api.com/v1")
+        config.provider_instances.insert(
+            "openai".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "api_key": "",
+                "enabled": true
+            }))
+            .unwrap(),
         );
-        assert_eq!(openai.model.as_deref(), Some("gpt-4o"));
-        assert!(!openai.explicit_prompt_cache_enabled());
-        assert_eq!(config.provider, "openai");
+        config.default_provider_instance = Some("openai".to_string());
+
+        let registry = ProviderRegistry::from_config(&config, temp.path().to_path_buf())
+            .await
+            .unwrap();
+
+        assert!(registry.get("openai").is_none());
+        assert!(registry.get_default().is_none());
     }
 
-    /// Issue #520: an Anthropic provider instance's `extra.thinking_replay_always`
-    /// (the GLM-style anthropic-compat opt-in) must project through to the
-    /// legacy `AnthropicConfig` slot `create_provider_by_name` reads.
-    #[test]
-    fn test_apply_instance_to_config_anthropic_projects_thinking_replay_always() {
+    #[tokio::test]
+    async fn hybrid_legacy_default_alias_remains_resolvable_without_other_stale_aliases() {
+        let temp = tempfile::tempdir().unwrap();
         let mut config = Config::default();
-        let mut extra = std::collections::BTreeMap::new();
-        extra.insert(
-            "thinking_replay_always".to_string(),
-            serde_json::json!(true),
-        );
-        let instance = ProviderInstanceConfig {
-            provider_type: "anthropic".to_string(),
-            label: Some("GLM compat".to_string()),
-            api_key: "glm-key".to_string(),
-            api_key_encrypted: None,
-            credential_ref: None,
-            base_url: Some("https://glm.example.com/anthropic".to_string()),
-            model: Some("glm-4.6".to_string()),
-            fast_model: None,
-            vision_model: None,
-            reasoning_effort: None,
-            responses_only_models: vec![],
-            request_overrides: None,
-            enabled: true,
-            extra,
+        *config.providers_mut() = bamboo_config::ProviderConfigs {
+            openai: Some(OpenAIConfig {
+                api_key: "sk-legacy-default".to_string(),
+                ..OpenAIConfig::default()
+            }),
+            anthropic: Some(bamboo_config::AnthropicConfig {
+                api_key: "sk-stale-anthropic".to_string(),
+                ..bamboo_config::AnthropicConfig::default()
+            }),
+            ..Default::default()
         };
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "api_key": "sk-work",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
+        config.default_provider_instance = Some("openai".to_string());
 
-        apply_instance_to_config(&mut config, &instance);
+        let registry = ProviderRegistry::from_config(&config, temp.path().to_path_buf())
+            .await
+            .unwrap();
 
-        let anthropic = config
-            .providers()
-            .anthropic
-            .as_ref()
-            .expect("anthropic should be set");
-        assert_eq!(anthropic.thinking_replay_always, Some(true));
+        assert_eq!(registry.default_provider_name(), "openai");
+        assert!(registry.get_default().is_some());
+        assert!(registry.get("work").is_some());
+        assert!(registry.get("anthropic").is_none());
     }
 
-    /// Without the `extra.thinking_replay_always` key at all, the projected
-    /// config must leave it `None` — `create_provider_by_name` then defaults
-    /// to `false`, the safe real-Anthropic behavior (#520).
-    #[test]
-    fn test_apply_instance_to_config_anthropic_defaults_thinking_replay_always_to_none() {
+    #[tokio::test]
+    async fn hybrid_legacy_provider_fallback_without_explicit_default_remains_resolvable() {
+        let temp = tempfile::tempdir().unwrap();
         let mut config = Config::default();
-        let instance = ProviderInstanceConfig {
-            provider_type: "anthropic".to_string(),
-            label: None,
-            api_key: "sk-ant-key".to_string(),
-            api_key_encrypted: None,
-            credential_ref: None,
-            base_url: None,
-            model: None,
-            fast_model: None,
-            vision_model: None,
-            reasoning_effort: None,
-            responses_only_models: vec![],
-            request_overrides: None,
-            enabled: true,
-            extra: Default::default(),
+        config.provider = "anthropic".to_string();
+        *config.providers_mut() = bamboo_config::ProviderConfigs {
+            anthropic: Some(bamboo_config::AnthropicConfig {
+                api_key: "sk-legacy-default".to_string(),
+                ..bamboo_config::AnthropicConfig::default()
+            }),
+            ..Default::default()
         };
+        config.provider_instances.insert(
+            "work".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "api_key": "sk-work",
+                "enabled": true
+            }))
+            .unwrap(),
+        );
 
-        apply_instance_to_config(&mut config, &instance);
+        let registry = ProviderRegistry::from_config(&config, temp.path().to_path_buf())
+            .await
+            .unwrap();
 
-        let anthropic = config
-            .providers()
-            .anthropic
-            .as_ref()
-            .expect("anthropic should be set");
-        assert_eq!(anthropic.thinking_replay_always, None);
+        assert_eq!(registry.default_provider_name(), "anthropic");
+        assert!(registry.get_default().is_some());
+        assert!(registry.get("work").is_some());
     }
 
     /// A poisoned lock must not brick the registry: every subsequent operation

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -63,8 +63,8 @@ default. The full field list of `Config`:
 | `provider` | `String` | Default provider name. Default `"anthropic"`. |
 | `defaults` | `Option<DefaultsConfig>` | Per-role model routing (`chat`/`fast`/`vision`/`planning`/...); only consulted when `features.provider_model_ref` is on. |
 | `providers` | `ProviderConfigs` | Legacy single-instance-per-type provider configs. See [Providers](#providers). |
-| `provider_instances` | `HashMap<String, ProviderInstanceConfig>` | Multi-instance provider configs, keyed by an id you choose (e.g. two Anthropic keys under different labels). Takes precedence over `providers` when non-empty. |
-| `default_provider_instance` | `Option<String>` | Which `provider_instances` entry is the default; overrides legacy `provider` when set. |
+| `provider_instances` | `HashMap<String, ProviderInstanceConfig>` | Authoritative provider configs, keyed by a stable routing id (e.g. two Anthropic keys under different labels). Runtime construction, model resolution, model discovery and child-agent credential scoping read these entries directly. |
+| `default_provider_instance` | `Option<String>` | Which enabled `provider_instances` entry is the default. A missing id is accepted only as a temporary hybrid reference to a real legacy provider stanza. |
 | `server` | `ServerConfig` | HTTP bind/port/TLS. See [Server](#server). |
 | `keyword_masking` | `KeywordMaskingConfig` | Outbound-body secret scrubbing. See [Keyword masking](#keyword-masking). |
 | `anthropic_model_mapping` / `gemini_model_mapping` | `{ mappings: HashMap<String,String> }` | Alias an OpenAI-shaped model id (e.g. `"gemini-pro"`) to the real upstream model id for that provider's compat endpoint. |
@@ -100,8 +100,9 @@ not part of Bamboo Issue #597.
 
 ## Providers
 
-Two shapes coexist; a fresh `bamboo init` writes the legacy single-instance
-`providers` shape, which is simplest for one key per provider:
+`provider_instances` is the durable and runtime authority. The legacy
+single-instance `providers` shape remains readable during the Lotus #177
+client-migration window:
 
 ```json
 {
@@ -135,8 +136,21 @@ affinity hint that can improve routing to a matching prefix; it does not
 guarantee a cache hit. `request_overrides` body patches run afterward, so an
 operator may replace the generated key or remove `prompt_cache_key` entirely.
 
-For more than one instance of a provider type (e.g. two separate Anthropic
-keys/workspaces), use `provider_instances` instead:
+The server idempotently materializes a usable selected legacy provider into
+`provider_instances` when it opens the modular configuration. Built-in provider
+type names become stable instance ids (`openai`, `anthropic`, and so on), the
+selected id becomes `default_provider_instance`, and provider-specific fields
+such as Anthropic `max_tokens` / `thinking_replay_always`, Copilot
+`headless_auth`, and Bodhi `target_provider` are retained. Existing credential
+references are reused; plaintext is never copied into `providers.json`.
+Migration commits use the provider-section revision and the configuration
+facade's recoverable transaction protocol. Reopening an already migrated
+configuration is a byte/revision no-op. If the provider or credential authority
+is degraded, a legacy reconciliation is pending, or the exact base revision has
+changed, migration does not overwrite that state; startup retains the readable
+last-known-good/hybrid view and retries on a later safe open.
+
+For one or more provider accounts, the canonical shape is:
 
 ```json
 {
@@ -150,8 +164,31 @@ keys/workspaces), use `provider_instances` instead:
 
 `provider_instances` entries have the same field set as the legacy stanzas
 plus `provider_type` (which of the five kinds this is) and `enabled` (default
-`true`). When `provider_instances` is non-empty it takes precedence over
-`providers`/`provider` as the routing source.
+`true`). An explicit instance id always wins over a same-named legacy alias,
+including when that instance is disabled or invalid; Bamboo never silently
+resurrects the stale alias. A temporary hybrid may keep a legacy default id
+only when a real stanza with that id still exists. Other instance-native paths
+do not re-project instances into global legacy slots.
+
+`BAMBOO_PROVIDER` may select an exact instance id. A built-in type value selects
+the lexicographically first enabled instance of that type, making multi-account
+startup deterministic. `BAMBOO_OPENAI_API_KEY`,
+`BAMBOO_ANTHROPIC_API_KEY`, and `BAMBOO_GEMINI_API_KEY` hydrate only instances
+marked for the standard environment override; they do not recreate legacy
+slots. Legacy-materialized instances keep that binding so the historical
+precedence remains stable: a present environment key wins, while a migrated
+credential reference remains the fallback after the variable is removed. The
+persisted marker records only the binding, never the secret. An environment-only
+instance with no stored fallback reports `configured: false` and
+`source: "environment"` whenever the variable is absent.
+
+Use the revisioned `GET/PUT /v1/bamboo/config/provider-settings` contract or the
+provider-instance CRUD endpoints for writes. The deprecated
+`GET /v1/bamboo/settings/provider` remains a secret-free, type-keyed projection
+for older clients. Its matching POST returns `400` after the default resolves
+to a native instance, rather than acknowledging a legacy write that the
+canonicalizer would discard. This compatibility boundary can be removed after
+Lotus #177 migrates its remaining callers.
 
 ## Server
 

--- a/tests/e2e/config_flow/flows.rs
+++ b/tests/e2e/config_flow/flows.rs
@@ -174,11 +174,26 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
     );
     let reloaded = bamboo_config::Config::from_data_dir_without_env(Some(data_dir.clone()));
     assert_eq!(
-        reloaded.providers().openai.as_ref().unwrap().api_key,
-        "sk-test-key"
+        reloaded.default_provider_instance.as_deref(),
+        Some("openai")
     );
+    let reloaded_openai = reloaded
+        .provider_instances
+        .get("openai")
+        .expect("legacy provider should materialize as the authoritative instance");
+    assert_eq!(reloaded_openai.api_key, "sk-test-key");
+    assert_eq!(
+        reloaded_openai
+            .credential_ref
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        Some("provider.openai.api_key")
+    );
+    assert!(reloaded.providers().openai.is_none());
 
-    // Attempt to inject api_key_encrypted via permissive endpoint - must be ignored.
+    // Attempt to inject api_key_encrypted via the permissive endpoint after
+    // legacy materialization. It must be ignored without resurrecting the
+    // retired type-keyed alias.
     let req = test::TestRequest::post()
         .uri("/v1/bamboo/config")
         .set_json(json!({
@@ -200,13 +215,17 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
     }
     let providers = config_document_data(&providers_document);
     let openai_ref_after = providers
-        .get("openai")
+        .get("provider_instances")
+        .and_then(|instances| instances.get("openai"))
         .and_then(|o| o.get("credential_ref"))
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
     assert_eq!(openai_ref_after, openai_ref_before);
-    assert!(providers["openai"].get("api_key_encrypted").is_none());
+    assert!(providers.get("openai").is_none());
+    assert!(providers["provider_instances"]["openai"]
+        .get("api_key_encrypted")
+        .is_none());
 
     // Ensure the permissive endpoint merges without clobbering prior provider/setup state.
     let req = test::TestRequest::get()
@@ -243,10 +262,13 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
     let providers_document = read_config_json(&providers_path);
     let providers = config_document_data(&providers_document);
     assert_eq!(
-        providers["openai"]["credential_ref"], "provider.openai.api_key",
+        providers["provider_instances"]["openai"]["credential_ref"], "provider.openai.api_key",
         "metadata-only updates must preserve the existing credential ref"
     );
-    assert!(providers["openai"].get("api_key_encrypted").is_none());
+    assert!(providers.get("openai").is_none());
+    assert!(providers["provider_instances"]["openai"]
+        .get("api_key_encrypted")
+        .is_none());
 }
 
 #[actix_web::test]


### PR DESCRIPTION
## Summary

- Persist legacy provider / providers.* configuration as idempotent native provider_instances with exact revision/CAS authority and stable credential references.
- Construct providers directly from ProviderInstanceConfig and make model, reasoning, session, schedule, SDK, Copilot auth, external-agent, and execute paths instance-aware.
- Preserve legacy environment-variable precedence without persisting plaintext: an active BAMBOO_*_API_KEY overrides the migrated credential, which remains the fallback when the variable is absent.
- Make deprecated provider reads and model fetches instance-aware and secret-safe while rejecting legacy writes after native authority is active.
- Extend canonical provider settings and provider-instance APIs for provider-specific fields, immutable provider identity, fail-closed explicit routing, credential availability validated against the active crypto key, and a shared fail-closed metadata/request-override secret classifier.

## Why

Provider instances were previously synthesized only in memory and then projected back into legacy single-provider configuration for construction. That left two runtime authorities, prevented durable migration, and blocked Lotus #177 from removing its legacy fallback.

This change completes the Bamboo-side persistent migration and native runtime authority needed to unblock Lotus #177. It intentionally retains a narrow, read-only compatibility boundary for old clients. The umbrella issue remains open for the Lotus migration and final removal of legacy endpoints/fields.

Refs #730

## Test Plan

- cargo fmt --all -- --check
- git diff --check
- cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code
- cargo test --test e2e_tests --all-features: 210 passed
- cargo test -p bamboo-config --all-features --lib: 697 passed
- cargo test -p bamboo-engine --all-features --lib: 1377 passed
- cargo test -p bamboo-server --all-features --lib: 1880 passed, 1 ignored
- cargo test -p bamboo-sdk --lib: 52 passed
- cargo test -p bamboo-llm provider_ --lib: 54 passed
- Focused restart, cross-facade CAS, provider identity, explicit routing, environment override/fallback, missing and undecryptable credential recovery, API compatibility, and secret-boundary regression tests

Security Audit and cargo-deny currently report RUSTSEC-2026-0258 for the h2 versions already present on dev@670eaf78. This PR changes no Cargo manifest or lockfile; required Test, E2E Tests, and Lint remain the protected merge gates.

## Screenshots

Not applicable; backend/configuration change only.
