### PR TITLE
fix(server): preserve graceful H1 drain across Actix update (#853)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -44,7 +44,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "derive_more",
  "futures-core",
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.13.1"
+version = "3.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
+checksum = "11004b0e9b44b4eb3d15e0c3132b96fb178c7e50a74758b2f17bb9cc9a7fb4f6"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -69,7 +69,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+checksum = "3716aae056e2f869b7b5cfd8a08fcf98890f8455bec61d69c7dff5d8576f9d2b"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -144,7 +144,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tracing",
 ]
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.14.0"
+version = "4.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4"
+checksum = "58356675d8c86d2e720480645a0316808471a62d0073f6a3b98810a5e0ca0e73"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -225,7 +225,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.4",
+ "socket2",
  "time",
  "tracing",
  "url",
@@ -392,7 +392,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -403,7 +403,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -571,7 +571,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -759,9 +759,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -805,11 +805,11 @@ dependencies = [
  "async-trait",
  "eventsource-stream",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "uuid",
 ]
@@ -860,7 +860,7 @@ dependencies = [
  "glob",
  "globset",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "libc",
  "mockall",
  "parking_lot",
@@ -877,7 +877,7 @@ dependencies = [
  "sha2 0.11.0",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -900,7 +900,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bamboo-domain",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "dashmap",
  "futures",
@@ -909,7 +909,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -923,7 +923,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -945,7 +945,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite 0.29.0",
@@ -972,7 +972,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tiktoken-rs",
  "tokio",
  "tracing",
@@ -986,7 +986,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bamboo-domain",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "dirs",
  "fs2",
@@ -1001,7 +1001,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "url",
  "uuid",
@@ -1020,7 +1020,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
 ]
@@ -1047,7 +1047,7 @@ dependencies = [
  "bamboo-storage",
  "bamboo-subagent",
  "bamboo-tools",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "colored",
@@ -1057,7 +1057,7 @@ dependencies = [
  "futures",
  "globset",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "libc",
  "mockall",
  "parking_lot",
@@ -1070,7 +1070,7 @@ dependencies = [
  "sha2 0.11.0",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -1119,7 +1119,7 @@ dependencies = [
  "serde_json",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -1134,13 +1134,13 @@ dependencies = [
  "async-trait",
  "bamboo-config",
  "bamboo-domain",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "eventsource-stream",
  "futures",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -1148,7 +1148,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1165,7 +1165,7 @@ dependencies = [
  "bamboo-domain",
  "bamboo-infrastructure",
  "bamboo-llm",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "dashmap",
  "eventsource-stream",
@@ -1178,7 +1178,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -1205,7 +1205,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -1238,7 +1238,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
 ]
@@ -1261,7 +1261,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tree-sitter",
@@ -1281,7 +1281,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -1301,7 +1301,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1331,7 +1331,7 @@ dependencies = [
  "futures",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1371,7 +1371,7 @@ dependencies = [
  "bamboo-storage",
  "bamboo-subagent",
  "bamboo-tools",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -1384,7 +1384,7 @@ dependencies = [
  "globset",
  "governor",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "mockall",
  "native-tls",
  "notify",
@@ -1403,10 +1403,10 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
- "socket2 0.6.4",
+ "socket2",
  "tar",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-native-tls",
  "tokio-stream",
@@ -1474,7 +1474,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "walkdir",
@@ -1488,7 +1488,7 @@ dependencies = [
  "async-trait",
  "bamboo-domain",
  "bamboo-subagent",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "dashmap",
  "fs2",
@@ -1497,7 +1497,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1517,7 +1517,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite 0.24.0",
@@ -1541,7 +1541,7 @@ dependencies = [
  "bamboo-memory",
  "bamboo-permission",
  "bamboo-storage",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "colored",
  "dashmap",
@@ -1556,7 +1556,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "toml",
  "tracing",
@@ -1572,7 +1572,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bamboo-client-core",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "clap",
  "crossterm 0.29.0",
@@ -1601,9 +1601,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -1660,9 +1660,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1934,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -2171,7 +2171,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -2184,7 +2184,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2506,7 +2506,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2515,7 +2515,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -2701,7 +2701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2743,7 +2743,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "launchdarkly-sdk-transport",
  "log",
  "pin-project",
@@ -2797,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
@@ -2977,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2992,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3002,15 +3002,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3019,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -3038,26 +3038,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -3067,9 +3067,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3161,9 +3161,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -3229,7 +3229,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
@@ -3313,7 +3313,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.2",
+ "http 1.5.0",
  "httpdate",
  "mime",
  "sha1 0.10.6",
@@ -3325,7 +3325,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -3383,9 +3383,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3398,7 +3398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -3409,7 +3409,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -3455,7 +3455,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -3475,7 +3475,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "pin-project-lite",
@@ -3489,7 +3489,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -3537,14 +3537,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3722,7 +3722,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -3821,15 +3821,15 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.2"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
+checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
 dependencies = [
  "ahash",
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex 0.18.0",
+ "fancy-regex 0.19.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -3850,18 +3850,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.2"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
+checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.2"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3879,7 +3879,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3918,7 +3918,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -3942,7 +3942,7 @@ checksum = "032d66802c461d7254ed1de887be6ca98ebbe126867d9a60c754baae81c4d10d"
 dependencies = [
  "bytes",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-http-proxy",
@@ -4056,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4071,7 +4071,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4323,7 +4323,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4336,7 +4336,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4373,7 +4373,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4405,7 +4405,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4423,7 +4423,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4556,7 +4556,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -4573,7 +4573,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -4619,7 +4619,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4742,7 +4742,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha2 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "windows 0.62.2",
  "windows-strings 0.5.1",
@@ -5339,7 +5339,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
@@ -5349,7 +5349,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -5404,7 +5404,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -5424,7 +5424,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5433,7 +5433,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5444,7 +5444,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5469,9 +5469,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.2"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
+checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -5498,9 +5498,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5531,7 +5531,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5570,10 +5570,10 @@ checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.2",
+ "http 1.5.0",
  "reqwest",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tower-service",
 ]
 
@@ -5587,12 +5587,12 @@ dependencies = [
  "async-trait",
  "futures",
  "getrandom 0.2.17",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "reqwest",
  "reqwest-middleware",
  "retry-policies",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "wasmtimer",
@@ -5676,16 +5676,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -5697,12 +5697,12 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.4"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
+checksum = "b41043523e0edcbd4e31d00903e26f12994f63b21bae9904f7405c1ed92752a5"
 dependencies = [
  "aes",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block-padding",
  "byteorder",
  "bytes",
@@ -5760,7 +5760,7 @@ dependencies = [
  "ssh-encoding",
  "ssh-key",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "typenum",
  "universal-hash",
@@ -5781,11 +5781,11 @@ dependencies = [
 
 [[package]]
 name = "russh-sftp"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9"
+checksum = "9de67aace74530a29086db0671fa200c470a58eb380081f28ad512ffb0c5356b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "chrono",
  "dashmap",
@@ -5793,7 +5793,7 @@ dependencies = [
  "log",
  "serde",
  "serde_bytes",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "wasm-bindgen-futures",
@@ -5843,7 +5843,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5856,18 +5856,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -6003,7 +6003,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6282,22 +6282,12 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6548,7 +6538,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -6580,7 +6570,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows 0.61.3",
  "windows-version",
 ]
@@ -6595,7 +6585,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6604,11 +6594,11 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6646,7 +6636,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -6691,11 +6681,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -6711,9 +6701,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6807,7 +6797,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6916,9 +6906,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -6952,9 +6942,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.3",
 ]
@@ -6997,10 +6987,10 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
  "tower 0.5.3",
@@ -7041,7 +7031,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -7098,9 +7088,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",
@@ -7155,7 +7145,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -7174,7 +7164,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "native-tls",
@@ -7182,7 +7172,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7205,7 +7195,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7300,7 +7290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
 ]
@@ -7343,9 +7333,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -7651,7 +7641,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8129,7 +8119,7 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -8352,7 +8342,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "zopfli",
 ]
 

--- a/crates/app/bamboo-server/src/server/h1.rs
+++ b/crates/app/bamboo-server/src/server/h1.rs
@@ -72,6 +72,11 @@ where
     }
 
     let mut builder = ServerBuilder::default().workers(workers);
+    // Bamboo constructs `HttpService` directly to keep inbound transports on
+    // HTTP/1.1. Unlike `actix_web::HttpServer`, a custom service is not wired
+    // to actix-server's drain notification automatically, so preserve that
+    // connection-level contract explicitly for every listener factory.
+    let graceful_shutdown_signal = builder.graceful_shutdown_signal();
 
     for (index, listener) in listeners.into_iter().enumerate() {
         let addr = listener.local_addr()?;
@@ -82,13 +87,19 @@ where
         builder = match &tls {
             Some(tls_config) => {
                 let tls_config = tls_config.clone();
+                let shutdown_signal = graceful_shutdown_signal.clone();
                 builder.listen(name, listener, move || {
+                    let shutdown_signal = shutdown_signal.clone();
                     let app_config = app_config(true, host.clone(), addr);
                     let app = app_factory()
                         .into_factory()
                         .map_err(|err| err.into().error_response());
 
                     HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let shutdown_signal = shutdown_signal.clone();
+                            async move { shutdown_signal.notified().await }
+                        })
                         .secure()
                         .local_addr(addr)
                         .client_disconnect_timeout(Duration::from_secs(1))
@@ -96,18 +107,26 @@ where
                         .rustls_0_23(tls_config.clone())
                 })?
             }
-            None => builder.listen(name, listener, move || {
-                let app_config = app_config(false, host.clone(), addr);
-                let app = app_factory()
-                    .into_factory()
-                    .map_err(|err| err.into().error_response());
+            None => {
+                let shutdown_signal = graceful_shutdown_signal.clone();
+                builder.listen(name, listener, move || {
+                    let shutdown_signal = shutdown_signal.clone();
+                    let app_config = app_config(false, host.clone(), addr);
+                    let app = app_factory()
+                        .into_factory()
+                        .map_err(|err| err.into().error_response());
 
-                HttpService::build()
-                    .local_addr(addr)
-                    .client_disconnect_timeout(Duration::from_secs(1))
-                    .h1(map_config(app, move |_| app_config.clone()))
-                    .tcp()
-            })?,
+                    HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let shutdown_signal = shutdown_signal.clone();
+                            async move { shutdown_signal.notified().await }
+                        })
+                        .local_addr(addr)
+                        .client_disconnect_timeout(Duration::from_secs(1))
+                        .h1(map_config(app, move |_| app_config.clone()))
+                        .tcp()
+                })?
+            }
         };
     }
 

--- a/crates/app/bamboo-server/src/server/tests.rs
+++ b/crates/app/bamboo-server/src/server/tests.rs
@@ -109,6 +109,11 @@ async fn blocking_drain_handler(state: web::Data<DrainState>) -> HttpResponse {
     HttpResponse::Ok().body("completed-current-request")
 }
 
+async fn queued_drain_handler(state: web::Data<DrainState>) -> HttpResponse {
+    state.calls.fetch_add(1, Ordering::SeqCst);
+    HttpResponse::Ok().body("unexpected-queued-request")
+}
+
 #[actix_web::test]
 async fn graceful_stop_closes_idle_keep_alive_connection_without_worker_timeout() {
     let (listener, port) = test_listener();
@@ -170,7 +175,12 @@ async fn graceful_stop_finishes_current_request_without_starting_buffered_reques
         move || {
             App::new()
                 .app_data(web::Data::from(state_for_factory.clone()))
-                .route("/drain", web::get().to(blocking_drain_handler))
+                .route(
+                    "/idle",
+                    web::get().to(|| async { HttpResponse::Ok().finish() }),
+                )
+                .route("/current", web::get().to(blocking_drain_handler))
+                .route("/queued", web::get().to(queued_drain_handler))
         },
         vec![listener],
         1,
@@ -180,13 +190,30 @@ async fn graceful_stop_finishes_current_request_without_starting_buffered_reques
     let handle = server.handle();
     let join = tokio::spawn(server);
 
+    // Keep a second connection idle so its prompt EOF is an observable barrier
+    // proving that the graceful-drain signal reached this worker's H1
+    // dispatchers before the active request is released.
+    let mut idle_stream = TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect idle keep-alive client");
+    idle_stream
+        .write_all(b"GET /idle HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")
+        .await
+        .expect("send idle keep-alive request");
+    let idle_response = read_http_response_head(&mut idle_stream).await;
+    assert!(
+        idle_response.starts_with(b"HTTP/1.1 200"),
+        "unexpected idle HTTP response: {}",
+        String::from_utf8_lossy(&idle_response)
+    );
+
     let mut stream = TcpStream::connect(("127.0.0.1", port))
         .await
         .expect("connect pipelined keep-alive client");
     stream
         .write_all(
-            b"GET /drain HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n\
-              GET /drain HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            b"GET /current HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n\
+              GET /queued HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
         )
         .await
         .expect("buffer two HTTP requests");
@@ -194,25 +221,47 @@ async fn graceful_stop_finishes_current_request_without_starting_buffered_reques
         .await
         .expect("current request starts before timeout");
 
-    // `stop(true)` queues the server command before returning its completion
-    // future. Give the worker a scheduling turn to deliver the drain signal
-    // while the first request remains in flight and the second is buffered.
-    let graceful_stop = handle.stop(true);
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    let mut graceful_stop = tokio::spawn(async move { handle.stop(true).await });
+
+    let mut trailing = [0_u8; 1];
+    let idle_connection_closed =
+        tokio::time::timeout(Duration::from_secs(3), idle_stream.read(&mut trailing)).await;
+
     state.release.notify_one();
 
-    if tokio::time::timeout(Duration::from_secs(3), graceful_stop)
-        .await
-        .is_err()
-    {
-        join.abort();
-        let _ = join.await;
-        panic!("graceful stop started a buffered request or waited for worker timeout");
+    // Read concurrently with the server's stop future. This gives the in-flight
+    // response room to drain before the connection is closed and lets an old,
+    // unwired dispatcher expose an incorrectly started queued response.
+    let active_response = tokio::time::timeout(Duration::from_secs(3), async {
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.map(|_| response)
+    })
+    .await;
+
+    // Always release client-held sockets before awaiting shutdown completion so
+    // a failing regression cannot strand Actix workers until their long default
+    // shutdown timeout.
+    drop((idle_stream, stream));
+
+    let graceful_stop_result =
+        tokio::time::timeout(Duration::from_secs(3), &mut graceful_stop).await;
+    if graceful_stop_result.is_err() {
+        graceful_stop.abort();
+        let _ = graceful_stop.await;
     }
 
-    let mut response = Vec::new();
-    tokio::time::timeout(Duration::from_secs(1), stream.read_to_end(&mut response))
-        .await
+    let mut join = join;
+    let server_join_result = tokio::time::timeout(Duration::from_secs(3), &mut join).await;
+    if server_join_result.is_err() {
+        join.abort();
+        let _ = join.await;
+    }
+
+    assert!(
+        matches!(idle_connection_closed, Ok(Ok(0))),
+        "idle keep-alive connection did not close after the drain signal: {idle_connection_closed:?}"
+    );
+    let response = active_response
         .expect("drained connection closes after current response")
         .expect("read drained HTTP response");
     assert_eq!(
@@ -235,9 +284,14 @@ async fn graceful_stop_finishes_current_request_without_starting_buffered_reques
         1,
         "the buffered request must not enter the application service"
     );
-    join.await
-        .expect("server task joins")
-        .expect("server exits cleanly");
+    assert!(
+        matches!(graceful_stop_result, Ok(Ok(()))),
+        "graceful stop did not complete cleanly: {graceful_stop_result:?}"
+    );
+    assert!(
+        matches!(server_join_result, Ok(Ok(Ok(())))),
+        "server did not exit cleanly: {server_join_result:?}"
+    );
 }
 
 #[actix_web::test]

--- a/crates/app/bamboo-server/src/server/tests.rs
+++ b/crates/app/bamboo-server/src/server/tests.rs
@@ -1,10 +1,21 @@
-use std::net::TcpListener;
+use std::{
+    net::TcpListener,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use actix_web::{web, App, HttpRequest, HttpResponse};
 use futures::{SinkExt, StreamExt};
 use native_tls::TlsConnector;
 use serde_json::{json, Value};
-use tokio::net::TcpStream;
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    sync::Notify,
+};
 use tokio_native_tls::TlsConnector as TokioTlsConnector;
 use tokio_tungstenite::{
     connect_async_tls_with_config,
@@ -39,6 +50,191 @@ async fn stop_server(
     join: tokio::task::JoinHandle<std::io::Result<()>>,
 ) {
     handle.stop(false).await;
+    join.await
+        .expect("server task joins")
+        .expect("server exits cleanly");
+}
+
+async fn stop_server_gracefully(
+    handle: actix_web::dev::ServerHandle,
+    join: tokio::task::JoinHandle<std::io::Result<()>>,
+) {
+    if tokio::time::timeout(Duration::from_secs(3), handle.stop(true))
+        .await
+        .is_err()
+    {
+        join.abort();
+        let _ = join.await;
+        panic!("graceful stop waited for the worker shutdown timeout");
+    }
+    join.await
+        .expect("server task joins")
+        .expect("server exits cleanly");
+}
+
+async fn read_http_response_head<R>(stream: &mut R) -> Vec<u8>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut response = Vec::new();
+    let mut chunk = [0_u8; 1024];
+
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while !response.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream
+                .read(&mut chunk)
+                .await
+                .expect("read HTTP response head");
+            assert_ne!(read, 0, "connection closed before the response head");
+            response.extend_from_slice(&chunk[..read]);
+        }
+    })
+    .await
+    .expect("HTTP response head arrives before timeout");
+
+    response
+}
+
+#[derive(Default)]
+struct DrainState {
+    calls: AtomicUsize,
+    started: Notify,
+    release: Notify,
+}
+
+async fn blocking_drain_handler(state: web::Data<DrainState>) -> HttpResponse {
+    state.calls.fetch_add(1, Ordering::SeqCst);
+    state.started.notify_one();
+    state.release.notified().await;
+    HttpResponse::Ok().body("completed-current-request")
+}
+
+#[actix_web::test]
+async fn graceful_stop_closes_idle_keep_alive_connection_without_worker_timeout() {
+    let (listener, port) = test_listener();
+    let server = build_h1_server(
+        || {
+            App::new().route(
+                "/idle",
+                web::get().to(|| async { HttpResponse::Ok().finish() }),
+            )
+        },
+        vec![listener],
+        1,
+        None,
+    )
+    .expect("build plaintext H1 server");
+    let handle = server.handle();
+    let join = tokio::spawn(server);
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect idle keep-alive client");
+    stream
+        .write_all(b"GET /idle HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")
+        .await
+        .expect("send idle keep-alive request");
+    let response = read_http_response_head(&mut stream).await;
+    assert!(
+        response.starts_with(b"HTTP/1.1 200"),
+        "unexpected HTTP response: {}",
+        String::from_utf8_lossy(&response)
+    );
+
+    if tokio::time::timeout(Duration::from_secs(3), handle.stop(true))
+        .await
+        .is_err()
+    {
+        join.abort();
+        let _ = join.await;
+        panic!("graceful stop waited for the worker shutdown timeout");
+    }
+
+    let mut trailing = [0_u8; 1];
+    let read = tokio::time::timeout(Duration::from_secs(1), stream.read(&mut trailing))
+        .await
+        .expect("graceful drain closes the idle connection")
+        .expect("read idle connection EOF");
+    assert_eq!(read, 0, "idle connection remained open after graceful stop");
+    join.await
+        .expect("server task joins")
+        .expect("server exits cleanly");
+}
+
+#[actix_web::test]
+async fn graceful_stop_finishes_current_request_without_starting_buffered_request() {
+    let state = Arc::new(DrainState::default());
+    let state_for_factory = state.clone();
+    let (listener, port) = test_listener();
+    let server = build_h1_server(
+        move || {
+            App::new()
+                .app_data(web::Data::from(state_for_factory.clone()))
+                .route("/drain", web::get().to(blocking_drain_handler))
+        },
+        vec![listener],
+        1,
+        None,
+    )
+    .expect("build plaintext H1 server");
+    let handle = server.handle();
+    let join = tokio::spawn(server);
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect pipelined keep-alive client");
+    stream
+        .write_all(
+            b"GET /drain HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n\
+              GET /drain HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .expect("buffer two HTTP requests");
+    tokio::time::timeout(Duration::from_secs(3), state.started.notified())
+        .await
+        .expect("current request starts before timeout");
+
+    // `stop(true)` queues the server command before returning its completion
+    // future. Give the worker a scheduling turn to deliver the drain signal
+    // while the first request remains in flight and the second is buffered.
+    let graceful_stop = handle.stop(true);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    state.release.notify_one();
+
+    if tokio::time::timeout(Duration::from_secs(3), graceful_stop)
+        .await
+        .is_err()
+    {
+        join.abort();
+        let _ = join.await;
+        panic!("graceful stop started a buffered request or waited for worker timeout");
+    }
+
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(1), stream.read_to_end(&mut response))
+        .await
+        .expect("drained connection closes after current response")
+        .expect("read drained HTTP response");
+    assert_eq!(
+        response
+            .windows(b"HTTP/1.1 200".len())
+            .filter(|window| *window == b"HTTP/1.1 200")
+            .count(),
+        1,
+        "only the in-flight request may receive a response: {}",
+        String::from_utf8_lossy(&response)
+    );
+    assert!(
+        response
+            .windows(b"completed-current-request".len())
+            .any(|window| window == b"completed-current-request"),
+        "the in-flight request must complete before the connection drains"
+    );
+    assert_eq!(
+        state.calls.load(Ordering::SeqCst),
+        1,
+        "the buffered request must not enter the application service"
+    );
     join.await
         .expect("server task joins")
         .expect("server exits cleanly");
@@ -226,5 +422,35 @@ async fn rustls_server_is_http11_secure_wss_and_never_negotiates_h2() {
     assert_eq!(pong["type"], "pong");
 
     websocket.close(None).await.expect("close WSS client");
-    stop_server(handle, join).await;
+
+    // Keep a real TLS/H1 connection idle while the server drains. This covers
+    // the Rustls listener factory independently from the plaintext drain
+    // tests above; without the propagated signal, stop(true) waits for the
+    // ordinary keep-alive or worker shutdown timeout.
+    let idle_tls = TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .request_alpns(&["http/1.1"])
+        .build()
+        .expect("idle H1 TLS connector");
+    let tcp = TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("TCP connection for idle H1 TLS client");
+    let mut idle_tls = TokioTlsConnector::from(idle_tls)
+        .connect("localhost", tcp)
+        .await
+        .expect("idle H1 TLS handshake");
+    idle_tls
+        .write_all(
+            b"GET /__transport HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n",
+        )
+        .await
+        .expect("send idle H1 TLS request");
+    let response = read_http_response_head(&mut idle_tls).await;
+    assert!(
+        response.starts_with(b"HTTP/1.1 200"),
+        "unexpected idle TLS response: {}",
+        String::from_utf8_lossy(&response)
+    );
+
+    stop_server_gracefully(handle, join).await;
 }


### PR DESCRIPTION
## Summary

- carry forward the complete dependency lock update from #851, including Actix 4.14.1 / actix-http 3.13.3 / actix-server 2.7.0 and russh 0.62.6
- forward the new actix-server graceful-shutdown signal into every custom plaintext and Rustls HTTP/1.1 service factory
- keep inbound ALPN pinned to `http/1.1` and retain the existing HTTPS/WSS behavior
- add live socket regressions proving idle keep-alive drain and completion of the current request without dispatching a buffered next request
- hold a real TLS/H1 keep-alive socket across `stop(true)` so the Rustls factory has the same regression coverage

This PR supersedes #851. The lock-only head of #851 is green but misses the new Actix drain wiring required by the custom H1 server introduced for #849.

## Root cause

The high-level Actix `HttpServer` now captures `ServerBuilder::graceful_shutdown_signal()` and injects it into each `HttpService`. Bamboo builds `ServerBuilder + HttpService` directly to avoid the vulnerable legacy H2 feature, so it must preserve that connection-level contract explicitly. Without it, SIGTERM or `stop(true)` waits for idle keep-alive expiry and can dispatch another pipelined request after shutdown has begun.

## Test Plan

- `cargo fmt --all -- --check`
- CI-equivalent `cargo clippy --all-features -- -D warnings ...`
- `cargo test -p bamboo-server --lib graceful_stop_ -- --nocapture`
- `cargo test -p bamboo-server --lib rustls_server_is_http11_secure_wss_and_never_negotiates_h2 -- --nocapture`
- `cargo test --all-features --lib --tests`
- `cargo audit`
- `cargo deny check`
- regression proof: with both signal injections temporarily removed, both new plaintext drain tests fail; restoring the bridge makes plaintext and Rustls tests pass

The two pre-existing audit warnings are tracked for immediate removal in #852; no advisory ignore is added here. Hermetic real SSH/SFTP CI for the russh update is tracked in #854.

## Screenshots

N/A — backend transport and dependency update.

Closes #853