### PR TITLE
test(engine): confirm account sink restart transitions (#860)

### DIFF
--- a/crates/engine/bamboo-engine/src/events/account_sink.rs
+++ b/crates/engine/bamboo-engine/src/events/account_sink.rs
@@ -958,16 +958,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sink = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
         let invalid = config_invalid("mcp", 7);
-        sink.record(None, &invalid);
-        sink.record(None, &invalid);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(sink.record_confirmed(None, &invalid).await);
+        assert!(sink.record_confirmed(None, &invalid).await);
         assert_eq!(journal::read_since(sink.events_dir(), 0).unwrap().len(), 1);
         drop(sink);
-        tokio::time::sleep(Duration::from_millis(20)).await;
 
         let restarted = AccountEventSink::new(dir.path().to_path_buf()).unwrap();
-        restarted.record(None, &invalid);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(restarted.record_confirmed(None, &invalid).await);
         assert_eq!(
             journal::read_since(restarted.events_dir(), 0)
                 .unwrap()
@@ -976,10 +973,17 @@ mod tests {
             "same failure stays deduped after watcher/sink restart"
         );
 
-        restarted.record(None, &config_recovered("mcp", 7));
-        restarted.record(None, &invalid);
-        restarted.record(None, &config_changed("mcp", 7));
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            restarted
+                .record_confirmed(None, &config_recovered("mcp", 7))
+                .await
+        );
+        assert!(restarted.record_confirmed(None, &invalid).await);
+        assert!(
+            restarted
+                .record_confirmed(None, &config_changed("mcp", 7))
+                .await
+        );
         let events = journal::read_since(restarted.events_dir(), 0).unwrap();
         assert_eq!(events.len(), 4);
         assert!(matches!(


### PR DESCRIPTION
## Summary

- replace fire-and-forget account-sink writes and fixed 20–50 ms sleeps in the restart/dedupe regression with `record_confirmed()` durability barriers
- confirm every expected transition before inspecting the journal while preserving the restart dedupe and exact event-order assertions
- keep production `AccountEventSink` behavior unchanged

## Stack relationship

This PR is intentionally stacked on #866 (`bamboo/fix/865-deterministic-h1-drain`). The #860 race is the only failure in #866's exact-head official Test workflow. After this PR is reviewed and merged into that branch, #866 will be rerun and independently reviewed at its new exact head before it advances into #864 and then `dev`.

## Test Plan

- `cargo +1.98.0 test --locked -p bamboo-engine --lib events::account_sink::tests::config_health_state_dedupes_only_consecutive_same_kind_across_restart -- --exact`
- direct compiled-test stress: two independent 400-run batches at 16-way concurrency (800/800 passed, no wall-clock sleeps)
- `cargo +1.98.0 test --locked -p bamboo-engine --lib` twice (1377/1377 each)
- `cargo +1.98.0 test --locked --tests` (full workspace gate passed)
- strict workspace Clippy using the CI deny/allow set
- `cargo +1.95.0 check --locked --workspace --all-targets --all-features`
- `cargo +1.98.0 fmt --all -- --check`
- `git diff --check`

## Screenshots

N/A — deterministic backend test-only change.

Closes #860
