### PR TITLE
fix: restore Rust 1.98 lint compatibility (#862)

### DIFF
--- a/crates/app/bamboo-server/src/server/tests.rs
+++ b/crates/app/bamboo-server/src/server/tests.rs
@@ -98,6 +98,7 @@ where
 #[derive(Default)]
 struct DrainState {
     calls: AtomicUsize,
+    completed: AtomicUsize,
     started: Notify,
     release: Notify,
 }
@@ -106,6 +107,7 @@ async fn blocking_drain_handler(state: web::Data<DrainState>) -> HttpResponse {
     state.calls.fetch_add(1, Ordering::SeqCst);
     state.started.notify_one();
     state.release.notified().await;
+    state.completed.fetch_add(1, Ordering::SeqCst);
     HttpResponse::Ok().body("completed-current-request")
 }
 
@@ -210,10 +212,26 @@ async fn graceful_stop_finishes_current_request_without_starting_buffered_reques
     let mut stream = TcpStream::connect(("127.0.0.1", port))
         .await
         .expect("connect pipelined keep-alive client");
+    // Complete one request on the connection that will carry active and queued
+    // work. This is the connection-local lifecycle barrier used by Actix's own
+    // graceful-drain regression: it proves that the dispatcher has completed a
+    // full request/response cycle and entered keep-alive before shutdown races
+    // with the next pipelined request.
+    stream
+        .write_all(b"GET /idle HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")
+        .await
+        .expect("establish active keep-alive connection");
+    let active_idle_response = read_http_response_head(&mut stream).await;
+    assert!(
+        active_idle_response.starts_with(b"HTTP/1.1 200"),
+        "unexpected active-connection warmup response: {}",
+        String::from_utf8_lossy(&active_idle_response)
+    );
+
     stream
         .write_all(
             b"GET /current HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n\
-              GET /queued HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+              GET /queued HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n",
         )
         .await
         .expect("buffer two HTTP requests");
@@ -278,6 +296,11 @@ async fn graceful_stop_finishes_current_request_without_starting_buffered_reques
             .windows(b"completed-current-request".len())
             .any(|window| window == b"completed-current-request"),
         "the in-flight request must complete before the connection drains"
+    );
+    assert_eq!(
+        state.completed.load(Ordering::SeqCst),
+        1,
+        "the in-flight handler must finish exactly once before its response drains"
     );
     assert_eq!(
         state.calls.load(Ordering::SeqCst),
@@ -351,11 +374,11 @@ async fn rustls_server_is_http11_secure_wss_and_never_negotiates_h2() {
     let mut unsafe_alpn = rustls.clone();
     unsafe_alpn.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
     let (unsafe_listener, _) = test_listener();
-    let unsafe_error =
-        match build_h1_server(|| App::new(), vec![unsafe_listener], 1, Some(unsafe_alpn)) {
-            Ok(_) => panic!("an H1 dispatcher must reject a config that advertises h2"),
-            Err(error) => error,
-        };
+    let unsafe_error = match build_h1_server(App::new, vec![unsafe_listener], 1, Some(unsafe_alpn))
+    {
+        Ok(_) => panic!("an H1 dispatcher must reject a config that advertises h2"),
+        Err(error) => error,
+    };
     assert_eq!(unsafe_error.kind(), std::io::ErrorKind::InvalidInput);
     assert!(unsafe_error.to_string().contains("only ALPN http/1.1"));
 

--- a/crates/app/bamboo-tui/src/file_change.rs
+++ b/crates/app/bamboo-tui/src/file_change.rs
@@ -606,7 +606,7 @@ fn parse_hunk_header(line: &str) -> Option<(usize, usize, usize, usize)> {
 
 fn parse_range(value: &str, prefix: char) -> Option<(usize, usize)> {
     let value = value.strip_prefix(prefix)?;
-    let (start, count) = value.split_once(',').map_or((value, "1"), |parts| parts);
+    let (start, count) = value.split_once(',').unwrap_or((value, "1"));
     Some((start.parse().ok()?, count.parse().ok()?))
 }
 

--- a/crates/engine/bamboo-engine/src/events/account_sink.rs
+++ b/crates/engine/bamboo-engine/src/events/account_sink.rs
@@ -958,16 +958,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
         let invalid = config_invalid("mcp", 7);
-        sink.record(None, &invalid);
-        sink.record(None, &invalid);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(sink.record_confirmed(None, &invalid).await);
+        assert!(sink.record_confirmed(None, &invalid).await);
         assert_eq!(journal::read_since(sink.events_dir(), 0).unwrap().len(), 1);
         drop(sink);
-        tokio::time::sleep(Duration::from_millis(20)).await;
 
         let restarted = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
-        restarted.record(None, &invalid);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(restarted.record_confirmed(None, &invalid).await);
         assert_eq!(
             journal::read_since(restarted.events_dir(), 0)
                 .unwrap()
@@ -976,10 +973,17 @@ mod tests {
             "same failure stays deduped after watcher/sink restart"
         );
 
-        restarted.record(None, &config_recovered("mcp", 7));
-        restarted.record(None, &invalid);
-        restarted.record(None, &config_changed("mcp", 7));
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            restarted
+                .record_confirmed(None, &config_recovered("mcp", 7))
+                .await
+        );
+        assert!(restarted.record_confirmed(None, &invalid).await);
+        assert!(
+            restarted
+                .record_confirmed(None, &config_changed("mcp", 7))
+                .await
+        );
         let events = journal::read_since(restarted.events_dir(), 0).unwrap();
         assert_eq!(events.len(), 4);
         assert!(matches!(

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -1105,7 +1105,7 @@ pub(super) async fn execute_llm_stream(
         Err(failure) => {
             let appended = append_interrupted_assistant_output(
                 session,
-                failure.partial_output,
+                *failure.partial_output,
                 &failure.error,
             );
             if appended {

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -224,7 +224,9 @@ impl From<&bamboo_agent_core::tools::PartialToolCall> for PartialToolCallSnapsho
 /// interrupted assistant record instead of losing already-visible output.
 pub(crate) struct StreamHandlingFailure {
     pub error: AgentError,
-    pub partial_output: InterruptedStreamOutput,
+    /// Failures are already the cold path; boxing the three-buffer snapshot
+    /// keeps this error small without changing the preserved fragment data.
+    pub partial_output: Box<InterruptedStreamOutput>,
 }
 
 pub async fn consume_llm_stream(

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
@@ -111,7 +111,7 @@ pub(super) async fn consume_llm_stream_internal_with_partial(
             _ = cancel_token.cancelled() => {
                 return Err(StreamHandlingFailure {
                     error: AgentError::Cancelled,
-                    partial_output: state.into_interrupted_output(),
+                    partial_output: Box::new(state.into_interrupted_output()),
                 });
             },
             next = stream.next() => match next {
@@ -135,7 +135,7 @@ pub(super) async fn consume_llm_stream_internal_with_partial(
                         last_transport_at,
                         last_semantic_at,
                     ),
-                    partial_output: state.into_interrupted_output(),
+                    partial_output: Box::new(state.into_interrupted_output()),
                 });
             }
         };
@@ -160,7 +160,7 @@ pub(super) async fn consume_llm_stream_internal_with_partial(
                         last_transport_at,
                         last_semantic_at,
                     ),
-                    partial_output: state.into_interrupted_output(),
+                    partial_output: Box::new(state.into_interrupted_output()),
                 });
             }
         }
@@ -170,7 +170,7 @@ pub(super) async fn consume_llm_stream_internal_with_partial(
         {
             return Err(StreamHandlingFailure {
                 error,
-                partial_output: state.into_interrupted_output(),
+                partial_output: Box::new(state.into_interrupted_output()),
             });
         }
     }

--- a/crates/infra/bamboo-hooks/src/configured.rs
+++ b/crates/infra/bamboo-hooks/src/configured.rs
@@ -2062,17 +2062,27 @@ esac
         );
     }
 
+    async fn auto_powershell_runtime_is_available() -> bool {
+        match Command::new("pwsh").arg("--version").output().await {
+            Ok(output) => output.status.success(),
+            Err(error) if error.kind() == ErrorKind::NotFound => Command::new("powershell")
+                .args([
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    "$PSVersionTable.PSVersion",
+                ])
+                .output()
+                .await
+                .is_ok_and(|output| output.status.success()),
+            Err(_) => false,
+        }
+    }
+
     #[tokio::test]
     async fn powershell_script_executes_when_a_system_runtime_is_installed() {
-        let pwsh_available = Command::new("pwsh").arg("--version").output().await.is_ok();
-        let windows_powershell_available = Command::new("powershell")
-            .arg("-NoLogo")
-            .arg("-Command")
-            .arg("$PSVersionTable.PSVersion")
-            .output()
-            .await
-            .is_ok();
-        if !pwsh_available && !windows_powershell_available {
+        if !auto_powershell_runtime_is_available().await {
             return;
         }
 
@@ -2089,7 +2099,11 @@ $null = [Console]::In.ReadToEnd()
             LifecycleHookEvent::SessionStart,
             path,
             LifecycleScriptRunner::Auto,
-            3_000,
+            // PowerShell cold starts can exceed a few seconds on a loaded CI
+            // runner. Keep this functional contract below the 60-second
+            // production default without coupling it to the dedicated
+            // millisecond-scale timeout and process-cleanup regressions.
+            30_000,
             None,
         );
 

--- a/crates/infra/bamboo-subagent/src/transport.rs
+++ b/crates/infra/bamboo-subagent/src/transport.rs
@@ -37,19 +37,55 @@ use crate::proto::{ChildFrame, ParentFrame, RunSpec};
 /// them on [`ParentFrame::ApprovalReply`]).
 type PendingReplies = Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum TransportError {
-    #[error("io: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("ws: {0}")]
-    Ws(#[from] tokio_tungstenite::tungstenite::Error),
-    #[error("decode: {0}")]
-    Decode(#[from] serde_json::Error),
-    #[error("protocol: {0}")]
+    Io(std::io::Error),
+    Ws(Box<tokio_tungstenite::tungstenite::Error>),
+    Decode(serde_json::Error),
     Protocol(String),
     /// TLS configuration / handshake failure (bad cert/key, provider, etc.).
-    #[error("tls: {0}")]
     Tls(String),
+}
+
+impl std::fmt::Display for TransportError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "io: {error}"),
+            Self::Ws(error) => write!(formatter, "ws: {error}"),
+            Self::Decode(error) => write!(formatter, "decode: {error}"),
+            Self::Protocol(message) => write!(formatter, "protocol: {message}"),
+            Self::Tls(message) => write!(formatter, "tls: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for TransportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Ws(error) => Some(error.as_ref()),
+            Self::Decode(error) => Some(error),
+            Self::Protocol(_) | Self::Tls(_) => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for TransportError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for TransportError {
+    fn from(error: tokio_tungstenite::tungstenite::Error) -> Self {
+        Self::Ws(Box::new(error))
+    }
+}
+
+impl From<serde_json::Error> for TransportError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Decode(error)
+    }
 }
 
 pub type TransportResult<T> = Result<T, TransportError>;
@@ -629,7 +665,7 @@ impl ChildClient {
         tls_config: Option<rustls::ClientConfig>,
     ) -> TransportResult<Self> {
         use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-        let mut request = endpoint.into_client_request().map_err(TransportError::Ws)?;
+        let mut request = endpoint.into_client_request()?;
         if let Some(token) = token {
             let value = format!("Bearer {token}")
                 .parse()
@@ -707,6 +743,65 @@ mod tests {
     use super::*;
     use crate::executor::EchoExecutor;
     use crate::proto::{ChildFrame, TerminalStatus};
+
+    #[test]
+    fn transport_error_conversions_preserve_diagnostics_and_sources() {
+        let io_source = std::io::Error::other("socket unavailable");
+        let io_error = TransportError::from(io_source);
+        assert_eq!(io_error.to_string(), "io: socket unavailable");
+        assert!(
+            std::error::Error::source(&io_error)
+                .and_then(|source| source.downcast_ref::<std::io::Error>())
+                .is_some(),
+            "the concrete IO error type must remain discoverable"
+        );
+
+        let decode_source = serde_json::from_str::<serde_json::Value>("{")
+            .expect_err("the fixture must be invalid JSON");
+        let decode_message = decode_source.to_string();
+        let decode_error = TransportError::from(decode_source);
+        assert_eq!(
+            decode_error.to_string(),
+            format!("decode: {decode_message}")
+        );
+        assert!(
+            std::error::Error::source(&decode_error)
+                .and_then(|source| source.downcast_ref::<serde_json::Error>())
+                .is_some(),
+            "the concrete JSON error type must remain discoverable"
+        );
+
+        let websocket_source = tokio_tungstenite::tungstenite::Error::ConnectionClosed;
+        let websocket_message = websocket_source.to_string();
+        let websocket_error = TransportError::from(websocket_source);
+
+        assert_eq!(
+            websocket_error.to_string(),
+            format!("ws: {websocket_message}")
+        );
+        let reported_source = std::error::Error::source(&websocket_error)
+            .expect("the boxed WebSocket error remains the transport error source");
+        assert_eq!(reported_source.to_string(), websocket_message);
+        assert!(
+            reported_source
+                .downcast_ref::<tokio_tungstenite::tungstenite::Error>()
+                .is_some(),
+            "the concrete WebSocket error type must remain discoverable"
+        );
+        assert!(matches!(
+            websocket_error,
+            TransportError::Ws(inner)
+                if matches!(*inner, tokio_tungstenite::tungstenite::Error::ConnectionClosed)
+        ));
+
+        let protocol_error = TransportError::Protocol("unexpected frame".to_string());
+        assert_eq!(protocol_error.to_string(), "protocol: unexpected frame");
+        assert!(std::error::Error::source(&protocol_error).is_none());
+
+        let tls_error = TransportError::Tls("bad certificate".to_string());
+        assert_eq!(tls_error.to_string(), "tls: bad certificate");
+        assert!(std::error::Error::source(&tls_error).is_none());
+    }
 
     /// In-process server + client over a real loopback socket (no subprocess).
     #[tokio::test]


### PR DESCRIPTION
## Summary

- restore the Rust 1.98 CI lint contract without adding workspace-wide lint exemptions
- keep TransportError diagnostics and concrete error sources intact while boxing the large WebSocket error variant
- keep interrupted stream fragments intact while moving the cold-path snapshot behind a Box, and apply the direct Rust 1.98 standard-library rewrites
- include independently reviewed deterministic Test-gate repairs for H1 graceful drain (#865), account-sink durability across restart (#860), and PowerShell cold-start coverage (#863)

## Stacked repairs

- PR #866 merged the reviewed #865 and #860 test repairs into this branch at e17406f261e4c953cb6ce55b689be3dddb07857b.
- PR #868 merged the reviewed #863 PowerShell test repair at final head 3729c334db999fa5d5f118068171d1de11ef0e6c.
- The final merge commit tree is byte-identical to reviewed #868 head acf8ed2814d568cb361665570b76f609083a7485; the merge introduced no conflict rewrite or extra file.
- Issues #865, #860, and #863 intentionally remained open while their PRs targeted this non-default branch. This dev-target PR closes them only after the complete stack reaches dev.

Closes #862
Closes #865
Closes #860
Closes #863

## Test Plan

### Rust 1.98 compatibility

- Rust 1.98 strict workspace Clippy with the repository CI allowlist
- bamboo-subagent, bamboo-engine, and bamboo-tui affected suites
- Rust 1.95 all-target/all-feature checks
- workspace all-target/all-feature check, fmt, and diff-check

### Deterministic gate repairs

- #865/#860 exact combined run 32416973424: Test/E2E/Lint/MSRV, three-platform release Build and TLS, audit, cargo-deny, docs, real SSH/SFTP all successful; H1 and account-sink targets passed in both workspace invocations
- #863 exact run 32423545343: same complete matrix successful; installed PowerShell target passed cold and warm workspace invocations, hooks 32/32 each
- local full cargo test --locked --tests on the final tree: complete exit 0, including config 694/694, engine 1377/1377, server 1858 passed + 1 ignored, and TUI 432/432
- intermediate e17406f2 dev-target PR CI run 32423111788: successful

### Final exact head

- protected PR CI run 32428015977 at 3729c334db999fa5d5f118068171d1de11ef0e6c
- full workflow_dispatch matrix run 32428100610 at the same exact head
- fresh independent exact-head review after both runs complete

## Screenshots

N/A — Rust error-representation and deterministic backend test changes with no UI behavior change.