### PR TITLE
refactor: migrate legacy workflows into canonical skills

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -915,51 +915,11 @@ where
         }
     };
 
-    if let Some(migrated) = skill_catalog.entries.iter().find(|entry| {
+    let existing_migration = skill_catalog.entries.iter().find(|entry| {
         entry.id == workflow_id
             && entry.source == published_source
             && entry.migration_status == Some(LegacyWorkflowMigrationStatus::Migrated)
-    }) {
-        let exact_migration = store
-            .get_skill(&workflow_id)
-            .await
-            .ok()
-            .is_some_and(|skill| {
-                skill.metadata.as_ref().is_some_and(|metadata| {
-                    metadata
-                        .get("legacy_migration")
-                        .and_then(serde_json::Value::as_bool)
-                        == Some(true)
-                        && metadata
-                            .get("original_source")
-                            .and_then(serde_json::Value::as_str)
-                            == Some(source_identity.as_str())
-                        && metadata
-                            .get("legacy_source_content_digest")
-                            .and_then(serde_json::Value::as_str)
-                            == Some(accepted.content_digest.as_str())
-                })
-            });
-        if exact_migration {
-            return Ok(HttpResponse::Ok()
-                .insert_header(("Cache-Control", "no-store"))
-                .json(MigrateWorkflowResponse {
-                    workflow_id,
-                    outcome: LegacyWorkflowMigrationOutcome::AlreadyMigrated,
-                    source_preserved: true,
-                    catalog_revision: skill_catalog.revision.max(workflow_catalog.revision),
-                }));
-        }
-        tracing::warn!(
-            workflow_id,
-            source = ?migrated.source,
-            "legacy migration target source identity is inconsistent"
-        );
-        return Ok(crate::error::json_error(
-            StatusCode::CONFLICT,
-            "Workflow migration conflicts with an existing target Skill",
-        ));
-    }
+    });
 
     let target_rank = |source| match source {
         WorkflowSource::Builtin => 0,
@@ -968,9 +928,11 @@ where
         WorkflowSource::Project => 3,
         WorkflowSource::Workspace => 4,
     };
-    if skill_catalog.entries.iter().any(|entry| {
-        entry.id == workflow_id && target_rank(entry.source) >= target_rank(published_source)
-    }) {
+    if existing_migration.is_none()
+        && skill_catalog.entries.iter().any(|entry| {
+            entry.id == workflow_id && target_rank(entry.source) >= target_rank(published_source)
+        })
+    {
         return Ok(crate::error::json_error(
             StatusCode::CONFLICT,
             "Workflow migration conflicts with an existing target Skill",
@@ -1029,6 +991,64 @@ where
         payload.description.as_deref(),
     )
     .map_err(|_| AppError::BadRequest("Legacy workflow cannot be migrated".to_string()))?;
+    if let Some(migrated) = existing_migration {
+        let requested_description = payload
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|description| !description.is_empty());
+        let exact_migration = store
+            .get_skill(&workflow_id)
+            .await
+            .ok()
+            .is_some_and(|skill| {
+                skill.metadata.as_ref().is_some_and(|metadata| {
+                    let description_matches = match requested_description {
+                        Some(description) => {
+                            metadata
+                                .get("legacy_migration_description_override")
+                                .and_then(serde_json::Value::as_str)
+                                == Some(description)
+                        }
+                        None => metadata
+                            .get("legacy_migration_description_override")
+                            .is_some_and(serde_json::Value::is_null),
+                    };
+                    metadata
+                        .get("legacy_migration")
+                        .and_then(serde_json::Value::as_bool)
+                        == Some(true)
+                        && metadata
+                            .get("original_source")
+                            .and_then(serde_json::Value::as_str)
+                            == Some(source_identity.as_str())
+                        && metadata
+                            .get("legacy_source_content_digest")
+                            .and_then(serde_json::Value::as_str)
+                            == Some(accepted.content_digest.as_str())
+                        && description_matches
+                })
+            });
+        if exact_migration {
+            return Ok(HttpResponse::Ok()
+                .insert_header(("Cache-Control", "no-store"))
+                .json(MigrateWorkflowResponse {
+                    workflow_id,
+                    outcome: LegacyWorkflowMigrationOutcome::AlreadyMigrated,
+                    source_preserved: true,
+                    catalog_revision: skill_catalog.revision.max(workflow_catalog.revision),
+                }));
+        }
+        tracing::warn!(
+            workflow_id,
+            source = ?migrated.source,
+            "legacy migration target request identity is inconsistent"
+        );
+        return Ok(crate::error::json_error(
+            StatusCode::CONFLICT,
+            "Workflow migration conflicts with an existing target Skill",
+        ));
+    }
     if let Err(error) = validate_clone_bundle(&prepared.files) {
         tracing::error!(
             ?error,

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -32,44 +32,6 @@ fn legacy_workflow_io_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
-fn legacy_source_is_same_file(selected: &std::fs::Metadata, current: &std::fs::Metadata) -> bool {
-    if selected.file_type().is_symlink()
-        || current.file_type().is_symlink()
-        || !selected.is_file()
-        || !current.is_file()
-    {
-        return false;
-    }
-    legacy_source_identity_matches(selected, current)
-}
-
-#[cfg(unix)]
-fn legacy_source_identity_matches(
-    selected: &std::fs::Metadata,
-    current: &std::fs::Metadata,
-) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    selected.dev() == current.dev() && selected.ino() == current.ino()
-}
-
-#[cfg(windows)]
-fn legacy_source_identity_matches(
-    selected: &std::fs::Metadata,
-    current: &std::fs::Metadata,
-) -> bool {
-    use std::os::windows::fs::MetadataExt;
-    selected.volume_serial_number() == current.volume_serial_number()
-        && selected.file_index() == current.file_index()
-}
-
-#[cfg(not(any(unix, windows)))]
-fn legacy_source_identity_matches(
-    selected: &std::fs::Metadata,
-    current: &std::fs::Metadata,
-) -> bool {
-    selected.len() == current.len() && selected.modified().ok() == current.modified().ok()
-}
-
 async fn workspace_publication_root(
     workspace: &std::path::Path,
 ) -> Result<std::path::PathBuf, AppError> {
@@ -818,6 +780,9 @@ where
     let canonical_source = tokio::fs::canonicalize(&catalog_source)
         .await
         .map_err(|_| AppError::BadRequest("Legacy workflow source is unavailable".to_string()))?;
+    let selected_identity = bamboo_skills::legacy::legacy_markdown_source_identity(&catalog_source)
+        .await
+        .map_err(|_| AppError::BadRequest("Legacy workflow source is unavailable".to_string()))?;
     let canonical_app_data = tokio::fs::canonicalize(&app_state.app_data_dir).await?;
     let canonical_workspace = match workspace.as_ref() {
         Some(workspace) => Some(tokio::fs::canonicalize(workspace).await?),
@@ -940,9 +905,11 @@ where
     }
 
     after_source_selection(&catalog_source);
-    let source_content =
-        match bamboo_skills::legacy::read_legacy_markdown_workflow(&catalog_source).await {
-            Ok(content) => content,
+    let (source_content, read_identity) =
+        match bamboo_skills::legacy::read_legacy_markdown_workflow_with_identity(&catalog_source)
+            .await
+        {
+            Ok(snapshot) => snapshot,
             Err(_) => {
                 return Ok(crate::error::json_error(
                     StatusCode::CONFLICT,
@@ -950,15 +917,16 @@ where
                 ));
             }
         };
-    let current_metadata = match tokio::fs::symlink_metadata(&catalog_source).await {
-        Ok(metadata) => metadata,
-        Err(_) => {
-            return Ok(crate::error::json_error(
-                StatusCode::CONFLICT,
-                "Legacy workflow source changed; refresh the catalog before migrating",
-            ));
-        }
-    };
+    let named_identity =
+        match bamboo_skills::legacy::legacy_markdown_source_identity(&catalog_source).await {
+            Ok(identity) => identity,
+            Err(_) => {
+                return Ok(crate::error::json_error(
+                    StatusCode::CONFLICT,
+                    "Legacy workflow source changed; refresh the catalog before migrating",
+                ));
+            }
+        };
     let live_digest = match bamboo_skills::legacy::legacy_markdown_catalog_content_digest(
         &accepted,
         &catalog_source,
@@ -973,7 +941,8 @@ where
             ));
         }
     };
-    if !legacy_source_is_same_file(&selected_metadata, &current_metadata)
+    if selected_identity != read_identity
+        || read_identity != named_identity
         || live_digest != accepted.content_digest
     {
         return Ok(crate::error::json_error(

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use actix_web::{http::StatusCode, web, HttpResponse};
@@ -9,8 +9,8 @@ use bamboo_skills::store::builtin::{
     builtin_clone_files, builtin_workflow_catalog_entry, load_builtin_skill_bundles,
 };
 use bamboo_skills::{
-    LegacyWorkflowMigrationStatus, SkillStore, WorkflowCatalogEntry, WorkflowCatalogSnapshot,
-    WorkflowSource, WorkflowStatus,
+    LegacyWorkflowMigrationStatus, ShadowedWorkflowCandidate, SkillStore, WorkflowCatalogEntry,
+    WorkflowCatalogSnapshot, WorkflowSource, WorkflowStatus,
 };
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -32,37 +32,97 @@ fn legacy_workflow_io_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
-async fn workspace_skills_dir(workspace: &std::path::Path) -> Result<std::path::PathBuf, AppError> {
+fn legacy_source_is_same_file(selected: &std::fs::Metadata, current: &std::fs::Metadata) -> bool {
+    if selected.file_type().is_symlink()
+        || current.file_type().is_symlink()
+        || !selected.is_file()
+        || !current.is_file()
+    {
+        return false;
+    }
+    legacy_source_identity_matches(selected, current)
+}
+
+#[cfg(unix)]
+fn legacy_source_identity_matches(
+    selected: &std::fs::Metadata,
+    current: &std::fs::Metadata,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    selected.dev() == current.dev() && selected.ino() == current.ino()
+}
+
+#[cfg(windows)]
+fn legacy_source_identity_matches(
+    selected: &std::fs::Metadata,
+    current: &std::fs::Metadata,
+) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    selected.volume_serial_number() == current.volume_serial_number()
+        && selected.file_index() == current.file_index()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn legacy_source_identity_matches(
+    selected: &std::fs::Metadata,
+    current: &std::fs::Metadata,
+) -> bool {
+    selected.len() == current.len() && selected.modified().ok() == current.modified().ok()
+}
+
+async fn workspace_publication_root(
+    workspace: &std::path::Path,
+) -> Result<std::path::PathBuf, AppError> {
     let workspace = tokio::fs::canonicalize(workspace).await?;
     let bamboo_dir = workspace.join(".bamboo");
-    let skills_dir = bamboo_dir.join("skills");
-    for directory in [&bamboo_dir, &skills_dir] {
-        match tokio::fs::symlink_metadata(directory).await {
-            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
-                return Err(AppError::Forbidden(format!(
-                    "Workspace publication directory '{}' must be a real directory",
-                    directory
-                        .strip_prefix(&workspace)
-                        .unwrap_or(directory)
-                        .display()
-                )));
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                tokio::fs::create_dir(directory).await?;
-            }
-            Err(error) => return Err(AppError::StorageError(error)),
-        }
-        let canonical = tokio::fs::canonicalize(directory).await?;
-        if !canonical.starts_with(&workspace) {
-            return Err(AppError::Forbidden(
-                "Workspace publication directory escapes the trusted workspace".to_string(),
-            ));
-        }
+    let metadata = tokio::fs::symlink_metadata(&bamboo_dir).await?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(AppError::Forbidden(
+            "Workspace publication root must be a real directory".to_string(),
+        ));
     }
-    tokio::fs::canonicalize(skills_dir)
-        .await
-        .map_err(AppError::StorageError)
+    let canonical = tokio::fs::canonicalize(bamboo_dir).await?;
+    if !canonical.starts_with(&workspace) {
+        return Err(AppError::Forbidden(
+            "Workspace publication root escapes the trusted workspace".to_string(),
+        ));
+    }
+    Ok(canonical)
+}
+
+fn public_workflow_catalog_snapshot(
+    mut skill_catalog: WorkflowCatalogSnapshot,
+    workflow_catalog: WorkflowCatalogSnapshot,
+) -> WorkflowCatalogSnapshot {
+    let workflow_revision = workflow_catalog.revision;
+    for workflow in workflow_catalog
+        .entries
+        .into_iter()
+        .filter(WorkflowCatalogEntry::is_public_workflow)
+    {
+        let migrated = skill_catalog.entries.iter_mut().find(|entry| {
+            entry.id == workflow.id
+                && entry.migration_status == Some(LegacyWorkflowMigrationStatus::Migrated)
+        });
+        if workflow.migration_status == Some(LegacyWorkflowMigrationStatus::Available) {
+            if let Some(migrated) = migrated {
+                let source = ShadowedWorkflowCandidate {
+                    source: workflow.source,
+                    status: workflow.status,
+                    legacy: true,
+                    migration_status: workflow.migration_status,
+                    last_error: workflow.last_error,
+                };
+                if !migrated.shadowed_candidates.contains(&source) {
+                    migrated.shadowed_candidates.push(source);
+                }
+                continue;
+            }
+        }
+        skill_catalog.entries.push(workflow);
+    }
+    skill_catalog.revision = skill_catalog.revision.max(workflow_revision);
+    skill_catalog
 }
 
 /// Metadata-only catalog shared by Lotus palette, explicit selection and model matching.
@@ -156,17 +216,7 @@ pub async fn list_workflow_catalog(
     // publication guard, then expose only the public Workflow side of the
     // orchestration/legacy namespace.
     let (skill_catalog, workflow_catalog) = store.command_catalog_snapshots().await;
-    let mut entries = skill_catalog.entries;
-    entries.extend(
-        workflow_catalog
-            .entries
-            .into_iter()
-            .filter(WorkflowCatalogEntry::is_public_workflow),
-    );
-    let snapshot = WorkflowCatalogSnapshot {
-        revision: skill_catalog.revision.max(workflow_catalog.revision),
-        entries,
-    };
+    let snapshot = public_workflow_catalog_snapshot(skill_catalog, workflow_catalog);
     Ok(HttpResponse::Ok()
         .insert_header(("Cache-Control", "no-store"))
         .json(snapshot))
@@ -640,25 +690,44 @@ pub async fn clone_workflow(
         }))
 }
 
-/// Clone one read-only global/workspace/plugin legacy workflow into the trusted
-/// session workspace's canonical `.bamboo/skills/<id>/SKILL.md` bundle.
-///
-/// The legacy source is never changed or removed, and an existing target is
-/// never overwritten. Repeating a completed migration is an idempotent
-/// `already_migrated` success.
+/// Migrate one read-only legacy workflow into its canonical user or Project
+/// Skill layer. The source stays untouched through the documented
+/// compatibility boundary and target publication is atomic no-replace.
 pub async fn migrate_workflow(
     app_state: web::Data<AppState>,
     workflow_id: web::Path<String>,
     payload: web::Json<MigrateWorkflowRequest>,
 ) -> Result<HttpResponse, AppError> {
-    let workflow_id = workflow_id.into_inner();
+    migrate_workflow_with_source_hook(
+        app_state,
+        workflow_id.into_inner(),
+        payload.into_inner(),
+        |_| {},
+    )
+    .await
+}
+
+pub(super) async fn migrate_workflow_with_source_hook<F>(
+    app_state: web::Data<AppState>,
+    workflow_id: String,
+    payload: MigrateWorkflowRequest,
+    after_source_selection: F,
+) -> Result<HttpResponse, AppError>
+where
+    F: FnOnce(&Path),
+{
     let session_id = payload.session_id.trim();
     if session_id.is_empty() {
         return Err(AppError::BadRequest("session_id is required".to_string()));
     }
+
+    let _session_guard = app_state.persistence.acquire_lock(session_id).await;
     let session = app_state
+        .persistence
+        .storage()
         .load_session(session_id)
         .await
+        .map_err(AppError::StorageError)?
         .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
     let project_id =
         match bamboo_engine::project_context::ProjectContextResolver::session_project_identity(
@@ -668,10 +737,10 @@ pub async fn migrate_workflow(
                 Some(project_id)
             }
             bamboo_engine::project_context::SessionProjectIdentity::Unassigned => None,
-            bamboo_engine::project_context::SessionProjectIdentity::Invalid { raw, message } => {
-                return Err(AppError::BadRequest(format!(
-                    "Session carries an invalid Project identity '{raw}': {message}"
-                )));
+            bamboo_engine::project_context::SessionProjectIdentity::Invalid { .. } => {
+                return Err(AppError::BadRequest(
+                    "Session Project identity is invalid".to_string(),
+                ));
             }
         };
     let persisted_workspace = (session
@@ -690,29 +759,27 @@ pub async fn migrate_workflow(
     .map_err(|error| match error {
         crate::project_context::ProjectWorkspaceValidationError::Invalid { .. }
         | crate::project_context::ProjectWorkspaceValidationError::Conflict { .. } => {
-            AppError::BadRequest(error.to_string())
+            AppError::BadRequest("Session Project/workspace assignment is invalid".to_string())
         }
         crate::project_context::ProjectWorkspaceValidationError::Store(error) => {
             AppError::InternalError(anyhow::anyhow!(error))
         }
-    })?
-    .ok_or_else(|| {
-        AppError::BadRequest("Legacy workflow migration requires a session workspace".to_string())
     })?;
 
-    let store = if let Some(project_id) = project_id {
-        app_state.project_store.get(&project_id).map_err(|error| {
-            AppError::BadRequest(format!("Assigned Project is unavailable: {error}"))
-        })?;
-        let project_home = app_state.project_store.paths().project_home(&project_id);
+    let store = if let Some(project_id) = project_id.as_ref() {
+        app_state
+            .project_store
+            .get(project_id)
+            .map_err(|_| AppError::BadRequest("Assigned Project is unavailable".to_string()))?;
+        let project_home = app_state.project_store.paths().project_home(project_id);
         app_state
             .skill_manager
-            .store_for_project_workspace(&project_id, &project_home, Some(&workspace))
+            .store_for_project_workspace(project_id, &project_home, workspace.as_deref())
             .await
     } else {
         app_state
             .skill_manager
-            .store_for_workspace(Some(&workspace))
+            .store_for_workspace(workspace.as_deref())
             .await
     }
     .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
@@ -720,137 +787,321 @@ pub async fn migrate_workflow(
         .reload()
         .await
         .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
-    let catalog = store.workflow_catalog_snapshot().await;
-    let entry = catalog
+    let (skill_catalog, workflow_catalog) = store.command_catalog_snapshots().await;
+
+    let accepted = workflow_catalog
         .entries
         .iter()
         .find(|entry| entry.id == workflow_id)
+        .cloned()
         .ok_or_else(|| AppError::NotFound(format!("Workflow '{workflow_id}'")))?;
-    if entry.migration_status == Some(LegacyWorkflowMigrationStatus::Migrated) {
-        return Ok(HttpResponse::Ok()
-            .insert_header(("Cache-Control", "no-store"))
-            .json(MigrateWorkflowResponse {
-                workflow_id,
-                outcome: LegacyWorkflowMigrationOutcome::AlreadyMigrated,
-                source_preserved: true,
-                catalog_revision: catalog.revision,
-            }));
-    }
-    if entry.migration_status != Some(LegacyWorkflowMigrationStatus::Available) {
-        if entry.shadowed_candidates.iter().any(|candidate| {
-            candidate.migration_status == Some(LegacyWorkflowMigrationStatus::Available)
-        }) {
-            return Ok(crate::error::json_error(
-                StatusCode::CONFLICT,
-                format!(
-                    "Workflow '{workflow_id}' already has a target Skill bundle; it was not overwritten"
-                ),
-            ));
-        }
-        return Err(AppError::BadRequest(format!(
-            "Workflow '{workflow_id}' is not a migratable legacy workflow"
-        )));
+    if accepted.migration_status != Some(LegacyWorkflowMigrationStatus::Available) {
+        return Ok(crate::error::json_error(
+            StatusCode::CONFLICT,
+            "Workflow is not an available legacy migration source",
+        ));
     }
 
-    let source = store
+    let catalog_source = store
         .get_legacy_workflow_source(&workflow_id)
         .await
-        .map_err(|error| {
-            AppError::BadRequest(format!("Legacy workflow is unavailable: {error}"))
-        })?;
-    let source = tokio::fs::canonicalize(&source).await.map_err(|error| {
-        AppError::BadRequest(format!("Legacy workflow source is unavailable: {error}"))
-    })?;
-    let canonical_workspace = tokio::fs::canonicalize(&workspace).await?;
-    let workspace_legacy = workspace.join(".bamboo/workflows");
-    let workspace_source_identity = match tokio::fs::canonicalize(&workspace_legacy).await {
-        Ok(root) => {
-            if root.starts_with(&canonical_workspace) && source.parent() == Some(root.as_path()) {
-                source
+        .map_err(|_| AppError::BadRequest("Legacy workflow source is unavailable".to_string()))?;
+    let selected_metadata = tokio::fs::symlink_metadata(&catalog_source)
+        .await
+        .map_err(|_| AppError::BadRequest("Legacy workflow source is unavailable".to_string()))?;
+    if selected_metadata.file_type().is_symlink() || !selected_metadata.is_file() {
+        return Ok(crate::error::json_error(
+            StatusCode::CONFLICT,
+            "Legacy workflow source changed; refresh the catalog before migrating",
+        ));
+    }
+    let canonical_source = tokio::fs::canonicalize(&catalog_source)
+        .await
+        .map_err(|_| AppError::BadRequest("Legacy workflow source is unavailable".to_string()))?;
+    let canonical_app_data = tokio::fs::canonicalize(&app_state.app_data_dir).await?;
+    let canonical_workspace = match workspace.as_ref() {
+        Some(workspace) => Some(tokio::fs::canonicalize(workspace).await?),
+        None => None,
+    };
+
+    enum LegacySourceLayer {
+        Workspace,
+        User,
+    }
+    let workspace_source_identity = if let Some(workspace) = workspace.as_ref() {
+        let workspace_legacy = workspace.join(".bamboo/workflows");
+        match tokio::fs::canonicalize(&workspace_legacy).await {
+            Ok(root)
+                if canonical_workspace
+                    .as_ref()
+                    .is_some_and(|workspace| root.starts_with(workspace))
+                    && canonical_source.parent() == Some(root.as_path()) =>
+            {
+                canonical_source
                     .file_name()
                     .and_then(|filename| filename.to_str())
                     .map(|filename| format!(".bamboo/workflows/{filename}"))
-            } else {
-                None
             }
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => return Err(AppError::StorageError(error)),
-    };
-    let plugin_source_identity =
-        match tokio::fs::canonicalize(app_state.app_data_dir.join("plugins")).await {
-            Ok(root) => source.strip_prefix(&root).ok().and_then(|relative| {
-                let components: Vec<_> = relative.components().collect();
-                if components.len() != 3 || components[1].as_os_str() != "workflows" {
-                    return None;
-                }
-                Some(format!(
-                    "plugins/{}/workflows/{}",
-                    components[0].as_os_str().to_str()?,
-                    components[2].as_os_str().to_str()?
-                ))
-            }),
+            Ok(_) => None,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
             Err(error) => return Err(AppError::StorageError(error)),
-        };
-    let global_workflows = app_state.app_data_dir.join("workflows");
-    let global_source_identity = match tokio::fs::symlink_metadata(&global_workflows).await {
-        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
-            let canonical_app_data = tokio::fs::canonicalize(&app_state.app_data_dir).await?;
-            let root = tokio::fs::canonicalize(&global_workflows).await?;
-            if root.starts_with(&canonical_app_data) && source.parent() == Some(root.as_path()) {
-                source
+        }
+    } else {
+        None
+    };
+    let global_source_identity =
+        match tokio::fs::canonicalize(app_state.app_data_dir.join("workflows")).await {
+            Ok(root)
+                if root.starts_with(&canonical_app_data)
+                    && canonical_source.parent() == Some(root.as_path()) =>
+            {
+                canonical_source
                     .file_name()
                     .and_then(|filename| filename.to_str())
                     .map(|filename| format!("workflows/{filename}"))
+            }
+            Ok(_) => None,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(AppError::StorageError(error)),
+        };
+    let plugin_source_identity =
+        match tokio::fs::canonicalize(app_state.app_data_dir.join("plugins")).await {
+            Ok(root) => canonical_source
+                .strip_prefix(&root)
+                .ok()
+                .and_then(|relative| {
+                    let components: Vec<_> = relative.components().collect();
+                    if components.len() != 3 || components[1].as_os_str() != "workflows" {
+                        return None;
+                    }
+                    Some(format!(
+                        "plugins/{}/workflows/{}",
+                        components[0].as_os_str().to_str()?,
+                        components[2].as_os_str().to_str()?
+                    ))
+                }),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(AppError::StorageError(error)),
+        };
+    let (source_identity, source_layer) = if let Some(identity) = workspace_source_identity {
+        (identity, LegacySourceLayer::Workspace)
+    } else if let Some(identity) = global_source_identity.or(plugin_source_identity) {
+        (identity, LegacySourceLayer::User)
+    } else {
+        return Err(AppError::Forbidden(
+            "Legacy workflow source is outside a supported migration scope".to_string(),
+        ));
+    };
+
+    let (trusted_root, published_source) = match source_layer {
+        LegacySourceLayer::User => (app_state.app_data_dir.clone(), WorkflowSource::User),
+        LegacySourceLayer::Workspace => {
+            if let Some(project_id) = project_id.as_ref() {
+                (
+                    app_state.project_store.paths().project_home(project_id),
+                    WorkflowSource::Project,
+                )
             } else {
-                None
+                let workspace = canonical_workspace.as_ref().ok_or_else(|| {
+                    AppError::BadRequest(
+                        "Workspace legacy migration requires a session workspace".to_string(),
+                    )
+                })?;
+                (
+                    workspace_publication_root(workspace).await?,
+                    WorkflowSource::Workspace,
+                )
             }
         }
-        Ok(_) => None,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => return Err(AppError::StorageError(error)),
     };
-    let source_identity = workspace_source_identity
-        .or(global_source_identity)
-        .or(plugin_source_identity)
-        .ok_or_else(|| {
-            AppError::Forbidden(
-                "Legacy workflow source is outside a migratable global/workspace/plugin scope"
-                    .to_string(),
-            )
-        })?;
 
-    let skills_dir = workspace_skills_dir(&canonical_workspace).await?;
-    let outcome = bamboo_skills::legacy::migrate_legacy_markdown_workflow(
-        &source,
-        &source_identity,
-        &skills_dir,
-        &workflow_id,
-        payload.description.as_deref(),
-    )
-    .await
-    .map_err(|error| AppError::BadRequest(format!("Legacy workflow migration failed: {error}")))?;
-    if outcome == LegacyWorkflowMigrationOutcome::Conflict {
+    if let Some(migrated) = skill_catalog.entries.iter().find(|entry| {
+        entry.id == workflow_id
+            && entry.source == published_source
+            && entry.migration_status == Some(LegacyWorkflowMigrationStatus::Migrated)
+    }) {
+        let exact_migration = store
+            .get_skill(&workflow_id)
+            .await
+            .ok()
+            .is_some_and(|skill| {
+                skill.metadata.as_ref().is_some_and(|metadata| {
+                    metadata
+                        .get("legacy_migration")
+                        .and_then(serde_json::Value::as_bool)
+                        == Some(true)
+                        && metadata
+                            .get("original_source")
+                            .and_then(serde_json::Value::as_str)
+                            == Some(source_identity.as_str())
+                        && metadata
+                            .get("legacy_source_content_digest")
+                            .and_then(serde_json::Value::as_str)
+                            == Some(accepted.content_digest.as_str())
+                })
+            });
+        if exact_migration {
+            return Ok(HttpResponse::Ok()
+                .insert_header(("Cache-Control", "no-store"))
+                .json(MigrateWorkflowResponse {
+                    workflow_id,
+                    outcome: LegacyWorkflowMigrationOutcome::AlreadyMigrated,
+                    source_preserved: true,
+                    catalog_revision: skill_catalog.revision.max(workflow_catalog.revision),
+                }));
+        }
+        tracing::warn!(
+            workflow_id,
+            source = ?migrated.source,
+            "legacy migration target source identity is inconsistent"
+        );
         return Ok(crate::error::json_error(
             StatusCode::CONFLICT,
-            format!(
-                "Workflow '{workflow_id}' already has a target Skill bundle; it was not overwritten"
-            ),
+            "Workflow migration conflicts with an existing target Skill",
         ));
     }
+
+    let target_rank = |source| match source {
+        WorkflowSource::Builtin => 0,
+        WorkflowSource::Plugin => 1,
+        WorkflowSource::User => 2,
+        WorkflowSource::Project => 3,
+        WorkflowSource::Workspace => 4,
+    };
+    if skill_catalog.entries.iter().any(|entry| {
+        entry.id == workflow_id && target_rank(entry.source) >= target_rank(published_source)
+    }) {
+        return Ok(crate::error::json_error(
+            StatusCode::CONFLICT,
+            "Workflow migration conflicts with an existing target Skill",
+        ));
+    }
+
+    after_source_selection(&catalog_source);
+    let source_content =
+        match bamboo_skills::legacy::read_legacy_markdown_workflow(&catalog_source).await {
+            Ok(content) => content,
+            Err(_) => {
+                return Ok(crate::error::json_error(
+                    StatusCode::CONFLICT,
+                    "Legacy workflow source changed; refresh the catalog before migrating",
+                ));
+            }
+        };
+    let current_metadata = match tokio::fs::symlink_metadata(&catalog_source).await {
+        Ok(metadata) => metadata,
+        Err(_) => {
+            return Ok(crate::error::json_error(
+                StatusCode::CONFLICT,
+                "Legacy workflow source changed; refresh the catalog before migrating",
+            ));
+        }
+    };
+    let live_digest = match bamboo_skills::legacy::legacy_markdown_catalog_content_digest(
+        &accepted,
+        &catalog_source,
+        &workflow_id,
+        &source_content,
+    ) {
+        Ok(digest) => digest,
+        Err(_) => {
+            return Ok(crate::error::json_error(
+                StatusCode::CONFLICT,
+                "Legacy workflow source changed; refresh the catalog before migrating",
+            ));
+        }
+    };
+    if !legacy_source_is_same_file(&selected_metadata, &current_metadata)
+        || live_digest != accepted.content_digest
+    {
+        return Ok(crate::error::json_error(
+            StatusCode::CONFLICT,
+            "Legacy workflow source changed; refresh the catalog before migrating",
+        ));
+    }
+
+    let prepared = bamboo_skills::legacy::prepare_legacy_markdown_workflow(
+        &catalog_source,
+        &source_identity,
+        &workflow_id,
+        &source_content,
+        Some((accepted.revision, accepted.content_digest.as_str())),
+        payload.description.as_deref(),
+    )
+    .map_err(|_| AppError::BadRequest("Legacy workflow cannot be migrated".to_string()))?;
+    if let Err(error) = validate_clone_bundle(&prepared.files) {
+        tracing::error!(
+            ?error,
+            "legacy migration bundle failed publication validation"
+        );
+        return Err(AppError::InternalError(anyhow::anyhow!(
+            "Legacy workflow bundle validation failed"
+        )));
+    }
+    let publish_id = workflow_id.clone();
+    let source_revision = accepted.revision;
+    let source_digest = accepted.content_digest.clone();
+    let publication = tokio::task::spawn_blocking(move || {
+        publish_builtin_clone(
+            &trusted_root,
+            &publish_id,
+            source_revision,
+            &source_digest,
+            &prepared.files,
+        )
+    })
+    .await
+    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    match publication {
+        Ok(_) => {}
+        Err(ClonePublicationError::Conflict(reason)) => {
+            tracing::warn!(workflow_id, reason, "legacy workflow migration conflict");
+            return Ok(crate::error::json_error(
+                StatusCode::CONFLICT,
+                "Workflow migration conflicts with an existing target Skill",
+            ));
+        }
+        Err(ClonePublicationError::Io(error)) => {
+            tracing::error!(%error, workflow_id, "legacy workflow publication failed");
+            return Err(AppError::InternalError(anyhow::anyhow!(
+                "Legacy workflow publication failed"
+            )));
+        }
+        Err(ClonePublicationError::Internal(reason)) => {
+            tracing::error!(
+                workflow_id,
+                reason,
+                "legacy workflow publication invariant failed"
+            );
+            return Err(AppError::InternalError(anyhow::anyhow!(
+                "Legacy workflow publication failed"
+            )));
+        }
+    }
+
     store
         .reload()
         .await
         .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
-    let revision = store.workflow_catalog_snapshot().await.revision;
+    let (published_skills, published_workflows) = store.command_catalog_snapshots().await;
+    let published = published_skills.entries.iter().any(|entry| {
+        entry.id == workflow_id
+            && entry.source == published_source
+            && entry.status == WorkflowStatus::Valid
+            && entry.migration_status == Some(LegacyWorkflowMigrationStatus::Migrated)
+    });
+    if !published {
+        return Err(AppError::InternalError(anyhow::anyhow!(
+            "Migrated workflow was not published in its canonical target layer"
+        )));
+    }
     Ok(HttpResponse::Ok()
         .insert_header(("Cache-Control", "no-store"))
         .json(MigrateWorkflowResponse {
             workflow_id,
-            outcome,
+            outcome: LegacyWorkflowMigrationOutcome::Migrated,
             source_preserved: true,
-            catalog_revision: revision,
+            catalog_revision: published_skills.revision.max(published_workflows.revision),
         }))
 }
 

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -781,6 +781,56 @@ async fn project_legacy_workflow_migration_is_exact_non_destructive_and_idempote
         "idempotent retry must not rewrite the editable target"
     );
 
+    let changed_request = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/daily-report/migrate")
+            .set_json(serde_json::json!({
+                "session_id": "legacy-migration-session",
+                "description": "Use a different migration description"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        changed_request.status(),
+        actix_web::http::StatusCode::CONFLICT
+    );
+    assert_eq!(
+        std::fs::read_to_string(target.join("SKILL.md")).unwrap(),
+        edited,
+        "a changed migration request must not rewrite the editable target"
+    );
+
+    let selected_generation = legacy_dir.join("daily-report.selected.md");
+    let raced_retry = super::handlers::migrate_workflow_with_source_hook(
+        state.clone(),
+        "daily-report".to_string(),
+        super::MigrateWorkflowRequest {
+            session_id: "legacy-migration-session".to_string(),
+            description: None,
+        },
+        |selected_path| {
+            std::fs::rename(selected_path, &selected_generation)
+                .expect("retain retry source generation");
+            std::fs::write(
+                selected_path,
+                "# Replaced during retry\n\nDifferent bytes.\n",
+            )
+            .expect("replace retry source generation");
+        },
+    )
+    .await
+    .expect("raced retry response");
+    assert_eq!(raced_retry.status(), actix_web::http::StatusCode::CONFLICT);
+    assert_eq!(
+        std::fs::read_to_string(target.join("SKILL.md")).unwrap(),
+        edited,
+        "a raced idempotent retry must not mutate the target"
+    );
+    std::fs::remove_file(&source).expect("remove raced replacement");
+    std::fs::rename(&selected_generation, &source).expect("restore selected source");
+
     let mismatched_source = edited.replace(
         "original_source: .bamboo/workflows/daily-report.md",
         "original_source: .bamboo/workflows/another-report.md",

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -584,6 +584,11 @@ async fn assigned_project_cannot_read_another_projects_workspace_workflows() {
         bamboo_agent_core::Session::new("cross-project-workflow-session", "test-model");
     session.set_project_id_meta(session_project.id.to_string());
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    state
+        .storage
+        .save_session(&session)
+        .await
+        .expect("persist cross-Project Session");
     state.sessions.insert(
         session.id.clone(),
         std::sync::Arc::new(parking_lot::RwLock::new(session)),
@@ -635,7 +640,7 @@ async fn assigned_project_cannot_read_another_projects_workspace_workflows() {
 }
 
 #[actix_web::test]
-async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_idempotent() {
+async fn project_legacy_workflow_migration_is_exact_non_destructive_and_idempotent() {
     let data = tempfile::tempdir().expect("data dir");
     let workspace = tempfile::tempdir().expect("workspace");
     let legacy_dir = workspace.path().join(".bamboo/workflows");
@@ -646,20 +651,39 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
     let protected_source = legacy_dir.join("protected.md");
     std::fs::write(&protected_source, "Legacy source must remain.\n")
         .expect("protected legacy workflow");
-    let protected_target = workspace.path().join(".bamboo/skills/protected/SKILL.md");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let project = state
+        .project_store
+        .create_with_bindings(
+            "Legacy Migration Project",
+            None,
+            vec![bamboo_domain::WorkspaceBinding {
+                path: workspace.path().to_string_lossy().into_owned(),
+                label: None,
+                git_common_dir: None,
+            }],
+        )
+        .expect("create Project");
+    let project_home = state.project_store.paths().project_home(&project.id);
+    let protected_target = project_home.join("skills/protected/SKILL.md");
     std::fs::create_dir_all(protected_target.parent().expect("protected target parent"))
         .expect("protected target dir");
     let protected_skill =
         "---\nname: protected\ndescription: Existing canonical Skill\n---\nKeep this target.\n";
     std::fs::write(&protected_target, protected_skill).expect("protected target");
 
-    let state = actix_web::web::Data::new(
-        crate::app_state::AppState::new(data.path().to_path_buf())
-            .await
-            .expect("app state"),
-    );
     let mut session = bamboo_agent_core::Session::new("legacy-migration-session", "test-model");
+    session.set_project_id_meta(project.id.to_string());
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    state
+        .storage
+        .save_session(&session)
+        .await
+        .expect("persist migration Session");
     state.sessions.insert(
         session.id.clone(),
         std::sync::Arc::new(parking_lot::RwLock::new(session)),
@@ -727,25 +751,60 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
     assert_eq!(first["source_preserved"], true);
     assert_eq!(std::fs::read_to_string(&source).unwrap(), original);
 
-    let target = workspace.path().join(".bamboo/skills/daily-report");
+    let target = project_home.join("skills/daily-report");
     let migrated = std::fs::read_to_string(target.join("SKILL.md")).expect("migrated Skill");
     assert!(migrated.contains("legacy_migration: true"));
     assert!(migrated.contains(".bamboo/workflows/daily-report.md"));
+    assert!(migrated.contains("legacy_source_removal_boundary: lotus-119-complete"));
     assert!(!migrated.contains(workspace.path().to_string_lossy().as_ref()));
     assert!(migrated.contains("Summarize today's changes."));
     assert!(target.join("agents/bamboo.yaml").exists());
+    assert!(
+        !workspace
+            .path()
+            .join(".bamboo/skills/daily-report")
+            .exists(),
+        "assigned Project migration must publish to Project home"
+    );
+
+    let edited = migrated.replace("Summarize today's changes.", "USER EDITED INSTRUCTIONS");
+    std::fs::write(target.join("SKILL.md"), &edited).expect("edit migrated target");
 
     let second = actix_web::test::call_service(&app, migrate()).await;
     assert!(second.status().is_success());
     let second: serde_json::Value = actix_web::test::read_body_json(second).await;
     assert_eq!(second["outcome"], "already_migrated");
     assert_eq!(std::fs::read_to_string(&source).unwrap(), original);
+    assert_eq!(
+        std::fs::read_to_string(target.join("SKILL.md")).unwrap(),
+        edited,
+        "idempotent retry must not rewrite the editable target"
+    );
+
+    let mismatched_source = edited.replace(
+        "original_source: .bamboo/workflows/daily-report.md",
+        "original_source: .bamboo/workflows/another-report.md",
+    );
+    assert_ne!(
+        mismatched_source, edited,
+        "fixture must change source identity"
+    );
+    std::fs::write(target.join("SKILL.md"), &mismatched_source)
+        .expect("change migration source identity");
+    let non_exact = actix_web::test::call_service(&app, migrate()).await;
+    assert_eq!(non_exact.status(), actix_web::http::StatusCode::CONFLICT);
+    assert_eq!(
+        std::fs::read_to_string(target.join("SKILL.md")).unwrap(),
+        mismatched_source,
+        "non-exact repeat must not rewrite the editable target"
+    );
+    std::fs::write(target.join("SKILL.md"), &edited).expect("restore exact migration fixture");
 
     let store = state
         .skill_manager
-        .store_for_workspace(Some(workspace.path()))
+        .store_for_project_workspace(&project.id, &project_home, Some(workspace.path()))
         .await
-        .expect("workspace SkillStore");
+        .expect("Project SkillStore");
     let skill_catalog = store.skill_catalog_snapshot().await;
     let migrated_skill = skill_catalog
         .entries
@@ -765,24 +824,41 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
     )
     .await;
     let entries = after["entries"].as_array().expect("catalog entries");
-    let migrated_workflow = entries
+    let same_id = entries
         .iter()
-        .find(|entry| entry["id"] == "daily-report" && entry["migration_status"] == "migrated")
-        .expect("migrated instruction entry");
-    let source_workflow = entries
-        .iter()
-        .find(|entry| entry["id"] == "daily-report" && entry["migration_status"] == "available")
-        .expect("source Workflow entry");
-    assert_ne!(
-        migrated_workflow["revision"], source_workflow["revision"],
-        "same-id instruction and source entries keep distinct typed revisions"
+        .filter(|entry| entry["id"] == "daily-report")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        same_id.len(),
+        1,
+        "public catalog must not duplicate migration"
     );
-    assert_eq!(source_workflow["migration_status"], "available");
-    assert!(source_workflow.get("shadowed_candidates").is_none());
+    let migrated_workflow = same_id[0];
+    assert_eq!(migrated_workflow["migration_status"], "migrated");
+    assert_eq!(migrated_workflow["source"], "project");
+    assert!(migrated_workflow["shadowed_candidates"]
+        .as_array()
+        .expect("preserved source diagnostic")
+        .iter()
+        .any(|candidate| candidate["migration_status"] == "available"));
+
+    let changed_source = "# Daily report\n\nUse changed source instructions.\n";
+    std::fs::write(&source, changed_source).expect("change legacy source after migration");
+    let changed_repeat = actix_web::test::call_service(&app, migrate()).await;
+    assert_eq!(
+        changed_repeat.status(),
+        actix_web::http::StatusCode::CONFLICT
+    );
+    assert_eq!(std::fs::read_to_string(&source).unwrap(), changed_source);
+    assert_eq!(
+        std::fs::read_to_string(target.join("SKILL.md")).unwrap(),
+        edited,
+        "changed source repeat must preserve the editable target"
+    );
 }
 
 #[actix_web::test]
-async fn global_legacy_workflow_advertised_as_available_migrates_into_session_workspace() {
+async fn global_legacy_workflow_migrates_into_canonical_user_skills() {
     let data = tempfile::tempdir().expect("data dir");
     let workspace = tempfile::tempdir().expect("workspace");
     let global_workflows = data.path().join("workflows");
@@ -799,6 +875,11 @@ async fn global_legacy_workflow_advertised_as_available_migrates_into_session_wo
     );
     let mut session = bamboo_agent_core::Session::new("global-migration-session", "test-model");
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    state
+        .storage
+        .save_session(&session)
+        .await
+        .expect("persist migration Session");
     state.sessions.insert(
         session.id.clone(),
         std::sync::Arc::new(parking_lot::RwLock::new(session)),
@@ -849,12 +930,18 @@ async fn global_legacy_workflow_advertised_as_available_migrates_into_session_wo
     assert_eq!(body["source_preserved"], true);
     assert_eq!(std::fs::read_to_string(&source).unwrap(), original);
 
-    let target = workspace
-        .path()
-        .join(".bamboo/skills/global-review/SKILL.md");
+    let target = data.path().join("skills/global-review/SKILL.md");
     let migrated = std::fs::read_to_string(&target).expect("migrated Skill");
     assert!(migrated.contains("workflows/global-review.md"));
+    assert!(migrated.contains("legacy_source_removal_boundary: lotus-119-complete"));
     assert!(!migrated.contains(data.path().to_string_lossy().as_ref()));
+    assert!(
+        !workspace
+            .path()
+            .join(".bamboo/skills/global-review")
+            .exists(),
+        "global migration must not create a workspace copy"
+    );
     let scoped = state
         .skill_manager
         .store_for_workspace(Some(workspace.path()))
@@ -878,6 +965,55 @@ async fn global_legacy_workflow_advertised_as_available_migrates_into_session_wo
         .unwrap(),
         std::fs::canonicalize(&source).unwrap()
     );
+}
+
+#[actix_web::test]
+async fn replacing_legacy_source_after_selection_conflicts_without_target_mutation() {
+    let data = tempfile::tempdir().expect("data dir");
+    let workflows = data.path().join("workflows");
+    std::fs::create_dir_all(&workflows).expect("global workflows");
+    let source = workflows.join("raced-review.md");
+    let selected = "---\ndescription: Review the selected bytes.\n---\nSELECTED BODY\n";
+    let replacement = "---\ndescription: Review replacement bytes.\n---\nREPLACEMENT BODY\n";
+    std::fs::write(&source, selected).expect("selected source");
+
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let session = bamboo_agent_core::Session::new("raced-migration-session", "test-model");
+    state
+        .storage
+        .save_session(&session)
+        .await
+        .expect("persist migration Session");
+
+    let original = workflows.join("raced-review.selected.md");
+    let response = super::handlers::migrate_workflow_with_source_hook(
+        state,
+        "raced-review".to_string(),
+        super::MigrateWorkflowRequest {
+            session_id: "raced-migration-session".to_string(),
+            description: None,
+        },
+        |selected_path| {
+            std::fs::rename(selected_path, &original).expect("retain selected generation");
+            std::fs::write(selected_path, replacement).expect("install replacement generation");
+        },
+    )
+    .await
+    .expect("migration response");
+
+    assert_eq!(response.status(), actix_web::http::StatusCode::CONFLICT);
+    assert_eq!(std::fs::read_to_string(&original).unwrap(), selected);
+    assert_eq!(std::fs::read_to_string(&source).unwrap(), replacement);
+    assert!(!data.path().join("skills/raced-review").exists());
+    assert!(!data
+        .path()
+        .join("skills/.raced-review.clone-v1.json")
+        .exists());
+    assert!(!data.path().join(".workflow-clone-txn").exists());
 }
 
 #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/types.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/types.rs
@@ -41,8 +41,8 @@ pub struct WorkflowCatalogQuery {
     pub session_id: Option<String>,
 }
 
-/// Request body for explicitly cloning a read-only legacy workflow into the
-/// current session workspace's canonical Skill directory.
+/// Request body for explicitly migrating a read-only legacy workflow into the
+/// canonical user or assigned-Project Skill layer selected by the source.
 #[derive(Debug, Default, Deserialize)]
 pub struct MigrateWorkflowRequest {
     /// Trusted session used to resolve the Project/workspace publication scope.

--- a/crates/infra/bamboo-skills/src/legacy.rs
+++ b/crates/infra/bamboo-skills/src/legacy.rs
@@ -111,16 +111,20 @@ fn public_legacy_error(error: &SkillError) -> String {
     }
 }
 
-async fn read_bounded_file(path: &Path, max_bytes: usize) -> SkillResult<Vec<u8>> {
-    let metadata_bytes = tokio::fs::metadata(path).await?.len() as usize;
+async fn read_bounded_file_with_identity(
+    path: &Path,
+    max_bytes: usize,
+) -> SkillResult<(Vec<u8>, Option<crate::clone_publication::CloneNodeIdentity>)> {
+    let mut file = open_skill_file_no_follow(path).await?;
+    let metadata_bytes = file.metadata().await?.len() as usize;
     if metadata_bytes > max_bytes {
         return Err(SkillError::Storage(format!(
             "legacy workflow exceeds per-file limit ({metadata_bytes} > {max_bytes} bytes)"
         )));
     }
-    let file = open_skill_file_no_follow(path).await?;
     let mut bytes = Vec::with_capacity(metadata_bytes.min(max_bytes));
-    file.take(max_bytes.saturating_add(1) as u64)
+    (&mut file)
+        .take(max_bytes.saturating_add(1) as u64)
         .read_to_end(&mut bytes)
         .await?;
     if bytes.len() > max_bytes {
@@ -129,7 +133,13 @@ async fn read_bounded_file(path: &Path, max_bytes: usize) -> SkillResult<Vec<u8>
             bytes.len()
         )));
     }
-    Ok(bytes)
+    let file = file.into_std().await;
+    let identity = crate::clone_publication::std_file_identity(&file);
+    Ok((bytes, identity))
+}
+
+async fn read_bounded_file(path: &Path, max_bytes: usize) -> SkillResult<Vec<u8>> {
+    Ok(read_bounded_file_with_identity(path, max_bytes).await?.0)
 }
 
 /// Read one legacy Workflow source without following symlinks and with the
@@ -138,6 +148,33 @@ pub async fn read_legacy_markdown_workflow(path: &Path) -> SkillResult<String> {
     let bytes = read_bounded_file(path, MAX_LEGACY_WORKFLOW_FILE_BYTES).await?;
     String::from_utf8(bytes)
         .map_err(|_| SkillError::Validation("legacy workflow is not valid UTF-8".to_string()))
+}
+
+/// Read one legacy Workflow through a no-follow handle and return the stable
+/// file identity bound to the bytes. Windows uses the handle volume/file ID;
+/// Unix uses device/inode identity.
+pub async fn read_legacy_markdown_workflow_with_identity(
+    path: &Path,
+) -> SkillResult<(String, crate::clone_publication::CloneNodeIdentity)> {
+    let (bytes, identity) =
+        read_bounded_file_with_identity(path, MAX_LEGACY_WORKFLOW_FILE_BYTES).await?;
+    let identity = identity.ok_or_else(|| {
+        SkillError::Storage("legacy workflow file identity is unavailable".to_string())
+    })?;
+    let content = String::from_utf8(bytes)
+        .map_err(|_| SkillError::Validation("legacy workflow is not valid UTF-8".to_string()))?;
+    Ok((content, identity))
+}
+
+/// Open a no-follow handle solely to bind a catalog selection to one durable
+/// source generation before its bytes are consumed.
+pub async fn legacy_markdown_source_identity(
+    path: &Path,
+) -> SkillResult<crate::clone_publication::CloneNodeIdentity> {
+    let file = open_skill_file_no_follow(path).await?.into_std().await;
+    crate::clone_publication::std_file_identity(&file).ok_or_else(|| {
+        SkillError::Storage("legacy workflow file identity is unavailable".to_string())
+    })
 }
 
 fn validate_legacy_description(description: &str) -> SkillResult<()> {

--- a/crates/infra/bamboo-skills/src/legacy.rs
+++ b/crates/infra/bamboo-skills/src/legacy.rs
@@ -260,6 +260,9 @@ pub fn prepare_legacy_markdown_workflow(
         "legacy_manual_only": manual_only,
         "legacy_name": source.file_stem().and_then(|value| value.to_str()).unwrap_or(id),
         "original_source": source_identity,
+        "legacy_migration_description_override": description_override
+            .map(str::trim)
+            .filter(|description| !description.is_empty()),
         "legacy_source_removal_boundary": LEGACY_WORKFLOW_SOURCE_REMOVAL_BOUNDARY,
         "format": "workspace_workflow_markdown"
     });

--- a/crates/infra/bamboo-skills/src/legacy.rs
+++ b/crates/infra/bamboo-skills/src/legacy.rs
@@ -1,6 +1,6 @@
 //! Non-destructive, idempotent adapters for pre-catalog workflow formats.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -18,7 +18,13 @@ use crate::types::SkillDefinition;
 use crate::types::{SkillError, SkillResult};
 
 static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(1);
-const MAX_LEGACY_WORKFLOW_FILE_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_LEGACY_WORKFLOW_FILE_BYTES: usize = 8 * 1024 * 1024;
+pub const LEGACY_WORKFLOW_SOURCE_REMOVAL_BOUNDARY: &str = "lotus-119-complete";
+
+pub struct PreparedLegacyWorkflowMigration {
+    pub files: BTreeMap<String, crate::store::builtin::BuiltinSkillFile>,
+    pub manual_only: bool,
+}
 
 fn migration_lock() -> &'static tokio::sync::Mutex<()> {
     static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
@@ -148,6 +154,19 @@ fn validate_legacy_description(description: &str) -> SkillResult<()> {
     Ok(())
 }
 
+fn validate_legacy_source_identity(source_identity: &str) -> SkillResult<()> {
+    if source_identity.trim().is_empty()
+        || source_identity.starts_with('/')
+        || source_identity.contains("..")
+        || source_identity.contains('\\')
+    {
+        return Err(SkillError::Validation(
+            "legacy workflow source identity must be a safe relative path".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn parse_legacy_markdown_adapter(
     source: &Path,
     id: &str,
@@ -203,6 +222,98 @@ fn parse_legacy_markdown_adapter(
         prompt,
         tool_refs: Vec::new(),
     })
+}
+
+/// Render one already-read legacy markdown source into its immutable canonical
+/// bundle. Publication remains the caller's responsibility so HTTP migration
+/// can reuse the atomic no-replace clone transaction.
+pub fn prepare_legacy_markdown_workflow(
+    source: &Path,
+    source_identity: &str,
+    id: &str,
+    content: &str,
+    source_catalog_identity: Option<(u64, &str)>,
+    description_override: Option<&str>,
+) -> SkillResult<PreparedLegacyWorkflowMigration> {
+    if !is_valid_skill_id(id) {
+        return Err(SkillError::InvalidId(id.to_string()));
+    }
+    validate_legacy_source_identity(source_identity)?;
+
+    let mut skill = parse_legacy_markdown_adapter(source, id, content)?;
+    let mut manual_only = skill
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("legacy_manual_only"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    if let Some(description) = description_override
+        .map(str::trim)
+        .filter(|description| !description.is_empty())
+    {
+        validate_legacy_description(description)?;
+        skill.description = description.to_string();
+        manual_only = false;
+    }
+    let mut migration_metadata = serde_json::json!({
+        "legacy_migration": true,
+        "legacy_manual_only": manual_only,
+        "legacy_name": source.file_stem().and_then(|value| value.to_str()).unwrap_or(id),
+        "original_source": source_identity,
+        "legacy_source_removal_boundary": LEGACY_WORKFLOW_SOURCE_REMOVAL_BOUNDARY,
+        "format": "workspace_workflow_markdown"
+    });
+    if let Some((source_revision, source_content_digest)) = source_catalog_identity {
+        let metadata = migration_metadata
+            .as_object_mut()
+            .expect("legacy migration metadata is an object");
+        metadata.insert(
+            "legacy_source_revision".to_string(),
+            serde_json::Value::from(source_revision),
+        );
+        metadata.insert(
+            "legacy_source_content_digest".to_string(),
+            serde_json::Value::from(source_content_digest),
+        );
+    }
+    skill.metadata = Some(migration_metadata);
+
+    let mut files = BTreeMap::new();
+    files.insert(
+        "SKILL.md".to_string(),
+        crate::store::builtin::BuiltinSkillFile {
+            bytes: render_skill_markdown(&skill)?.into_bytes(),
+            executable: false,
+        },
+    );
+    if manual_only {
+        files.insert(
+            "agents/bamboo.yaml".to_string(),
+            crate::store::builtin::BuiltinSkillFile {
+                bytes: b"version: '1'\ninvocation_policy:\n  explicit: true\n  automatic: false\n"
+                    .to_vec(),
+                executable: false,
+            },
+        );
+    }
+    Ok(PreparedLegacyWorkflowMigration { files, manual_only })
+}
+
+/// Rebuild the exact catalog digest of already-read source bytes. The handler
+/// compares this with the accepted catalog entry immediately before any target
+/// publication, making a selection/read replacement a deterministic conflict.
+pub fn legacy_markdown_catalog_content_digest(
+    entry: &crate::catalog::WorkflowCatalogEntry,
+    source: &Path,
+    id: &str,
+    content: &str,
+) -> SkillResult<String> {
+    let definition = parse_legacy_markdown_adapter(source, id, content)?;
+    Ok(crate::catalog::workflow_catalog_content_digest(
+        entry,
+        Some(&definition),
+        std::iter::empty::<(&str, &[u8])>(),
+    ))
 }
 
 /// Discover legacy markdown workflows without modifying their source directory.
@@ -488,44 +599,21 @@ pub async fn migrate_legacy_markdown_workflow(
     description_override: Option<&str>,
 ) -> SkillResult<LegacyWorkflowMigrationOutcome> {
     let _guard = migration_lock().lock().await;
-    if !is_valid_skill_id(id) {
-        return Err(SkillError::InvalidId(id.to_string()));
-    }
-    if source_identity.trim().is_empty()
-        || source_identity.starts_with('/')
-        || source_identity.contains("..")
-        || source_identity.contains('\\')
-    {
-        return Err(SkillError::Validation(
-            "legacy workflow source identity must be a safe relative path".to_string(),
-        ));
-    }
     let bytes = read_bounded_file(source, MAX_LEGACY_WORKFLOW_FILE_BYTES).await?;
     let content = String::from_utf8(bytes)
         .map_err(|_| SkillError::Validation("legacy workflow is not UTF-8".to_string()))?;
-    let mut skill = parse_legacy_markdown_adapter(source, id, &content)?;
-    let mut placeholder = skill
-        .metadata
-        .as_ref()
-        .and_then(|metadata| metadata.get("legacy_manual_only"))
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(true);
-    if let Some(description) = description_override
-        .map(str::trim)
-        .filter(|description| !description.is_empty())
-    {
-        validate_legacy_description(description)?;
-        skill.description = description.to_string();
-        placeholder = false;
-    }
-    skill.metadata = Some(serde_json::json!({
-        "legacy_migration": true,
-        "legacy_manual_only": placeholder,
-        "legacy_name": source.file_stem().and_then(|value| value.to_str()).unwrap_or(id),
-        "original_source": source_identity,
-        "format": "workspace_workflow_markdown"
-    }));
-    let rendered = render_skill_markdown(&skill)?;
+    let prepared = prepare_legacy_markdown_workflow(
+        source,
+        source_identity,
+        id,
+        &content,
+        None,
+        description_override,
+    )?;
+    let rendered = prepared
+        .files
+        .get("SKILL.md")
+        .expect("prepared legacy migration always contains SKILL.md");
 
     tokio::fs::create_dir_all(skills_dir).await?;
     if tokio::fs::symlink_metadata(skills_dir)
@@ -553,7 +641,7 @@ pub async fn migrate_legacy_markdown_workflow(
                 SkillError::Validation("existing Skill bundle is not UTF-8".to_string())
             })?;
             if is_owned_legacy_migration(&existing, &target, source_identity) {
-                ensure_manual_only_policy(&target_dir, placeholder).await?;
+                ensure_manual_only_policy(&target_dir, prepared.manual_only).await?;
                 return Ok(LegacyWorkflowMigrationOutcome::AlreadyMigrated);
             }
             return Ok(LegacyWorkflowMigrationOutcome::Conflict);
@@ -572,7 +660,7 @@ pub async fn migrate_legacy_markdown_workflow(
     let result = async {
         let (temporary, mut file) = unique_staging_file(&target_dir, "SKILL.md").await?;
         let write_result = async {
-            file.write_all(rendered.as_bytes()).await?;
+            file.write_all(&rendered.bytes).await?;
             file.flush().await?;
             file.sync_all().await?;
             drop(file);
@@ -581,7 +669,7 @@ pub async fn migrate_legacy_markdown_workflow(
         .await;
         let _ = tokio::fs::remove_file(&temporary).await;
         write_result?;
-        ensure_manual_only_policy(&target_dir, placeholder).await
+        ensure_manual_only_policy(&target_dir, prepared.manual_only).await
     }
     .await;
     if let Err(error) = result {
@@ -830,6 +918,11 @@ pub struct YamlMigrationDiagnostic {
     pub message: String,
 }
 
+const MAPPABLE_YAML_DIAGNOSTIC: &str =
+    "Legacy orchestration can be copied verbatim without changing execution semantics";
+const UNMAPPABLE_YAML_DIAGNOSTIC: &str =
+    "Legacy orchestration is invalid or cannot be mapped without changing execution semantics";
+
 /// Inspect old WorkflowDefinition YAML without writing or changing execution semantics.
 pub async fn diagnose_legacy_yaml_workflows(dir: &Path) -> Vec<YamlMigrationDiagnostic> {
     let mut diagnostics = Vec::new();
@@ -851,13 +944,11 @@ pub async fn diagnose_legacy_yaml_workflows(dir: &Path) -> Vec<YamlMigrationDiag
     paths.sort();
     for path in paths {
         let result = async {
-            let raw = tokio::fs::read_to_string(&path)
-                .await
-                .map_err(|e| e.to_string())?;
+            let raw = read_bounded_file(&path, MAX_LEGACY_WORKFLOW_FILE_BYTES).await?;
             let definition: bamboo_domain::WorkflowDefinition =
-                serde_yaml::from_str(&raw).map_err(|e| e.to_string())?;
-            definition.validate()?;
-            Ok::<_, String>(definition.id)
+                serde_yaml::from_slice(&raw).map_err(SkillError::from)?;
+            definition.validate().map_err(SkillError::Validation)?;
+            Ok::<_, SkillError>(definition.id)
         }
         .await;
         match result {
@@ -865,13 +956,13 @@ pub async fn diagnose_legacy_yaml_workflows(dir: &Path) -> Vec<YamlMigrationDiag
                 source: path,
                 workflow_id: Some(id),
                 can_map_to_bundle: true,
-                message: "Can be copied verbatim to workflow.yaml; execution remains owned by the orchestration runtime".to_string(),
+                message: MAPPABLE_YAML_DIAGNOSTIC.to_string(),
             }),
-            Err(error) => diagnostics.push(YamlMigrationDiagnostic {
+            Err(_) => diagnostics.push(YamlMigrationDiagnostic {
                 source: path,
                 workflow_id: None,
                 can_map_to_bundle: false,
-                message: error,
+                message: UNMAPPABLE_YAML_DIAGNOSTIC.to_string(),
             }),
         }
     }
@@ -947,18 +1038,21 @@ pub async fn migrate_legacy_yaml_workflows(
                         }
                         Err(error) => {
                             diagnostic.can_map_to_bundle = false;
-                            diagnostic.message = error.to_string();
+                            tracing::warn!(%error, "failed to publish legacy workflow.yaml");
+                            diagnostic.message = UNMAPPABLE_YAML_DIAGNOSTIC.to_string();
                         }
                     }
                 }
                 Err(error) => {
                     diagnostic.can_map_to_bundle = false;
-                    diagnostic.message = error.to_string();
+                    tracing::warn!(%error, "failed to stage legacy workflow.yaml");
+                    diagnostic.message = UNMAPPABLE_YAML_DIAGNOSTIC.to_string();
                 }
             },
             Err(error) => {
                 diagnostic.can_map_to_bundle = false;
-                diagnostic.message = error.to_string();
+                tracing::warn!(%error, "failed to read legacy workflow.yaml");
+                diagnostic.message = UNMAPPABLE_YAML_DIAGNOSTIC.to_string();
             }
         }
     }
@@ -1057,13 +1151,58 @@ mod tests {
         )
             .await
             .expect("safe yaml");
-        tokio::fs::write(temp.path().join("unsafe.yaml"), "id: unsafe\nsteps: []\n")
+        let unsafe_source = temp.path().join("unsafe.yaml");
+        let unsafe_bytes = b"id: unsafe\ndescription: PRIVATE-DIAGNOSTIC-SENTINEL\nsteps: []\n";
+        tokio::fs::write(&unsafe_source, unsafe_bytes)
             .await
             .expect("unsafe yaml");
         let diagnostics = diagnose_legacy_yaml_workflows(temp.path()).await;
         assert_eq!(diagnostics.len(), 2);
         assert!(diagnostics.iter().any(|item| item.can_map_to_bundle));
-        assert!(diagnostics.iter().any(|item| !item.can_map_to_bundle));
+        let invalid = diagnostics
+            .iter()
+            .find(|item| !item.can_map_to_bundle)
+            .expect("invalid diagnostic");
+        assert_eq!(invalid.message, UNMAPPABLE_YAML_DIAGNOSTIC);
+        assert!(!invalid.message.contains("PRIVATE-DIAGNOSTIC-SENTINEL"));
+        assert!(!invalid.message.contains("unsafe.yaml"));
+        assert_eq!(
+            tokio::fs::read(&unsafe_source)
+                .await
+                .expect("source remains"),
+            unsafe_bytes
+        );
+    }
+
+    #[test]
+    fn legacy_catalog_digest_binds_the_selected_source_bytes() {
+        let source = Path::new("workflows/review.md");
+        let selected = "---\ndescription: Review the selected change.\n---\nReview A.\n";
+        let replacement = "---\ndescription: Review the selected change.\n---\nReview B.\n";
+        let definition =
+            parse_legacy_markdown_adapter(source, "review", selected).expect("selected definition");
+        let mut entry = crate::catalog::entry_from_skill(
+            &definition,
+            SkillDirectorySource::Global,
+            7,
+            crate::catalog::BundleMetadata::default(),
+        );
+        entry.content_digest = crate::catalog::workflow_catalog_content_digest(
+            &entry,
+            Some(&definition),
+            std::iter::empty::<(&str, &[u8])>(),
+        );
+
+        assert_eq!(
+            legacy_markdown_catalog_content_digest(&entry, source, "review", selected)
+                .expect("selected digest"),
+            entry.content_digest
+        );
+        assert_ne!(
+            legacy_markdown_catalog_content_digest(&entry, source, "review", replacement)
+                .expect("replacement digest"),
+            entry.content_digest
+        );
     }
 
     #[tokio::test]
@@ -1259,6 +1398,10 @@ mod tests {
             .await
             .expect("migrated Skill");
         assert!(migrated.contains("legacy_migration: true"));
+        assert!(migrated.contains("original_source: .bamboo/workflows/review.md"));
+        assert!(migrated.contains(&format!(
+            "legacy_source_removal_boundary: {LEGACY_WORKFLOW_SOURCE_REMOVAL_BOUNDARY}"
+        )));
         assert!(migrated.contains("Review exactly this way."));
         assert!(skills.join("review/agents/bamboo.yaml").exists());
 

--- a/docs/project-identity.md
+++ b/docs/project-identity.md
@@ -64,9 +64,12 @@ override them. Deterministic workflows remain `workflow.yaml` files inside skill
 bundles—there is no standalone Project `workflows/` directory.
 
 For repository compatibility only, a Workspace may contain legacy read-only
-`.bamboo/workflows/*.md` sources. They can be explicitly cloned into that
-Workspace's `.bamboo/skills/` directory; migration never creates a Project-home
-`workflows/` directory or writes legacy content into Project storage.
+`.bamboo/workflows/*.md` sources. An assigned Project session explicitly
+migrates such a source into the Project home's canonical `skills/` layer; an
+unassigned legacy session retains the bounded Workspace `.bamboo/skills/`
+fallback. Migration never creates a Project-home `workflows/` directory,
+never modifies the source, and records the relative `original_source` plus the
+`lotus-119-complete` compatibility removal boundary in the migrated bundle.
 
 Project memory and Dream data are stored in
 `projects/<id>/memory/v1`. Assigned sessions never derive a write scope from a

--- a/docs/skills-and-project-instructions.md
+++ b/docs/skills-and-project-instructions.md
@@ -32,15 +32,26 @@ If a completed clone directory is later deleted, Bamboo records `retired`
 before starting a bounded replacement epoch; a different directory generation
 at the public name is never retired, adopted, or deleted.
 
-Migration is an explicit clone through
+Migration is an explicit transaction through
 `POST /api/v1/bamboo/workflow-catalog/<id>/migrate`, using a trusted session id
-to select the current workspace. It creates
-`<workspace>/.bamboo/skills/<id>/SKILL.md`, never modifies or deletes the
-legacy source, never overwrites an existing target, and is idempotent. The
-optional request `description` replaces the placeholder; otherwise the
-migrated bundle remains manual-only. The catalog reports the canonical winner
-as `migration_status: "migrated"` and retains the legacy adapter as a shadowed
-diagnostic.
+to resolve the source and canonical target layer. A user source under
+`${BAMBOO_DATA_DIR}/workflows` migrates to `${BAMBOO_DATA_DIR}/skills`; a
+Workspace legacy source owned by an assigned Project migrates to that
+Project's `skills` directory. Unassigned legacy sessions retain the bounded
+Workspace `.bamboo/skills` compatibility target. Publication reuses the same
+private staging, fsync, and atomic no-replace transaction as builtin clone.
+
+The source is never modified or deleted by migration, an existing target is
+never overwritten, and an exact repeat returns `already_migrated` without
+rewriting later user edits. Migrated `SKILL.md` metadata records
+`original_source`, the accepted source revision/content digest, and
+`legacy_source_removal_boundary: lotus-119-complete`. That boundary means the
+source compatibility path may be removed only after `bigduu/Lotus#119` is
+complete and consumers have moved to the canonical catalog; this endpoint
+does not remove it. The optional request `description` replaces the
+placeholder, otherwise the bundle remains manual-only. The public catalog
+reports one canonical `migration_status: "migrated"` entry and retains the
+read-only adapter only as a shadowed diagnostic, never as a duplicate row.
 
 [Claude Code Skills and legacy custom-command compatibility](https://code.claude.com/docs/en/slash-commands)
 remain rooted in `.claude/skills` and `<workspace>/.claude/commands`; Bamboo


### PR DESCRIPTION
## Summary

- route global legacy Markdown workflows into User Skills and project-bound legacy workflows into Project Skills
- bind migration, race detection, and idempotent retry to the accepted source identity plus restart-stable content digest, while reusing the atomic no-replace clone publication path
- collapse the migrated Skill and its legacy adapter into one public catalog row while retaining the original source as a shadow diagnostic
- preserve source files, record the explicit removal boundary, and return stable redacted diagnostics for unmappable YAML

Closes #875

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked` (passes; two pre-existing `too_many_arguments` warnings)
- `cargo clippy -p bamboo-skills -p bamboo-server --all-targets --all-features --locked --no-deps -- -D warnings -A clippy::too_many_arguments`
- `cargo test -p bamboo-skills legacy::tests --lib --locked` (10 passed)
- `cargo test -p bamboo-server handlers::settings::workflows::tests --lib --locked` (33 passed)
- `cargo test --workspace --locked` (passed, including 208 HTTP E2E tests and 1886 Bamboo Server unit tests; expected manual/feature-gated tests ignored)