### PR TITLE
feat: recover Workflow clone transactions

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/workflows/clone_publication.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/clone_publication.rs
@@ -4,16 +4,22 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
 
 use bamboo_skills::clone_publication::{
-    clone_marker_name, CloneNodeIdentity, ClonePublicationMarker, ClonePublicationPhase,
-    CLONE_MARKER_SCHEMA, MAX_CLONE_BUNDLE_BYTES, MAX_CLONE_BUNDLE_FILES, MAX_CLONE_MARKER_BYTES,
-    MAX_CLONE_RELATIVE_PATH_BYTES,
+    clone_marker_name, clone_marker_record_bytes, parse_clone_marker_journal, CloneMarkerJournal,
+    CloneNodeIdentity, ClonePublicationMarker, ClonePublicationPhase, CLONE_MARKER_SCHEMA,
+    MAX_CLONE_BUNDLE_BYTES, MAX_CLONE_BUNDLE_FILES, MAX_CLONE_MARKER_BYTES,
+    MAX_CLONE_MARKER_RECORDS, MAX_CLONE_RELATIVE_PATH_BYTES,
 };
 use bamboo_skills::store::builtin::{builtin_clone_bundle_digest, BuiltinSkillFile};
 #[cfg(unix)]
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir as CapDir, File as CapFile, OpenOptions as CapOpenOptions};
+use fs2::FileExt;
+use sha2::{Digest, Sha256};
 
 const CLONE_TRANSACTION_DIRECTORY: &str = ".workflow-clone-txn";
+const CLONE_TRANSACTION_LOCK: &str = ".publication.lock";
+const CLONE_ROLLOVER_RESET: &str = "reset.json";
+const CLONE_ROLLOVER_RETIRED: &str = "retired.json";
 
 #[derive(Debug)]
 pub(super) enum ClonePublicationError {
@@ -38,6 +44,13 @@ struct ClonePublicationRoot {
     skills_dir: CapDir,
 }
 
+struct OpenCloneMarker {
+    file: CapFile,
+    identity: CloneNodeIdentity,
+    journal: CloneMarkerJournal,
+    bytes: Vec<u8>,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum PublicationFault {
     #[default]
@@ -45,9 +58,23 @@ enum PublicationFault {
     #[cfg(test)]
     StopAfterPrepared,
     #[cfg(test)]
+    StopAfterStageDirectory,
+    #[cfg(test)]
+    StopAfterStageBound,
+    #[cfg(test)]
+    StopAfterStagePopulated,
+    #[cfg(test)]
     StopAfterStaged,
     #[cfg(test)]
     StopAfterRename,
+    #[cfg(test)]
+    StopAfterRetired,
+    #[cfg(test)]
+    StopAfterRolloverReset,
+    #[cfg(test)]
+    StopAfterRolloverArchive,
+    #[cfg(test)]
+    StopAfterRolloverInstall,
     #[cfg(test)]
     RenameReportsErrorAfterMove,
     #[cfg(test)]
@@ -327,6 +354,38 @@ fn open_transaction_parent(root: &ClonePublicationRoot) -> Result<CapDir, CloneP
         ));
     }
     Ok(transaction)
+}
+
+fn lock_clone_transactions(
+    transaction_parent: &CapDir,
+) -> Result<std::fs::File, ClonePublicationError> {
+    let name = Path::new(CLONE_TRANSACTION_LOCK);
+    let mut options = CapOpenOptions::new();
+    options.read(true).write(true).create(true);
+    let lock = transaction_parent.open_with(name, &options)?;
+    let metadata = lock.metadata()?;
+    if !metadata.is_file() || !cap_regular_file_has_single_link(&metadata) {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone transaction lock is invalid",
+        ));
+    }
+    let identity = cap_node_identity(&metadata);
+    ensure_cap_file_is_still_named(transaction_parent, name, &metadata)?;
+    sync_cap_directory(transaction_parent)?;
+    let lock = lock.into_std();
+    FileExt::lock_exclusive(&lock)?;
+    let named = transaction_parent.symlink_metadata(name)?;
+    if named.file_type().is_symlink()
+        || !named.is_file()
+        || cap_node_identity(&named) != identity
+        || !cap_regular_file_has_single_link(&named)
+    {
+        let _ = FileExt::unlock(&lock);
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone transaction lock changed while acquiring authority",
+        ));
+    }
+    Ok(lock)
 }
 
 fn checked_relative_path(path: &str) -> Result<PathBuf, ClonePublicationError> {
@@ -624,37 +683,509 @@ fn ensure_marker_is_still_named(
     Ok(())
 }
 
-fn write_marker(
-    root: &ClonePublicationRoot,
-    marker_name: &Path,
-    marker_file: &mut CapFile,
-    marker_identity: CloneNodeIdentity,
-    marker: &ClonePublicationMarker,
-) -> Result<(), ClonePublicationError> {
-    let bytes = serde_json::to_vec(marker).map_err(|_| {
-        ClonePublicationError::Internal("Workflow clone marker serialization failed")
+fn read_marker_bytes(marker_file: &mut CapFile) -> Result<Vec<u8>, ClonePublicationError> {
+    let metadata = marker_file.metadata()?;
+    let length = usize::try_from(metadata.len()).map_err(|_| {
+        ClonePublicationError::Conflict("Workflow clone marker exceeds its durable limit")
     })?;
-    if bytes.len() > MAX_CLONE_MARKER_BYTES {
-        return Err(ClonePublicationError::Internal(
+    if !metadata.is_file()
+        || !cap_regular_file_has_single_link(&metadata)
+        || length > MAX_CLONE_MARKER_BYTES
+    {
+        return Err(ClonePublicationError::Conflict(
             "Workflow clone marker exceeds its durable limit",
         ));
     }
-    ensure_marker_is_still_named(root, marker_name, marker_identity)?;
-    let metadata = marker_file.metadata()?;
-    if cap_node_identity(&metadata) != marker_identity
+    marker_file.seek(SeekFrom::Start(0))?;
+    let mut bytes = Vec::with_capacity(length);
+    Read::by_ref(marker_file)
+        .take(MAX_CLONE_MARKER_BYTES.saturating_add(1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() != length || bytes.len() > MAX_CLONE_MARKER_BYTES {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone marker changed while it was read",
+        ));
+    }
+    Ok(bytes)
+}
+
+fn open_clone_marker(
+    root: &ClonePublicationRoot,
+    marker_name: &Path,
+    workflow_id: &str,
+) -> Result<Option<OpenCloneMarker>, ClonePublicationError> {
+    let before = match root.skills_dir.symlink_metadata(marker_name) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if before.file_type().is_symlink()
+        || !before.is_file()
+        || !cap_regular_file_has_single_link(&before)
+    {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone marker is not exclusively owned",
+        ));
+    }
+    let mut options = CapOpenOptions::new();
+    options.read(true).write(true);
+    let mut file = root.skills_dir.open_with(marker_name, &options)?;
+    let opened = file.metadata()?;
+    let after = root.skills_dir.symlink_metadata(marker_name)?;
+    if !opened.is_file()
+        || after.file_type().is_symlink()
+        || !after.is_file()
+        || !cap_entries_match(&before, &opened)
+        || !cap_entries_match(&after, &opened)
+        || !cap_regular_file_has_single_link(&opened)
+    {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone marker changed while it was opened",
+        ));
+    }
+    let identity = cap_node_identity(&opened);
+    let bytes = read_marker_bytes(&mut file)?;
+    ensure_marker_is_still_named(root, marker_name, identity)?;
+    let journal = parse_clone_marker_journal(&bytes, workflow_id).ok_or(
+        ClonePublicationError::Conflict("Workflow clone marker contains divergent data"),
+    )?;
+    Ok(Some(OpenCloneMarker {
+        file,
+        identity,
+        journal,
+        bytes,
+    }))
+}
+
+fn create_clone_marker(
+    root: &ClonePublicationRoot,
+    marker_name: &Path,
+    _workflow_id: &str,
+) -> Result<OpenCloneMarker, ClonePublicationError> {
+    let mut options = CapOpenOptions::new();
+    options.read(true).write(true).create_new(true);
+    let file = root.skills_dir.open_with(marker_name, &options)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || !cap_regular_file_has_single_link(&metadata) {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone marker is not exclusively owned",
+        ));
+    }
+    let identity = cap_node_identity(&metadata);
+    ensure_marker_is_still_named(root, marker_name, identity)?;
+    Ok(OpenCloneMarker {
+        file,
+        identity,
+        journal: CloneMarkerJournal {
+            records: Vec::new(),
+            partial: Vec::new(),
+        },
+        bytes: Vec::new(),
+    })
+}
+
+fn append_marker_record(
+    root: &ClonePublicationRoot,
+    marker_name: &Path,
+    workflow_id: &str,
+    marker: &mut OpenCloneMarker,
+    record: &ClonePublicationMarker,
+) -> Result<(), ClonePublicationError> {
+    if marker.journal.current() == Some(record) && marker.journal.partial.is_empty() {
+        return Ok(());
+    }
+    let record_bytes = clone_marker_record_bytes(record).ok_or(ClonePublicationError::Internal(
+        "Workflow clone marker serialization failed",
+    ))?;
+    let append = if !marker.journal.partial.is_empty() {
+        if !record_bytes.starts_with(&marker.journal.partial) {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone marker contains divergent partial data",
+            ));
+        }
+        record_bytes[marker.journal.partial.len()..].to_vec()
+    } else if !marker.bytes.is_empty() && !marker.bytes.ends_with(b"\n") {
+        let mut append = Vec::with_capacity(record_bytes.len() + 1);
+        append.push(b'\n');
+        append.extend_from_slice(&record_bytes);
+        append
+    } else {
+        record_bytes
+    };
+    let mut projected = marker.bytes.clone();
+    projected.extend_from_slice(&append);
+    if projected.len() > MAX_CLONE_MARKER_BYTES {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone marker exceeds its durable limit",
+        ));
+    }
+    let projected_journal = parse_clone_marker_journal(&projected, workflow_id).ok_or(
+        ClonePublicationError::Conflict("Workflow clone marker transition is invalid"),
+    )?;
+    if projected_journal.records.len() > MAX_CLONE_MARKER_RECORDS
+        || projected_journal.current() != Some(record)
+        || !projected_journal.partial.is_empty()
+    {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone marker transition is invalid",
+        ));
+    }
+    ensure_marker_is_still_named(root, marker_name, marker.identity)?;
+    let metadata = marker.file.metadata()?;
+    if cap_node_identity(&metadata) != marker.identity
         || !cap_regular_file_has_single_link(&metadata)
     {
         return Err(ClonePublicationError::Conflict(
             "Workflow clone marker authority changed",
         ));
     }
-    marker_file.set_len(0)?;
-    marker_file.seek(SeekFrom::Start(0))?;
-    marker_file.write_all(&bytes)?;
-    marker_file.sync_all()?;
-    ensure_marker_is_still_named(root, marker_name, marker_identity)?;
+    marker.file.seek(SeekFrom::End(0))?;
+    marker.file.write_all(&append)?;
+    marker.file.sync_all()?;
+    ensure_marker_is_still_named(root, marker_name, marker.identity)?;
     sync_cap_directory(&root.skills_dir)?;
+    marker.bytes = projected;
+    marker.journal = projected_journal;
     Ok(())
+}
+
+fn clone_rollover_directory_name(workflow_id: &str) -> PathBuf {
+    let digest = Sha256::digest(workflow_id.as_bytes());
+    PathBuf::from(format!("marker-{}", hex::encode(&digest[..16])))
+}
+
+fn open_rollover_parent(
+    transaction_parent: &CapDir,
+    workflow_id: &str,
+) -> Result<CapDir, ClonePublicationError> {
+    let name = clone_rollover_directory_name(workflow_id);
+    let parent = ensure_real_child_dir(transaction_parent, &name)?;
+    #[cfg(unix)]
+    set_cap_directory_mode(&parent, 0o700)?;
+    ensure_open_child_is_still_named(transaction_parent, &name, &parent)?;
+    Ok(parent)
+}
+
+fn open_private_marker(
+    parent: &CapDir,
+    name: &Path,
+    workflow_id: &str,
+) -> Result<Option<OpenCloneMarker>, ClonePublicationError> {
+    let before = match parent.symlink_metadata(name) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if before.file_type().is_symlink()
+        || !before.is_file()
+        || !cap_regular_file_has_single_link(&before)
+    {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone rollover marker is invalid",
+        ));
+    }
+    let mut options = CapOpenOptions::new();
+    options.read(true).write(true);
+    let mut file = parent.open_with(name, &options)?;
+    let opened = file.metadata()?;
+    let after = parent.symlink_metadata(name)?;
+    if !opened.is_file()
+        || after.file_type().is_symlink()
+        || !after.is_file()
+        || !cap_entries_match(&before, &opened)
+        || !cap_entries_match(&after, &opened)
+        || !cap_regular_file_has_single_link(&opened)
+    {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone rollover marker changed while it was opened",
+        ));
+    }
+    let identity = cap_node_identity(&opened);
+    let bytes = read_marker_bytes(&mut file)?;
+    ensure_cap_file_is_still_named(parent, name, &opened)?;
+    let journal = parse_clone_marker_journal(&bytes, workflow_id).ok_or(
+        ClonePublicationError::Conflict("Workflow clone rollover marker is divergent"),
+    )?;
+    Ok(Some(OpenCloneMarker {
+        file,
+        identity,
+        journal,
+        bytes,
+    }))
+}
+
+fn create_private_prepared_marker(
+    parent: &CapDir,
+    name: &Path,
+    workflow_id: &str,
+    prepared: &ClonePublicationMarker,
+) -> Result<OpenCloneMarker, ClonePublicationError> {
+    let mut options = CapOpenOptions::new();
+    options.read(true).write(true).create_new(true);
+    let mut file = parent.open_with(name, &options)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || !cap_regular_file_has_single_link(&metadata) {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone rollover marker is not exclusively owned",
+        ));
+    }
+    let identity = cap_node_identity(&metadata);
+    let bytes = clone_marker_record_bytes(prepared).ok_or(ClonePublicationError::Internal(
+        "Workflow clone rollover marker serialization failed",
+    ))?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    ensure_cap_file_is_still_named(parent, name, &metadata)?;
+    sync_cap_directory(parent)?;
+    let journal = parse_clone_marker_journal(&bytes, workflow_id).ok_or(
+        ClonePublicationError::Internal("Workflow clone rollover marker validation failed"),
+    )?;
+    Ok(OpenCloneMarker {
+        file,
+        identity,
+        journal,
+        bytes,
+    })
+}
+
+fn marker_is_terminal(marker: &OpenCloneMarker) -> bool {
+    marker.journal.partial.is_empty()
+        && marker.journal.current().is_some_and(|record| {
+            matches!(
+                record.phase,
+                ClonePublicationPhase::Aborted | ClonePublicationPhase::Retired
+            )
+        })
+}
+
+fn remove_terminal_rollover_marker(
+    parent: &CapDir,
+    name: &Path,
+    workflow_id: &str,
+) -> Result<(), ClonePublicationError> {
+    let Some(marker) = open_private_marker(parent, name, workflow_id)? else {
+        return Ok(());
+    };
+    if !marker_is_terminal(&marker) {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone rollover archive is not terminal",
+        ));
+    }
+    let identity = marker.identity;
+    let metadata = marker.file.metadata()?;
+    ensure_cap_file_is_still_named(parent, name, &metadata)?;
+    drop(marker);
+    let named = parent.symlink_metadata(name)?;
+    if cap_node_identity(&named) != identity {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone rollover archive changed before cleanup",
+        ));
+    }
+    parent.remove_file(name)?;
+    sync_cap_directory(parent)?;
+    Ok(())
+}
+
+fn move_marker_noreplace(
+    source_parent: &CapDir,
+    source_name: &Path,
+    destination_parent: &CapDir,
+    destination_name: &Path,
+    expected: CloneNodeIdentity,
+) -> Result<(), ClonePublicationError> {
+    let result = rename_entry_noreplace(
+        source_parent,
+        source_name,
+        destination_parent,
+        destination_name,
+        expected,
+        false,
+    );
+    let moved = destination_parent
+        .symlink_metadata(destination_name)
+        .ok()
+        .is_some_and(|metadata| {
+            !metadata.file_type().is_symlink()
+                && metadata.is_file()
+                && cap_node_identity(&metadata) == expected
+        });
+    if moved {
+        return Ok(());
+    }
+    Err(result
+        .err()
+        .unwrap_or_else(|| {
+            std::io::Error::other("Workflow clone marker move did not create its destination")
+        })
+        .into())
+}
+
+fn finish_rollover_moves(
+    root: &ClonePublicationRoot,
+    rollover: &CapDir,
+    marker_name: &Path,
+    workflow_id: &str,
+    canonical: OpenCloneMarker,
+    reset: OpenCloneMarker,
+    _fault: PublicationFault,
+) -> Result<OpenCloneMarker, ClonePublicationError> {
+    if !marker_is_terminal(&canonical)
+        || !reset.journal.partial.is_empty()
+        || !reset
+            .journal
+            .current()
+            .is_some_and(|record| record.phase == ClonePublicationPhase::Prepared)
+    {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone rollover state is invalid",
+        ));
+    }
+    let canonical_identity = canonical.identity;
+    let reset_identity = reset.identity;
+    drop(canonical);
+    drop(reset);
+    move_marker_noreplace(
+        &root.skills_dir,
+        marker_name,
+        rollover,
+        Path::new(CLONE_ROLLOVER_RETIRED),
+        canonical_identity,
+    )?;
+    sync_cap_directory(&root.skills_dir)?;
+    sync_cap_directory(rollover)?;
+    #[cfg(test)]
+    if _fault == PublicationFault::StopAfterRolloverArchive {
+        return Err(injected_failure());
+    }
+    move_marker_noreplace(
+        rollover,
+        Path::new(CLONE_ROLLOVER_RESET),
+        &root.skills_dir,
+        marker_name,
+        reset_identity,
+    )?;
+    sync_cap_directory(rollover)?;
+    sync_cap_directory(&root.skills_dir)?;
+    #[cfg(test)]
+    if _fault == PublicationFault::StopAfterRolloverInstall {
+        return Err(injected_failure());
+    }
+    open_clone_marker(root, marker_name, workflow_id)?.ok_or(ClonePublicationError::Internal(
+        "Workflow clone rollover lost its canonical marker",
+    ))
+}
+
+fn recover_interrupted_rollover(
+    root: &ClonePublicationRoot,
+    transaction_parent: &CapDir,
+    workflow_id: &str,
+    marker_name: &Path,
+) -> Result<(), ClonePublicationError> {
+    let rollover_name = clone_rollover_directory_name(workflow_id);
+    let Some(rollover) = open_optional_real_child_dir(transaction_parent, &rollover_name)? else {
+        return Ok(());
+    };
+    let canonical = open_clone_marker(root, marker_name, workflow_id)?;
+    let reset = open_private_marker(&rollover, Path::new(CLONE_ROLLOVER_RESET), workflow_id)?;
+    let retired = open_private_marker(&rollover, Path::new(CLONE_ROLLOVER_RETIRED), workflow_id)?;
+    match (canonical, reset, retired) {
+        (Some(canonical), Some(reset), None) => {
+            let target_absent = root
+                .skills_dir
+                .symlink_metadata(Path::new(workflow_id))
+                .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound);
+            if !target_absent {
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow clone rollover target is no longer absent",
+                ));
+            }
+            finish_rollover_moves(
+                root,
+                &rollover,
+                marker_name,
+                workflow_id,
+                canonical,
+                reset,
+                PublicationFault::None,
+            )?;
+        }
+        (None, Some(reset), Some(retired)) => {
+            if !marker_is_terminal(&retired) {
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow clone rollover archive is invalid",
+                ));
+            }
+            let reset_identity = reset.identity;
+            drop(reset);
+            move_marker_noreplace(
+                &rollover,
+                Path::new(CLONE_ROLLOVER_RESET),
+                &root.skills_dir,
+                marker_name,
+                reset_identity,
+            )?;
+            sync_cap_directory(&rollover)?;
+            sync_cap_directory(&root.skills_dir)?;
+        }
+        (Some(_), None, Some(_)) | (Some(_), None, None) | (None, None, None) => {}
+        _ => {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone rollover state is ambiguous",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn rollover_terminal_marker(
+    root: &ClonePublicationRoot,
+    transaction_parent: &CapDir,
+    workflow_id: &str,
+    marker_name: &Path,
+    canonical: OpenCloneMarker,
+    prepared: &ClonePublicationMarker,
+    fault: PublicationFault,
+) -> Result<OpenCloneMarker, ClonePublicationError> {
+    if !marker_is_terminal(&canonical) {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone marker is not at a rollover boundary",
+        ));
+    }
+    match root.skills_dir.symlink_metadata(Path::new(workflow_id)) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Ok(_) => {
+            return Err(ClonePublicationError::Conflict(
+                "Workflow clone target must be absent before rollover",
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    }
+    let rollover = open_rollover_parent(transaction_parent, workflow_id)?;
+    remove_terminal_rollover_marker(&rollover, Path::new(CLONE_ROLLOVER_RETIRED), workflow_id)?;
+    if open_private_marker(&rollover, Path::new(CLONE_ROLLOVER_RESET), workflow_id)?.is_some() {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone rollover reset already exists",
+        ));
+    }
+    let reset = create_private_prepared_marker(
+        &rollover,
+        Path::new(CLONE_ROLLOVER_RESET),
+        workflow_id,
+        prepared,
+    )?;
+    #[cfg(test)]
+    if fault == PublicationFault::StopAfterRolloverReset {
+        return Err(injected_failure());
+    }
+    finish_rollover_moves(
+        root,
+        &rollover,
+        marker_name,
+        workflow_id,
+        canonical,
+        reset,
+        fault,
+    )
 }
 
 #[cfg(any(
@@ -663,18 +1194,20 @@ fn write_marker(
     target_vendor = "apple",
     target_os = "redox"
 ))]
-fn rename_stage_noreplace(
+fn rename_entry_noreplace(
     source_parent: &CapDir,
     source_name: &Path,
     destination_parent: &CapDir,
     destination_name: &Path,
     expected_source: CloneNodeIdentity,
+    expected_directory: bool,
 ) -> std::io::Result<()> {
     use std::os::fd::AsFd;
 
     let named = source_parent.symlink_metadata(source_name)?;
     if named.file_type().is_symlink()
-        || !named.is_dir()
+        || named.is_dir() != expected_directory
+        || named.is_file() == expected_directory
         || cap_node_identity(&named) != expected_source
     {
         return Err(std::io::Error::new(
@@ -693,27 +1226,29 @@ fn rename_stage_noreplace(
 }
 
 #[cfg(windows)]
-fn rename_stage_noreplace(
+fn rename_entry_noreplace(
     source_parent: &CapDir,
     source_name: &Path,
     destination_parent: &CapDir,
     destination_name: &Path,
     expected_source: CloneNodeIdentity,
+    expected_directory: bool,
 ) -> std::io::Result<()> {
     use std::os::windows::ffi::OsStrExt;
     use std::os::windows::fs::MetadataExt;
     use std::os::windows::io::{AsRawHandle, FromRawHandle};
     use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
     use windows_sys::Wdk::Storage::FileSystem::{
-        FileRenameInformationEx, NtCreateFile, NtSetInformationFile, FILE_OPEN,
-        FILE_OPEN_REPARSE_POINT, FILE_RENAME_INFORMATION, FILE_SYNCHRONOUS_IO_NONALERT,
+        FileRenameInformationEx, NtCreateFile, NtSetInformationFile, FILE_DIRECTORY_FILE,
+        FILE_NON_DIRECTORY_FILE, FILE_OPEN, FILE_OPEN_REPARSE_POINT, FILE_RENAME_INFORMATION,
+        FILE_SYNCHRONOUS_IO_NONALERT,
     };
     use windows_sys::Win32::Foundation::{
         RtlNtStatusToDosError, HANDLE, OBJ_CASE_INSENSITIVE, UNICODE_STRING,
     };
     use windows_sys::Win32::Storage::FileSystem::{
-        DELETE, FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_REPARSE_POINT, FILE_LIST_DIRECTORY,
-        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, SYNCHRONIZE,
+        DELETE, FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, SYNCHRONIZE,
     };
     use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
 
@@ -743,14 +1278,20 @@ fn rename_stage_noreplace(
     let opened = unsafe {
         NtCreateFile(
             &mut source_handle,
-            DELETE | FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+            DELETE | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
             &source_attributes,
             &mut source_status,
             std::ptr::null(),
             FILE_ATTRIBUTE_NORMAL,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
             FILE_OPEN,
-            FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT,
+            FILE_OPEN_REPARSE_POINT
+                | FILE_SYNCHRONOUS_IO_NONALERT
+                | if expected_directory {
+                    FILE_DIRECTORY_FILE
+                } else {
+                    FILE_NON_DIRECTORY_FILE
+                },
             std::ptr::null(),
             0,
         )
@@ -762,7 +1303,8 @@ fn rename_stage_noreplace(
     }
     let source = unsafe { std::fs::File::from_raw_handle(source_handle) };
     let metadata = source.metadata()?;
-    if !metadata.is_dir()
+    if metadata.is_dir() != expected_directory
+        || metadata.is_file() == expected_directory
         || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
         || bamboo_skills::clone_publication::std_file_identity(&source) != Some(expected_source)
     {
@@ -821,17 +1363,68 @@ fn rename_stage_noreplace(
     target_vendor = "apple",
     target_os = "redox"
 )))]
-fn rename_stage_noreplace(
+fn rename_entry_noreplace(
     _source_parent: &CapDir,
     _source_name: &Path,
     _destination_parent: &CapDir,
     _destination_name: &Path,
     _expected_source: CloneNodeIdentity,
+    _expected_directory: bool,
 ) -> std::io::Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "atomic no-replace directory publication is unavailable on this platform",
     ))
+}
+
+fn rename_stage_noreplace(
+    source_parent: &CapDir,
+    source_name: &Path,
+    destination_parent: &CapDir,
+    destination_name: &Path,
+    expected_source: CloneNodeIdentity,
+) -> std::io::Result<()> {
+    rename_entry_noreplace(
+        source_parent,
+        source_name,
+        destination_parent,
+        destination_name,
+        expected_source,
+        true,
+    )
+}
+
+fn marker_matches_request(
+    marker: &ClonePublicationMarker,
+    requested: &ClonePublicationMarker,
+) -> bool {
+    marker.schema == requested.schema
+        && marker.workflow_id == requested.workflow_id
+        && marker.source_revision == requested.source_revision
+        && marker.source_content_digest == requested.source_content_digest
+        && marker.bundle_digest == requested.bundle_digest
+}
+
+fn stage_is_empty(stage: &CapDir) -> Result<bool, ClonePublicationError> {
+    Ok(stage.entries()?.next().transpose()?.is_none())
+}
+
+fn open_exact_stage(
+    transaction_parent: &CapDir,
+    marker: &ClonePublicationMarker,
+) -> Result<CapDir, ClonePublicationError> {
+    let expected = marker
+        .stage_identity
+        .ok_or(ClonePublicationError::Conflict(
+            "Workflow clone staging identity is missing",
+        ))?;
+    let stage = open_real_child_dir(transaction_parent, Path::new(&marker.staging_name))?;
+    if cap_node_identity(&stage.dir_metadata()?) != expected {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone staging identity differs from its durable marker",
+        ));
+    }
+    Ok(stage)
 }
 
 pub(super) fn publish_builtin_clone(
@@ -862,21 +1455,13 @@ fn publish_builtin_clone_with_fault(
     validate_clone_bundle(files)?;
     let root = open_publication_root(trusted_root)?;
     let transaction_parent = open_transaction_parent(&root)?;
+    let _transaction_lock = lock_clone_transactions(&transaction_parent)?;
     let target_name = Path::new(workflow_id);
-    match root.skills_dir.symlink_metadata(target_name) {
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Ok(_) => {
-            return Err(ClonePublicationError::Conflict(
-                "Workflow already exists in the target layer",
-            ));
-        }
-        Err(error) => return Err(error.into()),
-    }
-
     let marker_name = PathBuf::from(clone_marker_name(workflow_id));
+    recover_interrupted_rollover(&root, &transaction_parent, workflow_id, &marker_name)?;
     let staging_name = format!("txn-{}", uuid::Uuid::new_v4());
     let bundle_digest = builtin_clone_bundle_digest(files);
-    let mut marker = ClonePublicationMarker {
+    let requested = ClonePublicationMarker {
         schema: CLONE_MARKER_SCHEMA,
         workflow_id: workflow_id.to_string(),
         source_revision,
@@ -887,71 +1472,243 @@ fn publish_builtin_clone_with_fault(
         stage_identity: None,
         target_identity: None,
     };
-    if !marker.validate_for(workflow_id) {
+    if !requested.validate_for(workflow_id) {
         return Err(ClonePublicationError::Internal(
             "Workflow clone marker validation failed",
         ));
     }
-    let mut marker_options = CapOpenOptions::new();
-    marker_options.read(true).write(true).create_new(true);
-    let mut marker_file = match root.skills_dir.open_with(&marker_name, &marker_options) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+    let (mut marker, marker_created) = match open_clone_marker(&root, &marker_name, workflow_id)? {
+        Some(marker) => (marker, false),
+        None => (create_clone_marker(&root, &marker_name, workflow_id)?, true),
+    };
+    if marker.journal.records.is_empty() {
+        if !marker_created {
             return Err(ClonePublicationError::Conflict(
-                "Workflow clone marker already exists",
+                "Workflow clone marker contains unowned partial data",
             ));
         }
-        Err(error) => return Err(error.into()),
-    };
-    let marker_metadata = marker_file.metadata()?;
-    if !marker_metadata.is_file() || !cap_regular_file_has_single_link(&marker_metadata) {
-        return Err(ClonePublicationError::Conflict(
-            "Workflow clone marker is not exclusively owned",
-        ));
-    }
-    let marker_identity = cap_node_identity(&marker_metadata);
-    write_marker(
-        &root,
-        &marker_name,
-        &mut marker_file,
-        marker_identity,
-        &marker,
-    )?;
-    #[cfg(test)]
-    if _fault == PublicationFault::StopAfterPrepared {
-        return Err(injected_failure());
+        append_marker_record(&root, &marker_name, workflow_id, &mut marker, &requested)?;
+        #[cfg(test)]
+        if _fault == PublicationFault::StopAfterPrepared {
+            return Err(injected_failure());
+        }
     }
 
-    match root.skills_dir.symlink_metadata(target_name) {
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Ok(_) => {
-            return Err(ClonePublicationError::Conflict(
-                "Workflow appeared in the target layer while cloning",
-            ));
+    let mut current = marker
+        .journal
+        .current()
+        .cloned()
+        .ok_or(ClonePublicationError::Conflict(
+            "Workflow clone marker is incomplete",
+        ))?;
+
+    if current.phase == ClonePublicationPhase::Complete {
+        match root.skills_dir.symlink_metadata(target_name) {
+            Ok(metadata) => {
+                let expected = current
+                    .target_identity
+                    .ok_or(ClonePublicationError::Conflict(
+                        "Workflow clone completion identity is missing",
+                    ))?;
+                if metadata.file_type().is_symlink()
+                    || !metadata.is_dir()
+                    || cap_node_identity(&metadata) != expected
+                {
+                    return Err(ClonePublicationError::Conflict(
+                        "Workflow clone completed target was replaced",
+                    ));
+                }
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow already exists in the target layer",
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if current.source_revision != requested.source_revision
+                    && current.source_content_digest == requested.source_content_digest
+                    && current.bundle_digest == requested.bundle_digest
+                {
+                    return Err(ClonePublicationError::Conflict(
+                        "Workflow clone revision changed without a new embedded identity",
+                    ));
+                }
+                let retired = ClonePublicationMarker {
+                    phase: ClonePublicationPhase::Retired,
+                    ..current.clone()
+                };
+                append_marker_record(&root, &marker_name, workflow_id, &mut marker, &retired)?;
+                current = retired;
+                #[cfg(test)]
+                if _fault == PublicationFault::StopAfterRetired {
+                    return Err(injected_failure());
+                }
+            }
+            Err(error) => return Err(error.into()),
         }
-        Err(error) => return Err(error.into()),
     }
-    transaction_parent.create_dir(&staging_name)?;
-    sync_cap_directory(&transaction_parent)?;
-    let stage = open_real_child_dir(&transaction_parent, Path::new(&staging_name))?;
-    let stage_identity = cap_node_identity(&stage.dir_metadata()?);
-    populate_stage(&stage, files)?;
-    verify_clone_tree(&stage, files)?;
-    sync_clone_tree_directories(&stage)?;
-    ensure_open_child_is_still_named(&transaction_parent, Path::new(&staging_name), &stage)?;
-    marker.phase = ClonePublicationPhase::Staged;
-    marker.stage_identity = Some(stage_identity);
-    write_marker(
-        &root,
-        &marker_name,
-        &mut marker_file,
-        marker_identity,
-        &marker,
-    )?;
-    #[cfg(test)]
-    if _fault == PublicationFault::StopAfterStaged {
-        return Err(injected_failure());
+
+    if current.phase == ClonePublicationPhase::Aborted {
+        match root.skills_dir.symlink_metadata(target_name) {
+            Ok(_) => {
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow already exists in the target layer",
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        if !marker_matches_request(&current, &requested) {
+            if current.stage_identity.is_some() {
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow clone has a recoverable staged older revision",
+                ));
+            }
+            marker = rollover_terminal_marker(
+                &root,
+                &transaction_parent,
+                workflow_id,
+                &marker_name,
+                marker,
+                &requested,
+                _fault,
+            )?;
+            current = requested.clone();
+        } else if let Some(previous) = marker.journal.records.iter().rev().nth(1).cloned() {
+            match previous.phase {
+                ClonePublicationPhase::Prepared => {}
+                ClonePublicationPhase::StageBound => {
+                    let stage = open_exact_stage(&transaction_parent, &previous)?;
+                    if !stage_is_empty(&stage)? {
+                        return Err(ClonePublicationError::Conflict(
+                            "Workflow clone aborted staging directory is divergent",
+                        ));
+                    }
+                }
+                ClonePublicationPhase::Staged => {
+                    let stage = open_exact_stage(&transaction_parent, &previous)?;
+                    verify_clone_tree(&stage, files)?;
+                }
+                _ => {
+                    return Err(ClonePublicationError::Conflict(
+                        "Workflow clone abort recovery state is invalid",
+                    ));
+                }
+            }
+            append_marker_record(&root, &marker_name, workflow_id, &mut marker, &previous)?;
+            current = previous;
+        }
     }
+
+    if current.phase == ClonePublicationPhase::Retired {
+        marker = rollover_terminal_marker(
+            &root,
+            &transaction_parent,
+            workflow_id,
+            &marker_name,
+            marker,
+            &requested,
+            _fault,
+        )?;
+        current = requested.clone();
+    }
+
+    if !marker_matches_request(&current, &requested) {
+        return Err(ClonePublicationError::Conflict(
+            "A different Workflow clone transaction requires recovery",
+        ));
+    }
+
+    if current.phase == ClonePublicationPhase::Prepared {
+        match root.skills_dir.symlink_metadata(target_name) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Ok(_) => {
+                let aborted = ClonePublicationMarker {
+                    phase: ClonePublicationPhase::Aborted,
+                    ..current.clone()
+                };
+                append_marker_record(&root, &marker_name, workflow_id, &mut marker, &aborted)?;
+                return Err(ClonePublicationError::Conflict(
+                    "Workflow appeared in the target layer while cloning",
+                ));
+            }
+            Err(error) => return Err(error.into()),
+        }
+        let stage_name = Path::new(&current.staging_name);
+        let stage = match transaction_parent.symlink_metadata(stage_name) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                transaction_parent.create_dir(stage_name)?;
+                sync_cap_directory(&transaction_parent)?;
+                open_real_child_dir(&transaction_parent, stage_name)?
+            }
+            Ok(expected) => {
+                let stage =
+                    open_expected_real_child_dir(&transaction_parent, stage_name, &expected)?;
+                if !stage_is_empty(&stage)? {
+                    return Err(ClonePublicationError::Conflict(
+                        "Workflow clone unbound staging directory is not empty",
+                    ));
+                }
+                stage
+            }
+            Err(error) => return Err(error.into()),
+        };
+        #[cfg(test)]
+        if _fault == PublicationFault::StopAfterStageDirectory {
+            return Err(injected_failure());
+        }
+        let stage_bound = ClonePublicationMarker {
+            phase: ClonePublicationPhase::StageBound,
+            stage_identity: Some(cap_node_identity(&stage.dir_metadata()?)),
+            ..current.clone()
+        };
+        append_marker_record(&root, &marker_name, workflow_id, &mut marker, &stage_bound)?;
+        current = stage_bound;
+        #[cfg(test)]
+        if _fault == PublicationFault::StopAfterStageBound {
+            return Err(injected_failure());
+        }
+    }
+
+    if current.phase == ClonePublicationPhase::StageBound {
+        let stage = open_exact_stage(&transaction_parent, &current)?;
+        if stage_is_empty(&stage)? {
+            populate_stage(&stage, files)?;
+        } else {
+            verify_clone_tree(&stage, files)?;
+        }
+        verify_clone_tree(&stage, files)?;
+        sync_clone_tree_directories(&stage)?;
+        ensure_open_child_is_still_named(
+            &transaction_parent,
+            Path::new(&current.staging_name),
+            &stage,
+        )?;
+        #[cfg(test)]
+        if _fault == PublicationFault::StopAfterStagePopulated {
+            return Err(injected_failure());
+        }
+        let staged = ClonePublicationMarker {
+            phase: ClonePublicationPhase::Staged,
+            ..current.clone()
+        };
+        append_marker_record(&root, &marker_name, workflow_id, &mut marker, &staged)?;
+        current = staged;
+        #[cfg(test)]
+        if _fault == PublicationFault::StopAfterStaged {
+            return Err(injected_failure());
+        }
+    }
+
+    if current.phase != ClonePublicationPhase::Staged {
+        return Err(ClonePublicationError::Conflict(
+            "Workflow clone transaction is not publishable",
+        ));
+    }
+    let stage_identity = current
+        .stage_identity
+        .ok_or(ClonePublicationError::Conflict(
+            "Workflow clone staging identity is missing",
+        ))?;
+
     #[cfg(test)]
     if _fault == PublicationFault::TargetDirectoryBeforeRename {
         root.skills_dir.create_dir(target_name)?;
@@ -964,15 +1721,50 @@ fn publish_builtin_clone_with_fault(
         sync_cap_directory(&competitor)?;
         sync_cap_directory(&root.skills_dir)?;
     }
-    drop(stage);
-
-    let rename_result = rename_stage_noreplace(
-        &transaction_parent,
-        Path::new(&staging_name),
-        &root.skills_dir,
-        target_name,
-        stage_identity,
-    );
+    let existing_target = root.skills_dir.symlink_metadata(target_name);
+    let rename_result = match existing_target {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let stage = open_exact_stage(&transaction_parent, &current)?;
+            verify_clone_tree(&stage, files)?;
+            drop(stage);
+            rename_stage_noreplace(
+                &transaction_parent,
+                Path::new(&current.staging_name),
+                &root.skills_dir,
+                target_name,
+                stage_identity,
+            )
+        }
+        Ok(metadata)
+            if !metadata.file_type().is_symlink()
+                && metadata.is_dir()
+                && cap_node_identity(&metadata) == stage_identity =>
+        {
+            Ok(())
+        }
+        Ok(_) => {
+            let stage_matches = open_optional_real_child_dir(
+                &transaction_parent,
+                Path::new(&current.staging_name),
+            )?
+            .is_some_and(|stage| {
+                stage
+                    .dir_metadata()
+                    .is_ok_and(|metadata| cap_node_identity(&metadata) == stage_identity)
+            });
+            if stage_matches {
+                let aborted = ClonePublicationMarker {
+                    phase: ClonePublicationPhase::Aborted,
+                    ..current.clone()
+                };
+                append_marker_record(&root, &marker_name, workflow_id, &mut marker, &aborted)?;
+            }
+            return Err(ClonePublicationError::Conflict(
+                "Workflow appeared in the target layer while cloning",
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    };
     #[cfg(test)]
     let rename_result =
         if rename_result.is_ok() && _fault == PublicationFault::RenameReportsErrorAfterMove {
@@ -997,6 +1789,20 @@ fn publish_builtin_clone_with_fault(
     };
     let target_identity = cap_node_identity(&target.dir_metadata()?);
     if target_identity != stage_identity {
+        let stage_matches =
+            open_optional_real_child_dir(&transaction_parent, Path::new(&current.staging_name))?
+                .is_some_and(|stage| {
+                    stage
+                        .dir_metadata()
+                        .is_ok_and(|metadata| cap_node_identity(&metadata) == stage_identity)
+                });
+        if stage_matches {
+            let aborted = ClonePublicationMarker {
+                phase: ClonePublicationPhase::Aborted,
+                ..current.clone()
+            };
+            append_marker_record(&root, &marker_name, workflow_id, &mut marker, &aborted)?;
+        }
         return Err(ClonePublicationError::Conflict(
             "Workflow clone publication resolved to a different target",
         ));
@@ -1011,15 +1817,12 @@ fn publish_builtin_clone_with_fault(
         return Err(injected_failure());
     }
 
-    marker.phase = ClonePublicationPhase::Complete;
-    marker.target_identity = Some(target_identity);
-    write_marker(
-        &root,
-        &marker_name,
-        &mut marker_file,
-        marker_identity,
-        &marker,
-    )?;
+    let complete = ClonePublicationMarker {
+        phase: ClonePublicationPhase::Complete,
+        target_identity: Some(target_identity),
+        ..current
+    };
+    append_marker_record(&root, &marker_name, workflow_id, &mut marker, &complete)?;
     Ok(ClonePublicationReceipt { target_identity })
 }
 
@@ -1042,6 +1845,30 @@ mod tests {
         fault: PublicationFault,
     ) -> Result<ClonePublicationReceipt, ClonePublicationError> {
         publish_builtin_clone_with_fault(root, "review", 7, &"a".repeat(64), &review_files(), fault)
+    }
+
+    fn publish_revision(
+        root: &Path,
+        revision: u64,
+        digest: char,
+        fault: PublicationFault,
+    ) -> Result<ClonePublicationReceipt, ClonePublicationError> {
+        publish_builtin_clone_with_fault(
+            root,
+            "review",
+            revision,
+            &digest.to_string().repeat(64),
+            &review_files(),
+            fault,
+        )
+    }
+
+    fn current_marker(root: &Path) -> ClonePublicationMarker {
+        let bytes =
+            std::fs::read(root.join("skills/.review.clone-v1.json")).expect("durable marker");
+        let journal = parse_clone_marker_journal(&bytes, "review").expect("marker journal");
+        assert!(journal.partial.is_empty());
+        journal.current().cloned().expect("current marker")
     }
 
     #[test]
@@ -1126,25 +1953,30 @@ mod tests {
     }
 
     #[test]
-    fn crash_points_leave_incomplete_marker_and_never_expose_partial_target() {
+    fn crash_points_resume_exact_transaction_without_exposing_partial_target() {
         for fault in [
             PublicationFault::StopAfterPrepared,
+            PublicationFault::StopAfterStageDirectory,
+            PublicationFault::StopAfterStageBound,
+            PublicationFault::StopAfterStagePopulated,
             PublicationFault::StopAfterStaged,
             PublicationFault::StopAfterRename,
         ] {
             let root = tempfile::tempdir().expect("root");
             assert!(publish_with_fault(root.path(), fault).is_err());
-            let marker: ClonePublicationMarker = serde_json::from_slice(
-                &std::fs::read(root.path().join("skills/.review.clone-v1.json"))
-                    .expect("durable marker"),
-            )
-            .expect("marker JSON");
+            let marker = current_marker(root.path());
             assert_ne!(marker.phase, ClonePublicationPhase::Complete);
             if fault == PublicationFault::StopAfterRename {
                 assert!(root.path().join("skills/review/SKILL.md").is_file());
             } else {
                 assert!(!root.path().join("skills/review").exists());
             }
+            publish_with_fault(root.path(), PublicationFault::None)
+                .expect("exact interrupted transaction resumes");
+            assert_eq!(
+                current_marker(root.path()).phase,
+                ClonePublicationPhase::Complete
+            );
         }
     }
 
@@ -1159,15 +1991,140 @@ mod tests {
             std::fs::read(root.path().join("skills/review/sentinel.txt")).unwrap(),
             b"competitor-owned"
         );
+        assert_eq!(
+            current_marker(root.path()).phase,
+            ClonePublicationPhase::Aborted
+        );
+        std::fs::remove_dir_all(root.path().join("skills/review")).expect("remove competitor");
+        publish_with_fault(root.path(), PublicationFault::None)
+            .expect("aborted exact stage resumes after competitor leaves");
 
         let root = tempfile::tempdir().expect("root");
         publish_with_fault(root.path(), PublicationFault::RenameReportsErrorAfterMove)
             .expect("exact moved target reconciles");
-        let marker: ClonePublicationMarker = serde_json::from_slice(
-            &std::fs::read(root.path().join("skills/.review.clone-v1.json")).unwrap(),
-        )
-        .unwrap();
+        let marker = current_marker(root.path());
         assert_eq!(marker.phase, ClonePublicationPhase::Complete);
         assert_eq!(marker.stage_identity, marker.target_identity);
+    }
+
+    #[test]
+    fn bound_aborted_stage_is_not_discarded_for_a_different_revision() {
+        let root = tempfile::tempdir().expect("root");
+        assert!(matches!(
+            publish_revision(
+                root.path(),
+                7,
+                'a',
+                PublicationFault::TargetDirectoryBeforeRename,
+            ),
+            Err(ClonePublicationError::Conflict(_))
+        ));
+        std::fs::remove_dir_all(root.path().join("skills/review")).expect("remove competitor");
+        let marker_before = current_marker(root.path());
+        let stage = root
+            .path()
+            .join(CLONE_TRANSACTION_DIRECTORY)
+            .join(&marker_before.staging_name);
+        let stage_skill = std::fs::read(stage.join("SKILL.md")).expect("bound stage");
+
+        assert!(matches!(
+            publish_revision(root.path(), 8, 'b', PublicationFault::None),
+            Err(ClonePublicationError::Conflict(_))
+        ));
+        assert_eq!(current_marker(root.path()), marker_before);
+        assert_eq!(
+            std::fs::read(stage.join("SKILL.md")).expect("preserved bound stage"),
+            stage_skill
+        );
+        assert!(!root.path().join("skills/review").exists());
+    }
+
+    #[test]
+    fn completed_target_deletion_retires_reclones_and_upgrades_revision() {
+        let root = tempfile::tempdir().expect("root");
+        publish_revision(root.path(), 7, 'a', PublicationFault::None).expect("revision seven");
+        let first_identity = current_marker(root.path()).target_identity;
+        std::fs::remove_dir_all(root.path().join("skills/review")).expect("delete clone");
+
+        publish_revision(root.path(), 8, 'b', PublicationFault::None).expect("revision eight");
+        let marker = current_marker(root.path());
+        assert_eq!(marker.phase, ClonePublicationPhase::Complete);
+        assert_eq!(marker.source_revision, 8);
+        assert_ne!(marker.target_identity, first_identity);
+    }
+
+    #[test]
+    fn completed_target_foreign_replacement_is_never_retired_or_mutated() {
+        let root = tempfile::tempdir().expect("root");
+        publish_with_fault(root.path(), PublicationFault::None).expect("publish");
+        let marker_before =
+            std::fs::read(root.path().join("skills/.review.clone-v1.json")).expect("marker before");
+        std::fs::remove_dir_all(root.path().join("skills/review")).expect("delete clone");
+        std::fs::create_dir(root.path().join("skills/review")).expect("foreign directory");
+        std::fs::write(
+            root.path().join("skills/review/sentinel.txt"),
+            b"foreign-owned",
+        )
+        .expect("foreign bytes");
+
+        assert!(matches!(
+            publish_revision(root.path(), 8, 'b', PublicationFault::None),
+            Err(ClonePublicationError::Conflict(_))
+        ));
+        assert_eq!(
+            std::fs::read(root.path().join("skills/review/sentinel.txt")).unwrap(),
+            b"foreign-owned"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("skills/.review.clone-v1.json")).unwrap(),
+            marker_before
+        );
+    }
+
+    #[test]
+    fn retirement_and_rollover_crash_points_forward_recover() {
+        for fault in [
+            PublicationFault::StopAfterRetired,
+            PublicationFault::StopAfterRolloverReset,
+            PublicationFault::StopAfterRolloverArchive,
+            PublicationFault::StopAfterRolloverInstall,
+        ] {
+            let root = tempfile::tempdir().expect("root");
+            publish_with_fault(root.path(), PublicationFault::None).expect("publish");
+            std::fs::remove_dir_all(root.path().join("skills/review")).expect("delete clone");
+            assert!(publish_with_fault(root.path(), fault).is_err());
+            publish_with_fault(root.path(), PublicationFault::None)
+                .expect("retirement rollover resumes");
+            assert_eq!(
+                current_marker(root.path()).phase,
+                ClonePublicationPhase::Complete
+            );
+        }
+    }
+
+    #[test]
+    fn repeated_retire_reclone_keeps_transaction_files_bounded() {
+        let root = tempfile::tempdir().expect("root");
+        for cycle in 0..12 {
+            publish_revision(
+                root.path(),
+                7 + cycle,
+                if cycle % 2 == 0 { 'a' } else { 'b' },
+                PublicationFault::None,
+            )
+            .expect("publication cycle");
+            let marker = std::fs::read(root.path().join("skills/.review.clone-v1.json"))
+                .expect("canonical marker");
+            assert!(marker.len() <= MAX_CLONE_MARKER_BYTES);
+            let transaction_entries =
+                walkdir::WalkDir::new(root.path().join(CLONE_TRANSACTION_DIRECTORY))
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("transaction entries");
+            assert!(transaction_entries.len() <= 6);
+            if cycle < 11 {
+                std::fs::remove_dir_all(root.path().join("skills/review")).expect("delete clone");
+            }
+        }
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -3,8 +3,11 @@ use std::sync::Arc;
 
 use actix_web::{http::StatusCode, web, HttpResponse};
 use bamboo_skills::catalog::workflow_catalog_content_digest;
+use bamboo_skills::clone_publication::clone_marker_name;
 use bamboo_skills::legacy::LegacyWorkflowMigrationOutcome;
-use bamboo_skills::store::builtin::{builtin_clone_files, load_builtin_skill_bundles};
+use bamboo_skills::store::builtin::{
+    builtin_clone_files, builtin_workflow_catalog_entry, load_builtin_skill_bundles,
+};
 use bamboo_skills::{
     LegacyWorkflowMigrationStatus, SkillStore, WorkflowCatalogEntry, WorkflowCatalogSnapshot,
     WorkflowSource, WorkflowStatus,
@@ -355,8 +358,9 @@ fn unique_winner<'a>(
 
 /// Publish one exact builtin Workflow into the canonical Project or user layer.
 ///
-/// This endpoint is intentionally fresh-publication-only. Recovery, marker
-/// retirement and delete/reclone are owned by #874.
+/// Interrupted exact transactions resume from their durable marker. A deleted
+/// completed generation retires before a bounded no-replace epoch rollover;
+/// existing or replacement targets are never adopted or overwritten.
 pub async fn clone_workflow(
     app_state: web::Data<AppState>,
     workflow_id: web::Path<String>,
@@ -397,14 +401,8 @@ pub async fn clone_workflow(
         ));
     }
     let source_catalog = combined_catalog_snapshot(&scope.store).await;
-    let source_entry = match unique_winner(&source_catalog, &workflow_id) {
-        Ok(Some(entry)) => entry.clone(),
-        Ok(None) => {
-            return Ok(fixed_clone_error(
-                StatusCode::NOT_FOUND,
-                "Workflow is not available",
-            ));
-        }
+    let catalog_winner = match unique_winner(&source_catalog, &workflow_id) {
+        Ok(entry) => entry.cloned(),
         Err(()) => {
             return Ok(fixed_clone_error(
                 StatusCode::CONFLICT,
@@ -412,16 +410,6 @@ pub async fn clone_workflow(
             ));
         }
     };
-    if source_entry.source != WorkflowSource::Builtin
-        || source_entry.status != WorkflowStatus::Valid
-        || source_entry.revision != payload.revision
-        || source_entry.content_digest != payload.content_digest
-    {
-        return Ok(fixed_clone_error(
-            StatusCode::CONFLICT,
-            "Workflow clone selection is stale or shadowed",
-        ));
-    }
 
     let bundles = match load_builtin_skill_bundles() {
         Ok(bundles) => bundles,
@@ -442,15 +430,57 @@ pub async fn clone_workflow(
             "Workflow clone source is not an embedded bundle",
         ));
     };
-    let source_digest = workflow_catalog_content_digest(
-        &source_entry,
-        Some(&bundle.skill),
-        bundle
-            .files
-            .iter()
-            .map(|(path, bytes)| (path.as_str(), bytes.as_slice())),
-    );
-    if source_digest != source_entry.content_digest {
+    let source_entry = match builtin_workflow_catalog_entry(&bundle, payload.revision) {
+        Ok(entry) => entry,
+        Err(error) => {
+            tracing::error!(%error, "failed to rebuild builtin Workflow catalog identity");
+            return Ok(fixed_clone_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Builtin Workflow identity is unavailable",
+            ));
+        }
+    };
+    if source_entry.revision != payload.revision
+        || source_entry.content_digest != payload.content_digest
+    {
+        return Ok(fixed_clone_error(
+            StatusCode::CONFLICT,
+            "Workflow clone selection is stale or shadowed",
+        ));
+    }
+    let winner_is_exact_builtin = catalog_winner.as_ref().is_some_and(|entry| {
+        entry.source == WorkflowSource::Builtin
+            && entry.status == WorkflowStatus::Valid
+            && entry.revision == payload.revision
+            && entry.content_digest == payload.content_digest
+    });
+    if !winner_is_exact_builtin {
+        let marker = scope
+            .trusted_root
+            .join("skills")
+            .join(clone_marker_name(&workflow_id));
+        match tokio::fs::symlink_metadata(&marker).await {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(fixed_clone_error(
+                    if catalog_winner.is_some() {
+                        StatusCode::CONFLICT
+                    } else {
+                        StatusCode::NOT_FOUND
+                    },
+                    "Workflow clone selection is stale or shadowed",
+                ));
+            }
+            Err(error) => {
+                tracing::error!(%error, workflow_id, "failed to inspect Workflow clone recovery marker");
+                return Ok(fixed_clone_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Workflow clone publication failed",
+                ));
+            }
+        }
+    }
+    if source_entry.source != WorkflowSource::Builtin {
         tracing::error!(
             workflow_id,
             "builtin Workflow catalog identity diverged from embedded bytes"

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -316,6 +316,46 @@ async fn user_builtin_clone_is_exact_private_and_fresh_only() {
         std::fs::read(target.join("SKILL.md")).expect("unchanged clone"),
         before
     );
+
+    std::fs::remove_dir_all(&target).expect("delete editable clone generation");
+    store.reload().await.expect("reload deleted generation");
+    let stale_revision = serde_json::json!({
+        "source": "builtin",
+        "revision": source.revision + 1,
+        "content_digest": source.content_digest.clone(),
+        "target": "user"
+    });
+    let stale = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/review/clone")
+            .set_json(stale_revision)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(stale.status(), actix_web::http::StatusCode::CONFLICT);
+    assert!(!target.exists());
+
+    let recloned = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/review/clone")
+            .set_json(&request_json)
+            .to_request(),
+    )
+    .await;
+    let recloned_status = recloned.status();
+    let recloned_body = actix_web::test::read_body(recloned).await;
+    assert_eq!(
+        recloned_status,
+        actix_web::http::StatusCode::CREATED,
+        "{}",
+        String::from_utf8_lossy(&recloned_body)
+    );
+    assert_eq!(
+        std::fs::read(target.join("SKILL.md")).expect("recloned definition"),
+        before
+    );
 }
 
 #[actix_web::test]

--- a/crates/infra/bamboo-skills/src/catalog.rs
+++ b/crates/infra/bamboo-skills/src/catalog.rs
@@ -283,20 +283,29 @@ pub(crate) async fn load_bundle_metadata(root: &Path) -> Result<BundleMetadata, 
     } else {
         "agents/bamboo.yaml"
     };
-    let raw = tokio::fs::read_to_string(&path)
+    let raw = tokio::fs::read(&path)
         .await
         .map_err(|error| format!("{display_name}: {error}"))?;
+    parse_bundle_metadata_bytes(display_name, &raw, path.ends_with("workflow.yaml"))
+}
+
+pub(crate) fn parse_bundle_metadata_bytes(
+    display_name: &str,
+    raw: &[u8],
+    is_workflow_definition: bool,
+) -> Result<BundleMetadata, String> {
+    let raw = std::str::from_utf8(raw)
+        .map_err(|_| format!("{display_name}: metadata is not valid UTF-8"))?;
     let metadata: BambooWorkflowMetadata =
-        serde_yaml::from_str(&raw).map_err(|error| public_yaml_error(display_name, error))?;
-    let is_workflow_definition = path.ends_with("workflow.yaml");
+        serde_yaml::from_str(raw).map_err(|error| public_yaml_error(display_name, error))?;
     if is_workflow_definition {
         if metadata.workflow_schema.is_some() {
-            let definition: bamboo_domain::WorkflowRunDefinition = serde_yaml::from_str(&raw)
+            let definition: bamboo_domain::WorkflowRunDefinition = serde_yaml::from_str(raw)
                 .map_err(|error| public_yaml_error(display_name, error))?;
             bamboo_domain::CompiledWorkflow::compile(definition.clone())
                 .map_err(|error| public_validation_error(display_name, error))?;
         } else {
-            let definition: bamboo_domain::WorkflowDefinition = serde_yaml::from_str(&raw)
+            let definition: bamboo_domain::WorkflowDefinition = serde_yaml::from_str(raw)
                 .map_err(|error| public_yaml_error(display_name, error))?;
             definition
                 .validate()
@@ -318,7 +327,7 @@ pub(crate) async fn load_bundle_metadata(root: &Path) -> Result<BundleMetadata, 
     }
     if is_workflow_definition && metadata.workflow_schema.is_some() {
         let definition: bamboo_domain::WorkflowRunDefinition =
-            serde_yaml::from_str(&raw).map_err(|error| public_yaml_error(display_name, error))?;
+            serde_yaml::from_str(raw).map_err(|error| public_yaml_error(display_name, error))?;
         result.version = definition.workflow_schema.to_string();
         result.argument_schema = definition.input_schema.clone();
         result.definition_revision = Some(definition.revision);

--- a/crates/infra/bamboo-skills/src/clone_publication.rs
+++ b/crates/infra/bamboo-skills/src/clone_publication.rs
@@ -1,14 +1,14 @@
-//! Shared, metadata-only boundary for fresh builtin Workflow clone publication.
+//! Shared, metadata-only boundary for builtin Workflow clone publication.
 //!
 //! The server owns the write protocol. Discovery only consumes this sealed
-//! receipt to decide whether a target directory may be catalog-visible. Crash
-//! recovery, retirement and delete/reclone epochs deliberately live in the
-//! follow-up recovery slice rather than this fresh-publication contract.
+//! journal to decide whether a target directory may be catalog-visible. Each
+//! bounded epoch is recoverable until completion, abort, or retirement.
 
 use serde::{Deserialize, Serialize};
 
 pub const CLONE_MARKER_SCHEMA: u8 = 1;
 pub const MAX_CLONE_MARKER_BYTES: usize = 64 * 1024;
+pub const MAX_CLONE_MARKER_RECORDS: usize = 8;
 pub const MAX_CLONE_BUNDLE_FILES: usize = 1024;
 pub const MAX_CLONE_BUNDLE_BYTES: usize = 32 * 1024 * 1024;
 pub const MAX_CLONE_RELATIVE_PATH_BYTES: usize = 1024;
@@ -23,8 +23,11 @@ pub struct CloneNodeIdentity {
 #[serde(rename_all = "snake_case")]
 pub enum ClonePublicationPhase {
     Prepared,
+    StageBound,
     Staged,
     Complete,
+    Aborted,
+    Retired,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -55,10 +58,19 @@ impl ClonePublicationMarker {
                 ClonePublicationPhase::Prepared => {
                     self.stage_identity.is_none() && self.target_identity.is_none()
                 }
+                ClonePublicationPhase::StageBound => {
+                    self.stage_identity.is_some() && self.target_identity.is_none()
+                }
                 ClonePublicationPhase::Staged => {
                     self.stage_identity.is_some() && self.target_identity.is_none()
                 }
                 ClonePublicationPhase::Complete => {
+                    self.stage_identity.is_some()
+                        && self.target_identity.is_some()
+                        && self.stage_identity == self.target_identity
+                }
+                ClonePublicationPhase::Aborted => self.target_identity.is_none(),
+                ClonePublicationPhase::Retired => {
                     self.stage_identity.is_some()
                         && self.target_identity.is_some()
                         && self.stage_identity == self.target_identity
@@ -71,6 +83,121 @@ impl ClonePublicationMarker {
             .then_some(self.target_identity)
             .flatten()
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CloneMarkerJournal {
+    pub records: Vec<ClonePublicationMarker>,
+    pub partial: Vec<u8>,
+}
+
+impl CloneMarkerJournal {
+    pub fn current(&self) -> Option<&ClonePublicationMarker> {
+        self.records.last()
+    }
+}
+
+fn same_epoch(left: &ClonePublicationMarker, right: &ClonePublicationMarker) -> bool {
+    left.schema == right.schema
+        && left.workflow_id == right.workflow_id
+        && left.source_revision == right.source_revision
+        && left.source_content_digest == right.source_content_digest
+        && left.bundle_digest == right.bundle_digest
+        && left.staging_name == right.staging_name
+}
+
+fn valid_transition(previous: &ClonePublicationMarker, next: &ClonePublicationMarker) -> bool {
+    if previous == next {
+        return true;
+    }
+    if !same_epoch(previous, next) {
+        return false;
+    }
+    match (previous.phase, next.phase) {
+        (ClonePublicationPhase::Prepared, ClonePublicationPhase::StageBound) => {
+            next.stage_identity.is_some() && next.target_identity.is_none()
+        }
+        (ClonePublicationPhase::StageBound, ClonePublicationPhase::Staged) => {
+            previous.stage_identity == next.stage_identity && next.target_identity.is_none()
+        }
+        (ClonePublicationPhase::Staged, ClonePublicationPhase::Complete) => {
+            previous.stage_identity == next.stage_identity
+                && next.target_identity == next.stage_identity
+        }
+        (
+            ClonePublicationPhase::Prepared
+            | ClonePublicationPhase::StageBound
+            | ClonePublicationPhase::Staged,
+            ClonePublicationPhase::Aborted,
+        ) => previous.stage_identity == next.stage_identity && next.target_identity.is_none(),
+        (ClonePublicationPhase::Complete, ClonePublicationPhase::Retired) => {
+            previous.stage_identity == next.stage_identity
+                && previous.target_identity == next.target_identity
+        }
+        (ClonePublicationPhase::Aborted, ClonePublicationPhase::Prepared) => {
+            next.stage_identity.is_none() && next.target_identity.is_none()
+        }
+        (
+            ClonePublicationPhase::Aborted,
+            ClonePublicationPhase::StageBound | ClonePublicationPhase::Staged,
+        ) => previous.stage_identity == next.stage_identity && next.target_identity.is_none(),
+        _ => false,
+    }
+}
+
+/// Parse one bounded publication epoch. Records are newline-delimited so a
+/// crash can leave only a recoverable final prefix; the last complete record
+/// remains authoritative until that suffix is completed exactly.
+pub fn parse_clone_marker_journal(bytes: &[u8], workflow_id: &str) -> Option<CloneMarkerJournal> {
+    if bytes.len() > MAX_CLONE_MARKER_BYTES {
+        return None;
+    }
+
+    if !bytes.contains(&b'\n') {
+        if let Ok(record) = serde_json::from_slice::<ClonePublicationMarker>(bytes) {
+            return (record.validate_for(workflow_id)).then_some(CloneMarkerJournal {
+                records: vec![record],
+                partial: Vec::new(),
+            });
+        }
+        return Some(CloneMarkerJournal {
+            records: Vec::new(),
+            partial: bytes.to_vec(),
+        });
+    }
+
+    let complete_len = bytes
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |index| index + 1);
+    let mut records = Vec::new();
+    for line in bytes[..complete_len].split(|byte| *byte == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+        let record = serde_json::from_slice::<ClonePublicationMarker>(line).ok()?;
+        if !record.validate_for(workflow_id)
+            || records
+                .last()
+                .is_some_and(|previous| !valid_transition(previous, &record))
+        {
+            return None;
+        }
+        records.push(record);
+    }
+    if records.len() > MAX_CLONE_MARKER_RECORDS {
+        return None;
+    }
+    Some(CloneMarkerJournal {
+        records,
+        partial: bytes[complete_len..].to_vec(),
+    })
+}
+
+pub fn clone_marker_record_bytes(marker: &ClonePublicationMarker) -> Option<Vec<u8>> {
+    let mut bytes = serde_json::to_vec(marker).ok()?;
+    bytes.push(b'\n');
+    (bytes.len() <= MAX_CLONE_MARKER_BYTES).then_some(bytes)
 }
 
 pub fn clone_marker_name(workflow_id: &str) -> String {
@@ -152,7 +279,11 @@ mod tests {
             staging_name: "txn-12345678-1234-1234-1234-123456789abc".to_string(),
             phase,
             stage_identity: (phase != ClonePublicationPhase::Prepared).then_some(identity),
-            target_identity: (phase == ClonePublicationPhase::Complete).then_some(identity),
+            target_identity: matches!(
+                phase,
+                ClonePublicationPhase::Complete | ClonePublicationPhase::Retired
+            )
+            .then_some(identity),
         }
     }
 
@@ -160,8 +291,11 @@ mod tests {
     fn marker_phase_contract_is_strict_and_generation_bound() {
         for phase in [
             ClonePublicationPhase::Prepared,
+            ClonePublicationPhase::StageBound,
             ClonePublicationPhase::Staged,
             ClonePublicationPhase::Complete,
+            ClonePublicationPhase::Aborted,
+            ClonePublicationPhase::Retired,
         ] {
             assert!(marker(phase).validate_for("review"));
         }
@@ -170,5 +304,19 @@ mod tests {
         malformed.target_identity = None;
         assert!(!malformed.validate_for("review"));
         assert!(!marker(ClonePublicationPhase::Complete).validate_for("other"));
+    }
+
+    #[test]
+    fn journal_keeps_the_last_complete_transition_and_a_partial_suffix() {
+        let prepared = marker(ClonePublicationPhase::Prepared);
+        let stage_bound = marker(ClonePublicationPhase::StageBound);
+        let mut bytes = clone_marker_record_bytes(&prepared).unwrap();
+        bytes.extend(clone_marker_record_bytes(&stage_bound).unwrap());
+        let complete = clone_marker_record_bytes(&marker(ClonePublicationPhase::Staged)).unwrap();
+        bytes.extend(&complete[..complete.len() / 2]);
+
+        let journal = parse_clone_marker_journal(&bytes, "review").expect("journal");
+        assert_eq!(journal.records, vec![prepared, stage_bound]);
+        assert!(!journal.partial.is_empty());
     }
 }

--- a/crates/infra/bamboo-skills/src/store/builtin.rs
+++ b/crates/infra/bamboo-skills/src/store/builtin.rs
@@ -4,7 +4,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use sha2::{Digest, Sha256};
 
+use crate::catalog::{
+    entry_from_skill, parse_bundle_metadata_bytes, workflow_catalog_content_digest, BundleMetadata,
+    WorkflowCatalogEntry,
+};
 use crate::store::parser::{parse_markdown_skill, render_skill_markdown};
+use crate::store::storage::SkillDirectorySource;
 use crate::types::{SkillError, SkillResult};
 
 include!(concat!(env!("OUT_DIR"), "/builtin_skills_embedded.rs"));
@@ -62,6 +67,38 @@ pub fn builtin_clone_bundle_digest(files: &BTreeMap<String, BuiltinSkillFile>) -
         digest.update(&file.bytes);
     }
     hex::encode(digest.finalize())
+}
+
+/// Rebuild the metadata-only identity of one embedded builtin without relying
+/// on the current catalog winner. Clone recovery uses this when a deleted user
+/// generation is still retained as last-known-good and shadows the builtin.
+pub fn builtin_workflow_catalog_entry(
+    bundle: &BuiltinSkillBundle,
+    revision: u64,
+) -> SkillResult<WorkflowCatalogEntry> {
+    let metadata = if let Some(bytes) = bundle.files.get("workflow.yaml") {
+        parse_bundle_metadata_bytes("workflow.yaml", bytes, true)
+    } else if let Some(bytes) = bundle.files.get("agents/bamboo.yaml") {
+        parse_bundle_metadata_bytes("agents/bamboo.yaml", bytes, false)
+    } else {
+        Ok(BundleMetadata::default())
+    }
+    .map_err(SkillError::Validation)?;
+    let mut entry = entry_from_skill(
+        &bundle.skill,
+        SkillDirectorySource::Builtin,
+        revision,
+        metadata,
+    );
+    entry.content_digest = workflow_catalog_content_digest(
+        &entry,
+        Some(&bundle.skill),
+        bundle
+            .files
+            .iter()
+            .map(|(path, bytes)| (path.as_str(), bytes.as_slice())),
+    );
+    Ok(entry)
 }
 
 /// Archive the pre-catalog global materialization only when every file proves

--- a/crates/infra/bamboo-skills/src/store/storage.rs
+++ b/crates/infra/bamboo-skills/src/store/storage.rs
@@ -8,7 +8,8 @@ use tokio::io::AsyncReadExt;
 use tracing::{debug, info, warn};
 
 use crate::clone_publication::{
-    clone_marker_name, std_file_identity, ClonePublicationMarker, MAX_CLONE_MARKER_BYTES,
+    clone_marker_name, parse_clone_marker_journal, std_file_identity, ClonePublicationPhase,
+    MAX_CLONE_MARKER_BYTES,
 };
 use crate::store::parser::{parse_markdown_skill, render_skill_markdown};
 use crate::types::{SkillDefinition, SkillError, SkillResult};
@@ -164,10 +165,21 @@ fn clone_marker_allows_publication_sync(skill_file: &Path) -> bool {
     {
         return false;
     }
-    let marker = match serde_json::from_slice::<ClonePublicationMarker>(&bytes) {
-        Ok(marker) => marker,
-        Err(_) => return false,
+    let Some(journal) = parse_clone_marker_journal(&bytes, workflow_id) else {
+        return false;
     };
+    if !journal.partial.is_empty() {
+        return false;
+    }
+    let Some(marker) = journal.current() else {
+        return false;
+    };
+    if matches!(
+        marker.phase,
+        ClonePublicationPhase::Aborted | ClonePublicationPhase::Retired
+    ) {
+        return true;
+    }
     let Some(expected_target) = marker.complete_target_identity(workflow_id) else {
         return false;
     };
@@ -633,7 +645,9 @@ pub async fn write_skill_file(skills_dir: &Path, skill: &SkillDefinition) -> Ski
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clone_publication::{ClonePublicationPhase, CLONE_MARKER_SCHEMA};
+    use crate::clone_publication::{
+        ClonePublicationMarker, ClonePublicationPhase, CLONE_MARKER_SCHEMA,
+    };
 
     fn valid_skill(name: &str) -> String {
         format!("---\nname: {name}\ndescription: test skill\n---\n\nFollow this skill.")
@@ -653,8 +667,15 @@ mod tests {
             bundle_digest: "b".repeat(64),
             staging_name: "txn-12345678-1234-1234-1234-123456789abc".to_string(),
             phase,
-            stage_identity: target_identity,
-            target_identity,
+            stage_identity: (phase != ClonePublicationPhase::Prepared)
+                .then_some(target_identity)
+                .flatten(),
+            target_identity: matches!(
+                phase,
+                ClonePublicationPhase::Complete | ClonePublicationPhase::Retired
+            )
+            .then_some(target_identity)
+            .flatten(),
         };
         std::fs::write(
             root.join(clone_marker_name(workflow_id)),
@@ -716,6 +737,33 @@ mod tests {
             .expect("mismatched discovery is typed");
         assert!(mismatched.loaded.is_empty());
         assert_eq!(mismatched.failed.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn aborted_and_retired_markers_release_an_ordinary_target() {
+        for phase in [
+            ClonePublicationPhase::Aborted,
+            ClonePublicationPhase::Retired,
+        ] {
+            let root = tempfile::tempdir().expect("root");
+            let skill = root.path().join("review");
+            fs::create_dir_all(&skill).await.expect("skill dir");
+            fs::write(skill.join("SKILL.md"), valid_skill("review"))
+                .await
+                .expect("skill");
+            let target = open_directory_no_follow(&skill).expect("target handle");
+            let identity = std_file_identity(&target).expect("target identity");
+            clone_marker(root.path(), "review", phase, Some(identity));
+            let report = load_skills_from_discovery_dirs_detailed(&[SkillDiscoveryDir {
+                dir: root.path().to_path_buf(),
+                source: SkillDirectorySource::Global,
+                mode: None,
+            }])
+            .await
+            .expect("terminal marker discovery");
+            assert_eq!(report.loaded.len(), 1);
+            assert!(report.failed.is_empty());
+        }
     }
 
     #[tokio::test]

--- a/docs/skills-and-project-instructions.md
+++ b/docs/skills-and-project-instructions.md
@@ -21,6 +21,17 @@ same adapter in place; installation never copies them into the user's global
 workflow directory. A legacy file without a description receives a placeholder
 description and is explicit/manual-only, never automatically invoked.
 
+Builtin workflows are cloned through
+`POST /api/v1/bamboo/workflow-catalog/<id>/clone`. Bamboo writes the bundle in
+the private same-filesystem `.workflow-clone-txn` directory, journals bounded
+`prepared -> stage_bound -> staged -> complete` transitions, and publishes it
+with an atomic no-replace rename. An exact retry resumes every fully journaled
+phase; ambiguous partial state or an identity mismatch fails closed without
+mutating it. A concurrent target wins unchanged after Bamboo durably records `aborted`.
+If a completed clone directory is later deleted, Bamboo records `retired`
+before starting a bounded replacement epoch; a different directory generation
+at the public name is never retired, adopted, or deleted.
+
 Migration is an explicit clone through
 `POST /api/v1/bamboo/workflow-catalog/<id>/migrate`, using a trusted session id
 to select the current workspace. It creates


### PR DESCRIPTION
## Summary

- add a bounded durable Prepared -> StageBound -> Staged -> Complete clone journal with exact recovery across publication crash points
- retire deleted completed generations through a crash-safe fixed-slot epoch rollover, while preserving foreign replacements and concurrent final-target winners
- keep staging outside discovery, use platform-native atomic no-replace publication, and expose Aborted/Retired marker semantics to catalog discovery
- rebuild embedded builtin identity for recovery without widening the generic catalog, migration, watcher, or session lifecycle scope

## Test Plan

- cargo test --all-features --lib --tests
- cargo test --tests
- cargo build --examples
- cargo +1.95.0 check --locked --workspace --all-targets --all-features
- cargo fmt --all -- --check
- cargo clippy --all-features with the repository CI deny/allow set
- cargo check --locked -p bamboo-server --lib --all-features --target x86_64-pc-windows-gnu
- python3 -m unittest discover -s scripts/tests -p test_*.py
- python3 scripts/check-msrv.py

No UI changes; screenshots are not applicable.

Closes #874