### PR TITLE
chore(server): eliminate macOS oversized __eh_frame test-link warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,12 @@ jobs:
       - name: Verify OpenSSL
         run: openssl version
 
+      - name: Run TLS fixture tests (macOS unwind guard)
+        if: runner.os == 'macOS'
+        run: scripts/run-macos-server-lib-tests.sh
+
       - name: Run TLS fixture tests
+        if: runner.os != 'macOS'
         run: cargo test --locked -p bamboo-server --lib server::tls::tests -- --nocapture
 
   e2e-test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,8 +179,9 @@ bamboo/
   `bamboo-server` lib-test. The library package's directly linked test/example
   artifacts disable Apple's compact-unwind table because the crate's DWARF
   unwind records exceed that format's 16 MiB offset limit. DWARF unwinding and
-  line tables remain enabled for panic backtraces and debugging; the rlib and
-  downstream dev/release binaries are unchanged.
+  line tables remain enabled for panic backtraces and debugging. The flag has
+  no final-link effect while creating the rlib and is not propagated to
+  downstream dev/release binaries.
 
 ### Documentation Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,12 @@ bamboo/
 - Include edge cases in tests
 - Use `#[tokio::test]` for async tests
 - Use `tempfile` for tests that need file system access
+- On macOS, use `scripts/run-macos-server-lib-tests.sh` for the monolithic
+  `bamboo-server` lib-test. The library package's directly linked test/example
+  artifacts disable Apple's compact-unwind table because the crate's DWARF
+  unwind records exceed that format's 16 MiB offset limit. DWARF unwinding and
+  line tables remain enabled for panic backtraces and debugging; the rlib and
+  downstream dev/release binaries are unchanged.
 
 ### Documentation Guidelines
 

--- a/crates/app/bamboo-server/build.rs
+++ b/crates/app/bamboo-server/build.rs
@@ -4,6 +4,23 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+fn configure_macos_test_unwinding() {
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+
+    // The monolithic bamboo-server lib-test has more than 16 MiB of DWARF
+    // unwind records. Apple's compact-unwind format cannot encode offsets that
+    // large and otherwise emits an oversized-__eh_frame warning on every test
+    // link. Disable compact-unwind synthesis for this library package's
+    // directly linked artifacts. `rustc-link-arg-tests` does not cover a
+    // library's own `#[cfg(test)]` harness, while the general form does. Cargo
+    // does not attach it to the rlib, so downstream dev/release binaries do not
+    // inherit it. The linker keeps __eh_frame, preserving Rust panic unwinding,
+    // backtraces, and line-table debugging.
+    println!("cargo:rustc-link-arg=-Wl,-no_compact_unwind");
+}
+
 fn write_frontend_package_embed(manifest_dir: &Path, out_dir: &Path) -> io::Result<()> {
     let frontend_root = manifest_dir.join("frontend_package");
     println!("cargo:rerun-if-changed={}", frontend_root.display());
@@ -49,6 +66,8 @@ fn write_frontend_package_embed(manifest_dir: &Path, out_dir: &Path) -> io::Resu
 }
 
 fn main() -> io::Result<()> {
+    configure_macos_test_unwinding();
+
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
 

--- a/crates/app/bamboo-server/build.rs
+++ b/crates/app/bamboo-server/build.rs
@@ -14,10 +14,11 @@ fn configure_macos_test_unwinding() {
     // large and otherwise emits an oversized-__eh_frame warning on every test
     // link. Disable compact-unwind synthesis for this library package's
     // directly linked artifacts. `rustc-link-arg-tests` does not cover a
-    // library's own `#[cfg(test)]` harness, while the general form does. Cargo
-    // does not attach it to the rlib, so downstream dev/release binaries do not
-    // inherit it. The linker keeps __eh_frame, preserving Rust panic unwinding,
-    // backtraces, and line-table debugging.
+    // library's own `#[cfg(test)]` harness, while the general form does. The
+    // argument has no final-link effect while rustc creates the rlib and Cargo
+    // does not propagate it to consumer links, so downstream dev/release
+    // binaries do not inherit it. The linker keeps __eh_frame, preserving Rust
+    // panic unwinding, backtraces, and line-table debugging.
     println!("cargo:rustc-link-arg=-Wl,-no_compact_unwind");
 }
 

--- a/crates/app/bamboo-server/src/server/tls.rs
+++ b/crates/app/bamboo-server/src/server/tls.rs
@@ -167,6 +167,33 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    #[cfg(target_os = "macos")]
+    #[inline(never)]
+    fn capture_test_backtrace() -> std::backtrace::Backtrace {
+        std::backtrace::Backtrace::force_capture()
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_test_link_keeps_dwarf_backtraces() {
+        // The macOS platform fixture links this crate's monolithic lib-test,
+        // whose build disables only compact-unwind synthesis. Exercise a real
+        // stack walk so the CI guard also proves that the retained __eh_frame
+        // records remain usable for test debugging.
+        let backtrace = capture_test_backtrace();
+        assert_eq!(
+            backtrace.status(),
+            std::backtrace::BacktraceStatus::Captured
+        );
+        assert!(
+            backtrace
+                .to_string()
+                .lines()
+                .any(|line| !line.trim().is_empty()),
+            "captured backtrace should contain at least one frame"
+        );
+    }
+
     #[test]
     fn build_rustls_config_errors_on_missing_cert_file() {
         let tls = TlsConfig {

--- a/scripts/run-macos-server-lib-tests.sh
+++ b/scripts/run-macos-server-lib-tests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "error: run-macos-server-lib-tests.sh requires macOS" >&2
+  exit 2
+fi
+
+log_file="$(mktemp "${TMPDIR:-/tmp}/bamboo-server-link.XXXXXX")"
+trap 'rm -f -- "$log_file"' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+set +e
+cargo test --locked -p bamboo-server --all-features --lib server::tls::tests -- --nocapture \
+  2>&1 | tee "$log_file"
+pipeline_status=("${PIPESTATUS[@]}")
+cargo_status=${pipeline_status[0]}
+tee_status=${pipeline_status[1]}
+set -e
+
+if ((tee_status != 0)); then
+  echo "error: failed to capture bamboo-server's macOS linker diagnostics" >&2
+  exit 1
+fi
+
+grep_status=0
+grep -Fq "__eh_frame section too large" "$log_file" || grep_status=$?
+if ((grep_status == 0)); then
+  echo "error: bamboo-server's macOS lib-test emitted the oversized __eh_frame warning" >&2
+  exit 1
+fi
+if ((grep_status != 1)); then
+  echo "error: failed to inspect bamboo-server's macOS linker diagnostics" >&2
+  exit 1
+fi
+
+exit "$cargo_status"


### PR DESCRIPTION
## Summary

- reshape the macOS `bamboo-server` lib-test link so Apple ld skips the compact-unwind table that cannot encode this crate's ~29.24 MB (~27.89 MiB) `__eh_frame`
- retain DWARF unwinding and add a real stack-walk regression test
- add a fail-closed macOS CI wrapper that rejects the exact oversized-`__eh_frame` diagnostic without suppressing unrelated linker messages
- document the macOS developer workflow and the deliberately narrow artifact scope

The linker argument is emitted only by the `bamboo-server` package on macOS. It has no final-link effect while rustc creates the rlib, and Cargo does not propagate it to consumer links, so downstream dev/release binaries do not inherit it. This preserves the issue's production-unwind boundary.

## Test Plan

- `scripts/run-macos-server-lib-tests.sh` — 5 passed; exact warning absent
- focused #715 reproduction — 1 passed; exact warning absent
- `cargo test --locked -p bamboo-server --all-features --lib -- --nocapture` — 1859 passed, 1 ignored; exact warning absent
- Mach-O inspection — test `__eh_frame` retained (29,244,100 bytes; ~27.89 MiB), `__unwind_info` absent
- verbose downstream `bamboo` link inspection — `-no_compact_unwind` is not present
- `cargo clippy --locked --all-features -- -D warnings ...`
- `cargo +1.95.0 check --locked -p bamboo-server --all-targets --all-features`
- `cargo build --locked --examples`
- `cargo doc --locked --workspace --all-features --no-deps`
- `cargo audit --deny warnings`
- `cargo deny check`
- `cargo fmt --all -- --check`
- `actionlint .github/workflows/ci.yml`
- `shellcheck scripts/run-macos-server-lib-tests.sh`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
- `python3 scripts/check-msrv.py`

A full workspace run had one pre-existing timing failure in `subagent_actor_via_server` under concurrent load; its exact test then passed three consecutive runs. This change does not touch that path.

## Security

No credential, network, or runtime request behavior changes. The wrapper uses a unique temporary log, cleans it on exit, and propagates both Cargo and `tee` failures.

## Screenshots

Not applicable; build/test tooling only.

Fixes #715
