### PR TITLE
test(hooks): stabilize PowerShell runtime coverage (#863)

### DIFF
--- a/crates/infra/bamboo-hooks/src/configured.rs
+++ b/crates/infra/bamboo-hooks/src/configured.rs
@@ -2062,17 +2062,27 @@ esac
         );
     }
 
+    async fn auto_powershell_runtime_is_available() -> bool {
+        match Command::new("pwsh").arg("--version").output().await {
+            Ok(output) => output.status.success(),
+            Err(error) if error.kind() == ErrorKind::NotFound => Command::new("powershell")
+                .args([
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    "$PSVersionTable.PSVersion",
+                ])
+                .output()
+                .await
+                .is_ok_and(|output| output.status.success()),
+            Err(_) => false,
+        }
+    }
+
     #[tokio::test]
     async fn powershell_script_executes_when_a_system_runtime_is_installed() {
-        let pwsh_available = Command::new("pwsh").arg("--version").output().await.is_ok();
-        let windows_powershell_available = Command::new("powershell")
-            .arg("-NoLogo")
-            .arg("-Command")
-            .arg("$PSVersionTable.PSVersion")
-            .output()
-            .await
-            .is_ok();
-        if !pwsh_available && !windows_powershell_available {
+        if !auto_powershell_runtime_is_available().await {
             return;
         }
 
@@ -2089,7 +2099,11 @@ $null = [Console]::In.ReadToEnd()
             LifecycleHookEvent::SessionStart,
             path,
             LifecycleScriptRunner::Auto,
-            3_000,
+            // PowerShell cold starts can exceed a few seconds on a loaded CI
+            // runner. Keep this functional contract below the 60-second
+            // production default without coupling it to the dedicated
+            // millisecond-scale timeout and process-cleanup regressions.
+            30_000,
             None,
         );
 


### PR DESCRIPTION
## Summary

- require the Auto-selected PowerShell runtime version probe to start and exit successfully before treating it as installed
- mirror production fallback semantics by probing Windows PowerShell only when pwsh is not found, while preserving the pwsh-first invocation order
- give only the functional PowerShell JSON-contract test a 30-second cold-start budget; production defaults and dedicated timeout/process-cleanup regressions remain unchanged

## Stacking

- This PR is intentionally based on PR #864 / Issue #862 at e17406f261e4c953cb6ce55b689be3dddb07857b.
- It removes the known PowerShell Test-gate debt discovered while validating PR #861 / Issue #859.
- After independent review and exact-head gates, this commit will merge into the #862 branch; PR #864 will then receive fresh exact-head CI and review before entering dev.

Closes #863 once this stacked commit reaches dev.

## Test Plan

- cargo +1.98.0 test --locked -p bamboo-hooks --lib: 32/32
- focused PowerShell target: 1/1 locally; local host has no PowerShell and returns immediately
- official exact-head Test job 96600557337: installed-runtime target explicitly passed in both workspace invocations; cold hooks suite 32/32 in 5.92s and warm suite 32/32 in 1.23s
- dedicated timeout/process-tree regressions: 3/3 with their original millisecond-scale budgets
- local cargo +1.98.0 test --locked --tests: full workspace exit 0, including config 694/694, engine 1377/1377, server 1858 passed + 1 ignored, and TUI 432/432
- strict bamboo-hooks test Clippy with the repository allowlist
- cargo +1.95.0 check --locked -p bamboo-hooks --all-targets --all-features
- Windows GNU bamboo-hooks test cross-check passed on the installed Rust 1.97 target; only unchanged infrastructure cfg warnings
- cargo +1.98.0 fmt --all -- --check
- git diff --check
- official exact-head workflow_dispatch run 32423545343: Test, E2E, Lint, MSRV, Ubuntu/macOS/Windows release builds and TLS fixtures, audit, cargo-deny, docs, and real SSH/SFTP fixture all successful

## Screenshots

N/A — test-only backend determinism change.