### PR TITLE
test(server): stabilize graceful drain lifecycle barrier (#865)

### DIFF
--- a/crates/app/bamboo-server/src/server/tests.rs
+++ b/crates/app/bamboo-server/src/server/tests.rs
@@ -98,6 +98,7 @@ where
 #[derive(Default)]
 struct DrainState {
     calls: AtomicUsize,
+    completed: AtomicUsize,
     started: Notify,
     release: Notify,
 }
@@ -106,6 +107,7 @@ async fn blocking_drain_handler(state: web::Data<DrainState>) -> HttpResponse {
     state.calls.fetch_add(1, Ordering::SeqCst);
     state.started.notify_one();
     state.release.notified().await;
+    state.completed.fetch_add(1, Ordering::SeqCst);
     HttpResponse::Ok().body("completed-current-request")
 }
 
@@ -210,10 +212,26 @@ async fn graceful_stop_finishes_current_request_without_starting_buffered_reques
     let mut stream = TcpStream::connect(("127.0.0.1", port))
         .await
         .expect("connect pipelined keep-alive client");
+    // Complete one request on the connection that will carry active and queued
+    // work. This is the connection-local lifecycle barrier used by Actix's own
+    // graceful-drain regression: it proves that the dispatcher has completed a
+    // full request/response cycle and entered keep-alive before shutdown races
+    // with the next pipelined request.
+    stream
+        .write_all(b"GET /idle HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")
+        .await
+        .expect("establish active keep-alive connection");
+    let active_idle_response = read_http_response_head(&mut stream).await;
+    assert!(
+        active_idle_response.starts_with(b"HTTP/1.1 200"),
+        "unexpected active-connection warmup response: {}",
+        String::from_utf8_lossy(&active_idle_response)
+    );
+
     stream
         .write_all(
             b"GET /current HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n\
-              GET /queued HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+              GET /queued HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n",
         )
         .await
         .expect("buffer two HTTP requests");
@@ -278,6 +296,11 @@ async fn graceful_stop_finishes_current_request_without_starting_buffered_reques
             .windows(b"completed-current-request".len())
             .any(|window| window == b"completed-current-request"),
         "the in-flight request must complete before the connection drains"
+    );
+    assert_eq!(
+        state.completed.load(Ordering::SeqCst),
+        1,
+        "the in-flight handler must finish exactly once before its response drains"
     );
     assert_eq!(
         state.calls.load(Ordering::SeqCst),
@@ -351,11 +374,11 @@ async fn rustls_server_is_http11_secure_wss_and_never_negotiates_h2() {
     let mut unsafe_alpn = rustls.clone();
     unsafe_alpn.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
     let (unsafe_listener, _) = test_listener();
-    let unsafe_error =
-        match build_h1_server(|| App::new(), vec![unsafe_listener], 1, Some(unsafe_alpn)) {
-            Ok(_) => panic!("an H1 dispatcher must reject a config that advertises h2"),
-            Err(error) => error,
-        };
+    let unsafe_error = match build_h1_server(App::new, vec![unsafe_listener], 1, Some(unsafe_alpn))
+    {
+        Ok(_) => panic!("an H1 dispatcher must reject a config that advertises h2"),
+        Err(error) => error,
+    };
     assert_eq!(unsafe_error.kind(), std::io::ErrorKind::InvalidInput);
     assert!(unsafe_error.to_string().contains("only ALPN http/1.1"));
 

--- a/crates/engine/bamboo-engine/src/events/account_sink.rs
+++ b/crates/engine/bamboo-engine/src/events/account_sink.rs
@@ -958,16 +958,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
         let invalid = config_invalid("mcp", 7);
-        sink.record(None, &invalid);
-        sink.record(None, &invalid);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(sink.record_confirmed(None, &invalid).await);
+        assert!(sink.record_confirmed(None, &invalid).await);
         assert_eq!(journal::read_since(sink.events_dir(), 0).unwrap().len(), 1);
         drop(sink);
-        tokio::time::sleep(Duration::from_millis(20)).await;
 
         let restarted = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
-        restarted.record(None, &invalid);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(restarted.record_confirmed(None, &invalid).await);
         assert_eq!(
             journal::read_since(restarted.events_dir(), 0)
                 .unwrap()
@@ -976,10 +973,17 @@ mod tests {
             "same failure stays deduped after watcher/sink restart"
         );
 
-        restarted.record(None, &config_recovered("mcp", 7));
-        restarted.record(None, &invalid);
-        restarted.record(None, &config_changed("mcp", 7));
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            restarted
+                .record_confirmed(None, &config_recovered("mcp", 7))
+                .await
+        );
+        assert!(restarted.record_confirmed(None, &invalid).await);
+        assert!(
+            restarted
+                .record_confirmed(None, &config_changed("mcp", 7))
+                .await
+        );
         let events = journal::read_since(restarted.events_dir(), 0).unwrap();
         assert_eq!(events.len(), 4);
         assert!(matches!(


### PR DESCRIPTION
## Summary

- complete a request/response cycle on the active HTTP/1.1 connection before racing graceful shutdown, matching the upstream Actix connection-lifecycle barrier
- assert the in-flight handler completes exactly once while the already-buffered request never enters the application service
- keep the queued request on keep-alive so graceful shutdown is the only close cause, and remove a pre-existing redundant test closure without adding lint allowances
- incorporate the separately reviewed #860 durability-barrier repair so the required workspace Test gate no longer relies on fixed account-sink sleeps

## Stacking

- This PR is intentionally based on #864 / #862 (`bamboo/fix/862-box-websocket-error`).
- #865 removes the nondeterministic H1 Test gate blocking #864; #860/PR #867 separately removes the account-sink timing gate discovered while validating this exact stack.
- PR #867 was independently reviewed and merged into this branch as `2147f2540966e8d84eec9cc3089b984743e15785`.
- This combined exact head must pass a fresh full CI run and independent review before merge into the #862 branch. Then #864 will be rerun and exact-head reviewed against `dev`.

## Test Plan

### H1 drain regression

- `cargo +1.98.0 test --locked -p bamboo-server --lib` twice: 1858 passed, 0 failed, 1 ignored on each run
- graceful-drain regression stress: two independent 400-run, 16-way batches; 400/400 passed in each batch
- negative proof: temporarily removed both production graceful-shutdown signal hooks; the new regression failed at the idle-EOF barrier within its 3-second bound; production hooks were restored before commit
- `cargo +1.98.0 test --locked -p bamboo-server --lib server::tests::`: 5 passed

### Account-sink dependency gate (#860)

- focused exact test: 1/1
- two independent 400-run, 16-way stress batches: 800/800, with no fixed sleeps
- `cargo +1.98.0 test --locked -p bamboo-engine --lib`: 1377/1377
- official exact-head #867 CI run 32411974762: all Test/E2E/Lint/MSRV/three-platform Build+TLS/audit/deny/docs gates green

### Shared gates

- strict workspace Clippy with the repository CI allowlist
- strict `bamboo-server` Clippy including lib tests
- Rust 1.95 all-target/all-feature check
- `cargo +1.98.0 fmt --all -- --check`
- `git diff --check`
- fresh combined-head official CI: run 32416973424

## Screenshots

N/A — deterministic backend test-only changes.

Closes #865 once this stacked commit reaches `dev`.
