### PR TITLE
fix(deps): eliminate remaining dependency unsoundness warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,10 @@ jobs:
         # discovery path — a bare root-level `audit.toml` is NOT picked up),
         # where each entry carries a justification and a re-check trigger
         # instead of being a silent, undocumented flag (bamboo-agent#254).
-        run: cargo audit
+        # Deny every other warning as well as vulnerabilities so a newly
+        # introduced unsound, unmaintained, or yanked dependency cannot leave
+        # this required security job green without an explicit review.
+        run: cargo audit --deny warnings
 
   deny:
     name: cargo-deny (licenses/bans/advisories/sources)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,11 +2715,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -4132,9 +4131,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]


### PR DESCRIPTION
## Summary

- update `event-listener` from 5.4.1 to 5.4.2, removing the unsound `concurrent-queue` path
- update `lru` from 0.18.0 to 0.18.2 to pick up the upstream unsoundness fix
- make every non-ignored `cargo audit` warning fatal in CI so future unsound, unmaintained, or yanked dependencies cannot leave the security job green without explicit review
- keep the two existing, documented no-fixed-release audit exceptions unchanged; no new ignore, fork, vendor patch, or broad dependency churn

## Test Plan

- `cargo audit --deny warnings`
- `cargo deny check`
- `cargo tree --locked --workspace --all-features --target all -i event-listener`
- `cargo tree --locked --workspace --all-features -i lru`
- `cargo test --locked -p bamboo-tui --lib` (432 passed)
- `cargo test --locked -p bamboo-server --lib notify_sinks` (21 passed)
- `cargo test --all-features --lib --tests` (full workspace passed)
- CI-equivalent workspace Clippy with warnings denied
- `cargo fmt --all -- --check`
- `git diff --check`

## Screenshots

N/A — dependency/security CI change only.

Closes #852