### PR TITLE
feat: expose typed workflow UI contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "governor",
  "hex",
  "http 1.5.0",
+ "libc",
  "mockall",
  "native-tls",
  "notify",

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -107,6 +107,7 @@ anyhow = "1"
 parking_lot = "0.12"
 dashmap = "6"
 fs2 = "0.4"
+libc = "0.2"
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "form", "query", "native-tls", "charset", "http2", "system-proxy"] }
 reqwest-middleware = { version = "0.5", features = ["json", "form"] }
 reqwest-retry = "0.9"

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -450,8 +450,11 @@ impl AppState {
         // owns handles to both maps.
         spawn_session_map_cleanup_task(agent_runners.clone(), session_event_senders.clone(), None);
 
-        // Bridge global workflow catalog transitions onto the same durable account feed used by
-        // SSE and v2 WebSocket clients. Catalog events are account-scoped (no session id).
+        // Bridge both instruction-Skill and orchestration catalog transitions
+        // onto the same durable account feed used by SSE and v2 WebSocket
+        // clients. The product-level Workflow Library unifies both kinds, so a
+        // change to either namespace must invalidate clients immediately.
+        // Catalog events are account-scoped (no session id).
         {
             let mut workflow_events = skill_manager.store().subscribe_workflow_catalog();
             let account_sink = account_sink.clone();
@@ -465,9 +468,6 @@ impl AppState {
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     };
-                    if !event.public_workflow {
-                        continue;
-                    }
                     let event = match event.kind {
                         bamboo_skills::WorkflowCatalogEventKind::Changed => {
                             AgentEvent::WorkflowChanged {

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -44,14 +44,23 @@ fn sync_runtime_workspace(
 /// non-reentrant lock again. A plain storage save is safe because the chat
 /// transaction owns the lock from its authoritative reload through its final
 /// message checkpoint.
+async fn persist_and_cache_session_locked(
+    state: &AppState,
+    session: &bamboo_agent_core::Session,
+) -> std::io::Result<()> {
+    state.persistence.storage().save_session(session).await?;
+    state.sessions.insert(
+        session.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+    );
+    Ok(())
+}
+
 async fn save_and_cache_session_locked(
     state: &AppState,
     session: &bamboo_agent_core::Session,
 ) -> Result<(), HttpResponse> {
-    state
-        .persistence
-        .storage()
-        .save_session(session)
+    persist_and_cache_session_locked(state, session)
         .await
         .map_err(|error| {
             HttpResponse::InternalServerError().json(serde_json::json!({
@@ -59,12 +68,35 @@ async fn save_and_cache_session_locked(
                     "Failed to persist chat session: {error}"
                 ))
             }))
-        })?;
-    state.sessions.insert(
-        session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        })
+}
+
+fn publish_committed_chat(state: &web::Data<AppState>, session: &bamboo_agent_core::Session) {
+    if let Some(message) = session.messages.last() {
+        state.account_sink.record(
+            Some(&session.id),
+            &bamboo_agent_core::AgentEvent::MessageAppended {
+                session_id: session.id.clone(),
+                message_id: message.id.clone(),
+                role: message.role.clone(),
+                content: message.content.clone(),
+                created_at: message.created_at,
+            },
+        );
+    }
+
+    tracing::debug!(
+        "[{}] Chat turn persisted: messages={}, last_role={:?} -> client should now POST /execute",
+        session.id,
+        session.messages.len(),
+        session
+            .messages
+            .last()
+            .map(|message| format!("{:?}", message.role)),
     );
-    Ok(())
+    if !session.title_generated {
+        crate::title_gen::spawn_title_generation(state.clone().into_inner(), session.id.clone());
+    }
 }
 
 fn project_context_error_response(
@@ -212,6 +244,15 @@ fn workflow_selection_error_response(
     }))
 }
 
+fn workflow_catalog_unavailable_response(error: &bamboo_skills::SkillError) -> HttpResponse {
+    tracing::error!(%error, "failed to pin typed workflow catalog revision");
+    workflow_selection_error_response(bamboo_skills::WorkflowActivationDiagnostic {
+        code: bamboo_skills::WorkflowActivationErrorCode::SnapshotUnavailable,
+        message: "Workflow catalog is temporarily unavailable; retry the request".to_string(),
+        recoverable: true,
+    })
+}
+
 async fn pin_explicit_workflow_candidate(
     state: &AppState,
     session: &mut bamboo_agent_core::Session,
@@ -239,12 +280,7 @@ async fn pin_explicit_workflow_candidate(
                 context.workspace.as_deref(),
             )
             .await
-            .map_err(|error| {
-                crate::error::json_error(
-                    actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
-                    format!("Workflow catalog is unavailable: {error}"),
-                )
-            })?;
+            .map_err(|error| workflow_catalog_unavailable_response(&error))?;
         let activation = state
             .skill_manager
             .resolve_and_pin_activation_in_project_workspace_with_mode_and_budget(
@@ -261,16 +297,22 @@ async fn pin_explicit_workflow_candidate(
             .await;
         (store, activation)
     } else if let Some(workspace) = workspace.as_deref() {
+        // A session-scoped fallback is previewed without filesystem mutation.
+        // Materialize it before opening the workspace catalog, but do not
+        // publish it into runtime state until the base session checkpoint is
+        // durable below. The resolver refuses to recreate missing paths
+        // outside its authoritative root.
+        state
+            .workspace_resolver
+            .materialize_resolved_workspace(workspace)
+            .map_err(|error| {
+                workflow_catalog_unavailable_response(&bamboo_skills::SkillError::Io(error))
+            })?;
         let store = state
             .skill_manager
             .store_for_workspace(Some(workspace))
             .await
-            .map_err(|error| {
-                crate::error::json_error(
-                    actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
-                    format!("Workflow catalog is unavailable: {error}"),
-                )
-            })?;
+            .map_err(|error| workflow_catalog_unavailable_response(&error))?;
         let activation = state
             .skill_manager
             .resolve_and_pin_activation_in_workspace_with_mode_and_budget(
@@ -289,12 +331,7 @@ async fn pin_explicit_workflow_candidate(
             .skill_manager
             .store_for_workspace(None)
             .await
-            .map_err(|error| {
-                crate::error::json_error(
-                    actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
-                    format!("Workflow catalog is unavailable: {error}"),
-                )
-            })?;
+            .map_err(|error| workflow_catalog_unavailable_response(&error))?;
         let activation = state
             .skill_manager
             .resolve_and_pin_activation_for_request_with_mode_and_budget(
@@ -315,15 +352,7 @@ async fn pin_explicit_workflow_candidate(
                 .skill_manager
                 .release_activation_for_workspace(&staging_activation_id, workspace.as_deref())
                 .await;
-            return Err(workflow_selection_error_response(
-                bamboo_skills::WorkflowActivationDiagnostic {
-                    code: bamboo_skills::WorkflowActivationErrorCode::RevisionMissing,
-                    message: format!(
-                        "selected workflow could not be pinned at its catalog revision: {error}"
-                    ),
-                    recoverable: true,
-                },
-            ));
+            return Err(workflow_catalog_unavailable_response(&error));
         }
     };
     let snapshot = match store
@@ -358,6 +387,237 @@ async fn pin_explicit_workflow_candidate(
         return Err(workflow_selection_error_response(diagnostic));
     }
     Ok(staging_activation_id)
+}
+
+struct StagedWorkflowActivation {
+    activation_id: String,
+    metadata_upserts: Vec<(String, String)>,
+    metadata_removals: Vec<String>,
+    skill_manager: std::sync::Arc<bamboo_skills::SkillManager>,
+    cleanup_armed: bool,
+}
+
+impl Drop for StagedWorkflowActivation {
+    fn drop(&mut self) {
+        if !self.cleanup_armed {
+            return;
+        }
+        let skill_manager = self.skill_manager.clone();
+        let activation_id = self.activation_id.clone();
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                let _cleanup = handle.spawn(async move {
+                    if let Err(error) = skill_manager
+                        .release_activation_for_workspace(&activation_id, None)
+                        .await
+                    {
+                        tracing::error!(
+                            %activation_id,
+                            %error,
+                            "failed to release abandoned staged Workflow activation"
+                        );
+                    }
+                });
+            }
+            Err(error) => {
+                tracing::error!(
+                    activation_id = %self.activation_id,
+                    %error,
+                    "runtime unavailable while releasing staged Workflow activation"
+                );
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct WorkflowMetadataCheckpoint {
+    entries: std::collections::HashMap<String, String>,
+}
+
+impl WorkflowMetadataCheckpoint {
+    fn capture(session: Option<&bamboo_agent_core::Session>) -> Self {
+        let entries = session
+            .into_iter()
+            .flat_map(|session| session.metadata.iter())
+            .filter(|(key, _)| workflow_transaction_metadata_key(key))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        Self { entries }
+    }
+
+    fn restore(&self, session: &mut bamboo_agent_core::Session) {
+        session
+            .metadata
+            .retain(|key, _| !workflow_transaction_metadata_key(key));
+        session.metadata.extend(self.entries.clone());
+    }
+}
+
+fn workflow_transaction_metadata_key(key: &str) -> bool {
+    key.starts_with("workflow.")
+        || key.starts_with("skill_runtime_")
+        || matches!(key, "selected_skill_ids" | "skill_mode")
+}
+
+fn workflow_runner_is_active(runner: Option<&crate::app_state::AgentRunner>) -> bool {
+    runner.is_some_and(|runner| {
+        matches!(
+            runner.status,
+            crate::app_state::AgentStatus::Pending | crate::app_state::AgentStatus::Running
+        )
+    })
+}
+
+fn workflow_activation_running_conflict_response(session_id: &str) -> HttpResponse {
+    HttpResponse::Conflict().json(serde_json::json!({
+        "error": {
+            "type": "api_error",
+            "code": "workflow_activation_running_conflict",
+            "message": "A running or starting session cannot replace its active Workflow"
+        },
+        "session_id": session_id,
+    }))
+}
+
+#[cfg(test)]
+struct WorkflowCommitTestBarrier {
+    reached: tokio::sync::Semaphore,
+    resume: tokio::sync::Semaphore,
+}
+
+#[cfg(test)]
+impl Default for WorkflowCommitTestBarrier {
+    fn default() -> Self {
+        Self {
+            reached: tokio::sync::Semaphore::new(0),
+            resume: tokio::sync::Semaphore::new(0),
+        }
+    }
+}
+
+#[cfg(test)]
+static WORKFLOW_COMMIT_TEST_BARRIERS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<WorkflowCommitTestBarrier>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+#[cfg(test)]
+static WORKFLOW_POST_SAVE_TEST_BARRIERS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<WorkflowCommitTestBarrier>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+#[cfg(test)]
+fn install_workflow_commit_test_barrier(
+    session_id: &str,
+) -> std::sync::Arc<WorkflowCommitTestBarrier> {
+    let barrier = std::sync::Arc::new(WorkflowCommitTestBarrier::default());
+    WORKFLOW_COMMIT_TEST_BARRIERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(session_id.to_string(), barrier.clone());
+    barrier
+}
+
+#[cfg(test)]
+async fn wait_at_workflow_commit_test_barrier(session_id: &str) {
+    let barrier = WORKFLOW_COMMIT_TEST_BARRIERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .remove(session_id);
+    if let Some(barrier) = barrier {
+        barrier.reached.add_permits(1);
+        barrier
+            .resume
+            .acquire()
+            .await
+            .expect("workflow commit test barrier remains open")
+            .forget();
+    }
+}
+
+#[cfg(test)]
+fn install_workflow_post_save_test_barrier(
+    session_id: &str,
+) -> std::sync::Arc<WorkflowCommitTestBarrier> {
+    let barrier = std::sync::Arc::new(WorkflowCommitTestBarrier::default());
+    WORKFLOW_POST_SAVE_TEST_BARRIERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(session_id.to_string(), barrier.clone());
+    barrier
+}
+
+#[cfg(test)]
+async fn wait_at_workflow_post_save_test_barrier(session_id: &str) {
+    let barrier = WORKFLOW_POST_SAVE_TEST_BARRIERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .remove(session_id);
+    if let Some(barrier) = barrier {
+        barrier.reached.add_permits(1);
+        barrier
+            .resume
+            .acquire()
+            .await
+            .expect("workflow post-save test barrier remains open")
+            .forget();
+    }
+}
+
+impl StagedWorkflowActivation {
+    fn between(
+        activation_id: String,
+        current: &std::collections::HashMap<String, String>,
+        candidate: &std::collections::HashMap<String, String>,
+        skill_manager: std::sync::Arc<bamboo_skills::SkillManager>,
+    ) -> Self {
+        let metadata_upserts = candidate
+            .iter()
+            .filter(|(key, value)| {
+                workflow_transaction_metadata_key(key) && current.get(*key) != Some(*value)
+            })
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let metadata_removals = current
+            .keys()
+            .filter(|key| workflow_transaction_metadata_key(key) && !candidate.contains_key(*key))
+            .cloned()
+            .collect();
+        Self {
+            activation_id,
+            metadata_upserts,
+            metadata_removals,
+            skill_manager,
+            cleanup_armed: true,
+        }
+    }
+
+    fn apply(&self, metadata: &mut std::collections::HashMap<String, String>) {
+        for key in &self.metadata_removals {
+            metadata.remove(key);
+        }
+        for (key, value) in &self.metadata_upserts {
+            metadata.insert(key.clone(), value.clone());
+        }
+    }
+
+    async fn release(&mut self) {
+        if !self.cleanup_armed {
+            return;
+        }
+        match self
+            .skill_manager
+            .release_activation_for_workspace(&self.activation_id, None)
+            .await
+        {
+            Ok(()) => self.cleanup_armed = false,
+            Err(error) => tracing::error!(
+                activation_id = %self.activation_id,
+                %error,
+                "failed to release staged Workflow activation"
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -628,6 +888,7 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
         return project_context_error_response(error);
     }
     let workspace_was_explicit = req.workspace_path.is_some();
+    let requested_workflow_selection = req.workflow_selection.clone();
     let mut input = bamboo_engine::session_app::types::ChatTurnInput {
         session_id: session_id.clone(),
         project_id: effective_project_id,
@@ -646,8 +907,15 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
             .then(|| project_preflight.workspace_path_meta())
             .flatten(),
         default_workspace_path: configured_default_workspace,
-        selected_skill_ids: req.selected_skill_ids.clone(),
-        workflow_selection: req.workflow_selection.clone(),
+        selected_skill_ids: if requested_workflow_selection.is_some() {
+            None
+        } else {
+            req.selected_skill_ids.clone()
+        },
+        // A typed selection is resolved into a separate candidate below. The
+        // authoritative session must retain its current activation until every
+        // fallible hook, attachment and message write in this request succeeds.
+        workflow_selection: None,
         orchestration_opt_in: req.orchestration_opt_in,
         copilot_conclusion_with_options_enhancement_enabled: req
             .copilot_conclusion_with_options_enhancement_enabled,
@@ -659,6 +927,20 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     // same lock and therefore cannot slip between the second load and a stale
     // chat snapshot save.
     let persistence_guard = state.persistence.acquire_lock(&session_id).await;
+    // Reject an already-running session before doing catalog or hook work. A
+    // second check immediately before publication below closes the race with a
+    // reservation that appears while this request is being prepared.
+    if requested_workflow_selection.is_some() {
+        let runners = state.agent_runners.read().await;
+        let runner_is_active = workflow_runner_is_active(runners.get(&session_id));
+        let startup_is_active = crate::handlers::agent::events::execute_startup_is_in_flight(
+            state.as_ref(),
+            &session_id,
+        );
+        if runner_is_active || startup_is_active {
+            return workflow_activation_running_conflict_response(&session_id);
+        }
+    }
     let authoritative_session = match state.persistence.storage().load_session(&session_id).await {
         Ok(session) => session,
         Err(error) => {
@@ -669,6 +951,8 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
             );
         }
     };
+    let workflow_metadata_checkpoint =
+        WorkflowMetadataCheckpoint::capture(authoritative_session.as_ref());
     let authoritative_workspace_present = authoritative_session.as_ref().is_some_and(|session| {
         session.workspace_path_meta().is_some()
             && session
@@ -783,44 +1067,51 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     {
         return project_context_error_response(error);
     }
-    let staged_workflow_activation = if let Some(selection) = req.workflow_selection.as_ref() {
-        let disabled_skill_ids = config_snapshot.disabled_skill_ids();
-        let staging_id = match pin_explicit_workflow_candidate(
-            state.as_ref(),
-            &mut session,
-            selection,
-            &disabled_skill_ids,
-        )
-        .await
-        {
-            Ok(staging_id) => staging_id,
-            Err(response) => return response,
+    let mut staged_workflow_activation =
+        if let Some(selection) = requested_workflow_selection.as_ref() {
+            let mut candidate = session.clone();
+            if let Err(error) = bamboo_engine::session_app::chat::resolve_workflow_selection(
+                &mut candidate,
+                Some(selection),
+                req.selected_skill_ids.as_deref(),
+                &req.message,
+            ) {
+                return HttpResponse::BadRequest().json(serde_json::json!({
+                    "error": crate::error::error_value(error.to_string())
+                }));
+            }
+            let disabled_skill_ids = config_snapshot.disabled_skill_ids();
+            let staging_id = match pin_explicit_workflow_candidate(
+                state.as_ref(),
+                &mut candidate,
+                selection,
+                &disabled_skill_ids,
+            )
+            .await
+            {
+                Ok(staging_id) => staging_id,
+                Err(response) => return response,
+            };
+            Some(StagedWorkflowActivation::between(
+                staging_id,
+                &session.metadata,
+                &candidate.metadata,
+                state.skill_manager.clone(),
+            ))
+        } else {
+            None
         };
-        Some(staging_id)
-    } else {
-        None
-    };
-    if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
-        if let Some(staging_id) = staged_workflow_activation.as_deref() {
-            let _ = state
-                .skill_manager
-                .release_activation_for_workspace(staging_id, None)
-                .await;
+    // Publish the prepared checkpoint without any speculative Workflow
+    // normalization. The in-memory turn keeps those changes for a successful
+    // final commit, while every rejected/failing path continues to expose the
+    // exact pre-request Workflow authority.
+    let mut durable_base = session.clone();
+    workflow_metadata_checkpoint.restore(&mut durable_base);
+    if let Err(response) = save_and_cache_session_locked(state.as_ref(), &durable_base).await {
+        if let Some(staging) = staged_workflow_activation.as_mut() {
+            staging.release().await;
         }
         return response;
-    }
-    if let Some(staging_id) = staged_workflow_activation.as_deref() {
-        // The durable exact snapshot now owns the next execution. Remove any
-        // prior live activation only after that commit, then drop staging. A
-        // subsequent execute restores from the persisted candidate bytes.
-        let _ = state
-            .skill_manager
-            .release_activation_for_workspace(&session.id, None)
-            .await;
-        let _ = state
-            .skill_manager
-            .release_activation_for_workspace(staging_id, None)
-            .await;
     }
     sync_runtime_workspace(
         state.as_ref(),
@@ -851,7 +1142,11 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     {
         Ok(message) => message,
         Err(reason) => {
+            if let Some(staging) = staged_workflow_activation.as_mut() {
+                staging.release().await;
+            }
             // Persist the hook checkpoint but never the rejected user message.
+            workflow_metadata_checkpoint.restore(&mut session);
             if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
                 return response;
             }
@@ -872,9 +1167,39 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
         // Goal metadata writers acquire the same per-session lock and load the
         // latest durable session themselves. The prepared checkpoint is
         // already durable, so hand ownership over before invoking them.
+        if let Some(staging) = staged_workflow_activation.as_mut() {
+            staging.release().await;
+        }
         drop(persistence_guard);
         return handle_goal_command(state.as_ref(), &session_id, &goal_cmd).await;
     }
+
+    #[cfg(test)]
+    wait_at_workflow_commit_test_barrier(&session_id).await;
+
+    // A typed activation replaces both durable Workflow metadata and the
+    // session-id keyed immutable skill pin. Re-check after all fallible hook
+    // work, then retain the runners read guard through attachment persistence,
+    // the final session save and pin handoff. The persistence lock linearizes
+    // HTTP execute startup; the runners guard closes reservation races from
+    // resume, schedule and connect entry points.
+    let workflow_commit_guard = if staged_workflow_activation.is_some() {
+        let runners = state.agent_runners.clone().read_owned().await;
+        let runner_is_active = workflow_runner_is_active(runners.get(&session_id));
+        let startup_is_active = crate::handlers::agent::events::execute_startup_is_in_flight(
+            state.as_ref(),
+            &session_id,
+        );
+        if runner_is_active || startup_is_active {
+            if let Some(staging) = staged_workflow_activation.as_mut() {
+                staging.release().await;
+            }
+            return workflow_activation_running_conflict_response(&session_id);
+        }
+        Some(runners)
+    } else {
+        None
+    };
 
     // Image handling stays in the handler layer (depends on AppState attachment reader).
     if let Err(response) = images::append_user_message(
@@ -885,46 +1210,74 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     )
     .await
     {
+        if let Some(staging) = staged_workflow_activation.as_mut() {
+            staging.release().await;
+        }
         return response;
     }
 
-    // Re-save to persist image attachments (if any).
-    if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
-        return response;
-    }
+    if let Some(mut staging) = staged_workflow_activation {
+        staging.apply(&mut session.metadata);
+        let commit_state = state.clone();
+        let commit_session_id = session_id.clone();
+        let commit = tokio::spawn(async move {
+            // These owned guards make the exact save -> pin handoff
+            // cancellation-resistant. Dropping the caller's HTTP future only
+            // detaches this task; it cannot expose committed B metadata while
+            // the session-id pin still serves A.
+            let _persistence_guard = persistence_guard;
+            let _workflow_commit_guard = workflow_commit_guard;
+            if let Err(error) =
+                persist_and_cache_session_locked(commit_state.as_ref(), &session).await
+            {
+                staging.release().await;
+                return Err(error.to_string());
+            }
+            #[cfg(test)]
+            wait_at_workflow_post_save_test_barrier(&commit_session_id).await;
 
-    // Publish the user message onto the account change feed so other clients
-    // see it without reloading history. The feed seq becomes the message's
-    // delta coordinate for `GET /history?since`.
-    if let Some(msg) = session.messages.last() {
-        state.account_sink.record(
-            Some(&session_id),
-            &bamboo_agent_core::AgentEvent::MessageAppended {
-                session_id: session_id.clone(),
-                message_id: msg.id.clone(),
-                role: msg.role.clone(),
-                content: msg.content.clone(),
-                created_at: msg.created_at,
-            },
-        );
-    }
-
-    tracing::debug!(
-        "[{}] Chat turn persisted: messages={}, last_role={:?} -> client should now POST /execute",
-        session_id,
-        session.messages.len(),
-        session.messages.last().map(|m| format!("{:?}", m.role)),
-    );
-    let should_generate_title = !session.title_generated;
-    drop(persistence_guard);
-
-    // Start title generation immediately after the user message is durable.
-    // This is intentionally independent of POST /execute and assistant-stream
-    // completion. Failed/no-text attempts leave the lifecycle pending, so a
-    // later durable user message can retry; the in-flight guard deduplicates
-    // overlapping chat requests.
-    if should_generate_title {
-        crate::title_gen::spawn_title_generation(state.clone().into_inner(), session_id.clone());
+            // The durable user turn and exact snapshot now own the next
+            // execution. Only now may the prior live activation be released.
+            if let Err(error) = commit_state
+                .skill_manager
+                .release_activation_for_workspace(&commit_session_id, None)
+                .await
+            {
+                tracing::error!(
+                    session_id = %commit_session_id,
+                    %error,
+                    "failed to release prior Workflow activation after commit"
+                );
+            }
+            staging.release().await;
+            publish_committed_chat(&commit_state, &session);
+            Ok::<(), String>(())
+        });
+        match commit.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                return HttpResponse::InternalServerError().json(serde_json::json!({
+                    "error": crate::error::error_value(format!(
+                        "Failed to persist chat session: {error}"
+                    ))
+                }));
+            }
+            Err(error) => {
+                tracing::error!(%error, "typed Workflow chat commit task failed");
+                return crate::error::json_error(
+                    actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to commit typed Workflow chat",
+                );
+            }
+        }
+    } else {
+        // Re-save to persist image attachments (if any).
+        if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
+            return response;
+        }
+        drop(workflow_commit_guard);
+        publish_committed_chat(&state, &session);
+        drop(persistence_guard);
     }
 
     HttpResponse::Created().json(ChatResponse {

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -162,6 +162,204 @@ fn project_context_error_response(
     }
 }
 
+fn workflow_selection_error_response(
+    diagnostic: bamboo_skills::WorkflowActivationDiagnostic,
+) -> HttpResponse {
+    use bamboo_skills::WorkflowActivationErrorCode;
+
+    let (status, code) = match diagnostic.code {
+        WorkflowActivationErrorCode::RevisionMissing => (
+            actix_web::http::StatusCode::CONFLICT,
+            "workflow_revision_missing",
+        ),
+        WorkflowActivationErrorCode::RevisionMismatch => (
+            actix_web::http::StatusCode::CONFLICT,
+            "workflow_revision_mismatch",
+        ),
+        WorkflowActivationErrorCode::SourceMismatch => (
+            actix_web::http::StatusCode::CONFLICT,
+            "workflow_source_mismatch",
+        ),
+        WorkflowActivationErrorCode::ManualOnly => (
+            actix_web::http::StatusCode::UNPROCESSABLE_ENTITY,
+            "workflow_manual_only",
+        ),
+        WorkflowActivationErrorCode::InvalidSelection => (
+            actix_web::http::StatusCode::UNPROCESSABLE_ENTITY,
+            "workflow_selection_invalid",
+        ),
+        WorkflowActivationErrorCode::SnapshotUnavailable => (
+            actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
+            "workflow_snapshot_unavailable",
+        ),
+        WorkflowActivationErrorCode::SnapshotTooLarge => (
+            actix_web::http::StatusCode::PAYLOAD_TOO_LARGE,
+            "workflow_snapshot_too_large",
+        ),
+        WorkflowActivationErrorCode::ProviderFailed
+        | WorkflowActivationErrorCode::ProviderOutputInvalid => (
+            actix_web::http::StatusCode::UNPROCESSABLE_ENTITY,
+            "workflow_context_invalid",
+        ),
+    };
+    HttpResponse::build(status).json(serde_json::json!({
+        "error": {
+            "type": "api_error",
+            "code": code,
+            "message": diagnostic.message,
+            "recoverable": diagnostic.recoverable
+        }
+    }))
+}
+
+async fn pin_explicit_workflow_candidate(
+    state: &AppState,
+    session: &mut bamboo_agent_core::Session,
+    selection: &bamboo_skills::WorkflowSelection,
+    disabled_skill_ids: &std::collections::BTreeSet<String>,
+) -> Result<String, HttpResponse> {
+    let selected_ids = [selection.id.clone()];
+    // Resolve into an isolated staging activation. A stale/invalid request must
+    // never replace or release the activation currently serving this session.
+    // The staged bytes become durable authority only after the session save;
+    // execute then restores them under the canonical session id.
+    let staging_activation_id = format!("{}:chat-candidate:{}", session.id, uuid::Uuid::new_v4());
+    let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+    let resolved_project = state
+        .project_context_resolver
+        .resolve(session, workspace.as_deref())
+        .await
+        .map_err(project_context_error_response)?;
+    let (store, activation) = if let Some(context) = resolved_project {
+        let store = state
+            .skill_manager
+            .store_for_project_workspace(
+                &context.project.id,
+                &context.project.home,
+                context.workspace.as_deref(),
+            )
+            .await
+            .map_err(|error| {
+                crate::error::json_error(
+                    actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
+                    format!("Workflow catalog is unavailable: {error}"),
+                )
+            })?;
+        let activation = state
+            .skill_manager
+            .resolve_and_pin_activation_in_project_workspace_with_mode_and_budget(
+                &context.project.id,
+                &context.project.home,
+                context.workspace.as_deref(),
+                &staging_activation_id,
+                disabled_skill_ids,
+                Some(&selected_ids),
+                None,
+                None,
+                bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+            )
+            .await;
+        (store, activation)
+    } else if let Some(workspace) = workspace.as_deref() {
+        let store = state
+            .skill_manager
+            .store_for_workspace(Some(workspace))
+            .await
+            .map_err(|error| {
+                crate::error::json_error(
+                    actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
+                    format!("Workflow catalog is unavailable: {error}"),
+                )
+            })?;
+        let activation = state
+            .skill_manager
+            .resolve_and_pin_activation_in_workspace_with_mode_and_budget(
+                workspace,
+                &staging_activation_id,
+                disabled_skill_ids,
+                Some(&selected_ids),
+                None,
+                None,
+                bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+            )
+            .await;
+        (store, activation)
+    } else {
+        let store = state
+            .skill_manager
+            .store_for_workspace(None)
+            .await
+            .map_err(|error| {
+                crate::error::json_error(
+                    actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
+                    format!("Workflow catalog is unavailable: {error}"),
+                )
+            })?;
+        let activation = state
+            .skill_manager
+            .resolve_and_pin_activation_for_request_with_mode_and_budget(
+                &staging_activation_id,
+                disabled_skill_ids,
+                Some(&selected_ids),
+                None,
+                None,
+                bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+            )
+            .await;
+        (store, activation)
+    };
+    let activation = match activation {
+        Ok(activation) => activation,
+        Err(error) => {
+            let _ = state
+                .skill_manager
+                .release_activation_for_workspace(&staging_activation_id, workspace.as_deref())
+                .await;
+            return Err(workflow_selection_error_response(
+                bamboo_skills::WorkflowActivationDiagnostic {
+                    code: bamboo_skills::WorkflowActivationErrorCode::RevisionMissing,
+                    message: format!(
+                        "selected workflow could not be pinned at its catalog revision: {error}"
+                    ),
+                    recoverable: true,
+                },
+            ));
+        }
+    };
+    let snapshot = match store
+        .export_activation_snapshot(&staging_activation_id)
+        .await
+    {
+        Some(snapshot) => snapshot,
+        None => {
+            let _ = state
+                .skill_manager
+                .release_activation_for_workspace(&staging_activation_id, workspace.as_deref())
+                .await;
+            return Err(workflow_selection_error_response(
+                bamboo_skills::WorkflowActivationDiagnostic {
+                    code: bamboo_skills::WorkflowActivationErrorCode::SnapshotUnavailable,
+                    message: "selected workflow snapshot could not be retained".to_string(),
+                    recoverable: true,
+                },
+            ));
+        }
+    };
+    if let Err(diagnostic) = bamboo_skills::persist_explicit_workflow_candidate(
+        &mut session.metadata,
+        selection,
+        &activation,
+        &snapshot,
+    ) {
+        let _ = state
+            .skill_manager
+            .release_activation_for_workspace(&staging_activation_id, workspace.as_deref())
+            .await;
+        return Err(workflow_selection_error_response(diagnostic));
+    }
+    Ok(staging_activation_id)
+}
+
 #[cfg(test)]
 mod tests;
 
@@ -585,8 +783,44 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     {
         return project_context_error_response(error);
     }
+    let staged_workflow_activation = if let Some(selection) = req.workflow_selection.as_ref() {
+        let disabled_skill_ids = config_snapshot.disabled_skill_ids();
+        let staging_id = match pin_explicit_workflow_candidate(
+            state.as_ref(),
+            &mut session,
+            selection,
+            &disabled_skill_ids,
+        )
+        .await
+        {
+            Ok(staging_id) => staging_id,
+            Err(response) => return response,
+        };
+        Some(staging_id)
+    } else {
+        None
+    };
     if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
+        if let Some(staging_id) = staged_workflow_activation.as_deref() {
+            let _ = state
+                .skill_manager
+                .release_activation_for_workspace(staging_id, None)
+                .await;
+        }
         return response;
+    }
+    if let Some(staging_id) = staged_workflow_activation.as_deref() {
+        // The durable exact snapshot now owns the next execution. Remove any
+        // prior live activation only after that commit, then drop staging. A
+        // subsequent execute restores from the persisted candidate bytes.
+        let _ = state
+            .skill_manager
+            .release_activation_for_workspace(&session.id, None)
+            .await;
+        let _ = state
+            .skill_manager
+            .release_activation_for_workspace(staging_id, None)
+            .await;
     }
     sync_runtime_workspace(
         state.as_ref(),

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -8,6 +8,105 @@ use bamboo_engine::session_app::chat::{
     resolve_selected_skill_ids, resolve_workspace_path,
 };
 
+#[actix_web::test]
+async fn typed_workflow_candidate_is_pinned_exactly_and_stale_revision_fails_closed() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+    let state = crate::AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state");
+    let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+    let review = catalog
+        .entries
+        .iter()
+        .find(|entry| entry.id == "review" && entry.winner)
+        .expect("builtin review catalog entry");
+    let selection = bamboo_skills::WorkflowSelection {
+        id: review.id.clone(),
+        source: review.source,
+        revision: review.revision,
+        args: serde_json::json!({}),
+    };
+    let mut session = Session::new("typed-review", "model");
+    let staging_id = super::pin_explicit_workflow_candidate(
+        &state,
+        &mut session,
+        &selection,
+        &std::collections::BTreeSet::new(),
+    )
+    .await
+    .expect("pin exact typed Workflow");
+
+    let snapshot: bamboo_skills::SkillActivationSnapshot = serde_json::from_str(
+        session
+            .metadata
+            .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY)
+            .expect("durable pre-execute snapshot"),
+    )
+    .expect("snapshot contract");
+    assert_eq!(snapshot.skills.len(), 1);
+    assert_eq!(snapshot.skills["review"].revision, review.revision);
+    assert_eq!(
+        session
+            .metadata
+            .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY)
+            .map(String::as_str),
+        Some("explicit")
+    );
+    let request_identity = serde_json::to_string(&selection).expect("selection JSON");
+    assert!(!request_identity.contains(&review.description));
+    assert!(!request_identity.contains("prompt"));
+
+    state
+        .skill_manager
+        .release_activation_for_workspace(&staging_id, None)
+        .await
+        .expect("release exact candidate");
+
+    let existing_ids = ["plan".to_string()];
+    let existing = state
+        .skill_manager
+        .resolve_and_pin_activation_for_request_with_mode_and_budget(
+            "typed-review-stale",
+            &std::collections::BTreeSet::new(),
+            Some(&existing_ids),
+            None,
+            None,
+            bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+        )
+        .await
+        .expect("existing live activation");
+    let mut stale_session = Session::new("typed-review-stale", "model");
+    let stale = bamboo_skills::WorkflowSelection {
+        revision: review.revision + 1,
+        ..selection
+    };
+    let response = super::pin_explicit_workflow_candidate(
+        &state,
+        &mut stale_session,
+        &stale,
+        &std::collections::BTreeSet::new(),
+    )
+    .await
+    .expect_err("stale revision must fail before chat persistence");
+    assert_eq!(response.status(), actix_web::http::StatusCode::CONFLICT);
+    assert!(!stale_session
+        .metadata
+        .contains_key(bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY));
+    assert!(stale_session.messages.is_empty());
+    let retained = state
+        .skill_manager
+        .pinned_activation_for_workspace("typed-review-stale", None)
+        .await
+        .expect("inspect existing activation")
+        .expect("failed request must retain existing activation");
+    assert_eq!(
+        retained.descriptor.skill_revisions,
+        existing.descriptor.skill_revisions
+    );
+    assert_eq!(retained.skills[0].id, "plan");
+}
+
 /// Regression: `/goal off` and `/goal clear` must clear the stale runtime
 /// `goal.state` (status / continuation budget / double-check eval history).
 /// Previously the cleanup was gated behind `should_resume`, so only

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -107,6 +107,66 @@ async fn typed_workflow_candidate_is_pinned_exactly_and_stale_revision_fails_clo
     assert_eq!(retained.skills[0].id, "plan");
 }
 
+#[actix_web::test]
+async fn typed_workflow_capacity_failure_is_sanitized_and_retryable() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+    let state = crate::AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state");
+    let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+    let review = catalog
+        .entries
+        .iter()
+        .find(|entry| entry.id == "review" && entry.winner)
+        .expect("builtin review");
+    for index in 0..256 {
+        state
+            .skill_manager
+            .pin_current_activation_for_workspace(
+                &format!("capacity-{index}"),
+                None,
+                &["plan".to_string()],
+                None,
+            )
+            .await
+            .expect("fill activation capacity");
+    }
+    let selection = bamboo_skills::WorkflowSelection {
+        id: review.id.clone(),
+        source: review.source,
+        revision: review.revision,
+        args: serde_json::json!({}),
+    };
+    let mut session = Session::new("capacity-overflow", "model");
+    let response = super::pin_explicit_workflow_candidate(
+        &state,
+        &mut session,
+        &selection,
+        &std::collections::BTreeSet::new(),
+    )
+    .await
+    .expect_err("capacity exhaustion must fail closed");
+    assert_eq!(
+        response.status(),
+        actix_web::http::StatusCode::SERVICE_UNAVAILABLE
+    );
+    let body = actix_web::body::to_bytes(response.into_body())
+        .await
+        .expect("response body");
+    let body: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+    assert_eq!(body["error"]["code"], "workflow_snapshot_unavailable");
+    assert_eq!(
+        body["error"]["message"],
+        "Workflow catalog is temporarily unavailable; retry the request"
+    );
+    let rendered = body.to_string();
+    assert!(!rendered.contains("capacity"));
+    assert!(!rendered.contains(temp_dir.path().to_string_lossy().as_ref()));
+    assert!(session.metadata.is_empty());
+    assert!(session.messages.is_empty());
+}
+
 /// Regression: `/goal off` and `/goal clear` must clear the stale runtime
 /// `goal.state` (status / continuation budget / double-check eval history).
 /// Previously the cleanup was gated behind `should_resume`, so only
@@ -454,10 +514,84 @@ mod optional_model_e2e {
     use crate::routes::configure_routes;
     use crate::AppState;
 
+    const CONCURRENCY_ASSERT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
     async fn new_state() -> web::Data<AppState> {
         let temp_dir = tempdir().expect("tempdir").keep();
         bamboo_config::paths::init_bamboo_dir(temp_dir.clone());
         web::Data::new(AppState::new(temp_dir).await.expect("app state"))
+    }
+
+    async fn seed_active_instruction_workflow(
+        state: &web::Data<AppState>,
+        session_id: &str,
+        workflow_id: &str,
+    ) -> bamboo_skills::WorkflowSelection {
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let entry = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == workflow_id && entry.winner)
+            .expect("builtin instruction Workflow")
+            .clone();
+        let selection = bamboo_skills::WorkflowSelection {
+            id: entry.id.clone(),
+            source: entry.source,
+            revision: entry.revision,
+            args: serde_json::json!({}),
+        };
+        let ids = [entry.id.clone()];
+        let activation = state
+            .skill_manager
+            .resolve_and_pin_activation_for_request_with_mode_and_budget(
+                session_id,
+                &std::collections::BTreeSet::new(),
+                Some(&ids),
+                None,
+                None,
+                bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+            )
+            .await
+            .expect("pin canonical live activation");
+        let snapshot = state
+            .skill_manager
+            .store()
+            .export_activation_snapshot(session_id)
+            .await
+            .expect("export canonical activation snapshot");
+        let mut session = Session::new(session_id, "test-model");
+        session.metadata.insert(
+            bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY.to_string(),
+            serde_json::to_string(&selection).expect("selection JSON"),
+        );
+        bamboo_skills::persist_explicit_workflow_candidate(
+            &mut session.metadata,
+            &selection,
+            &activation,
+            &snapshot,
+        )
+        .expect("persist exact candidate");
+        bamboo_skills::record_loaded_workflow_activation(
+            &mut session.metadata,
+            workflow_id,
+            format!("sha256:{workflow_id}"),
+        )
+        .expect("publish active Workflow");
+        state.save_and_cache_session(&mut session).await;
+        selection
+    }
+
+    fn workflow_runtime_metadata(session: &Session) -> std::collections::BTreeMap<String, String> {
+        session
+            .metadata
+            .iter()
+            .filter(|(key, _)| {
+                key.starts_with("workflow.")
+                    || key.starts_with("skill_runtime_")
+                    || key.as_str() == "selected_skill_ids"
+            })
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect()
     }
 
     struct BlockingTitleProvider {
@@ -989,8 +1123,9 @@ mod optional_model_e2e {
                 .to_request(),
         )
         .await;
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let status = response.status();
         let body: Value = test::read_body_json(response).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
         assert_eq!(body["error"]["code"], "workspace_invalid");
         assert!(state
             .storage
@@ -1388,8 +1523,23 @@ mod optional_model_e2e {
     }
 
     #[actix_web::test]
-    async fn user_prompt_submit_block_returns_reason_and_persists_no_user_message() {
+    async fn user_prompt_submit_block_preserves_existing_workflow_and_persists_no_user_message() {
         let state = new_state().await;
+        let session_id = "blocked-user-prompt";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let before = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        let expected_workflow_metadata = workflow_runtime_metadata(&before);
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
         {
             let mut config = state.config.write().await;
             config.lifecycle_hooks = bamboo_config::LifecycleHooksConfig {
@@ -1417,22 +1567,29 @@ mod optional_model_e2e {
             test::TestRequest::post()
                 .uri("/api/v1/chat")
                 .set_json(serde_json::json!({
-                    "session_id": "blocked-user-prompt",
+                    "session_id": session_id,
                     "message": "must not persist",
-                    "model": "test-model"
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {}
+                    }
                 }))
                 .to_request(),
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let status = response.status();
         let body: Value = test::read_body_json(response).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
         assert!(body.to_string().contains("prompt rejected by policy"));
         assert_eq!(body["hook_event"], "UserPromptSubmit");
 
         let session = state
             .storage
-            .load_session("blocked-user-prompt")
+            .load_session(session_id)
             .await
             .expect("load")
             .expect("prepared session is persisted for hook observability");
@@ -1447,5 +1604,449 @@ mod optional_model_e2e {
                 .map(|state| state.checkpoints.len()),
             Some(1)
         );
+        assert_eq!(
+            workflow_runtime_metadata(&session),
+            expected_workflow_metadata,
+            "rejected typed selection must not disturb durable Workflow authority"
+        );
+        let live = state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect canonical activation")
+            .expect("existing activation remains pinned");
+        assert_eq!(live.skills.len(), 1);
+        assert_eq!(live.skills[0].id, "plan");
+    }
+
+    #[actix_web::test]
+    async fn image_rejection_preserves_existing_workflow_and_persists_no_user_message() {
+        let state = new_state().await;
+        let session_id = "rejected-image-workflow";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let before = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        let expected_workflow_metadata = workflow_runtime_metadata(&before);
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id": session_id,
+                    "message": "must not persist",
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {}
+                    },
+                    "images": [{
+                        "base64": "not-valid-base64%%%",
+                        "type": "image/png"
+                    }]
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let after = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("reload session")
+            .expect("session remains");
+        assert!(after
+            .messages
+            .iter()
+            .all(|message| !matches!(message.role, bamboo_agent_core::Role::User)));
+        assert_eq!(
+            workflow_runtime_metadata(&after),
+            expected_workflow_metadata,
+            "failed attachment must not publish speculative Workflow metadata"
+        );
+        let live = state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect canonical activation")
+            .expect("existing activation remains pinned");
+        assert_eq!(live.skills[0].id, "plan");
+    }
+
+    #[actix_web::test]
+    async fn running_session_rejects_typed_workflow_replacement_without_mutation() {
+        let state = new_state().await;
+        let session_id = "running-workflow-replacement";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let before = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        let expected_workflow_metadata = workflow_runtime_metadata(&before);
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let mut runner = crate::app_state::AgentRunner::new();
+        runner.status = crate::app_state::AgentStatus::Running;
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), runner);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id": session_id,
+                    "message": "must wait",
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {}
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(
+            body["error"]["code"],
+            "workflow_activation_running_conflict"
+        );
+        let after = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("reload session")
+            .expect("session remains");
+        assert_eq!(
+            workflow_runtime_metadata(&after),
+            expected_workflow_metadata
+        );
+        assert!(after.messages.is_empty());
+        let live = state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect canonical activation")
+            .expect("existing activation remains pinned");
+        assert_eq!(live.skills[0].id, "plan");
+    }
+
+    #[actix_web::test]
+    async fn runner_reserved_during_typed_chat_rejects_commit_without_mutation() {
+        let state = new_state().await;
+        let session_id = "workflow-reserved-before-commit";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let before = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        let expected_workflow_metadata = workflow_runtime_metadata(&before);
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let barrier = super::super::install_workflow_commit_test_barrier(session_id);
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id": session_id,
+                    "message": "must lose the reservation race",
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {}
+                    }
+                }))
+                .to_request(),
+        );
+        tokio::pin!(response);
+
+        let reached = barrier.reached.acquire();
+        tokio::pin!(reached);
+        let reached_permit = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, async {
+            tokio::select! {
+                permit = &mut reached => permit.expect("workflow commit barrier remains open"),
+                early = &mut response => panic!(
+                    "typed chat completed before the commit barrier: {}",
+                    early.status()
+                ),
+            }
+        })
+        .await
+        .expect("typed chat reaches the deterministic pre-commit barrier");
+        reached_permit.forget();
+
+        let mut runner = crate::app_state::AgentRunner::new();
+        runner.status = crate::app_state::AgentStatus::Pending;
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), runner);
+        barrier.resume.add_permits(1);
+
+        let response = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, &mut response)
+            .await
+            .expect("typed chat rejects the newly reserved runner");
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(
+            body["error"]["code"],
+            "workflow_activation_running_conflict"
+        );
+
+        let after = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("reload session")
+            .expect("session remains");
+        assert_eq!(
+            workflow_runtime_metadata(&after),
+            expected_workflow_metadata,
+            "a late runner reservation must leave durable Workflow authority unchanged"
+        );
+        assert!(after
+            .messages
+            .iter()
+            .all(|message| !matches!(message.role, bamboo_agent_core::Role::User)));
+        let live = state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect canonical activation")
+            .expect("existing activation remains pinned");
+        assert_eq!(live.skills[0].id, "plan");
+    }
+
+    #[actix_web::test]
+    async fn cancelled_typed_chat_finishes_the_committed_pin_handoff() {
+        let state = new_state().await;
+        let session_id = "workflow-cancelled-after-save";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let barrier = super::super::install_workflow_post_save_test_barrier(session_id);
+        let mut feed = state.account_sink.subscribe();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        {
+            let response = test::call_service(
+                &app,
+                test::TestRequest::post()
+                    .uri("/api/v1/chat")
+                    .set_json(serde_json::json!({
+                        "session_id": session_id,
+                        "message": "commit despite response cancellation",
+                        "model": "test-model",
+                        "workflow_selection": {
+                            "id": review.id,
+                            "source": review.source,
+                            "revision": review.revision,
+                            "args": {}
+                        }
+                    }))
+                    .to_request(),
+            );
+            tokio::pin!(response);
+            let reached = barrier.reached.acquire();
+            tokio::pin!(reached);
+            let reached_permit = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, async {
+                tokio::select! {
+                    permit = &mut reached => permit.expect("post-save barrier remains open"),
+                    early = &mut response => panic!(
+                        "typed chat completed before the post-save barrier: {}",
+                        early.status()
+                    ),
+                }
+            })
+            .await
+            .expect("typed chat reaches the deterministic post-save barrier");
+            reached_permit.forget();
+
+            let live_before_handoff = state
+                .skill_manager
+                .pinned_activation_for_workspace(session_id, None)
+                .await
+                .expect("inspect old canonical pin")
+                .expect("old activation remains until durable save returns");
+            assert_eq!(live_before_handoff.skills[0].id, "plan");
+            // Dropping the Actix response future simulates a disconnected
+            // client. The detached commit task must retain both locks and
+            // finish cache/feed/pin publication.
+        }
+        barrier.resume.add_permits(1);
+
+        let event = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, async {
+            loop {
+                let event = feed.recv().await.expect("account feed remains open");
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::MessageAppended { session_id: id, .. }
+                        if id == session_id
+                ) {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("detached typed commit publishes its durable message");
+        assert!(matches!(
+            event.event,
+            bamboo_agent_core::AgentEvent::MessageAppended { .. }
+        ));
+
+        let persisted = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("reload committed session")
+            .expect("committed session");
+        let selection: bamboo_skills::WorkflowSelection = serde_json::from_str(
+            persisted
+                .metadata
+                .get(bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY)
+                .expect("committed typed selection"),
+        )
+        .expect("selection JSON");
+        assert_eq!(selection.id, "review");
+        assert!(persisted.messages.iter().any(|message| {
+            matches!(message.role, bamboo_agent_core::Role::User)
+                && message.content == "commit despite response cancellation"
+        }));
+        assert!(state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect released canonical pin")
+            .is_none());
+        let guard = tokio::time::timeout(
+            CONCURRENCY_ASSERT_TIMEOUT,
+            state.persistence.acquire_lock(session_id),
+        )
+        .await
+        .expect("detached commit releases the persistence lock");
+        drop(guard);
+    }
+
+    #[actix_web::test]
+    async fn typed_instruction_secret_args_fail_before_any_session_or_prompt_persistence() {
+        const SECRET_MARKER: &str = "sk-instruction-secret-must-never-persist";
+        let state = new_state().await;
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let session_id = "secret-workflow-args";
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id": session_id,
+                    "message": "review this",
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {"scope": SECRET_MARKER}
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["error"]["code"], "workflow_selection_invalid");
+        assert!(!body.to_string().contains(SECRET_MARKER));
+        assert!(state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load rejected session")
+            .is_none());
+        assert!(state.sessions.get(session_id).is_none());
+        let durable_files = walkdir::WalkDir::new(&state.app_data_dir)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+            .filter_map(|entry| std::fs::read(entry.path()).ok())
+            .collect::<Vec<_>>();
+        assert!(durable_files.iter().all(|bytes| !bytes
+            .windows(SECRET_MARKER.len())
+            .any(|window| window == SECRET_MARKER.as_bytes())));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -30,6 +30,12 @@ mod patch_test_hooks {
         HOOKS.get_or_init(|| Mutex::new(HashMap::new()))
     }
 
+    fn scope_commit_hooks() -> &'static Mutex<HashMap<String, Arc<PermissionInterleaveHook>>> {
+        static HOOKS: OnceLock<Mutex<HashMap<String, Arc<PermissionInterleaveHook>>>> =
+            OnceLock::new();
+        HOOKS.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
     pub(super) fn install(session_id: &str) -> Arc<PermissionInterleaveHook> {
         let hook = Arc::new(PermissionInterleaveHook {
             reached: Notify::new(),
@@ -46,6 +52,29 @@ mod patch_test_hooks {
         let hook = hooks()
             .lock()
             .expect("permission interleave hooks lock")
+            .remove(session_id);
+        if let Some(hook) = hook {
+            hook.reached.notify_one();
+            hook.resume.notified().await;
+        }
+    }
+
+    pub(super) fn install_scope_commit(session_id: &str) -> Arc<PermissionInterleaveHook> {
+        let hook = Arc::new(PermissionInterleaveHook {
+            reached: Notify::new(),
+            resume: Notify::new(),
+        });
+        scope_commit_hooks()
+            .lock()
+            .expect("scope commit hooks lock")
+            .insert(session_id.to_string(), hook.clone());
+        hook
+    }
+
+    pub(super) async fn pause_after_scope_save(session_id: &str) {
+        let hook = scope_commit_hooks()
+            .lock()
+            .expect("scope commit hooks lock")
             .remove(session_id);
         if let Some(hook) = hook {
             hook.reached.notify_one();
@@ -246,7 +275,7 @@ pub async fn patch_session(
                 "session_id": session_id,
             })));
         };
-        let _guard = state.persistence.acquire_lock(&session_id).await;
+        let guard = state.persistence.acquire_lock(&session_id).await;
         if is_session_running(&state, &session_id).await
             || crate::handlers::agent::events::execute_startup_is_in_flight(
                 state.as_ref(),
@@ -447,6 +476,10 @@ pub async fn patch_session(
                             bamboo_engine::project_context::WorkspaceSource::Explicit.as_str(),
                         )));
         if membership_changed || workspace_changed {
+            let workflow_scope_changed =
+                bamboo_engine::session_app::chat::clear_workflow_authority_for_resource_scope_change(
+                    &mut session,
+                );
             match target.as_ref() {
                 Some(project_id) if membership_changed => {
                     session.set_project_id_meta(project_id.to_string())
@@ -486,40 +519,81 @@ pub async fn patch_session(
                 return Ok(project_context_error_response(error));
             }
 
-            state
-                .persistence
-                .storage()
-                .save_session(&session)
-                .await
-                .map_err(|error| {
-                    crate::error::json_internal_server_error(format!(
-                        "Failed to save Project/Workspace update: {error}"
-                    ))
-                })?;
-            state.sessions.insert(
-                session_id.clone(),
-                std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
-            );
-            if let Some(workspace) = session
-                .workspace_path_meta()
-                .map(std::path::PathBuf::from)
-                .and_then(|path| std::fs::canonicalize(&path).ok().or(Some(path)))
-            {
-                state.workspace_resolver.publish_resolved_workspace(
-                    &session_id,
-                    workspace,
-                    "session_metadata_patch",
+            let commit_state = state.clone();
+            let commit_session_id = session_id.clone();
+            session = match tokio::spawn(async move {
+                // A disconnected PATCH caller must not expose a new durable
+                // resource scope while leaving the cache, event feed or old
+                // immutable Workflow pin behind. The detached task owns the
+                // session lock through the complete post-commit publication.
+                let _guard = guard;
+                if let Err(error) = commit_state
+                    .persistence
+                    .storage()
+                    .save_session(&session)
+                    .await
+                {
+                    tracing::error!(
+                        session_id = %commit_session_id,
+                        %error,
+                        "failed to save Project/Workspace update"
+                    );
+                    return Err("Failed to save Project/Workspace update");
+                }
+                #[cfg(test)]
+                patch_test_hooks::pause_after_scope_save(&commit_session_id).await;
+                if workflow_scope_changed {
+                    if let Err(error) = commit_state
+                        .skill_manager
+                        .release_activation_for_workspace(&commit_session_id, None)
+                        .await
+                    {
+                        tracing::error!(
+                            session_id = %commit_session_id,
+                            %error,
+                            "failed to release prior Workflow activation after scope change"
+                        );
+                    }
+                }
+                commit_state.sessions.insert(
+                    commit_session_id.clone(),
+                    std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
                 );
-            }
-            state.account_sink.record(
-                Some(&session_id),
-                &bamboo_agent_core::AgentEvent::SessionProjectUpdated {
-                    session_id: session_id.clone(),
-                    project_id: target.as_ref().map(ToString::to_string),
-                    workspace_path: session.workspace_path_meta(),
-                    metadata_version: session.metadata_version,
-                },
-            );
+                if let Some(workspace) = session
+                    .workspace_path_meta()
+                    .map(std::path::PathBuf::from)
+                    .and_then(|path| std::fs::canonicalize(&path).ok().or(Some(path)))
+                {
+                    commit_state.workspace_resolver.publish_resolved_workspace(
+                        &commit_session_id,
+                        workspace,
+                        "session_metadata_patch",
+                    );
+                }
+                commit_state.account_sink.record(
+                    Some(&commit_session_id),
+                    &bamboo_agent_core::AgentEvent::SessionProjectUpdated {
+                        session_id: commit_session_id.clone(),
+                        project_id: session.project_id_meta(),
+                        workspace_path: session.workspace_path_meta(),
+                        metadata_version: session.metadata_version,
+                    },
+                );
+                Ok::<bamboo_agent_core::Session, &'static str>(session)
+            })
+            .await
+            {
+                Ok(Ok(session)) => session,
+                Ok(Err(message)) => {
+                    return Err(crate::error::json_internal_server_error(message));
+                }
+                Err(error) => {
+                    tracing::error!(%error, "Project/Workspace commit task failed");
+                    return Err(crate::error::json_internal_server_error(
+                        "Failed to commit Project/Workspace update",
+                    ));
+                }
+            };
         }
         // Preserve a valid CAS token for any lower-risk fields included in the
         // same PATCH. A real metadata change bumped it; an idempotent request
@@ -820,6 +894,8 @@ mod tests {
 
     use crate::routes::configure_routes;
     use crate::AppState;
+
+    const CONCURRENCY_ASSERT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
     async fn new_state() -> web::Data<AppState> {
         let temp_dir = tempdir().expect("tempdir").keep();
@@ -1406,6 +1482,107 @@ mod tests {
         );
     }
 
+    async fn seed_active_workflow_authority(
+        state: &web::Data<AppState>,
+        session_id: &str,
+        project_id: &bamboo_domain::ProjectId,
+        workspace: &Path,
+    ) -> bamboo_skills::SkillActivationSnapshot {
+        let project_home = state.project_store.paths().project_home(project_id);
+        let store = state
+            .skill_manager
+            .store_for_project_workspace(project_id, &project_home, Some(workspace))
+            .await
+            .expect("project workflow store");
+        store
+            .pin_current_activation(session_id, &["plan".to_string()], None)
+            .await
+            .expect("pin active workflow");
+        let snapshot = store
+            .export_activation_snapshot(session_id)
+            .await
+            .expect("durable workflow snapshot");
+        let entry = snapshot.skills.get("plan").expect("plan snapshot");
+        let selection = bamboo_skills::WorkflowSelection {
+            id: "plan".to_string(),
+            source: entry.catalog_entry.source.clone(),
+            revision: entry.revision,
+            args: serde_json::json!({"depth": "full"}),
+        };
+        let active = bamboo_skills::ActiveWorkflow {
+            id: selection.id.clone(),
+            source: selection.source.clone(),
+            revision: selection.revision,
+            kind: entry.catalog_entry.kind,
+            args: selection.args.clone(),
+            invoked_by: bamboo_skills::WorkflowInvokedBy::User,
+            activated_at: chrono::Utc::now(),
+            status: bamboo_skills::WorkflowActivationStatus::Active,
+            diagnostic: None,
+            context_fingerprint: Some("scope-a-context".to_string()),
+            dynamic_context: Vec::new(),
+        };
+        let mut session = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        session.metadata.insert(
+            bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY.to_string(),
+            serde_json::to_string(&selection).expect("selection json"),
+        );
+        session.metadata.insert(
+            bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY.to_string(),
+            serde_json::to_string(&active).expect("active json"),
+        );
+        session.metadata.insert(
+            bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY.to_string(),
+            serde_json::to_string(&bamboo_skills::DurableWorkflowActivation {
+                active,
+                snapshot: snapshot.clone(),
+            })
+            .expect("durable json"),
+        );
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY.to_string(),
+            serde_json::to_string(&snapshot).expect("candidate json"),
+        );
+        session.metadata.insert(
+            bamboo_skills::WORKFLOW_CONTEXT_CACHE_METADATA_KEY.to_string(),
+            "scope-a-cache".to_string(),
+        );
+        session.set_selected_skill_ids(vec!["plan".to_string()]);
+        state
+            .storage
+            .save_session(&session)
+            .await
+            .expect("persist workflow authority");
+        state.sessions.insert(
+            session_id.to_string(),
+            std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        );
+        snapshot
+    }
+
+    fn assert_workflow_authority_cleared(session: &bamboo_agent_core::Session) {
+        assert!(session.selected_skill_ids().is_none());
+        for key in [
+            bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY,
+            bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY,
+            bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY,
+            bamboo_skills::WORKFLOW_CONTEXT_CACHE_METADATA_KEY,
+            bamboo_skills::WORKFLOW_LAST_DYNAMIC_CONTEXT_METADATA_KEY,
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY,
+        ] {
+            assert!(!session.metadata.contains_key(key), "stale key: {key}");
+        }
+        assert!(session
+            .metadata
+            .get(bamboo_skills::WORKFLOW_ACTIVATION_EVENT_METADATA_KEY)
+            .is_some_and(|event| event.contains("resource_scope_changed")));
+    }
+
     #[actix_web::test]
     async fn patch_with_matching_if_match_succeeds_and_bumps_etag() {
         let state = new_state().await;
@@ -1936,6 +2113,314 @@ mod tests {
         );
         assert_eq!(persisted.metadata_version, 0);
         drop(startup_guard);
+    }
+
+    #[actix_web::test]
+    async fn project_reassignment_atomically_clears_old_workflow_scope_and_pin() {
+        let state = new_state().await;
+        let workspace_a = tempdir().expect("workspace A");
+        let workspace_b = tempdir().expect("workspace B");
+        let project_a = state
+            .project_store
+            .create_with_project_path(
+                "Project A",
+                None,
+                workspace_a.path().to_string_lossy(),
+                Vec::new(),
+            )
+            .expect("Project A");
+        let project_b = state
+            .project_store
+            .create_with_project_path(
+                "Project B",
+                None,
+                workspace_b.path().to_string_lossy(),
+                Vec::new(),
+            )
+            .expect("Project B");
+        let session_id = "project-workflow-scope-change";
+        seed_session(
+            &state,
+            session_id,
+            Some(&project_a.id),
+            Some(workspace_a.path()),
+        )
+        .await;
+        let old_snapshot =
+            seed_active_workflow_authority(&state, session_id, &project_a.id, workspace_a.path())
+                .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/v1/sessions/{session_id}"))
+                .insert_header((header::IF_MATCH, "\"0\""))
+                .set_json(serde_json::json!({
+                    "project_id": project_b.id,
+                    "workspace_path": workspace_b.path(),
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let persisted = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load reassigned session")
+            .expect("reassigned session");
+        assert_workflow_authority_cleared(&persisted);
+        assert_eq!(
+            persisted.project_id_meta().as_deref(),
+            Some(project_b.id.as_str())
+        );
+        let old_pin = state
+            .skill_manager
+            .pinned_activation_for_project_workspace(
+                &project_a.id,
+                &state.project_store.paths().project_home(&project_a.id),
+                Some(workspace_a.path()),
+                session_id,
+            )
+            .await
+            .expect("inspect old pin");
+        assert!(old_pin.is_none(), "old Project pin must be released");
+        let new_store = state
+            .skill_manager
+            .store_for_project_workspace(
+                &project_b.id,
+                &state.project_store.paths().project_home(&project_b.id),
+                Some(workspace_b.path()),
+            )
+            .await
+            .expect("new Project store");
+        assert!(new_store
+            .restore_activation_snapshot(session_id, old_snapshot)
+            .await
+            .expect_err("Project A bytes cannot restore in Project B")
+            .to_string()
+            .contains("resource scope mismatch"));
+
+        let restarted = bamboo_storage::SessionStoreV2::new(state.app_data_dir.clone())
+            .await
+            .expect("restart storage");
+        let restarted_session = restarted
+            .load_session(session_id)
+            .await
+            .expect("restart load")
+            .expect("restart session");
+        assert_workflow_authority_cleared(&restarted_session);
+    }
+
+    #[actix_web::test]
+    async fn cancelled_project_reassignment_finishes_scope_and_pin_publication() {
+        let state = new_state().await;
+        let workspace_a = tempdir().expect("workspace A");
+        let workspace_b = tempdir().expect("workspace B");
+        let project_a = state
+            .project_store
+            .create_with_project_path(
+                "Cancellation Project A",
+                None,
+                workspace_a.path().to_string_lossy(),
+                Vec::new(),
+            )
+            .expect("Project A");
+        let project_b = state
+            .project_store
+            .create_with_project_path(
+                "Cancellation Project B",
+                None,
+                workspace_b.path().to_string_lossy(),
+                Vec::new(),
+            )
+            .expect("Project B");
+        let session_id = "cancelled-project-workflow-scope-change";
+        seed_session(
+            &state,
+            session_id,
+            Some(&project_a.id),
+            Some(workspace_a.path()),
+        )
+        .await;
+        seed_active_workflow_authority(&state, session_id, &project_a.id, workspace_a.path()).await;
+        let hook = super::patch_test_hooks::install_scope_commit(session_id);
+        let mut feed = state.account_sink.subscribe();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        {
+            let response = test::call_service(
+                &app,
+                test::TestRequest::patch()
+                    .uri(&format!("/api/v1/sessions/{session_id}"))
+                    .insert_header((header::IF_MATCH, "\"0\""))
+                    .set_json(serde_json::json!({
+                        "project_id": project_b.id,
+                        "workspace_path": workspace_b.path(),
+                    }))
+                    .to_request(),
+            );
+            tokio::pin!(response);
+            let reached = hook.reached.notified();
+            tokio::pin!(reached);
+            tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, async {
+                tokio::select! {
+                    () = &mut reached => {}
+                    early = &mut response => panic!(
+                        "Project PATCH completed before the post-save barrier: {}",
+                        early.status()
+                    ),
+                }
+            })
+            .await
+            .expect("Project PATCH reaches the deterministic post-save barrier");
+
+            let old_pin = state
+                .skill_manager
+                .pinned_activation_for_project_workspace(
+                    &project_a.id,
+                    &state.project_store.paths().project_home(&project_a.id),
+                    Some(workspace_a.path()),
+                    session_id,
+                )
+                .await
+                .expect("inspect old pin before handoff");
+            assert!(old_pin.is_some());
+            // Cancelling the response future must not cancel the detached
+            // durable post-commit publication that still owns the session lock.
+        }
+        hook.resume.notify_one();
+
+        let event = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, async {
+            loop {
+                let event = feed.recv().await.expect("account feed remains open");
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::SessionProjectUpdated { session_id: id, .. }
+                        if id == session_id
+                ) {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("detached Project commit publishes its correlated event");
+        assert!(matches!(
+            event.event,
+            bamboo_agent_core::AgentEvent::SessionProjectUpdated { .. }
+        ));
+
+        let persisted = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load committed reassignment")
+            .expect("committed session");
+        assert_eq!(
+            persisted.project_id_meta().as_deref(),
+            Some(project_b.id.as_str())
+        );
+        assert_workflow_authority_cleared(&persisted);
+        assert!(state
+            .skill_manager
+            .pinned_activation_for_project_workspace(
+                &project_a.id,
+                &state.project_store.paths().project_home(&project_a.id),
+                Some(workspace_a.path()),
+                session_id,
+            )
+            .await
+            .expect("inspect released old pin")
+            .is_none());
+        let cached = state.sessions.get(session_id).expect("published cache");
+        assert_eq!(
+            cached.read().project_id_meta().as_deref(),
+            Some(project_b.id.as_str())
+        );
+        drop(cached);
+        let guard = tokio::time::timeout(
+            CONCURRENCY_ASSERT_TIMEOUT,
+            state.persistence.acquire_lock(session_id),
+        )
+        .await
+        .expect("detached Project commit releases the session lock");
+        drop(guard);
+    }
+
+    #[actix_web::test]
+    async fn workspace_switch_clears_old_workflow_scope_and_pin() {
+        let state = new_state().await;
+        let workspace_a = tempdir().expect("workspace A");
+        let workspace_b = tempdir().expect("workspace B");
+        let project = state
+            .project_store
+            .create_with_project_path(
+                "Workspace Scope Project",
+                None,
+                workspace_a.path().to_string_lossy(),
+                vec![binding(workspace_b.path())],
+            )
+            .expect("Project");
+        let session_id = "workspace-workflow-scope-change";
+        seed_session(
+            &state,
+            session_id,
+            Some(&project.id),
+            Some(workspace_a.path()),
+        )
+        .await;
+        seed_active_workflow_authority(&state, session_id, &project.id, workspace_a.path()).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/v1/sessions/{session_id}"))
+                .insert_header((header::IF_MATCH, "\"0\""))
+                .set_json(serde_json::json!({"workspace_path": workspace_b.path()}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let persisted = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load switched session")
+            .expect("switched session");
+        assert_workflow_authority_cleared(&persisted);
+        assert_eq!(
+            persisted.workspace_path_meta().as_deref(),
+            Some(display(workspace_b.path()).as_str())
+        );
+        let old_pin = state
+            .skill_manager
+            .pinned_activation_for_project_workspace(
+                &project.id,
+                &state.project_store.paths().project_home(&project.id),
+                Some(workspace_a.path()),
+                session_id,
+            )
+            .await
+            .expect("inspect old workspace pin");
+        assert!(old_pin.is_none(), "old workspace pin must be released");
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
@@ -98,15 +98,29 @@ pub async fn get_session(
             let mut summary = SessionSummary::from_entry(entry, is_running);
             summary.running_child_count = running_child_count;
 
+            // Load the authoritative session once for both its ETag and the
+            // public-safe active Workflow identity. The index deliberately
+            // does not mirror this richer lifecycle object.
+            let durable_session = state.storage.load_session(&session_id).await.ok().flatten();
+            summary.active_workflow = durable_session.as_ref().and_then(|session| {
+                session
+                    .metadata
+                    .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
+                    .and_then(|raw| match serde_json::from_str(raw) {
+                        Ok(active) => Some(active),
+                        Err(error) => {
+                            tracing::warn!(
+                                %session_id,
+                                %error,
+                                "ignoring malformed active Workflow metadata in session detail"
+                            );
+                            None
+                        }
+                    })
+            });
             // Surface the session ETag (`metadata_version`) so clients can send
             // it back as `If-Match` on metadata writes (optimistic concurrency).
-            let etag = state
-                .storage
-                .load_session(&session_id)
-                .await
-                .ok()
-                .flatten()
-                .map(|s| s.metadata_version);
+            let etag = durable_session.map(|session| session.metadata_version);
 
             let mut response = HttpResponse::Ok();
             if let Some(version) = etag {
@@ -273,5 +287,63 @@ mod pagination_http_tests {
         assert_eq!(body["error"]["type"], "api_error");
         assert_eq!(body["error"]["message"], "Session not found");
         assert_eq!(body["session_id"], "does-not-exist");
+    }
+
+    #[actix_web::test]
+    async fn session_detail_restores_public_active_workflow_but_list_stays_lightweight() {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let mut session = Session::new("workflow-session", "model");
+        session.metadata.insert(
+            bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY.to_string(),
+            serde_json::json!({
+                "id": "review",
+                "source": "builtin",
+                "revision": 7,
+                "kind": "instruction",
+                "args": {"focus": "security"},
+                "invoked_by": "user",
+                "activated_at": "2026-08-21T00:00:00Z",
+                "status": "active",
+                "context_fingerprint": "sha256:test"
+            })
+            .to_string(),
+        );
+        state.save_and_cache_session(&mut session).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let list: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions")
+                .to_request(),
+        )
+        .await;
+        assert!(list["sessions"][0].get("active_workflow").is_none());
+
+        let detail: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions/workflow-session")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(detail["session"]["active_workflow"]["id"], "review");
+        assert_eq!(detail["session"]["active_workflow"]["source"], "builtin");
+        assert_eq!(
+            detail["session"]["active_workflow"]["args"]["focus"],
+            "security"
+        );
+        assert!(detail["session"]["active_workflow"].get("prompt").is_none());
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
@@ -5,7 +5,8 @@ use actix_web::{web, HttpResponse, Result};
 use crate::app_state::AppState;
 
 use super::super::super::types::{
-    GetSessionResponse, ListSessionsQuery, ListSessionsResponse, SessionSummary,
+    GetSessionResponse, ListSessionsQuery, ListSessionsResponse, SessionActiveWorkflow,
+    SessionSummary,
 };
 use super::running::{is_session_running, running_session_ids};
 
@@ -101,31 +102,78 @@ pub async fn get_session(
             // Load the authoritative session once for both its ETag and the
             // public-safe active Workflow identity. The index deliberately
             // does not mirror this richer lifecycle object.
-            let durable_session = state.storage.load_session(&session_id).await.ok().flatten();
-            summary.active_workflow = durable_session.as_ref().and_then(|session| {
-                session
-                    .metadata
-                    .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
-                    .and_then(|raw| match serde_json::from_str(raw) {
-                        Ok(active) => Some(active),
-                        Err(error) => {
+            let durable_session = match state.storage.load_session(&session_id).await {
+                Ok(Some(session)) => session,
+                Ok(None) => {
+                    tracing::warn!(
+                        %session_id,
+                        "session index entry has no authoritative durable session"
+                    );
+                    return Ok(HttpResponse::NotFound().json(serde_json::json!({
+                        "error": crate::error::error_value("Session not found"),
+                        "session_id": session_id
+                    })));
+                }
+                Err(error) => {
+                    tracing::error!(
+                        %session_id,
+                        %error,
+                        "failed to load authoritative session detail"
+                    );
+                    return Ok(crate::error::json_error(
+                        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to load session detail",
+                    ));
+                }
+            };
+            let selected_catalog = durable_session
+                .metadata
+                .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_CATALOG_KEY)
+                .and_then(|raw| {
+                    serde_json::from_str::<Vec<bamboo_skills::WorkflowCatalogEntry>>(raw)
+                        .map_err(|error| {
                             tracing::warn!(
                                 %session_id,
                                 %error,
-                                "ignoring malformed active Workflow metadata in session detail"
+                                "ignored invalid pinned workflow catalog metadata in session detail"
                             );
-                            None
-                        }
-                    })
-            });
+                        })
+                        .ok()
+                })
+                .unwrap_or_default();
+            summary.active_workflow = match durable_session
+                .metadata
+                .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
+            {
+                Some(raw) => match serde_json::from_str::<bamboo_skills::ActiveWorkflow>(raw) {
+                    Ok(active) => {
+                        let entry = selected_catalog.iter().find(|entry| {
+                            entry.id == active.id
+                                && entry.source == active.source
+                                && entry.revision == active.revision
+                        });
+                        Some(SessionActiveWorkflow::from_active(active, entry))
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            %session_id,
+                            %error,
+                            "active Workflow metadata is malformed in authoritative session detail"
+                        );
+                        return Ok(crate::error::json_error(
+                            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            "Failed to load active Workflow state",
+                        ));
+                    }
+                },
+                None => None,
+            };
             // Surface the session ETag (`metadata_version`) so clients can send
             // it back as `If-Match` on metadata writes (optimistic concurrency).
-            let etag = durable_session.map(|session| session.metadata_version);
+            let etag = durable_session.metadata_version;
 
             let mut response = HttpResponse::Ok();
-            if let Some(version) = etag {
-                response.insert_header((actix_web::http::header::ETAG, format!("\"{version}\"")));
-            }
+            response.insert_header((actix_web::http::header::ETAG, format!("\"{etag}\"")));
             Ok(response.json(GetSessionResponse { session: summary }))
         }
         None => Ok(HttpResponse::NotFound().json(serde_json::json!({
@@ -310,8 +358,36 @@ mod pagination_http_tests {
                 "invoked_by": "user",
                 "activated_at": "2026-08-21T00:00:00Z",
                 "status": "active",
-                "context_fingerprint": "sha256:test"
+                "context_fingerprint": "sha256:test",
+                "dynamic_context": [{
+                    "provider_id": "private-provider",
+                    "tool": "context",
+                    "provenance": "private",
+                    "generated_at": "2026-08-21T00:00:00Z",
+                    "expires_at": null,
+                    "status": "active",
+                    "stop_on_failure": false,
+                    "content": "secret dynamic provider output"
+                }]
             })
+            .to_string(),
+        );
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_CATALOG_KEY.to_string(),
+            serde_json::json!([{
+                "id": "review",
+                "name": "Review changes",
+                "description": "Pinned public metadata",
+                "kind": "instruction",
+                "source": "builtin",
+                "revision": 7,
+                "version": "3",
+                "invocation_policy": {"automatic": true, "explicit": true},
+                "argument_schema": {"type": "object"},
+                "status": "valid",
+                "legacy": false,
+                "winner": true
+            }])
             .to_string(),
         );
         state.save_and_cache_session(&mut session).await;
@@ -339,11 +415,113 @@ mod pagination_http_tests {
         )
         .await;
         assert_eq!(detail["session"]["active_workflow"]["id"], "review");
-        assert_eq!(detail["session"]["active_workflow"]["source"], "builtin");
         assert_eq!(
-            detail["session"]["active_workflow"]["args"]["focus"],
-            "security"
+            detail["session"]["active_workflow"]["name"],
+            "Review changes"
         );
-        assert!(detail["session"]["active_workflow"].get("prompt").is_none());
+        assert_eq!(detail["session"]["active_workflow"]["source"], "builtin");
+        assert_eq!(detail["session"]["active_workflow"]["version"], "3");
+        let active = &detail["session"]["active_workflow"];
+        assert_eq!(active["kind"], "instruction");
+        assert_eq!(active["invoked_by"], "user");
+        assert!(active.get("args").is_none());
+        assert!(active.get("context_fingerprint").is_none());
+        assert!(active.get("dynamic_context").is_none());
+        assert!(!detail
+            .to_string()
+            .contains("secret dynamic provider output"));
+    }
+
+    #[actix_web::test]
+    async fn session_detail_fails_closed_when_durable_load_fails() {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let mut session = Session::new("broken-session-detail", "model");
+        state.save_and_cache_session(&mut session).await;
+        let entry = state
+            .session_store
+            .get_index_entry("broken-session-detail")
+            .await
+            .expect("durable index entry");
+        let session_json = temp_dir.path().join(entry.rel_path).join("session.json");
+        tokio::fs::remove_file(&session_json)
+            .await
+            .expect("remove durable session file");
+        tokio::fs::create_dir(&session_json)
+            .await
+            .expect("inject unreadable session path");
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions/broken-session-detail")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert!(response
+            .headers()
+            .get(actix_web::http::header::ETAG)
+            .is_none());
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["error"]["message"], "Failed to load session detail");
+        assert!(!body
+            .to_string()
+            .contains(&session_json.to_string_lossy()[..]));
+    }
+
+    #[actix_web::test]
+    async fn session_detail_fails_closed_for_malformed_active_workflow_metadata() {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let mut session = Session::new("malformed-active-workflow", "model");
+        session.metadata.insert(
+            bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY.to_string(),
+            r#"{"id":"private-id","args":{"api_key":"must-not-echo"}"#.to_string(),
+        );
+        state.save_and_cache_session(&mut session).await;
+        let app = test::init_service(App::new().app_data(state).configure(configure_routes)).await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions/malformed-active-workflow")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert!(response
+            .headers()
+            .get(actix_web::http::header::ETAG)
+            .is_none());
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(
+            body["error"]["message"],
+            "Failed to load active Workflow state"
+        );
+        assert!(!body.to_string().contains("must-not-echo"));
+        assert!(!body.to_string().contains("private-id"));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
@@ -80,6 +80,12 @@ pub struct SessionSummary {
     /// Lets the frontend render plan-mode UI without loading full session history.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan_mode: Option<bamboo_domain::PlanModeState>,
+    /// Public-safe durable workflow identity restored from the authoritative
+    /// session metadata. List rows intentionally leave this empty; the detail
+    /// endpoint hydrates it from `session.json` so browser refreshes do not
+    /// depend on an already-consumed account-feed event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_workflow: Option<bamboo_skills::ActiveWorkflow>,
     /// Number of child sessions currently running under this session.
     /// Computed dynamically at query time by scanning running sessions.
     #[serde(default)]
@@ -157,6 +163,7 @@ impl SessionSummary {
             resident_name: entry.resident_name,
             has_pending_question: entry.has_pending_question,
             plan_mode: entry.plan_mode,
+            active_workflow: None,
             running_child_count: 0,
             gold_config: parse_session_gold_config(entry.gold_config_json.as_deref()),
             bypass_permissions: entry.bypass_permissions
@@ -588,6 +595,7 @@ mod tests {
             resident_name: None,
             has_pending_question: false,
             plan_mode: None,
+            active_workflow: None,
             running_child_count: 0,
             gold_config: None,
         };
@@ -638,6 +646,7 @@ mod tests {
             resident_name: None,
             has_pending_question: false,
             plan_mode: None,
+            active_workflow: None,
             running_child_count: 0,
             gold_config: None,
         };
@@ -775,6 +784,7 @@ mod tests {
             resident_name: None,
             has_pending_question: false,
             plan_mode: None,
+            active_workflow: None,
             running_child_count: 0,
             gold_config: None,
         };

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
@@ -7,6 +7,44 @@ use bamboo_storage::{SessionIndexEntry, SessionPlacement};
 
 use bamboo_engine::model_config_helper::parse_session_gold_config;
 
+/// Minimal public workflow lifecycle identity. Durable activation metadata also
+/// contains the immutable arguments, context fingerprint and dynamic provider
+/// output used by the runtime; none of those payloads belong in a session
+/// summary response.
+#[derive(Debug, Serialize)]
+pub struct SessionActiveWorkflow {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub source: bamboo_skills::WorkflowSource,
+    pub revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub kind: bamboo_skills::WorkflowKind,
+    pub invoked_by: bamboo_skills::WorkflowInvokedBy,
+    pub activated_at: chrono::DateTime<chrono::Utc>,
+    pub status: bamboo_skills::WorkflowActivationStatus,
+}
+
+impl SessionActiveWorkflow {
+    pub fn from_active(
+        active: bamboo_skills::ActiveWorkflow,
+        catalog_entry: Option<&bamboo_skills::WorkflowCatalogEntry>,
+    ) -> Self {
+        Self {
+            id: active.id,
+            name: catalog_entry.map(|entry| entry.name.clone()),
+            source: active.source,
+            revision: active.revision,
+            version: catalog_entry.map(|entry| entry.version.clone()),
+            kind: active.kind,
+            invoked_by: active.invoked_by,
+            activated_at: active.activated_at,
+            status: active.status,
+        }
+    }
+}
+
 /// Deserialize an explicitly-present nullable Project id while preserving the
 /// distinction between an absent field (`None`, no-op) and JSON `null`
 /// (`Some(None)`, explicit unassign).
@@ -85,7 +123,7 @@ pub struct SessionSummary {
     /// endpoint hydrates it from `session.json` so browser refreshes do not
     /// depend on an already-consumed account-feed event.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_workflow: Option<bamboo_skills::ActiveWorkflow>,
+    pub active_workflow: Option<SessionActiveWorkflow>,
     /// Number of child sessions currently running under this session.
     /// Computed dynamically at query time by scanning running sessions.
     #[serde(default)]

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -57,8 +57,9 @@ pub use redaction::{redact_config_for_api, redact_providers_for_api};
 pub use setup::{get_setup_status, mark_setup_complete, mark_setup_incomplete};
 pub(crate) use workflows::is_safe_workflow_name;
 pub use workflows::{
-    delete_workflow, get_workflow, list_workflow_catalog, list_workflows, migrate_workflow,
-    save_workflow, MigrateWorkflowRequest, SaveWorkflowRequest, WorkflowCatalogQuery,
+    clone_workflow, delete_workflow, get_workflow, list_workflow_catalog, list_workflows,
+    migrate_workflow, save_workflow, CloneWorkflowRequest, MigrateWorkflowRequest,
+    SaveWorkflowRequest, WorkflowCatalogQuery,
 };
 
 // NOTE: the production `/bamboo/*` route map lives in `routes::bamboo_v1_routes`

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -1,20 +1,121 @@
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
 use actix_web::{http::StatusCode, web, HttpResponse};
 use bamboo_skills::legacy::LegacyWorkflowMigrationOutcome;
-use bamboo_skills::LegacyWorkflowMigrationStatus;
+use bamboo_skills::{
+    LegacyWorkflowMigrationStatus, SkillStore, WorkflowCatalogEntry, WorkflowSource, WorkflowStatus,
+};
+use fs2::FileExt;
+use sha2::{Digest, Sha256};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
 use crate::{app_state::AppState, error::AppError};
 
 use super::types::{
-    MigrateWorkflowRequest, MigrateWorkflowResponse, SaveWorkflowRequest, WorkflowCatalogQuery,
-    WorkflowGetResponse, WorkflowListItem,
+    CloneWorkflowRequest, CloneWorkflowResponse, CloneWorkflowTarget, MigrateWorkflowRequest,
+    MigrateWorkflowResponse, SaveWorkflowRequest, WorkflowCatalogQuery, WorkflowGetResponse,
+    WorkflowListItem,
 };
 use super::validation::is_safe_workflow_name;
 
 fn legacy_workflow_io_lock() -> &'static tokio::sync::Mutex<()> {
     static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+#[derive(Clone)]
+struct ResolvedWorkflowScope {
+    store: Arc<SkillStore>,
+    project_home: Option<PathBuf>,
+    workspace: Option<PathBuf>,
+}
+
+async fn resolve_workflow_scope(
+    app_state: &AppState,
+    session_id: Option<&str>,
+) -> Result<ResolvedWorkflowScope, AppError> {
+    let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(ResolvedWorkflowScope {
+            store: app_state
+                .skill_manager
+                .store_for_workspace(None)
+                .await
+                .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?,
+            project_home: None,
+            workspace: None,
+        });
+    };
+    let session = app_state
+        .load_session(session_id)
+        .await
+        .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
+    let project_id =
+        match bamboo_engine::project_context::ProjectContextResolver::session_project_identity(
+            &session,
+        ) {
+            bamboo_engine::project_context::SessionProjectIdentity::Assigned(project_id) => {
+                Some(project_id)
+            }
+            bamboo_engine::project_context::SessionProjectIdentity::Unassigned => None,
+            bamboo_engine::project_context::SessionProjectIdentity::Invalid { raw, message } => {
+                return Err(AppError::BadRequest(format!(
+                    "Session carries an invalid Project identity '{raw}': {message}"
+                )));
+            }
+        };
+    let persisted_workspace = (session
+        .metadata
+        .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+        .map(String::as_str)
+        != Some(bamboo_engine::project_context::WorkspaceSource::ProjectDefault.as_str()))
+    .then(|| session.workspace_path_meta())
+    .flatten();
+    let workspace = crate::project_context::validate_workspace_assignment_with_resolver(
+        &app_state.project_store,
+        project_id.as_ref(),
+        persisted_workspace.as_deref(),
+        &app_state.workspace_resolver,
+    )
+    .map_err(|error| match error {
+        crate::project_context::ProjectWorkspaceValidationError::Invalid { .. }
+        | crate::project_context::ProjectWorkspaceValidationError::Conflict { .. } => {
+            AppError::BadRequest(error.to_string())
+        }
+        crate::project_context::ProjectWorkspaceValidationError::Store(error) => {
+            AppError::InternalError(anyhow::anyhow!(error))
+        }
+    })?;
+    let project_home = if let Some(project_id) = project_id.as_ref() {
+        app_state.project_store.get(project_id).map_err(|error| {
+            AppError::BadRequest(format!("Assigned Project is unavailable: {error}"))
+        })?;
+        Some(app_state.project_store.paths().project_home(project_id))
+    } else {
+        None
+    };
+    let store = match (project_id.as_ref(), project_home.as_ref()) {
+        (Some(project_id), Some(project_home)) => {
+            app_state
+                .skill_manager
+                .store_for_project_workspace(project_id, project_home, workspace.as_deref())
+                .await
+        }
+        _ => {
+            app_state
+                .skill_manager
+                .store_for_workspace(workspace.as_deref())
+                .await
+        }
+    }
+    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    Ok(ResolvedWorkflowScope {
+        store,
+        project_home,
+        workspace,
+    })
 }
 
 async fn workspace_skills_dir(workspace: &std::path::Path) -> Result<std::path::PathBuf, AppError> {
@@ -55,93 +156,587 @@ pub async fn list_workflow_catalog(
     app_state: web::Data<AppState>,
     query: web::Query<WorkflowCatalogQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let snapshot = if let Some(session_id) = query
-        .session_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let session = app_state
-            .load_session(session_id)
-            .await
-            .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
-        let project_id =
-            match bamboo_engine::project_context::ProjectContextResolver::session_project_identity(
-                &session,
-            ) {
-                bamboo_engine::project_context::SessionProjectIdentity::Assigned(project_id) => {
-                    Some(project_id)
-                }
-                bamboo_engine::project_context::SessionProjectIdentity::Unassigned => None,
-                bamboo_engine::project_context::SessionProjectIdentity::Invalid {
-                    raw,
-                    message,
-                } => {
-                    return Err(AppError::BadRequest(format!(
-                        "Session carries an invalid Project identity '{raw}': {message}"
-                    )));
-                }
-            };
-        let persisted_workspace = (session
-            .metadata
-            .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
-            .map(String::as_str)
-            != Some(bamboo_engine::project_context::WorkspaceSource::ProjectDefault.as_str()))
-        .then(|| session.workspace_path_meta())
-        .flatten();
-        let workspace = crate::project_context::validate_workspace_assignment_with_resolver(
-            &app_state.project_store,
-            project_id.as_ref(),
-            persisted_workspace.as_deref(),
-            &app_state.workspace_resolver,
-        )
-        .map_err(|error| match error {
-            crate::project_context::ProjectWorkspaceValidationError::Invalid { .. }
-            | crate::project_context::ProjectWorkspaceValidationError::Conflict { .. } => {
-                AppError::BadRequest(error.to_string())
-            }
-            crate::project_context::ProjectWorkspaceValidationError::Store(error) => {
-                AppError::InternalError(anyhow::anyhow!(error))
-            }
-        })?;
-        if let Some(project_id) = project_id {
-            app_state.project_store.get(&project_id).map_err(|error| {
-                AppError::BadRequest(format!("Assigned Project is unavailable: {error}"))
-            })?;
-            let project_home = app_state.project_store.paths().project_home(&project_id);
-            app_state
-                .skill_manager
-                .workflow_catalog_for_project_workspace(
-                    &project_id,
-                    &project_home,
-                    workspace.as_deref(),
-                )
-                .await
-                .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
-        } else if let Some(workspace) = workspace.as_ref() {
-            app_state
-                .skill_manager
-                .store()
-                .workflow_catalog_for_workspace(workspace)
-                .await
-                .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
-        } else {
-            app_state
-                .skill_manager
-                .store()
-                .workflow_catalog_snapshot()
-                .await
-        }
-    } else {
-        app_state
-            .skill_manager
-            .store()
-            .workflow_catalog_snapshot()
-            .await
-    };
+    let scope = resolve_workflow_scope(&app_state, query.session_id.as_deref()).await?;
+    let snapshot = scope.store.workflow_catalog_snapshot().await;
     Ok(HttpResponse::Ok()
         .insert_header(("Cache-Control", "no-store"))
         .json(snapshot.public_workflows()))
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+struct ClonePublicationMarker {
+    schema: u8,
+    workflow_id: String,
+    source_revision: u64,
+    digest: String,
+}
+
+#[derive(Debug)]
+enum ClonePublicationError {
+    Conflict(String),
+    Io(std::io::Error),
+    Internal(String),
+}
+
+impl From<std::io::Error> for ClonePublicationError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+async fn confined_skills_dir(root: &Path) -> Result<PathBuf, AppError> {
+    let metadata = tokio::fs::symlink_metadata(root).await?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(AppError::Forbidden(
+            "Workflow clone root must be a real directory".to_string(),
+        ));
+    }
+    let canonical_root = tokio::fs::canonicalize(root).await?;
+    let skills_dir = root.join("skills");
+    match tokio::fs::symlink_metadata(&skills_dir).await {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(AppError::Forbidden(
+                "Workflow clone target must be a real skills directory".to_string(),
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            tokio::fs::create_dir(&skills_dir).await?;
+        }
+        Err(error) => return Err(AppError::StorageError(error)),
+    }
+    let canonical_skills = tokio::fs::canonicalize(&skills_dir).await?;
+    if !canonical_skills.starts_with(&canonical_root) {
+        return Err(AppError::Forbidden(
+            "Workflow clone target escapes its trusted root".to_string(),
+        ));
+    }
+    Ok(canonical_skills)
+}
+
+fn clone_bundle_files(
+    bundle: &bamboo_skills::store::builtin::BuiltinSkillBundle,
+) -> Result<BTreeMap<String, Vec<u8>>, AppError> {
+    let mut files = bundle
+        .files
+        .iter()
+        .map(|(path, bytes)| (path.clone(), bytes.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let markdown = bamboo_skills::store::parser::render_skill_markdown(&bundle.skill)
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    files.insert("SKILL.md".to_string(), markdown.into_bytes());
+    Ok(files)
+}
+
+fn clone_bundle_digest(files: &BTreeMap<String, Vec<u8>>) -> String {
+    let mut digest = Sha256::new();
+    for (path, bytes) in files {
+        digest.update((path.len() as u64).to_le_bytes());
+        digest.update(path.as_bytes());
+        digest.update((bytes.len() as u64).to_le_bytes());
+        digest.update(bytes);
+    }
+    hex::encode(digest.finalize())
+}
+
+fn checked_clone_relative_path(path: &str) -> Result<PathBuf, ClonePublicationError> {
+    let path = Path::new(path);
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(ClonePublicationError::Internal(
+            "embedded Workflow bundle contains an unsafe resource path".to_string(),
+        ));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn ensure_clone_parent(root: &Path, relative: &Path) -> Result<(), ClonePublicationError> {
+    let Some(parent) = relative.parent() else {
+        return Ok(());
+    };
+    let mut current = root.to_path_buf();
+    for component in parent.components() {
+        let Component::Normal(component) = component else {
+            return Err(ClonePublicationError::Internal(
+                "embedded Workflow bundle contains an unsafe resource parent".to_string(),
+            ));
+        };
+        current.push(component);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+                return Err(ClonePublicationError::Conflict(format!(
+                    "clone target '{}' is not a real directory",
+                    current.display()
+                )));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir(&current)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+fn write_clone_file(
+    target_root: &Path,
+    relative: &str,
+    bytes: &[u8],
+) -> Result<(), ClonePublicationError> {
+    let relative_path = checked_clone_relative_path(relative)?;
+    ensure_clone_parent(target_root, &relative_path)?;
+    let target = target_root.join(&relative_path);
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&target)
+    {
+        Ok(mut file) => {
+            use std::io::Write;
+            file.write_all(bytes)?;
+            file.sync_all()?;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = std::fs::symlink_metadata(&target)?;
+            if metadata.file_type().is_symlink()
+                || !metadata.is_file()
+                || std::fs::read(&target)? != bytes
+            {
+                return Err(ClonePublicationError::Conflict(format!(
+                    "clone target resource '{relative}' already exists with different content"
+                )));
+            }
+        }
+        Err(error) => return Err(error.into()),
+    }
+    #[cfg(unix)]
+    if relative.starts_with("scripts/") {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))?;
+        std::fs::File::open(&target)?.sync_all()?;
+    }
+    Ok(())
+}
+
+fn sync_clone_directory(path: &Path) -> Result<(), ClonePublicationError> {
+    #[cfg(unix)]
+    std::fs::File::open(path)?.sync_all()?;
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn verify_clone_tree(
+    target: &Path,
+    workflow_id: &str,
+    files: &BTreeMap<String, Vec<u8>>,
+) -> Result<(), ClonePublicationError> {
+    let mut actual = BTreeMap::new();
+    for entry in walkdir::WalkDir::new(target).follow_links(false) {
+        let entry = entry.map_err(|error| ClonePublicationError::Internal(error.to_string()))?;
+        if entry.path() == target {
+            continue;
+        }
+        if entry.file_type().is_symlink() {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone target contains a symbolic link".to_string(),
+            ));
+        }
+        if entry.file_type().is_file() {
+            let relative = entry
+                .path()
+                .strip_prefix(target)
+                .map_err(|error| ClonePublicationError::Internal(error.to_string()))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            actual.insert(relative, std::fs::read(entry.path())?);
+        } else if !entry.file_type().is_dir() {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone target contains a non-regular resource".to_string(),
+            ));
+        }
+    }
+    if actual != *files {
+        return Err(ClonePublicationError::Conflict(format!(
+            "Workflow clone target '{workflow_id}' contains divergent resources"
+        )));
+    }
+    Ok(())
+}
+
+fn sync_clone_tree_directories(root: &Path) -> Result<(), ClonePublicationError> {
+    #[cfg(unix)]
+    {
+        let mut directories = walkdir::WalkDir::new(root)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_dir())
+            .map(|entry| entry.into_path())
+            .collect::<Vec<_>>();
+        directories.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+        for directory in directories {
+            sync_clone_directory(&directory)?;
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = root;
+    Ok(())
+}
+
+fn clone_staging_parent(skills_dir: &Path) -> Result<PathBuf, ClonePublicationError> {
+    let trusted_root = skills_dir.parent().ok_or_else(|| {
+        ClonePublicationError::Internal(
+            "Workflow clone skills directory has no trusted parent".to_string(),
+        )
+    })?;
+    let canonical_trusted_root = std::fs::canonicalize(trusted_root)?;
+    let staging_parent = canonical_trusted_root.join(".workflow-clone-staging");
+    match std::fs::symlink_metadata(&staging_parent) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone staging root is not a real directory".to_string(),
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir(&staging_parent)?;
+            sync_clone_directory(&canonical_trusted_root)?;
+        }
+        Err(error) => return Err(error.into()),
+    }
+    let canonical = std::fs::canonicalize(&staging_parent)?;
+    if !canonical.starts_with(&canonical_trusted_root) {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone staging root escapes its trusted directory".to_string(),
+        ));
+    }
+    Ok(canonical)
+}
+
+fn publish_clone_marker(
+    skills_dir: &Path,
+    workflow_id: &str,
+    marker_path: &Path,
+    marker_bytes: &[u8],
+) -> Result<(), ClonePublicationError> {
+    let temporary = skills_dir.join(format!(".{workflow_id}.clone-v1.json.tmp"));
+    match std::fs::symlink_metadata(&temporary) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone temporary marker is not a regular file".to_string(),
+            ));
+        }
+        Ok(_) => {
+            // No authoritative marker or target exists while the clone lock is
+            // held, so this can only be an uncommitted pre-rename crash remnant.
+            std::fs::remove_file(&temporary)?;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let mut marker_file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)?;
+    use std::io::Write;
+    marker_file.write_all(marker_bytes)?;
+    marker_file.sync_all()?;
+    drop(marker_file);
+    std::fs::rename(&temporary, marker_path)?;
+    sync_clone_directory(skills_dir)?;
+    Ok(())
+}
+
+fn publish_builtin_clone_blocking(
+    skills_dir: &Path,
+    workflow_id: &str,
+    source_revision: u64,
+    files: &BTreeMap<String, Vec<u8>>,
+) -> Result<(), ClonePublicationError> {
+    let skill_markdown = files.get("SKILL.md").ok_or_else(|| {
+        ClonePublicationError::Internal("embedded Workflow bundle is missing SKILL.md".to_string())
+    })?;
+    for relative in files.keys() {
+        checked_clone_relative_path(relative)?;
+    }
+    let lock_path = skills_dir.join(".workflow-clone.lock");
+    if std::fs::symlink_metadata(&lock_path)
+        .is_ok_and(|metadata| metadata.file_type().is_symlink() || !metadata.is_file())
+    {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone lock path is not a regular file".to_string(),
+        ));
+    }
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    FileExt::lock_exclusive(&lock)?;
+
+    let marker = ClonePublicationMarker {
+        schema: 1,
+        workflow_id: workflow_id.to_string(),
+        source_revision,
+        digest: clone_bundle_digest(files),
+    };
+    let marker_bytes = serde_json::to_vec(&marker)
+        .map_err(|error| ClonePublicationError::Internal(error.to_string()))?;
+    let marker_path = skills_dir.join(format!(".{workflow_id}.clone-v1.json"));
+    let target = skills_dir.join(workflow_id);
+
+    let marker_exists = match std::fs::symlink_metadata(&marker_path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow clone recovery marker is not a regular file".to_string(),
+                ));
+            }
+            if std::fs::read(&marker_path)? != marker_bytes {
+                return Err(ClonePublicationError::Conflict(format!(
+                    "a different clone publication for '{workflow_id}' requires recovery"
+                )));
+            }
+            true
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error.into()),
+    };
+    match std::fs::symlink_metadata(&target) {
+        Ok(metadata) => {
+            if !marker_exists {
+                return Err(ClonePublicationError::Conflict(format!(
+                    "Workflow '{workflow_id}' already exists in the target layer"
+                )));
+            }
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(ClonePublicationError::Conflict(format!(
+                    "Workflow clone target '{workflow_id}' is not a real directory"
+                )));
+            }
+            // A crash may occur after the atomic directory rename but before
+            // marker removal. Exact bytes prove the publication completed;
+            // only then is it safe to acknowledge and clear recovery state.
+            verify_clone_tree(&target, workflow_id, files)?;
+            std::fs::remove_file(&marker_path)?;
+            sync_clone_directory(skills_dir)?;
+            FileExt::unlock(&lock)?;
+            return Ok(());
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if !marker_exists {
+                publish_clone_marker(skills_dir, workflow_id, &marker_path, &marker_bytes)?;
+            }
+        }
+        Err(error) => return Err(error.into()),
+    }
+
+    // Build outside the recursively scanned skills root, then atomically rename
+    // the complete tree into place. A crash at any individual file write only
+    // damages server-owned staging bytes, which the exact marker authorizes us
+    // to discard and rebuild; clients never observe a partial Workflow bundle.
+    let staging_parent = clone_staging_parent(skills_dir)?;
+    let staging = staging_parent.join(format!("{workflow_id}.clone-v1"));
+    match std::fs::symlink_metadata(&staging) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone staging target is not a real directory".to_string(),
+            ));
+        }
+        Ok(_) => std::fs::remove_dir_all(&staging)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    std::fs::create_dir(&staging)?;
+    for (relative, bytes) in files.iter().filter(|(path, _)| path.as_str() != "SKILL.md") {
+        write_clone_file(&staging, relative, bytes)?;
+    }
+    write_clone_file(&staging, "SKILL.md", skill_markdown)?;
+    verify_clone_tree(&staging, workflow_id, files)?;
+    sync_clone_tree_directories(&staging)?;
+    std::fs::rename(&staging, &target)?;
+    sync_clone_directory(skills_dir)?;
+    verify_clone_tree(&target, workflow_id, files)?;
+    std::fs::remove_file(&marker_path)?;
+    sync_clone_directory(skills_dir)?;
+    FileExt::unlock(&lock)?;
+    Ok(())
+}
+
+fn exact_catalog_entry<'a>(
+    skill_entries: &'a [WorkflowCatalogEntry],
+    workflow_entries: &'a [WorkflowCatalogEntry],
+    workflow_id: &str,
+    source: WorkflowSource,
+) -> Option<&'a WorkflowCatalogEntry> {
+    skill_entries
+        .iter()
+        .chain(workflow_entries)
+        .find(|entry| entry.id == workflow_id && entry.source == source && entry.winner)
+}
+
+/// Clone one immutable builtin bundle into the current Project or user layer.
+/// Client-controlled filesystem paths are never accepted, the selected source
+/// revision must still be exact, and an existing target is never overwritten.
+pub async fn clone_workflow(
+    app_state: web::Data<AppState>,
+    workflow_id: web::Path<String>,
+    payload: web::Json<CloneWorkflowRequest>,
+) -> Result<HttpResponse, AppError> {
+    let workflow_id = workflow_id.into_inner();
+    if !is_safe_workflow_name(&workflow_id) || payload.revision == 0 {
+        return Err(AppError::BadRequest(
+            "A safe workflow id and positive revision are required".to_string(),
+        ));
+    }
+    if payload.source != WorkflowSource::Builtin {
+        return Err(AppError::BadRequest(
+            "Only read-only builtin Workflows can be cloned".to_string(),
+        ));
+    }
+    if payload.target == CloneWorkflowTarget::Project
+        && payload
+            .session_id
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty)
+    {
+        return Err(AppError::BadRequest(
+            "session_id is required for a Project clone".to_string(),
+        ));
+    }
+    let scope_session_id = match payload.target {
+        CloneWorkflowTarget::Project => payload.session_id.as_deref(),
+        CloneWorkflowTarget::User => None,
+    };
+    let scope = resolve_workflow_scope(&app_state, scope_session_id).await?;
+    scope
+        .store
+        .reload()
+        .await
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    let (skill_catalog, workflow_catalog) = scope.store.command_catalog_snapshots().await;
+    let entry = exact_catalog_entry(
+        &skill_catalog.entries,
+        &workflow_catalog.entries,
+        &workflow_id,
+        payload.source,
+    );
+    let Some(entry) = entry else {
+        let known_but_shadowed = skill_catalog
+            .entries
+            .iter()
+            .chain(&workflow_catalog.entries)
+            .any(|entry| {
+                entry.id == workflow_id
+                    && (entry.source == payload.source
+                        || entry
+                            .shadowed_candidates
+                            .iter()
+                            .any(|candidate| candidate.source == payload.source))
+            });
+        if known_but_shadowed {
+            return Ok(crate::error::json_error(
+                StatusCode::CONFLICT,
+                format!(
+                    "Builtin Workflow '{workflow_id}' is shadowed; refresh the catalog before cloning"
+                ),
+            ));
+        }
+        return Err(AppError::NotFound(format!(
+            "Builtin Workflow '{workflow_id}'"
+        )));
+    };
+    if entry.status != WorkflowStatus::Valid || entry.revision != payload.revision {
+        return Ok(crate::error::json_error(
+            StatusCode::CONFLICT,
+            format!(
+                "Builtin Workflow '{workflow_id}' changed or became invalid; refresh the catalog"
+            ),
+        ));
+    }
+    let bundles = bamboo_skills::store::builtin::load_builtin_skill_bundles()
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    let bundle = bundles
+        .iter()
+        .find(|bundle| bundle.skill.id == workflow_id)
+        .ok_or_else(|| AppError::NotFound(format!("Builtin Workflow '{workflow_id}'")))?;
+    let target_root = match payload.target {
+        CloneWorkflowTarget::Project => scope.project_home.as_deref().ok_or_else(|| {
+            AppError::BadRequest(
+                "Project clone requires a session assigned to an active Project".to_string(),
+            )
+        })?,
+        CloneWorkflowTarget::User => app_state.app_data_dir.as_path(),
+    };
+    let skills_dir = confined_skills_dir(target_root).await?;
+    let files = clone_bundle_files(bundle)?;
+    let publish_skills_dir = skills_dir.clone();
+    let publish_id = workflow_id.clone();
+    let revision = payload.revision;
+    match tokio::task::spawn_blocking(move || {
+        publish_builtin_clone_blocking(&publish_skills_dir, &publish_id, revision, &files)
+    })
+    .await
+    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
+    {
+        Ok(()) => {}
+        Err(ClonePublicationError::Conflict(message)) => {
+            return Ok(crate::error::json_error(StatusCode::CONFLICT, message));
+        }
+        Err(ClonePublicationError::Io(error)) => return Err(AppError::StorageError(error)),
+        Err(ClonePublicationError::Internal(message)) => {
+            return Err(AppError::InternalError(anyhow::anyhow!(message)));
+        }
+    }
+
+    // Reload both the global base and the session-scoped composite store so the
+    // response and subsequent palette request observe the clone immediately.
+    app_state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    scope
+        .store
+        .reload()
+        .await
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    let (skill_catalog, workflow_catalog) = scope.store.command_catalog_snapshots().await;
+    let target_source = match payload.target {
+        CloneWorkflowTarget::Project => WorkflowSource::Project,
+        CloneWorkflowTarget::User => WorkflowSource::User,
+    };
+    let entry = exact_catalog_entry(
+        &skill_catalog.entries,
+        &workflow_catalog.entries,
+        &workflow_id,
+        target_source,
+    )
+    .cloned()
+    .ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "cloned Workflow was not published in the target catalog"
+        ))
+    })?;
+    let catalog_revision = skill_catalog.revision.max(workflow_catalog.revision);
+    Ok(HttpResponse::Created()
+        .insert_header(("Cache-Control", "no-store"))
+        .json(CloneWorkflowResponse {
+            workflow_id,
+            target: payload.target,
+            source_preserved: true,
+            catalog_revision,
+            entry,
+        }))
 }
 
 /// Clone one read-only global/workspace/plugin legacy workflow into the trusted
@@ -160,66 +755,11 @@ pub async fn migrate_workflow(
     if session_id.is_empty() {
         return Err(AppError::BadRequest("session_id is required".to_string()));
     }
-    let session = app_state
-        .load_session(session_id)
-        .await
-        .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
-    let project_id =
-        match bamboo_engine::project_context::ProjectContextResolver::session_project_identity(
-            &session,
-        ) {
-            bamboo_engine::project_context::SessionProjectIdentity::Assigned(project_id) => {
-                Some(project_id)
-            }
-            bamboo_engine::project_context::SessionProjectIdentity::Unassigned => None,
-            bamboo_engine::project_context::SessionProjectIdentity::Invalid { raw, message } => {
-                return Err(AppError::BadRequest(format!(
-                    "Session carries an invalid Project identity '{raw}': {message}"
-                )));
-            }
-        };
-    let persisted_workspace = (session
-        .metadata
-        .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
-        .map(String::as_str)
-        != Some(bamboo_engine::project_context::WorkspaceSource::ProjectDefault.as_str()))
-    .then(|| session.workspace_path_meta())
-    .flatten();
-    let workspace = crate::project_context::validate_workspace_assignment_with_resolver(
-        &app_state.project_store,
-        project_id.as_ref(),
-        persisted_workspace.as_deref(),
-        &app_state.workspace_resolver,
-    )
-    .map_err(|error| match error {
-        crate::project_context::ProjectWorkspaceValidationError::Invalid { .. }
-        | crate::project_context::ProjectWorkspaceValidationError::Conflict { .. } => {
-            AppError::BadRequest(error.to_string())
-        }
-        crate::project_context::ProjectWorkspaceValidationError::Store(error) => {
-            AppError::InternalError(anyhow::anyhow!(error))
-        }
-    })?
-    .ok_or_else(|| {
+    let scope = resolve_workflow_scope(&app_state, Some(session_id)).await?;
+    let workspace = scope.workspace.as_ref().ok_or_else(|| {
         AppError::BadRequest("Legacy workflow migration requires a session workspace".to_string())
     })?;
-
-    let store = if let Some(project_id) = project_id {
-        app_state.project_store.get(&project_id).map_err(|error| {
-            AppError::BadRequest(format!("Assigned Project is unavailable: {error}"))
-        })?;
-        let project_home = app_state.project_store.paths().project_home(&project_id);
-        app_state
-            .skill_manager
-            .store_for_project_workspace(&project_id, &project_home, Some(&workspace))
-            .await
-    } else {
-        app_state
-            .skill_manager
-            .store_for_workspace(Some(&workspace))
-            .await
-    }
-    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    let store = scope.store;
     store
         .reload()
         .await
@@ -567,4 +1107,109 @@ fn legacy_response() -> actix_web::HttpResponseBuilder {
             "</api/v1/bamboo/workflow-catalog>; rel=\"successor-version\"",
         ));
     response
+}
+
+#[cfg(test)]
+mod clone_publication_tests {
+    use super::*;
+
+    fn resumable_files() -> BTreeMap<String, Vec<u8>> {
+        BTreeMap::from([
+            (
+                "SKILL.md".to_string(),
+                b"---\nid: resumable\nname: Resumable\ndescription: exact recovery\n---\n\nInstructions\n"
+                    .to_vec(),
+            ),
+            (
+                "references/contract.txt".to_string(),
+                b"immutable contract\n".to_vec(),
+            ),
+        ])
+    }
+
+    #[test]
+    fn builtin_clone_recovers_uncommitted_partial_marker_write() {
+        let temporary = tempfile::tempdir().expect("temporary clone root");
+        let skills_dir = temporary.path().join("skills");
+        std::fs::create_dir(&skills_dir).expect("skills directory");
+        std::fs::write(
+            skills_dir.join(".resumable.clone-v1.json.tmp"),
+            b"{\"schema\":1",
+        )
+        .expect("partial marker write");
+        let files = resumable_files();
+
+        publish_builtin_clone_blocking(&skills_dir, "resumable", 7, &files)
+            .expect("uncommitted marker temp is safely rebuilt");
+
+        assert_eq!(
+            std::fs::read(skills_dir.join("resumable/SKILL.md")).expect("published definition"),
+            files["SKILL.md"]
+        );
+        assert!(!skills_dir.join(".resumable.clone-v1.json.tmp").exists());
+        assert!(!skills_dir.join(".resumable.clone-v1.json").exists());
+    }
+
+    #[test]
+    fn builtin_clone_resumes_partial_staging_and_post_rename_crashes_without_overwrite() {
+        let temporary = tempfile::tempdir().expect("temporary clone root");
+        let skills_dir = temporary.path().join("skills");
+        std::fs::create_dir(&skills_dir).expect("skills directory");
+        let files = resumable_files();
+        let marker = ClonePublicationMarker {
+            schema: 1,
+            workflow_id: "resumable".to_string(),
+            source_revision: 7,
+            digest: clone_bundle_digest(&files),
+        };
+        std::fs::write(
+            skills_dir.join(".resumable.clone-v1.json"),
+            serde_json::to_vec(&marker).expect("marker serialization"),
+        )
+        .expect("recovery marker");
+        let staging = temporary
+            .path()
+            .join(".workflow-clone-staging/resumable.clone-v1");
+        std::fs::create_dir_all(staging.join("references")).expect("partial staging target");
+        std::fs::write(
+            staging.join("references/contract.txt"),
+            b"partial resource write",
+        )
+        .expect("partial staged resource");
+        let target = skills_dir.join("resumable");
+
+        publish_builtin_clone_blocking(&skills_dir, "resumable", 7, &files)
+            .expect("exact partial staging resumes");
+
+        assert_eq!(
+            std::fs::read(target.join("SKILL.md")).expect("published definition"),
+            files["SKILL.md"]
+        );
+        assert_eq!(
+            std::fs::read(target.join("references/contract.txt")).expect("published resource"),
+            files["references/contract.txt"]
+        );
+        assert!(!skills_dir.join(".resumable.clone-v1.json").exists());
+        assert!(!staging.exists());
+
+        // Simulate a crash after the complete staging tree was atomically
+        // renamed but before the durable marker was removed.
+        std::fs::write(
+            skills_dir.join(".resumable.clone-v1.json"),
+            serde_json::to_vec(&marker).expect("marker serialization"),
+        )
+        .expect("post-rename recovery marker");
+        publish_builtin_clone_blocking(&skills_dir, "resumable", 7, &files)
+            .expect("complete post-rename publication is acknowledged exactly");
+        assert!(!skills_dir.join(".resumable.clone-v1.json").exists());
+
+        let before = std::fs::read(target.join("SKILL.md")).expect("definition before retry");
+        let error = publish_builtin_clone_blocking(&skills_dir, "resumable", 7, &files)
+            .expect_err("completed clone must never be overwritten");
+        assert!(matches!(error, ClonePublicationError::Conflict(_)));
+        assert_eq!(
+            std::fs::read(target.join("SKILL.md")).expect("definition after retry"),
+            before
+        );
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use actix_web::{http::StatusCode, web, HttpResponse};
 use bamboo_skills::legacy::LegacyWorkflowMigrationOutcome;
 use bamboo_skills::{
-    LegacyWorkflowMigrationStatus, SkillStore, WorkflowCatalogEntry, WorkflowSource, WorkflowStatus,
+    LegacyWorkflowMigrationStatus, SkillStore, WorkflowCatalogEntry, WorkflowCatalogSnapshot,
+    WorkflowSource, WorkflowStatus,
 };
 use fs2::FileExt;
 use sha2::{Digest, Sha256};
@@ -24,6 +25,51 @@ use super::validation::is_safe_workflow_name;
 fn legacy_workflow_io_lock() -> &'static tokio::sync::Mutex<()> {
     static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+#[cfg(test)]
+pub(crate) mod clone_scope_test_hooks {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    use tokio::sync::Semaphore;
+
+    pub(crate) struct CloneScopeHook {
+        pub(crate) reached: Semaphore,
+        pub(crate) resume: Semaphore,
+    }
+
+    fn hooks() -> &'static Mutex<HashMap<String, Arc<CloneScopeHook>>> {
+        static HOOKS: OnceLock<Mutex<HashMap<String, Arc<CloneScopeHook>>>> = OnceLock::new();
+        HOOKS.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    pub(crate) fn install(session_id: &str) -> Arc<CloneScopeHook> {
+        let hook = Arc::new(CloneScopeHook {
+            reached: Semaphore::new(0),
+            resume: Semaphore::new(0),
+        });
+        hooks()
+            .lock()
+            .expect("clone scope hooks lock")
+            .insert(session_id.to_string(), hook.clone());
+        hook
+    }
+
+    pub(crate) async fn pause_after_authoritative_scope(session_id: &str) {
+        let hook = hooks()
+            .lock()
+            .expect("clone scope hooks lock")
+            .remove(session_id);
+        if let Some(hook) = hook {
+            hook.reached.add_permits(1);
+            hook.resume
+                .acquire()
+                .await
+                .expect("clone scope test barrier remains open")
+                .forget();
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -52,9 +98,17 @@ async fn resolve_workflow_scope(
         .load_session(session_id)
         .await
         .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
+    resolve_workflow_scope_from_session(app_state, session_id, &session).await
+}
+
+async fn resolve_workflow_scope_from_session(
+    app_state: &AppState,
+    session_id: &str,
+    session: &bamboo_agent_core::Session,
+) -> Result<ResolvedWorkflowScope, AppError> {
     let project_id =
         match bamboo_engine::project_context::ProjectContextResolver::session_project_identity(
-            &session,
+            session,
         ) {
             bamboo_engine::project_context::SessionProjectIdentity::Assigned(project_id) => {
                 Some(project_id)
@@ -89,9 +143,14 @@ async fn resolve_workflow_scope(
         }
     })?;
     let project_home = if let Some(project_id) = project_id.as_ref() {
-        app_state.project_store.get(project_id).map_err(|error| {
+        let project = app_state.project_store.get(project_id).map_err(|error| {
             AppError::BadRequest(format!("Assigned Project is unavailable: {error}"))
         })?;
+        if project.status != bamboo_domain::ProjectStatus::Active {
+            return Err(AppError::Forbidden(format!(
+                "Session '{session_id}' is assigned to archived Project '{project_id}'"
+            )));
+        }
         Some(app_state.project_store.paths().project_home(project_id))
     } else {
         None
@@ -157,10 +216,21 @@ pub async fn list_workflow_catalog(
     query: web::Query<WorkflowCatalogQuery>,
 ) -> Result<HttpResponse, AppError> {
     let scope = resolve_workflow_scope(&app_state, query.session_id.as_deref()).await?;
-    let snapshot = scope.store.workflow_catalog_snapshot().await;
+    let (skill_catalog, workflow_catalog) = scope.store.command_catalog_snapshots().await;
+    let mut entries = skill_catalog.entries;
+    entries.extend(
+        workflow_catalog
+            .entries
+            .into_iter()
+            .filter(WorkflowCatalogEntry::is_public_workflow),
+    );
+    let snapshot = WorkflowCatalogSnapshot {
+        revision: skill_catalog.revision.max(workflow_catalog.revision),
+        entries,
+    };
     Ok(HttpResponse::Ok()
         .insert_header(("Cache-Control", "no-store"))
-        .json(snapshot.public_workflows()))
+        .json(snapshot))
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -216,7 +286,7 @@ async fn confined_skills_dir(root: &Path) -> Result<PathBuf, AppError> {
 
 fn clone_bundle_files(
     bundle: &bamboo_skills::store::builtin::BuiltinSkillBundle,
-) -> Result<BTreeMap<String, Vec<u8>>, AppError> {
+) -> Result<BTreeMap<String, bamboo_skills::store::builtin::BuiltinSkillFile>, AppError> {
     let mut files = bundle
         .files
         .iter()
@@ -224,17 +294,26 @@ fn clone_bundle_files(
         .collect::<BTreeMap<_, _>>();
     let markdown = bamboo_skills::store::parser::render_skill_markdown(&bundle.skill)
         .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
-    files.insert("SKILL.md".to_string(), markdown.into_bytes());
+    files.insert(
+        "SKILL.md".to_string(),
+        bamboo_skills::store::builtin::BuiltinSkillFile {
+            bytes: markdown.into_bytes(),
+            executable: false,
+        },
+    );
     Ok(files)
 }
 
-fn clone_bundle_digest(files: &BTreeMap<String, Vec<u8>>) -> String {
+fn clone_bundle_digest(
+    files: &BTreeMap<String, bamboo_skills::store::builtin::BuiltinSkillFile>,
+) -> String {
     let mut digest = Sha256::new();
-    for (path, bytes) in files {
+    for (path, file) in files {
         digest.update((path.len() as u64).to_le_bytes());
         digest.update(path.as_bytes());
-        digest.update((bytes.len() as u64).to_le_bytes());
-        digest.update(bytes);
+        digest.update([u8::from(file.executable)]);
+        digest.update((file.bytes.len() as u64).to_le_bytes());
+        digest.update(&file.bytes);
     }
     hex::encode(digest.finalize())
 }
@@ -268,10 +347,9 @@ fn ensure_clone_parent(root: &Path, relative: &Path) -> Result<(), ClonePublicat
         current.push(component);
         match std::fs::symlink_metadata(&current) {
             Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
-                return Err(ClonePublicationError::Conflict(format!(
-                    "clone target '{}' is not a real directory",
-                    current.display()
-                )));
+                return Err(ClonePublicationError::Conflict(
+                    "clone target resource parent is not a real directory".to_string(),
+                ));
             }
             Ok(_) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -286,7 +364,7 @@ fn ensure_clone_parent(root: &Path, relative: &Path) -> Result<(), ClonePublicat
 fn write_clone_file(
     target_root: &Path,
     relative: &str,
-    bytes: &[u8],
+    embedded: &bamboo_skills::store::builtin::BuiltinSkillFile,
 ) -> Result<(), ClonePublicationError> {
     let relative_path = checked_clone_relative_path(relative)?;
     ensure_clone_parent(target_root, &relative_path)?;
@@ -296,16 +374,16 @@ fn write_clone_file(
         .create_new(true)
         .open(&target)
     {
-        Ok(mut file) => {
+        Ok(mut output) => {
             use std::io::Write;
-            file.write_all(bytes)?;
-            file.sync_all()?;
+            output.write_all(&embedded.bytes)?;
+            output.sync_all()?;
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let metadata = std::fs::symlink_metadata(&target)?;
             if metadata.file_type().is_symlink()
                 || !metadata.is_file()
-                || std::fs::read(&target)? != bytes
+                || std::fs::read(&target)? != embedded.bytes
             {
                 return Err(ClonePublicationError::Conflict(format!(
                     "clone target resource '{relative}' already exists with different content"
@@ -315,9 +393,12 @@ fn write_clone_file(
         Err(error) => return Err(error.into()),
     }
     #[cfg(unix)]
-    if relative.starts_with("scripts/") {
+    {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))?;
+        std::fs::set_permissions(
+            &target,
+            std::fs::Permissions::from_mode(if embedded.executable { 0o755 } else { 0o644 }),
+        )?;
         std::fs::File::open(&target)?.sync_all()?;
     }
     Ok(())
@@ -334,7 +415,7 @@ fn sync_clone_directory(path: &Path) -> Result<(), ClonePublicationError> {
 fn verify_clone_tree(
     target: &Path,
     workflow_id: &str,
-    files: &BTreeMap<String, Vec<u8>>,
+    files: &BTreeMap<String, bamboo_skills::store::builtin::BuiltinSkillFile>,
 ) -> Result<(), ClonePublicationError> {
     let mut actual = BTreeMap::new();
     for entry in walkdir::WalkDir::new(target).follow_links(false) {
@@ -354,7 +435,22 @@ fn verify_clone_tree(
                 .map_err(|error| ClonePublicationError::Internal(error.to_string()))?
                 .to_string_lossy()
                 .replace('\\', "/");
-            actual.insert(relative, std::fs::read(entry.path())?);
+            #[cfg(unix)]
+            let executable = {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::metadata(entry.path())?.permissions().mode() & 0o111 != 0
+            };
+            #[cfg(not(unix))]
+            let executable = files
+                .get(&relative)
+                .is_some_and(|expected| expected.executable);
+            actual.insert(
+                relative,
+                bamboo_skills::store::builtin::BuiltinSkillFile {
+                    bytes: std::fs::read(entry.path())?,
+                    executable,
+                },
+            );
         } else if !entry.file_type().is_dir() {
             return Err(ClonePublicationError::Conflict(
                 "Workflow clone target contains a non-regular resource".to_string(),
@@ -435,6 +531,12 @@ fn publish_clone_marker(
         Ok(_) => {
             // No authoritative marker or target exists while the clone lock is
             // held, so this can only be an uncommitted pre-rename crash remnant.
+            let partial = std::fs::read(&temporary)?;
+            if !marker_bytes.starts_with(&partial) {
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow clone temporary marker contains divergent data".to_string(),
+                ));
+            }
             std::fs::remove_file(&temporary)?;
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -448,7 +550,14 @@ fn publish_clone_marker(
     marker_file.write_all(marker_bytes)?;
     marker_file.sync_all()?;
     drop(marker_file);
-    std::fs::rename(&temporary, marker_path)?;
+    if let Err(error) = rename_noreplace(&temporary, marker_path) {
+        if std::fs::symlink_metadata(marker_path).is_ok() {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone recovery marker appeared concurrently".to_string(),
+            ));
+        }
+        return Err(error.into());
+    }
     sync_clone_directory(skills_dir)?;
     Ok(())
 }
@@ -457,8 +566,119 @@ fn publish_builtin_clone_blocking(
     skills_dir: &Path,
     workflow_id: &str,
     source_revision: u64,
-    files: &BTreeMap<String, Vec<u8>>,
+    files: &BTreeMap<String, bamboo_skills::store::builtin::BuiltinSkillFile>,
 ) -> Result<(), ClonePublicationError> {
+    publish_builtin_clone_blocking_with_before_publish(
+        skills_dir,
+        workflow_id,
+        source_revision,
+        files,
+        |_| {},
+    )
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn rename_noreplace(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let from = CString::new(from.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let to = CString::new(to.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    // SAFETY: both C strings are owned for the duration of the call. renameat2
+    // performs the publication atomically and RENAME_NOREPLACE makes a
+    // check-to-rename target race fail instead of replacing user content.
+    let result = unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+fn rename_noreplace(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let from = CString::new(from.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let to = CString::new(to.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    // SAFETY: both pointers reference live C strings and RENAME_EXCL is the
+    // Darwin atomic no-replace primitive.
+    let result = unsafe { libc::renamex_np(from.as_ptr(), to.as_ptr(), libc::RENAME_EXCL) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn rename_noreplace(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn MoveFileExW(
+            existing_file_name: *const u16,
+            new_file_name: *const u16,
+            flags: u32,
+        ) -> i32;
+    }
+
+    let from = from
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let to = to
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    // SAFETY: both UTF-16 buffers are NUL-terminated and live for the call.
+    // Passing zero flags deliberately omits MOVEFILE_REPLACE_EXISTING, so a
+    // concurrent destination is never overwritten (unlike std::fs::rename).
+    let result = unsafe { MoveFileExW(from.as_ptr(), to.as_ptr(), 0) };
+    if result != 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android", target_vendor = "apple"))
+))]
+fn rename_noreplace(_from: &Path, _to: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "atomic no-replace directory publication is unavailable on this platform",
+    ))
+}
+
+fn publish_builtin_clone_blocking_with_before_publish<F>(
+    skills_dir: &Path,
+    workflow_id: &str,
+    source_revision: u64,
+    files: &BTreeMap<String, bamboo_skills::store::builtin::BuiltinSkillFile>,
+    before_publish: F,
+) -> Result<(), ClonePublicationError>
+where
+    F: FnOnce(&Path),
+{
     let skill_markdown = files.get("SKILL.md").ok_or_else(|| {
         ClonePublicationError::Internal("embedded Workflow bundle is missing SKILL.md".to_string())
     })?;
@@ -530,11 +750,7 @@ fn publish_builtin_clone_blocking(
             FileExt::unlock(&lock)?;
             return Ok(());
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            if !marker_exists {
-                publish_clone_marker(skills_dir, workflow_id, &marker_path, &marker_bytes)?;
-            }
-        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error.into()),
     }
 
@@ -544,6 +760,20 @@ fn publish_builtin_clone_blocking(
     // to discard and rebuild; clients never observe a partial Workflow bundle.
     let staging_parent = clone_staging_parent(skills_dir)?;
     let staging = staging_parent.join(format!("{workflow_id}.clone-v1"));
+    if !marker_exists {
+        match std::fs::symlink_metadata(&staging) {
+            Ok(_) => {
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow clone found unclaimed staging data; refusing to overwrite it"
+                        .to_string(),
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                publish_clone_marker(skills_dir, workflow_id, &marker_path, &marker_bytes)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
     match std::fs::symlink_metadata(&staging) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
             return Err(ClonePublicationError::Conflict(
@@ -555,13 +785,21 @@ fn publish_builtin_clone_blocking(
         Err(error) => return Err(error.into()),
     }
     std::fs::create_dir(&staging)?;
-    for (relative, bytes) in files.iter().filter(|(path, _)| path.as_str() != "SKILL.md") {
-        write_clone_file(&staging, relative, bytes)?;
+    for (relative, file) in files.iter().filter(|(path, _)| path.as_str() != "SKILL.md") {
+        write_clone_file(&staging, relative, file)?;
     }
     write_clone_file(&staging, "SKILL.md", skill_markdown)?;
     verify_clone_tree(&staging, workflow_id, files)?;
     sync_clone_tree_directories(&staging)?;
-    std::fs::rename(&staging, &target)?;
+    before_publish(&target);
+    if let Err(error) = rename_noreplace(&staging, &target) {
+        if std::fs::symlink_metadata(&target).is_ok() {
+            return Err(ClonePublicationError::Conflict(format!(
+                "Workflow '{workflow_id}' appeared in the target layer while cloning"
+            )));
+        }
+        return Err(error.into());
+    }
     sync_clone_directory(skills_dir)?;
     verify_clone_tree(&target, workflow_id, files)?;
     std::fs::remove_file(&marker_path)?;
@@ -612,11 +850,35 @@ pub async fn clone_workflow(
             "session_id is required for a Project clone".to_string(),
         ));
     }
-    let scope_session_id = match payload.target {
-        CloneWorkflowTarget::Project => payload.session_id.as_deref(),
-        CloneWorkflowTarget::User => None,
+    // A Project clone derives its destination exclusively from the current
+    // durable session. Hold the same per-session lock used by Project/Workspace
+    // PATCH through the final publication and catalog reload: a reassignment
+    // can therefore happen wholly before or wholly after this clone, never in
+    // the scope-resolution -> filesystem-publication gap.
+    let (scope_guard, scope) = match payload.target {
+        CloneWorkflowTarget::Project => {
+            let session_id = payload
+                .session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .expect("Project session_id was validated above");
+            let guard = app_state.persistence.acquire_lock(session_id).await;
+            let session = app_state
+                .persistence
+                .storage()
+                .load_session(session_id)
+                .await
+                .map_err(AppError::StorageError)?
+                .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
+            let scope =
+                resolve_workflow_scope_from_session(&app_state, session_id, &session).await?;
+            #[cfg(test)]
+            clone_scope_test_hooks::pause_after_authoritative_scope(session_id).await;
+            (Some(guard), scope)
+        }
+        CloneWorkflowTarget::User => (None, resolve_workflow_scope(&app_state, None).await?),
     };
-    let scope = resolve_workflow_scope(&app_state, scope_session_id).await?;
     scope
         .store
         .reload()
@@ -681,12 +943,16 @@ pub async fn clone_workflow(
     let publish_skills_dir = skills_dir.clone();
     let publish_id = workflow_id.clone();
     let revision = payload.revision;
-    match tokio::task::spawn_blocking(move || {
-        publish_builtin_clone_blocking(&publish_skills_dir, &publish_id, revision, &files)
+    let (publication, scope_guard) = tokio::task::spawn_blocking(move || {
+        let publication =
+            publish_builtin_clone_blocking(&publish_skills_dir, &publish_id, revision, &files);
+        // Keep Project/Workspace reassignment serialized even if the request
+        // future is cancelled while this non-cancellable filesystem task runs.
+        (publication, scope_guard)
     })
     .await
-    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
-    {
+    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    match publication {
         Ok(()) => {}
         Err(ClonePublicationError::Conflict(message)) => {
             return Ok(crate::error::json_error(StatusCode::CONFLICT, message));
@@ -711,6 +977,11 @@ pub async fn clone_workflow(
         .await
         .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
     let (skill_catalog, workflow_catalog) = scope.store.command_catalog_snapshots().await;
+    // On the ordinary path retain the returned guard through both catalog
+    // reloads and the correlated response snapshot. On request cancellation,
+    // the blocking task owns it until publication finishes and then dropping
+    // the unobserved output releases it.
+    drop(scope_guard);
     let target_source = match payload.target {
         CloneWorkflowTarget::Project => WorkflowSource::Project,
         CloneWorkflowTarget::User => WorkflowSource::User,
@@ -755,7 +1026,15 @@ pub async fn migrate_workflow(
     if session_id.is_empty() {
         return Err(AppError::BadRequest("session_id is required".to_string()));
     }
-    let scope = resolve_workflow_scope(&app_state, Some(session_id)).await?;
+    let _scope_guard = app_state.persistence.acquire_lock(session_id).await;
+    let session = app_state
+        .persistence
+        .storage()
+        .load_session(session_id)
+        .await
+        .map_err(AppError::StorageError)?
+        .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
+    let scope = resolve_workflow_scope_from_session(&app_state, session_id, &session).await?;
     let workspace = scope.workspace.as_ref().ok_or_else(|| {
         AppError::BadRequest("Legacy workflow migration requires a session workspace".to_string())
     })?;
@@ -1113,16 +1392,36 @@ fn legacy_response() -> actix_web::HttpResponseBuilder {
 mod clone_publication_tests {
     use super::*;
 
-    fn resumable_files() -> BTreeMap<String, Vec<u8>> {
+    fn embedded_file(
+        bytes: &[u8],
+        executable: bool,
+    ) -> bamboo_skills::store::builtin::BuiltinSkillFile {
+        bamboo_skills::store::builtin::BuiltinSkillFile {
+            bytes: bytes.to_vec(),
+            executable,
+        }
+    }
+
+    fn resumable_files() -> BTreeMap<String, bamboo_skills::store::builtin::BuiltinSkillFile> {
         BTreeMap::from([
             (
                 "SKILL.md".to_string(),
-                b"---\nid: resumable\nname: Resumable\ndescription: exact recovery\n---\n\nInstructions\n"
-                    .to_vec(),
+                embedded_file(
+                    b"---\nid: resumable\nname: Resumable\ndescription: exact recovery\n---\n\nInstructions\n",
+                    false,
+                ),
             ),
             (
                 "references/contract.txt".to_string(),
-                b"immutable contract\n".to_vec(),
+                embedded_file(b"immutable contract\n", false),
+            ),
+            (
+                "scripts/run.sh".to_string(),
+                embedded_file(b"#!/bin/sh\nexit 0\n", true),
+            ),
+            (
+                "scripts/helpers.py".to_string(),
+                embedded_file(b"HELPER = True\n", false),
             ),
         ])
     }
@@ -1144,10 +1443,104 @@ mod clone_publication_tests {
 
         assert_eq!(
             std::fs::read(skills_dir.join("resumable/SKILL.md")).expect("published definition"),
-            files["SKILL.md"]
+            files["SKILL.md"].bytes
         );
         assert!(!skills_dir.join(".resumable.clone-v1.json.tmp").exists());
         assert!(!skills_dir.join(".resumable.clone-v1.json").exists());
+    }
+
+    #[test]
+    fn builtin_clone_preserves_divergent_temporary_marker_data() {
+        let temporary = tempfile::tempdir().expect("temporary clone root");
+        let skills_dir = temporary.path().join("skills");
+        std::fs::create_dir(&skills_dir).expect("skills directory");
+        let temporary_marker = skills_dir.join(".resumable.clone-v1.json.tmp");
+        std::fs::write(&temporary_marker, b"unrelated writer data").expect("divergent marker data");
+
+        let error = publish_builtin_clone_blocking(&skills_dir, "resumable", 7, &resumable_files())
+            .expect_err("divergent hidden data must never be deleted as a crash remnant");
+
+        assert!(matches!(error, ClonePublicationError::Conflict(_)));
+        assert_eq!(
+            std::fs::read(&temporary_marker).expect("divergent marker remains"),
+            b"unrelated writer data"
+        );
+        assert!(!skills_dir.join(".resumable.clone-v1.json").exists());
+        assert!(!skills_dir.join("resumable").exists());
+    }
+
+    #[test]
+    fn builtin_clone_preserves_staging_without_an_authoritative_marker() {
+        let temporary = tempfile::tempdir().expect("temporary clone root");
+        let skills_dir = temporary.path().join("skills");
+        std::fs::create_dir(&skills_dir).expect("skills directory");
+        let staging = temporary
+            .path()
+            .join(".workflow-clone-staging/resumable.clone-v1");
+        std::fs::create_dir_all(&staging).expect("unclaimed staging");
+        let sentinel = staging.join("user-sentinel.txt");
+        std::fs::write(&sentinel, b"must remain").expect("unclaimed staging data");
+
+        let error = publish_builtin_clone_blocking(&skills_dir, "resumable", 7, &resumable_files())
+            .expect_err("staging without a durable marker is not server-owned");
+
+        assert!(matches!(error, ClonePublicationError::Conflict(_)));
+        assert_eq!(
+            std::fs::read(&sentinel).expect("unclaimed staging remains"),
+            b"must remain"
+        );
+        assert!(!skills_dir.join(".resumable.clone-v1.json").exists());
+        assert!(!skills_dir.join("resumable").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn builtin_clone_preserves_and_verifies_executable_modes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temporary = tempfile::tempdir().expect("temporary clone root");
+        let skills_dir = temporary.path().join("skills");
+        std::fs::create_dir(&skills_dir).expect("skills directory");
+        let files = resumable_files();
+        publish_builtin_clone_blocking(&skills_dir, "resumable", 7, &files)
+            .expect("publish exact modes");
+        let target = skills_dir.join("resumable");
+        assert_ne!(
+            std::fs::metadata(target.join("scripts/run.sh"))
+                .expect("script metadata")
+                .permissions()
+                .mode()
+                & 0o111,
+            0
+        );
+        assert_eq!(
+            std::fs::metadata(target.join("scripts/helpers.py"))
+                .expect("helper metadata")
+                .permissions()
+                .mode()
+                & 0o111,
+            0
+        );
+
+        let marker = ClonePublicationMarker {
+            schema: 1,
+            workflow_id: "resumable".to_string(),
+            source_revision: 7,
+            digest: clone_bundle_digest(&files),
+        };
+        std::fs::write(
+            skills_dir.join(".resumable.clone-v1.json"),
+            serde_json::to_vec(&marker).expect("marker JSON"),
+        )
+        .expect("recovery marker");
+        std::fs::set_permissions(
+            target.join("scripts/helpers.py"),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .expect("inject mode drift");
+        let error = publish_builtin_clone_blocking(&skills_dir, "resumable", 7, &files)
+            .expect_err("mode drift must not be accepted as exact recovery");
+        assert!(matches!(error, ClonePublicationError::Conflict(_)));
     }
 
     #[test]
@@ -1183,11 +1576,11 @@ mod clone_publication_tests {
 
         assert_eq!(
             std::fs::read(target.join("SKILL.md")).expect("published definition"),
-            files["SKILL.md"]
+            files["SKILL.md"].bytes
         );
         assert_eq!(
             std::fs::read(target.join("references/contract.txt")).expect("published resource"),
-            files["references/contract.txt"]
+            files["references/contract.txt"].bytes
         );
         assert!(!skills_dir.join(".resumable.clone-v1.json").exists());
         assert!(!staging.exists());
@@ -1211,5 +1604,83 @@ mod clone_publication_tests {
             std::fs::read(target.join("SKILL.md")).expect("definition after retry"),
             before
         );
+    }
+
+    #[test]
+    fn builtin_clone_does_not_replace_directory_created_during_publish() {
+        let temporary = tempfile::tempdir().expect("temporary clone root");
+        let skills_dir = temporary.path().join("skills");
+        std::fs::create_dir(&skills_dir).expect("skills directory");
+        let files = resumable_files();
+        let target = skills_dir.join("resumable");
+
+        let error = publish_builtin_clone_blocking_with_before_publish(
+            &skills_dir,
+            "resumable",
+            7,
+            &files,
+            |publish_target| std::fs::create_dir(publish_target).expect("racing target"),
+        )
+        .expect_err("racing target must win without replacement");
+
+        assert!(matches!(error, ClonePublicationError::Conflict(_)));
+        assert!(target.is_dir());
+        assert!(std::fs::read_dir(&target)
+            .expect("racing directory")
+            .next()
+            .is_none());
+    }
+
+    #[test]
+    fn clone_publication_never_replaces_a_concurrent_marker() {
+        let temporary = tempfile::tempdir().expect("temporary clone root");
+        let staging = temporary.path().join("marker.tmp");
+        let marker = temporary.path().join("marker.json");
+        std::fs::write(&staging, b"server marker").expect("staging marker");
+        std::fs::write(&marker, b"concurrent writer").expect("racing marker");
+
+        rename_noreplace(&staging, &marker).expect_err("existing marker must win");
+
+        assert_eq!(
+            std::fs::read(&marker).expect("racing marker remains"),
+            b"concurrent writer"
+        );
+        assert_eq!(
+            std::fs::read(&staging).expect("server staging remains recoverable"),
+            b"server marker"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn builtin_clone_does_not_replace_symlink_created_during_publish() {
+        use std::os::unix::fs::symlink;
+
+        let temporary = tempfile::tempdir().expect("temporary clone root");
+        let skills_dir = temporary.path().join("skills");
+        std::fs::create_dir(&skills_dir).expect("skills directory");
+        let outside = temporary.path().join("outside");
+        std::fs::create_dir(&outside).expect("outside directory");
+        let files = resumable_files();
+        let target = skills_dir.join("resumable");
+
+        let error = publish_builtin_clone_blocking_with_before_publish(
+            &skills_dir,
+            "resumable",
+            7,
+            &files,
+            |publish_target| symlink(&outside, publish_target).expect("racing symlink"),
+        )
+        .expect_err("racing symlink must win without replacement");
+
+        assert!(matches!(error, ClonePublicationError::Conflict(_)));
+        assert!(std::fs::symlink_metadata(&target)
+            .expect("racing target")
+            .file_type()
+            .is_symlink());
+        assert!(std::fs::read_dir(&outside)
+            .expect("outside directory")
+            .next()
+            .is_none());
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/mod.rs
@@ -5,9 +5,11 @@ mod types;
 mod validation;
 
 pub use handlers::{
-    delete_workflow, get_workflow, list_workflow_catalog, list_workflows, migrate_workflow,
-    save_workflow,
+    clone_workflow, delete_workflow, get_workflow, list_workflow_catalog, list_workflows,
+    migrate_workflow, save_workflow,
 };
-pub use types::{MigrateWorkflowRequest, SaveWorkflowRequest, WorkflowCatalogQuery};
+pub use types::{
+    CloneWorkflowRequest, MigrateWorkflowRequest, SaveWorkflowRequest, WorkflowCatalogQuery,
+};
 
 pub(crate) use validation::is_safe_workflow_name;

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -118,6 +118,143 @@ async fn workflow_catalog_session_without_workspace_uses_global_snapshot() {
 }
 
 #[actix_web::test]
+async fn builtin_clone_to_user_is_exact_read_only_and_never_overwrites() {
+    let data = tempfile::tempdir().expect("data dir");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let review = state
+        .skill_manager
+        .store()
+        .skill_catalog_snapshot()
+        .await
+        .entries
+        .into_iter()
+        .find(|entry| {
+            entry.id == "review" && entry.source == bamboo_skills::WorkflowSource::Builtin
+        })
+        .expect("builtin review");
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state.clone()).route(
+        "/catalog/{workflow_id}/clone",
+        actix_web::web::post().to(super::clone_workflow),
+    ))
+    .await;
+    let payload = serde_json::json!({
+        "source": "builtin",
+        "revision": review.revision,
+        "target": "user",
+        "session_id": "ignored-for-user-target"
+    });
+    let response = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/review/clone")
+            .set_json(&payload)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), actix_web::http::StatusCode::CREATED);
+    let body: serde_json::Value = actix_web::test::read_body_json(response).await;
+    assert_eq!(body["entry"]["source"], "user");
+    assert_eq!(body["entry"]["id"], "review");
+    assert_eq!(body["source_preserved"], true);
+    let clone = data.path().join("skills/review/SKILL.md");
+    let builtin = data.path().join("skills-builtin-v1/review/SKILL.md");
+    assert!(clone.is_file());
+    assert!(
+        builtin.is_file(),
+        "read-only builtin source must remain intact"
+    );
+    let cloned_before = std::fs::read(&clone).expect("clone bytes");
+    assert!(!data.path().join("skills/.review.clone-v1.json").exists());
+
+    let conflict = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/review/clone")
+            .set_json(&payload)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(conflict.status(), actix_web::http::StatusCode::CONFLICT);
+    assert_eq!(
+        std::fs::read(&clone).expect("clone remains"),
+        cloned_before,
+        "repeat clone must not overwrite an editable user bundle"
+    );
+}
+
+#[actix_web::test]
+async fn builtin_clone_to_project_uses_durable_session_identity_not_a_client_path() {
+    let data = tempfile::tempdir().expect("data dir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let project = state
+        .project_store
+        .create("Clone Project", None)
+        .expect("create Project");
+    let mut session = bamboo_agent_core::Session::new("project-clone-session", "model");
+    session.set_project_id_meta(project.id.to_string());
+    session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    state.save_and_cache_session(&mut session).await;
+    let store = state
+        .skill_manager
+        .store_for_project_workspace(
+            &project.id,
+            &state.project_store.paths().project_home(&project.id),
+            Some(workspace.path()),
+        )
+        .await
+        .expect("Project Workflow store");
+    let review = store
+        .skill_catalog_snapshot()
+        .await
+        .entries
+        .into_iter()
+        .find(|entry| {
+            entry.id == "review" && entry.source == bamboo_skills::WorkflowSource::Builtin
+        })
+        .expect("builtin review");
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state.clone()).route(
+        "/catalog/{workflow_id}/clone",
+        actix_web::web::post().to(super::clone_workflow),
+    ))
+    .await;
+    let response = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/review/clone")
+            .set_json(serde_json::json!({
+                "source": "builtin",
+                "revision": review.revision,
+                "target": "project",
+                "session_id": "project-clone-session"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), actix_web::http::StatusCode::CREATED);
+    let body: serde_json::Value = actix_web::test::read_body_json(response).await;
+    assert_eq!(body["entry"]["source"], "project");
+    assert!(state
+        .project_store
+        .paths()
+        .project_home(&project.id)
+        .join("skills/review/SKILL.md")
+        .is_file());
+    assert!(
+        !data.path().join("skills/review/SKILL.md").exists(),
+        "Project clone must not fall back to the user layer"
+    );
+}
+
+#[actix_web::test]
 async fn assigned_project_workflow_catalog_reports_workspace_then_project_sources() {
     let data = tempfile::tempdir().expect("data dir");
     let workspace = tempfile::tempdir().expect("workspace");
@@ -584,6 +721,83 @@ async fn legacy_api_keeps_workflow_source_only_and_bridges_catalog_event() {
     })
     .await;
     assert!(bridged.is_ok(), "workflow.changed must reach account feed");
+}
+
+#[actix_web::test]
+async fn instruction_skill_changed_invalid_and_recovered_reach_account_feed() {
+    let data = tempfile::tempdir().expect("data dir");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let mut account_events = state.account_sink.subscribe();
+    let skill_dir = data.path().join("skills/library-refresh");
+    tokio::fs::create_dir_all(&skill_dir)
+        .await
+        .expect("skill dir");
+    let skill_file = skill_dir.join("SKILL.md");
+    let valid = "---\nname: library-refresh\ndescription: Refresh the Workflow Library.\n---\n\nRefresh it.\n";
+
+    tokio::fs::write(&skill_file, valid)
+        .await
+        .expect("create instruction Skill");
+    state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .expect("reload created Skill");
+    tokio::fs::write(&skill_file, "---\nname: [\n")
+        .await
+        .expect("corrupt instruction Skill");
+    state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .expect("publish invalid LKG Skill");
+    tokio::fs::write(&skill_file, valid)
+        .await
+        .expect("recover instruction Skill");
+    state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .expect("publish recovered Skill");
+
+    let observed = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        let mut changed = false;
+        let mut invalid = false;
+        let mut recovered = false;
+        while !(changed && invalid && recovered) {
+            let event = account_events.recv().await.expect("account event");
+            match &event.event {
+                bamboo_agent_core::AgentEvent::WorkflowChanged { workflow_id, .. }
+                    if workflow_id == "library-refresh" =>
+                {
+                    changed = true
+                }
+                bamboo_agent_core::AgentEvent::WorkflowInvalid { workflow_id, .. }
+                    if workflow_id == "library-refresh" =>
+                {
+                    invalid = true
+                }
+                bamboo_agent_core::AgentEvent::WorkflowRecovered { workflow_id, .. }
+                    if workflow_id == "library-refresh" =>
+                {
+                    recovered = true
+                }
+                _ => {}
+            }
+        }
+    })
+    .await;
+    assert!(
+        observed.is_ok(),
+        "instruction catalog transitions must invalidate Workflow clients"
+    );
 }
 
 #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -23,7 +23,7 @@ async fn assert_legacy_endpoint_success(context: &str, response: actix_web::dev:
 }
 
 #[actix_web::test]
-async fn workflow_catalog_excludes_instruction_skills_and_returns_orchestration_metadata() {
+async fn workflow_catalog_unifies_instruction_and_orchestration_metadata_without_bodies() {
     let data = tempfile::tempdir().expect("data dir");
     let skill = data.path().join("skills/review");
     tokio::fs::create_dir_all(&skill).await.expect("skill dir");
@@ -54,7 +54,7 @@ async fn workflow_catalog_excludes_instruction_skills_and_returns_orchestration_
             .await
             .expect("app state"),
     );
-    let app = actix_web::test::init_service(actix_web::App::new().app_data(state).route(
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state.clone()).route(
         "/catalog",
         actix_web::web::get().to(super::list_workflow_catalog),
     ))
@@ -64,12 +64,102 @@ async fn workflow_catalog_excludes_instruction_skills_and_returns_orchestration_
         .to_request();
     let body = actix_web::test::call_and_read_body(&app, request).await;
     let text = std::str::from_utf8(&body).expect("utf8 response");
-    assert!(!text.contains("Reviews changes"));
+    assert!(text.contains("Reviews changes"));
+    assert!(text.contains("\"kind\":\"instruction\""));
     assert!(text.contains("Deploys changes"));
+    assert!(text.contains("\"kind\":\"orchestration\""));
     assert!(text.contains("\"revision\""));
     assert!(!text.contains("TOP SECRET INSTRUCTIONS"));
     assert!(!text.contains("WORKFLOW SECRET BODY"));
     assert!(!text.contains("SKILL.md"));
+    let initial: serde_json::Value = serde_json::from_slice(&body).expect("catalog json");
+    let review = initial["entries"]
+        .as_array()
+        .expect("entries")
+        .iter()
+        .find(|entry| entry["id"] == "review")
+        .expect("review entry");
+    assert_eq!(review["source"], "user");
+    assert_eq!(review["status"], "valid");
+    assert!(review["shadowed_candidates"]
+        .as_array()
+        .expect("shadowed candidates")
+        .iter()
+        .any(|candidate| candidate["source"] == "builtin"));
+
+    const PRIVATE_INVALID_FIELD: &str = "private_invalid_catalog_field";
+    const PRIVATE_INVALID_BODY: &str = "PRIVATE INVALID REPLACEMENT BODY";
+    tokio::fs::write(
+        skill.join("SKILL.md"),
+        format!(
+            "---\nname: review\ndescription: changed too early\n{PRIVATE_INVALID_FIELD}: secret\n---\n{PRIVATE_INVALID_BODY}\n"
+        ),
+    )
+    .await
+    .expect("break instruction bundle");
+    state
+        .skill_manager
+        .store()
+        .reload_global_workflow_views()
+        .await
+        .expect("invalid publication stays isolated");
+    let invalid: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/catalog")
+            .to_request(),
+    )
+    .await;
+    let invalid_review = invalid["entries"]
+        .as_array()
+        .expect("invalid entries")
+        .iter()
+        .find(|entry| entry["id"] == "review")
+        .expect("invalid review remains visible");
+    assert_eq!(invalid_review["status"], "invalid");
+    assert_eq!(invalid_review["description"], "Reviews changes");
+    assert!(invalid_review["last_error"].is_string());
+    let rendered = invalid_review.to_string();
+    assert!(!rendered.contains(PRIVATE_INVALID_FIELD));
+    assert!(!rendered.contains(PRIVATE_INVALID_BODY));
+    assert!(!rendered.contains(data.path().to_string_lossy().as_ref()));
+    assert!(invalid_review["shadowed_candidates"]
+        .as_array()
+        .expect("invalid shadowed candidates")
+        .iter()
+        .any(|candidate| candidate["source"] == "builtin"));
+
+    tokio::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: review\ndescription: Recovered review\n---\nRECOVERED PRIVATE BODY\n",
+    )
+    .await
+    .expect("repair instruction bundle");
+    state
+        .skill_manager
+        .store()
+        .reload_global_workflow_views()
+        .await
+        .expect("recovered publication");
+    let recovered: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/catalog")
+            .to_request(),
+    )
+    .await;
+    let recovered_review = recovered["entries"]
+        .as_array()
+        .expect("recovered entries")
+        .iter()
+        .find(|entry| entry["id"] == "review")
+        .expect("recovered review");
+    assert_eq!(recovered_review["status"], "valid");
+    assert_eq!(recovered_review["description"], "Recovered review");
+    assert!(recovered_review.get("last_error").is_none());
+    assert!(!recovered_review
+        .to_string()
+        .contains("RECOVERED PRIVATE BODY"));
 }
 
 #[actix_web::test]
@@ -255,6 +345,199 @@ async fn builtin_clone_to_project_uses_durable_session_identity_not_a_client_pat
 }
 
 #[actix_web::test]
+async fn builtin_clone_rejects_archived_project_without_writing() {
+    let data = tempfile::tempdir().expect("data dir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let project = state
+        .project_store
+        .create_with_project_path(
+            "Archived Clone Project",
+            None,
+            workspace.path().to_string_lossy(),
+            Vec::new(),
+        )
+        .expect("create Project");
+    state
+        .project_store
+        .archive(&project.id, project.revision)
+        .expect("archive Project");
+    let mut session = bamboo_agent_core::Session::new("archived-clone-session", "model");
+    session.set_project_id_meta(project.id.to_string());
+    session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    session.metadata.insert(
+        bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
+        bamboo_engine::project_context::WorkspaceSource::Explicit
+            .as_str()
+            .to_string(),
+    );
+    state.save_and_cache_session(&mut session).await;
+    let review = state
+        .skill_manager
+        .store()
+        .skill_catalog_snapshot()
+        .await
+        .entries
+        .into_iter()
+        .find(|entry| {
+            entry.id == "review" && entry.source == bamboo_skills::WorkflowSource::Builtin
+        })
+        .expect("builtin review");
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state.clone()).route(
+        "/catalog/{workflow_id}/clone",
+        actix_web::web::post().to(super::clone_workflow),
+    ))
+    .await;
+
+    let response = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/review/clone")
+            .set_json(serde_json::json!({
+                "source": "builtin",
+                "revision": review.revision,
+                "target": "project",
+                "session_id": session.id,
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), actix_web::http::StatusCode::FORBIDDEN);
+    assert!(!state
+        .project_store
+        .paths()
+        .project_home(&project.id)
+        .join("skills/review")
+        .exists());
+}
+
+#[actix_web::test]
+async fn project_clone_serializes_scope_resolution_and_reassignment_through_publication() {
+    let data = tempfile::tempdir().expect("data dir");
+    let workspace_a = tempfile::tempdir().expect("workspace A");
+    let workspace_b = tempfile::tempdir().expect("workspace B");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let project_a = state
+        .project_store
+        .create_with_project_path(
+            "Clone Project A",
+            None,
+            workspace_a.path().to_string_lossy(),
+            Vec::new(),
+        )
+        .expect("Project A");
+    let project_b = state
+        .project_store
+        .create_with_project_path(
+            "Clone Project B",
+            None,
+            workspace_b.path().to_string_lossy(),
+            Vec::new(),
+        )
+        .expect("Project B");
+    let session_id = "clone-reassignment-race";
+    let mut session = bamboo_agent_core::Session::new(session_id, "model");
+    session.set_project_id_meta(project_a.id.to_string());
+    session.set_workspace_path_meta(workspace_a.path().to_string_lossy().into_owned());
+    session.metadata.insert(
+        bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
+        bamboo_engine::project_context::WorkspaceSource::Explicit
+            .as_str()
+            .to_string(),
+    );
+    state.save_and_cache_session(&mut session).await;
+    let review = state
+        .skill_manager
+        .store()
+        .skill_catalog_snapshot()
+        .await
+        .entries
+        .into_iter()
+        .find(|entry| {
+            entry.id == "review" && entry.source == bamboo_skills::WorkflowSource::Builtin
+        })
+        .expect("builtin review");
+    let hook = super::handlers::clone_scope_test_hooks::install(session_id);
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(state.clone())
+            .configure(crate::routes::configure_routes),
+    )
+    .await;
+    let clone_request = actix_web::test::TestRequest::post()
+        .uri("/api/v1/bamboo/workflow-catalog/review/clone")
+        .set_json(serde_json::json!({
+            "source": "builtin",
+            "revision": review.revision,
+            "target": "project",
+            "session_id": session_id,
+        }))
+        .to_request();
+    let clone = actix_web::test::call_service(&app, clone_request);
+    let reassign = async {
+        hook.reached
+            .acquire()
+            .await
+            .expect("clone scope barrier remains open")
+            .forget();
+        let patch_request = actix_web::test::TestRequest::patch()
+            .uri(&format!("/api/v1/sessions/{session_id}"))
+            .insert_header((actix_web::http::header::IF_MATCH, "\"0\""))
+            .set_json(serde_json::json!({
+                "project_id": project_b.id,
+                "workspace_path": workspace_b.path(),
+            }))
+            .to_request();
+        let mut patch = Box::pin(actix_web::test::call_service(&app, patch_request));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), patch.as_mut())
+                .await
+                .is_err(),
+            "Project PATCH must wait while clone owns the session authority lock"
+        );
+        hook.resume.add_permits(1);
+        patch.await
+    };
+    let (clone_response, patch_response) = futures::join!(clone, reassign);
+
+    assert_eq!(
+        clone_response.status(),
+        actix_web::http::StatusCode::CREATED
+    );
+    assert_eq!(patch_response.status(), actix_web::http::StatusCode::OK);
+    assert!(state
+        .project_store
+        .paths()
+        .project_home(&project_a.id)
+        .join("skills/review/SKILL.md")
+        .is_file());
+    assert!(!state
+        .project_store
+        .paths()
+        .project_home(&project_b.id)
+        .join("skills/review")
+        .exists());
+    let persisted = state
+        .storage
+        .load_session(session_id)
+        .await
+        .expect("load reassigned session")
+        .expect("session");
+    assert_eq!(
+        persisted.project_id_meta().as_deref(),
+        Some(project_b.id.as_str())
+    );
+}
+
+#[actix_web::test]
 async fn assigned_project_workflow_catalog_reports_workspace_then_project_sources() {
     let data = tempfile::tempdir().expect("data dir");
     let workspace = tempfile::tempdir().expect("workspace");
@@ -371,10 +654,7 @@ async fn assigned_project_cannot_read_another_projects_workspace_workflows() {
         bamboo_agent_core::Session::new("cross-project-workflow-session", "test-model");
     session.set_project_id_meta(session_project.id.to_string());
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
-    state.sessions.insert(
-        session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
-    );
+    state.save_and_cache_session(&mut session).await;
 
     let app = actix_web::test::init_service(
         actix_web::App::new()
@@ -447,10 +727,7 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
     );
     let mut session = bamboo_agent_core::Session::new("legacy-migration-session", "test-model");
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
-    state.sessions.insert(
-        session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
-    );
+    state.save_and_cache_session(&mut session).await;
     let app = actix_web::test::init_service(
         actix_web::App::new()
             .app_data(state.clone())
@@ -551,12 +828,19 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
             .to_request(),
     )
     .await;
-    let source_workflow = after["entries"]
-        .as_array()
-        .expect("catalog entries")
+    let entries = after["entries"].as_array().expect("catalog entries");
+    let migrated_workflow = entries
         .iter()
-        .find(|entry| entry["id"] == "daily-report")
+        .find(|entry| entry["id"] == "daily-report" && entry["migration_status"] == "migrated")
+        .expect("migrated instruction Workflow entry");
+    let source_workflow = entries
+        .iter()
+        .find(|entry| entry["id"] == "daily-report" && entry["migration_status"] == "available")
         .expect("source Workflow entry");
+    assert_ne!(
+        migrated_workflow["revision"], source_workflow["revision"],
+        "id/source/revision remains an unambiguous typed catalog identity"
+    );
     assert_eq!(source_workflow["migration_status"], "available");
     assert!(source_workflow.get("shadowed_candidates").is_none());
 }
@@ -579,10 +863,7 @@ async fn global_legacy_workflow_advertised_as_available_migrates_into_session_wo
     );
     let mut session = bamboo_agent_core::Session::new("global-migration-session", "test-model");
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
-    state.sessions.insert(
-        session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
-    );
+    state.save_and_cache_session(&mut session).await;
     let app = actix_web::test::init_service(
         actix_web::App::new()
             .app_data(state.clone())
@@ -657,6 +938,82 @@ async fn global_legacy_workflow_advertised_as_available_migrates_into_session_wo
         )
         .unwrap(),
         std::fs::canonicalize(&source).unwrap()
+    );
+}
+
+#[actix_web::test]
+async fn legacy_migration_reloads_durable_workspace_after_waiting_for_reassignment() {
+    let data = tempfile::tempdir().expect("data dir");
+    let workspace_a = tempfile::tempdir().expect("workspace A");
+    let workspace_b = tempfile::tempdir().expect("workspace B");
+    let global_workflows = data.path().join("workflows");
+    std::fs::create_dir_all(&global_workflows).expect("global workflows");
+    std::fs::write(
+        global_workflows.join("durable-scope.md"),
+        "---\ndescription: Durable scope migration.\n---\nUse the current workspace.\n",
+    )
+    .expect("global legacy workflow");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let session_id = "migration-durable-scope";
+    let mut session = bamboo_agent_core::Session::new(session_id, "test-model");
+    session.set_workspace_path_meta(workspace_a.path().to_string_lossy().into_owned());
+    state.save_and_cache_session(&mut session).await;
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state.clone()).route(
+        "/catalog/{workflow_id}/migrate",
+        actix_web::web::post().to(super::migrate_workflow),
+    ))
+    .await;
+
+    let guard = state.persistence.acquire_lock(session_id).await;
+    let migration = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/durable-scope/migrate")
+            .set_json(serde_json::json!({"session_id": session_id}))
+            .to_request(),
+    );
+    tokio::pin!(migration);
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), &mut migration)
+            .await
+            .is_err(),
+        "migration must wait for the session authority lock"
+    );
+
+    let mut reassigned = state
+        .persistence
+        .storage()
+        .load_session(session_id)
+        .await
+        .expect("load authoritative session")
+        .expect("session");
+    reassigned.set_workspace_path_meta(workspace_b.path().to_string_lossy().into_owned());
+    state
+        .persistence
+        .storage()
+        .save_session(&reassigned)
+        .await
+        .expect("persist reassignment while owning lock");
+    // Deliberately leave the memory cache pointing at workspace A. The
+    // migration must reload durable authority after it acquires the lock.
+    drop(guard);
+
+    let response = migration.await;
+    assert!(response.status().is_success());
+    assert!(workspace_b
+        .path()
+        .join(".bamboo/skills/durable-scope/SKILL.md")
+        .is_file());
+    assert!(
+        !workspace_a
+            .path()
+            .join(".bamboo/skills/durable-scope")
+            .exists(),
+        "stale cache scope must never receive the migrated bundle"
     );
 }
 

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/types.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/types.rs
@@ -27,6 +27,37 @@ pub struct MigrateWorkflowResponse {
     pub catalog_revision: u64,
 }
 
+/// Server-resolved writable layer for cloning one immutable builtin bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloneWorkflowTarget {
+    Project,
+    User,
+}
+
+/// Clone requests carry the exact catalog identity observed by the client.
+/// Bamboo rejects a stale revision/source instead of copying a newer bundle.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CloneWorkflowRequest {
+    pub source: bamboo_skills::WorkflowSource,
+    pub revision: u64,
+    pub target: CloneWorkflowTarget,
+    /// Required for `project`, optional for `user`. The server resolves Project
+    /// identity and paths from this durable session; no client path is accepted.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CloneWorkflowResponse {
+    pub workflow_id: String,
+    pub target: CloneWorkflowTarget,
+    pub source_preserved: bool,
+    pub catalog_revision: u64,
+    pub entry: bamboo_skills::WorkflowCatalogEntry,
+}
+
 /// Workflow list item for API responses.
 #[derive(Serialize)]
 pub(super) struct WorkflowListItem {

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -43,6 +43,10 @@ pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
             web::post().to(settings::migrate_workflow),
         )
         .route(
+            "/bamboo/workflow-catalog/{workflow_id}/clone",
+            web::post().to(settings::clone_workflow),
+        )
+        .route(
             "/sessions/{session_id}/workflow-runs",
             web::post().to(workflow_runs::start),
         )

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -98,31 +98,36 @@ async fn bamboo_v1_routes_resolve_under_both_canonical_and_legacy_prefix() {
     // A representative sample spanning every route group registered by
     // `bamboo_routes_scope` (commands / settings / skills / tools / workspace /
     // copilot / provider-catalog / provider-instances / cluster nodes).
-    let relative_paths = [
-        "/commands",
-        "/bamboo/workflows",
-        "/sessions/session/workflow-runs",
-        "/sessions/session/workflow-runs/example",
-        "/bamboo/setup/status",
-        "/bamboo/config",
-        "/bamboo/config/notifications",
-        "/bamboo/config/connect",
-        "/bamboo/access/status",
-        "/bamboo/model-limits/defaults",
-        "/bamboo/tools",
-        "/bamboo/env-vars",
-        "/skills",
-        "/skills/available-tools",
-        "/workspace/recent",
-        "/bamboo/provider-catalog",
-        "/bamboo/settings/provider-instances",
-        "/bamboo/settings/nodes",
+    let relative_routes = [
+        ("GET", "/commands"),
+        ("GET", "/bamboo/workflows"),
+        ("POST", "/bamboo/workflow-catalog/builtin-workflow/clone"),
+        ("GET", "/sessions/session/workflow-runs"),
+        ("GET", "/sessions/session/workflow-runs/example"),
+        ("GET", "/bamboo/setup/status"),
+        ("GET", "/bamboo/config"),
+        ("GET", "/bamboo/config/notifications"),
+        ("GET", "/bamboo/config/connect"),
+        ("GET", "/bamboo/access/status"),
+        ("GET", "/bamboo/model-limits/defaults"),
+        ("GET", "/bamboo/tools"),
+        ("GET", "/bamboo/env-vars"),
+        ("GET", "/skills"),
+        ("GET", "/skills/available-tools"),
+        ("GET", "/workspace/recent"),
+        ("GET", "/bamboo/provider-catalog"),
+        ("GET", "/bamboo/settings/provider-instances"),
+        ("GET", "/bamboo/settings/nodes"),
     ];
 
-    for relative in relative_paths {
+    for (method, relative) in relative_routes {
         for prefix in ["/api/v1", "/v1"] {
             let uri = format!("{prefix}{relative}");
-            let req = test::TestRequest::get()
+            let request = match method {
+                "POST" => test::TestRequest::post(),
+                _ => test::TestRequest::get(),
+            };
+            let req = request
                 .uri(&uri)
                 .insert_header((header::HOST, "localhost:9562"))
                 .to_request();
@@ -130,7 +135,7 @@ async fn bamboo_v1_routes_resolve_under_both_canonical_and_legacy_prefix() {
             assert_ne!(
                 resp.status(),
                 StatusCode::NOT_FOUND,
-                "expected {uri} to be registered (alias parity, #251 finding 1)"
+                "expected {method} {uri} to be registered (alias parity, #251 finding 1)"
             );
         }
     }

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -54,28 +54,13 @@ where
 {
     if !workspace.exists() {
         if let Some(config) = root_config() {
-            let root = canonicalize_best_effort(&config.root);
-            let candidate = canonicalize_best_effort(&workspace);
-            if candidate.starts_with(&root) {
-                if let Err(error) = std::fs::create_dir_all(&candidate) {
-                    tracing::warn!(
-                        path = %candidate.display(),
-                        workspace_root = %root.display(),
-                        workspace_source = source,
-                        %error,
-                        "failed to materialize validated workspace"
-                    );
-                }
-            } else {
-                // A configured default may disappear after preview. Never
-                // recreate a missing arbitrary path outside the authoritative
-                // root; emit enough non-secret context to diagnose the race.
+            if let Err(error) = materialize_workspace_under_root(&workspace, &config.root) {
                 tracing::warn!(
-                    path = %candidate.display(),
-                    workspace_root = %root.display(),
+                    path = %workspace.display(),
+                    workspace_root = %config.root.display(),
                     workspace_source = source,
-                    "validated workspace is missing outside the workspace root; \
-                     refusing to recreate it"
+                    %error,
+                    "failed to materialize validated workspace"
                 );
             }
         }
@@ -90,6 +75,21 @@ where
     );
     evict_oldest_if_needed(store, MAX_TRACKED_WORKSPACES);
     workspace
+}
+
+fn materialize_workspace_under_root(workspace: &Path, root: &Path) -> std::io::Result<PathBuf> {
+    let root = canonicalize_best_effort(root);
+    let candidate = canonicalize_best_effort(workspace);
+    if !candidate.starts_with(&root) {
+        // A configured default may disappear after preview. Never recreate a
+        // missing arbitrary path outside the authoritative root.
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "validated workspace is outside the authoritative workspace root",
+        ));
+    }
+    std::fs::create_dir_all(&candidate)?;
+    Ok(candidate)
 }
 
 /// Resolve the final path that [`set_workspace`] would store without mutating
@@ -356,6 +356,26 @@ impl WorkspaceResolver {
             &config.root,
             config.confine,
         ))
+    }
+
+    /// Materialize a trusted, already-previewed workspace without publishing
+    /// it into the runtime session registry.
+    ///
+    /// Transactional request paths use this before reading a workspace-scoped
+    /// catalog. Publication remains deferred until the corresponding session
+    /// checkpoint is durable. Missing paths outside this resolver's
+    /// authoritative root are rejected rather than recreated.
+    pub fn materialize_resolved_workspace(&self, workspace: &Path) -> std::io::Result<PathBuf> {
+        if workspace.exists() {
+            return Ok(workspace.to_path_buf());
+        }
+        let config = self.workspace_root_config().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "workspace root is unavailable for materialization",
+            )
+        })?;
+        materialize_workspace_under_root(workspace, &config.root)
     }
 
     /// Publish a previously validated candidate through this instance's root.
@@ -834,6 +854,41 @@ mod tests {
         assert!(!confined.exists(), "confinement preview must not create");
         resolver.publish_resolved_workspace("instance-confined", confined.clone(), "request");
         assert!(confined.is_dir());
+    }
+
+    #[test]
+    fn instance_resolver_can_materialize_without_publishing_runtime_state() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let root = state_dir.path().join("workspaces");
+        let resolver = WorkspaceResolver::new(|| None, {
+            let root = root.clone();
+            move || WorkspaceRootConfig {
+                root: root.clone(),
+                confine: false,
+            }
+        });
+        let session_id = "materialize-without-publication";
+        let fallback = resolver
+            .preview_session_fallback(session_id)
+            .expect("instance fallback");
+
+        let materialized = resolver
+            .materialize_resolved_workspace(&fallback)
+            .expect("materialize trusted fallback");
+
+        assert_eq!(materialized, canonicalize_best_effort(&fallback));
+        assert!(materialized.is_dir());
+        assert!(
+            peek_workspace(session_id).is_none(),
+            "catalog preparation must not publish a pre-commit workspace"
+        );
+
+        let outside = state_dir.path().join("outside/missing");
+        let error = resolver
+            .materialize_resolved_workspace(&outside)
+            .expect_err("missing path outside the authority root must fail closed");
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(!outside.exists());
     }
 
     #[test]

--- a/crates/core/bamboo-domain/src/workflow/mod.rs
+++ b/crates/core/bamboo-domain/src/workflow/mod.rs
@@ -7,8 +7,13 @@ pub mod compiler;
 pub mod definition;
 pub mod run;
 pub mod schema;
+pub mod security;
 
 pub use compiler::{CompiledWorkflow, WorkflowCompileError};
 pub use definition::{validate_expr, validate_required, WorkflowDefinition, WorkflowLoadError};
 pub use run::*;
 pub use schema::{validate_schema, validate_schema_shape};
+pub use security::{
+    reject_instruction_secret_material, reject_secret_material,
+    reject_secret_material_in_definition,
+};

--- a/crates/core/bamboo-domain/src/workflow/security.rs
+++ b/crates/core/bamboo-domain/src/workflow/security.rs
@@ -1,0 +1,267 @@
+//! Shared fail-closed credential classification for Workflow values.
+
+use serde_json::Value;
+
+use super::ValueRef;
+
+/// Reject raw credential-shaped material while permitting the orchestration
+/// engine's explicit `{ "$secret": "name" }` reference contract.
+pub fn reject_secret_material(value: &Value) -> Result<(), String> {
+    reject_secret_material_inner(value, false, true)
+}
+
+/// Reject credential material in a Workflow definition while permitting typed
+/// non-literal bindings and explicit secret references resolved by the
+/// orchestration runtime.
+pub fn reject_secret_material_in_definition(value: &Value) -> Result<(), String> {
+    reject_secret_material_inner(value, true, true)
+}
+
+/// Instruction Workflow arguments are persisted and injected into a prompt;
+/// that path has no secret-reference resolver, so both raw values and opaque
+/// handles fail closed.
+pub fn reject_instruction_secret_material(value: &Value) -> Result<(), String> {
+    reject_secret_material_inner(value, false, false)
+}
+
+fn normalized_credential_key(key: &str) -> String {
+    key.chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn public_token_metadata_key(normalized: &str) -> bool {
+    matches!(
+        normalized,
+        "budgettokens"
+            | "completiontokens"
+            | "contextwindowtokens"
+            | "inputtokens"
+            | "maxcompletiontokens"
+            | "maxcontexttokens"
+            | "maxinputtokens"
+            | "maxoutputtokens"
+            | "maxprompttokens"
+            | "maxtokens"
+            | "maxtotaltokens"
+            | "outputtokens"
+            | "prompttokens"
+            | "totaltokens"
+    )
+}
+
+fn secret_bearing_key(key: &str) -> bool {
+    let normalized = normalized_credential_key(key);
+    matches!(
+        normalized.as_str(),
+        "auth"
+            | "authentication"
+            | "authorization"
+            | "bearer"
+            | "cookie"
+            | "cookies"
+            | "credential"
+            | "credentials"
+            | "oauth"
+            | "oauth2"
+            | "password"
+            | "passwords"
+            | "passphrase"
+            | "passphrases"
+            | "privatekey"
+            | "privatekeys"
+            | "secret"
+            | "secrets"
+            | "token"
+            | "tokens"
+    ) || normalized.contains("apikey")
+        || normalized.ends_with("accesskey")
+        || normalized.ends_with("accesskeys")
+        || normalized.ends_with("authkey")
+        || normalized.ends_with("authkeys")
+        || normalized.ends_with("clientsecret")
+        || normalized.ends_with("clientsecrets")
+        || normalized.ends_with("clientsecretref")
+        || normalized.ends_with("clientsecretreference")
+        || normalized.ends_with("credential")
+        || normalized.ends_with("credentials")
+        || normalized.ends_with("credentialref")
+        || normalized.ends_with("credentialrefs")
+        || normalized.ends_with("credentialreference")
+        || normalized.ends_with("credentialreferences")
+        || normalized.ends_with("devicekey")
+        || normalized.ends_with("devicekeys")
+        || normalized.ends_with("encryptionkey")
+        || normalized.ends_with("encryptionkeys")
+        || normalized.ends_with("password")
+        || normalized.ends_with("passwords")
+        || normalized.ends_with("passphrase")
+        || normalized.ends_with("passphrases")
+        || normalized.ends_with("privatekey")
+        || normalized.ends_with("privatekeys")
+        || normalized.ends_with("privatekeyref")
+        || normalized.ends_with("privatekeyreference")
+        || normalized.ends_with("secret")
+        || normalized.ends_with("secrets")
+        || normalized.ends_with("secretref")
+        || normalized.ends_with("secretrefs")
+        || normalized.ends_with("secretreference")
+        || normalized.ends_with("secretreferences")
+        || normalized.ends_with("secretkey")
+        || normalized.ends_with("secretkeys")
+        || normalized.ends_with("signingkey")
+        || normalized.ends_with("signingkeys")
+        || normalized.ends_with("token")
+        || normalized.ends_with("tokenref")
+        || normalized.ends_with("tokenrefs")
+        || normalized.ends_with("tokenreference")
+        || normalized.ends_with("tokenreferences")
+        || (normalized.ends_with("tokens") && !public_token_metadata_key(&normalized))
+}
+
+fn string_looks_like_secret(value: &str) -> bool {
+    let trimmed = value.trim();
+    let bearer = trimmed
+        .get(.."Bearer ".len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("Bearer "));
+    let basic = trimmed
+        .get(.."Basic ".len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("Basic "));
+    trimmed.starts_with("capability://")
+        || bearer
+        || basic
+        || trimmed.starts_with("sk-")
+        || trimmed.starts_with("ghp_")
+        || trimmed.starts_with("github_pat_")
+        || trimmed.starts_with("glpat-")
+        || trimmed.starts_with("hf_")
+        || trimmed.starts_with("xoxb-")
+        || trimmed.starts_with("xoxp-")
+        || trimmed.starts_with("AIza")
+        || (trimmed.starts_with("AKIA") && trimmed.len() >= 16)
+        || trimmed.starts_with("-----BEGIN PRIVATE KEY-----")
+        || trimmed.starts_with("-----BEGIN RSA PRIVATE KEY-----")
+        || trimmed.starts_with("-----BEGIN OPENSSH PRIVATE KEY-----")
+}
+
+fn reject_secret_material_inner(
+    value: &Value,
+    allow_bindings: bool,
+    allow_secret_references: bool,
+) -> Result<(), String> {
+    fn walk(
+        value: &Value,
+        key: Option<&str>,
+        allow_bindings: bool,
+        allow_secret_references: bool,
+    ) -> Result<(), String> {
+        if value.as_object().is_some_and(|object| {
+            object.len() == 1
+                && object
+                    .get("$secret")
+                    .and_then(Value::as_str)
+                    .is_some_and(|handle| !handle.trim().is_empty())
+        }) {
+            return if allow_secret_references {
+                Ok(())
+            } else {
+                Err(
+                    "opaque credential handles are not enabled for instruction Workflows"
+                        .to_string(),
+                )
+            };
+        }
+        let safe_binding = allow_bindings
+            && serde_json::from_value::<ValueRef>(value.clone())
+                .is_ok_and(|reference| !matches!(reference, ValueRef::Literal { .. }));
+        let typed_secret_schema_annotation = allow_bindings
+            && key.is_some_and(|key| normalized_credential_key(key) == "xbamboosecret")
+            && value.is_boolean();
+        if key.is_some_and(secret_bearing_key) && !safe_binding && !typed_secret_schema_annotation {
+            return Err("secret-bearing fields are not accepted by Workflows".to_string());
+        }
+        if value.as_str().is_some_and(string_looks_like_secret) {
+            return Err("opaque credential handles are not enabled for Workflows".to_string());
+        }
+        match value {
+            Value::Object(object) => {
+                for (key, value) in object {
+                    if key == "properties" {
+                        let properties = value.as_object().ok_or_else(|| {
+                            "workflow schema properties must be an object".to_string()
+                        })?;
+                        for schema in properties.values() {
+                            walk(schema, None, allow_bindings, allow_secret_references)?;
+                        }
+                    } else {
+                        walk(value, Some(key), allow_bindings, allow_secret_references)?;
+                    }
+                }
+            }
+            Value::Array(array) => {
+                for value in array {
+                    walk(value, None, allow_bindings, allow_secret_references)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    walk(value, None, allow_bindings, allow_secret_references)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instruction_arguments_reject_keys_prefixes_and_secret_references() {
+        for value in [
+            serde_json::json!({"api_key": "ordinary-looking"}),
+            serde_json::json!({"nested": {"client_tokens": ["value"]}}),
+            serde_json::json!({"X-Client-Tokens": ["value"]}),
+            serde_json::json!({"secrets": {"primary": "value"}}),
+            serde_json::json!({"credential_ref": "internal-provider-key"}),
+            serde_json::json!({"secret_reference": "internal-secret-name"}),
+            serde_json::json!({"value": "sk-secret"}),
+            serde_json::json!({"value": "xoxb-secret"}),
+            serde_json::json!({"value": "bEaReR opaque-value"}),
+            serde_json::json!({"value": "basic opaque-value"}),
+            serde_json::json!({"value": {"$secret": "provider-key"}}),
+        ] {
+            assert!(reject_instruction_secret_material(&value).is_err());
+        }
+        assert!(reject_instruction_secret_material(&serde_json::json!({
+            "focus": "security",
+            "paths": ["src/lib.rs"],
+            "max_tokens": 4096,
+            "input_tokens": 128
+        }))
+        .is_ok());
+    }
+
+    #[test]
+    fn definitions_allow_only_the_typed_secret_schema_annotation() {
+        assert!(reject_secret_material_in_definition(&serde_json::json!({
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "credential": {
+                        "type": "object",
+                        "x-bamboo-secret": true
+                    }
+                }
+            }
+        }))
+        .is_ok());
+        assert!(reject_secret_material_in_definition(&serde_json::json!({
+            "x-bamboo-secret": "raw-secret"
+        }))
+        .is_err());
+        assert!(reject_instruction_secret_material(&serde_json::json!({
+            "x-bamboo-secret": true
+        }))
+        .is_err());
+    }
+}

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
@@ -196,7 +196,7 @@ pub(super) async fn load_skill_context(
     session: &Session,
     session_id: &str,
     request_hint: &str,
-    must_resume_pinned_activation: bool,
+    _must_resume_pinned_activation: bool,
 ) -> Result<SkillContextLoadResult, String> {
     if let Some(skill_manager) = config.skill_manager.as_ref() {
         let resource_scope = SkillResourceScope::resolve(config, session).await?;
@@ -225,9 +225,13 @@ pub(super) async fn load_skill_context(
             .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
             .and_then(|raw| serde_json::from_str::<bamboo_skills::ActiveWorkflow>(raw).ok())
             .is_some_and(|active| active.status == bamboo_skills::WorkflowActivationStatus::Active);
+        // A chat-boundary explicit pin is durable authority even before the
+        // first execute starts. Restore it after a process restart regardless
+        // of whether the prior runtime state was suspended; otherwise a
+        // catalog edit in the POST /chat -> POST /execute window could silently
+        // substitute a newer revision.
         if retained_activation.is_none()
-            && (has_active_workflow
-                || (must_resume_pinned_activation && persisted_selection_requires_snapshot))
+            && (has_active_workflow || persisted_selection_requires_snapshot)
         {
             let restored = async {
                 let snapshot = if has_active_workflow {

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -377,6 +377,94 @@ async fn session_setup_publishes_current_skill_allowlist_before_tool_execution()
 }
 
 #[tokio::test]
+async fn pre_execute_explicit_snapshot_restores_after_restart_without_suspended_runtime() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let config = SkillStoreConfig {
+        skills_dir: directory.path().join("skills"),
+        ..Default::default()
+    };
+    let first = Arc::new(SkillManager::with_config(config.clone()));
+    first.initialize().await.expect("initialize first manager");
+    let review = first
+        .store()
+        .skill_catalog_snapshot()
+        .await
+        .entries
+        .into_iter()
+        .find(|entry| entry.id == "review" && entry.winner)
+        .expect("review entry");
+    let selected_ids = [review.id.clone()];
+    let activation = first
+        .resolve_and_pin_activation_for_request_with_mode_and_budget(
+            "pre-execute-restart",
+            &std::collections::BTreeSet::new(),
+            Some(&selected_ids),
+            None,
+            None,
+            bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+        )
+        .await
+        .expect("pin first process candidate");
+    let snapshot = first
+        .store()
+        .export_activation_snapshot("pre-execute-restart")
+        .await
+        .expect("export candidate");
+    let selection = bamboo_skills::WorkflowSelection {
+        id: review.id,
+        source: review.source,
+        revision: review.revision,
+        args: serde_json::json!({}),
+    };
+    let mut session = Session::new("pre-execute-restart", "model");
+    session.metadata.insert(
+        bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY.to_string(),
+        serde_json::to_string(&selection).expect("selection JSON"),
+    );
+    bamboo_skills::persist_explicit_workflow_candidate(
+        &mut session.metadata,
+        &selection,
+        &activation,
+        &snapshot,
+    )
+    .expect("persist candidate");
+    first
+        .release_activation_for_workspace("pre-execute-restart", None)
+        .await
+        .expect("simulate process exit");
+    drop(first);
+
+    let restarted = Arc::new(SkillManager::with_config(config));
+    restarted
+        .initialize()
+        .await
+        .expect("initialize restarted manager");
+    let loop_config = crate::runtime::config::AgentLoopConfig {
+        skill_manager: Some(restarted.clone()),
+        selected_skill_ids: Some(selected_ids.to_vec()),
+        ..Default::default()
+    };
+    let loaded = super::skill_context::load_skill_context(
+        &loop_config,
+        &session,
+        "pre-execute-restart",
+        "Review this change",
+        false,
+    )
+    .await
+    .expect("restore chat-boundary candidate without suspended runtime");
+    assert_eq!(loaded.selected_skill_ids, vec!["review"]);
+    assert_eq!(loaded.skill_revisions["review"], selection.revision);
+    assert!(
+        restarted
+            .store()
+            .activation_was_restored("pre-execute-restart")
+            .await,
+        "restart must use durable pinned bytes, not silently re-resolve live catalog"
+    );
+}
+
+#[tokio::test]
 async fn session_setup_requires_model_issued_load_for_one_explicit_skill() {
     let directory = tempfile::tempdir().expect("tempdir");
     let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {

--- a/crates/engine/bamboo-engine/src/session_app/chat.rs
+++ b/crates/engine/bamboo-engine/src/session_app/chat.rs
@@ -9,7 +9,9 @@ use bamboo_skills::selection::normalize_selected_skill_ids;
 use bamboo_skills::{
     ActiveWorkflow, WorkflowActivationStatus, WorkflowSelection, ACTIVE_WORKFLOW_METADATA_KEY,
     ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY, WORKFLOW_ACTIVATION_EVENT_METADATA_KEY,
-    WORKFLOW_ORCHESTRATION_OPT_IN_METADATA_KEY, WORKFLOW_SELECTION_METADATA_KEY,
+    WORKFLOW_CATALOG_DIAGNOSTIC_METADATA_KEY, WORKFLOW_CONTEXT_CACHE_METADATA_KEY,
+    WORKFLOW_LAST_DYNAMIC_CONTEXT_METADATA_KEY, WORKFLOW_ORCHESTRATION_OPT_IN_METADATA_KEY,
+    WORKFLOW_SELECTION_METADATA_KEY,
 };
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
@@ -493,6 +495,28 @@ pub fn resolve_workflow_selection(
         return Ok(());
     }
 
+    // A typed chat candidate is durable authority for the next execute, even
+    // when another ordinary message is appended before execution starts.
+    // Keep its visible selected id aligned with the retained immutable
+    // snapshot; only an explicit replacement/deactivation may cancel it.
+    if let Some(pending) = session
+        .metadata
+        .get(WORKFLOW_SELECTION_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<WorkflowSelection>(raw).ok())
+        .filter(|_| {
+            session
+                .metadata
+                .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY)
+                .is_some_and(|source| source == "explicit")
+                && session.metadata.contains_key(
+                    bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY,
+                )
+        })
+    {
+        persist_selected_skill_ids_metadata(session, Some(&[pending.id]));
+        return Ok(());
+    }
+
     if let Some(active) = session
         .metadata
         .get(ACTIVE_WORKFLOW_METADATA_KEY)
@@ -537,6 +561,67 @@ fn deactivate_active_workflow(session: &mut Session) {
 pub fn clear_skill_runtime_state(session: &mut Session) {
     session.metadata.remove(SKILL_RUNTIME_LOADED_KEY);
     session.metadata.remove(SKILL_RUNTIME_LAST_KEY);
+}
+
+/// Remove every workflow authority tied to the session's previous
+/// Project/workspace publication. Callers must persist this mutation before
+/// releasing the corresponding in-memory pin.
+pub fn clear_workflow_authority_for_resource_scope_change(session: &mut Session) -> bool {
+    let active_identity = session
+        .metadata
+        .get(ACTIVE_WORKFLOW_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<ActiveWorkflow>(raw).ok())
+        .map(|active| (active.id, active.revision))
+        .or_else(|| {
+            session
+                .metadata
+                .get(WORKFLOW_SELECTION_METADATA_KEY)
+                .and_then(|raw| serde_json::from_str::<WorkflowSelection>(raw).ok())
+                .map(|selection| (selection.id, selection.revision))
+        });
+    let had_authority = active_identity.is_some()
+        || session.selected_skill_ids().is_some()
+        || session.metadata.keys().any(|key| {
+            key.starts_with("skill_runtime_")
+                || matches!(
+                    key.as_str(),
+                    WORKFLOW_SELECTION_METADATA_KEY
+                        | ACTIVE_WORKFLOW_METADATA_KEY
+                        | ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY
+                        | WORKFLOW_CONTEXT_CACHE_METADATA_KEY
+                        | WORKFLOW_LAST_DYNAMIC_CONTEXT_METADATA_KEY
+                        | WORKFLOW_CATALOG_DIAGNOSTIC_METADATA_KEY
+                )
+        });
+
+    session.metadata.retain(|key, _| {
+        !key.starts_with("skill_runtime_")
+            && !matches!(
+                key.as_str(),
+                WORKFLOW_SELECTION_METADATA_KEY
+                    | ACTIVE_WORKFLOW_METADATA_KEY
+                    | ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY
+                    | WORKFLOW_ACTIVATION_EVENT_METADATA_KEY
+                    | WORKFLOW_CONTEXT_CACHE_METADATA_KEY
+                    | WORKFLOW_LAST_DYNAMIC_CONTEXT_METADATA_KEY
+                    | WORKFLOW_CATALOG_DIAGNOSTIC_METADATA_KEY
+            )
+    });
+    session.clear_selected_skill_ids();
+    if let Some((workflow_id, revision)) = active_identity {
+        session.metadata.insert(
+            WORKFLOW_ACTIVATION_EVENT_METADATA_KEY.to_string(),
+            serde_json::json!({
+                "type": "workflow.deactivated",
+                "workflow_id": workflow_id,
+                "revision": revision,
+                "reason": "resource_scope_changed",
+                "deactivated_at": chrono::Utc::now(),
+            })
+            .to_string(),
+        );
+    }
+    had_authority
 }
 
 fn persist_selected_skill_ids_metadata(
@@ -1046,6 +1131,47 @@ mod tests {
             Some(vec!["review".to_string()])
         );
         assert!(session.metadata.contains_key(ACTIVE_WORKFLOW_METADATA_KEY));
+    }
+
+    #[test]
+    fn pending_typed_workflow_survives_an_ordinary_chat_before_execute() {
+        let mut session = Session::new("pending-selection", "model");
+        let selection = WorkflowSelection {
+            id: "review".to_string(),
+            source: bamboo_skills::WorkflowSource::Builtin,
+            revision: 7,
+            args: serde_json::json!({}),
+        };
+        session.metadata.insert(
+            WORKFLOW_SELECTION_METADATA_KEY.to_string(),
+            serde_json::to_string(&selection).expect("selection json"),
+        );
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+            "explicit".to_string(),
+        );
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY.to_string(),
+            "opaque durable snapshot".to_string(),
+        );
+
+        resolve_workflow_selection(&mut session, None, None, "one more detail")
+            .expect("retain pending selection");
+
+        assert_eq!(
+            session.selected_skill_ids(),
+            Some(vec!["review".to_string()])
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(WORKFLOW_SELECTION_METADATA_KEY)
+                .and_then(|raw| serde_json::from_str::<WorkflowSelection>(raw).ok()),
+            Some(selection)
+        );
+        assert!(session
+            .metadata
+            .contains_key(bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY));
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/workflow_run/executor.rs
+++ b/crates/engine/bamboo-engine/src/workflow_run/executor.rs
@@ -429,12 +429,13 @@ impl WorkflowRunEngine {
         self.enforce_ceilings(&compiled.definition.budgets)?;
         let definition_value = serde_json::to_value(&compiled.definition)
             .map_err(|error| WorkflowRunError::Preflight(error.to_string()))?;
-        reject_secret_material_in_definition(&definition_value)
+        bamboo_domain::reject_secret_material_in_definition(&definition_value)
             .map_err(WorkflowRunError::Preflight)?;
         compiled
             .validate_input(&request.args)
             .map_err(WorkflowRunError::InvalidInput)?;
-        reject_secret_material(&request.args).map_err(WorkflowRunError::InvalidInput)?;
+        bamboo_domain::reject_secret_material(&request.args)
+            .map_err(WorkflowRunError::InvalidInput)?;
         let allowed_capabilities = request
             .allowed_capabilities
             .into_iter()
@@ -746,7 +747,8 @@ impl WorkflowRunEngine {
         let serialized = serde_json::to_value(bundle).map_err(|_| {
             WorkflowRunError::Preflight("workflow bundle is not serializable".into())
         })?;
-        reject_secret_material_in_definition(&serialized).map_err(WorkflowRunError::Preflight)?;
+        bamboo_domain::reject_secret_material_in_definition(&serialized)
+            .map_err(WorkflowRunError::Preflight)?;
         let mut stack = vec![(root.id.clone(), root.revision, Vec::<String>::new())];
         let mut visited = BTreeSet::new();
         while let Some((id, revision, path)) = stack.pop() {
@@ -1430,7 +1432,7 @@ impl RunContext {
             Err(error) => Err(error),
         };
         let result = result.and_then(|output| {
-            reject_secret_material(&output)
+            bamboo_domain::reject_secret_material(&output)
                 .map(|()| output)
                 .map_err(|message| failure(WorkflowFailureCode::InvalidOutput, message, false))
         });
@@ -2304,91 +2306,6 @@ fn parse_tool_result(result: ToolResult) -> Result<Value, WorkflowFailure> {
     }
     Ok(serde_json::from_str(&result.result).unwrap_or(Value::String(result.result)))
 }
-fn reject_secret_material(value: &Value) -> Result<(), String> {
-    reject_secret_material_inner(value, false)
-}
-
-fn reject_secret_material_in_definition(value: &Value) -> Result<(), String> {
-    reject_secret_material_inner(value, true)
-}
-
-fn reject_secret_material_inner(value: &Value, allow_bindings: bool) -> Result<(), String> {
-    fn walk(value: &Value, key: Option<&str>, allow_bindings: bool) -> Result<(), String> {
-        if value.as_object().is_some_and(|object| {
-            object.len() == 1
-                && object
-                    .get("$secret")
-                    .and_then(Value::as_str)
-                    .is_some_and(|handle| !handle.trim().is_empty())
-        }) {
-            return Ok(());
-        }
-        let safe_binding = allow_bindings
-            && serde_json::from_value::<ValueRef>(value.clone())
-                .is_ok_and(|reference| !matches!(reference, ValueRef::Literal { .. }));
-        if key.is_some_and(|key| {
-            let normalized = key
-                .chars()
-                .filter(|character| character.is_ascii_alphanumeric())
-                .flat_map(char::to_lowercase)
-                .collect::<String>();
-            matches!(
-                normalized.as_str(),
-                "secret"
-                    | "token"
-                    | "password"
-                    | "credential"
-                    | "credentials"
-                    | "apikey"
-                    | "accesskey"
-                    | "accesstoken"
-                    | "secretkey"
-                    | "privatekey"
-            )
-        }) && !safe_binding
-        {
-            return Err("secret-bearing fields are not accepted by workflow runs".to_string());
-        }
-        if value.as_str().is_some_and(|value| {
-            let trimmed = value.trim();
-            trimmed.starts_with("capability://")
-                || trimmed.starts_with("Bearer ")
-                || trimmed.starts_with("sk-")
-                || trimmed.starts_with("ghp_")
-                || trimmed.starts_with("github_pat_")
-        }) {
-            // No production capability resolver is part of #578. Treating an
-            // arbitrary caller string as an opaque handle would be an injection
-            // channel, so handles and common raw credential forms fail closed.
-            return Err("opaque credential handles are not enabled for workflows".to_string());
-        }
-        match value {
-            Value::Object(object) => {
-                for (key, value) in object {
-                    if key == "properties" {
-                        let properties = value.as_object().ok_or_else(|| {
-                            "workflow schema properties must be an object".to_string()
-                        })?;
-                        for schema in properties.values() {
-                            walk(schema, None, allow_bindings)?;
-                        }
-                    } else {
-                        walk(value, Some(key), allow_bindings)?;
-                    }
-                }
-            }
-            Value::Array(array) => {
-                for value in array {
-                    walk(value, None, allow_bindings)?;
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-    walk(value, None, allow_bindings)
-}
-
 fn contains_secret_handle(value: &Value) -> bool {
     match value {
         Value::Object(object) => {

--- a/crates/infra/bamboo-skills/build.rs
+++ b/crates/infra/bamboo-skills/build.rs
@@ -13,6 +13,18 @@ const BUILTIN_SKILL_WHITELIST: &[&str] = &[
     "skill-creator",
 ];
 
+// Git executable bits are not represented consistently in a Windows checkout.
+// Keep the embedded permission contract explicit and platform-independent.
+const BUILTIN_EXECUTABLE_FILES: &[&str] = &[
+    "skill-creator/scripts/aggregate_benchmark.py",
+    "skill-creator/scripts/generate_report.py",
+    "skill-creator/scripts/improve_description.py",
+    "skill-creator/scripts/package_skill.py",
+    "skill-creator/scripts/quick_validate.py",
+    "skill-creator/scripts/run_eval.py",
+    "skill-creator/scripts/run_loop.py",
+];
+
 fn is_builtin_skill_enabled(name: &str) -> bool {
     BUILTIN_SKILL_WHITELIST.contains(&name)
 }
@@ -80,16 +92,26 @@ fn main() -> io::Result<()> {
 
     files.sort();
 
+    for executable in BUILTIN_EXECUTABLE_FILES {
+        if !files.iter().any(|path| to_unix_path(path) == *executable) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("builtin executable manifest references missing file '{executable}'"),
+            ));
+        }
+    }
+
     writeln!(
         file,
-        "pub static BUILTIN_SKILL_FILES: &[(&str, &[u8])] = &["
+        "pub static BUILTIN_SKILL_FILES: &[(&str, &[u8], bool)] = &["
     )?;
     for relative in files {
         let relative_unix = to_unix_path(&relative);
+        let executable = BUILTIN_EXECUTABLE_FILES.contains(&relative_unix.as_str());
         writeln!(
             file,
-            "    (\"{relative}\", include_bytes!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../../../builtin_skills/{relative}\"))),",
-            relative = relative_unix
+            "    (\"{relative}\", include_bytes!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../../../builtin_skills/{relative}\")), {executable}),",
+            relative = relative_unix,
         )?;
     }
     writeln!(file, "];")?;

--- a/crates/infra/bamboo-skills/src/activation.rs
+++ b/crates/infra/bamboo-skills/src/activation.rs
@@ -62,8 +62,10 @@ pub enum WorkflowActivationStatus {
     Deactivated,
 }
 
-/// Durable, public-safe active workflow metadata. The immutable payload is
-/// stored separately under [`ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY`].
+/// Durable runtime activation metadata. This includes caller arguments and
+/// dynamic provider context and must not be serialized directly at a public
+/// API boundary. The immutable bundle payload is stored separately under
+/// [`ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActiveWorkflow {
     pub id: String,
@@ -240,6 +242,13 @@ pub fn persist_explicit_workflow_candidate(
             WorkflowActivationErrorCode::InvalidSelection,
             &format!("workflow arguments do not match the catalog schema: {error}"),
             true,
+        ));
+    }
+    if let Err(error) = bamboo_domain::reject_instruction_secret_material(&selection.args) {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::InvalidSelection,
+            &format!("workflow arguments contain unsupported credential material: {error}"),
+            false,
         ));
     }
     let Some(snapshot_entry) = snapshot.skills.get(&selection.id) else {
@@ -602,6 +611,7 @@ mod tests {
             ),
         );
         let candidate = SkillActivationSnapshot {
+            resource_scope_fingerprint: "sha256:test-scope".to_string(),
             catalog_revision: 41,
             selected_skill_mode: None,
             skills,
@@ -667,6 +677,7 @@ mod tests {
     fn activation_rejects_selected_workflow_over_durable_limit_atomically() {
         let selected = entry("oversized", 11);
         let snapshot = SkillActivationSnapshot {
+            resource_scope_fingerprint: "sha256:test-scope".to_string(),
             catalog_revision: 52,
             selected_skill_mode: None,
             skills: BTreeMap::from([(
@@ -746,6 +757,7 @@ mod tests {
             descriptor,
         };
         let snapshot = SkillActivationSnapshot {
+            resource_scope_fingerprint: "sha256:test-scope".to_string(),
             catalog_revision: 71,
             selected_skill_mode: Some("explicit".to_string()),
             skills: BTreeMap::from([(

--- a/crates/infra/bamboo-skills/src/activation.rs
+++ b/crates/infra/bamboo-skills/src/activation.rs
@@ -172,6 +172,192 @@ pub struct DynamicContextBlock {
 
 pub type DynamicContextCache = BTreeMap<String, DynamicContextBlock>;
 
+/// Persist one exact, already-pinned instruction candidate before a chat turn
+/// is acknowledged. This closes the chat-to-execute restart window: the
+/// server can restore the immutable revision even if the live catalog changes
+/// or the process restarts after `POST /chat` and before `POST /execute`.
+///
+/// Every serialized value is prepared before the metadata map is mutated, so
+/// an error leaves the caller's prior runtime candidate untouched.
+pub fn persist_explicit_workflow_candidate(
+    metadata: &mut HashMap<String, String>,
+    selection: &WorkflowSelection,
+    activation: &crate::SkillActivationSelection,
+    snapshot: &SkillActivationSnapshot,
+) -> Result<(), WorkflowActivationDiagnostic> {
+    let diagnostic = |code, message: &str, recoverable| WorkflowActivationDiagnostic {
+        code,
+        message: message.to_string(),
+        recoverable,
+    };
+    let entry = match activation.catalog_entries.as_slice() {
+        [entry] if entry.id == selection.id => entry,
+        _ => {
+            return Err(diagnostic(
+                WorkflowActivationErrorCode::RevisionMissing,
+                "selected workflow is unavailable or disabled",
+                true,
+            ));
+        }
+    };
+    if entry.status != crate::WorkflowStatus::Valid {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::RevisionMissing,
+            "selected workflow is invalid",
+            true,
+        ));
+    }
+    if entry.source != selection.source {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::SourceMismatch,
+            "selected workflow source changed; refresh the catalog",
+            true,
+        ));
+    }
+    if entry.revision != selection.revision {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::RevisionMismatch,
+            "selected workflow revision changed; refresh the catalog",
+            true,
+        ));
+    }
+    if entry.kind != WorkflowKind::Instruction {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::InvalidSelection,
+            "orchestration workflows must be started through the Workflow Run API",
+            false,
+        ));
+    }
+    if entry.invocation_policy["explicit"].as_bool() != Some(true) {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::ManualOnly,
+            "selected workflow does not allow explicit activation",
+            false,
+        ));
+    }
+    if let Err(error) = bamboo_domain::validate_schema(&entry.argument_schema, &selection.args) {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::InvalidSelection,
+            &format!("workflow arguments do not match the catalog schema: {error}"),
+            true,
+        ));
+    }
+    let Some(snapshot_entry) = snapshot.skills.get(&selection.id) else {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "pinned workflow snapshot is missing the selected definition",
+            true,
+        ));
+    };
+    if snapshot.skills.len() != 1
+        || snapshot_entry.revision != selection.revision
+        || snapshot_entry.catalog_entry != *entry
+    {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::RevisionMismatch,
+            "pinned workflow snapshot does not match the selected catalog identity",
+            true,
+        ));
+    }
+
+    use crate::runtime_metadata::{
+        SKILL_RUNTIME_ACTIVATION_ERROR_KEY, SKILL_RUNTIME_ACTIVATION_GENERATION_KEY,
+        SKILL_RUNTIME_PINNED_SNAPSHOT_KEY, SKILL_RUNTIME_SELECTED_CATALOG_KEY,
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY, SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY,
+        SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY, SKILL_RUNTIME_SELECTION_COUNT_KEY,
+        SKILL_RUNTIME_SELECTION_SOURCE_KEY, SKILL_RUNTIME_SELECTION_TRACE_KEY,
+    };
+    let snapshot_json = serde_json::to_string(snapshot).map_err(|_| {
+        diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "pinned workflow snapshot could not be serialized",
+            true,
+        )
+    })?;
+    if snapshot_json.len() > MAX_DURABLE_WORKFLOW_ACTIVATION_BYTES {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::SnapshotTooLarge,
+            "selected workflow snapshot exceeds the durable session limit",
+            true,
+        ));
+    }
+    let catalog_json = serde_json::to_string(&activation.catalog_entries).map_err(|_| {
+        diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "selected workflow catalog identity could not be serialized",
+            true,
+        )
+    })?;
+    let selected_ids = vec![selection.id.clone()];
+    let selected_ids_json = serde_json::to_string(&selected_ids).map_err(|_| {
+        diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "selected workflow id could not be serialized",
+            true,
+        )
+    })?;
+    let revisions_json =
+        serde_json::to_string(&activation.descriptor.skill_revisions).map_err(|_| {
+            diagnostic(
+                WorkflowActivationErrorCode::SnapshotUnavailable,
+                "selected workflow revision map could not be serialized",
+                true,
+            )
+        })?;
+    let diagnostic_json = serde_json::to_string(&activation.catalog_diagnostic).map_err(|_| {
+        diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "selected workflow catalog diagnostic could not be serialized",
+            true,
+        )
+    })?;
+    let trace_json = serde_json::json!({
+        "source": "explicit",
+        "selected_skill_ids": selected_ids,
+        "selected_skill_mode": activation.descriptor.selected_skill_mode,
+        "request_hint_present": false
+    })
+    .to_string();
+
+    metadata.insert(
+        SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+        "explicit".to_string(),
+    );
+    metadata.insert(SKILL_RUNTIME_SELECTED_CATALOG_KEY.to_string(), catalog_json);
+    metadata.insert(
+        WORKFLOW_CATALOG_DIAGNOSTIC_METADATA_KEY.to_string(),
+        diagnostic_json,
+    );
+    metadata.insert(SKILL_RUNTIME_PINNED_SNAPSHOT_KEY.to_string(), snapshot_json);
+    metadata.insert(
+        SKILL_RUNTIME_SELECTION_COUNT_KEY.to_string(),
+        "1".to_string(),
+    );
+    metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        selected_ids_json,
+    );
+    metadata.insert(
+        SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+        activation.descriptor.catalog_revision.to_string(),
+    );
+    metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+        revisions_json,
+    );
+    metadata.insert(SKILL_RUNTIME_SELECTION_TRACE_KEY.to_string(), trace_json);
+    if let Some(mode) = activation.descriptor.selected_skill_mode.as_ref() {
+        metadata.insert(
+            SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY.to_string(),
+            mode.clone(),
+        );
+    } else {
+        metadata.remove(SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY);
+    }
+    metadata.remove(SKILL_RUNTIME_ACTIVATION_ERROR_KEY);
+    Ok(())
+}
+
 /// Record activation only after `load_skill` has returned the pinned payload.
 /// This is shared by explicit preload and model-driven automatic activation.
 pub fn record_loaded_workflow_activation(
@@ -358,7 +544,8 @@ mod tests {
         SKILL_RUNTIME_SELECTION_SOURCE_KEY,
     };
     use crate::{
-        SkillActivationSnapshotEntry, SkillDefinition, WorkflowCatalogEntry, WorkflowStatus,
+        SkillActivationDescriptor, SkillActivationSelection, SkillActivationSnapshotEntry,
+        SkillDefinition, WorkflowCatalogEntry, WorkflowStatus,
     };
 
     fn entry(id: &str, revision: u64) -> WorkflowCatalogEntry {
@@ -526,5 +713,69 @@ mod tests {
         )
         .expect("valid unchanged candidate snapshot");
         assert_eq!(unchanged.skills["oversized"].revision, 11);
+    }
+
+    #[test]
+    fn explicit_candidate_rejects_invalid_arguments_without_metadata_mutation() {
+        let mut selected = entry("review", 13);
+        selected.argument_schema = serde_json::json!({
+            "type": "object",
+            "properties": {"depth": {"type": "integer"}},
+            "required": ["depth"],
+            "additionalProperties": false
+        });
+        let descriptor = SkillActivationDescriptor {
+            catalog_revision: 71,
+            skill_revisions: BTreeMap::from([("review".to_string(), 13)]),
+            selected_skill_mode: Some("explicit".to_string()),
+        };
+        let activation = SkillActivationSelection {
+            skills: vec![snapshot_entry(selected.clone(), BTreeMap::new()).definition],
+            catalog_entries: vec![selected.clone()],
+            catalog_diagnostic: WorkflowCatalogDiagnostic {
+                total_candidates: 1,
+                advertised_candidates: 1,
+                initial_chars: 128,
+                final_chars: 128,
+                char_budget: 1024,
+                token_budget: 256,
+                compressed_descriptions: false,
+                shortlisted: false,
+                omitted_ids: Vec::new(),
+            },
+            descriptor,
+        };
+        let snapshot = SkillActivationSnapshot {
+            catalog_revision: 71,
+            selected_skill_mode: Some("explicit".to_string()),
+            skills: BTreeMap::from([(
+                "review".to_string(),
+                snapshot_entry(selected, BTreeMap::new()),
+            )]),
+        };
+        let selection = WorkflowSelection {
+            id: "review".to_string(),
+            source: WorkflowSource::Project,
+            revision: 13,
+            args: serde_json::json!({"depth": "deep"}),
+        };
+        let mut metadata = HashMap::from([
+            ("preserve".to_string(), "exact".to_string()),
+            (
+                SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+                "prior".to_string(),
+            ),
+        ]);
+        let before = metadata.clone();
+
+        let diagnostic =
+            persist_explicit_workflow_candidate(&mut metadata, &selection, &activation, &snapshot)
+                .expect_err("invalid arguments fail before metadata publication");
+
+        assert_eq!(
+            diagnostic.code,
+            WorkflowActivationErrorCode::InvalidSelection
+        );
+        assert_eq!(metadata, before);
     }
 }

--- a/crates/infra/bamboo-skills/src/store/builtin.rs
+++ b/crates/infra/bamboo-skills/src/store/builtin.rs
@@ -7,9 +7,15 @@ use crate::types::{SkillError, SkillResult};
 
 include!(concat!(env!("OUT_DIR"), "/builtin_skills_embedded.rs"));
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuiltinSkillFile {
+    pub bytes: Vec<u8>,
+    pub executable: bool,
+}
+
 pub struct BuiltinSkillBundle {
     pub skill: crate::types::SkillDefinition,
-    pub files: HashMap<String, Vec<u8>>,
+    pub files: HashMap<String, BuiltinSkillFile>,
 }
 
 /// Archive the pre-catalog global materialization only when every file proves
@@ -28,7 +34,10 @@ pub async fn archive_exact_legacy_materialization(
     let mut expected = bundle.files.clone();
     expected.insert(
         "SKILL.md".to_string(),
-        render_skill_markdown(&bundle.skill)?.into_bytes(),
+        BuiltinSkillFile {
+            bytes: render_skill_markdown(&bundle.skill)?.into_bytes(),
+            executable: false,
+        },
     );
     let mut actual = HashMap::new();
     for entry in walkdir::WalkDir::new(&legacy_root).follow_links(false) {
@@ -49,10 +58,33 @@ pub async fn archive_exact_legacy_materialization(
             Ok(relative) => relative.to_string_lossy().replace('\\', "/"),
             Err(_) => return Ok(false),
         };
-        actual.insert(relative, tokio::fs::read(entry.path()).await?);
+        #[cfg(unix)]
+        let executable = {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::metadata(entry.path())?.permissions().mode() & 0o111 != 0
+        };
+        #[cfg(not(unix))]
+        let executable = expected
+            .get(&relative)
+            .is_some_and(|expected| expected.executable);
+        actual.insert(
+            relative,
+            BuiltinSkillFile {
+                bytes: tokio::fs::read(entry.path()).await?,
+                executable,
+            },
+        );
     }
 
-    if actual != expected {
+    // Releases predating the embedded mode manifest made every file below
+    // `scripts/` executable. Recognize that exact historical generator output
+    // as Bamboo-owned too, while still preserving any byte or unrelated mode
+    // customization as a user override.
+    let mut historical_expected = expected.clone();
+    for (relative, file) in &mut historical_expected {
+        file.executable = relative.starts_with("scripts/");
+    }
+    if actual != expected && actual != historical_expected {
         return Ok(false);
     }
 
@@ -81,7 +113,7 @@ pub async fn archive_exact_legacy_materialization(
 fn discover_skill_roots() -> Vec<String> {
     let mut roots = BUILTIN_SKILL_FILES
         .iter()
-        .filter_map(|(path, _)| path.strip_suffix("/SKILL.md"))
+        .filter_map(|(path, _, _)| path.strip_suffix("/SKILL.md"))
         .map(str::to_string)
         .collect::<Vec<_>>();
 
@@ -102,27 +134,28 @@ pub fn load_builtin_skill_bundles() -> SkillResult<Vec<BuiltinSkillBundle>> {
         return Ok(bundles);
     }
 
-    let mut grouped: HashMap<String, Vec<(String, Vec<u8>)>> = HashMap::new();
-    for (path, bytes) in BUILTIN_SKILL_FILES {
+    let mut grouped: HashMap<String, Vec<(String, Vec<u8>, bool)>> = HashMap::new();
+    for (path, bytes, executable) in BUILTIN_SKILL_FILES {
         if let Some(root) = roots.iter().find(|root| {
             let prefix = format!("{}/", root);
             path.starts_with(&prefix)
         }) {
             let prefix = format!("{}/", root);
             if let Some(relative_path) = path.strip_prefix(&prefix) {
-                grouped
-                    .entry(root.clone())
-                    .or_default()
-                    .push((relative_path.to_string(), bytes.to_vec()));
+                grouped.entry(root.clone()).or_default().push((
+                    relative_path.to_string(),
+                    bytes.to_vec(),
+                    *executable,
+                ));
             }
         }
     }
 
     for (skill_root, files) in grouped {
         let mut skill_markdown: Option<String> = None;
-        let mut assets: HashMap<String, Vec<u8>> = HashMap::new();
+        let mut assets: HashMap<String, BuiltinSkillFile> = HashMap::new();
 
-        for (relative_path, bytes) in files {
+        for (relative_path, bytes, executable) in files {
             if relative_path == "SKILL.md" {
                 let raw = String::from_utf8(bytes).map_err(|error| {
                     SkillError::Validation(format!(
@@ -132,7 +165,7 @@ pub fn load_builtin_skill_bundles() -> SkillResult<Vec<BuiltinSkillBundle>> {
                 })?;
                 skill_markdown = Some(raw.replace("<SKILLS_DIR>", &skills_dir_display));
             } else {
-                assets.insert(relative_path, bytes);
+                assets.insert(relative_path, BuiltinSkillFile { bytes, executable });
             }
         }
 
@@ -199,6 +232,27 @@ mod tests {
             .contains_key("eval-viewer/generate_review.py"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn embedded_builtin_executable_manifest_matches_repository_modes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../builtin_skills");
+        for (relative, _, embedded_executable) in super::BUILTIN_SKILL_FILES {
+            let source = root.join(relative);
+            let source_executable = std::fs::metadata(&source)
+                .unwrap_or_else(|error| panic!("{}: {error}", source.display()))
+                .permissions()
+                .mode()
+                & 0o111
+                != 0;
+            assert_eq!(
+                *embedded_executable, source_executable,
+                "embedded mode drift for {relative}"
+            );
+        }
+    }
+
     #[test]
     fn builtin_personal_assistant_bundle_carries_assistant_tool_refs() {
         let bundles = load_builtin_skill_bundles().expect("load builtin bundles");
@@ -247,7 +301,9 @@ mod tests {
                 bundle
                     .files
                     .get("agents/bamboo.yaml")
-                    .unwrap_or_else(|| panic!("{id} needs Bamboo metadata")),
+                    .unwrap_or_else(|| panic!("{id} needs Bamboo metadata"))
+                    .bytes
+                    .as_slice(),
             )
             .expect("utf8 Bamboo metadata");
             let bamboo_metadata: serde_yaml::Value =
@@ -267,7 +323,9 @@ mod tests {
                 bundle
                     .files
                     .get("evals/trigger-evals.json")
-                    .unwrap_or_else(|| panic!("{id} needs trigger evals")),
+                    .unwrap_or_else(|| panic!("{id} needs trigger evals"))
+                    .bytes
+                    .as_slice(),
             )
             .expect("valid trigger evals");
             assert!(
@@ -315,7 +373,9 @@ mod tests {
                 bundle
                     .files
                     .get("evals/scenarios.json")
-                    .unwrap_or_else(|| panic!("{id} needs scenario evals")),
+                    .unwrap_or_else(|| panic!("{id} needs scenario evals"))
+                    .bytes
+                    .as_slice(),
             )
             .expect("valid scenario evals");
             let kinds = scenarios

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -1454,7 +1454,7 @@ impl SkillStore {
         *skills_guard = resolved_skills;
         *roots_guard = resolved_roots;
         *resources_guard = resolved_resources;
-        *skill_catalog_guard = next_skill_catalog;
+        *skill_catalog_guard = next_skill_catalog.clone();
         *workflows_guard = resolved_workflows;
         *workflow_roots_guard = resolved_workflow_roots;
         *workflow_resources_guard = resolved_workflow_resources;
@@ -1468,6 +1468,11 @@ impl SkillStore {
         drop(roots_guard);
         drop(skills_guard);
         drop(_snapshot_guard);
+        self.publish_catalog_events(
+            &previous_skill_catalog,
+            &next_skill_catalog,
+            &skill_definition_changed,
+        );
         self.publish_catalog_events(
             &previous_catalog,
             &next_catalog,
@@ -3735,7 +3740,7 @@ mod tests {
     use crate::store::storage::write_skill_file;
     use crate::store::storage::SkillDirectorySource;
     use crate::types::SkillStoreConfig;
-    use crate::{SkillManager, WorkflowSource, WorkflowStatus};
+    use crate::{SkillManager, WorkflowCatalogEventKind, WorkflowSource, WorkflowStatus};
 
     #[test]
     fn agents_skill_precedence_is_below_bamboo_global_and_above_plugin() {
@@ -4566,7 +4571,7 @@ Use this skill for testing.
     }
 
     #[tokio::test]
-    async fn invalid_skill_reload_retains_lkg_without_workflow_events() {
+    async fn invalid_skill_reload_retains_lkg_and_publishes_sanitized_lifecycle_events() {
         const PRIVATE_FIELD: &str = "private-lkg-frontmatter-field";
         const PRIVATE_INSTRUCTIONS: &str = "Private LKG replacement instructions";
         let directory = tempfile::tempdir().expect("tempdir");
@@ -4605,10 +4610,11 @@ Use this skill for testing.
         assert!(!public_error.contains(PRIVATE_FIELD));
         assert!(!public_error.contains(PRIVATE_INSTRUCTIONS));
         assert!(!public_error.contains(root.to_string_lossy().as_ref()));
-        assert!(matches!(
-            events.try_recv(),
-            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
-        ));
+        let invalid_event = events.try_recv().expect("instruction invalid event");
+        assert_eq!(invalid_event.workflow_id, "steady");
+        assert_eq!(invalid_event.kind, WorkflowCatalogEventKind::Invalid);
+        assert!(!invalid_event.public_workflow);
+        assert_eq!(invalid_event.scope, "global");
 
         write_skill(
             root.parent().expect("skills root"),
@@ -4627,10 +4633,11 @@ Use this skill for testing.
                 .description,
             "recovered"
         );
-        assert!(matches!(
-            events.try_recv(),
-            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
-        ));
+        let recovered_event = events.try_recv().expect("instruction recovered event");
+        assert_eq!(recovered_event.workflow_id, "steady");
+        assert_eq!(recovered_event.kind, WorkflowCatalogEventKind::Recovered);
+        assert!(!recovered_event.public_workflow);
+        assert_eq!(recovered_event.scope, "global");
     }
 
     #[tokio::test]
@@ -5327,10 +5334,14 @@ Use this skill for testing.
         })
         .await
         .expect("workspace watcher publication");
-        assert!(matches!(
-            events.try_recv(),
-            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
-        ));
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .expect("workspace catalog event bridge")
+            .expect("workspace catalog event");
+        assert_eq!(event.workflow_id, "only-one");
+        assert_eq!(event.kind, WorkflowCatalogEventKind::Changed);
+        assert!(!event.public_workflow);
+        assert!(event.scope.starts_with("workspace:"));
         let untouched = second_store.skill_catalog_snapshot().await;
         assert!(updated.revision > first.revision);
         assert_eq!(untouched.revision, second.revision);

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -56,6 +56,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use sha2::{Digest, Sha256};
 use tokio::io::AsyncReadExt;
 use tokio::sync::RwLock;
 use tracing::info;
@@ -338,6 +339,11 @@ pub struct SkillActivationDescriptor {
 /// revision after a server restart without consulting a newer catalog.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SkillActivationSnapshot {
+    /// Opaque identity of the global/Project/workspace publication that owns
+    /// these bytes. Durable snapshots must never be replayed in another
+    /// resource scope after a session is reassigned.
+    #[serde(default)]
+    pub resource_scope_fingerprint: String,
     pub catalog_revision: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selected_skill_mode: Option<String>,
@@ -896,6 +902,60 @@ pub struct SkillStore {
 }
 
 impl SkillStore {
+    /// Return an opaque, restart-stable identity for this resource
+    /// publication. No filesystem path is persisted in the snapshot.
+    pub fn resource_scope_fingerprint(&self) -> String {
+        fn update_path(hasher: &mut Sha256, path: &Path) {
+            let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+            #[cfg(unix)]
+            {
+                use std::os::unix::ffi::OsStrExt;
+                let bytes = canonical.as_os_str().as_bytes();
+                hasher.update(b"unix\0");
+                hasher.update((bytes.len() as u64).to_be_bytes());
+                hasher.update(bytes);
+            }
+            #[cfg(windows)]
+            {
+                use std::os::windows::ffi::OsStrExt;
+                let units = canonical.as_os_str().encode_wide().collect::<Vec<_>>();
+                hasher.update(b"windows-utf16\0");
+                hasher.update((units.len() as u64).to_be_bytes());
+                for unit in units {
+                    hasher.update(unit.to_le_bytes());
+                }
+            }
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(b"bamboo.skill-resource-scope.v1\0");
+        update_path(&mut hasher, &self.config.skills_dir);
+        match (
+            self.project_home_dir.as_deref(),
+            self.workspace_overlay_dir.as_deref(),
+        ) {
+            (Some(project_home), workspace) => {
+                hasher.update(b"project\0");
+                update_path(&mut hasher, project_home);
+                if let Some(workspace) = workspace {
+                    hasher.update(b"workspace\0");
+                    update_path(&mut hasher, workspace);
+                }
+            }
+            (None, Some(workspace)) => {
+                hasher.update(b"workspace\0");
+                update_path(&mut hasher, workspace);
+            }
+            (None, None) => hasher.update(b"global\0"),
+        }
+        if let Some(mode) = self.effective_mode(None) {
+            hasher.update(b"mode\0");
+            hasher.update((mode.len() as u64).to_be_bytes());
+            hasher.update(mode.as_bytes());
+        }
+        format!("sha256:{}", hex::encode(hasher.finalize()))
+    }
+
     fn normalize_mode(raw_mode: Option<&str>) -> Option<String> {
         let raw = raw_mode?.trim();
         if raw.is_empty() {
@@ -2087,6 +2147,7 @@ impl SkillStore {
         let activations = self.pinned_activations.read().await;
         let activation = activations.by_id.get(activation_id)?;
         Some(SkillActivationSnapshot {
+            resource_scope_fingerprint: self.resource_scope_fingerprint(),
             catalog_revision: activation.catalog_revision,
             selected_skill_mode: activation.selected_skill_mode.clone(),
             skills: activation
@@ -2121,6 +2182,14 @@ impl SkillStore {
         const MAX_DURABLE_ACTIVATION_BYTES: usize = 512 * 1024;
         const MAX_DURABLE_ACTIVATION_SKILLS: usize = 32;
         const MAX_DURABLE_ACTIVATION_RESOURCES: usize = 1_024;
+        let expected_scope = self.resource_scope_fingerprint();
+        if snapshot.resource_scope_fingerprint.is_empty()
+            || snapshot.resource_scope_fingerprint != expected_scope
+        {
+            return Err(SkillError::Validation(
+                "persisted workflow activation resource scope mismatch".to_string(),
+            ));
+        }
         if snapshot.skills.is_empty() {
             return Err(SkillError::Validation(
                 "persisted workflow activation is empty".to_string(),
@@ -2419,19 +2488,19 @@ impl SkillStore {
     }
 
     /// Release a session pin without depending on its workspace still existing.
-    /// Session IDs are unique across scopes, so clearing the root and every cached
-    /// workspace store is both safe and robust to deleted/unmounted projects.
+    /// Session IDs are unique across scopes, so clearing the root and every
+    /// cached workspace, Project/workspace, and mode store is both safe and
+    /// robust to reassignment or deleted/unmounted resources.
     pub async fn release_activation_across_cached_scopes(&self, activation_id: &str) {
         self.release_activation(activation_id).await;
-        let workspace_stores = self
-            .workspace_stores
-            .read()
-            .await
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        for store in workspace_stores {
+        let mut pending = self.cached_dependent_stores().await;
+        let mut visited = HashSet::new();
+        while let Some(store) = pending.pop() {
+            if !visited.insert(store.store_token) {
+                continue;
+            }
             store.release_activation(activation_id).await;
+            pending.extend(store.cached_dependent_stores().await);
         }
     }
 
@@ -3085,21 +3154,19 @@ impl SkillStore {
             let skill_id = bundle.skill.id.clone();
             write_skill_file(&builtin_skills_dir, &bundle.skill).await?;
 
-            for (relative_path, content) in bundle.files {
+            for (relative_path, file) in bundle.files {
                 let full_path = builtin_skills_dir.join(&skill_id).join(&relative_path);
                 if let Some(parent) = full_path.parent() {
                     tokio::fs::create_dir_all(parent).await?;
                 }
-                tokio::fs::write(&full_path, content).await?;
-                // Make script files executable on Unix
+                tokio::fs::write(&full_path, file.bytes).await?;
+                // Reproduce the embedded Git permission contract exactly.
                 #[cfg(unix)]
                 {
-                    if relative_path.starts_with("scripts/") {
-                        use std::os::unix::fs::PermissionsExt;
-                        let mut perms = tokio::fs::metadata(&full_path).await?.permissions();
-                        perms.set_mode(0o755);
-                        tokio::fs::set_permissions(&full_path, perms).await?;
-                    }
+                    use std::os::unix::fs::PermissionsExt;
+                    let mode = if file.executable { 0o755 } else { 0o644 };
+                    tokio::fs::set_permissions(&full_path, std::fs::Permissions::from_mode(mode))
+                        .await?;
                 }
             }
         }
@@ -3852,12 +3919,24 @@ mod tests {
         write_skill_file(skills_dir, &bundle.skill)
             .await
             .expect("legacy SKILL.md");
-        for (relative, bytes) in &bundle.files {
+        for (relative, file) in &bundle.files {
             let path = skills_dir.join(&bundle.skill.id).join(relative);
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent).await.expect("legacy parent");
             }
-            fs::write(path, bytes).await.expect("legacy resource");
+            fs::write(&path, &file.bytes)
+                .await
+                .expect("legacy resource");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(
+                    path,
+                    std::fs::Permissions::from_mode(if file.executable { 0o755 } else { 0o644 }),
+                )
+                .await
+                .expect("legacy resource mode");
+            }
         }
     }
 
@@ -4011,6 +4090,48 @@ Use this skill for testing.
                 .source,
             WorkflowSource::Builtin
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn historical_all_scripts_executable_builtin_is_still_migrated() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let bundle = load_builtin_skill_bundles()
+            .expect("builtin bundles")
+            .into_iter()
+            .find(|bundle| bundle.skill.id == "skill-creator")
+            .expect("skill creator");
+        materialize_legacy_builtin(&skills_dir, &bundle).await;
+        for relative in bundle
+            .files
+            .keys()
+            .filter(|relative| relative.starts_with("scripts/"))
+        {
+            fs::set_permissions(
+                skills_dir.join("skill-creator").join(relative),
+                std::fs::Permissions::from_mode(0o755),
+            )
+            .await
+            .expect("historical executable mode");
+        }
+
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: skills_dir.clone(),
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+
+        assert!(
+            !skills_dir.join("skill-creator").exists(),
+            "known historical generator output must not shadow versioned builtins"
+        );
+        assert!(directory
+            .path()
+            .join("data/legacy-builtins-v1/skill-creator")
+            .exists());
     }
 
     #[tokio::test]
@@ -5548,6 +5669,65 @@ Use this skill for testing.
         assert!(store.activation_descriptor("active-0").await.is_some());
         assert!(store
             .activation_descriptor("restore-over-capacity")
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn durable_restore_rejects_another_resource_scope_and_legacy_unscoped_bytes() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let workspace_a = directory.path().join("workspace-a");
+        let workspace_b = directory.path().join("workspace-b");
+        fs::create_dir_all(&workspace_a).await.expect("workspace A");
+        fs::create_dir_all(&workspace_b).await.expect("workspace B");
+        write_skill(
+            &workspace_a.join(".bamboo/skills"),
+            "private-a",
+            "private",
+            "A-only instructions",
+        )
+        .await
+        .expect("workspace A skill");
+
+        let store_a = SkillStore::new(SkillStoreConfig {
+            skills_dir: skills_dir.clone(),
+            project_dir: Some(workspace_a),
+            active_mode: None,
+        });
+        store_a.initialize().await.expect("initialize A");
+        store_a
+            .pin_current_activation("scope-a", &["private-a".to_string()], None)
+            .await
+            .expect("pin A");
+        let snapshot = store_a
+            .export_activation_snapshot("scope-a")
+            .await
+            .expect("snapshot A");
+        assert!(snapshot.resource_scope_fingerprint.starts_with("sha256:"));
+
+        let store_b = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            project_dir: Some(workspace_b),
+            active_mode: None,
+        });
+        store_b.initialize().await.expect("initialize B");
+        let mismatch = store_b
+            .restore_activation_snapshot("scope-b", snapshot.clone())
+            .await
+            .expect_err("scope A bytes must not restore in B");
+        assert!(mismatch.to_string().contains("resource scope mismatch"));
+        assert!(store_b.activation_descriptor("scope-b").await.is_none());
+
+        let mut legacy = snapshot;
+        legacy.resource_scope_fingerprint.clear();
+        let legacy_error = store_a
+            .restore_activation_snapshot("legacy-unscoped", legacy)
+            .await
+            .expect_err("unscoped legacy bytes fail closed");
+        assert!(legacy_error.to_string().contains("resource scope mismatch"));
+        assert!(store_a
+            .activation_descriptor("legacy-unscoped")
             .await
             .is_none());
     }

--- a/docs/skills-and-project-instructions.md
+++ b/docs/skills-and-project-instructions.md
@@ -31,11 +31,13 @@ migrated bundle remains manual-only. The catalog reports the canonical winner
 as `migration_status: "migrated"` and retains the legacy adapter as a shadowed
 diagnostic.
 
-Product clients build one metadata-only Workflow Library from instruction
-entries returned by `GET /api/v1/commands` and orchestration/legacy entries
-returned by `GET /api/v1/bamboo/workflow-catalog`. Neither listing contains
-instructions or resource bytes. Changes, invalid definitions, and LKG recovery
-for both namespaces publish `workflow.changed`, `workflow.invalid`, or
+Product clients build one metadata-only Workflow Library from instruction,
+orchestration, and legacy entries returned by
+`GET /api/v1/bamboo/workflow-catalog`. `GET /api/v1/commands` remains the
+separate compatibility surface for slash commands, MCP tools, goals, and other
+non-Workflow palette actions. Neither endpoint returns Workflow instructions
+or resource bytes. Changes, invalid definitions, and LKG recovery in either
+Workflow namespace publish `workflow.changed`, `workflow.invalid`, or
 `workflow.recovered` on the account feed; the 30-second client cache is only a
 fallback when the event stream is unavailable.
 
@@ -56,7 +58,11 @@ bundle before acknowledging the chat turn, and persists the candidate snapshot
 with the session so a restart between chat and execute cannot substitute a
 newer revision. Stale or missing identities fail before the user message is
 committed. `GET /api/v1/sessions/<id>` returns the public-safe
-`active_workflow` identity after activation; list rows remain lightweight.
+`active_workflow` identity after activation; arguments, context fingerprints,
+dynamic provider output, and immutable bundle bytes remain server-internal.
+List rows remain lightweight. Project or Workspace reassignment atomically
+clears the old scoped activation, and a persisted bundle snapshot is accepted
+after restart only by the exact resource scope that produced it.
 
 [Claude Code Skills and legacy custom-command compatibility](https://code.claude.com/docs/en/slash-commands)
 remain rooted in `.claude/skills` and `<workspace>/.claude/commands`; Bamboo

--- a/docs/skills-and-project-instructions.md
+++ b/docs/skills-and-project-instructions.md
@@ -31,6 +31,33 @@ migrated bundle remains manual-only. The catalog reports the canonical winner
 as `migration_status: "migrated"` and retains the legacy adapter as a shadowed
 diagnostic.
 
+Product clients build one metadata-only Workflow Library from instruction
+entries returned by `GET /api/v1/commands` and orchestration/legacy entries
+returned by `GET /api/v1/bamboo/workflow-catalog`. Neither listing contains
+instructions or resource bytes. Changes, invalid definitions, and LKG recovery
+for both namespaces publish `workflow.changed`, `workflow.invalid`, or
+`workflow.recovered` on the account feed; the 30-second client cache is only a
+fallback when the event stream is unavailable.
+
+Versioned builtins are read-only. A client may clone one exact builtin through
+`POST /api/v1/bamboo/workflow-catalog/<id>/clone` with
+`{"source":"builtin","revision":<n>,"target":"user"}` or target
+`"project"` plus a trusted `session_id`. Bamboo resolves every destination
+from server-owned state, writes the bundle outside the scanned skills tree,
+fsyncs it, and atomically renames it into place. A stale source, existing
+override, divergent recovery marker, symlink, or client filesystem path is
+rejected; the builtin is never changed. Interrupted publications resume only
+when their source revision and content digest still match.
+
+Explicit instruction activation uses the typed `POST /api/v1/chat` field
+`workflow_selection: {id, source, revision, args}`. The request never carries
+expanded instructions. Bamboo validates arguments, pins the exact immutable
+bundle before acknowledging the chat turn, and persists the candidate snapshot
+with the session so a restart between chat and execute cannot substitute a
+newer revision. Stale or missing identities fail before the user message is
+committed. `GET /api/v1/sessions/<id>` returns the public-safe
+`active_workflow` identity after activation; list rows remain lightweight.
+
 [Claude Code Skills and legacy custom-command compatibility](https://code.claude.com/docs/en/slash-commands)
 remain rooted in `.claude/skills` and `<workspace>/.claude/commands`; Bamboo
 does not introduce or label a `.claude/workflows` convention. Repository


### PR DESCRIPTION
> [!CAUTION]
> **Scope-frozen on 2026-08-22. Do not merge this PR.**
>
> The implementation audit found that this draft combined several independently
> shippable contracts and had attracted unrelated lifecycle/storage work. Keep
> it only as reference/patch material while extracting focused child branches.

## Extraction targets

- #870 — metadata-only Workflow catalog and lifecycle events
- #871 — WorkflowRun snapshot/event/cancel UI contract
- #872 — typed instruction activation and public session receipt
- #873 — atomic no-replace builtin clone publication
- #874 — clone recovery and retirement
- #875 — legacy Workflow migration

Each target must start from current `dev` in a fresh worktree, include only its
acceptance slice, and get its own PR. Adjacent review findings do not expand a
child unless the child diff directly introduces the defect.

---

## Summary

- expose one metadata-only Workflow catalog for instruction and orchestration entries, including invalid/LKG/recovered and shadow diagnostics without prompt bodies, arguments, dynamic context, credential material, or storage paths
- persist exact typed instruction candidates at the chat boundary, reject raw secret-shaped arguments, retain the prior activation across every fallible pre-commit step, and make the durable save -> pin handoff cancellation-resistant
- reject Workflow replacement while an execution is starting or running; preserve pending candidates across ordinary chat turns and restore them after restart without sending expanded instructions from the UI
- bind retained Workflow snapshots to their Project/workspace resource scope and atomically clear/release Workflow authority when a session changes Project or workspace, including request-cancellation and restart paths
- return a minimal public `active_workflow` session DTO and fail closed on missing, malformed, or unreadable authoritative session state instead of leaking args, fingerprints, diagnostics, or dynamic provider content
- add exact-revision builtin clone APIs for user and Project layers with authoritative locked Project resolution, active-project enforcement, platform-native atomic no-replace publication, fsync/crash recovery, exact executable-mode fidelity, and no absolute-path disclosure
- share the secret-material classifier between instruction activation and orchestration execution, and bridge Workflow catalog changed/invalid/recovered transitions onto the durable account feed
- document the typed selection, catalog, scope, clone, event, recovery, and compatibility contracts consumed by bigduu/Lotus#119

## Safety and concurrency guarantees

- rejected hook/image/secret/revision/capacity requests cannot mutate the existing durable activation or live pin
- a successful typed chat cannot race an active runner, expose committed candidate B with pin A, or be split by HTTP request cancellation
- Project/workspace reassignment cannot retain or restore bytes from the old resource scope, even after restart or caller cancellation
- clone cannot overwrite a directory, file, symlink, or marker created during the publication race; server staging remains recoverable
- public APIs and error responses do not expose Workflow bodies, args, dynamic context, raw catalog errors, secret-shaped metadata, or server filesystem paths

## Test Plan

- `cargo test --locked -p bamboo-domain --lib` (204 passed)
- `cargo test --locked -p bamboo-agent-core --lib` (152 passed)
- `cargo test --locked -p bamboo-skills --lib` (136 passed)
- `cargo test --locked -p bamboo-engine --lib` (1379 passed)
- `cargo test --locked -p bamboo-server --lib --quiet` (1885 passed, 1 ignored because it requires an installed Codex CLI)
- typed-chat parallel regression group repeated three times at default test concurrency (3 x 19 passed)
- `cargo check --locked --target x86_64-pc-windows-gnu -p bamboo-server --lib`
- `cargo clippy --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code`
- `cargo +1.95.0 check --locked --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

## Cross-module scope

This is the Bamboo contract half of bigduu/Lotus#119. The Lotus consumer PR follows on its own repository branch after this exact backend contract is independently approved and merged; this PR does not close the Lotus issue by itself.