### PR TITLE
fix(server): eliminate vulnerable legacy h2 transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,6 @@ dependencies = [
  "flate2",
  "foldhash 0.2.0",
  "futures-core",
- "h2 0.3.27",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -170,8 +169,6 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "futures-core",
- "http 0.2.12",
- "http 1.4.2",
  "impl-more 0.1.9",
  "pin-project-lite",
  "rustls-pki-types",
@@ -204,7 +201,6 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
- "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "bytes",
@@ -396,7 +392,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -407,7 +403,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -801,40 +797,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "awc"
-version = "3.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7dc0207013c5059ddce268fe12045bd12b2e919318ee660c891bfe297a54f1f"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
- "actix-tls",
- "actix-utils",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "cookie",
- "derive_more",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "itoa",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.9.4",
- "rustls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
-]
 
 [[package]]
 name = "bamboo-a2a"
@@ -1379,16 +1341,17 @@ dependencies = [
 name = "bamboo-server"
 version = "0.0.0"
 dependencies = [
- "actix-codec",
  "actix-cors",
  "actix-files",
+ "actix-http",
  "actix-rt",
+ "actix-server",
+ "actix-service",
  "actix-web",
  "actix-ws",
  "anyhow",
  "async-stream",
  "async-trait",
- "awc",
  "bamboo-agent-core",
  "bamboo-broker",
  "bamboo-compression",
@@ -1423,6 +1386,7 @@ dependencies = [
  "hex",
  "http 1.4.2",
  "mockall",
+ "native-tls",
  "notify",
  "notify-rust",
  "parking_lot",
@@ -1439,10 +1403,12 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
+ "socket2 0.6.4",
  "tar",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-native-tls",
  "tokio-stream",
  "tokio-test",
  "tokio-tungstenite 0.29.0",
@@ -2540,7 +2506,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2735,7 +2701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3254,28 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3507,7 +3454,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2",
  "http 1.4.2",
  "http-body",
  "httparse",
@@ -3597,7 +3544,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4476,7 +4423,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5583,7 +5530,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.15",
+ "h2",
  "http 1.4.2",
  "http-body",
  "http-body-util",
@@ -5913,7 +5860,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6350,7 +6297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6648,7 +6595,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6661,7 +6608,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7258,7 +7205,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7704,7 +7651,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,21 @@ bamboo-tui = { path = "crates/app/bamboo-tui" }
 tokio = { version = "1", features = ["full"] }
 
 # Web framework
-actix-web = "4"
+# Bamboo's inbound face is intentionally HTTP/1.1-only. Keep Actix's ordinary
+# default surface except for `http2`: Actix 4 still resolves the vulnerable
+# `h2 0.3` line (RUSTSEC-2026-0258), while Bamboo's WSS transport uses the
+# HTTP/1.1 Upgrade protocol. Outbound provider clients retain HTTP/2 through
+# Reqwest's patched `h2 0.4` dependency.
+actix-web = { version = "4", default-features = false, features = [
+    "macros",
+    "compress-brotli",
+    "compress-gzip",
+    "compress-zstd",
+    "cookies",
+    "unicode",
+    "compat",
+    "ws",
+] }
 actix-cors = "0.7"
 actix-files = "0.6"
 

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -43,11 +43,24 @@ bamboo-projects = { path = "../../infra/bamboo-projects" }
 # server-side DTO that could drift from the wire record).
 bamboo-subagent = { path = "../../infra/bamboo-subagent" }
 
-# Web framework
-# `rustls-0_23` enables actix-web's TLS bind/listen against rustls 0.23
-# (`bind_rustls_0_23` / `listen_rustls_0_23`) for the v2 self-terminated TLS
-# face (#181). Without it the `*_rustls_0_23` methods do not exist.
-actix-web = { version = "4", features = ["rustls-0_23"] }
+# Web framework. Preserve Actix's ordinary default surface except inbound
+# HTTP/2. Actix 4's `http2` feature still resolves vulnerable `h2 0.3`; Bamboo's
+# public WSS contract uses HTTP/1.1 Upgrade and is served by the explicit H1
+# builder in `server/h1.rs` (#849).
+actix-web = { version = "4", default-features = false, features = [
+    "macros",
+    "compress-brotli",
+    "compress-gzip",
+    "compress-zstd",
+    "cookies",
+    "unicode",
+    "compat",
+    "ws",
+] }
+actix-http = { version = "3", default-features = false, features = ["rustls-0_23"] }
+actix-server = "2"
+actix-service = "2"
+socket2 = "0.6"
 actix-cors = "0.7"
 actix-files = "0.6"
 # v2-P1 (#181): the `GET /v2/stream` unified WebSocket multiplex. `actix-ws`
@@ -159,12 +172,8 @@ tokio-test = "0.4"
 mockall = "0.15"
 http = "1"
 actix-rt = "2"
-# v2-P1 (#187): live WS integration harness for `GET /v2/stream`. `awc` is
-# actix's own HTTP+WS client, so it composes with the actix-web 4 server already
-# in-tree (one runtime, one ws codec) and drives a real loopback `ws://` upgrade.
-# `actix-codec` names the `Framed` half `awc::ws connect()` returns.
-awc = { version = "3", features = ["rustls-0_23"] }
-actix-codec = "0.5"
+native-tls = { version = "0.2", features = ["alpn"] }
+tokio-native-tls = "0.3"
 bamboo-infrastructure = { path = "../../infra/bamboo-infrastructure", features = ["test-utils"] }
 bamboo-llm = { path = "../../infra/bamboo-llm" }
 # Existing server unit tests use bamboo-config's encryption and transaction

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -3,10 +3,11 @@ use std::path::{Path, PathBuf};
 use actix_files as fs;
 use actix_web::{
     dev::{fn_service, ServiceRequest, ServiceResponse},
-    web, App, HttpResponse, HttpServer,
+    web, App, HttpResponse,
 };
 use tracing::{error, info};
 
+use super::h1::build_h1_server;
 use super::listeners::{build_bind_listeners, build_desktop_listeners, resolve_worker_count};
 use super::tls::build_rustls_config;
 use crate::app_state::AppState;
@@ -108,7 +109,7 @@ pub async fn run(bamboo_home_dir: PathBuf, port: u16) -> Result<(), String> {
 
 /// Like [`run`], but terminates TLS itself when `tls` is `Some` (#181).
 ///
-/// Desktop loopback callers pass `None` and get the unchanged plaintext path.
+/// Desktop loopback callers pass `None` and get the unchanged plaintext H1 path.
 pub async fn run_with_tls(
     bamboo_home_dir: PathBuf,
     port: u16,
@@ -182,7 +183,7 @@ pub async fn run_with_tls(
 
     // Fail-fast: when TLS is configured, build the rustls config up front so a
     // bad/missing cert refuses startup instead of silently falling back to
-    // plaintext. `None` → unchanged plaintext path.
+    // plaintext. `None` → unchanged plaintext H1 path.
     let rustls_cfg = match &tls {
         Some(tls) => Some(build_rustls_config(tls)?),
         None => None,
@@ -190,19 +191,8 @@ pub async fn run_with_tls(
 
     let listeners = build_desktop_listeners(port)?;
 
-    let mut http = HttpServer::new(app_factory).workers(workers);
-    for (idx, listener) in listeners.into_iter().enumerate() {
-        http = match &rustls_cfg {
-            Some(cfg) => http
-                .listen_rustls_0_23(listener, cfg.clone())
-                .map_err(|e| format!("Failed to attach TLS listener #{idx}: {e}"))?,
-            None => http
-                .listen(listener)
-                .map_err(|e| format!("Failed to attach listener #{idx}: {e}"))?,
-        };
-    }
-
-    let server = http.run();
+    let server = build_h1_server(app_factory, listeners, workers, rustls_cfg.clone())
+        .map_err(|e| format!("Failed to build HTTP/1.1 server: {e}"))?;
 
     let scheme = if rustls_cfg.is_some() {
         "https"
@@ -285,7 +275,7 @@ pub async fn run_with_bind_and_static(
 }
 
 /// Like [`run_with_bind_and_static`], but terminates TLS itself when `tls` is
-/// `Some` (#181). When `None`, the plaintext `.listen()` path is unchanged.
+/// `Some` (#181). When `None`, the plaintext HTTP/1.1 path is unchanged.
 pub async fn run_with_bind_and_static_tls(
     bamboo_home_dir: PathBuf,
     port: u16,
@@ -384,7 +374,7 @@ pub async fn run_with_bind_and_static_tls(
 
     // Fail-fast: build the rustls config before binding so a bad/missing cert
     // refuses startup rather than silently downgrading to plaintext. `None` →
-    // unchanged plaintext path (desktop/loopback behavior preserved). #181.
+    // unchanged plaintext H1 path (desktop/loopback behavior preserved). #181.
     let rustls_cfg = match &tls {
         Some(tls) => Some(build_rustls_config(tls)?),
         None => None,
@@ -392,19 +382,8 @@ pub async fn run_with_bind_and_static_tls(
 
     let listeners = build_bind_listeners(bind, port)?;
 
-    let mut http = HttpServer::new(app_factory).workers(workers);
-    for (idx, listener) in listeners.into_iter().enumerate() {
-        http = match &rustls_cfg {
-            Some(cfg) => http
-                .listen_rustls_0_23(listener, cfg.clone())
-                .map_err(|e| format!("Failed to attach TLS listener #{idx}: {e}"))?,
-            None => http
-                .listen(listener)
-                .map_err(|e| format!("Failed to attach listener #{idx}: {e}"))?,
-        };
-    }
-
-    let server = http.run();
+    let server = build_h1_server(app_factory, listeners, workers, rustls_cfg.clone())
+        .map_err(|e| format!("Failed to build HTTP/1.1 server: {e}"))?;
 
     let scheme = if rustls_cfg.is_some() {
         "https"

--- a/crates/app/bamboo-server/src/server/h1.rs
+++ b/crates/app/bamboo-server/src/server/h1.rs
@@ -1,0 +1,115 @@
+//! Shared HTTP/1.1 server construction for Bamboo's Actix application face.
+//!
+//! Actix Web 4 couples each high-level Rustls feature to its HTTP/2 feature.
+//! That HTTP/2 feature still resolves `h2 0.3`, which is affected by
+//! RUSTSEC-2026-0258. Bamboo's client transport contract is HTTPS plus WSS
+//! (HTTP/1.1 Upgrade), so every inbound listener is constructed explicitly as
+//! HTTP/1.1 here. Outbound Reqwest clients retain HTTP/2 independently.
+//!
+//! Keeping plaintext and Rustls construction in this one module is a security
+//! invariant: a TLS listener must never advertise `h2` and then hand the stream
+//! to an H1-only dispatcher.
+
+use std::{
+    fmt, io,
+    net::{SocketAddr, TcpListener},
+    time::Duration,
+};
+
+use actix_http::{body::MessageBody, HttpService, Request, Response};
+use actix_server::{Server, ServerBuilder};
+use actix_service::{map_config, IntoServiceFactory, Service, ServiceFactory, ServiceFactoryExt};
+use actix_web::{dev::AppConfig, Error};
+use rustls::ServerConfig;
+
+const HTTP11_ALPN: &[u8] = b"http/1.1";
+
+/// Actix keeps `AppConfig`'s ordinary constructor crate-private and exposes
+/// this semver-exempt constructor for external server harnesses. Isolate that
+/// dependency seam here so every app factory receives the real listener host,
+/// local address, and secure bit; a default config would incorrectly report
+/// HTTPS requests as `http`.
+fn app_config(secure: bool, host: String, addr: SocketAddr) -> AppConfig {
+    AppConfig::__priv_test_new(secure, host, addr)
+}
+
+/// Build and start an HTTP/1.1-only Actix server over the supplied listeners.
+///
+/// `tls = None` serves plaintext HTTP/1.1. A Rustls config serves HTTPS/WSS and
+/// must advertise only `http/1.1`; [`crate::server::tls::build_rustls_config`]
+/// establishes that invariant before this function is called.
+pub(super) fn build_h1_server<F, I, S, B>(
+    factory: F,
+    listeners: Vec<TcpListener>,
+    workers: usize,
+    tls: Option<ServerConfig>,
+) -> io::Result<Server>
+where
+    F: Fn() -> I + Send + Clone + 'static,
+    I: IntoServiceFactory<S, Request>,
+    S: ServiceFactory<Request, Config = AppConfig> + 'static,
+    S::Error: Into<Error> + 'static,
+    S::InitError: fmt::Debug,
+    S::Response: Into<Response<B>> + 'static,
+    S::Service: 'static,
+    <S::Service as Service<Request>>::Future: 'static,
+    B: MessageBody + 'static,
+{
+    if let Some(config) = &tls {
+        if config.alpn_protocols.len() != 1 || config.alpn_protocols[0].as_slice() != HTTP11_ALPN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Bamboo's inbound TLS config must advertise only ALPN http/1.1",
+            ));
+        }
+    }
+
+    if listeners.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            "at least one HTTP listener is required",
+        ));
+    }
+
+    let mut builder = ServerBuilder::default().workers(workers);
+
+    for (index, listener) in listeners.into_iter().enumerate() {
+        let addr = listener.local_addr()?;
+        let name = format!("bamboo-http1-{index}-{addr}");
+        let host = addr.to_string();
+        let app_factory = factory.clone();
+
+        builder = match &tls {
+            Some(tls_config) => {
+                let tls_config = tls_config.clone();
+                builder.listen(name, listener, move || {
+                    let app_config = app_config(true, host.clone(), addr);
+                    let app = app_factory()
+                        .into_factory()
+                        .map_err(|err| err.into().error_response());
+
+                    HttpService::build()
+                        .secure()
+                        .local_addr(addr)
+                        .client_disconnect_timeout(Duration::from_secs(1))
+                        .h1(map_config(app, move |_| app_config.clone()))
+                        .rustls_0_23(tls_config.clone())
+                })?
+            }
+            None => builder.listen(name, listener, move || {
+                let app_config = app_config(false, host.clone(), addr);
+                let app = app_factory()
+                    .into_factory()
+                    .map_err(|err| err.into().error_response());
+
+                HttpService::build()
+                    .local_addr(addr)
+                    .client_disconnect_timeout(Duration::from_secs(1))
+                    .h1(map_config(app, move |_| app_config.clone()))
+                    .tcp()
+            })?,
+        };
+    }
+
+    Ok(builder.run())
+}

--- a/crates/app/bamboo-server/src/server/listeners.rs
+++ b/crates/app/bamboo-server/src/server/listeners.rs
@@ -1,6 +1,9 @@
-use std::net::TcpListener;
+use std::net::{TcpListener, ToSocketAddrs};
 
+use socket2::{Domain, Protocol, Socket, Type};
 use tracing::warn;
+
+const HTTP_LISTEN_BACKLOG: i32 = 1024;
 
 pub(super) const DEFAULT_WORKER_COUNT: usize = 10;
 
@@ -26,6 +29,63 @@ pub(super) fn resolve_worker_count() -> usize {
 
 fn try_make_listener(addr: &str) -> std::io::Result<TcpListener> {
     let listener = TcpListener::bind(addr)?;
+    listener.set_nonblocking(true)?;
+    Ok(listener)
+}
+
+/// Resolve and bind every address for an `HttpServer::bind((host, port))`
+/// compatible call. `WebService` historically used that API, which keeps any
+/// successful IPv4/IPv6 listener even if another resolved address fails.
+pub(super) fn build_resolved_listeners(bind: &str, port: u16) -> Result<Vec<TcpListener>, String> {
+    let addresses = (bind, port)
+        .to_socket_addrs()
+        .map_err(|e| format!("Failed to resolve bind address {bind}:{port}: {e}"))?;
+    let mut listeners = Vec::new();
+    let mut last_error = None;
+
+    for address in addresses {
+        match make_http_listener(address) {
+            Ok(listener) => {
+                listeners.push(listener);
+            }
+            Err(error) => last_error = Some((address, error)),
+        }
+    }
+
+    if !listeners.is_empty() {
+        Ok(listeners)
+    } else if let Some((address, error)) = last_error {
+        Err(format!("Failed to bind listener {address}: {error}"))
+    } else {
+        Err(format!(
+            "Bind address {bind}:{port} resolved to no socket addresses"
+        ))
+    }
+}
+
+/// Match the socket options used by Actix Web's high-level `HttpServer::bind`.
+/// This keeps rapid Unix restarts and Windows IPv6 dual-stack behavior stable
+/// after the HTTP/1.1-only server moved to pre-bound listeners.
+fn make_http_listener(address: std::net::SocketAddr) -> std::io::Result<TcpListener> {
+    let socket = Socket::new(
+        Domain::for_address(address),
+        Type::STREAM,
+        Some(Protocol::TCP),
+    )?;
+
+    #[cfg(not(windows))]
+    socket.set_reuse_address(true)?;
+
+    #[cfg(windows)]
+    if address.is_ipv6() {
+        if let Err(error) = socket.set_only_v6(false) {
+            warn!(%address, %error, "failed to enable IPv4 on the IPv6 HTTP listener");
+        }
+    }
+
+    socket.bind(&address.into())?;
+    socket.listen(HTTP_LISTEN_BACKLOG)?;
+    let listener = TcpListener::from(socket);
     listener.set_nonblocking(true)?;
     Ok(listener)
 }
@@ -116,4 +176,46 @@ pub(super) fn build_bind_listeners(bind: &str, port: u16) -> Result<Vec<TcpListe
     }
 
     Ok(listeners)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_listener_preserves_exact_ipv4_bind() {
+        let listeners =
+            build_resolved_listeners("127.0.0.1", 0).expect("bind an ephemeral IPv4 listener");
+        assert_eq!(listeners.len(), 1);
+        let address = listeners[0].local_addr().expect("listener address");
+        assert!(address.is_ipv4());
+        assert!(address.ip().is_loopback());
+        assert_ne!(address.port(), 0);
+    }
+
+    #[test]
+    fn resolved_localhost_listeners_remain_loopback() {
+        let listeners =
+            build_resolved_listeners("localhost", 0).expect("bind resolved localhost listeners");
+        assert!(!listeners.is_empty());
+        assert!(listeners.iter().all(|listener| listener
+            .local_addr()
+            .expect("listener address")
+            .ip()
+            .is_loopback()));
+    }
+
+    #[test]
+    fn production_loopback_listeners_are_all_loopback() {
+        let listeners = build_bind_listeners("127.0.0.1", 0).expect("build loopback listeners");
+        assert!(!listeners.is_empty());
+        assert!(listeners.iter().all(|listener| listener
+            .local_addr()
+            .expect("listener address")
+            .ip()
+            .is_loopback()));
+        assert!(listeners
+            .iter()
+            .any(|listener| listener.local_addr().expect("listener address").is_ipv4()));
+    }
 }

--- a/crates/app/bamboo-server/src/server/mod.rs
+++ b/crates/app/bamboo-server/src/server/mod.rs
@@ -4,6 +4,7 @@
 //! Eliminates the proxy pattern by using unified AppState
 
 mod entrypoints;
+mod h1;
 mod listeners;
 mod tls;
 mod web_service;

--- a/crates/app/bamboo-server/src/server/tests.rs
+++ b/crates/app/bamboo-server/src/server/tests.rs
@@ -1,8 +1,230 @@
+use std::net::TcpListener;
+
+use actix_web::{web, App, HttpRequest, HttpResponse};
+use futures::{SinkExt, StreamExt};
+use native_tls::TlsConnector;
+use serde_json::{json, Value};
+use tokio::net::TcpStream;
+use tokio_native_tls::TlsConnector as TokioTlsConnector;
+use tokio_tungstenite::{
+    connect_async_tls_with_config,
+    tungstenite::{client::IntoClientRequest, Message},
+    Connector, MaybeTlsStream,
+};
+
+use super::h1::build_h1_server;
+use super::tls::{build_rustls_config, test_support::gen_self_signed};
 use super::WebService;
+use crate::{routes::configure_routes, AppState};
+use bamboo_config::TlsConfig;
 
 #[test]
 fn test_web_service_lifecycle() {
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
     let ws = WebService::new(temp_dir.path().to_path_buf());
     assert!(!ws.is_running());
+}
+
+fn test_listener() -> (TcpListener, u16) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("ephemeral test listener");
+    listener
+        .set_nonblocking(true)
+        .expect("listener must be nonblocking");
+    let port = listener.local_addr().expect("listener address").port();
+    (listener, port)
+}
+
+async fn stop_server(
+    handle: actix_web::dev::ServerHandle,
+    join: tokio::task::JoinHandle<std::io::Result<()>>,
+) {
+    handle.stop(false).await;
+    join.await
+        .expect("server task joins")
+        .expect("server exits cleanly");
+}
+
+#[actix_web::test]
+async fn plaintext_server_is_http11_and_reports_insecure_context() {
+    async fn transport(req: HttpRequest) -> HttpResponse {
+        HttpResponse::Ok().json(json!({
+            "scheme": req.connection_info().scheme(),
+            "version": format!("{:?}", req.version()),
+        }))
+    }
+
+    let (listener, port) = test_listener();
+    let server = build_h1_server(
+        || App::new().route("/transport", web::get().to(transport)),
+        vec![listener],
+        1,
+        None,
+    )
+    .expect("build plaintext H1 server");
+    let handle = server.handle();
+    let join = tokio::spawn(server);
+
+    let response = reqwest::get(format!("http://127.0.0.1:{port}/transport"))
+        .await
+        .expect("plaintext request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(response.version(), reqwest::Version::HTTP_11);
+    let body: Value = response.json().await.expect("transport response JSON");
+    assert_eq!(body["scheme"], "http");
+    assert_eq!(body["version"], "HTTP/1.1");
+
+    stop_server(handle, join).await;
+}
+
+#[actix_web::test]
+async fn rustls_server_is_http11_secure_wss_and_never_negotiates_h2() {
+    async fn transport(req: HttpRequest) -> HttpResponse {
+        HttpResponse::Ok().json(json!({
+            "scheme": req.connection_info().scheme(),
+            "version": format!("{:?}", req.version()),
+        }))
+    }
+
+    let fixture = tempfile::tempdir().expect("TLS fixture tempdir");
+    let Some((cert_file, key_file)) =
+        gen_self_signed(fixture.path()).expect("present openssl should generate the TLS fixture")
+    else {
+        eprintln!("skipping live TLS transport test: openssl unavailable");
+        return;
+    };
+    let tls = TlsConfig {
+        cert_file,
+        key_file,
+    };
+    let rustls = build_rustls_config(&tls).expect("valid Rustls config");
+
+    let mut unsafe_alpn = rustls.clone();
+    unsafe_alpn.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    let (unsafe_listener, _) = test_listener();
+    let unsafe_error =
+        match build_h1_server(|| App::new(), vec![unsafe_listener], 1, Some(unsafe_alpn)) {
+            Ok(_) => panic!("an H1 dispatcher must reject a config that advertises h2"),
+            Err(error) => error,
+        };
+    assert_eq!(unsafe_error.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(unsafe_error.to_string().contains("only ALPN http/1.1"));
+
+    let state_dir = tempfile::tempdir().expect("AppState tempdir");
+    let state = web::Data::new(
+        AppState::new(state_dir.path().to_path_buf())
+            .await
+            .expect("test AppState"),
+    );
+    let state_for_factory = state.clone();
+    let (listener, port) = test_listener();
+    let server = build_h1_server(
+        move || {
+            App::new()
+                .app_data(state_for_factory.clone())
+                .route("/__transport", web::get().to(transport))
+                .configure(configure_routes)
+        },
+        vec![listener],
+        1,
+        Some(rustls),
+    )
+    .expect("build Rustls H1 server");
+    let handle = server.handle();
+    let join = tokio::spawn(server);
+
+    // A normal HTTPS client that offers H2 and H1 must be pinned to H1, and
+    // Actix must still mark the request context secure for URL/cookie logic.
+    let https = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .expect("HTTPS test client");
+    let response = https
+        .get(format!("https://127.0.0.1:{port}/__transport"))
+        .send()
+        .await
+        .expect("HTTPS request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(response.version(), reqwest::Version::HTTP_11);
+    let body: Value = response.json().await.expect("transport response JSON");
+    assert_eq!(body["scheme"], "https");
+    assert_eq!(body["version"], "HTTP/1.1");
+
+    // Even an H2-only client can never select H2. TLS stacks may either reject
+    // the no-overlap handshake or complete it with no ALPN; both are safe.
+    let h2_only = TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .request_alpns(&["h2"])
+        .build()
+        .expect("H2-only TLS connector");
+    let tcp = TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("TCP connection for H2-only ALPN");
+    if let Ok(stream) = TokioTlsConnector::from(h2_only)
+        .connect("localhost", tcp)
+        .await
+    {
+        assert_ne!(
+            stream
+                .get_ref()
+                .negotiated_alpn()
+                .expect("query negotiated ALPN")
+                .as_deref(),
+            Some(b"h2".as_slice()),
+            "the H1-only listener must never negotiate h2"
+        );
+    }
+
+    // Exercise the real `/v2/stream` WSS upgrade, application ping/pong, and
+    // negotiated ALPN through the replacement Tungstenite client.
+    let native = TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .request_alpns(&["h2", "http/1.1"])
+        .build()
+        .expect("WSS TLS connector");
+    let request = format!("wss://127.0.0.1:{port}/v2/stream")
+        .into_client_request()
+        .expect("WSS request");
+    let (mut websocket, upgrade) =
+        connect_async_tls_with_config(request, None, false, Some(Connector::NativeTls(native)))
+            .await
+            .expect("real WSS /v2/stream upgrade");
+    assert_eq!(upgrade.status().as_u16(), 101);
+    match websocket.get_ref() {
+        MaybeTlsStream::NativeTls(stream) => assert_eq!(
+            stream
+                .get_ref()
+                .negotiated_alpn()
+                .expect("query WSS ALPN")
+                .as_deref(),
+            Some(b"http/1.1".as_slice())
+        ),
+        stream => panic!("expected native TLS WSS stream, got {stream:?}"),
+    }
+
+    websocket
+        .send(Message::Text(r#"{"type":"ping"}"#.into()))
+        .await
+        .expect("send WSS application ping");
+    let pong = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            match websocket.next().await.expect("WSS remains open") {
+                Ok(Message::Text(text)) => {
+                    let value: Value = serde_json::from_str(text.as_str()).expect("JSON WSS frame");
+                    if value["type"] == "pong" {
+                        break value;
+                    }
+                }
+                Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => continue,
+                Ok(Message::Close(frame)) => panic!("WSS closed before pong: {frame:?}"),
+                Ok(other) => panic!("unexpected WSS frame before pong: {other:?}"),
+                Err(error) => panic!("WSS read failed before pong: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("application pong arrives before timeout");
+    assert_eq!(pong["type"], "pong");
+
+    websocket.close(None).await.expect("close WSS client");
+    stop_server(handle, join).await;
 }

--- a/crates/app/bamboo-server/src/server/tls.rs
+++ b/crates/app/bamboo-server/src/server/tls.rs
@@ -2,9 +2,9 @@
 //!
 //! bamboo terminates TLS itself via rustls — no reverse proxy. Certificates are
 //! manual PEM files configured under `server.tls` (see
-//! `docs/api-v2-transport.md` §3). When `server.tls` is absent the server keeps
-//! its existing plaintext `.bind()` / `.listen()` path unchanged; this module is
-//! only consulted when TLS is explicitly configured.
+//! `docs/design/api-v2-transport.md` §3). When `server.tls` is absent the server
+//! keeps its plaintext HTTP/1.1 path unchanged; this module is only consulted
+//! when TLS is explicitly configured.
 //!
 //! **Fail-fast invariant:** if `server.tls` is set but the cert/key files are
 //! missing or unparseable, [`build_rustls_config`] returns an `Err` and the
@@ -57,14 +57,23 @@ pub(super) fn build_rustls_config(tls: &TlsConfig) -> Result<ServerConfig, Strin
     // Build against an explicit `ring` provider so we never rely on a process
     // default being installed (avoids the rustls 0.23 no-provider panic).
     let provider = Arc::new(ring::default_provider());
-    ServerConfig::builder_with_provider(provider)
+    let mut config = ServerConfig::builder_with_provider(provider)
         .with_safe_default_protocol_versions()
         .map_err(|e| format!("TLS: rustls protocol version setup failed: {e}"))?
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .map_err(|e| {
             format!("TLS: rustls rejected the cert/key pair (cert '{cert_path}', key '{key_path}'): {e}")
-        })
+        })?;
+
+    // Bamboo's inbound Actix face is intentionally HTTP/1.1-only (#849).
+    // Advertising `h2` here would be worse than a clean rejection: the stream
+    // would reach an H1 dispatcher after ALPN had promised HTTP/2. Keep this
+    // explicit even though rustls's empty default would also fall back to H1,
+    // so clients and regression tests can verify the transport contract.
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    Ok(config)
 }
 
 /// Load the first usable private key from a PEM file, trying PKCS#8, then
@@ -83,30 +92,18 @@ fn load_private_key(path: &std::path::Path) -> Result<PrivateKeyDer<'static>, St
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+pub(super) mod test_support {
     use std::path::{Path, PathBuf};
     use std::process::Command;
-
-    fn tmp_dir() -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "bamboo-tls-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
-    }
 
     /// Generate a throwaway X.509 v3 self-signed cert + PKCS#8 key via openssl.
     ///
     /// `Ok(None)` is reserved for an absent openssl executable. A present
     /// executable that fails must fail the test instead of silently skipping
     /// the rustls success path.
-    fn gen_self_signed(dir: &Path) -> Result<Option<(PathBuf, PathBuf)>, String> {
+    pub(in crate::server) fn gen_self_signed(
+        dir: &Path,
+    ) -> Result<Option<(PathBuf, PathBuf)>, String> {
         let cert = dir.join("cert.pem");
         let key = dir.join("key.pem");
         let output = Command::new("openssl")
@@ -141,7 +138,7 @@ mod tests {
         Ok(Some((cert, key)))
     }
 
-    fn assert_x509_v3(cert: &Path) {
+    pub(in crate::server) fn assert_x509_v3(cert: &Path) {
         let output = Command::new("openssl")
             .args(["x509", "-in"])
             .arg(cert)
@@ -162,6 +159,13 @@ mod tests {
             "expected generated TLS fixture to be X.509 v3:\n{certificate_text}"
         );
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{assert_x509_v3, gen_self_signed};
+    use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn build_rustls_config_errors_on_missing_cert_file() {
@@ -182,9 +186,9 @@ mod tests {
 
     #[test]
     fn build_rustls_config_errors_on_empty_cert_file() {
-        let dir = tmp_dir();
-        let cert = dir.join("cert.pem");
-        let key = dir.join("key.pem");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cert = dir.path().join("cert.pem");
+        let key = dir.path().join("key.pem");
         std::fs::write(&cert, "not a pem certificate\n").unwrap();
         std::fs::write(&key, "not a pem key\n").unwrap();
         let tls = TlsConfig {
@@ -200,15 +204,15 @@ mod tests {
 
     #[test]
     fn build_rustls_config_errors_on_missing_key_in_keyfile() {
-        let dir = tmp_dir();
+        let dir = tempfile::tempdir().expect("tempdir");
         // A valid-looking cert file but a key file with no key block.
         let Some((cert, _key)) =
-            gen_self_signed(&dir).expect("present openssl should generate the TLS fixture")
+            gen_self_signed(dir.path()).expect("present openssl should generate the TLS fixture")
         else {
             eprintln!("skipping: openssl unavailable");
             return;
         };
-        let bad_key = dir.join("bad_key.pem");
+        let bad_key = dir.path().join("bad_key.pem");
         std::fs::write(
             &bad_key,
             "-----BEGIN GARBAGE-----\nzz\n-----END GARBAGE-----\n",
@@ -230,9 +234,9 @@ mod tests {
         // Smoke test the full success path (parse + crypto provider + accept the
         // cert/key pair) when openssl is available to mint a throwaway cert.
         // Skips gracefully on environments without openssl.
-        let dir = tmp_dir();
+        let dir = tempfile::tempdir().expect("tempdir");
         let Some((cert, key)) =
-            gen_self_signed(&dir).expect("present openssl should generate the TLS fixture")
+            gen_self_signed(dir.path()).expect("present openssl should generate the TLS fixture")
         else {
             eprintln!("skipping build_rustls_config success test: openssl unavailable");
             return;
@@ -247,6 +251,11 @@ mod tests {
         assert!(
             !cfg.crypto_provider().cipher_suites.is_empty(),
             "expected a non-empty cipher suite set from the ring provider"
+        );
+        assert_eq!(
+            cfg.alpn_protocols,
+            vec![b"http/1.1".to_vec()],
+            "the inbound TLS face must never advertise vulnerable HTTP/2 (#849)"
         );
     }
 }

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -2,11 +2,12 @@ use std::path::PathBuf;
 
 use actix_files as fs;
 use actix_web::dev::{ServiceFactory, ServiceRequest, ServiceResponse};
-use actix_web::{web, App, HttpServer};
+use actix_web::{web, App};
 use tokio::sync::oneshot;
 use tracing::{error, info};
 
-use super::listeners::DEFAULT_WORKER_COUNT;
+use super::h1::build_h1_server;
+use super::listeners::{build_resolved_listeners, DEFAULT_WORKER_COUNT};
 
 /// Request body size limits, applied on EVERY serve path so the desktop/embedded
 /// server accepts the same payloads (e.g. an inline-image chat request) as the
@@ -91,7 +92,7 @@ impl WebService {
 
     /// Start the web service, terminating TLS itself when `tls` is `Some` (#181).
     ///
-    /// `None` keeps the plaintext `.bind()` path unchanged (desktop loopback).
+    /// `None` keeps the plaintext HTTP/1.1 path unchanged (desktop loopback).
     pub async fn start_with_bind_tls(
         &mut self,
         port: u16,
@@ -120,28 +121,21 @@ impl WebService {
         // Retain a handle so stop()/Drop can stop AppState-owned background tasks. #119
         self.app_state = Some(app_state.clone());
         let bind_addr = bind.to_string();
-        let listen_addr = format!("{bind}:{port}");
         let bind_for_log = bind_addr.clone();
 
-        let server = HttpServer::new(move || {
+        let app_factory = move || {
             with_body_limits(App::new())
                 .app_data(app_state.clone())
                 .wrap(build_cors(&bind_addr, port))
                 .configure(configure_routes) // No rate limiting for WebService
-        })
-        .workers(DEFAULT_WORKER_COUNT);
+        };
 
         // Fail-fast: build the rustls config before binding; `None` → unchanged
-        // plaintext `.bind()` path. #181.
-        let server = match tls {
-            Some(tls) => server
-                .bind_rustls_0_23(&listen_addr, build_rustls_config(tls)?)
-                .map_err(|e| format!("Failed to bind TLS server: {e}"))?,
-            None => server
-                .bind(&listen_addr)
-                .map_err(|e| format!("Failed to bind server: {e}"))?,
-        }
-        .run();
+        // plaintext HTTP/1.1 path. #181.
+        let rustls_config = tls.map(build_rustls_config).transpose()?;
+        let listeners = build_resolved_listeners(bind, port)?;
+        let server = build_h1_server(app_factory, listeners, DEFAULT_WORKER_COUNT, rustls_config)
+            .map_err(|e| format!("Failed to build HTTP/1.1 server: {e}"))?;
 
         let server_handle = tokio::spawn(async move {
             tokio::select! {
@@ -180,7 +174,7 @@ impl WebService {
     }
 
     /// Like [`WebService::start_with_bind_and_static`], terminating TLS itself
-    /// when `tls` is `Some` (#181). `None` keeps the plaintext path unchanged.
+    /// when `tls` is `Some` (#181). `None` keeps the plaintext HTTP/1.1 path unchanged.
     pub async fn start_with_bind_and_static_tls(
         &mut self,
         port: u16,
@@ -228,10 +222,9 @@ impl WebService {
         // Per-IP rate limiter for the network-exposed production server (#13).
         let rate_limiter = build_rate_limiter();
         let bind_addr = bind.to_string();
-        let listen_addr = format!("{bind}:{port}");
         let bind_for_log = bind_addr.clone();
 
-        let server = HttpServer::new(move || {
+        let app_factory = move || {
             // WRAP ORDER (#169 part 2, #428): Governor + CORS are applied
             // together, in the fixed order enforced by the shared
             // `wrap_governor_and_cors` helper (Governor inner, CORS outer) —
@@ -261,20 +254,14 @@ impl WebService {
                     .disable_content_disposition()
                     .disable_content_disposition(),
             )
-        })
-        .workers(DEFAULT_WORKER_COUNT);
+        };
 
         // Fail-fast: build the rustls config before binding; `None` → unchanged
-        // plaintext `.bind()` path. #181.
-        let server = match tls {
-            Some(tls) => server
-                .bind_rustls_0_23(&listen_addr, build_rustls_config(tls)?)
-                .map_err(|e| format!("Failed to bind TLS server: {e}"))?,
-            None => server
-                .bind(&listen_addr)
-                .map_err(|e| format!("Failed to bind server: {e}"))?,
-        }
-        .run();
+        // plaintext HTTP/1.1 path. #181.
+        let rustls_config = tls.map(build_rustls_config).transpose()?;
+        let listeners = build_resolved_listeners(bind, port)?;
+        let server = build_h1_server(app_factory, listeners, DEFAULT_WORKER_COUNT, rustls_config)
+            .map_err(|e| format!("Failed to build HTTP/1.1 server: {e}"))?;
 
         let server_handle = tokio::spawn(async move {
             tokio::select! {

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -1,7 +1,7 @@
 //! Live WebSocket integration harness for `GET /v2/stream` (issue #187, Epic #181).
 //!
 //! These tests stand up a REAL bound `bamboo-server` on an ephemeral loopback
-//! port and drive a REAL `awc` WebSocket client through the actual ws_v2 driver /
+//! port and drive a REAL `tokio-tungstenite` WebSocket client through the actual ws_v2 driver /
 //! forwarder concurrency — the path that `test::init_service` (which never binds a
 //! socket) and the in-module unit tests cannot exercise end to end. The
 //! concurrency-heavy driver, the per-channel queue fair-merge, the #186
@@ -20,7 +20,6 @@ use std::sync::Once;
 use std::time::Duration;
 
 use actix_web::{web, App, HttpServer};
-use awc::ws;
 use bamboo_agent_core::AgentEvent;
 use bamboo_config::{AccessControlConfig, DeviceCredential};
 use bamboo_domain::{AgentRuntimeState, AgentStatusState, SessionKind};
@@ -29,7 +28,16 @@ use bamboo_server::{AgentRunner, AgentStatus, AppState};
 use futures::{SinkExt, StreamExt};
 use serde_json::{json, Value};
 use tempfile::TempDir;
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{
+        client::IntoClientRequest,
+        http::{header, HeaderValue, Response},
+        Message,
+    },
+    MaybeTlsStream, WebSocketStream,
+};
 
 /// The shortened unauthorized auth deadline for the whole test binary. Long
 /// enough that an authorized/local connection always authenticates inside it, but
@@ -122,33 +130,46 @@ impl TestServer {
     }
 }
 
-/// One live WS connection: the framed read/write half of an `awc` upgrade.
-type WsConn = actix_codec::Framed<awc::BoxedSocket, ws::Codec>;
+/// One live WS connection backed by the same Tungstenite transport family used
+/// by Bamboo's broker/client code.
+type WsConn = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+async fn connect_request(
+    request: tokio_tungstenite::tungstenite::http::Request<()>,
+    expectation: &str,
+) -> (WsConn, Response<Option<Vec<u8>>>) {
+    let (connection, response) = connect_async(request).await.expect(expectation);
+    (connection, response)
+}
 
 /// Open a WS connection as a LOCAL client (no Host override → `127.0.0.1` host,
 /// so `is_local_request` is true and the connection is pre-authorized).
 async fn connect_local(server: &TestServer) -> WsConn {
-    let (_resp, framed) = awc::Client::new()
-        .ws(&server.base_ws_url)
-        .connect()
-        .await
-        .expect("local ws upgrade");
-    framed
+    let request = server
+        .base_ws_url
+        .as_str()
+        .into_client_request()
+        .expect("local ws request");
+    connect_request(request, "local ws upgrade").await.0
 }
 
-/// Open a WS connection as a NON-LOCAL client by overriding the `Host` header to
-/// a public name. `awc` only injects a `Host` when one is absent, so this makes
-/// `is_local_request` return false (mirrors the `access_control` unit test
+/// Open a WS connection as a NON-LOCAL client by overriding the generated
+/// loopback `Host` header with a public name. This makes `is_local_request`
+/// return false (mirrors the `access_control` unit test
 /// `remote_host_is_not_local_even_when_peer_is_loopback`). With an active device
 /// configured, such a connection is NOT pre-authorized and must `hello`.
 async fn connect_remote(server: &TestServer) -> WsConn {
-    let (_resp, framed) = awc::Client::new()
-        .ws(&server.base_ws_url)
-        .set_header(awc::http::header::HOST, "bamboo.example.com")
-        .connect()
+    let mut request = server
+        .base_ws_url
+        .as_str()
+        .into_client_request()
+        .expect("remote ws request");
+    request
+        .headers_mut()
+        .insert(header::HOST, HeaderValue::from_static("bamboo.example.com"));
+    connect_request(request, "remote ws upgrade (open per #189)")
         .await
-        .expect("remote ws upgrade (open per #189)");
-    framed
+        .0
 }
 
 /// Open a LOCAL WS connection negotiating the `bamboo.v2.msgpack` subprotocol
@@ -156,15 +177,19 @@ async fn connect_remote(server: &TestServer) -> WsConn {
 /// on the upgrade response (per RFC 6455 the server echoes the single selected
 /// subprotocol), so the test can assert the handshake negotiated msgpack.
 async fn connect_local_msgpack(server: &TestServer) -> (WsConn, Option<String>) {
-    let (resp, framed) = awc::Client::new()
-        .ws(&server.base_ws_url)
-        .protocols(["bamboo.v2.msgpack"])
-        .connect()
-        .await
-        .expect("local msgpack ws upgrade");
+    let mut request = server
+        .base_ws_url
+        .as_str()
+        .into_client_request()
+        .expect("local msgpack ws request");
+    request.headers_mut().insert(
+        header::SEC_WEBSOCKET_PROTOCOL,
+        HeaderValue::from_static("bamboo.v2.msgpack"),
+    );
+    let (framed, resp) = connect_request(request, "local msgpack ws upgrade").await;
     let echoed = resp
         .headers()
-        .get(awc::http::header::SEC_WEBSOCKET_PROTOCOL)
+        .get(header::SEC_WEBSOCKET_PROTOCOL)
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
     (framed, echoed)
@@ -175,7 +200,7 @@ async fn connect_local_msgpack(server: &TestServer) -> (WsConn, Option<String>) 
 /// bytes carry the SAME logical schema the server's `decode_client_frame` expects.
 async fn send_msgpack(conn: &mut WsConn, value: Value) {
     let bytes = rmp_serde::to_vec_named(&value).expect("encode client frame as msgpack");
-    conn.send(ws::Message::Binary(bytes.into()))
+    conn.send(Message::Binary(bytes.into()))
         .await
         .expect("send msgpack client frame");
 }
@@ -191,7 +216,7 @@ async fn next_msgpack_envelope(conn: &mut WsConn) -> Option<Value> {
             .await
             .expect("frame did not arrive before timeout")?;
         match frame.expect("ws protocol error") {
-            ws::Frame::Binary(bytes) => {
+            Message::Binary(bytes) => {
                 let value: Value = rmp_serde::from_slice(&bytes).expect("envelope is msgpack");
                 // Skip interleaved `sys` keepalives (#533), like a tolerant client.
                 if value["ch"] == "sys" {
@@ -199,12 +224,12 @@ async fn next_msgpack_envelope(conn: &mut WsConn) -> Option<Value> {
                 }
                 return Some(value);
             }
-            ws::Frame::Text(bytes) => panic!(
+            Message::Text(bytes) => panic!(
                 "msgpack mode must yield BINARY frames, got text: {}",
-                String::from_utf8_lossy(&bytes)
+                bytes.as_str()
             ),
-            ws::Frame::Ping(_) | ws::Frame::Pong(_) => continue,
-            ws::Frame::Close(_) => return None,
+            Message::Ping(_) | Message::Pong(_) => continue,
+            Message::Close(_) => return None,
             other => panic!("unexpected ws frame: {other:?}"),
         }
     }
@@ -212,7 +237,7 @@ async fn next_msgpack_envelope(conn: &mut WsConn) -> Option<Value> {
 
 /// Send a JSON client frame.
 async fn send_json(conn: &mut WsConn, value: Value) {
-    conn.send(ws::Message::Text(value.to_string().into()))
+    conn.send(Message::Text(value.to_string().into()))
         .await
         .expect("send client frame");
 }
@@ -227,16 +252,16 @@ async fn next_envelope(conn: &mut WsConn) -> Option<Value> {
             .await
             .expect("frame did not arrive before timeout")?;
         match frame.expect("ws protocol error") {
-            ws::Frame::Text(bytes) => {
-                let value: Value = serde_json::from_slice(&bytes).expect("envelope is JSON");
+            Message::Text(bytes) => {
+                let value: Value = serde_json::from_str(bytes.as_str()).expect("envelope is JSON");
                 // Skip interleaved `sys` keepalives (#533), like a tolerant client.
                 if value["ch"] == "sys" {
                     continue;
                 }
                 return Some(value);
             }
-            ws::Frame::Ping(_) | ws::Frame::Pong(_) => continue,
-            ws::Frame::Close(_) => return None,
+            Message::Ping(_) | Message::Pong(_) => continue,
+            Message::Close(_) => return None,
             other => panic!("unexpected ws frame: {other:?}"),
         }
     }
@@ -254,8 +279,8 @@ async fn next_sys_keepalive(conn: &mut WsConn) -> Value {
             .expect("sys keepalive did not arrive before timeout")
             .expect("connection closed while waiting for sys keepalive");
         let value: Value = match frame.expect("ws protocol error") {
-            ws::Frame::Text(bytes) => serde_json::from_slice(&bytes).expect("envelope is JSON"),
-            ws::Frame::Binary(bytes) => rmp_serde::from_slice(&bytes).expect("envelope is msgpack"),
+            Message::Text(bytes) => serde_json::from_str(bytes.as_str()).expect("envelope is JSON"),
+            Message::Binary(bytes) => rmp_serde::from_slice(&bytes).expect("envelope is msgpack"),
             _ => continue,
         };
         if value["ch"] == "sys" {
@@ -276,19 +301,18 @@ async fn next_app_pong(conn: &mut WsConn, msgpack: bool) -> Value {
             .expect("connection closed while waiting for application pong")
             .expect("ws protocol error");
         let value: Value = match frame {
-            ws::Frame::Text(bytes) if !msgpack => {
-                serde_json::from_slice(&bytes).expect("pong is JSON")
+            Message::Text(bytes) if !msgpack => {
+                serde_json::from_str(bytes.as_str()).expect("pong is JSON")
             }
-            ws::Frame::Binary(bytes) if msgpack => {
+            Message::Binary(bytes) if msgpack => {
                 rmp_serde::from_slice(&bytes).expect("pong is msgpack")
             }
-            ws::Frame::Text(bytes) => panic!(
-                "msgpack pong must be BINARY, got text: {}",
-                String::from_utf8_lossy(&bytes)
-            ),
-            ws::Frame::Binary(_) => panic!("JSON pong must be TEXT"),
-            ws::Frame::Ping(_) | ws::Frame::Pong(_) => continue,
-            ws::Frame::Close(_) => panic!("connection closed before application pong"),
+            Message::Text(bytes) => {
+                panic!("msgpack pong must be BINARY, got text: {}", bytes.as_str())
+            }
+            Message::Binary(_) => panic!("JSON pong must be TEXT"),
+            Message::Ping(_) | Message::Pong(_) => continue,
+            Message::Close(_) => panic!("connection closed before application pong"),
             other => panic!("unexpected ws frame: {other:?}"),
         };
         if value["ch"] == "sys" {
@@ -309,12 +333,12 @@ async fn expect_closed(conn: &mut WsConn) {
             .expect("connection did not close before timeout");
         match next {
             None => return,
-            Some(Ok(ws::Frame::Close(_))) => return,
-            Some(Ok(ws::Frame::Ping(_))) | Some(Ok(ws::Frame::Pong(_))) => continue,
-            Some(Ok(ws::Frame::Text(bytes))) => {
+            Some(Ok(Message::Close(_))) => return,
+            Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) => continue,
+            Some(Ok(Message::Text(bytes))) => {
                 panic!(
                     "expected the connection to be closed, got a text frame: {}",
-                    String::from_utf8_lossy(&bytes)
+                    bytes.as_str()
                 )
             }
             Some(Ok(other)) => panic!("expected close, got {other:?}"),
@@ -925,16 +949,15 @@ async fn msgpack_subprotocol_subscribe_event_roundtrip() {
 async fn no_subprotocol_stays_json_with_no_echo() {
     let server = TestServer::start(|_| {}).await;
 
-    let (resp, mut conn) = awc::Client::new()
-        .ws(&server.base_ws_url)
-        .connect()
-        .await
-        .expect("local ws upgrade");
+    let request = server
+        .base_ws_url
+        .as_str()
+        .into_client_request()
+        .expect("local ws request");
+    let (mut conn, resp) = connect_request(request, "local ws upgrade").await;
     // No subprotocol offered → none echoed (legacy handshake unchanged).
     assert!(
-        resp.headers()
-            .get(awc::http::header::SEC_WEBSOCKET_PROTOCOL)
-            .is_none(),
+        resp.headers().get(header::SEC_WEBSOCKET_PROTOCOL).is_none(),
         "a client offering no subprotocol must get no echo"
     );
 

--- a/docs/design/api-v2-transport.md
+++ b/docs/design/api-v2-transport.md
@@ -105,7 +105,7 @@ pub struct ServerConfig {
     #[serde(default = "default_workers")]
     pub workers: usize,
 
-    /// v2: TLS 配置。两者都给 → bind_rustls;缺省 → 裸 bind(桌面 loopback 不受影响)。
+    /// v2: TLS 配置。两者都给 → Rustls H1;缺省 → 明文 H1(桌面 loopback 不受影响)。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls: Option<TlsConfig>,
 
@@ -135,18 +135,25 @@ pub struct TlsConfig {
 }
 ```
 
-### 3.3 接入点(4 处一行换)
+### 3.3 接入点(当前实现)
 
-**客户端面(actix-web)**——`HttpServer::new(...).bind(addr)` → `.bind_rustls(addr, config)`:
+**客户端面(actix-web)**——4 个启动入口统一通过
+`server/h1.rs::build_h1_server` 构建服务：明文监听器使用
+`HttpService::build().h1(...).tcp()`，TLS 监听器使用
+`HttpService::build().secure().h1(...).rustls_0_23(...)`。`web_service.rs`
+与 `entrypoints.rs` 不再各自选择 Actix 的高层 `bind/listen_rustls` 方法，
+因此中间件、路由、worker 数、IPv4/IPv6 listener 与关闭生命周期仍由同一
+app factory 驱动，而协议选择只有一个权威位置。
 
-| 文件:行 | 现状 | v2 |
-|---|---|---|
-| `server/web_service.rs:79` | `.bind(&listen_addr)` | `.bind_rustls(&listen_addr, rustls_cfg)`(当 `server.tls` 存在) |
-| `server/web_service.rs:163` | `.bind(&listen_addr)` | 同上 |
-| `server/entrypoints.rs:148` | `HttpServer::new(...).workers(..)` 后 `.bind` | 同上 |
-| `server/entrypoints.rs:293` | 同上 | 同上 |
+> **入站协议边界（#849）**：Bamboo 的 HTTP/WSS face 明确只支持 HTTP/1.1。
+> Actix Web 4 的高层 Rustls feature 会强制启用仍依赖 `h2 0.3` 的 HTTP/2
+> feature，该版本受 RUSTSEC-2026-0258 影响。Bamboo 的统一 WebSocket face
+> 使用 HTTP/1.1 Upgrade，因此禁用入站 HTTP/2 不影响 WSS 合同；provider、
+> MCP 等出站 Reqwest 客户端继续使用已修复的 `h2 0.4` HTTP/2 栈。不得通过
+> audit ignore 或本地 fork 绕过此边界。
 
-统一在一处构建 `RustlsConfig`:
+统一在 `server/tls.rs` 构建 `rustls::ServerConfig`，并把 ALPN 固定为
+`http/1.1`：
 
 ```rust
 fn build_rustls(tls: &TlsConfig) -> Result<actix_web::rustls::server::ServerConfig, String> {
@@ -154,10 +161,14 @@ fn build_rustls(tls: &TlsConfig) -> Result<actix_web::rustls::server::ServerConf
         .collect::<Result<Vec<_>, _>>().map_err(|e| format!("read cert: {e}"))?;
     let key = rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(File::open(&tls.key_file)?))
         .next().ok_or("no key in key_file")??;
-    let cfg = actix_web::rustls::server::ServerConfig::builder()
+    let provider = Arc::new(ring::default_provider());
+    let mut cfg = rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("rustls versions: {e}"))?
         .with_no_client_auth()
         .with_single_cert(certs, key.into())
         .map_err(|e| format!("rustls config: {e}"))?;
+    cfg.alpn_protocols = vec![b"http/1.1".to_vec()];
     Ok(cfg)
 }
 ```
@@ -165,8 +176,8 @@ fn build_rustls(tls: &TlsConfig) -> Result<actix_web::rustls::server::ServerConf
 **判定逻辑**(复用 `listeners.rs` 既有双模式):
 
 ```
-server.tls 给齐 → bind_rustls(0.0.0.0:port)        // 公网暴露模式
-server.tls 缺省 → bind(127.0.0.1:port)             // 桌面 loopback 模式(行为不变)
+server.tls 给齐 → Rustls + HTTP/1.1(0.0.0.0:port)  // 公网暴露模式
+server.tls 缺省 → 明文 HTTP/1.1(127.0.0.1:port)    // 桌面 loopback 模式(行为不变)
 ```
 
 桌面本地开发 `server.tls` 缺省,**零行为回退**;公网部署补两张 PEM 即可。
@@ -202,7 +213,9 @@ let ws = accept_async(tls_stream).await?;
 tokio-rustls = "0.26"
 rustls = "0.23"
 rustls-pemfile = "2"
-# actix-web 的 rustls feature 已内建
+# client face 通过 actix-http 的 H1 Rustls service，actix-web 不启用 http2
+actix-http = { version = "3", default-features = false, features = ["rustls-0_23"] }
+actix-server = "2"
 ```
 
 ---
@@ -494,7 +507,7 @@ WS 标准 RFC 7692 扩展,握手自动协商。对 JSON 文本通常 −60~80%�
 
 ### v2-P1 — TLS + 客户端面 WSS
 
-- `ServerConfig.tls` + 手动证书;4 处 `bind`→`bind_rustls`;broker `accept_async` 套 `TlsAcceptor`。
+- `ServerConfig.tls` + 手动证书;4 个入口统一进入 H1/Rustls builder;broker `accept_async` 套 `TlsAcceptor`。
 - `GET /v2/stream` 单 WSS 入口;`feed` + `agent.{sid}` + `control` channel;cursor 续传。
 - **验收**:公网 `wss://` 桌面+移动端跑通;断线重连 cursor 补漏无丢无重;`/v1` 桌面 loopback 不变。
 


### PR DESCRIPTION
## Summary

- serve every Bamboo inbound HTTP, HTTPS, WebSocket, and WSS listener through a shared HTTP/1.1-only Actix service
- preserve Rustls HTTPS/WSS, resolved-address listener behavior, socket reuse, backlog, local-address propagation, and client-disconnect timeout semantics
- replace the `awc` live WebSocket test dependency with `tokio-tungstenite` and update the retained outbound HTTP/2 stack to patched `h2` 0.4.16

## Security

- removes the legacy `h2` 0.3.27 dependency path affected by RUSTSEC-2026-0258
- constrains TLS ALPN to `http/1.1` and rejects unsafe TLS configurations that advertise HTTP/2
- adds no advisory ignore, dependency fork, plaintext downgrade, or long-lived compatibility workaround
- retains outbound Reqwest/Hyper HTTP/2 support through fixed `h2` 0.4.16

## Test Plan

- `cargo test -p bamboo-server`
- `cargo test --all-features --lib --tests`
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code`
- `cargo deny check`
- `cargo audit` with cargo-audit 0.22.2 (no h2 advisory; existing configured warning-only advisories unchanged)
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo tree --locked --all-features -i h2`

Closes #849