### PR TITLE
fix(subagent): retry transient ETXTBSY discovery (#859)

### DIFF
--- a/crates/infra/bamboo-subagent/src/codex_discovery.rs
+++ b/crates/infra/bamboo-subagent/src/codex_discovery.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
+use crate::executor_util::retry_on_etxtbsy;
+
 /// The oldest Codex CLI schema Bamboo intentionally supports.
 pub const MIN_CODEX_VERSION: (u64, u64, u64) = (0, 144, 0);
 
@@ -193,9 +195,16 @@ async fn verify_help_surface(
 
 async fn command_output(binary: &Path, args: &[&str]) -> Result<std::process::Output, String> {
     let command_label = format!("'{} {}'", binary.display(), args.join(" "));
-    let mut command = Command::new(binary);
-    command.args(args).kill_on_drop(true);
-    tokio::time::timeout(PREFLIGHT_COMMAND_TIMEOUT, command.output())
+    // Keep the timeout outside the complete retry future. Five transient spawn
+    // attempts therefore share one 10-second budget instead of multiplying it.
+    tokio::time::timeout(
+        PREFLIGHT_COMMAND_TIMEOUT,
+        retry_on_etxtbsy(|| {
+            let mut command = Command::new(binary);
+            command.args(args).kill_on_drop(true);
+            async move { command.output().await }
+        }),
+    )
         .await
         .map_err(|_| {
             format!(

--- a/crates/infra/bamboo-subagent/src/executor_util.rs
+++ b/crates/infra/bamboo-subagent/src/executor_util.rs
@@ -3,11 +3,66 @@
 //! use these helpers so transcript rendering and atomic state writes do not
 //! drift between Claude Code and Codex.
 
+use std::future::Future;
+use std::io;
 use std::path::Path;
+use std::time::Duration;
 
 use serde::Serialize;
 use serde_json::Value;
 use tokio::io::AsyncWriteExt;
+use tokio::process::{Child, Command};
+
+const ETXTBSY_RETRY_ATTEMPTS: usize = 5;
+const ETXTBSY_RETRY_DELAY: Duration = Duration::from_millis(10);
+#[cfg(unix)]
+const ETXTBSY_RAW_OS_ERROR: i32 = 26;
+
+/// Retry a process operation when Unix reports `ETXTBSY` ("text file busy").
+///
+/// Parallel test threads can briefly inherit another thread's write file
+/// descriptor across `fork`, making an otherwise closed executable fail its
+/// first `exec`. Production wrappers can hit the same race while being
+/// atomically replaced. Only raw Unix error 26 is retryable; every other error
+/// remains fail-fast. The operation is awaited inline, so a caller's timeout or
+/// cancellation remains an overall bound and cannot leave a retry task behind.
+pub(crate) async fn retry_on_etxtbsy<T, Operation, OperationFuture>(
+    mut operation: Operation,
+) -> io::Result<T>
+where
+    Operation: FnMut() -> OperationFuture,
+    OperationFuture: Future<Output = io::Result<T>>,
+{
+    for attempt in 0..ETXTBSY_RETRY_ATTEMPTS {
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(error) if is_etxtbsy(&error) && attempt + 1 < ETXTBSY_RETRY_ATTEMPTS => {
+                tokio::time::sleep(ETXTBSY_RETRY_DELAY).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("the bounded retry loop always returns on its final attempt")
+}
+
+/// Build and spawn a Tokio child with the shared bounded `ETXTBSY` policy.
+pub async fn spawn_with_etxtbsy_retry(
+    mut build: impl FnMut() -> io::Result<Command>,
+) -> io::Result<Child> {
+    retry_on_etxtbsy(|| std::future::ready(build().and_then(|mut command| command.spawn()))).await
+}
+
+fn is_etxtbsy(error: &io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        error.raw_os_error() == Some(ETXTBSY_RAW_OS_ERROR)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = error;
+        false
+    }
+}
 
 /// Fallback history cap shared by external CLI executors: retain the newest
 /// roughly 40 messages and no more than roughly 24k characters.
@@ -204,9 +259,108 @@ fn truncate_chars(text: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::future;
+    use std::io;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use serde_json::{json, Value};
 
-    use super::{build_rehydrated_turn, render_history_preamble, write_json_atomic};
+    #[cfg(unix)]
+    use super::ETXTBSY_RAW_OS_ERROR;
+    use super::{
+        build_rehydrated_turn, render_history_preamble, retry_on_etxtbsy, write_json_atomic,
+        ETXTBSY_RETRY_ATTEMPTS,
+    };
+
+    struct DropMarker(Arc<AtomicBool>);
+
+    impl Drop for DropMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn etxtbsy_retry_recovers_after_transient_errors() {
+        let attempts = AtomicUsize::new(0);
+        let value = retry_on_etxtbsy(|| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if attempt < 2 {
+                    Err(io::Error::from_raw_os_error(ETXTBSY_RAW_OS_ERROR))
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(value, 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn etxtbsy_retry_returns_the_final_error_after_the_bound() {
+        let attempts = AtomicUsize::new(0);
+        let error = retry_on_etxtbsy(|| {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            future::ready(Err::<(), _>(io::Error::from_raw_os_error(
+                ETXTBSY_RAW_OS_ERROR,
+            )))
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.raw_os_error(), Some(ETXTBSY_RAW_OS_ERROR));
+        assert_eq!(attempts.load(Ordering::SeqCst), ETXTBSY_RETRY_ATTEMPTS);
+    }
+
+    #[tokio::test]
+    async fn etxtbsy_retry_fails_fast_for_other_errors() {
+        let attempts = AtomicUsize::new(0);
+        let error = retry_on_etxtbsy(|| {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            future::ready(Err::<(), _>(io::Error::from(
+                io::ErrorKind::PermissionDenied,
+            )))
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn caller_timeout_cancels_the_in_flight_retry_operation() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_by_operation = dropped.clone();
+        let result = tokio::time::timeout(
+            Duration::from_millis(10),
+            retry_on_etxtbsy(|| {
+                let marker = DropMarker(dropped_by_operation.clone());
+                async move {
+                    let _marker = marker;
+                    future::pending::<io::Result<()>>().await
+                }
+            }),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "the caller timeout should remain authoritative"
+        );
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "cancelling the retry future must drop its in-flight operation"
+        );
+    }
 
     #[test]
     fn rehydration_is_bounded_oldest_first_and_excludes_current_assignment() {

--- a/crates/infra/bamboo-subagent/src/executor_util.rs
+++ b/crates/infra/bamboo-subagent/src/executor_util.rs
@@ -267,12 +267,11 @@ mod tests {
 
     use serde_json::{json, Value};
 
-    #[cfg(unix)]
-    use super::ETXTBSY_RAW_OS_ERROR;
     use super::{
         build_rehydrated_turn, render_history_preamble, retry_on_etxtbsy, write_json_atomic,
-        ETXTBSY_RETRY_ATTEMPTS,
     };
+    #[cfg(unix)]
+    use super::{ETXTBSY_RAW_OS_ERROR, ETXTBSY_RETRY_ATTEMPTS};
 
     struct DropMarker(Arc<AtomicBool>);
 

--- a/src/claude_code_executor.rs
+++ b/src/claude_code_executor.rs
@@ -36,7 +36,9 @@ use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
 use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, HostBridge, SteerInbox};
-use bamboo_subagent::executor_util::{render_history_preamble, write_json_atomic};
+use bamboo_subagent::executor_util::{
+    render_history_preamble, spawn_with_etxtbsy_retry, write_json_atomic,
+};
 use bamboo_subagent::proto::RunSpec;
 
 /// Upper bound on a single stdout NDJSON line. Tool results can be huge (the
@@ -644,7 +646,7 @@ impl ClaudeCodeExecutor {
     ) -> (ChildOutcome, bool) {
         let permission_mode_override = Some(self.mapped_permission_mode(permission));
         let mut child = match spawn_with_etxtbsy_retry(|| {
-            self.build_command(resume_id, permission_mode_override)
+            Ok(self.build_command(resume_id, permission_mode_override))
         })
         .await
         {
@@ -901,29 +903,6 @@ impl ChildExecutor for ClaudeCodeExecutor {
         steer_drain.abort();
         outcome
     }
-}
-
-/// Spawn with a short retry on `ETXTBSY` ("text file busy", raw os error 26
-/// on Linux). On Linux, exec-ing an executable that was written moments ago
-/// can transiently fail when ANOTHER thread in this process still holds a
-/// write fd to it at fork time (the fd is inherited across fork until the
-/// exec). In production the `claude` binary is never freshly written, so
-/// this never fires; in the stub-binary test suite, parallel test threads
-/// each writing their own stub make it a real (observed-on-CI) flake. A few
-/// 10ms retries are a complete cure and harmless otherwise.
-async fn spawn_with_etxtbsy_retry(mut build: impl FnMut() -> Command) -> std::io::Result<Child> {
-    let mut last_err = None;
-    for _ in 0..5 {
-        match build().spawn() {
-            Ok(child) => return Ok(child),
-            Err(e) if e.raw_os_error() == Some(26) => {
-                last_err = Some(e);
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-            Err(e) => return Err(e),
-        }
-    }
-    Err(last_err.expect("retry loop always records an error before exhausting"))
 }
 
 /// Which signal [`signal_process_group`] sends.

--- a/src/codex_app_server_executor.rs
+++ b/src/codex_app_server_executor.rs
@@ -24,7 +24,9 @@ use tokio_util::sync::CancellationToken;
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
 use bamboo_subagent::codex_discovery::discover_codex_app_server;
 use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, HostBridge, SteerInbox};
-use bamboo_subagent::executor_util::{build_rehydrated_turn, write_json_atomic};
+use bamboo_subagent::executor_util::{
+    build_rehydrated_turn, spawn_with_etxtbsy_retry, write_json_atomic,
+};
 use bamboo_subagent::proto::RunSpec;
 
 use crate::codex_cli_executor::{
@@ -381,12 +383,15 @@ impl CodexAppServerExecutor {
 
     async fn start_connection(&self) -> Result<AppServerConnection, String> {
         self.prepare_auth_home().await?;
-        let mut child = self.build_command()?.spawn().map_err(|error| {
-            format!(
-                "spawn Codex app-server '{}': {error}",
-                self.binary.display()
-            )
-        })?;
+        let mut child =
+            spawn_with_etxtbsy_retry(|| self.build_command().map_err(std::io::Error::other))
+                .await
+                .map_err(|error| {
+                    format!(
+                        "spawn Codex app-server '{}': {error}",
+                        self.binary.display()
+                    )
+                })?;
         let stdin = child
             .stdin
             .take()

--- a/src/codex_cli_executor.rs
+++ b/src/codex_cli_executor.rs
@@ -27,7 +27,9 @@ use tokio_util::sync::CancellationToken;
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
 use bamboo_subagent::codex_discovery::discover_codex_cli;
 use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, SteerInbox};
-use bamboo_subagent::executor_util::{build_rehydrated_turn, write_json_atomic};
+use bamboo_subagent::executor_util::{
+    build_rehydrated_turn, spawn_with_etxtbsy_retry, write_json_atomic,
+};
 use bamboo_subagent::proto::RunSpec;
 
 /// The oldest Codex CLI schema this executor intentionally supports. The
@@ -1175,6 +1177,7 @@ impl CodexExecutor {
 
         let mut child = match spawn_with_etxtbsy_retry(|| {
             self.build_command(run_provider_token, &policy, resume_id)
+                .map_err(std::io::Error::other)
         })
         .await
         {
@@ -1905,25 +1908,6 @@ fn validate_codex_forward_env(mode: CodexAuthMode, names: &[String]) -> Result<(
         return Err("OPENAI_API_KEY may only be forwarded in Codex api_key auth mode".to_string());
     }
     Ok(())
-}
-
-async fn spawn_with_etxtbsy_retry(
-    mut build: impl FnMut() -> Result<Command, String>,
-) -> Result<Child, String> {
-    let mut last_error = None;
-    for _ in 0..5 {
-        match build()?.spawn() {
-            Ok(child) => return Ok(child),
-            Err(error) if error.raw_os_error() == Some(26) => {
-                last_error = Some(error);
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-            Err(error) => return Err(error.to_string()),
-        }
-    }
-    Err(last_error
-        .expect("retry loop records ETXTBSY before exhausting")
-        .to_string())
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary

- centralize the bounded Unix `ETXTBSY` retry policy in `bamboo-subagent`
- wrap the complete Codex discovery retry future in the existing 10-second overall timeout
- reuse the same spawn policy for Codex exec, Codex app-server, and Claude Code while preserving actionable command context
- cover transient success, retry exhaustion, fail-fast errors, and caller cancellation deterministically

Closes #859

## Rebase provenance

- rebased without conflicts onto `dev@9583ef3dd4770ff17e37ad58d03f08b1b9407da1` after #864 merged
- post-rebase head: `46854ebc7b3a129b0f684a9d988dd518ff4f6eff`
- stable patch-id/range-diff matches the previously reviewed implementation; the final diff remains the same five executor/discovery files and no #864 stability repair was rewritten or dropped

## Test Plan

Local exact-head verification:

- `cargo fmt --all -- --check`
- `cargo test --locked -p bamboo-subagent --lib executor_util -- --nocapture` — 7/7
- `cargo test --locked -p bamboo-subagent --lib codex_discovery -- --nocapture` — 2/2
- original `subprocess_stub_completes_full_handshake_and_allow_path` regression — 1/1, plus 40/40 over 8 concurrent exact-binary workers
- Rust 1.98 CI-equivalent strict workspace Clippy — pass
- Rust 1.95 `cargo check --locked --workspace --all-targets --all-features` — pass
- `git diff --check`

Remote exact-head verification:

- protected PR CI run `32432208544` — success, including required Test/E2E/Lint, MSRV, three-platform TLS, audit/deny/docs, and real SSH/SFTP
- CodeQL run `32432205676` — success for Actions, JavaScript/TypeScript, Python, and Rust
- full workflow-dispatch matrix `32432246592` — success, including Test plus macOS/Windows/Ubuntu release builds
- raw Test logs execute the full handshake, parallel server detection, and all four ETXTBSY retry/cancellation regressions in both workspace passes
- fresh independent exact-head review after all runs complete

## Screenshots

Not applicable; backend process-spawn reliability change.
