### PR TITLE
feat: expose unified Workflow catalog metadata

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -450,8 +450,11 @@ impl AppState {
         // owns handles to both maps.
         spawn_session_map_cleanup_task(agent_runners.clone(), session_event_senders.clone(), None);
 
-        // Bridge global workflow catalog transitions onto the same durable account feed used by
-        // SSE and v2 WebSocket clients. Catalog events are account-scoped (no session id).
+        // Bridge both instruction and orchestration catalog transitions onto
+        // the same durable account feed used by SSE and v2 WebSocket clients.
+        // The public Workflow Library unifies both kinds, so either namespace
+        // must invalidate clients. Catalog events are account-scoped (no
+        // session id).
         {
             let mut workflow_events = skill_manager.store().subscribe_workflow_catalog();
             let account_sink = account_sink.clone();
@@ -465,9 +468,6 @@ impl AppState {
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     };
-                    if !event.public_workflow {
-                        continue;
-                    }
                     let event = match event.kind {
                         bamboo_skills::WorkflowCatalogEventKind::Changed => {
                             AgentEvent::WorkflowChanged {

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -1,6 +1,6 @@
 use actix_web::{http::StatusCode, web, HttpResponse};
 use bamboo_skills::legacy::LegacyWorkflowMigrationOutcome;
-use bamboo_skills::LegacyWorkflowMigrationStatus;
+use bamboo_skills::{LegacyWorkflowMigrationStatus, WorkflowCatalogEntry, WorkflowCatalogSnapshot};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
@@ -55,7 +55,7 @@ pub async fn list_workflow_catalog(
     app_state: web::Data<AppState>,
     query: web::Query<WorkflowCatalogQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let snapshot = if let Some(session_id) = query
+    let store = if let Some(session_id) = query
         .session_id
         .as_deref()
         .map(str::trim)
@@ -111,37 +111,50 @@ pub async fn list_workflow_catalog(
             let project_home = app_state.project_store.paths().project_home(&project_id);
             app_state
                 .skill_manager
-                .workflow_catalog_for_project_workspace(
-                    &project_id,
-                    &project_home,
-                    workspace.as_deref(),
-                )
+                .store_for_project_workspace(&project_id, &project_home, workspace.as_deref())
                 .await
                 .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
         } else if let Some(workspace) = workspace.as_ref() {
             app_state
                 .skill_manager
-                .store()
-                .workflow_catalog_for_workspace(workspace)
+                .store_for_workspace(Some(workspace))
                 .await
                 .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
         } else {
             app_state
                 .skill_manager
-                .store()
-                .workflow_catalog_snapshot()
+                .store_for_workspace(None)
                 .await
+                .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
         }
     } else {
         app_state
             .skill_manager
-            .store()
-            .workflow_catalog_snapshot()
+            .store_for_workspace(None)
             .await
+            .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
+    };
+
+    // Instruction Skills and orchestration definitions are independent
+    // activation namespaces, but they form one product-level Workflow
+    // Library. Clone both metadata-only snapshots while the store holds one
+    // publication guard, then expose only the public Workflow side of the
+    // orchestration/legacy namespace.
+    let (skill_catalog, workflow_catalog) = store.command_catalog_snapshots().await;
+    let mut entries = skill_catalog.entries;
+    entries.extend(
+        workflow_catalog
+            .entries
+            .into_iter()
+            .filter(WorkflowCatalogEntry::is_public_workflow),
+    );
+    let snapshot = WorkflowCatalogSnapshot {
+        revision: skill_catalog.revision.max(workflow_catalog.revision),
+        entries,
     };
     Ok(HttpResponse::Ok()
         .insert_header(("Cache-Control", "no-store"))
-        .json(snapshot.public_workflows()))
+        .json(snapshot))
 }
 
 /// Clone one read-only global/workspace/plugin legacy workflow into the trusted

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -23,7 +23,7 @@ async fn assert_legacy_endpoint_success(context: &str, response: actix_web::dev:
 }
 
 #[actix_web::test]
-async fn workflow_catalog_excludes_instruction_skills_and_returns_orchestration_metadata() {
+async fn workflow_catalog_unifies_metadata_without_exposing_bodies_or_paths() {
     let data = tempfile::tempdir().expect("data dir");
     let skill = data.path().join("skills/review");
     tokio::fs::create_dir_all(&skill).await.expect("skill dir");
@@ -54,7 +54,7 @@ async fn workflow_catalog_excludes_instruction_skills_and_returns_orchestration_
             .await
             .expect("app state"),
     );
-    let app = actix_web::test::init_service(actix_web::App::new().app_data(state).route(
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state.clone()).route(
         "/catalog",
         actix_web::web::get().to(super::list_workflow_catalog),
     ))
@@ -64,12 +64,101 @@ async fn workflow_catalog_excludes_instruction_skills_and_returns_orchestration_
         .to_request();
     let body = actix_web::test::call_and_read_body(&app, request).await;
     let text = std::str::from_utf8(&body).expect("utf8 response");
-    assert!(!text.contains("Reviews changes"));
+    assert!(text.contains("Reviews changes"));
+    assert!(text.contains("\"kind\":\"instruction\""));
     assert!(text.contains("Deploys changes"));
+    assert!(text.contains("\"kind\":\"orchestration\""));
     assert!(text.contains("\"revision\""));
     assert!(!text.contains("TOP SECRET INSTRUCTIONS"));
     assert!(!text.contains("WORKFLOW SECRET BODY"));
     assert!(!text.contains("SKILL.md"));
+
+    let initial: serde_json::Value = serde_json::from_slice(&body).expect("catalog json");
+    let entries = initial["entries"].as_array().expect("catalog entries");
+    let review = entries
+        .iter()
+        .find(|entry| entry["id"] == "review")
+        .expect("instruction entry");
+    assert_eq!(review["source"], "user");
+    assert_eq!(review["status"], "valid");
+    assert!(review["shadowed_candidates"]
+        .as_array()
+        .expect("safe shadow diagnostics")
+        .iter()
+        .any(|candidate| candidate["source"] == "builtin"));
+    let deploy = entries
+        .iter()
+        .find(|entry| entry["id"] == "deploy")
+        .expect("orchestration entry");
+    assert_eq!(deploy["status"], "valid");
+
+    const PRIVATE_INVALID_FIELD: &str = "private_invalid_catalog_field";
+    const PRIVATE_INVALID_BODY: &str = "PRIVATE INVALID REPLACEMENT BODY";
+    tokio::fs::write(
+        skill.join("SKILL.md"),
+        format!(
+            "---\nname: review\ndescription: changed too early\n{PRIVATE_INVALID_FIELD}: secret\n---\n{PRIVATE_INVALID_BODY}\n"
+        ),
+    )
+    .await
+    .expect("break instruction bundle");
+    state
+        .skill_manager
+        .store()
+        .reload_global_workflow_views()
+        .await
+        .expect("invalid publication stays isolated");
+    let invalid: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/catalog")
+            .to_request(),
+    )
+    .await;
+    let invalid_entries = invalid["entries"].as_array().expect("invalid entries");
+    let invalid_review = invalid_entries
+        .iter()
+        .find(|entry| entry["id"] == "review")
+        .expect("invalid instruction remains visible through LKG");
+    assert_eq!(invalid_review["status"], "invalid");
+    assert_eq!(invalid_review["description"], "Reviews changes");
+    assert!(invalid_review["last_error"].is_string());
+    let rendered = invalid_review.to_string();
+    assert!(!rendered.contains(PRIVATE_INVALID_FIELD));
+    assert!(!rendered.contains(PRIVATE_INVALID_BODY));
+    assert!(!rendered.contains(data.path().to_string_lossy().as_ref()));
+    assert!(invalid_entries
+        .iter()
+        .any(|entry| entry["id"] == "deploy" && entry["status"] == "valid"));
+
+    tokio::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: review\ndescription: Recovered review\n---\nRECOVERED PRIVATE BODY\n",
+    )
+    .await
+    .expect("repair instruction bundle");
+    state
+        .skill_manager
+        .store()
+        .reload_global_workflow_views()
+        .await
+        .expect("recovered publication");
+    let recovered: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/catalog")
+            .to_request(),
+    )
+    .await;
+    let recovered_review = recovered["entries"]
+        .as_array()
+        .expect("recovered entries")
+        .iter()
+        .find(|entry| entry["id"] == "review")
+        .expect("recovered instruction");
+    assert_eq!(recovered_review["status"], "valid");
+    assert_eq!(recovered_review["description"], "Recovered review");
+    assert!(!recovered.to_string().contains("RECOVERED PRIVATE BODY"));
 }
 
 #[actix_web::test]
@@ -414,12 +503,19 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
             .to_request(),
     )
     .await;
-    let source_workflow = after["entries"]
-        .as_array()
-        .expect("catalog entries")
+    let entries = after["entries"].as_array().expect("catalog entries");
+    let migrated_workflow = entries
         .iter()
-        .find(|entry| entry["id"] == "daily-report")
+        .find(|entry| entry["id"] == "daily-report" && entry["migration_status"] == "migrated")
+        .expect("migrated instruction entry");
+    let source_workflow = entries
+        .iter()
+        .find(|entry| entry["id"] == "daily-report" && entry["migration_status"] == "available")
         .expect("source Workflow entry");
+    assert_ne!(
+        migrated_workflow["revision"], source_workflow["revision"],
+        "same-id instruction and source entries keep distinct typed revisions"
+    );
     assert_eq!(source_workflow["migration_status"], "available");
     assert!(source_workflow.get("shadowed_candidates").is_none());
 }
@@ -584,6 +680,80 @@ async fn legacy_api_keeps_workflow_source_only_and_bridges_catalog_event() {
     })
     .await;
     assert!(bridged.is_ok(), "workflow.changed must reach account feed");
+}
+
+#[actix_web::test]
+async fn instruction_catalog_lifecycle_reaches_the_durable_account_feed_in_order() {
+    let data = tempfile::tempdir().expect("data dir");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let mut account_events = state.account_sink.subscribe();
+    let skill_dir = data.path().join("skills/library-refresh");
+    tokio::fs::create_dir_all(&skill_dir)
+        .await
+        .expect("skill dir");
+    let skill_file = skill_dir.join("SKILL.md");
+    let valid = "---\nname: library-refresh\ndescription: Refresh the Workflow Library.\n---\nRefresh it.\n";
+
+    tokio::fs::write(&skill_file, valid)
+        .await
+        .expect("create instruction");
+    state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .expect("publish changed instruction");
+    tokio::fs::write(&skill_file, "---\nname: [\n")
+        .await
+        .expect("invalidate instruction");
+    state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .expect("publish invalid LKG instruction");
+    tokio::fs::write(&skill_file, valid)
+        .await
+        .expect("recover instruction");
+    state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .expect("publish recovered instruction");
+
+    let observed = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        let mut kinds = Vec::new();
+        while kinds.len() < 3 {
+            let event = account_events.recv().await.expect("account event");
+            match &event.event {
+                bamboo_agent_core::AgentEvent::WorkflowChanged { workflow_id, .. }
+                    if workflow_id == "library-refresh" =>
+                {
+                    kinds.push("changed")
+                }
+                bamboo_agent_core::AgentEvent::WorkflowInvalid { workflow_id, .. }
+                    if workflow_id == "library-refresh" =>
+                {
+                    kinds.push("invalid")
+                }
+                bamboo_agent_core::AgentEvent::WorkflowRecovered { workflow_id, .. }
+                    if workflow_id == "library-refresh" =>
+                {
+                    kinds.push("recovered")
+                }
+                _ => {}
+            }
+        }
+        kinds
+    })
+    .await
+    .expect("instruction catalog events reach the account feed");
+    assert_eq!(observed, ["changed", "invalid", "recovered"]);
 }
 
 #[actix_web::test]

--- a/crates/infra/bamboo-skills/src/catalog.rs
+++ b/crates/infra/bamboo-skills/src/catalog.rs
@@ -128,8 +128,9 @@ pub struct WorkflowCatalogEvent {
     pub workflow_id: String,
     pub revision: u64,
     pub kind: WorkflowCatalogEventKind,
-    /// Whether this transition belongs to the public Workflow identity rather
-    /// than to an instruction-only Skill sharing the internal catalog.
+    /// Compatibility discriminator for consumers predating the unified
+    /// instruction and orchestration Workflow catalog. Newly published catalog
+    /// events always set this; legacy decoded events default to `false`.
     #[serde(default)]
     pub public_workflow: bool,
     /// `global`, `project:<id>`, or an opaque `workspace:<hash>`; never an

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -1454,7 +1454,7 @@ impl SkillStore {
         *skills_guard = resolved_skills;
         *roots_guard = resolved_roots;
         *resources_guard = resolved_resources;
-        *skill_catalog_guard = next_skill_catalog;
+        *skill_catalog_guard = next_skill_catalog.clone();
         *workflows_guard = resolved_workflows;
         *workflow_roots_guard = resolved_workflow_roots;
         *workflow_resources_guard = resolved_workflow_resources;
@@ -1468,6 +1468,11 @@ impl SkillStore {
         drop(roots_guard);
         drop(skills_guard);
         drop(_snapshot_guard);
+        self.publish_catalog_events(
+            &previous_skill_catalog,
+            &next_skill_catalog,
+            &skill_definition_changed,
+        );
         self.publish_catalog_events(
             &previous_catalog,
             &next_catalog,
@@ -2527,8 +2532,7 @@ impl SkillStore {
                 workflow_id: entry.id.clone(),
                 revision: next.revision,
                 kind,
-                public_workflow: entry.is_public_workflow()
-                    || old.is_some_and(WorkflowCatalogEntry::is_public_workflow),
+                public_workflow: true,
                 scope: "global".to_string(),
             });
         }
@@ -2542,7 +2546,7 @@ impl SkillStore {
                 workflow_id: removed.id.clone(),
                 revision: next.revision,
                 kind: WorkflowCatalogEventKind::Changed,
-                public_workflow: removed.is_public_workflow(),
+                public_workflow: true,
                 scope: "global".to_string(),
             });
         }
@@ -3735,7 +3739,7 @@ mod tests {
     use crate::store::storage::write_skill_file;
     use crate::store::storage::SkillDirectorySource;
     use crate::types::SkillStoreConfig;
-    use crate::{SkillManager, WorkflowSource, WorkflowStatus};
+    use crate::{SkillManager, WorkflowCatalogEventKind, WorkflowSource, WorkflowStatus};
 
     #[test]
     fn agents_skill_precedence_is_below_bamboo_global_and_above_plugin() {
@@ -4566,7 +4570,7 @@ Use this skill for testing.
     }
 
     #[tokio::test]
-    async fn invalid_skill_reload_retains_lkg_without_workflow_events() {
+    async fn instruction_change_invalid_and_recovered_events_follow_atomic_publication() {
         const PRIVATE_FIELD: &str = "private-lkg-frontmatter-field";
         const PRIVATE_INSTRUCTIONS: &str = "Private LKG replacement instructions";
         let directory = tempfile::tempdir().expect("tempdir");
@@ -4581,6 +4585,25 @@ Use this skill for testing.
         store.initialize().await.expect("initialize");
         let mut events = store.subscribe_workflow_catalog();
 
+        write_skill(
+            root.parent().expect("skills root"),
+            "steady",
+            "updated",
+            "Updated prompt",
+        )
+        .await
+        .expect("update skill");
+        store.reload().await.expect("changed reload");
+        let changed_event = events.try_recv().expect("instruction changed event");
+        assert_eq!(changed_event.workflow_id, "steady");
+        assert_eq!(changed_event.kind, WorkflowCatalogEventKind::Changed);
+        assert!(changed_event.public_workflow);
+        assert_eq!(changed_event.scope, "global");
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+
         fs::write(
             root.join("SKILL.md"),
             format!(
@@ -4591,7 +4614,7 @@ Use this skill for testing.
             .expect("break skill");
         store.reload().await.expect("invalid reload is isolated");
         let skill = store.get_skill("steady").await.expect("LKG retained");
-        assert_eq!(skill.description, "original");
+        assert_eq!(skill.description, "updated");
         let invalid = store
             .skill_catalog_snapshot()
             .await
@@ -4605,6 +4628,12 @@ Use this skill for testing.
         assert!(!public_error.contains(PRIVATE_FIELD));
         assert!(!public_error.contains(PRIVATE_INSTRUCTIONS));
         assert!(!public_error.contains(root.to_string_lossy().as_ref()));
+        let invalid_event = events.try_recv().expect("instruction invalid event");
+        assert_eq!(invalid_event.workflow_id, "steady");
+        assert_eq!(invalid_event.kind, WorkflowCatalogEventKind::Invalid);
+        assert!(invalid_event.public_workflow);
+        assert!(invalid_event.revision > changed_event.revision);
+        assert_eq!(invalid_event.scope, "global");
         assert!(matches!(
             events.try_recv(),
             Err(tokio::sync::broadcast::error::TryRecvError::Empty)
@@ -4627,6 +4656,12 @@ Use this skill for testing.
                 .description,
             "recovered"
         );
+        let recovered_event = events.try_recv().expect("instruction recovered event");
+        assert_eq!(recovered_event.workflow_id, "steady");
+        assert_eq!(recovered_event.kind, WorkflowCatalogEventKind::Recovered);
+        assert!(recovered_event.public_workflow);
+        assert!(recovered_event.revision > invalid_event.revision);
+        assert_eq!(recovered_event.scope, "global");
         assert!(matches!(
             events.try_recv(),
             Err(tokio::sync::broadcast::error::TryRecvError::Empty)
@@ -5327,6 +5362,14 @@ Use this skill for testing.
         })
         .await
         .expect("workspace watcher publication");
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .expect("workspace catalog event bridge")
+            .expect("workspace catalog event");
+        assert_eq!(event.workflow_id, "only-one");
+        assert_eq!(event.kind, WorkflowCatalogEventKind::Changed);
+        assert!(event.public_workflow);
+        assert!(event.scope.starts_with("workspace:"));
         assert!(matches!(
             events.try_recv(),
             Err(tokio::sync::broadcast::error::TryRecvError::Empty)


### PR DESCRIPTION
## Summary

- expose instruction and orchestration entries through one scoped metadata-only Workflow catalog
- publish instruction changed, invalid, and recovered transitions only after atomic catalog publication
- bridge the unified lifecycle stream into the durable account feed without bodies or filesystem paths
- preserve sanitized last-known-good metadata and unrelated valid entries on candidate failure

## Scope

Implements Bamboo #870 only. Clone publication, activation, WorkflowRun execution, legacy migration mechanics, watcher hardening, teardown, SDK, and Lotus UI remain in their dedicated follow-up Issues.

## Test Plan

- cargo fmt --all -- --check
- git diff --check
- cargo test --locked -p bamboo-skills --lib (132 passed)
- cargo test --locked -p bamboo-server handlers::settings::workflows::tests:: --lib -- --test-threads=1 (29 passed)
- cargo test --locked -p bamboo-server --lib (1859 passed, 1 ignored)
- cargo check --locked -p bamboo-server --all-features
- cargo clippy --locked -p bamboo-skills --lib --no-deps -- -D warnings
- cargo clippy --locked -p bamboo-server --lib --no-deps -- -A clippy::too_many_arguments -D warnings

Strict target-wide clippy remains blocked by pre-existing too_many_arguments warnings in bamboo-storage/src/session_merge.rs and bamboo-server/src/connect/bridge.rs; neither file is changed here.

Closes #870