### PR TITLE
feat: persist typed instruction activation

### DIFF
--- a/crates/app/bamboo-server-tools/src/skill_runtime/load_skill.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/load_skill.rs
@@ -954,7 +954,7 @@ impl Tool for LoadSkillTool {
                     ))
                 })?;
         }
-        let (skill, skill_root, revision, resources, payload_descriptor) = store
+        let (skill, _skill_root, revision, _resources, payload_descriptor) = store
             .get_pinned_skill_with_root_and_descriptor(session_id, skill_id)
             .await
             .map_err(|err| {
@@ -980,19 +980,6 @@ impl Tool for LoadSkillTool {
                     .to_string(),
             ));
         }
-        let restored_snapshot = store.activation_was_restored(session_id).await;
-        let canonical_skill_root = if restored_snapshot
-            || catalog_entry.migration_status
-                == Some(bamboo_skills::LegacyWorkflowMigrationStatus::Available)
-        {
-            None
-        } else {
-            Some(
-                tokio::fs::canonicalize(&skill_root)
-                    .await
-                    .unwrap_or(skill_root),
-            )
-        };
         let mut session = self
             .access
             .session_for_context(Some(session_id))
@@ -1061,25 +1048,6 @@ impl Tool for LoadSkillTool {
             block.status == bamboo_skills::WorkflowActivationStatus::Degraded
                 && block.stop_on_failure
         });
-        let payload = json!({
-            "skill_id": skill.id.clone(),
-            "revision": revision,
-            "name": skill.name.clone(),
-            "description": skill.description.clone(),
-            "license": skill.license.clone(),
-            "compatibility": skill.compatibility.clone(),
-            "allowed_tools": skill.tool_refs.clone(),
-            "instructions": skill.prompt.clone(),
-            "skill_base_dir": canonical_skill_root
-                .as_ref()
-                .map(|root| bamboo_config::paths::path_to_display_string(root)),
-            "snapshot_provenance": if restored_snapshot { "durable_session_lkg" } else { "live_catalog_pin" },
-            "resource_files": resources,
-            "dynamic_context": dynamic_context.clone(),
-            // Non-stopping provider degradation is carried inside the typed
-            // runtime blocks while the workflow itself remains active.
-            "activation_status": if activation_stopped { "degraded" } else { "active" },
-        });
         if activation_stopped {
             session.metadata.insert(
                 bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY.to_string(),
@@ -1101,17 +1069,35 @@ impl Tool for LoadSkillTool {
             .await?;
             return Ok(ToolOutcome::Completed(ToolResult {
                 success: true,
-                result: payload.to_string(),
+                // Public transports and durable Tool messages receive only
+                // this typed receipt. Instructions, resources, paths,
+                // arguments and dynamic provider output remain in the
+                // session's runtime-only activation authority.
+                result: json!({
+                    "skill_id": skill.id,
+                    "revision": revision,
+                    "source": catalog_entry.source,
+                    "kind": catalog_entry.kind,
+                    "activation_status": "degraded",
+                })
+                .to_string(),
                 display_preference: Some("Collapsible".to_string()),
                 images: Vec::new(),
             }));
         }
+        let receipt = json!({
+            "skill_id": skill.id.clone(),
+            "revision": revision,
+            "source": catalog_entry.source,
+            "kind": catalog_entry.kind,
+            "activation_status": "active",
+        });
         let canonical_context = json!({
             "id": skill.id,
             "revision": revision,
             "selection": session.metadata.get(bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY),
             "instructions": skill.prompt,
-            "dynamic_context": payload.get("dynamic_context"),
+            "dynamic_context": dynamic_context,
         });
         let fingerprint = hex::encode(Sha256::digest(canonical_context.to_string().as_bytes()));
         let mut loaded_ids = session
@@ -1152,7 +1138,7 @@ impl Tool for LoadSkillTool {
             .await?;
             return Ok(ToolOutcome::Completed(ToolResult {
                 success: true,
-                result: payload.to_string(),
+                result: receipt.to_string(),
                 display_preference: Some("Collapsible".to_string()),
                 images: Vec::new(),
             }));
@@ -1189,8 +1175,9 @@ impl Tool for LoadSkillTool {
                     result: json!({
                         "skill_id": skill_id,
                         "revision": revision,
+                        "source": catalog_entry.source,
+                        "kind": catalog_entry.kind,
                         "activation_status": "degraded",
-                        "diagnostic": diagnostic,
                     })
                     .to_string(),
                     display_preference: Some("Collapsible".to_string()),
@@ -1236,7 +1223,7 @@ impl Tool for LoadSkillTool {
 
         Ok(ToolOutcome::Completed(ToolResult {
             success: true,
-            result: payload.to_string(),
+            result: receipt.to_string(),
             display_preference: Some("Collapsible".to_string()),
             images: Vec::new(),
         }))

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -22,6 +22,42 @@ use bamboo_agent_core::Session;
 use bamboo_llm::Config;
 use bamboo_skills::{SkillManager, SkillStoreConfig};
 
+fn public_load_skill_receipt(result: &ToolResult) -> serde_json::Value {
+    let value: serde_json::Value =
+        serde_json::from_str(&result.result).expect("load_skill receipt JSON");
+    let keys = value
+        .as_object()
+        .expect("load_skill receipt object")
+        .keys()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        keys,
+        std::collections::BTreeSet::from([
+            "activation_status",
+            "kind",
+            "revision",
+            "skill_id",
+            "source",
+        ]),
+        "load_skill must expose only its typed public receipt"
+    );
+    for private_key in [
+        "instructions",
+        "skill_base_dir",
+        "resource_files",
+        "dynamic_context",
+        "allowed_tools",
+        "args",
+    ] {
+        assert!(
+            value.get(private_key).is_none(),
+            "public load_skill receipt exposed {private_key}: {value:#}"
+        );
+    }
+    value
+}
+
 #[tokio::test]
 async fn real_runner_auto_load_skill_survives_final_save_and_restart() {
     use bamboo_agent_core::storage::AttachmentReader;
@@ -79,6 +115,12 @@ metadata:
 RUNNER_RUNTIME_INSTRUCTIONS"#,
     )
     .expect("skill");
+    std::fs::create_dir_all(skill_dir.join("references")).expect("resource directory");
+    std::fs::write(
+        skill_dir.join("references/private.txt"),
+        "RUNNER_PRIVATE_RESOURCE_SENTINEL",
+    )
+    .expect("private workflow resource");
     let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
         skills_dir: directory.path().join("skills"),
         ..Default::default()
@@ -147,7 +189,7 @@ RUNNER_RUNTIME_INSTRUCTIONS"#,
         "Please use RUNNER_AUTO_REVIEW_NEEDLE",
     ));
     repo.save(&mut session).await.expect("seed session");
-    let (event_tx, _event_rx) = tokio::sync::mpsc::channel(128);
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(128);
     agent
         .execute(
             &mut session,
@@ -189,6 +231,46 @@ RUNNER_RUNTIME_INSTRUCTIONS"#,
             .as_ref()
             .is_some_and(|calls| calls.iter().any(|call| call.function.name == "load_skill"))
     }));
+    let durable_messages = serde_json::to_string(&saved.messages).expect("durable messages");
+    let private_root = directory.path().to_string_lossy().into_owned();
+    for private in [
+        "RUNNER_RUNTIME_INSTRUCTIONS",
+        "RUNNER_PRIVATE_RESOURCE_SENTINEL",
+        private_root.as_str(),
+        "skill_base_dir",
+        "resource_files",
+        "dynamic_context",
+    ] {
+        assert!(
+            !durable_messages.contains(private),
+            "durable/public history leaked {private}: {durable_messages}"
+        );
+    }
+    let mut tool_complete = None;
+    while let Ok(event) = event_rx.try_recv() {
+        if let bamboo_agent_core::AgentEvent::ToolComplete { result, .. } = event {
+            tool_complete = Some(result);
+        }
+    }
+    let tool_complete = tool_complete.expect("ToolComplete event");
+    let receipt = public_load_skill_receipt(&tool_complete);
+    assert_eq!(receipt["skill_id"], "runner-review");
+    assert_eq!(receipt["activation_status"], "active");
+    let tool_complete_json =
+        serde_json::to_string(&tool_complete).expect("serialized ToolComplete result");
+    for private in [
+        "RUNNER_RUNTIME_INSTRUCTIONS",
+        "RUNNER_PRIVATE_RESOURCE_SENTINEL",
+        private_root.as_str(),
+        "skill_base_dir",
+        "resource_files",
+        "dynamic_context",
+    ] {
+        assert!(
+            !tool_complete_json.contains(private),
+            "live ToolComplete leaked {private}: {tool_complete_json}"
+        );
+    }
 
     let requests = provider.requests.lock().await;
     let second = serde_json::to_string(&requests[1]).expect("second request");
@@ -535,14 +617,8 @@ Use the dynamic context."#,
         else {
             panic!("load must complete")
         };
-        let payload: serde_json::Value =
-            serde_json::from_str(&result.result).expect("payload json");
+        let payload = public_load_skill_receipt(&result);
         assert_eq!(payload["activation_status"], "active");
-        assert!(payload["dynamic_context"][0]["content"]
-            .as_str()
-            .is_some_and(|content| content.contains("[REDACTED]")
-                && !content.contains("super-secret-output")));
-        assert!(payload["dynamic_context"][0]["diagnostic"].is_object());
     }
     assert_eq!(
         provider.calls.load(Ordering::SeqCst),
@@ -570,6 +646,16 @@ Use the dynamic context."#,
         .expect("bounded cache metadata");
     assert!(!cache.contains("input.txt"));
     assert!(!cache.contains("super-secret-output"));
+    let active = saved
+        .metadata
+        .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<bamboo_skills::ActiveWorkflow>(raw).ok())
+        .expect("durable private activation metadata");
+    assert!(active.dynamic_context[0].content.contains("[REDACTED]"));
+    assert!(!active.dynamic_context[0]
+        .content
+        .contains("super-secret-output"));
+    assert!(active.dynamic_context[0].diagnostic.is_some());
 
     let production_session_id = "dynamic-context-production-authority";
     let mut production_session = Session::new(production_session_id, "model");
@@ -610,14 +696,8 @@ Use the dynamic context."#,
     else {
         panic!("production load completes")
     };
-    let production: serde_json::Value =
-        serde_json::from_str(&production.result).expect("production payload");
+    let production = public_load_skill_receipt(&production);
     assert_eq!(production["activation_status"], "active");
-    assert_eq!(
-        production["dynamic_context"][0]["provenance"],
-        "typed_authority_unavailable"
-    );
-    assert_eq!(production["dynamic_context"][0]["content"], "");
     assert_eq!(provider.calls.load(Ordering::SeqCst), calls_before);
     let production_saved = repo
         .storage()
@@ -628,6 +708,16 @@ Use the dynamic context."#,
     assert!(production_saved
         .metadata
         .contains_key(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY));
+    let production_active = production_saved
+        .metadata
+        .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<bamboo_skills::ActiveWorkflow>(raw).ok())
+        .expect("private production activation");
+    assert_eq!(
+        production_active.dynamic_context[0].provenance,
+        "typed_authority_unavailable"
+    );
+    assert_eq!(production_active.dynamic_context[0].content, "");
     assert!(!production_saved
         .metadata
         .contains_key(bamboo_skills::WORKFLOW_CONTEXT_CACHE_METADATA_KEY));
@@ -680,16 +770,26 @@ Use the dynamic context."#,
     else {
         panic!("typed authority load completes")
     };
-    let typed: serde_json::Value =
-        serde_json::from_str(&typed.result).expect("typed authority payload");
+    let typed = public_load_skill_receipt(&typed);
     assert_eq!(typed["activation_status"], "active");
+    let typed_saved = repo
+        .storage()
+        .load_session(typed_session_id)
+        .await
+        .expect("load typed authority session")
+        .expect("typed authority session remains durable");
+    let typed_active = typed_saved
+        .metadata
+        .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<bamboo_skills::ActiveWorkflow>(raw).ok())
+        .expect("private typed activation");
     assert_eq!(
-        typed["dynamic_context"][0]["provenance"],
+        typed_active.dynamic_context[0].provenance,
         "registered_tool_permission_checked"
     );
-    assert!(typed["dynamic_context"][0]["content"]
-        .as_str()
-        .is_some_and(|content| content.contains("workspace input")));
+    assert!(typed_active.dynamic_context[0]
+        .content
+        .contains("workspace input"));
     assert_eq!(permission_config.policy_revision(), 41);
 }
 
@@ -820,8 +920,7 @@ Plan must block this provider before dispatch."#,
     else {
         panic!("Plan+Auto read provider must not return a pause")
     };
-    let plan_read_payload: serde_json::Value =
-        serde_json::from_str(&plan_read_result.result).expect("Plan+Auto read payload");
+    let plan_read_payload = public_load_skill_receipt(&plan_read_result);
     assert_eq!(plan_read_payload["activation_status"], "degraded");
     assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
     assert!(!provider.saw_bypass.load(Ordering::SeqCst));
@@ -851,19 +950,28 @@ Plan must block this provider before dispatch."#,
     else {
         panic!("invalid mutating provider metadata must not return a pause")
     };
-    let invalid_write_payload: serde_json::Value =
-        serde_json::from_str(&invalid_write_result.result)
-            .expect("invalid mutating provider payload");
+    let invalid_write_payload = public_load_skill_receipt(&invalid_write_result);
     assert_eq!(invalid_write_payload["activation_status"], "degraded");
+    let invalid_write_session = storage
+        .load_session(session_id)
+        .await
+        .expect("load invalid provider session")
+        .expect("invalid provider session remains durable");
+    let invalid_write_context = invalid_write_session
+        .metadata
+        .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY)
+        .and_then(|raw| serde_json::from_str::<Vec<bamboo_skills::DynamicContextBlock>>(raw).ok())
+        .expect("private invalid provider diagnostic");
     assert_eq!(
-        invalid_write_payload["dynamic_context"][0]["provenance"],
+        invalid_write_context[0].provenance,
         "invalid_workflow_metadata"
     );
     assert!(
-        invalid_write_payload["dynamic_context"][0]["diagnostic"]["message"]
-            .as_str()
-            .is_some_and(|message| message.contains("invalid")),
-        "unexpected invalid metadata diagnostic: {invalid_write_payload:#}"
+        invalid_write_context[0]
+            .diagnostic
+            .as_ref()
+            .is_some_and(|diagnostic| diagnostic.message.contains("invalid")),
+        "unexpected invalid metadata diagnostic: {invalid_write_context:#?}"
     );
     assert_eq!(
         provider.calls.load(Ordering::SeqCst),
@@ -1236,8 +1344,9 @@ async fn runtime_generation_marker_prevents_stale_metadata_from_repinning_live_c
     else {
         panic!("load_skill should complete")
     };
-    let loaded: serde_json::Value = serde_json::from_str(&loaded.result).expect("load result");
-    assert_eq!(loaded["instructions"], "review N");
+    let loaded = public_load_skill_receipt(&loaded);
+    assert_eq!(loaded["skill_id"], "review-demo");
+    assert_eq!(loaded["activation_status"], "active");
     let ToolOutcome::Completed(resource) = read_tool
         .invoke(
             serde_json::json!({
@@ -1644,7 +1753,7 @@ async fn session_workspace_skill_catalog_selection_and_runtime_roots_are_isolate
     storage.save_session(&session_one).await.expect("save one");
     storage.save_session(&session_two).await.expect("save two");
     let persistence = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
-    let repo = bamboo_engine::SessionRepository::new(sessions, storage, persistence);
+    let repo = bamboo_engine::SessionRepository::new(sessions, storage.clone(), persistence);
     let config = Arc::new(RwLock::new(Config::default()));
     let load_tool = LoadSkillTool::new(skill_manager.clone(), config.clone(), repo.clone());
     let read_tool = ReadSkillResourceTool::new(skill_manager, config, repo);
@@ -1685,17 +1794,31 @@ async fn session_workspace_skill_catalog_selection_and_runtime_roots_are_isolate
         else {
             panic!("load_skill should complete")
         };
-        let loaded: serde_json::Value =
-            serde_json::from_str(&loaded.result).expect("load result json");
-        assert_eq!(loaded["instructions"], expected_instructions);
-        let expected_workspace =
-            std::fs::canonicalize(expected_workspace).expect("canonical workspace");
-        let skill_root = loaded["skill_base_dir"].as_str().expect("skill root");
-        assert!(
-            skill_root.starts_with(expected_workspace.to_string_lossy().as_ref()),
-            "runtime root {skill_root} must stay under {}",
-            expected_workspace.display()
+        let loaded = public_load_skill_receipt(&loaded);
+        assert_eq!(loaded["skill_id"], "shared-workflow");
+        let durable = storage
+            .load_session(session_id)
+            .await
+            .expect("load workspace activation")
+            .expect("workspace activation remains durable")
+            .metadata
+            .get(bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY)
+            .and_then(|raw| {
+                serde_json::from_str::<bamboo_skills::DurableWorkflowActivation>(raw).ok()
+            })
+            .expect("private workspace activation snapshot");
+        assert_eq!(
+            durable
+                .snapshot
+                .skills
+                .get("shared-workflow")
+                .expect("workspace activation entry")
+                .definition
+                .prompt,
+            expected_instructions
         );
+        let _expected_workspace =
+            std::fs::canonicalize(expected_workspace).expect("canonical workspace");
         if session_id == "workspace-session-one" {
             std::fs::remove_dir_all(&workspace_one)
                 .expect("delete workspace after immutable activation is loaded");

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -44,14 +44,23 @@ fn sync_runtime_workspace(
 /// non-reentrant lock again. A plain storage save is safe because the chat
 /// transaction owns the lock from its authoritative reload through its final
 /// message checkpoint.
+async fn persist_and_cache_session_locked(
+    state: &AppState,
+    session: &bamboo_agent_core::Session,
+) -> std::io::Result<()> {
+    state.persistence.storage().save_session(session).await?;
+    state.sessions.insert(
+        session.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+    );
+    Ok(())
+}
+
 async fn save_and_cache_session_locked(
     state: &AppState,
     session: &bamboo_agent_core::Session,
 ) -> Result<(), HttpResponse> {
-    state
-        .persistence
-        .storage()
-        .save_session(session)
+    persist_and_cache_session_locked(state, session)
         .await
         .map_err(|error| {
             HttpResponse::InternalServerError().json(serde_json::json!({
@@ -59,12 +68,35 @@ async fn save_and_cache_session_locked(
                     "Failed to persist chat session: {error}"
                 ))
             }))
-        })?;
-    state.sessions.insert(
-        session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        })
+}
+
+fn publish_committed_chat(state: &web::Data<AppState>, session: &bamboo_agent_core::Session) {
+    if let Some(message) = session.messages.last() {
+        state.account_sink.record(
+            Some(&session.id),
+            &bamboo_agent_core::AgentEvent::MessageAppended {
+                session_id: session.id.clone(),
+                message_id: message.id.clone(),
+                role: message.role.clone(),
+                content: message.content.clone(),
+                created_at: message.created_at,
+            },
+        );
+    }
+
+    tracing::debug!(
+        "[{}] Chat turn persisted: messages={}, last_role={:?} -> client should now POST /execute",
+        session.id,
+        session.messages.len(),
+        session
+            .messages
+            .last()
+            .map(|message| format!("{:?}", message.role)),
     );
-    Ok(())
+    if !session.title_generated {
+        crate::title_gen::spawn_title_generation(state.clone().into_inner(), session.id.clone());
+    }
 }
 
 fn project_context_error_response(
@@ -158,6 +190,432 @@ fn project_context_error_response(
                 actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to resolve Project context",
             )
+        }
+    }
+}
+
+fn workflow_selection_error_response(
+    diagnostic: bamboo_skills::WorkflowActivationDiagnostic,
+) -> HttpResponse {
+    use bamboo_skills::WorkflowActivationErrorCode;
+
+    let (status, code) = match diagnostic.code {
+        WorkflowActivationErrorCode::RevisionMissing => (
+            actix_web::http::StatusCode::CONFLICT,
+            "workflow_revision_missing",
+        ),
+        WorkflowActivationErrorCode::RevisionMismatch => (
+            actix_web::http::StatusCode::CONFLICT,
+            "workflow_revision_mismatch",
+        ),
+        WorkflowActivationErrorCode::SourceMismatch => (
+            actix_web::http::StatusCode::CONFLICT,
+            "workflow_source_mismatch",
+        ),
+        WorkflowActivationErrorCode::ManualOnly => (
+            actix_web::http::StatusCode::UNPROCESSABLE_ENTITY,
+            "workflow_manual_only",
+        ),
+        WorkflowActivationErrorCode::InvalidSelection => (
+            actix_web::http::StatusCode::UNPROCESSABLE_ENTITY,
+            "workflow_selection_invalid",
+        ),
+        WorkflowActivationErrorCode::SnapshotUnavailable => (
+            actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
+            "workflow_snapshot_unavailable",
+        ),
+        WorkflowActivationErrorCode::SnapshotTooLarge => (
+            actix_web::http::StatusCode::PAYLOAD_TOO_LARGE,
+            "workflow_snapshot_too_large",
+        ),
+        WorkflowActivationErrorCode::ProviderFailed
+        | WorkflowActivationErrorCode::ProviderOutputInvalid => (
+            actix_web::http::StatusCode::UNPROCESSABLE_ENTITY,
+            "workflow_context_invalid",
+        ),
+    };
+    HttpResponse::build(status).json(serde_json::json!({
+        "error": {
+            "type": "api_error",
+            "code": code,
+            "message": diagnostic.message,
+            "recoverable": diagnostic.recoverable
+        }
+    }))
+}
+
+fn workflow_catalog_unavailable_response(error: &bamboo_skills::SkillError) -> HttpResponse {
+    tracing::error!(%error, "failed to pin typed workflow catalog revision");
+    workflow_selection_error_response(bamboo_skills::WorkflowActivationDiagnostic {
+        code: bamboo_skills::WorkflowActivationErrorCode::SnapshotUnavailable,
+        message: "Workflow catalog is temporarily unavailable; retry the request".to_string(),
+        recoverable: true,
+    })
+}
+
+async fn pin_explicit_workflow_candidate(
+    state: &AppState,
+    session: &mut bamboo_agent_core::Session,
+    selection: &bamboo_skills::WorkflowSelection,
+    disabled_skill_ids: &std::collections::BTreeSet<String>,
+) -> Result<String, HttpResponse> {
+    let selected_ids = [selection.id.clone()];
+    // Resolve into an isolated staging activation. A stale/invalid request must
+    // never replace or release the activation currently serving this session.
+    // The staged bytes become durable authority only after the session save;
+    // execute then restores them under the canonical session id.
+    let staging_activation_id = format!("{}:chat-candidate:{}", session.id, uuid::Uuid::new_v4());
+    let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+    let resolved_project = state
+        .project_context_resolver
+        .resolve(session, workspace.as_deref())
+        .await
+        .map_err(project_context_error_response)?;
+    let (store, activation) = if let Some(context) = resolved_project {
+        let store = state
+            .skill_manager
+            .store_for_project_workspace(
+                &context.project.id,
+                &context.project.home,
+                context.workspace.as_deref(),
+            )
+            .await
+            .map_err(|error| workflow_catalog_unavailable_response(&error))?;
+        let activation = state
+            .skill_manager
+            .resolve_and_pin_activation_in_project_workspace_with_mode_and_budget(
+                &context.project.id,
+                &context.project.home,
+                context.workspace.as_deref(),
+                &staging_activation_id,
+                disabled_skill_ids,
+                Some(&selected_ids),
+                None,
+                None,
+                bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+            )
+            .await;
+        (store, activation)
+    } else if let Some(workspace) = workspace.as_deref() {
+        // A session-scoped fallback is previewed without filesystem mutation.
+        // Materialize it before opening the workspace catalog, but do not
+        // publish it into runtime state until the base session checkpoint is
+        // durable below. The resolver refuses to recreate missing paths
+        // outside its authoritative root.
+        state
+            .workspace_resolver
+            .materialize_resolved_workspace(workspace)
+            .map_err(|error| {
+                workflow_catalog_unavailable_response(&bamboo_skills::SkillError::Io(error))
+            })?;
+        let store = state
+            .skill_manager
+            .store_for_workspace(Some(workspace))
+            .await
+            .map_err(|error| workflow_catalog_unavailable_response(&error))?;
+        let activation = state
+            .skill_manager
+            .resolve_and_pin_activation_in_workspace_with_mode_and_budget(
+                workspace,
+                &staging_activation_id,
+                disabled_skill_ids,
+                Some(&selected_ids),
+                None,
+                None,
+                bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+            )
+            .await;
+        (store, activation)
+    } else {
+        let store = state
+            .skill_manager
+            .store_for_workspace(None)
+            .await
+            .map_err(|error| workflow_catalog_unavailable_response(&error))?;
+        let activation = state
+            .skill_manager
+            .resolve_and_pin_activation_for_request_with_mode_and_budget(
+                &staging_activation_id,
+                disabled_skill_ids,
+                Some(&selected_ids),
+                None,
+                None,
+                bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+            )
+            .await;
+        (store, activation)
+    };
+    let activation = match activation {
+        Ok(activation) => activation,
+        Err(error) => {
+            let _ = state
+                .skill_manager
+                .release_activation_for_workspace(&staging_activation_id, workspace.as_deref())
+                .await;
+            return Err(workflow_catalog_unavailable_response(&error));
+        }
+    };
+    let snapshot = match store
+        .export_activation_snapshot(&staging_activation_id)
+        .await
+    {
+        Some(snapshot) => snapshot,
+        None => {
+            let _ = state
+                .skill_manager
+                .release_activation_for_workspace(&staging_activation_id, workspace.as_deref())
+                .await;
+            return Err(workflow_selection_error_response(
+                bamboo_skills::WorkflowActivationDiagnostic {
+                    code: bamboo_skills::WorkflowActivationErrorCode::SnapshotUnavailable,
+                    message: "selected workflow snapshot could not be retained".to_string(),
+                    recoverable: true,
+                },
+            ));
+        }
+    };
+    if let Err(diagnostic) = bamboo_skills::persist_explicit_workflow_candidate(
+        &mut session.metadata,
+        selection,
+        &activation,
+        &snapshot,
+    ) {
+        let _ = state
+            .skill_manager
+            .release_activation_for_workspace(&staging_activation_id, workspace.as_deref())
+            .await;
+        return Err(workflow_selection_error_response(diagnostic));
+    }
+    Ok(staging_activation_id)
+}
+
+struct StagedWorkflowActivation {
+    activation_id: String,
+    metadata_upserts: Vec<(String, String)>,
+    metadata_removals: Vec<String>,
+    skill_manager: std::sync::Arc<bamboo_skills::SkillManager>,
+    cleanup_armed: bool,
+}
+
+impl Drop for StagedWorkflowActivation {
+    fn drop(&mut self) {
+        if !self.cleanup_armed {
+            return;
+        }
+        let skill_manager = self.skill_manager.clone();
+        let activation_id = self.activation_id.clone();
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                let _cleanup = handle.spawn(async move {
+                    if let Err(error) = skill_manager
+                        .release_activation_for_workspace(&activation_id, None)
+                        .await
+                    {
+                        tracing::error!(
+                            %activation_id,
+                            %error,
+                            "failed to release abandoned staged Workflow activation"
+                        );
+                    }
+                });
+            }
+            Err(error) => {
+                tracing::error!(
+                    activation_id = %self.activation_id,
+                    %error,
+                    "runtime unavailable while releasing staged Workflow activation"
+                );
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct WorkflowMetadataCheckpoint {
+    entries: std::collections::HashMap<String, String>,
+}
+
+impl WorkflowMetadataCheckpoint {
+    fn capture(session: Option<&bamboo_agent_core::Session>) -> Self {
+        let entries = session
+            .into_iter()
+            .flat_map(|session| session.metadata.iter())
+            .filter(|(key, _)| workflow_transaction_metadata_key(key))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        Self { entries }
+    }
+
+    fn restore(&self, session: &mut bamboo_agent_core::Session) {
+        session
+            .metadata
+            .retain(|key, _| !workflow_transaction_metadata_key(key));
+        session.metadata.extend(self.entries.clone());
+    }
+}
+
+fn workflow_transaction_metadata_key(key: &str) -> bool {
+    key.starts_with("workflow.")
+        || key.starts_with("skill_runtime_")
+        || matches!(key, "selected_skill_ids" | "skill_mode")
+}
+
+fn workflow_runner_is_active(runner: Option<&crate::app_state::AgentRunner>) -> bool {
+    runner.is_some_and(|runner| {
+        matches!(
+            runner.status,
+            crate::app_state::AgentStatus::Pending | crate::app_state::AgentStatus::Running
+        )
+    })
+}
+
+fn workflow_activation_running_conflict_response(session_id: &str) -> HttpResponse {
+    HttpResponse::Conflict().json(serde_json::json!({
+        "error": {
+            "type": "api_error",
+            "code": "workflow_activation_running_conflict",
+            "message": "A running or starting session cannot replace its active Workflow"
+        },
+        "session_id": session_id,
+    }))
+}
+
+#[cfg(test)]
+struct WorkflowCommitTestBarrier {
+    reached: tokio::sync::Semaphore,
+    resume: tokio::sync::Semaphore,
+}
+
+#[cfg(test)]
+impl Default for WorkflowCommitTestBarrier {
+    fn default() -> Self {
+        Self {
+            reached: tokio::sync::Semaphore::new(0),
+            resume: tokio::sync::Semaphore::new(0),
+        }
+    }
+}
+
+#[cfg(test)]
+static WORKFLOW_COMMIT_TEST_BARRIERS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<WorkflowCommitTestBarrier>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+#[cfg(test)]
+static WORKFLOW_POST_SAVE_TEST_BARRIERS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<WorkflowCommitTestBarrier>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+#[cfg(test)]
+fn install_workflow_commit_test_barrier(
+    session_id: &str,
+) -> std::sync::Arc<WorkflowCommitTestBarrier> {
+    let barrier = std::sync::Arc::new(WorkflowCommitTestBarrier::default());
+    WORKFLOW_COMMIT_TEST_BARRIERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(session_id.to_string(), barrier.clone());
+    barrier
+}
+
+#[cfg(test)]
+async fn wait_at_workflow_commit_test_barrier(session_id: &str) {
+    let barrier = WORKFLOW_COMMIT_TEST_BARRIERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .remove(session_id);
+    if let Some(barrier) = barrier {
+        barrier.reached.add_permits(1);
+        barrier
+            .resume
+            .acquire()
+            .await
+            .expect("workflow commit test barrier remains open")
+            .forget();
+    }
+}
+
+#[cfg(test)]
+fn install_workflow_post_save_test_barrier(
+    session_id: &str,
+) -> std::sync::Arc<WorkflowCommitTestBarrier> {
+    let barrier = std::sync::Arc::new(WorkflowCommitTestBarrier::default());
+    WORKFLOW_POST_SAVE_TEST_BARRIERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(session_id.to_string(), barrier.clone());
+    barrier
+}
+
+#[cfg(test)]
+async fn wait_at_workflow_post_save_test_barrier(session_id: &str) {
+    let barrier = WORKFLOW_POST_SAVE_TEST_BARRIERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .remove(session_id);
+    if let Some(barrier) = barrier {
+        barrier.reached.add_permits(1);
+        barrier
+            .resume
+            .acquire()
+            .await
+            .expect("workflow post-save test barrier remains open")
+            .forget();
+    }
+}
+
+impl StagedWorkflowActivation {
+    fn between(
+        activation_id: String,
+        current: &std::collections::HashMap<String, String>,
+        candidate: &std::collections::HashMap<String, String>,
+        skill_manager: std::sync::Arc<bamboo_skills::SkillManager>,
+    ) -> Self {
+        let metadata_upserts = candidate
+            .iter()
+            .filter(|(key, value)| {
+                workflow_transaction_metadata_key(key) && current.get(*key) != Some(*value)
+            })
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let metadata_removals = current
+            .keys()
+            .filter(|key| workflow_transaction_metadata_key(key) && !candidate.contains_key(*key))
+            .cloned()
+            .collect();
+        Self {
+            activation_id,
+            metadata_upserts,
+            metadata_removals,
+            skill_manager,
+            cleanup_armed: true,
+        }
+    }
+
+    fn apply(&self, metadata: &mut std::collections::HashMap<String, String>) {
+        for key in &self.metadata_removals {
+            metadata.remove(key);
+        }
+        for (key, value) in &self.metadata_upserts {
+            metadata.insert(key.clone(), value.clone());
+        }
+    }
+
+    async fn release(&mut self) {
+        if !self.cleanup_armed {
+            return;
+        }
+        match self
+            .skill_manager
+            .release_activation_for_workspace(&self.activation_id, None)
+            .await
+        {
+            Ok(()) => self.cleanup_armed = false,
+            Err(error) => tracing::error!(
+                activation_id = %self.activation_id,
+                %error,
+                "failed to release staged Workflow activation"
+            ),
         }
     }
 }
@@ -430,6 +888,7 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
         return project_context_error_response(error);
     }
     let workspace_was_explicit = req.workspace_path.is_some();
+    let requested_workflow_selection = req.workflow_selection.clone();
     let mut input = bamboo_engine::session_app::types::ChatTurnInput {
         session_id: session_id.clone(),
         project_id: effective_project_id,
@@ -448,8 +907,15 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
             .then(|| project_preflight.workspace_path_meta())
             .flatten(),
         default_workspace_path: configured_default_workspace,
-        selected_skill_ids: req.selected_skill_ids.clone(),
-        workflow_selection: req.workflow_selection.clone(),
+        selected_skill_ids: if requested_workflow_selection.is_some() {
+            None
+        } else {
+            req.selected_skill_ids.clone()
+        },
+        // A typed selection is resolved into a separate candidate below. The
+        // authoritative session must retain its current activation until every
+        // fallible hook, attachment and message write in this request succeeds.
+        workflow_selection: None,
         orchestration_opt_in: req.orchestration_opt_in,
         copilot_conclusion_with_options_enhancement_enabled: req
             .copilot_conclusion_with_options_enhancement_enabled,
@@ -461,6 +927,20 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     // same lock and therefore cannot slip between the second load and a stale
     // chat snapshot save.
     let persistence_guard = state.persistence.acquire_lock(&session_id).await;
+    // Reject an already-running session before doing catalog or hook work. A
+    // second check immediately before publication below closes the race with a
+    // reservation that appears while this request is being prepared.
+    if requested_workflow_selection.is_some() {
+        let runners = state.agent_runners.read().await;
+        let runner_is_active = workflow_runner_is_active(runners.get(&session_id));
+        let startup_is_active = crate::handlers::agent::events::execute_startup_is_in_flight(
+            state.as_ref(),
+            &session_id,
+        );
+        if runner_is_active || startup_is_active {
+            return workflow_activation_running_conflict_response(&session_id);
+        }
+    }
     let authoritative_session = match state.persistence.storage().load_session(&session_id).await {
         Ok(session) => session,
         Err(error) => {
@@ -471,6 +951,8 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
             );
         }
     };
+    let workflow_metadata_checkpoint =
+        WorkflowMetadataCheckpoint::capture(authoritative_session.as_ref());
     let authoritative_workspace_present = authoritative_session.as_ref().is_some_and(|session| {
         session.workspace_path_meta().is_some()
             && session
@@ -585,7 +1067,50 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     {
         return project_context_error_response(error);
     }
-    if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
+    let mut staged_workflow_activation =
+        if let Some(selection) = requested_workflow_selection.as_ref() {
+            let mut candidate = session.clone();
+            if let Err(error) = bamboo_engine::session_app::chat::resolve_workflow_selection(
+                &mut candidate,
+                Some(selection),
+                req.selected_skill_ids.as_deref(),
+                &req.message,
+            ) {
+                return HttpResponse::BadRequest().json(serde_json::json!({
+                    "error": crate::error::error_value(error.to_string())
+                }));
+            }
+            let disabled_skill_ids = config_snapshot.disabled_skill_ids();
+            let staging_id = match pin_explicit_workflow_candidate(
+                state.as_ref(),
+                &mut candidate,
+                selection,
+                &disabled_skill_ids,
+            )
+            .await
+            {
+                Ok(staging_id) => staging_id,
+                Err(response) => return response,
+            };
+            Some(StagedWorkflowActivation::between(
+                staging_id,
+                &session.metadata,
+                &candidate.metadata,
+                state.skill_manager.clone(),
+            ))
+        } else {
+            None
+        };
+    // Publish the prepared checkpoint without any speculative Workflow
+    // normalization. The in-memory turn keeps those changes for a successful
+    // final commit, while every rejected/failing path continues to expose the
+    // exact pre-request Workflow authority.
+    let mut durable_base = session.clone();
+    workflow_metadata_checkpoint.restore(&mut durable_base);
+    if let Err(response) = save_and_cache_session_locked(state.as_ref(), &durable_base).await {
+        if let Some(staging) = staged_workflow_activation.as_mut() {
+            staging.release().await;
+        }
         return response;
     }
     sync_runtime_workspace(
@@ -617,7 +1142,11 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     {
         Ok(message) => message,
         Err(reason) => {
+            if let Some(staging) = staged_workflow_activation.as_mut() {
+                staging.release().await;
+            }
             // Persist the hook checkpoint but never the rejected user message.
+            workflow_metadata_checkpoint.restore(&mut session);
             if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
                 return response;
             }
@@ -638,9 +1167,39 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
         // Goal metadata writers acquire the same per-session lock and load the
         // latest durable session themselves. The prepared checkpoint is
         // already durable, so hand ownership over before invoking them.
+        if let Some(staging) = staged_workflow_activation.as_mut() {
+            staging.release().await;
+        }
         drop(persistence_guard);
         return handle_goal_command(state.as_ref(), &session_id, &goal_cmd).await;
     }
+
+    #[cfg(test)]
+    wait_at_workflow_commit_test_barrier(&session_id).await;
+
+    // A typed activation replaces both durable Workflow metadata and the
+    // session-id keyed immutable skill pin. Re-check after all fallible hook
+    // work, then retain the runners read guard through attachment persistence,
+    // the final session save and pin handoff. The persistence lock linearizes
+    // HTTP execute startup; the runners guard closes reservation races from
+    // resume, schedule and connect entry points.
+    let workflow_commit_guard = if staged_workflow_activation.is_some() {
+        let runners = state.agent_runners.clone().read_owned().await;
+        let runner_is_active = workflow_runner_is_active(runners.get(&session_id));
+        let startup_is_active = crate::handlers::agent::events::execute_startup_is_in_flight(
+            state.as_ref(),
+            &session_id,
+        );
+        if runner_is_active || startup_is_active {
+            if let Some(staging) = staged_workflow_activation.as_mut() {
+                staging.release().await;
+            }
+            return workflow_activation_running_conflict_response(&session_id);
+        }
+        Some(runners)
+    } else {
+        None
+    };
 
     // Image handling stays in the handler layer (depends on AppState attachment reader).
     if let Err(response) = images::append_user_message(
@@ -651,46 +1210,74 @@ async fn handle_chat(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     )
     .await
     {
+        if let Some(staging) = staged_workflow_activation.as_mut() {
+            staging.release().await;
+        }
         return response;
     }
 
-    // Re-save to persist image attachments (if any).
-    if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
-        return response;
-    }
+    if let Some(mut staging) = staged_workflow_activation {
+        staging.apply(&mut session.metadata);
+        let commit_state = state.clone();
+        let commit_session_id = session_id.clone();
+        let commit = tokio::spawn(async move {
+            // These owned guards make the exact save -> pin handoff
+            // cancellation-resistant. Dropping the caller's HTTP future only
+            // detaches this task; it cannot expose committed B metadata while
+            // the session-id pin still serves A.
+            let _persistence_guard = persistence_guard;
+            let _workflow_commit_guard = workflow_commit_guard;
+            if let Err(error) =
+                persist_and_cache_session_locked(commit_state.as_ref(), &session).await
+            {
+                staging.release().await;
+                return Err(error.to_string());
+            }
+            #[cfg(test)]
+            wait_at_workflow_post_save_test_barrier(&commit_session_id).await;
 
-    // Publish the user message onto the account change feed so other clients
-    // see it without reloading history. The feed seq becomes the message's
-    // delta coordinate for `GET /history?since`.
-    if let Some(msg) = session.messages.last() {
-        state.account_sink.record(
-            Some(&session_id),
-            &bamboo_agent_core::AgentEvent::MessageAppended {
-                session_id: session_id.clone(),
-                message_id: msg.id.clone(),
-                role: msg.role.clone(),
-                content: msg.content.clone(),
-                created_at: msg.created_at,
-            },
-        );
-    }
-
-    tracing::debug!(
-        "[{}] Chat turn persisted: messages={}, last_role={:?} -> client should now POST /execute",
-        session_id,
-        session.messages.len(),
-        session.messages.last().map(|m| format!("{:?}", m.role)),
-    );
-    let should_generate_title = !session.title_generated;
-    drop(persistence_guard);
-
-    // Start title generation immediately after the user message is durable.
-    // This is intentionally independent of POST /execute and assistant-stream
-    // completion. Failed/no-text attempts leave the lifecycle pending, so a
-    // later durable user message can retry; the in-flight guard deduplicates
-    // overlapping chat requests.
-    if should_generate_title {
-        crate::title_gen::spawn_title_generation(state.clone().into_inner(), session_id.clone());
+            // The durable user turn and exact snapshot now own the next
+            // execution. Only now may the prior live activation be released.
+            if let Err(error) = commit_state
+                .skill_manager
+                .release_activation_for_workspace(&commit_session_id, None)
+                .await
+            {
+                tracing::error!(
+                    session_id = %commit_session_id,
+                    %error,
+                    "failed to release prior Workflow activation after commit"
+                );
+            }
+            staging.release().await;
+            publish_committed_chat(&commit_state, &session);
+            Ok::<(), String>(())
+        });
+        match commit.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                return HttpResponse::InternalServerError().json(serde_json::json!({
+                    "error": crate::error::error_value(format!(
+                        "Failed to persist chat session: {error}"
+                    ))
+                }));
+            }
+            Err(error) => {
+                tracing::error!(%error, "typed Workflow chat commit task failed");
+                return crate::error::json_error(
+                    actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to commit typed Workflow chat",
+                );
+            }
+        }
+    } else {
+        // Re-save to persist image attachments (if any).
+        if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
+            return response;
+        }
+        drop(workflow_commit_guard);
+        publish_committed_chat(&state, &session);
+        drop(persistence_guard);
     }
 
     HttpResponse::Created().json(ChatResponse {

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -8,6 +8,165 @@ use bamboo_engine::session_app::chat::{
     resolve_selected_skill_ids, resolve_workspace_path,
 };
 
+#[actix_web::test]
+async fn typed_workflow_candidate_is_pinned_exactly_and_stale_revision_fails_closed() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+    let state = crate::AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state");
+    let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+    let review = catalog
+        .entries
+        .iter()
+        .find(|entry| entry.id == "review" && entry.winner)
+        .expect("builtin review catalog entry");
+    let selection = bamboo_skills::WorkflowSelection {
+        id: review.id.clone(),
+        source: review.source,
+        revision: review.revision,
+        args: serde_json::json!({}),
+    };
+    let mut session = Session::new("typed-review", "model");
+    let staging_id = super::pin_explicit_workflow_candidate(
+        &state,
+        &mut session,
+        &selection,
+        &std::collections::BTreeSet::new(),
+    )
+    .await
+    .expect("pin exact typed Workflow");
+
+    let snapshot: bamboo_skills::SkillActivationSnapshot = serde_json::from_str(
+        session
+            .metadata
+            .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY)
+            .expect("durable pre-execute snapshot"),
+    )
+    .expect("snapshot contract");
+    assert_eq!(snapshot.skills.len(), 1);
+    assert_eq!(snapshot.skills["review"].revision, review.revision);
+    assert_eq!(
+        session
+            .metadata
+            .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY)
+            .map(String::as_str),
+        Some("explicit")
+    );
+    let request_identity = serde_json::to_string(&selection).expect("selection JSON");
+    assert!(!request_identity.contains(&review.description));
+    assert!(!request_identity.contains("prompt"));
+
+    state
+        .skill_manager
+        .release_activation_for_workspace(&staging_id, None)
+        .await
+        .expect("release exact candidate");
+
+    let existing_ids = ["plan".to_string()];
+    let existing = state
+        .skill_manager
+        .resolve_and_pin_activation_for_request_with_mode_and_budget(
+            "typed-review-stale",
+            &std::collections::BTreeSet::new(),
+            Some(&existing_ids),
+            None,
+            None,
+            bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+        )
+        .await
+        .expect("existing live activation");
+    let mut stale_session = Session::new("typed-review-stale", "model");
+    let stale = bamboo_skills::WorkflowSelection {
+        revision: review.revision + 1,
+        ..selection
+    };
+    let response = super::pin_explicit_workflow_candidate(
+        &state,
+        &mut stale_session,
+        &stale,
+        &std::collections::BTreeSet::new(),
+    )
+    .await
+    .expect_err("stale revision must fail before chat persistence");
+    assert_eq!(response.status(), actix_web::http::StatusCode::CONFLICT);
+    assert!(!stale_session
+        .metadata
+        .contains_key(bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY));
+    assert!(stale_session.messages.is_empty());
+    let retained = state
+        .skill_manager
+        .pinned_activation_for_workspace("typed-review-stale", None)
+        .await
+        .expect("inspect existing activation")
+        .expect("failed request must retain existing activation");
+    assert_eq!(
+        retained.descriptor.skill_revisions,
+        existing.descriptor.skill_revisions
+    );
+    assert_eq!(retained.skills[0].id, "plan");
+}
+
+#[actix_web::test]
+async fn typed_workflow_capacity_failure_is_sanitized_and_retryable() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+    let state = crate::AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state");
+    let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+    let review = catalog
+        .entries
+        .iter()
+        .find(|entry| entry.id == "review" && entry.winner)
+        .expect("builtin review");
+    for index in 0..256 {
+        state
+            .skill_manager
+            .pin_current_activation_for_workspace(
+                &format!("capacity-{index}"),
+                None,
+                &["plan".to_string()],
+                None,
+            )
+            .await
+            .expect("fill activation capacity");
+    }
+    let selection = bamboo_skills::WorkflowSelection {
+        id: review.id.clone(),
+        source: review.source,
+        revision: review.revision,
+        args: serde_json::json!({}),
+    };
+    let mut session = Session::new("capacity-overflow", "model");
+    let response = super::pin_explicit_workflow_candidate(
+        &state,
+        &mut session,
+        &selection,
+        &std::collections::BTreeSet::new(),
+    )
+    .await
+    .expect_err("capacity exhaustion must fail closed");
+    assert_eq!(
+        response.status(),
+        actix_web::http::StatusCode::SERVICE_UNAVAILABLE
+    );
+    let body = actix_web::body::to_bytes(response.into_body())
+        .await
+        .expect("response body");
+    let body: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+    assert_eq!(body["error"]["code"], "workflow_snapshot_unavailable");
+    assert_eq!(
+        body["error"]["message"],
+        "Workflow catalog is temporarily unavailable; retry the request"
+    );
+    let rendered = body.to_string();
+    assert!(!rendered.contains("capacity"));
+    assert!(!rendered.contains(temp_dir.path().to_string_lossy().as_ref()));
+    assert!(session.metadata.is_empty());
+    assert!(session.messages.is_empty());
+}
+
 /// Regression: `/goal off` and `/goal clear` must clear the stale runtime
 /// `goal.state` (status / continuation budget / double-check eval history).
 /// Previously the cleanup was gated behind `should_resume`, so only
@@ -355,10 +514,84 @@ mod optional_model_e2e {
     use crate::routes::configure_routes;
     use crate::AppState;
 
+    const CONCURRENCY_ASSERT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
     async fn new_state() -> web::Data<AppState> {
         let temp_dir = tempdir().expect("tempdir").keep();
         bamboo_config::paths::init_bamboo_dir(temp_dir.clone());
         web::Data::new(AppState::new(temp_dir).await.expect("app state"))
+    }
+
+    async fn seed_active_instruction_workflow(
+        state: &web::Data<AppState>,
+        session_id: &str,
+        workflow_id: &str,
+    ) -> bamboo_skills::WorkflowSelection {
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let entry = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == workflow_id && entry.winner)
+            .expect("builtin instruction Workflow")
+            .clone();
+        let selection = bamboo_skills::WorkflowSelection {
+            id: entry.id.clone(),
+            source: entry.source,
+            revision: entry.revision,
+            args: serde_json::json!({}),
+        };
+        let ids = [entry.id.clone()];
+        let activation = state
+            .skill_manager
+            .resolve_and_pin_activation_for_request_with_mode_and_budget(
+                session_id,
+                &std::collections::BTreeSet::new(),
+                Some(&ids),
+                None,
+                None,
+                bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+            )
+            .await
+            .expect("pin canonical live activation");
+        let snapshot = state
+            .skill_manager
+            .store()
+            .export_activation_snapshot(session_id)
+            .await
+            .expect("export canonical activation snapshot");
+        let mut session = Session::new(session_id, "test-model");
+        session.metadata.insert(
+            bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY.to_string(),
+            serde_json::to_string(&selection).expect("selection JSON"),
+        );
+        bamboo_skills::persist_explicit_workflow_candidate(
+            &mut session.metadata,
+            &selection,
+            &activation,
+            &snapshot,
+        )
+        .expect("persist exact candidate");
+        bamboo_skills::record_loaded_workflow_activation(
+            &mut session.metadata,
+            workflow_id,
+            format!("sha256:{workflow_id}"),
+        )
+        .expect("publish active Workflow");
+        state.save_and_cache_session(&mut session).await;
+        selection
+    }
+
+    fn workflow_runtime_metadata(session: &Session) -> std::collections::BTreeMap<String, String> {
+        session
+            .metadata
+            .iter()
+            .filter(|(key, _)| {
+                key.starts_with("workflow.")
+                    || key.starts_with("skill_runtime_")
+                    || key.as_str() == "selected_skill_ids"
+            })
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect()
     }
 
     struct BlockingTitleProvider {
@@ -890,8 +1123,9 @@ mod optional_model_e2e {
                 .to_request(),
         )
         .await;
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let status = response.status();
         let body: Value = test::read_body_json(response).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
         assert_eq!(body["error"]["code"], "workspace_invalid");
         assert!(state
             .storage
@@ -1289,8 +1523,23 @@ mod optional_model_e2e {
     }
 
     #[actix_web::test]
-    async fn user_prompt_submit_block_returns_reason_and_persists_no_user_message() {
+    async fn user_prompt_submit_block_preserves_existing_workflow_and_persists_no_user_message() {
         let state = new_state().await;
+        let session_id = "blocked-user-prompt";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let before = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        let expected_workflow_metadata = workflow_runtime_metadata(&before);
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
         {
             let mut config = state.config.write().await;
             config.lifecycle_hooks = bamboo_config::LifecycleHooksConfig {
@@ -1318,22 +1567,29 @@ mod optional_model_e2e {
             test::TestRequest::post()
                 .uri("/api/v1/chat")
                 .set_json(serde_json::json!({
-                    "session_id": "blocked-user-prompt",
+                    "session_id": session_id,
                     "message": "must not persist",
-                    "model": "test-model"
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {}
+                    }
                 }))
                 .to_request(),
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let status = response.status();
         let body: Value = test::read_body_json(response).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
         assert!(body.to_string().contains("prompt rejected by policy"));
         assert_eq!(body["hook_event"], "UserPromptSubmit");
 
         let session = state
             .storage
-            .load_session("blocked-user-prompt")
+            .load_session(session_id)
             .await
             .expect("load")
             .expect("prepared session is persisted for hook observability");
@@ -1348,5 +1604,389 @@ mod optional_model_e2e {
                 .map(|state| state.checkpoints.len()),
             Some(1)
         );
+        assert_eq!(
+            workflow_runtime_metadata(&session),
+            expected_workflow_metadata,
+            "rejected typed selection must not disturb durable Workflow authority"
+        );
+        let live = state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect canonical activation")
+            .expect("existing activation remains pinned");
+        assert_eq!(live.skills.len(), 1);
+        assert_eq!(live.skills[0].id, "plan");
+    }
+
+    #[actix_web::test]
+    async fn image_rejection_preserves_existing_workflow_and_persists_no_user_message() {
+        let state = new_state().await;
+        let session_id = "rejected-image-workflow";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let before = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        let expected_workflow_metadata = workflow_runtime_metadata(&before);
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id": session_id,
+                    "message": "must not persist",
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {}
+                    },
+                    "images": [{
+                        "base64": "not-valid-base64%%%",
+                        "type": "image/png"
+                    }]
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let after = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("reload session")
+            .expect("session remains");
+        assert!(after
+            .messages
+            .iter()
+            .all(|message| !matches!(message.role, bamboo_agent_core::Role::User)));
+        assert_eq!(
+            workflow_runtime_metadata(&after),
+            expected_workflow_metadata,
+            "failed attachment must not publish speculative Workflow metadata"
+        );
+        let live = state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect canonical activation")
+            .expect("existing activation remains pinned");
+        assert_eq!(live.skills[0].id, "plan");
+    }
+
+    #[actix_web::test]
+    async fn running_session_rejects_typed_workflow_replacement_without_mutation() {
+        let state = new_state().await;
+        let session_id = "running-workflow-replacement";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let before = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        let expected_workflow_metadata = workflow_runtime_metadata(&before);
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let mut runner = crate::app_state::AgentRunner::new();
+        runner.status = crate::app_state::AgentStatus::Running;
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), runner);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id": session_id,
+                    "message": "must wait",
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {}
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(
+            body["error"]["code"],
+            "workflow_activation_running_conflict"
+        );
+        let after = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("reload session")
+            .expect("session remains");
+        assert_eq!(
+            workflow_runtime_metadata(&after),
+            expected_workflow_metadata
+        );
+        assert!(after.messages.is_empty());
+        let live = state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect canonical activation")
+            .expect("existing activation remains pinned");
+        assert_eq!(live.skills[0].id, "plan");
+    }
+
+    #[actix_web::test]
+    async fn runner_reserved_during_typed_chat_rejects_commit_without_mutation() {
+        let state = new_state().await;
+        let session_id = "workflow-reserved-before-commit";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let before = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load seeded session")
+            .expect("seeded session");
+        let expected_workflow_metadata = workflow_runtime_metadata(&before);
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let barrier = super::super::install_workflow_commit_test_barrier(session_id);
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id": session_id,
+                    "message": "must lose the reservation race",
+                    "model": "test-model",
+                    "workflow_selection": {
+                        "id": review.id,
+                        "source": review.source,
+                        "revision": review.revision,
+                        "args": {}
+                    }
+                }))
+                .to_request(),
+        );
+        tokio::pin!(response);
+
+        let reached = barrier.reached.acquire();
+        tokio::pin!(reached);
+        let reached_permit = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, async {
+            tokio::select! {
+                permit = &mut reached => permit.expect("workflow commit barrier remains open"),
+                early = &mut response => panic!(
+                    "typed chat completed before the commit barrier: {}",
+                    early.status()
+                ),
+            }
+        })
+        .await
+        .expect("typed chat reaches the deterministic pre-commit barrier");
+        reached_permit.forget();
+
+        let mut runner = crate::app_state::AgentRunner::new();
+        runner.status = crate::app_state::AgentStatus::Pending;
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.to_string(), runner);
+        barrier.resume.add_permits(1);
+
+        let response = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, &mut response)
+            .await
+            .expect("typed chat rejects the newly reserved runner");
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(
+            body["error"]["code"],
+            "workflow_activation_running_conflict"
+        );
+
+        let after = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("reload session")
+            .expect("session remains");
+        assert_eq!(
+            workflow_runtime_metadata(&after),
+            expected_workflow_metadata,
+            "a late runner reservation must leave durable Workflow authority unchanged"
+        );
+        assert!(after
+            .messages
+            .iter()
+            .all(|message| !matches!(message.role, bamboo_agent_core::Role::User)));
+        let live = state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect canonical activation")
+            .expect("existing activation remains pinned");
+        assert_eq!(live.skills[0].id, "plan");
+    }
+
+    #[actix_web::test]
+    async fn cancelled_typed_chat_finishes_the_committed_pin_handoff() {
+        let state = new_state().await;
+        let session_id = "workflow-cancelled-after-save";
+        seed_active_instruction_workflow(&state, session_id, "plan").await;
+        let catalog = state.skill_manager.store().skill_catalog_snapshot().await;
+        let review = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review" && entry.winner)
+            .expect("builtin review Workflow");
+        let barrier = super::super::install_workflow_post_save_test_barrier(session_id);
+        let mut feed = state.account_sink.subscribe();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        {
+            let response = test::call_service(
+                &app,
+                test::TestRequest::post()
+                    .uri("/api/v1/chat")
+                    .set_json(serde_json::json!({
+                        "session_id": session_id,
+                        "message": "commit despite response cancellation",
+                        "model": "test-model",
+                        "workflow_selection": {
+                            "id": review.id,
+                            "source": review.source,
+                            "revision": review.revision,
+                            "args": {}
+                        }
+                    }))
+                    .to_request(),
+            );
+            tokio::pin!(response);
+            let reached = barrier.reached.acquire();
+            tokio::pin!(reached);
+            let reached_permit = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, async {
+                tokio::select! {
+                    permit = &mut reached => permit.expect("post-save barrier remains open"),
+                    early = &mut response => panic!(
+                        "typed chat completed before the post-save barrier: {}",
+                        early.status()
+                    ),
+                }
+            })
+            .await
+            .expect("typed chat reaches the deterministic post-save barrier");
+            reached_permit.forget();
+
+            let live_before_handoff = state
+                .skill_manager
+                .pinned_activation_for_workspace(session_id, None)
+                .await
+                .expect("inspect old canonical pin")
+                .expect("old activation remains until durable save returns");
+            assert_eq!(live_before_handoff.skills[0].id, "plan");
+            // Dropping the Actix response future simulates a disconnected
+            // client. The detached commit task must retain both locks and
+            // finish cache/feed/pin publication.
+        }
+        barrier.resume.add_permits(1);
+
+        let event = tokio::time::timeout(CONCURRENCY_ASSERT_TIMEOUT, async {
+            loop {
+                let event = feed.recv().await.expect("account feed remains open");
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::MessageAppended { session_id: id, .. }
+                        if id == session_id
+                ) {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("detached typed commit publishes its durable message");
+        assert!(matches!(
+            event.event,
+            bamboo_agent_core::AgentEvent::MessageAppended { .. }
+        ));
+
+        let persisted = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("reload committed session")
+            .expect("committed session");
+        let selection: bamboo_skills::WorkflowSelection = serde_json::from_str(
+            persisted
+                .metadata
+                .get(bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY)
+                .expect("committed typed selection"),
+        )
+        .expect("selection JSON");
+        assert_eq!(selection.id, "review");
+        assert!(persisted.messages.iter().any(|message| {
+            matches!(message.role, bamboo_agent_core::Role::User)
+                && message.content == "commit despite response cancellation"
+        }));
+        assert!(state
+            .skill_manager
+            .pinned_activation_for_workspace(session_id, None)
+            .await
+            .expect("inspect released canonical pin")
+            .is_none());
+        let guard = tokio::time::timeout(
+            CONCURRENCY_ASSERT_TIMEOUT,
+            state.persistence.acquire_lock(session_id),
+        )
+        .await
+        .expect("detached commit releases the persistence lock");
+        drop(guard);
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
@@ -5,7 +5,8 @@ use actix_web::{web, HttpResponse, Result};
 use crate::app_state::AppState;
 
 use super::super::super::types::{
-    GetSessionResponse, ListSessionsQuery, ListSessionsResponse, SessionSummary,
+    GetSessionResponse, ListSessionsQuery, ListSessionsResponse, SessionActiveWorkflow,
+    SessionSummary,
 };
 use super::running::{is_session_running, running_session_ids};
 
@@ -98,20 +99,81 @@ pub async fn get_session(
             let mut summary = SessionSummary::from_entry(entry, is_running);
             summary.running_child_count = running_child_count;
 
+            // Load the authoritative session once for both its ETag and the
+            // public-safe active Workflow identity. The index deliberately
+            // does not mirror this richer lifecycle object.
+            let durable_session = match state.storage.load_session(&session_id).await {
+                Ok(Some(session)) => session,
+                Ok(None) => {
+                    tracing::warn!(
+                        %session_id,
+                        "session index entry has no authoritative durable session"
+                    );
+                    return Ok(HttpResponse::NotFound().json(serde_json::json!({
+                        "error": crate::error::error_value("Session not found"),
+                        "session_id": session_id
+                    })));
+                }
+                Err(error) => {
+                    tracing::error!(
+                        %session_id,
+                        %error,
+                        "failed to load authoritative session detail"
+                    );
+                    return Ok(crate::error::json_error(
+                        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to load session detail",
+                    ));
+                }
+            };
+            let selected_catalog = durable_session
+                .metadata
+                .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_CATALOG_KEY)
+                .and_then(|raw| {
+                    serde_json::from_str::<Vec<bamboo_skills::WorkflowCatalogEntry>>(raw)
+                        .map_err(|error| {
+                            tracing::warn!(
+                                %session_id,
+                                %error,
+                                "ignored invalid pinned workflow catalog metadata in session detail"
+                            );
+                        })
+                        .ok()
+                })
+                .unwrap_or_default();
+            summary.active_workflow = match durable_session
+                .metadata
+                .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
+            {
+                Some(raw) => match serde_json::from_str::<bamboo_skills::ActiveWorkflow>(raw) {
+                    Ok(active) => {
+                        let entry = selected_catalog.iter().find(|entry| {
+                            entry.id == active.id
+                                && entry.source == active.source
+                                && entry.revision == active.revision
+                        });
+                        Some(SessionActiveWorkflow::from_active(active, entry))
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            %session_id,
+                            %error,
+                            "active Workflow metadata is malformed in authoritative session detail"
+                        );
+                        return Ok(crate::error::json_error(
+                            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            "Failed to load active Workflow state",
+                        ));
+                    }
+                },
+                None => None,
+            };
             // Surface the session ETag (`metadata_version`) so clients can send
             // it back as `If-Match` on metadata writes (optimistic concurrency).
-            let etag = state
-                .storage
-                .load_session(&session_id)
-                .await
-                .ok()
-                .flatten()
-                .map(|s| s.metadata_version);
+            let etag = durable_session.metadata_version;
 
             let mut response = HttpResponse::Ok();
-            if let Some(version) = etag {
-                response.insert_header((actix_web::http::header::ETAG, format!("\"{version}\"")));
-            }
+            response.insert_header((actix_web::http::header::ETAG, format!("\"{etag}\"")));
             Ok(response.json(GetSessionResponse { session: summary }))
         }
         None => Ok(HttpResponse::NotFound().json(serde_json::json!({
@@ -273,5 +335,193 @@ mod pagination_http_tests {
         assert_eq!(body["error"]["type"], "api_error");
         assert_eq!(body["error"]["message"], "Session not found");
         assert_eq!(body["session_id"], "does-not-exist");
+    }
+
+    #[actix_web::test]
+    async fn session_detail_restores_public_active_workflow_but_list_stays_lightweight() {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let mut session = Session::new("workflow-session", "model");
+        session.metadata.insert(
+            bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY.to_string(),
+            serde_json::json!({
+                "id": "review",
+                "source": "builtin",
+                "revision": 7,
+                "kind": "instruction",
+                "args": {"focus": "security"},
+                "invoked_by": "user",
+                "activated_at": "2026-08-21T00:00:00Z",
+                "status": "active",
+                "context_fingerprint": "sha256:test",
+                "dynamic_context": [{
+                    "provider_id": "private-provider",
+                    "tool": "context",
+                    "provenance": "private",
+                    "generated_at": "2026-08-21T00:00:00Z",
+                    "expires_at": null,
+                    "status": "active",
+                    "stop_on_failure": false,
+                    "content": "secret dynamic provider output"
+                }]
+            })
+            .to_string(),
+        );
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_CATALOG_KEY.to_string(),
+            serde_json::json!([{
+                "id": "review",
+                "name": "Review changes",
+                "description": "Pinned public metadata",
+                "kind": "instruction",
+                "source": "builtin",
+                "revision": 7,
+                "version": "3",
+                "invocation_policy": {"automatic": true, "explicit": true},
+                "argument_schema": {"type": "object"},
+                "status": "valid",
+                "legacy": false,
+                "winner": true
+            }])
+            .to_string(),
+        );
+        state.save_and_cache_session(&mut session).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let list: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions")
+                .to_request(),
+        )
+        .await;
+        assert!(list["sessions"][0].get("active_workflow").is_none());
+
+        let detail: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions/workflow-session")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(detail["session"]["active_workflow"]["id"], "review");
+        assert_eq!(
+            detail["session"]["active_workflow"]["name"],
+            "Review changes"
+        );
+        assert_eq!(detail["session"]["active_workflow"]["source"], "builtin");
+        assert_eq!(detail["session"]["active_workflow"]["version"], "3");
+        let active = &detail["session"]["active_workflow"];
+        assert_eq!(active["kind"], "instruction");
+        assert_eq!(active["invoked_by"], "user");
+        assert!(active.get("args").is_none());
+        assert!(active.get("context_fingerprint").is_none());
+        assert!(active.get("dynamic_context").is_none());
+        assert!(!detail
+            .to_string()
+            .contains("secret dynamic provider output"));
+    }
+
+    #[actix_web::test]
+    async fn session_detail_fails_closed_when_durable_load_fails() {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let mut session = Session::new("broken-session-detail", "model");
+        state.save_and_cache_session(&mut session).await;
+        let entry = state
+            .session_store
+            .get_index_entry("broken-session-detail")
+            .await
+            .expect("durable index entry");
+        let session_json = temp_dir.path().join(entry.rel_path).join("session.json");
+        tokio::fs::remove_file(&session_json)
+            .await
+            .expect("remove durable session file");
+        tokio::fs::create_dir(&session_json)
+            .await
+            .expect("inject unreadable session path");
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions/broken-session-detail")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert!(response
+            .headers()
+            .get(actix_web::http::header::ETAG)
+            .is_none());
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["error"]["message"], "Failed to load session detail");
+        assert!(!body
+            .to_string()
+            .contains(&session_json.to_string_lossy()[..]));
+    }
+
+    #[actix_web::test]
+    async fn session_detail_fails_closed_for_malformed_active_workflow_metadata() {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let mut session = Session::new("malformed-active-workflow", "model");
+        session.metadata.insert(
+            bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY.to_string(),
+            r#"{"id":"private-id","args":{"api_key":"must-not-echo"}"#.to_string(),
+        );
+        state.save_and_cache_session(&mut session).await;
+        let app = test::init_service(App::new().app_data(state).configure(configure_routes)).await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions/malformed-active-workflow")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert!(response
+            .headers()
+            .get(actix_web::http::header::ETAG)
+            .is_none());
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(
+            body["error"]["message"],
+            "Failed to load active Workflow state"
+        );
+        assert!(!body.to_string().contains("must-not-echo"));
+        assert!(!body.to_string().contains("private-id"));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
@@ -7,6 +7,44 @@ use bamboo_storage::{SessionIndexEntry, SessionPlacement};
 
 use bamboo_engine::model_config_helper::parse_session_gold_config;
 
+/// Minimal public workflow lifecycle identity. Durable activation metadata also
+/// contains the immutable arguments, context fingerprint and dynamic provider
+/// output used by the runtime; none of those payloads belong in a session
+/// summary response.
+#[derive(Debug, Serialize)]
+pub struct SessionActiveWorkflow {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub source: bamboo_skills::WorkflowSource,
+    pub revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub kind: bamboo_skills::WorkflowKind,
+    pub invoked_by: bamboo_skills::WorkflowInvokedBy,
+    pub activated_at: chrono::DateTime<chrono::Utc>,
+    pub status: bamboo_skills::WorkflowActivationStatus,
+}
+
+impl SessionActiveWorkflow {
+    pub fn from_active(
+        active: bamboo_skills::ActiveWorkflow,
+        catalog_entry: Option<&bamboo_skills::WorkflowCatalogEntry>,
+    ) -> Self {
+        Self {
+            id: active.id,
+            name: catalog_entry.map(|entry| entry.name.clone()),
+            source: active.source,
+            revision: active.revision,
+            version: catalog_entry.map(|entry| entry.version.clone()),
+            kind: active.kind,
+            invoked_by: active.invoked_by,
+            activated_at: active.activated_at,
+            status: active.status,
+        }
+    }
+}
+
 /// Deserialize an explicitly-present nullable Project id while preserving the
 /// distinction between an absent field (`None`, no-op) and JSON `null`
 /// (`Some(None)`, explicit unassign).
@@ -80,6 +118,12 @@ pub struct SessionSummary {
     /// Lets the frontend render plan-mode UI without loading full session history.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan_mode: Option<bamboo_domain::PlanModeState>,
+    /// Public-safe durable workflow identity restored from the authoritative
+    /// session metadata. List rows intentionally leave this empty; the detail
+    /// endpoint hydrates it from `session.json` so browser refreshes do not
+    /// depend on an already-consumed account-feed event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_workflow: Option<SessionActiveWorkflow>,
     /// Number of child sessions currently running under this session.
     /// Computed dynamically at query time by scanning running sessions.
     #[serde(default)]
@@ -157,6 +201,7 @@ impl SessionSummary {
             resident_name: entry.resident_name,
             has_pending_question: entry.has_pending_question,
             plan_mode: entry.plan_mode,
+            active_workflow: None,
             running_child_count: 0,
             gold_config: parse_session_gold_config(entry.gold_config_json.as_deref()),
             bypass_permissions: entry.bypass_permissions
@@ -588,6 +633,7 @@ mod tests {
             resident_name: None,
             has_pending_question: false,
             plan_mode: None,
+            active_workflow: None,
             running_child_count: 0,
             gold_config: None,
         };
@@ -638,6 +684,7 @@ mod tests {
             resident_name: None,
             has_pending_question: false,
             plan_mode: None,
+            active_workflow: None,
             running_child_count: 0,
             gold_config: None,
         };
@@ -775,6 +822,7 @@ mod tests {
             resident_name: None,
             has_pending_question: false,
             plan_mode: None,
+            active_workflow: None,
             running_child_count: 0,
             gold_config: None,
         };

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -54,28 +54,13 @@ where
 {
     if !workspace.exists() {
         if let Some(config) = root_config() {
-            let root = canonicalize_best_effort(&config.root);
-            let candidate = canonicalize_best_effort(&workspace);
-            if candidate.starts_with(&root) {
-                if let Err(error) = std::fs::create_dir_all(&candidate) {
-                    tracing::warn!(
-                        path = %candidate.display(),
-                        workspace_root = %root.display(),
-                        workspace_source = source,
-                        %error,
-                        "failed to materialize validated workspace"
-                    );
-                }
-            } else {
-                // A configured default may disappear after preview. Never
-                // recreate a missing arbitrary path outside the authoritative
-                // root; emit enough non-secret context to diagnose the race.
+            if let Err(error) = materialize_workspace_under_root(&workspace, &config.root) {
                 tracing::warn!(
-                    path = %candidate.display(),
-                    workspace_root = %root.display(),
+                    path = %workspace.display(),
+                    workspace_root = %config.root.display(),
                     workspace_source = source,
-                    "validated workspace is missing outside the workspace root; \
-                     refusing to recreate it"
+                    %error,
+                    "failed to materialize validated workspace"
                 );
             }
         }
@@ -90,6 +75,21 @@ where
     );
     evict_oldest_if_needed(store, MAX_TRACKED_WORKSPACES);
     workspace
+}
+
+fn materialize_workspace_under_root(workspace: &Path, root: &Path) -> std::io::Result<PathBuf> {
+    let root = canonicalize_best_effort(root);
+    let candidate = canonicalize_best_effort(workspace);
+    if !candidate.starts_with(&root) {
+        // A configured default may disappear after preview. Never recreate a
+        // missing arbitrary path outside the authoritative root.
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "validated workspace is outside the authoritative workspace root",
+        ));
+    }
+    std::fs::create_dir_all(&candidate)?;
+    Ok(candidate)
 }
 
 /// Resolve the final path that [`set_workspace`] would store without mutating
@@ -356,6 +356,26 @@ impl WorkspaceResolver {
             &config.root,
             config.confine,
         ))
+    }
+
+    /// Materialize a trusted, already-previewed workspace without publishing
+    /// it into the runtime session registry.
+    ///
+    /// Transactional request paths use this before reading a workspace-scoped
+    /// catalog. Publication remains deferred until the corresponding session
+    /// checkpoint is durable. Missing paths outside this resolver's
+    /// authoritative root are rejected rather than recreated.
+    pub fn materialize_resolved_workspace(&self, workspace: &Path) -> std::io::Result<PathBuf> {
+        if workspace.exists() {
+            return Ok(workspace.to_path_buf());
+        }
+        let config = self.workspace_root_config().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "workspace root is unavailable for materialization",
+            )
+        })?;
+        materialize_workspace_under_root(workspace, &config.root)
     }
 
     /// Publish a previously validated candidate through this instance's root.
@@ -834,6 +854,41 @@ mod tests {
         assert!(!confined.exists(), "confinement preview must not create");
         resolver.publish_resolved_workspace("instance-confined", confined.clone(), "request");
         assert!(confined.is_dir());
+    }
+
+    #[test]
+    fn instance_resolver_can_materialize_without_publishing_runtime_state() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let root = state_dir.path().join("workspaces");
+        let resolver = WorkspaceResolver::new(|| None, {
+            let root = root.clone();
+            move || WorkspaceRootConfig {
+                root: root.clone(),
+                confine: false,
+            }
+        });
+        let session_id = "materialize-without-publication";
+        let fallback = resolver
+            .preview_session_fallback(session_id)
+            .expect("instance fallback");
+
+        let materialized = resolver
+            .materialize_resolved_workspace(&fallback)
+            .expect("materialize trusted fallback");
+
+        assert_eq!(materialized, canonicalize_best_effort(&fallback));
+        assert!(materialized.is_dir());
+        assert!(
+            peek_workspace(session_id).is_none(),
+            "catalog preparation must not publish a pre-commit workspace"
+        );
+
+        let outside = state_dir.path().join("outside/missing");
+        let error = resolver
+            .materialize_resolved_workspace(&outside)
+            .expect_err("missing path outside the authority root must fail closed");
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(!outside.exists());
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
@@ -1,8 +1,10 @@
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use super::{
-    emit_context_pressure_notification, enforce_model_context_ledger_retention,
-    maybe_apply_host_context_compression, prepare_round_context, LAST_PRESSURE_LEVEL_KEY,
+    build_compression_context_blocks, emit_context_pressure_notification,
+    enforce_model_context_ledger_retention, maybe_apply_host_context_compression,
+    prepare_round_context, LAST_PRESSURE_LEVEL_KEY,
 };
 use crate::runtime::config::{AgentLoopConfig, ImageFallbackConfig, ImageFallbackMode};
 use bamboo_agent_core::tools::{FunctionCall, ToolCall};
@@ -1622,6 +1624,69 @@ fn activate_plan_mode(session: &mut Session) {
     });
 }
 
+fn attach_durable_instruction_workflow(session: &mut Session) {
+    const WORKFLOW_ID: &str = "compression-workflow-872";
+    const WORKFLOW_REVISION: u64 = 7;
+
+    let definition = bamboo_skills::SkillDefinition::new(
+        WORKFLOW_ID,
+        "Compression Workflow",
+        "Private durable workflow used by the compression regression",
+        "WORKFLOW_PRIVATE_INSTRUCTION_872",
+    );
+    let catalog_entry = bamboo_skills::WorkflowCatalogEntry {
+        id: WORKFLOW_ID.to_string(),
+        name: "Compression Workflow".to_string(),
+        description: "Private durable workflow used by the compression regression".to_string(),
+        kind: bamboo_skills::WorkflowKind::Instruction,
+        source: bamboo_skills::WorkflowSource::Builtin,
+        revision: WORKFLOW_REVISION,
+        version: "1.0.0".to_string(),
+        invocation_policy: serde_json::json!({"manual": true}),
+        argument_schema: serde_json::json!({"type": "object"}),
+        status: bamboo_skills::WorkflowStatus::Valid,
+        legacy: false,
+        migration_status: None,
+        last_error: None,
+        winner: true,
+        shadowed_candidates: Vec::new(),
+    };
+    let mut skills = BTreeMap::new();
+    skills.insert(
+        WORKFLOW_ID.to_string(),
+        bamboo_skills::SkillActivationSnapshotEntry {
+            definition,
+            catalog_entry,
+            revision: WORKFLOW_REVISION,
+            resources: BTreeMap::new(),
+        },
+    );
+    let durable = bamboo_skills::DurableWorkflowActivation {
+        active: bamboo_skills::ActiveWorkflow {
+            id: WORKFLOW_ID.to_string(),
+            source: bamboo_skills::WorkflowSource::Builtin,
+            revision: WORKFLOW_REVISION,
+            kind: bamboo_skills::WorkflowKind::Instruction,
+            args: serde_json::json!({"private_scope": "WORKFLOW_PRIVATE_ARG_872"}),
+            invoked_by: bamboo_skills::WorkflowInvokedBy::User,
+            activated_at: chrono::Utc::now(),
+            status: bamboo_skills::WorkflowActivationStatus::Active,
+            diagnostic: None,
+            context_fingerprint: Some("workflow-context-fingerprint-872".to_string()),
+            dynamic_context: Vec::new(),
+        },
+        snapshot: bamboo_skills::SkillActivationSnapshot {
+            catalog_revision: 11,
+            selected_skill_mode: None,
+            skills,
+        },
+    };
+    session.metadata.insert(
+        bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY.to_string(),
+        serde_json::to_string(&durable).expect("serialize durable workflow fixture"),
+    );
+}
+
 #[tokio::test]
 async fn mid_turn_host_context_compression_includes_unified_context_blocks_in_summary_prompt() {
     let mut session = Session::new("session-cp-mid-turn-context-blocks", "test-model");
@@ -1742,6 +1807,7 @@ async fn mid_turn_host_context_compression_includes_unified_context_blocks_in_su
 async fn pre_turn_host_context_compression_includes_available_context_blocks_in_summary_prompt() {
     let mut session = Session::new("session-cp-pre-turn-context-blocks", "test-model");
     activate_plan_mode(&mut session);
+    attach_durable_instruction_workflow(&mut session);
     session.token_budget = Some(TokenBudget {
         max_context_tokens: 5000,
         max_output_tokens: 200,
@@ -1795,6 +1861,10 @@ async fn pre_turn_host_context_compression_includes_available_context_blocks_in_
         thinking_tokens: 0,
         cache_read_input_tokens: 0,
     });
+    assert!(session.messages.iter().all(|message| {
+        !message.content.contains("WORKFLOW_PRIVATE_INSTRUCTION_872")
+            && !message.content.contains("WORKFLOW_PRIVATE_ARG_872")
+    }));
 
     let config = AgentLoopConfig {
         model_name: Some("test-model".to_string()),
@@ -1817,6 +1887,10 @@ async fn pre_turn_host_context_compression_includes_available_context_blocks_in_
     .expect("pre-turn host compression should run");
 
     assert!(applied, "expected pre-turn compression to be applied");
+    assert!(session.messages.iter().all(|message| {
+        !message.content.contains("WORKFLOW_PRIVATE_INSTRUCTION_872")
+            && !message.content.contains("WORKFLOW_PRIVATE_ARG_872")
+    }));
 
     let requests = requests
         .lock()
@@ -1829,11 +1903,37 @@ async fn pre_turn_host_context_compression_includes_available_context_blocks_in_
 
     assert!(prompt.contains("## Compression Context Blocks"));
     assert!(prompt.contains("type: task_snapshot"));
+    assert!(prompt.contains("type: workflow_runtime"));
     assert!(prompt.contains("type: plan_mode_state"));
     assert!(prompt.contains("type: plan_runtime_state"));
     assert!(prompt.contains("Current Task List"));
     assert!(prompt.contains("Plan Mode State"));
     assert!(prompt.contains("Durable Plan Execution Context"));
+    assert_eq!(
+        prompt.matches("WORKFLOW_PRIVATE_INSTRUCTION_872").count(),
+        1
+    );
+    assert_eq!(prompt.matches("WORKFLOW_PRIVATE_ARG_872").count(), 1);
+
+    let workflow_blocks = build_compression_context_blocks(&session, None)
+        .into_iter()
+        .filter(|block| block.block_type == ContextBlockType::WorkflowRuntime)
+        .collect::<Vec<_>>();
+    assert_eq!(workflow_blocks.len(), 1);
+    assert_eq!(
+        workflow_blocks[0]
+            .content
+            .matches("WORKFLOW_PRIVATE_INSTRUCTION_872")
+            .count(),
+        1
+    );
+    assert_eq!(
+        workflow_blocks[0]
+            .content
+            .matches("WORKFLOW_PRIVATE_ARG_872")
+            .count(),
+        1
+    );
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
@@ -196,7 +196,7 @@ pub(super) async fn load_skill_context(
     session: &Session,
     session_id: &str,
     request_hint: &str,
-    must_resume_pinned_activation: bool,
+    _must_resume_pinned_activation: bool,
 ) -> Result<SkillContextLoadResult, String> {
     if let Some(skill_manager) = config.skill_manager.as_ref() {
         let resource_scope = SkillResourceScope::resolve(config, session).await?;
@@ -225,9 +225,13 @@ pub(super) async fn load_skill_context(
             .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
             .and_then(|raw| serde_json::from_str::<bamboo_skills::ActiveWorkflow>(raw).ok())
             .is_some_and(|active| active.status == bamboo_skills::WorkflowActivationStatus::Active);
+        // A chat-boundary explicit pin is durable authority even before the
+        // first execute starts. Restore it after a process restart regardless
+        // of whether the prior runtime state was suspended; otherwise a
+        // catalog edit in the POST /chat -> POST /execute window could silently
+        // substitute a newer revision.
         if retained_activation.is_none()
-            && (has_active_workflow
-                || (must_resume_pinned_activation && persisted_selection_requires_snapshot))
+            && (has_active_workflow || persisted_selection_requires_snapshot)
         {
             let restored = async {
                 let snapshot = if has_active_workflow {

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -377,6 +377,94 @@ async fn session_setup_publishes_current_skill_allowlist_before_tool_execution()
 }
 
 #[tokio::test]
+async fn pre_execute_explicit_snapshot_restores_after_restart_without_suspended_runtime() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let config = SkillStoreConfig {
+        skills_dir: directory.path().join("skills"),
+        ..Default::default()
+    };
+    let first = Arc::new(SkillManager::with_config(config.clone()));
+    first.initialize().await.expect("initialize first manager");
+    let review = first
+        .store()
+        .skill_catalog_snapshot()
+        .await
+        .entries
+        .into_iter()
+        .find(|entry| entry.id == "review" && entry.winner)
+        .expect("review entry");
+    let selected_ids = [review.id.clone()];
+    let activation = first
+        .resolve_and_pin_activation_for_request_with_mode_and_budget(
+            "pre-execute-restart",
+            &std::collections::BTreeSet::new(),
+            Some(&selected_ids),
+            None,
+            None,
+            bamboo_skills::DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
+        )
+        .await
+        .expect("pin first process candidate");
+    let snapshot = first
+        .store()
+        .export_activation_snapshot("pre-execute-restart")
+        .await
+        .expect("export candidate");
+    let selection = bamboo_skills::WorkflowSelection {
+        id: review.id,
+        source: review.source,
+        revision: review.revision,
+        args: serde_json::json!({}),
+    };
+    let mut session = Session::new("pre-execute-restart", "model");
+    session.metadata.insert(
+        bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY.to_string(),
+        serde_json::to_string(&selection).expect("selection JSON"),
+    );
+    bamboo_skills::persist_explicit_workflow_candidate(
+        &mut session.metadata,
+        &selection,
+        &activation,
+        &snapshot,
+    )
+    .expect("persist candidate");
+    first
+        .release_activation_for_workspace("pre-execute-restart", None)
+        .await
+        .expect("simulate process exit");
+    drop(first);
+
+    let restarted = Arc::new(SkillManager::with_config(config));
+    restarted
+        .initialize()
+        .await
+        .expect("initialize restarted manager");
+    let loop_config = crate::runtime::config::AgentLoopConfig {
+        skill_manager: Some(restarted.clone()),
+        selected_skill_ids: Some(selected_ids.to_vec()),
+        ..Default::default()
+    };
+    let loaded = super::skill_context::load_skill_context(
+        &loop_config,
+        &session,
+        "pre-execute-restart",
+        "Review this change",
+        false,
+    )
+    .await
+    .expect("restore chat-boundary candidate without suspended runtime");
+    assert_eq!(loaded.selected_skill_ids, vec!["review"]);
+    assert_eq!(loaded.skill_revisions["review"], selection.revision);
+    assert!(
+        restarted
+            .store()
+            .activation_was_restored("pre-execute-restart")
+            .await,
+        "restart must use durable pinned bytes, not silently re-resolve live catalog"
+    );
+}
+
+#[tokio::test]
 async fn session_setup_requires_model_issued_load_for_one_explicit_skill() {
     let directory = tempfile::tempdir().expect("tempdir");
     let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {

--- a/crates/engine/bamboo-engine/src/session_app/chat.rs
+++ b/crates/engine/bamboo-engine/src/session_app/chat.rs
@@ -493,6 +493,28 @@ pub fn resolve_workflow_selection(
         return Ok(());
     }
 
+    // A typed chat candidate is durable authority for the next execute, even
+    // when another ordinary message is appended before execution starts.
+    // Keep its visible selected id aligned with the retained immutable
+    // snapshot; only an explicit replacement/deactivation may cancel it.
+    if let Some(pending) = session
+        .metadata
+        .get(WORKFLOW_SELECTION_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<WorkflowSelection>(raw).ok())
+        .filter(|_| {
+            session
+                .metadata
+                .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY)
+                .is_some_and(|source| source == "explicit")
+                && session.metadata.contains_key(
+                    bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY,
+                )
+        })
+    {
+        persist_selected_skill_ids_metadata(session, Some(&[pending.id]));
+        return Ok(());
+    }
+
     if let Some(active) = session
         .metadata
         .get(ACTIVE_WORKFLOW_METADATA_KEY)
@@ -1046,6 +1068,47 @@ mod tests {
             Some(vec!["review".to_string()])
         );
         assert!(session.metadata.contains_key(ACTIVE_WORKFLOW_METADATA_KEY));
+    }
+
+    #[test]
+    fn pending_typed_workflow_survives_an_ordinary_chat_before_execute() {
+        let mut session = Session::new("pending-selection", "model");
+        let selection = WorkflowSelection {
+            id: "review".to_string(),
+            source: bamboo_skills::WorkflowSource::Builtin,
+            revision: 7,
+            args: serde_json::json!({}),
+        };
+        session.metadata.insert(
+            WORKFLOW_SELECTION_METADATA_KEY.to_string(),
+            serde_json::to_string(&selection).expect("selection json"),
+        );
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+            "explicit".to_string(),
+        );
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY.to_string(),
+            "opaque durable snapshot".to_string(),
+        );
+
+        resolve_workflow_selection(&mut session, None, None, "one more detail")
+            .expect("retain pending selection");
+
+        assert_eq!(
+            session.selected_skill_ids(),
+            Some(vec!["review".to_string()])
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(WORKFLOW_SELECTION_METADATA_KEY)
+                .and_then(|raw| serde_json::from_str::<WorkflowSelection>(raw).ok()),
+            Some(selection)
+        );
+        assert!(session
+            .metadata
+            .contains_key(bamboo_skills::runtime_metadata::SKILL_RUNTIME_PINNED_SNAPSHOT_KEY));
     }
 
     #[test]

--- a/crates/infra/bamboo-skills/src/activation.rs
+++ b/crates/infra/bamboo-skills/src/activation.rs
@@ -62,8 +62,10 @@ pub enum WorkflowActivationStatus {
     Deactivated,
 }
 
-/// Durable, public-safe active workflow metadata. The immutable payload is
-/// stored separately under [`ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY`].
+/// Durable runtime activation metadata. This includes caller arguments and
+/// dynamic provider context and must not be serialized directly at a public
+/// API boundary. The immutable bundle payload is stored separately under
+/// [`ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActiveWorkflow {
     pub id: String,
@@ -171,6 +173,192 @@ pub struct DynamicContextBlock {
 }
 
 pub type DynamicContextCache = BTreeMap<String, DynamicContextBlock>;
+
+/// Persist one exact, already-pinned instruction candidate before a chat turn
+/// is acknowledged. This closes the chat-to-execute restart window: the
+/// server can restore the immutable revision even if the live catalog changes
+/// or the process restarts after `POST /chat` and before `POST /execute`.
+///
+/// Every serialized value is prepared before the metadata map is mutated, so
+/// an error leaves the caller's prior runtime candidate untouched.
+pub fn persist_explicit_workflow_candidate(
+    metadata: &mut HashMap<String, String>,
+    selection: &WorkflowSelection,
+    activation: &crate::SkillActivationSelection,
+    snapshot: &SkillActivationSnapshot,
+) -> Result<(), WorkflowActivationDiagnostic> {
+    let diagnostic = |code, message: &str, recoverable| WorkflowActivationDiagnostic {
+        code,
+        message: message.to_string(),
+        recoverable,
+    };
+    let entry = match activation.catalog_entries.as_slice() {
+        [entry] if entry.id == selection.id => entry,
+        _ => {
+            return Err(diagnostic(
+                WorkflowActivationErrorCode::RevisionMissing,
+                "selected workflow is unavailable or disabled",
+                true,
+            ));
+        }
+    };
+    if entry.status != crate::WorkflowStatus::Valid {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::RevisionMissing,
+            "selected workflow is invalid",
+            true,
+        ));
+    }
+    if entry.source != selection.source {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::SourceMismatch,
+            "selected workflow source changed; refresh the catalog",
+            true,
+        ));
+    }
+    if entry.revision != selection.revision {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::RevisionMismatch,
+            "selected workflow revision changed; refresh the catalog",
+            true,
+        ));
+    }
+    if entry.kind != WorkflowKind::Instruction {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::InvalidSelection,
+            "orchestration workflows must be started through the Workflow Run API",
+            false,
+        ));
+    }
+    if entry.invocation_policy["explicit"].as_bool() != Some(true) {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::ManualOnly,
+            "selected workflow does not allow explicit activation",
+            false,
+        ));
+    }
+    if let Err(error) = bamboo_domain::validate_schema(&entry.argument_schema, &selection.args) {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::InvalidSelection,
+            &format!("workflow arguments do not match the catalog schema: {error}"),
+            true,
+        ));
+    }
+    let Some(snapshot_entry) = snapshot.skills.get(&selection.id) else {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "pinned workflow snapshot is missing the selected definition",
+            true,
+        ));
+    };
+    if snapshot.skills.len() != 1
+        || snapshot_entry.revision != selection.revision
+        || snapshot_entry.catalog_entry != *entry
+    {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::RevisionMismatch,
+            "pinned workflow snapshot does not match the selected catalog identity",
+            true,
+        ));
+    }
+
+    use crate::runtime_metadata::{
+        SKILL_RUNTIME_ACTIVATION_ERROR_KEY, SKILL_RUNTIME_ACTIVATION_GENERATION_KEY,
+        SKILL_RUNTIME_PINNED_SNAPSHOT_KEY, SKILL_RUNTIME_SELECTED_CATALOG_KEY,
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY, SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY,
+        SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY, SKILL_RUNTIME_SELECTION_COUNT_KEY,
+        SKILL_RUNTIME_SELECTION_SOURCE_KEY, SKILL_RUNTIME_SELECTION_TRACE_KEY,
+    };
+    let snapshot_json = serde_json::to_string(snapshot).map_err(|_| {
+        diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "pinned workflow snapshot could not be serialized",
+            true,
+        )
+    })?;
+    if snapshot_json.len() > MAX_DURABLE_WORKFLOW_ACTIVATION_BYTES {
+        return Err(diagnostic(
+            WorkflowActivationErrorCode::SnapshotTooLarge,
+            "selected workflow snapshot exceeds the durable session limit",
+            true,
+        ));
+    }
+    let catalog_json = serde_json::to_string(&activation.catalog_entries).map_err(|_| {
+        diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "selected workflow catalog identity could not be serialized",
+            true,
+        )
+    })?;
+    let selected_ids = vec![selection.id.clone()];
+    let selected_ids_json = serde_json::to_string(&selected_ids).map_err(|_| {
+        diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "selected workflow id could not be serialized",
+            true,
+        )
+    })?;
+    let revisions_json =
+        serde_json::to_string(&activation.descriptor.skill_revisions).map_err(|_| {
+            diagnostic(
+                WorkflowActivationErrorCode::SnapshotUnavailable,
+                "selected workflow revision map could not be serialized",
+                true,
+            )
+        })?;
+    let diagnostic_json = serde_json::to_string(&activation.catalog_diagnostic).map_err(|_| {
+        diagnostic(
+            WorkflowActivationErrorCode::SnapshotUnavailable,
+            "selected workflow catalog diagnostic could not be serialized",
+            true,
+        )
+    })?;
+    let trace_json = serde_json::json!({
+        "source": "explicit",
+        "selected_skill_ids": selected_ids,
+        "selected_skill_mode": activation.descriptor.selected_skill_mode,
+        "request_hint_present": false
+    })
+    .to_string();
+
+    metadata.insert(
+        SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+        "explicit".to_string(),
+    );
+    metadata.insert(SKILL_RUNTIME_SELECTED_CATALOG_KEY.to_string(), catalog_json);
+    metadata.insert(
+        WORKFLOW_CATALOG_DIAGNOSTIC_METADATA_KEY.to_string(),
+        diagnostic_json,
+    );
+    metadata.insert(SKILL_RUNTIME_PINNED_SNAPSHOT_KEY.to_string(), snapshot_json);
+    metadata.insert(
+        SKILL_RUNTIME_SELECTION_COUNT_KEY.to_string(),
+        "1".to_string(),
+    );
+    metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        selected_ids_json,
+    );
+    metadata.insert(
+        SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+        activation.descriptor.catalog_revision.to_string(),
+    );
+    metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+        revisions_json,
+    );
+    metadata.insert(SKILL_RUNTIME_SELECTION_TRACE_KEY.to_string(), trace_json);
+    if let Some(mode) = activation.descriptor.selected_skill_mode.as_ref() {
+        metadata.insert(
+            SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY.to_string(),
+            mode.clone(),
+        );
+    } else {
+        metadata.remove(SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY);
+    }
+    metadata.remove(SKILL_RUNTIME_ACTIVATION_ERROR_KEY);
+    Ok(())
+}
 
 /// Record activation only after `load_skill` has returned the pinned payload.
 /// This is shared by explicit preload and model-driven automatic activation.
@@ -358,7 +546,8 @@ mod tests {
         SKILL_RUNTIME_SELECTION_SOURCE_KEY,
     };
     use crate::{
-        SkillActivationSnapshotEntry, SkillDefinition, WorkflowCatalogEntry, WorkflowStatus,
+        SkillActivationDescriptor, SkillActivationSelection, SkillActivationSnapshotEntry,
+        SkillDefinition, WorkflowCatalogEntry, WorkflowStatus,
     };
 
     fn entry(id: &str, revision: u64) -> WorkflowCatalogEntry {
@@ -526,5 +715,69 @@ mod tests {
         )
         .expect("valid unchanged candidate snapshot");
         assert_eq!(unchanged.skills["oversized"].revision, 11);
+    }
+
+    #[test]
+    fn explicit_candidate_rejects_invalid_arguments_without_metadata_mutation() {
+        let mut selected = entry("review", 13);
+        selected.argument_schema = serde_json::json!({
+            "type": "object",
+            "properties": {"depth": {"type": "integer"}},
+            "required": ["depth"],
+            "additionalProperties": false
+        });
+        let descriptor = SkillActivationDescriptor {
+            catalog_revision: 71,
+            skill_revisions: BTreeMap::from([("review".to_string(), 13)]),
+            selected_skill_mode: Some("explicit".to_string()),
+        };
+        let activation = SkillActivationSelection {
+            skills: vec![snapshot_entry(selected.clone(), BTreeMap::new()).definition],
+            catalog_entries: vec![selected.clone()],
+            catalog_diagnostic: WorkflowCatalogDiagnostic {
+                total_candidates: 1,
+                advertised_candidates: 1,
+                initial_chars: 128,
+                final_chars: 128,
+                char_budget: 1024,
+                token_budget: 256,
+                compressed_descriptions: false,
+                shortlisted: false,
+                omitted_ids: Vec::new(),
+            },
+            descriptor,
+        };
+        let snapshot = SkillActivationSnapshot {
+            catalog_revision: 71,
+            selected_skill_mode: Some("explicit".to_string()),
+            skills: BTreeMap::from([(
+                "review".to_string(),
+                snapshot_entry(selected, BTreeMap::new()),
+            )]),
+        };
+        let selection = WorkflowSelection {
+            id: "review".to_string(),
+            source: WorkflowSource::Project,
+            revision: 13,
+            args: serde_json::json!({"depth": "deep"}),
+        };
+        let mut metadata = HashMap::from([
+            ("preserve".to_string(), "exact".to_string()),
+            (
+                SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+                "prior".to_string(),
+            ),
+        ]);
+        let before = metadata.clone();
+
+        let diagnostic =
+            persist_explicit_workflow_candidate(&mut metadata, &selection, &activation, &snapshot)
+                .expect_err("invalid arguments fail before metadata publication");
+
+        assert_eq!(
+            diagnostic.code,
+            WorkflowActivationErrorCode::InvalidSelection
+        );
+        assert_eq!(metadata, before);
     }
 }


### PR DESCRIPTION
## Summary

- validate and stage typed instruction selections against one exact catalog revision, then commit the durable selection and immutable snapshot without disturbing the previous activation on stale, invalid, hook, attachment, runner-race, or persistence failures
- make the chat commit cancellation-resistant and restore the exact private workflow runtime context after restart and context compression without copying bodies, arguments, resources, paths, or dynamic context into public messages
- expose a minimal durable `active_workflow` session-detail projection and return a typed public `load_skill` receipt that is safe for history, SSE, and WebSocket replay

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/private/tmp/bamboo-872.SG3qVz/target cargo test --locked -p bamboo-skills -p bamboo-agent-core -p bamboo-engine -p bamboo-server-tools -p bamboo-server --lib` (3672 passed, 1 existing ignored)
- `CARGO_TARGET_DIR=/private/tmp/bamboo-872.SG3qVz/target cargo clippy --locked -p bamboo-server --tests --all-features -- -D warnings -A clippy::too-many-arguments`

Strict clippy without the command-line allowance stops on the existing `bamboo-storage/src/session_merge.rs` `too_many_arguments` baseline; this PR does not change that unrelated API.

Closes #872