### PR TITLE
test(broker): automate real SSH transport contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Run integration tests
         run: cargo test --tests
 
+      - name: Run real SSH/SFTP transport test
+        timeout-minutes: 10
+        run: scripts/run-russh-live.sh
+
       - name: Build examples
         # Compile-only (no network/config needed): guards `examples/*.rs` —
         # and the README SDK snippet each one's doc comment mirrors — against

--- a/crates/app/bamboo-broker/src/deploy_russh.rs
+++ b/crates/app/bamboo-broker/src/deploy_russh.rs
@@ -15,10 +15,12 @@
 //! alive keeps the tunnel + worker up; `shutdown`/`shutdown_with_timeout`
 //! signal the remote worker and POLL for it to exit — keeping the session and
 //! reverse tunnel up throughout, so an in-flight reply can drain through it —
-//! before hard-killing and disconnecting (session-bound lifetime, like the
-//! system-ssh path — true survive-restart durability is a later phase). #489.
+//! before a bounded hard-kill fallback, reverse-listener cancellation, active
+//! forwarding drain, and disconnect (session-bound lifetime, like the system-ssh
+//! path — true survive-restart durability is a later phase). #489.
 
 use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -30,7 +32,7 @@ use russh_sftp::client::SftpSession;
 use russh_sftp::protocol::OpenFlags;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use crate::deploy::{
     agent_argv, broker_port, broker_scheme, sh_quote, AgentDeployment, DeployedAgent, Deployer,
@@ -42,6 +44,12 @@ use crate::error::{BrokerError, BrokerResult};
 /// [`RusshHandle::shutdown_with_timeout`]. Short enough to notice a fast exit
 /// promptly, long enough not to hammer the SSH connection with exec requests.
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Once the remote worker is gone and the server has acknowledged cancellation
+/// of the reverse listener, allow already-accepted forwarding tasks to flush
+/// their final bytes before disconnecting the SSH session. This is a separate,
+/// short bound because the worker already consumed its explicit grace window.
+const FORWARDED_CONNECTION_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Decrypted SSH credentials for the russh path (the fabric layer decrypts the
 /// at-rest ciphertext before constructing the deployer).
@@ -117,12 +125,17 @@ impl RusshDeployer {
     /// Connect + host-key TOFU + authenticate, returning the live session.
     /// `broker_local` is only used to bridge reverse-tunnel connections (unused
     /// during preflight, where no `tcpip_forward` is requested).
-    async fn connect_and_auth(&self, broker_local: String) -> BrokerResult<Handle<FabricHandler>> {
+    async fn connect_and_auth(
+        &self,
+        broker_local: String,
+        forwarded_connections: Arc<ForwardedConnections>,
+    ) -> BrokerResult<Handle<FabricHandler>> {
         let config = Arc::new(client::Config::default());
         let handler = FabricHandler {
             expected: self.expected_fingerprint.clone(),
             observed: self.observed.clone(),
             broker_local,
+            forwarded_connections,
         };
         let mut session = client::connect(config, (self.host.as_str(), self.port), handler)
             .await
@@ -174,6 +187,53 @@ struct FabricHandler {
     observed: Arc<Mutex<Option<String>>>,
     /// Local broker address to bridge forwarded connections to (`127.0.0.1:9600`).
     broker_local: String,
+    forwarded_connections: Arc<ForwardedConnections>,
+}
+
+/// Tracks forwarding tasks independently from the russh session task. An SSH
+/// channel can still have bytes buffered after the remote worker exits; dropping
+/// the session at that point truncates the worker's final broker frame.
+#[derive(Default)]
+struct ForwardedConnections {
+    active: AtomicUsize,
+    changed: Notify,
+}
+
+impl ForwardedConnections {
+    fn track(self: &Arc<Self>) -> ForwardedConnectionGuard {
+        self.active.fetch_add(1, Ordering::AcqRel);
+        ForwardedConnectionGuard(self.clone())
+    }
+
+    async fn wait_for_idle(&self, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            // Create the waiter before checking the count. The final guard uses
+            // `notify_one`, which retains a permit even if this future has not
+            // been polled yet, so the check/await boundary cannot miss it.
+            let changed = self.changed.notified();
+            if self.active.load(Ordering::Acquire) == 0 {
+                return true;
+            }
+            if tokio::time::timeout_at(deadline, changed).await.is_err() {
+                return false;
+            }
+        }
+    }
+}
+
+struct ForwardedConnectionGuard(Arc<ForwardedConnections>);
+
+impl Drop for ForwardedConnectionGuard {
+    fn drop(&mut self) {
+        let previous = self.0.active.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "forwarded connection count underflow");
+        if previous == 1 {
+            // `notify_one` stores a permit if the waiter has not been polled
+            // yet, avoiding the missed-wakeup window of `notify_waiters`.
+            self.0.changed.notify_one();
+        }
+    }
 }
 
 impl client::Handler for FabricHandler {
@@ -208,7 +268,9 @@ impl client::Handler for FabricHandler {
         reply.accept().await;
         // A worker on the remote dialed the tunnel mouth; splice it to the broker.
         let broker = self.broker_local.clone();
+        let connection = self.forwarded_connections.track();
         tokio::spawn(async move {
+            let _connection = connection;
             match TcpStream::connect(&broker).await {
                 Ok(mut tcp) => {
                     let mut stream = channel.into_stream();
@@ -225,7 +287,8 @@ impl client::Handler for FabricHandler {
 
 /// Live remote handle: owns the `russh` session (keeping the tunnel + worker
 /// alive). `shutdown`/`shutdown_with_timeout` signal the worker by id, poll for
-/// its exit through the still-open tunnel, then hard-kill + disconnect (#489).
+/// its exit through the still-open tunnel, then hard-kill if needed, drain
+/// accepted forwarding tasks, and disconnect (#489).
 struct RusshHandle {
     session: Mutex<Option<Handle<FabricHandler>>>,
     worker_id: String,
@@ -233,6 +296,8 @@ struct RusshHandle {
     /// token). Removed on shutdown, and — being globally unique — the safest
     /// `pkill` anchor (the truncated worker_id can substring-collide across nodes).
     remote_spec_path: Option<String>,
+    broker_port: u32,
+    forwarded_connections: Arc<ForwardedConnections>,
 }
 
 #[async_trait]
@@ -244,8 +309,8 @@ impl RemoteDeployment for RusshHandle {
     /// signal, severing the graceful drain #488 added mid-reply. Fix: signal,
     /// then POLL the remote for the worker's exit — keeping the session/tunnel
     /// alive — for up to `timeout` (mirrors `DeployedAgent::shutdown_with_timeout`'s
-    /// local-process SIGTERM-then-poll pattern), THEN hard-kill as a fallback
-    /// and only then disconnect.
+    /// local-process SIGTERM-then-poll pattern), THEN hard-kill as a fallback,
+    /// cancel the listener, flush accepted forwarding tasks, and disconnect.
     async fn shutdown_with_timeout(&self, timeout: Duration) {
         let Some(session) = self.session.lock().await.take() else {
             return;
@@ -253,26 +318,25 @@ impl RemoteDeployment for RusshHandle {
         // Anchored on the unique spec path when present — the truncated
         // worker_id can substring-collide across nodes.
         let kill_anchor = self.remote_spec_path.as_deref().unwrap_or(&self.worker_id);
+        let process_pattern = exact_process_argument_pattern(kill_anchor);
 
         // 1. SIGTERM (pkill's default signal): give the worker's own shutdown
         //    handler a chance to drain cleanly, same as the local-process path.
-        let term_cmd = format!("pkill -f {}", sh_quote(kill_anchor));
-        if let Ok(channel) = session.channel_open_session().await {
-            let _ = channel.exec(false, term_cmd).await;
-        }
+        let term_cmd = format!("pkill -f {}", sh_quote(&process_pattern));
+        let _ = exec_capture(&session, &term_cmd).await;
 
         // 2. Poll for the worker's exit within the grace window. The session
         //    (and therefore the reverse tunnel) stays open the entire time, so
         //    a reply the worker is still draining through it can complete.
         //    Best-effort: a poll that errors (e.g. a transient exec hiccup) is
         //    treated as "still alive" rather than aborting the wait early.
-        poll_until_exited(
+        let exited = poll_until_exited(
             || async {
                 exec_capture(
                     &session,
                     &format!(
                         "pgrep -f {} >/dev/null 2>&1 && echo 1 || echo 0",
-                        sh_quote(kill_anchor)
+                        sh_quote(&process_pattern)
                     ),
                 )
                 .await
@@ -284,15 +348,51 @@ impl RemoteDeployment for RusshHandle {
         )
         .await;
 
-        // 3. Hard-kill fallback (harmless no-op if it already exited above) +
-        //    remove the creds-bearing spec file, THEN disconnect — only now is
-        //    the reverse tunnel torn down.
-        let mut cmd = format!("pkill -9 -f {}", sh_quote(kill_anchor));
-        if let Some(spec) = &self.remote_spec_path {
-            cmd.push_str(&format!("; rm -f {}", sh_quote(spec)));
+        // 3. Hard-kill fallback when the grace window expired. Wait for the
+        //    command channel to close so cancellation cannot race ahead of it.
+        if !exited {
+            let _ = exec_capture(
+                &session,
+                &format!("pkill -9 -f {}", sh_quote(&process_pattern)),
+            )
+            .await;
         }
-        if let Ok(channel) = session.channel_open_session().await {
-            let _ = channel.exec(false, cmd).await;
+
+        // 4. Stop accepting new reverse connections, then wait for every
+        //    already-accepted copy task to flush. The cancellation acknowledgement
+        //    is the ordering barrier: once it arrives, no earlier forwarded-open
+        //    message remains unaccounted for by `forwarded_connections`.
+        let drain_deadline = tokio::time::Instant::now() + FORWARDED_CONNECTION_DRAIN_TIMEOUT;
+        match tokio::time::timeout_at(
+            drain_deadline,
+            session.cancel_tcpip_forward("127.0.0.1", self.broker_port),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                tracing::warn!("cancel russh reverse tunnel failed during shutdown: {error}");
+            }
+            Err(_) => {
+                tracing::warn!("cancel russh reverse tunnel timed out during shutdown");
+            }
+        }
+        let remaining_drain = drain_deadline.saturating_duration_since(tokio::time::Instant::now());
+        if !self
+            .forwarded_connections
+            .wait_for_idle(remaining_drain)
+            .await
+        {
+            tracing::warn!(
+                timeout_ms = FORWARDED_CONNECTION_DRAIN_TIMEOUT.as_millis() as u64,
+                "russh reverse tunnel still had active connections at the drain deadline"
+            );
+        }
+
+        // 5. Remove the creds-bearing spec file, then disconnect. The uploaded
+        //    worker binary intentionally remains reusable on a durable host.
+        if let Some(spec) = &self.remote_spec_path {
+            let _ = exec_capture(&session, &format!("rm -f {}", sh_quote(spec))).await;
         }
         let _ = session
             .disconnect(russh::Disconnect::ByApplication, "", "")
@@ -330,15 +430,40 @@ fn transport(msg: impl std::fmt::Display) -> BrokerError {
     BrokerError::Transport(msg.to_string())
 }
 
+/// Build a POSIX ERE that matches `literal` as one complete process argument.
+/// Besides avoiding substring collisions, the boundary wrapper prevents the
+/// `pgrep`/`pkill` command itself from matching its own pattern argument (the
+/// literal inside that argument is adjacent to regex syntax, not whitespace).
+fn exact_process_argument_pattern(literal: &str) -> String {
+    if literal.is_empty() {
+        // Never turn an invalid empty worker identity into a process-wide match.
+        return "a^".to_string();
+    }
+    let mut escaped = String::with_capacity(literal.len());
+    for ch in literal.chars() {
+        if matches!(
+            ch,
+            '.' | '[' | ']' | '\\' | '*' | '^' | '$' | '(' | ')' | '+' | '?' | '{' | '}' | '|'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    format!("(^|[[:space:]]){escaped}([[:space:]]|$)")
+}
+
 #[async_trait]
 impl Deployer for RusshDeployer {
     async fn deploy(&self, d: &AgentDeployment) -> BrokerResult<DeployedAgent> {
         let bport = broker_port(&d.broker_endpoint)
             .ok_or_else(|| transport(format!("no broker port in '{}'", d.broker_endpoint)))?;
         let broker_local = format!("127.0.0.1:{bport}");
+        let forwarded_connections = Arc::new(ForwardedConnections::default());
 
         // 1–2. Connect + host-key TOFU + authenticate.
-        let session = self.connect_and_auth(broker_local).await?;
+        let session = self
+            .connect_and_auth(broker_local, forwarded_connections.clone())
+            .await?;
 
         // 3. Upload the binary (hash-skip) + chmod +x.
         if let Some(spec) = &self.upload {
@@ -407,6 +532,8 @@ impl Deployer for RusshDeployer {
                 session: Mutex::new(Some(session)),
                 worker_id: d.id.clone(),
                 remote_spec_path,
+                broker_port: bport as u32,
+                forwarded_connections,
             }),
         ))
     }
@@ -414,7 +541,9 @@ impl Deployer for RusshDeployer {
     /// Connect + auth + `uname -s -m`, then disconnect. No deploy, no tunnel —
     /// proves the node is reachable and the stored credentials work.
     async fn preflight(&self) -> BrokerResult<String> {
-        let session = self.connect_and_auth(String::new()).await?;
+        let session = self
+            .connect_and_auth(String::new(), Arc::new(ForwardedConnections::default()))
+            .await?;
         let uname = exec_capture(&session, "uname -s -m").await?;
         let _ = session
             .disconnect(russh::Disconnect::ByApplication, "", "")
@@ -423,7 +552,9 @@ impl Deployer for RusshDeployer {
     }
 
     async fn tail_log(&self, log_path: &str, lines: usize) -> BrokerResult<String> {
-        let session = self.connect_and_auth(String::new()).await?;
+        let session = self
+            .connect_and_auth(String::new(), Arc::new(ForwardedConnections::default()))
+            .await?;
         let out = exec_capture(
             &session,
             &format!("tail -n {lines} {} 2>/dev/null || true", sh_quote(log_path)),
@@ -703,10 +834,58 @@ mod tests {
         assert!(parse_private_key("not a key", None).is_err());
     }
 
+    #[test]
+    fn process_pattern_is_argument_bounded_and_escapes_posix_ere_syntax() {
+        assert_eq!(exact_process_argument_pattern(""), "a^");
+        assert_eq!(
+            exact_process_argument_pattern("node.alpha+[1]"),
+            r"(^|[[:space:]])node\.alpha\+\[1\]([[:space:]]|$)"
+        );
+        let command = format!(
+            "pgrep -f {}",
+            sh_quote(&exact_process_argument_pattern("node.alpha+[1]"))
+        );
+        assert!(command.contains("node\\.alpha"));
+        assert!(
+            !command.contains(" node.alpha+[1] "),
+            "the probe command must not contain an unbounded literal that can match itself"
+        );
+    }
+
+    #[tokio::test]
+    async fn forwarded_connection_tracker_waits_until_the_last_copy_finishes() {
+        let tracker = Arc::new(ForwardedConnections::default());
+        let connection = tracker.track();
+        let waiting_tracker = tracker.clone();
+        let waiter =
+            tokio::spawn(
+                async move { waiting_tracker.wait_for_idle(Duration::from_secs(1)).await },
+            );
+
+        tokio::task::yield_now().await;
+        assert!(
+            !waiter.is_finished(),
+            "an active forwarded connection must hold the drain barrier"
+        );
+        drop(connection);
+        assert!(waiter.await.expect("drain waiter task"));
+    }
+
+    #[tokio::test]
+    async fn forwarded_connection_tracker_has_a_bounded_deadline() {
+        let tracker = Arc::new(ForwardedConnections::default());
+        let _connection = tracker.track();
+        assert!(
+            !tracker.wait_for_idle(Duration::from_millis(20)).await,
+            "a stuck forwarding task must not make shutdown unbounded"
+        );
+    }
+
     // #489: `poll_until_exited` backs `RusshHandle::shutdown_with_timeout`'s
     // grace-window wait. It can't be exercised against a real remote without a
-    // live SSH session (see `tests/russh_live.rs`, gated behind
-    // `BAMBOO_RUSSH_LIVE=1`), so these tests drive it directly with a fake
+    // live SSH session (see the ignored `tests/russh_live.rs`, which the
+    // hermetic `scripts/run-russh-live.sh` fixture drives in protected CI), so
+    // these tests drive it directly with a fake
     // liveness check instead — the polling/timeout behavior is identical
     // either way, since `poll_until_exited` doesn't know or care that the real
     // liveness check is an SSH `pgrep` exec.

--- a/crates/app/bamboo-broker/tests/fixtures/russh/Dockerfile
+++ b/crates/app/bamboo-broker/tests/fixtures/russh/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+
+RUN apk add --no-cache \
+      netcat-openbsd \
+      openssh-server \
+      procps \
+    && adduser -D -h /home/deploy -s /bin/sh deploy \
+    && passwd -d deploy \
+    && mkdir -p /home/deploy/.ssh /run/bamboo-russh-fixture /run/sshd \
+    && chown -R deploy:deploy /home/deploy \
+    && chmod 0700 /home/deploy/.ssh
+
+COPY sshd_config /etc/ssh/sshd_config
+COPY entrypoint.sh /usr/local/bin/bamboo-russh-fixture
+
+RUN chmod 0755 /usr/local/bin/bamboo-russh-fixture
+
+EXPOSE 22
+
+HEALTHCHECK --interval=1s --timeout=2s --start-period=1s --retries=20 \
+  CMD nc -z -w 1 127.0.0.1 22 || exit 1
+
+ENTRYPOINT ["/usr/local/bin/bamboo-russh-fixture"]

--- a/crates/app/bamboo-broker/tests/fixtures/russh/README.md
+++ b/crates/app/bamboo-broker/tests/fixtures/russh/README.md
@@ -1,0 +1,36 @@
+# Real russh transport fixture
+
+The repository-level runner starts this fixture and executes the ignored
+`russh_live` integration test:
+
+```sh
+scripts/run-russh-live.sh
+```
+
+The runner requires a working Docker daemon, `ssh-keygen`, and Cargo. It creates
+an ephemeral Ed25519 client key, builds the digest-pinned Alpine fixture, binds
+the SSH port to a random loopback port, waits for the container health check,
+and always removes the container, image tag, and key directory on exit.
+
+The container generates a fresh Ed25519 host key at startup. Only public-key
+authentication for the unprivileged `deploy` user is enabled; password, root,
+agent, X11, and local forwarding are disabled. Remote forwarding and
+`internal-sftp` remain enabled because they are the production contracts under
+test. No repository secret or external SSH service is used.
+
+For an already-running SSH server, invoke the ignored test directly with either
+`RUSSH_KEY_PATH` (recommended) or `RUSSH_PASS`:
+
+```sh
+RUSSH_HOST=127.0.0.1 \
+RUSSH_PORT=2222 \
+RUSSH_USER=deploy \
+RUSSH_KEY_PATH=/path/to/test_ed25519 \
+cargo test --locked -p bamboo-broker --test russh_live \
+  russh_deploys_through_reverse_tunnel -- --exact --ignored --nocapture
+```
+
+The Rust test has a 60-second contract timeout. The protected Linux `Test` CI
+job additionally bounds the complete fixture build and execution to ten
+minutes, so startup or cleanup regressions fail closed instead of silently
+skipping.

--- a/crates/app/bamboo-broker/tests/fixtures/russh/entrypoint.sh
+++ b/crates/app/bamboo-broker/tests/fixtures/russh/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+authorized_key=/run/bamboo-russh-fixture/authorized_key.pub
+
+if [ ! -s "$authorized_key" ]; then
+  echo "fixture public key is missing or empty" >&2
+  exit 1
+fi
+
+cp "$authorized_key" /home/deploy/.ssh/authorized_keys
+chown deploy:deploy /home/deploy/.ssh/authorized_keys
+chmod 0600 /home/deploy/.ssh/authorized_keys
+
+# Generate a fresh host identity for every container so the test exercises TOFU
+# and pinning rather than inheriting a baked-in key.
+rm -f /etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key.pub
+ssh-keygen -q -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key
+
+/usr/sbin/sshd -t -f /etc/ssh/sshd_config
+exec /usr/sbin/sshd -D -e -f /etc/ssh/sshd_config

--- a/crates/app/bamboo-broker/tests/fixtures/russh/sshd_config
+++ b/crates/app/bamboo-broker/tests/fixtures/russh/sshd_config
@@ -1,0 +1,26 @@
+Port 22
+ListenAddress 0.0.0.0
+HostKey /etc/ssh/ssh_host_ed25519_key
+PidFile /run/sshd.pid
+
+UsePAM no
+UseDNS no
+StrictModes yes
+PermitRootLogin no
+PermitEmptyPasswords no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+AuthorizedKeysFile .ssh/authorized_keys
+AllowUsers deploy
+
+AllowTcpForwarding remote
+GatewayPorts no
+AllowAgentForwarding no
+X11Forwarding no
+PermitTunnel no
+PermitTTY no
+
+Subsystem sftp internal-sftp
+LogLevel INFO

--- a/crates/app/bamboo-broker/tests/russh_live.rs
+++ b/crates/app/bamboo-broker/tests/russh_live.rs
@@ -1,83 +1,147 @@
 //! Live integration test for [`RusshDeployer`] against a real Linux sshd.
 //!
-//! Gated behind `BAMBOO_RUSSH_LIVE=1` (needs an sshd container; not run in normal
-//! `cargo test`). Bring the target up first:
-//!
-//! ```sh
-//! docker build -t bamboo-russh-test <fixture>   # alpine + openssh + netcat, user deploy/testpass123
-//! docker run -d --name bamboo-russh -p 2222:22 bamboo-russh-test
-//! BAMBOO_RUSSH_LIVE=1 cargo test -p bamboo-broker --test russh_live -- --nocapture
-//! ```
+//! The test is explicitly ignored because it needs the hermetic Docker fixture.
+//! Run it locally with `scripts/run-russh-live.sh`; the protected Linux `Test`
+//! job runs that same command on every pull request.
 //!
 //! What it proves (the whole russh path end-to-end, no Linux bamboo binary
-//! needed): connect + host-key TOFU + password auth + SFTP upload + chmod + the
-//! reverse tunnel + worker launch. The "binary" we upload is a tiny shell script
-//! that, when launched, dials the tunnel mouth (`127.0.0.1:<broker>`) and
-//! announces its `--id`; the host-side dummy broker must receive that line —
-//! which can only happen if the reverse tunnel bridged container → host.
+//! needed): connect + host-key TOFU and pin rejection + public-key auth + SFTP
+//! upload + chmod + reverse tunnel + worker launch and graceful cleanup. The
+//! uploaded "binary" is a tiny shell script that announces both startup and
+//! SIGTERM shutdown through the tunnel.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use bamboo_broker::{AgentDeployment, Deployer, RusshAuth, RusshDeployer, UploadSpec};
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+
+const CONTRACT_TIMEOUT: Duration = Duration::from_secs(60);
 
 fn env_or(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_string())
 }
 
-#[tokio::test]
-async fn russh_deploys_through_reverse_tunnel() {
-    if std::env::var("BAMBOO_RUSSH_LIVE").is_err() {
-        eprintln!("skipping: set BAMBOO_RUSSH_LIVE=1 (needs the sshd container)");
-        return;
+fn fixture_auth() -> RusshAuth {
+    if let Some(path) = std::env::var_os("RUSSH_KEY_PATH") {
+        let path = PathBuf::from(path);
+        let pem = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read RUSSH_KEY_PATH '{}': {e}", path.display()));
+        return RusshAuth::PrivateKey {
+            pem,
+            passphrase: None,
+        };
     }
 
-    let host = env_or("RUSSH_HOST", "127.0.0.1");
-    let port: u16 = env_or("RUSSH_PORT", "2222").parse().unwrap();
-    let user = env_or("RUSSH_USER", "deploy");
-    let pass = env_or("RUSSH_PASS", "testpass123");
-    let broker_port: u16 = env_or("RUSSH_BROKER_PORT", "9600").parse().unwrap();
+    let password = std::env::var("RUSSH_PASS").expect(
+        "set RUSSH_KEY_PATH (recommended) or RUSSH_PASS when running the ignored live test",
+    );
+    RusshAuth::Password(password)
+}
 
-    // 1. Host-side dummy "broker": a listener that captures the first line.
-    let listener = TcpListener::bind(("127.0.0.1", broker_port))
+async fn receive_announcements(listener: TcpListener, tx: mpsc::Sender<String>) {
+    for ordinal in 1..=2 {
+        let (mut socket, _) = tokio::time::timeout(Duration::from_secs(20), listener.accept())
+            .await
+            .unwrap_or_else(|_| panic!("announcement {ordinal} did not reach the tunnel in 20s"))
+            .unwrap_or_else(|e| panic!("accept announcement {ordinal}: {e}"));
+        let mut message = String::new();
+        tokio::time::timeout(Duration::from_secs(5), socket.read_to_string(&mut message))
+            .await
+            .unwrap_or_else(|_| panic!("announcement {ordinal} did not close in 5s"))
+            .unwrap_or_else(|e| panic!("read announcement {ordinal}: {e}"));
+        tx.send(message)
+            .await
+            .unwrap_or_else(|_| panic!("announcement receiver dropped at message {ordinal}"));
+    }
+}
+
+async fn run_transport_contract() {
+    let host = env_or("RUSSH_HOST", "127.0.0.1");
+    let port: u16 = env_or("RUSSH_PORT", "2222")
+        .parse()
+        .expect("RUSSH_PORT must be a valid u16");
+    let user = env_or("RUSSH_USER", "deploy");
+    let worker_id = env_or(
+        "RUSSH_WORKER_ID",
+        &format!("node-russh-live-{}", std::process::id()),
+    );
+
+    // Bind port 0 so concurrent tests and developer services cannot collide.
+    let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
         .expect("bind dummy broker");
-    let recv = tokio::spawn(async move {
-        let (mut sock, _) = tokio::time::timeout(Duration::from_secs(20), listener.accept())
-            .await
-            .expect("tunnel connection within 20s")
-            .expect("accept");
-        let mut buf = vec![0u8; 256];
-        let n = sock.read(&mut buf).await.unwrap_or(0);
-        String::from_utf8_lossy(&buf[..n]).to_string()
-    });
+    let broker_port = listener.local_addr().expect("dummy broker address").port();
+    let (announcement_tx, mut announcement_rx) = mpsc::channel(2);
+    let receiver = tokio::spawn(receive_announcements(listener, announcement_tx));
 
-    // 2. The "binary": a probe script that dials the tunnel mouth and announces
-    //    its --id. (Runs in the container; reaches the host only via the tunnel.)
-    let script = format!(
+    // First contact is TOFU: authentication succeeds and the exact host key is
+    // recorded for durable pinning by the caller.
+    let tofu = RusshDeployer::new(&host, port, &user, fixture_auth());
+    let platform = tofu.preflight().await.expect("TOFU preflight");
+    assert!(
+        platform.starts_with("Linux "),
+        "fixture preflight must execute uname on Linux, got {platform:?}"
+    );
+    let fingerprint = tofu
+        .observed_fingerprint()
+        .await
+        .expect("TOFU must record a SHA-256 host-key fingerprint");
+    assert!(
+        fingerprint.starts_with("SHA256:"),
+        "unexpected host-key fingerprint: {fingerprint:?}"
+    );
+
+    // A changed pin must fail closed before a deployment or upload can occur.
+    let wrong_pin = RusshDeployer::new(&host, port, &user, fixture_auth()).with_fingerprint(Some(
+        "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into(),
+    ));
+    assert!(
+        wrong_pin.preflight().await.is_err(),
+        "a mismatched host-key pin must be rejected"
+    );
+    assert_eq!(
+        wrong_pin.observed_fingerprint().await.as_deref(),
+        Some(fingerprint.as_str()),
+        "the rejected connection must still report the actually observed key"
+    );
+
+    let temp = tempfile::tempdir().expect("create probe tempdir");
+    let local_probe = temp.path().join("bamboo-russh-probe.sh");
+    let probe = format!(
         "#!/bin/sh\n\
          id=\"\"\n\
-         while [ $# -gt 0 ]; do [ \"$1\" = \"--id\" ] && id=\"$2\"; shift; done\n\
-         printf 'WORKER_UP id=%s\\n' \"$id\" | nc -w 3 127.0.0.1 {broker_port}\n\
-         sleep 30\n"
+         while [ $# -gt 0 ]; do\n\
+           if [ \"$1\" = \"--id\" ]; then id=\"$2\"; shift; fi\n\
+           shift\n\
+         done\n\
+         announce() {{ printf '%s id=%s\\n' \"$1\" \"$id\" | nc -N -w 3 127.0.0.1 {broker_port}; }}\n\
+         on_term() {{ announce WORKER_DOWN; exit 0; }}\n\
+         trap on_term TERM INT\n\
+         announce WORKER_UP\n\
+         while :; do sleep 1 & wait $!; done\n"
     );
-    let local = std::env::temp_dir().join("bamboo-russh-probe.sh");
-    tokio::fs::write(&local, script).await.expect("write probe");
+    tokio::fs::write(&local_probe, probe)
+        .await
+        .expect("write probe");
+    let remote_probe = format!("/home/deploy/bamboo-probe-{worker_id}");
 
-    // 3. Deploy via russh (TOFU host key, password auth, SFTP upload, tunnel).
-    let deployer = RusshDeployer::new(host, port, user, RusshAuth::Password(pass)).with_upload(
-        Some(UploadSpec {
-            local_path: local.to_string_lossy().to_string(),
-            remote_path: "/home/deploy/bamboo-probe".to_string(),
-        }),
-    );
-
+    // Reconnect with the TOFU result pinned, then exercise SFTP upload, chmod,
+    // reverse forwarding, and remote launch. Successful execution of the probe
+    // is also the chmod assertion.
+    let deployer = RusshDeployer::new(host, port, user, fixture_auth())
+        .with_fingerprint(Some(fingerprint.clone()))
+        .with_upload(Some(UploadSpec {
+            local_path: local_probe.to_string_lossy().into_owned(),
+            remote_path: remote_probe,
+        }));
     let deployment = AgentDeployment {
-        id: "node-russhtest".to_string(),
+        id: worker_id.clone(),
         role: Some("worker".to_string()),
         broker_endpoint: format!("ws://127.0.0.1:{broker_port}"),
-        token: "tok".to_string(),
+        token: "fixture-local-token".to_string(),
         model: None,
         workspace: None,
         echo: true,
@@ -88,22 +152,41 @@ async fn russh_deploys_through_reverse_tunnel() {
     };
 
     let handle = deployer.deploy(&deployment).await.expect("russh deploy");
-
-    // 4. The reverse tunnel must carry the worker's announcement home.
-    let got = recv.await.expect("recv task");
-    assert!(
-        got.contains("WORKER_UP id=node-russhtest"),
-        "expected the worker to announce via the reverse tunnel, got: {got:?}"
+    assert_eq!(
+        deployer.observed_fingerprint().await.as_deref(),
+        Some(fingerprint.as_str()),
+        "the pinned deployment must observe the same host key"
     );
 
-    // 5. TOFU recorded a fingerprint.
-    let fp = deployer.observed_fingerprint().await;
-    assert!(
-        fp.as_deref()
-            .map(|s| s.starts_with("SHA256:"))
-            .unwrap_or(false),
-        "host-key fingerprint should be recorded, got: {fp:?}"
-    );
+    let up = tokio::time::timeout(Duration::from_secs(20), announcement_rx.recv())
+        .await
+        .expect("worker startup announcement within 20s")
+        .expect("startup announcement channel");
+    assert_eq!(up.trim(), format!("WORKER_UP id={worker_id}"));
 
-    handle.shutdown().await;
+    // Shutdown must remain bounded, deliver SIGTERM to the remote worker, and
+    // keep the reverse tunnel alive long enough for the worker's trap to report
+    // that it exited. This proves launch cleanup rather than merely destroying
+    // the fixture container afterward.
+    let shutdown_started = tokio::time::Instant::now();
+    handle.shutdown_with_timeout(Duration::from_secs(5)).await;
+    assert!(
+        shutdown_started.elapsed() < Duration::from_secs(4),
+        "the cooperative worker must exit before the five-second hard-kill deadline"
+    );
+    let down = tokio::time::timeout(Duration::from_secs(10), announcement_rx.recv())
+        .await
+        .expect("worker shutdown announcement within 10s")
+        .expect("shutdown announcement channel");
+    assert_eq!(down.trim(), format!("WORKER_DOWN id={worker_id}"));
+
+    receiver.await.expect("announcement receiver task");
+}
+
+#[tokio::test]
+#[ignore = "requires the hermetic sshd fixture; run scripts/run-russh-live.sh"]
+async fn russh_deploys_through_reverse_tunnel() {
+    tokio::time::timeout(CONTRACT_TIMEOUT, run_transport_contract())
+        .await
+        .expect("real SSH/SFTP transport contract exceeded 60 seconds");
 }

--- a/scripts/run-russh-live.sh
+++ b/scripts/run-russh-live.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_dir
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+readonly repo_root
+readonly fixture_dir="${repo_root}/crates/app/bamboo-broker/tests/fixtures/russh"
+
+for command_name in cargo docker ssh-keygen; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "required command is unavailable: ${command_name}" >&2
+    exit 1
+  fi
+done
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon is unavailable; start Docker before running the live transport test" >&2
+  exit 1
+fi
+
+fixture_tmp_dir=""
+fixture_container=""
+fixture_image=""
+
+cleanup() {
+  local exit_status=$?
+  local cleanup_failed=0
+  trap - EXIT INT TERM HUP
+  set +e
+
+  if [[ -n "${fixture_container}" ]]; then
+    if ! docker container rm --force "${fixture_container}" >/dev/null 2>&1; then
+      echo "failed to remove the SSH fixture container" >&2
+      cleanup_failed=1
+    fi
+  fi
+  if [[ -n "${fixture_image}" ]]; then
+    if ! docker image rm --force "${fixture_image}" >/dev/null 2>&1; then
+      echo "failed to remove the SSH fixture image tag" >&2
+      cleanup_failed=1
+    fi
+  fi
+  if [[ -n "${fixture_tmp_dir}" && -d "${fixture_tmp_dir}" ]]; then
+    if ! rm -rf -- "${fixture_tmp_dir}"; then
+      echo "failed to remove the SSH fixture key directory" >&2
+      cleanup_failed=1
+    fi
+  fi
+
+  if (( exit_status == 0 && cleanup_failed != 0 )); then
+    exit_status=1
+  fi
+
+  exit "${exit_status}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+umask 077
+fixture_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/bamboo-russh-live.XXXXXX")"
+readonly private_key="${fixture_tmp_dir}/client_ed25519"
+readonly public_key="${private_key}.pub"
+readonly run_identity="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-$$"
+fixture_container="bamboo-russh-live-${run_identity}"
+fixture_image="bamboo-russh-live:${run_identity}"
+
+ssh-keygen -q -t ed25519 -N '' -C bamboo-russh-live -f "${private_key}"
+
+docker build --pull --tag "${fixture_image}" "${fixture_dir}"
+docker run --detach \
+  --name "${fixture_container}" \
+  --publish 127.0.0.1::22/tcp \
+  --mount "type=bind,src=${public_key},dst=/run/bamboo-russh-fixture/authorized_key.pub,readonly" \
+  "${fixture_image}" >/dev/null
+
+readonly readiness_deadline=$((SECONDS + 30))
+fixture_health=""
+while (( SECONDS < readiness_deadline )); do
+  fixture_health="$(docker inspect --format '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{end}}' "${fixture_container}" 2>/dev/null || true)"
+  if [[ "${fixture_health}" == "running healthy" ]]; then
+    break
+  fi
+  if [[ "${fixture_health}" == exited* || "${fixture_health}" == dead* ]]; then
+    break
+  fi
+  sleep 0.25
+done
+
+if [[ "${fixture_health}" != "running healthy" ]]; then
+  echo "SSH fixture did not become healthy within 30 seconds (state: ${fixture_health:-missing})" >&2
+  docker logs "${fixture_container}" >&2 || true
+  exit 1
+fi
+
+ssh_endpoint="$(docker port "${fixture_container}" 22/tcp | head -n 1)"
+readonly ssh_port="${ssh_endpoint##*:}"
+if [[ ! "${ssh_port}" =~ ^[0-9]+$ ]] || (( ssh_port < 1 || ssh_port > 65535 )); then
+  echo "Docker returned an invalid fixture SSH endpoint: ${ssh_endpoint}" >&2
+  exit 1
+fi
+
+cd "${repo_root}"
+RUSSH_HOST=127.0.0.1 \
+RUSSH_PORT="${ssh_port}" \
+RUSSH_USER=deploy \
+RUSSH_KEY_PATH="${private_key}" \
+RUSSH_WORKER_ID="node-russh-live-${run_identity}" \
+cargo test --locked -p bamboo-broker --test russh_live \
+  russh_deploys_through_reverse_tunnel -- \
+  --exact --ignored --nocapture --test-threads=1


### PR DESCRIPTION
## Summary

- add a digest-pinned Alpine/OpenSSH fixture with fresh host and client Ed25519 keys, an unprivileged key-only user, loopback-only random host port binding, bounded readiness, and fail-closed cleanup
- run the real russh/russh-sftp contract in the protected Linux Test job instead of allowing an environment-gated silent pass
- cover TOFU capture, wrong-pin rejection, public-key authentication, SFTP upload, chmod through successful execution, reverse forwarding, worker startup, SIGTERM cleanup, and the WORKER_DOWN drain path
- fix two production shutdown defects exposed by the real fixture: pgrep/pkill matching their own command line, and SSH disconnect racing the final accepted forwarding task

## Test Plan

- scripts/run-russh-live.sh (final pass plus repeated and 8-way parallel stress passes)
- cargo test --locked --all-features --lib --tests
- cargo test --locked --tests
- cargo clippy --locked --all-features -- -D warnings with the repository lint allowlist
- cargo +1.95.0 check --locked -p bamboo-broker --all-targets --all-features
- python3 -m unittest discover -s scripts/tests -p test_*.py
- python3 scripts/check-msrv.py
- cargo build --locked --examples
- cargo audit --deny warnings
- cargo deny check
- cargo fmt --all -- --check
- shellcheck scripts/run-russh-live.sh crates/app/bamboo-broker/tests/fixtures/russh/entrypoint.sh
- actionlint .github/workflows/ci.yml
- git diff --check

## Security

- no repository secret, persistent credential, or external SSH target is used
- client private keys live only in a mode-restricted temporary directory and are removed by the exit trap
- the fixture disables password, root, agent, X11, local forwarding, TTY, and tunnel access; only the remote-forwarding and internal-SFTP contracts under test remain enabled
- cleanup failures are explicit failures, and the final local run left no fixture container, image tag, or temporary key directory

## Screenshots

Not applicable (backend transport and CI infrastructure only).

Fixes #854