### PR TITLE
[bamboo-plugin] feat: route ToolEvents through bounded per-sink queues

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -5,6 +5,7 @@ use super::init::{
 };
 use super::tools::{build_base_tools, build_root_tools};
 use super::*;
+use crate::tool_event_router::{CombinedToolEventPublisher, ToolEventRouter};
 use crate::tools::OptionalSubagentModelResolver;
 use bamboo_agent_core::storage::Storage;
 use bamboo_plugin_protocol::{NoopToolEventPublisher, ToolEventPublisher};
@@ -334,6 +335,16 @@ impl AppState {
             init_mcp_manager(config.clone(), &bamboo_home_dir);
         let skill_manager = init_skill_manager(&data_dir).await;
         let metrics_service = init_metrics_service(&data_dir).await?;
+
+        // Service input and ToolEvent routing share one AppState-owned
+        // lifecycle. The router is built before the tool surfaces so every
+        // executor receives the production publisher from its first call;
+        // it remains inert until install/boot reconciliation declares sinks.
+        let service_manager = Arc::new(crate::service_manager::ServiceManager::new());
+        let tool_event_router = ToolEventRouter::new(service_manager.clone());
+        let tool_event_publisher: Arc<dyn ToolEventPublisher> = Arc::new(
+            CombinedToolEventPublisher::new(tool_event_router.clone(), tool_event_publisher),
+        );
 
         let startup_sessions = {
             let entries = session_store.list_index_entries().await;
@@ -1006,7 +1017,6 @@ impl AppState {
         // until a plugin install or the boot-time reconcile below starts
         // something — mirrors `mcp_manager`/`connect_manager`'s
         // always-alive lifecycle.
-        let service_manager = Arc::new(crate::service_manager::ServiceManager::new());
         // Backgrounded (mirrors `init_mcp_manager`'s background MCP
         // bootstrap): a service that `installed.json` says should be
         // running but isn't (the previous `bamboo serve` process, if
@@ -1020,10 +1030,15 @@ impl AppState {
         // blocked on plugin service spawns.
         let boot_reconcile_services_handle = {
             let service_manager = service_manager.clone();
+            let tool_event_router = tool_event_router.clone();
             let app_data_dir = bamboo_home_dir.clone();
             tokio::spawn(async move {
-                crate::plugin_installer::boot_reconcile_services(&app_data_dir, &service_manager)
-                    .await;
+                crate::plugin_installer::boot_reconcile_services(
+                    &app_data_dir,
+                    &service_manager,
+                    &tool_event_router,
+                )
+                .await;
             })
         };
 
@@ -1041,6 +1056,7 @@ impl AppState {
         Ok(Self {
             app_data_dir: bamboo_home_dir,
             tool_event_publisher,
+            tool_event_router,
             config,
             config_facade,
             config_io_lock,

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -1024,10 +1024,11 @@ impl AppState {
         //
         // The `JoinHandle` is kept (not discarded) purely so tests can
         // deterministically wait it out via
-        // `AppState::wait_for_boot_reconcile_services` instead of racing
-        // this unsynchronized pass — see that method's doc comment and issue
-        // #486. Production code never awaits it; server startup is never
-        // blocked on plugin service spawns.
+        // `AppState::wait_for_boot_reconcile_services`. The pass shares the
+        // plugin operation lock with install/update/uninstall, so its
+        // manifest/provenance generation cannot race a newer mutation; see
+        // that method's doc comment and issue #486. Production code never
+        // awaits it; server startup is never blocked on plugin service spawns.
         let boot_reconcile_services_handle = {
             let service_manager = service_manager.clone();
             let tool_event_router = tool_event_router.clone();

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -160,9 +160,15 @@ pub struct AppState {
     /// Application data directory (configured via `BAMBOO_DATA_DIR`; default `${HOME}/.bamboo`)
     pub app_data_dir: PathBuf,
 
-    /// Instance-local, best-effort tool-event boundary. Never process-global;
-    /// every tool executor assembled for this state receives this exact Arc.
+    /// Instance-local, best-effort tool-event boundary. Production publication
+    /// fans into `tool_event_router`; the additional publisher preserves the
+    /// existing test/embedder injection seam. Never process-global.
     pub tool_event_publisher: Arc<dyn bamboo_plugin_protocol::ToolEventPublisher>,
+
+    /// Server-owned plugin ToolEvent registry and bounded per-sink delivery
+    /// plane. It is always present but inert until reconciliation installs an
+    /// eligible event-sink declaration.
+    pub tool_event_router: Arc<crate::tool_event_router::ToolEventRouter>,
 
     /// Hot-reloadable application configuration
     ///
@@ -379,11 +385,10 @@ pub struct AppState {
 
     /// Handle to the background boot-time service reconcile pass
     /// (`plugin_installer::boot_reconcile_services`, spawned fire-and-forget
-    /// by `app_state::builder` — see its comment). It is deliberately NOT
-    /// synchronized against `plugin_installer::PLUGIN_OP_LOCK`, so it can, in
-    /// principle, race a `ServerPluginInstaller::install`/
-    /// `stop_services_for_upgrade` call that lands on the SAME data dir
-    /// while it is still in flight (e.g. immediately after construction).
+    /// by `app_state::builder` — see its comment). It acquires the same
+    /// `plugin_installer::PLUGIN_OP_LOCK` used by install,
+    /// update, and uninstall before reading provenance, so its service/sink
+    /// plan cannot race a newer plugin generation.
     /// Production code never touches this field; it exists purely as a
     /// test-only synchronization point (see
     /// [`AppState::wait_for_boot_reconcile_services`]) so

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
@@ -64,13 +64,14 @@
 use serde::{Deserialize, Serialize};
 
 use bamboo_plugin::{
-    InstalledPlugin, PluginInstallStatus, PluginManifest, PluginSource, RegisteredCapabilities,
-    ServiceInputProtocol,
+    EventSinkInactiveReason, InstalledPlugin, PluginInstallStatus, PluginManifest, PluginSource,
+    RegisteredCapabilities, ServiceInputProtocol,
 };
 
 use crate::service_manager::{
     ServiceInputHealth, ServiceInputStatusSnapshot, ServiceManager, ServiceState,
 };
+use crate::tool_event_router::{ToolEventRouter, ToolEventSinkState, ToolEventSinkStatusSnapshot};
 
 /// Shared body for `POST /install` and `POST /{id}/update`.
 #[derive(Debug, Deserialize)]
@@ -105,6 +106,47 @@ pub struct InstalledPluginView {
     /// `registered`'s other `Vec` fields.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub service_status: Vec<ServiceStatusView>,
+    /// Bounded, payload-free health for provenance-owned event sinks. No
+    /// service stderr, serialized event, path, or OS error is retained here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub event_sink_status: Vec<ToolEventSinkStatusView>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolEventSinkStatusView {
+    pub id: String,
+    pub service_id: String,
+    pub state: ToolEventSinkState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inactive_reason: Option<EventSinkInactiveReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation: Option<u64>,
+    pub queue_capacity: usize,
+    pub max_event_bytes: usize,
+    pub delivered: u64,
+    pub queue_full: u64,
+    pub service_down: u64,
+    pub serialization: u64,
+    pub oversize: u64,
+}
+
+impl From<ToolEventSinkStatusSnapshot> for ToolEventSinkStatusView {
+    fn from(snapshot: ToolEventSinkStatusSnapshot) -> Self {
+        Self {
+            id: snapshot.id,
+            service_id: snapshot.service_id,
+            state: snapshot.state,
+            inactive_reason: snapshot.inactive_reason,
+            generation: snapshot.generation,
+            queue_capacity: snapshot.queue_capacity,
+            max_event_bytes: snapshot.max_event_bytes,
+            delivered: snapshot.delivered,
+            queue_full: snapshot.queue_full,
+            service_down: snapshot.service_down,
+            serialization: snapshot.serialization,
+            oversize: snapshot.oversize,
+        }
+    }
 }
 
 /// Wire projection of [`crate::service_manager::ServiceStatusSnapshot`] —
@@ -186,6 +228,7 @@ pub struct PluginListResponse {
 pub async fn to_view(
     entry: InstalledPlugin,
     service_manager: &ServiceManager,
+    tool_event_router: &ToolEventRouter,
 ) -> InstalledPluginView {
     let name = read_manifest_name(&entry.plugin_dir).await;
     let mut service_status = Vec::with_capacity(entry.registered.service_ids.len());
@@ -214,6 +257,12 @@ pub async fn to_view(
         };
         service_status.push(view);
     }
+    let event_sink_status = tool_event_router
+        .status_for_ids(&entry.registered.event_sink_ids)
+        .await
+        .into_iter()
+        .map(Into::into)
+        .collect();
     InstalledPluginView {
         id: entry.id,
         name,
@@ -222,6 +271,7 @@ pub async fn to_view(
         status: entry.status,
         registered: entry.registered,
         service_status,
+        event_sink_status,
     }
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
@@ -68,7 +68,8 @@ pub async fn list_plugins(state: web::Data<AppState>) -> impl Responder {
         Ok(entries) => {
             let mut plugins = Vec::with_capacity(entries.len());
             for entry in entries {
-                plugins.push(to_view(entry, &state.service_manager).await);
+                plugins
+                    .push(to_view(entry, &state.service_manager, &state.tool_event_router).await);
             }
             HttpResponse::Ok().json(PluginListResponse { plugins })
         }
@@ -98,7 +99,8 @@ pub async fn install_plugin(
     )
     .await
     {
-        Ok(entry) => HttpResponse::Created().json(to_view(entry, &state.service_manager).await),
+        Ok(entry) => HttpResponse::Created()
+            .json(to_view(entry, &state.service_manager, &state.tool_event_router).await),
         Err(error) => plugin_error_response(&error),
     }
 }
@@ -133,7 +135,8 @@ pub async fn update_plugin(
     )
     .await
     {
-        Ok(entry) => HttpResponse::Ok().json(to_view(entry, &state.service_manager).await),
+        Ok(entry) => HttpResponse::Ok()
+            .json(to_view(entry, &state.service_manager, &state.tool_event_router).await),
         Err(error) => plugin_error_response(&error),
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
@@ -239,6 +239,48 @@ async fn install_list_reinstall_conflict_then_delete() {
     assert!(hello_plugin_example_dir().join("plugin.json").exists());
 }
 
+#[actix_web::test]
+async fn installed_event_sink_exposes_bounded_sanitized_status() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let source_root = tempfile::tempdir().unwrap();
+    let source = write_event_sink_plugin_dir(
+        source_root.path(),
+        "status-source",
+        "status-plugin",
+        "1.0.0",
+        "payload-must-not-enter-status",
+    )
+    .await;
+    let manifest_path = source.join("plugin.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&tokio::fs::read_to_string(&manifest_path).await.unwrap()).unwrap();
+    manifest["provides"]["services"][0]["enabled"] = serde_json::json!(false);
+    tokio::fs::write(&manifest_path, manifest.to_string())
+        .await
+        .unwrap();
+
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state)).await;
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(local_dir_source(&source))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let view = body_json(resp).await;
+    let status = &view["event_sink_status"][0];
+    assert_eq!(status["id"], "shared-sink");
+    assert_eq!(status["service_id"], "audit-service");
+    assert_eq!(status["state"], "inactive");
+    assert_eq!(status["inactive_reason"]["reason"], "service_disabled");
+    assert_eq!(status["queue_capacity"], 64);
+    assert_eq!(status["max_event_bytes"], 16 * 1024);
+    assert_eq!(status["delivered"], 0);
+    let safe = serde_json::to_string(status).unwrap();
+    assert!(!safe.contains("payload-must-not-enter-status"));
+    assert!(!safe.contains(source.to_string_lossy().as_ref()));
+}
+
 // ---------------------------------------------------------------------
 // A bad manifest (fails PluginManifest::validate) -> 400.
 // ---------------------------------------------------------------------

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
@@ -130,7 +130,8 @@ async fn write_event_sink_plugin_dir(
                 "services": [{
                     "id": "audit-service",
                     "enabled": true,
-                    "command": "${platform_bin}"
+                    "command": "${platform_bin}",
+                    "input_protocol": "ndjson_v1"
                 }],
                 "event_sinks": [{
                     "id": "shared-sink",

--- a/crates/app/bamboo-server/src/lib.rs
+++ b/crates/app/bamboo-server/src/lib.rs
@@ -127,6 +127,7 @@ pub mod server;
 pub mod service_manager;
 pub mod services;
 pub mod session_app;
+pub mod tool_event_router;
 
 // Re-export shims: these modules were relocated to bamboo-engine; keep the
 // historical bamboo_server::… paths working for external/integration-test refs.

--- a/crates/app/bamboo-server/src/plugin_installer.rs
+++ b/crates/app/bamboo-server/src/plugin_installer.rs
@@ -221,6 +221,12 @@ struct InstallRollback {
     service_ids_started: Vec<String>,
 }
 
+#[derive(Default)]
+struct InstallFailureInjection {
+    before_service_replacement: bool,
+    final_provenance_commit: bool,
+}
+
 impl ServerPluginInstaller {
     pub fn new(state: actix_web::web::Data<AppState>) -> Self {
         Self { state }
@@ -525,26 +531,25 @@ impl ServerPluginInstaller {
     /// beneath a still-live sink generation. A retained sink id may change
     /// its backing service id, which `RegisteredCapabilities::removed_since`
     /// cannot express because provenance stores capability ids rather than
-    /// sink-to-service edges. If any old service is being dropped, revoke and
-    /// join every prior sink first; the replacement plan is installed only
-    /// after the new services have been registered.
-    ///
-    /// Returns whether the complete prior sink set was already revoked, so
-    /// the later same-service replacement seam can avoid redundant work.
+    /// sink-to-service edges. Before stopping dropped services, revoke only
+    /// prior sinks whose current router declaration is actually backed by one
+    /// of those services. Unrelated retained routes must survive failures
+    /// before the later full service-replacement seam.
     async fn deregister_upgrade_drop_diff(
         &self,
+        plugin_id: &str,
         previous: &RegisteredCapabilities,
         dropped: &RegisteredCapabilities,
-    ) -> bool {
-        let revoked_all_prior_sinks = !dropped.service_ids.is_empty();
-        if revoked_all_prior_sinks {
-            self.state
-                .tool_event_router
-                .unregister_sinks(&previous.event_sink_ids)
-                .await;
-        }
+    ) {
+        self.state
+            .tool_event_router
+            .unregister_plugin_sinks_backed_by_services(
+                plugin_id,
+                &previous.event_sink_ids,
+                &dropped.service_ids,
+            )
+            .await;
         self.deregister_capabilities(dropped).await;
-        revoked_all_prior_sinks
     }
 
     /// Best-effort undo of an `install()` that failed partway through steps
@@ -976,7 +981,35 @@ impl ServerPluginInstaller {
             disposition,
             installed_at,
             _guard,
-            false,
+            InstallFailureInjection::default(),
+        )
+        .await
+    }
+
+    /// Deterministic test seam immediately after the Step-0 drop-diff and
+    /// crash-safety journal, but before every prior sink is revoked for
+    /// possible same-id service replacement.
+    #[cfg(test)]
+    pub(crate) async fn install_with_operation_failing_before_service_replacement(
+        &self,
+        manifest: &PluginManifest,
+        plugin_dir: &Path,
+        source: PluginSource,
+        disposition: InstallDisposition,
+        installed_at: DateTime<Utc>,
+        guard: &PluginOperationGuard,
+    ) -> PluginResult<InstalledPlugin> {
+        self.install_with_operation_inner(
+            manifest,
+            plugin_dir,
+            source,
+            disposition,
+            installed_at,
+            guard,
+            InstallFailureInjection {
+                before_service_replacement: true,
+                ..InstallFailureInjection::default()
+            },
         )
         .await
     }
@@ -1001,7 +1034,10 @@ impl ServerPluginInstaller {
             disposition,
             installed_at,
             guard,
-            true,
+            InstallFailureInjection {
+                final_provenance_commit: true,
+                ..InstallFailureInjection::default()
+            },
         )
         .await
     }
@@ -1014,7 +1050,7 @@ impl ServerPluginInstaller {
         disposition: InstallDisposition,
         installed_at: DateTime<Utc>,
         _guard: &PluginOperationGuard,
-        fail_final_provenance_commit: bool,
+        failure_injection: InstallFailureInjection,
     ) -> PluginResult<InstalledPlugin> {
         let installed_json_path = self.installed_json_path();
 
@@ -1069,7 +1105,6 @@ impl ServerPluginInstaller {
         // no longer declares BEFORE registering anything new (BLOCKER 2). Also
         // fires for a recovery over an `Installing` leftover: its intended set
         // is diffed the same way, so a crashed attempt's extra ids get cleaned.
-        let mut prior_sinks_revoked_for_service_drop = false;
         if let Some(previous) = &previous {
             let dropped = intended.removed_since(&previous.registered);
             if !dropped.is_empty() {
@@ -1083,8 +1118,7 @@ impl ServerPluginInstaller {
                     dropped_event_sinks = ?dropped.event_sink_ids,
                     "install drop-diff: de-registering capabilities the new/completed version no longer declares"
                 );
-                prior_sinks_revoked_for_service_drop = self
-                    .deregister_upgrade_drop_diff(&previous.registered, &dropped)
+                self.deregister_upgrade_drop_diff(&manifest.id, &previous.registered, &dropped)
                     .await;
             }
         }
@@ -1132,22 +1166,30 @@ impl ServerPluginInstaller {
             }
         };
 
+        if failure_injection.before_service_replacement {
+            let error = PluginError::Registration(
+                "injected failure before service replacement".to_string(),
+            );
+            self.abort_install(&rollback, &previous, &manifest.id, &installed_json_path)
+                .await;
+            return Err(error);
+        }
+
         // Direct `PluginInstaller::install(..., Upgrade, ...)` callers do not
         // pass through plugin_source's pre-swap stop hook. Revoke every prior
         // sink generation at the last common point before `register_services`
         // can stop/replace a same-id service. When Step 0 did not drop an old
         // service, keeping this after the journal and MCP step means an
         // earlier failure leaves that still-running service and route intact.
-        // If Step 0 did drop a service, all prior sinks were necessarily
-        // revoked before that stop. The source path may also have revoked the
-        // set already; unregister is intentionally idempotent.
-        if !prior_sinks_revoked_for_service_drop {
-            if let Some(previous) = &previous {
-                self.state
-                    .tool_event_router
-                    .unregister_sinks(&previous.registered.event_sink_ids)
-                    .await;
-            }
+        // Step 0 revoked only sinks backed by services it actually dropped;
+        // this full revoke is therefore always required before retained
+        // same-id service replacement. The source path may also have revoked
+        // the set already; unregister is intentionally idempotent.
+        if let Some(previous) = &previous {
+            self.state
+                .tool_event_router
+                .unregister_sinks(&previous.registered.event_sink_ids)
+                .await;
         }
 
         // Step 1b: Services (issue #479). Runs right after MCP, before the
@@ -1224,7 +1266,7 @@ impl ServerPluginInstaller {
             status: PluginInstallStatus::Installed,
             registered,
         };
-        let final_commit = if fail_final_provenance_commit {
+        let final_commit = if failure_injection.final_provenance_commit {
             Err(PluginError::Registration(
                 "injected final Installed provenance commit failure".to_string(),
             ))

--- a/crates/app/bamboo-server/src/plugin_installer.rs
+++ b/crates/app/bamboo-server/src/plugin_installer.rs
@@ -989,7 +989,7 @@ impl ServerPluginInstaller {
     /// Deterministic test seam immediately after the Step-0 drop-diff and
     /// crash-safety journal, but before every prior sink is revoked for
     /// possible same-id service replacement.
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub(crate) async fn install_with_operation_failing_before_service_replacement(
         &self,
         manifest: &PluginManifest,

--- a/crates/app/bamboo-server/src/plugin_installer.rs
+++ b/crates/app/bamboo-server/src/plugin_installer.rs
@@ -10,16 +10,15 @@
 //! downstream `impl PluginInstaller for ServerPluginInstaller` (the trait is
 //! foreign, the type is local — no orphan-rule issue).
 //!
-//! # Why a borrowed `web::Data<AppState>` and no `AppState` struct change
+//! # Why a borrowed `web::Data<AppState>`
 //!
 //! `ServerPluginInstaller` holds a `web::Data<AppState>` clone — the exact
 //! handle every HTTP handler in this crate already receives as an argument
 //! (`web::Data` is `Arc`-backed, so cloning it is cheap). An HTTP handler
 //! constructs one per request: `ServerPluginInstaller::new(state.clone())`.
-//! `AppState` itself is intentionally untouched — no new field, no
-//! coordinated append to `app_state/mod.rs` / `app_state/builder.rs` — so
-//! this branch can never conflict with the other Wave-2 branches that also
-//! stack on `feat/plugin-framework`.
+//! The installer coordinates the AppState-owned service manager and ToolEvent
+//! router, so runtime registration and revocation share the same lifecycle
+//! boundary as durable plugin provenance.
 //!
 //! # Path derivation: `state.app_data_dir`, not the `bamboo_config::paths` globals
 //!
@@ -520,6 +519,32 @@ impl ServerPluginInstaller {
         for service_id in &registered.service_ids {
             self.remove_service(service_id).await;
         }
+    }
+
+    /// Apply an upgrade's id-level drop-diff without ever stopping a service
+    /// beneath a still-live sink generation. A retained sink id may change
+    /// its backing service id, which `RegisteredCapabilities::removed_since`
+    /// cannot express because provenance stores capability ids rather than
+    /// sink-to-service edges. If any old service is being dropped, revoke and
+    /// join every prior sink first; the replacement plan is installed only
+    /// after the new services have been registered.
+    ///
+    /// Returns whether the complete prior sink set was already revoked, so
+    /// the later same-service replacement seam can avoid redundant work.
+    async fn deregister_upgrade_drop_diff(
+        &self,
+        previous: &RegisteredCapabilities,
+        dropped: &RegisteredCapabilities,
+    ) -> bool {
+        let revoked_all_prior_sinks = !dropped.service_ids.is_empty();
+        if revoked_all_prior_sinks {
+            self.state
+                .tool_event_router
+                .unregister_sinks(&previous.event_sink_ids)
+                .await;
+        }
+        self.deregister_capabilities(dropped).await;
+        revoked_all_prior_sinks
     }
 
     /// Best-effort undo of an `install()` that failed partway through steps
@@ -1044,6 +1069,7 @@ impl ServerPluginInstaller {
         // no longer declares BEFORE registering anything new (BLOCKER 2). Also
         // fires for a recovery over an `Installing` leftover: its intended set
         // is diffed the same way, so a crashed attempt's extra ids get cleaned.
+        let mut prior_sinks_revoked_for_service_drop = false;
         if let Some(previous) = &previous {
             let dropped = intended.removed_since(&previous.registered);
             if !dropped.is_empty() {
@@ -1057,7 +1083,9 @@ impl ServerPluginInstaller {
                     dropped_event_sinks = ?dropped.event_sink_ids,
                     "install drop-diff: de-registering capabilities the new/completed version no longer declares"
                 );
-                self.deregister_capabilities(&dropped).await;
+                prior_sinks_revoked_for_service_drop = self
+                    .deregister_upgrade_drop_diff(&previous.registered, &dropped)
+                    .await;
             }
         }
 
@@ -1107,15 +1135,19 @@ impl ServerPluginInstaller {
         // Direct `PluginInstaller::install(..., Upgrade, ...)` callers do not
         // pass through plugin_source's pre-swap stop hook. Revoke every prior
         // sink generation at the last common point before `register_services`
-        // can stop/replace a same-id service. Keeping this after the journal
-        // and MCP step means an earlier failure leaves the still-running old
-        // service and its route intact. The source path may already have
-        // revoked it; unregister is intentionally idempotent.
-        if let Some(previous) = &previous {
-            self.state
-                .tool_event_router
-                .unregister_sinks(&previous.registered.event_sink_ids)
-                .await;
+        // can stop/replace a same-id service. When Step 0 did not drop an old
+        // service, keeping this after the journal and MCP step means an
+        // earlier failure leaves that still-running service and route intact.
+        // If Step 0 did drop a service, all prior sinks were necessarily
+        // revoked before that stop. The source path may also have revoked the
+        // set already; unregister is intentionally idempotent.
+        if !prior_sinks_revoked_for_service_drop {
+            if let Some(previous) = &previous {
+                self.state
+                    .tool_event_router
+                    .unregister_sinks(&previous.registered.event_sink_ids)
+                    .await;
+            }
         }
 
         // Step 1b: Services (issue #479). Runs right after MCP, before the

--- a/crates/app/bamboo-server/src/plugin_installer.rs
+++ b/crates/app/bamboo-server/src/plugin_installer.rs
@@ -141,7 +141,8 @@ use bamboo_domain::mcp_config::McpServerConfig;
 use bamboo_plugin::installer::{load_previous_for_disposition, preflight_install};
 use bamboo_plugin::manifest::{Platform, ServiceManifestEntry};
 use bamboo_plugin::registry::{
-    reconcile_exclusive, reconcile_plugin_boot, PluginBootCandidate, RegisteredCapabilities,
+    reconcile_event_sinks, reconcile_exclusive, reconcile_plugin_boot, PluginBootCandidate,
+    RegisteredCapabilities,
 };
 use bamboo_plugin::{
     InstallDisposition, InstalledPlugin, InstalledPlugins, PluginError, PluginInstallStatus,
@@ -155,6 +156,7 @@ use crate::handlers::agent::prompt_presets::{
     ensure_unique_preset_id, load_store, save_store, store_file_path, StoredPromptPreset,
 };
 use crate::service_manager::{ServiceManager, ServiceRuntimeConfig};
+use crate::tool_event_router::ToolEventRouter;
 
 /// Process-wide serialization of plugin install/uninstall operations.
 ///
@@ -381,10 +383,10 @@ impl ServerPluginInstaller {
             .collect())
     }
 
-    /// Event-sink ids are process/AppState registration keys in #905. Until
-    /// that runtime exists, installed provenance is the authoritative global
-    /// ownership index and lets #903 reject cross-plugin borrowing before any
-    /// install mutation.
+    /// Event-sink ids are process/AppState registration keys. Installed
+    /// provenance remains the authoritative global ownership index; the live
+    /// router only activates a reconciliation plan after this check has
+    /// rejected cross-plugin borrowing before any install mutation.
     async fn existing_event_sink_ids(&self, exclude_plugin_id: &str) -> PluginResult<Vec<String>> {
         let store = InstalledPlugins::load(&self.installed_json_path()).await?;
         store.get_unique(exclude_plugin_id)?;
@@ -499,6 +501,13 @@ impl ServerPluginInstaller {
     /// upgrade drop-diff and for `uninstall`). Skill dirs need no shared-store
     /// action — they are only ever removed by deleting `plugin_dir` itself.
     async fn deregister_capabilities(&self, registered: &RegisteredCapabilities) {
+        // #903's removal contract is authority-bearing: revoke the hot routing
+        // snapshot and await every exact-generation worker before the backing
+        // service can be stopped by the loop below.
+        self.state
+            .tool_event_router
+            .unregister_sinks(&registered.removal_order().event_sink_ids_before_services)
+            .await;
         for mcp_id in &registered.mcp_server_ids {
             self.remove_mcp_server(mcp_id).await;
         }
@@ -904,6 +913,15 @@ impl ServerPluginInstaller {
             }
         };
         let mut stopped = Vec::with_capacity(entry.registered.service_ids.len());
+        self.state
+            .tool_event_router
+            .unregister_sinks(
+                &entry
+                    .registered
+                    .removal_order()
+                    .event_sink_ids_before_services,
+            )
+            .await;
         for service_id in &entry.registered.service_ids {
             match self.state.service_manager.stop_service(service_id).await {
                 Ok(()) => stopped.push(service_id.clone()),
@@ -1086,6 +1104,20 @@ impl ServerPluginInstaller {
             }
         };
 
+        // Direct `PluginInstaller::install(..., Upgrade, ...)` callers do not
+        // pass through plugin_source's pre-swap stop hook. Revoke every prior
+        // sink generation at the last common point before `register_services`
+        // can stop/replace a same-id service. Keeping this after the journal
+        // and MCP step means an earlier failure leaves the still-running old
+        // service and its route intact. The source path may already have
+        // revoked it; unregister is intentionally idempotent.
+        if let Some(previous) = &previous {
+            self.state
+                .tool_event_router
+                .unregister_sinks(&previous.registered.event_sink_ids)
+                .await;
+        }
+
         // Step 1b: Services (issue #479). Runs right after MCP, before the
         // never-refusing Prompts step, so a services conflict fails the
         // install as early as the other REFUSE-on-conflict kinds do. Note:
@@ -1145,6 +1177,12 @@ impl ServerPluginInstaller {
             service_ids,
             event_sink_ids: event_sink_reconciliation.to_register,
         };
+        let runtime_sink_plan = reconcile_event_sinks(
+            manifest,
+            &registered,
+            PluginInstallStatus::Installed,
+            Platform::current(),
+        )?;
         let entry = InstalledPlugin {
             id: manifest.id.clone(),
             version: manifest.version.clone(),
@@ -1167,6 +1205,14 @@ impl ServerPluginInstaller {
                 .await;
             return Err(error);
         }
+
+        // Provenance is committed before runtime publication. The router
+        // records eligible/inactive declarations now, but only creates a live
+        // queue after ServiceManager exposes a Ready exact-generation sender.
+        self.state
+            .tool_event_router
+            .apply_plugin_plan(&manifest.id, manifest, &runtime_sink_plan)
+            .await;
 
         Ok(entry)
     }
@@ -1289,7 +1335,16 @@ fn resolve_service_config_under(
 /// Deliberately reads `installed.json` + each plugin's on-disk
 /// `plugin.json` directly rather than going through `ServerPluginInstaller`
 /// (which needs a fully-built `web::Data<AppState>` this runs before).
-pub async fn boot_reconcile_services(app_data_dir: &Path, service_manager: &ServiceManager) {
+pub async fn boot_reconcile_services(
+    app_data_dir: &Path,
+    service_manager: &ServiceManager,
+    tool_event_router: &std::sync::Arc<ToolEventRouter>,
+) {
+    // Boot reads a provenance snapshot and then mutates both service and sink
+    // generations from that plan. Serialize the whole pass with install,
+    // update, and uninstall so an old boot plan can never unregister or
+    // overwrite a route those operations just committed.
+    let _op_guard = PLUGIN_OP_LOCK.lock().await;
     let installed_json_path = app_data_dir.join("plugins").join("installed.json");
     let store = match InstalledPlugins::load(&installed_json_path).await {
         Ok(store) => store,
@@ -1327,15 +1382,15 @@ pub async fn boot_reconcile_services(app_data_dir: &Path, service_manager: &Serv
 
     for (candidate, plan) in candidates.iter().zip(plans) {
         let plugin = &candidate.installed;
+        tool_event_router
+            .unregister_sinks(&plan.event_sinks.deactivate_before_services)
+            .await;
         for issue in &plan.issues {
             tracing::warn!(
                 plugin_id = %plugin.id,
                 ?issue,
                 "service boot-reconcile: provenance audit kept capabilities inactive"
             );
-        }
-        if plan.service_ids_to_start.is_empty() {
-            continue;
         }
         let Some(manifest) = candidate.manifest.as_ref() else {
             continue;
@@ -1384,6 +1439,9 @@ pub async fn boot_reconcile_services(app_data_dir: &Path, service_manager: &Serv
                 ),
             }
         }
+        tool_event_router
+            .apply_plugin_plan(&plugin.id, manifest, &plan.event_sinks)
+            .await;
     }
 }
 

--- a/crates/app/bamboo-server/src/plugin_installer/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_installer/tests.rs
@@ -12,8 +12,9 @@ use bamboo_plugin_protocol::{
 };
 use chrono::Utc;
 
-use super::ServerPluginInstaller;
+use super::{boot_reconcile_services, ServerPluginInstaller, PLUGIN_OP_LOCK};
 use crate::app_state::AppState;
+use crate::tool_event_router::ToolEventSinkState;
 
 /// A never-resolves stdio command: `Command::spawn` fails immediately (ENOENT)
 /// so `mcp_manager.start_server` returns a fast `Err` instead of hanging on a
@@ -26,18 +27,11 @@ async fn new_installer(data_dir: &Path) -> (web::Data<AppState>, ServerPluginIns
         .await
         .expect("app state should initialize");
     // `AppState::new` fires the boot-time service reconcile pass
-    // (`plugin_installer::boot_reconcile_services`) in the background,
-    // unsynchronized against `PLUGIN_OP_LOCK` (see that function's doc
-    // comment). On a fresh `data_dir` it is a same-tick no-op (nothing in
-    // `installed.json` yet) — UNLESS it is still in flight when a
-    // service-lifecycle test below writes `installed.json` and starts/stops
-    // a service moments later, in which case it can race back in and
-    // resurrect (or fail to see) a service the test just
-    // installed/stopped, producing exactly the `is_running` flakes tracked
-    // by issue #486. Draining it here (once, before any test touches
-    // `installed.json`) removes that race entirely: by construction it can
-    // only observe an empty store at this point, so this always resolves
-    // near-instantly.
+    // (`plugin_installer::boot_reconcile_services`) in the background. It now
+    // shares `PLUGIN_OP_LOCK` with installer mutations, preventing a stale
+    // service/sink plan from racing a newer plugin generation. Tests still
+    // drain the one-shot pass here so each fixture starts from deterministic
+    // completed boot state rather than depending on lock-waiter scheduling.
     state.wait_for_boot_reconcile_services().await;
     let data = web::Data::new(state);
     let installer = ServerPluginInstaller::new(data.clone());
@@ -1828,4 +1822,84 @@ async fn stop_services_for_upgrade_on_a_plugin_with_no_services_is_a_harmless_no
     let (_state, installer) = new_installer(&root.path().join("bamboo-home")).await;
     let stopped = installer.stop_services_for_upgrade("never-installed").await;
     assert!(stopped.is_empty());
+}
+
+#[tokio::test]
+async fn boot_reconcile_takes_plugin_op_lock_before_reading_its_generation_plan() {
+    let root = tempfile::tempdir().unwrap();
+    let data_dir = root.path().join("bamboo-home");
+    let (state, _installer) = new_installer(&data_dir).await;
+    let plugins_root = data_dir.join("plugins");
+    tokio::fs::create_dir_all(&plugins_root).await.unwrap();
+
+    let old_dir = plugins_root.join("generation-old");
+    let new_dir = plugins_root.join("generation-new");
+    tokio::fs::create_dir_all(&old_dir).await.unwrap();
+    tokio::fs::create_dir_all(&new_dir).await.unwrap();
+    let old_manifest = event_sink_manifest_json(
+        "generation-plugin",
+        "1.0.0",
+        "generation-service",
+        &[("old-sink", TOOL_EVENT_V1_SCHEMA_VERSION)],
+    );
+    let new_manifest = event_sink_manifest_json(
+        "generation-plugin",
+        "2.0.0",
+        "generation-service",
+        &[("new-sink", TOOL_EVENT_V1_SCHEMA_VERSION)],
+    );
+    tokio::fs::write(old_dir.join("plugin.json"), old_manifest)
+        .await
+        .unwrap();
+    tokio::fs::write(new_dir.join("plugin.json"), new_manifest)
+        .await
+        .unwrap();
+
+    let entry = |version: &str, plugin_dir: PathBuf, sink_id: &str| InstalledPlugin {
+        id: "generation-plugin".to_string(),
+        version: version.to_string(),
+        source: PluginSource::LocalDir {
+            path: plugin_dir.clone(),
+        },
+        plugin_dir,
+        installed_at: Utc::now(),
+        status: PluginInstallStatus::Installed,
+        registered: RegisteredCapabilities {
+            service_ids: vec!["generation-service".to_string()],
+            event_sink_ids: vec![sink_id.to_string()],
+            ..Default::default()
+        },
+    };
+    let installed_path = plugins_root.join("installed.json");
+    let op_guard = PLUGIN_OP_LOCK.lock().await;
+    let mut old_store = InstalledPlugins::default();
+    old_store.plugins.push(entry("1.0.0", old_dir, "old-sink"));
+    old_store.save(&installed_path).await.unwrap();
+
+    let boot = {
+        let data_dir = data_dir.clone();
+        let service_manager = state.service_manager.clone();
+        let router = state.tool_event_router.clone();
+        tokio::spawn(async move {
+            boot_reconcile_services(&data_dir, &service_manager, &router).await;
+        })
+    };
+    tokio::task::yield_now().await;
+    assert!(
+        !boot.is_finished(),
+        "boot must wait for the plugin operation generation lock"
+    );
+
+    let mut new_store = InstalledPlugins::default();
+    new_store.plugins.push(entry("2.0.0", new_dir, "new-sink"));
+    new_store.save(&installed_path).await.unwrap();
+    drop(op_guard);
+    boot.await.unwrap();
+
+    let status = state
+        .tool_event_router
+        .status_for_ids(&["old-sink".to_string(), "new-sink".to_string()])
+        .await;
+    assert_eq!(status[0].state, ToolEventSinkState::Unavailable);
+    assert_eq!(status[1].state, ToolEventSinkState::Inactive);
 }

--- a/crates/app/bamboo-server/src/plugin_installer/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_installer/tests.rs
@@ -1922,12 +1922,9 @@ async fn changed_backing_service_revokes_retained_sink_before_old_service_stop()
     .await
     .expect("old sink worker becomes live");
 
-    assert!(
-        installer
-            .deregister_upgrade_drop_diff(&previous, &dropped)
-            .await,
-        "a dropped service must force full prior-sink revocation"
-    );
+    installer
+        .deregister_upgrade_drop_diff("changed-service-plugin", &previous, &dropped)
+        .await;
     assert_eq!(
         state
             .tool_event_router
@@ -1937,6 +1934,184 @@ async fn changed_backing_service_revokes_retained_sink_before_old_service_stop()
         ToolEventSinkState::Unavailable
     );
     assert!(!state.service_manager.is_running("old-service"));
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_upgrade_dropping_unrelated_service_preserves_retained_live_route() {
+    use std::time::Duration;
+
+    use bamboo_domain::mcp_config::ReconnectConfig;
+    use bamboo_plugin::manifest::{GracefulShutdown, HealthCheckSpec, ServiceInputProtocol};
+    use bamboo_plugin::reconcile_event_sinks;
+
+    use crate::service_manager::ServiceRuntimeConfig;
+
+    let root = tempfile::tempdir().unwrap();
+    let data_dir = root.path().join("bamboo-home");
+    let (state, installer) = new_installer(&data_dir).await;
+    let plugin_dir = data_dir.join("plugins").join("rollback-route-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+
+    let old_raw = event_sink_manifest_json(
+        "rollback-route-plugin",
+        "1.0.0",
+        "retained-service",
+        &[("retained-sink", TOOL_EVENT_V1_SCHEMA_VERSION)],
+    );
+    let mut old_value: serde_json::Value = serde_json::from_str(&old_raw).unwrap();
+    old_value["provides"]["services"][0]["enabled"] = serde_json::json!(true);
+    old_value["provides"]["services"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "id": "dropped-service",
+            "enabled": true,
+            "command": "${platform_bin}",
+            "input_protocol": "ndjson_v1"
+        }));
+    let old_manifest = PluginManifest::parse_str(&old_value.to_string()).unwrap();
+    old_manifest.validate().unwrap();
+
+    let mut new_value = old_value.clone();
+    new_value["version"] = serde_json::json!("2.0.0");
+    new_value["provides"]["services"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|service| service["id"] == "retained-service");
+    let new_raw = new_value.to_string();
+    tokio::fs::write(plugin_dir.join("plugin.json"), &new_raw)
+        .await
+        .unwrap();
+    let new_manifest = PluginManifest::parse_str(&new_raw).unwrap();
+    new_manifest.validate().unwrap();
+
+    let previous_registered = RegisteredCapabilities {
+        service_ids: vec![
+            "retained-service".to_string(),
+            "dropped-service".to_string(),
+        ],
+        event_sink_ids: vec!["retained-sink".to_string()],
+        ..Default::default()
+    };
+    let previous_entry = InstalledPlugin {
+        id: "rollback-route-plugin".to_string(),
+        version: "1.0.0".to_string(),
+        source: PluginSource::LocalDir {
+            path: plugin_dir.clone(),
+        },
+        plugin_dir: plugin_dir.clone(),
+        installed_at: Utc::now(),
+        status: PluginInstallStatus::Installed,
+        registered: previous_registered.clone(),
+    };
+    let mut store = InstalledPlugins::default();
+    store.add(previous_entry.clone());
+    store
+        .save(&data_dir.join("plugins").join("installed.json"))
+        .await
+        .unwrap();
+
+    for service_id in ["retained-service", "dropped-service"] {
+        state
+            .service_manager
+            .start_service(ServiceRuntimeConfig {
+                id: service_id.to_string(),
+                plugin_id: "rollback-route-plugin".to_string(),
+                name: None,
+                command: PathBuf::from("/bin/sh"),
+                args: vec![
+                    "-c".to_string(),
+                    "while IFS= read -r line; do :; done".to_string(),
+                ],
+                cwd: None,
+                env: Default::default(),
+                health_check: HealthCheckSpec::default(),
+                restart_policy: ReconnectConfig {
+                    enabled: false,
+                    ..ReconnectConfig::default()
+                },
+                graceful_shutdown: GracefulShutdown::default(),
+                input_protocol: ServiceInputProtocol::NdjsonV1,
+                user_config_path: root.path().join(format!("{service_id}-config.json")),
+            })
+            .await
+            .unwrap();
+    }
+    let old_plan = reconcile_event_sinks(
+        &old_manifest,
+        &previous_registered,
+        PluginInstallStatus::Installed,
+        Platform::current(),
+    )
+    .unwrap();
+    state
+        .tool_event_router
+        .apply_plugin_plan("rollback-route-plugin", &old_manifest, &old_plan)
+        .await;
+    let prior_generation = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let status = state
+                .tool_event_router
+                .status_for_ids(&["retained-sink".to_string()])
+                .await;
+            if status[0].state == ToolEventSinkState::Live {
+                break status[0].generation.expect("live route generation");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("retained route becomes live");
+
+    let guard = installer.begin_operation().await;
+    let error = installer
+        .install_with_operation_failing_before_service_replacement(
+            &new_manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::Upgrade,
+            Utc::now(),
+            &guard,
+        )
+        .await
+        .expect_err("injected failure must abort before service replacement");
+    drop(guard);
+    assert!(error
+        .to_string()
+        .contains("injected failure before service replacement"));
+
+    let retained_status = state
+        .tool_event_router
+        .status_for_ids(&["retained-sink".to_string()])
+        .await;
+    assert_eq!(retained_status[0].state, ToolEventSinkState::Live);
+    assert_eq!(retained_status[0].generation, Some(prior_generation));
+    assert!(state.service_manager.is_running("retained-service"));
+    assert!(!state.service_manager.is_running("dropped-service"));
+
+    let restored = InstalledPlugins::load(&data_dir.join("plugins").join("installed.json"))
+        .await
+        .unwrap();
+    assert_eq!(
+        restored
+            .get_unique("rollback-route-plugin")
+            .unwrap()
+            .expect("previous provenance restored"),
+        &previous_entry
+    );
+
+    state
+        .tool_event_router
+        .unregister_sinks(&["retained-sink".to_string()])
+        .await;
+    state
+        .service_manager
+        .stop_service("retained-service")
+        .await
+        .unwrap();
 }
 
 // ---------------------------------------------------------------------

--- a/crates/app/bamboo-server/src/plugin_installer/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_installer/tests.rs
@@ -139,7 +139,8 @@ fn event_sink_manifest_json(
             "services": [{
                 "id": service_id,
                 "enabled": false,
-                "command": "${platform_bin}"
+                "command": "${platform_bin}",
+                "input_protocol": "ndjson_v1"
             }],
             "event_sinks": sinks
         }
@@ -1683,6 +1684,68 @@ async fn invalid_sink_policy_fails_before_mcp_or_service_registration() {
 }
 
 #[tokio::test]
+async fn tool_event_v1_without_ndjson_input_fails_before_runtime_or_provenance_mutation() {
+    let root = tempfile::tempdir().unwrap();
+    let (state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+    let plugin_dir = root.path().join("plugins").join("null-stdin-event-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+
+    let raw = event_sink_manifest_json(
+        "null-stdin-event-plugin",
+        "1.0.0",
+        "must-not-start-service",
+        &[("must-not-register-sink", TOOL_EVENT_V1_SCHEMA_VERSION)],
+    );
+    let mut value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    value["provides"]["services"][0]
+        .as_object_mut()
+        .expect("service object")
+        .remove("input_protocol");
+    value["provides"]["services"][0]["enabled"] = serde_json::json!(true);
+    value["provides"]["mcp_servers"] = serde_json::json!([{
+        "id": "must-not-register-mcp",
+        "transport": {"type": "stdio", "command": NONEXISTENT_COMMAND}
+    }]);
+    let raw = value.to_string();
+    tokio::fs::write(plugin_dir.join("plugin.json"), &raw)
+        .await
+        .unwrap();
+    let manifest = PluginManifest::parse_str(&raw).unwrap();
+
+    let error = installer
+        .install(
+            &manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::FailIfInstalled,
+            Utc::now(),
+        )
+        .await
+        .expect_err("a V1 sink backed by null stdin must fail pure preflight");
+    assert!(error.to_string().contains("input_protocol 'ndjson_v1'"));
+    assert!(installer.list().await.unwrap().is_empty());
+    assert!(!state
+        .config
+        .read()
+        .await
+        .mcp
+        .servers
+        .iter()
+        .any(|server| server.id == "must-not-register-mcp"));
+    assert!(!state.service_manager.is_running("must-not-start-service"));
+    assert_eq!(
+        state
+            .tool_event_router
+            .status_for_ids(&["must-not-register-sink".to_string()])
+            .await[0]
+            .state,
+        ToolEventSinkState::Unavailable
+    );
+}
+
+#[tokio::test]
 async fn upgrade_replaces_event_sink_provenance_exactly_and_frees_removed_id() {
     let root = tempfile::tempdir().unwrap();
     let (_state, installer) = new_installer(&root.path().join("bamboo-home")).await;
@@ -1769,6 +1832,111 @@ async fn upgrade_replaces_event_sink_provenance_exactly_and_frees_removed_id() {
         )
         .await
         .expect("removed sink id must be free for another plugin");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn changed_backing_service_revokes_retained_sink_before_old_service_stop() {
+    use std::time::Duration;
+
+    use bamboo_domain::mcp_config::ReconnectConfig;
+    use bamboo_plugin::manifest::{GracefulShutdown, HealthCheckSpec, ServiceInputProtocol};
+    use bamboo_plugin::reconcile_event_sinks;
+
+    use crate::service_manager::ServiceRuntimeConfig;
+
+    let root = tempfile::tempdir().unwrap();
+    let (state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+    let raw = event_sink_manifest_json(
+        "changed-service-plugin",
+        "1.0.0",
+        "old-service",
+        &[("retained-sink", TOOL_EVENT_V1_SCHEMA_VERSION)],
+    );
+    let mut value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    value["provides"]["services"][0]["enabled"] = serde_json::json!(true);
+    let old_manifest = PluginManifest::parse_str(&value.to_string()).unwrap();
+    old_manifest.validate().unwrap();
+
+    let previous = RegisteredCapabilities {
+        service_ids: vec!["old-service".to_string()],
+        event_sink_ids: vec!["retained-sink".to_string()],
+        ..Default::default()
+    };
+    let replacement = RegisteredCapabilities {
+        service_ids: vec!["new-service".to_string()],
+        event_sink_ids: vec!["retained-sink".to_string()],
+        ..Default::default()
+    };
+    let dropped = replacement.removed_since(&previous);
+    assert!(dropped.event_sink_ids.is_empty());
+    assert_eq!(dropped.service_ids, vec!["old-service".to_string()]);
+
+    state
+        .service_manager
+        .start_service(ServiceRuntimeConfig {
+            id: "old-service".to_string(),
+            plugin_id: "changed-service-plugin".to_string(),
+            name: None,
+            command: PathBuf::from("/bin/sh"),
+            args: vec![
+                "-c".to_string(),
+                "while IFS= read -r line; do :; done".to_string(),
+            ],
+            cwd: None,
+            env: Default::default(),
+            health_check: HealthCheckSpec::default(),
+            restart_policy: ReconnectConfig {
+                enabled: false,
+                ..ReconnectConfig::default()
+            },
+            graceful_shutdown: GracefulShutdown::default(),
+            input_protocol: ServiceInputProtocol::NdjsonV1,
+            user_config_path: root.path().join("service-config.json"),
+        })
+        .await
+        .unwrap();
+    let plan = reconcile_event_sinks(
+        &old_manifest,
+        &previous,
+        PluginInstallStatus::Installed,
+        Platform::current(),
+    )
+    .unwrap();
+    state
+        .tool_event_router
+        .apply_plugin_plan("changed-service-plugin", &old_manifest, &plan)
+        .await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let status = state
+                .tool_event_router
+                .status_for_ids(&["retained-sink".to_string()])
+                .await;
+            if status[0].state == ToolEventSinkState::Live {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("old sink worker becomes live");
+
+    assert!(
+        installer
+            .deregister_upgrade_drop_diff(&previous, &dropped)
+            .await,
+        "a dropped service must force full prior-sink revocation"
+    );
+    assert_eq!(
+        state
+            .tool_event_router
+            .status_for_ids(&["retained-sink".to_string()])
+            .await[0]
+            .state,
+        ToolEventSinkState::Unavailable
+    );
+    assert!(!state.service_manager.is_running("old-service"));
 }
 
 // ---------------------------------------------------------------------

--- a/crates/app/bamboo-server/src/plugin_source/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_source/tests.rs
@@ -1876,7 +1876,11 @@ fn event_sink_service_plugin_manifest_json(version: &str, sink_id: &str) -> Stri
         "name": "Service Event Sink Plugin",
         "version": version,
         "provides": {
-            "services": [{"id": "svc", "command": "${platform_bin}"}],
+            "services": [{
+                "id": "svc",
+                "command": "${platform_bin}",
+                "input_protocol": "ndjson_v1"
+            }],
             "event_sinks": [{
                 "id": sink_id,
                 "service_id": "svc",

--- a/crates/app/bamboo-server/src/service_manager/mod.rs
+++ b/crates/app/bamboo-server/src/service_manager/mod.rs
@@ -244,11 +244,13 @@ impl ServiceManager {
             input,
         });
         // Atomic check-and-insert via the entry API: a plain
-        // contains_key→insert would let two racing callers (boot reconcile —
-        // spawned outside PLUGIN_OP_LOCK — vs a concurrent install of the
-        // same plugin) both pass the check, the second overwriting the
-        // first's runtime and orphaning its supervisor task + child process
-        // beyond stop_service's reach.
+        // contains_key→insert would let two racing callers (for example,
+        // direct ServiceManager users or any future reconciliation path that
+        // does not share the plugin-operation boundary) both pass the check,
+        // the second overwriting the first's runtime and orphaning its
+        // supervisor task + child process beyond stop_service's reach. Boot
+        // and plugin mutations are now serialized separately, but the manager
+        // still enforces its own invariant at this public boundary.
         match self.runtimes.entry(id) {
             dashmap::mapref::entry::Entry::Occupied(occupied) => {
                 return Err(ServiceManagerError::AlreadyRunning(occupied.key().clone()));

--- a/crates/app/bamboo-server/src/tool_event_router.rs
+++ b/crates/app/bamboo-server/src/tool_event_router.rs
@@ -9,7 +9,7 @@
 //! process-generation changes, queue workers, and shutdown joins happen
 //! outside tool execution.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -527,6 +527,53 @@ impl ToolEventRouter {
         self.refresh_monitor().await;
     }
 
+    /// Revoke only the prior plugin sinks whose current declaration is backed
+    /// by a service that an upgrade is about to remove. Provenance records ids
+    /// but not sink-to-service edges, so the live desired registration is the
+    /// authority for this narrow Step-0 ordering seam.
+    ///
+    /// The plugin id and provenance-owned sink ids are both checked before a
+    /// registration can be removed. This prevents a stale/corrupt provenance
+    /// row from borrowing another plugin's route while still guaranteeing
+    /// that every matching worker is joined before its service is stopped.
+    pub(crate) async fn unregister_plugin_sinks_backed_by_services(
+        self: &Arc<Self>,
+        plugin_id: &str,
+        ids: &[String],
+        service_ids: &[String],
+    ) {
+        if ids.is_empty() || service_ids.is_empty() {
+            return;
+        }
+        let ids: HashSet<&str> = ids.iter().map(String::as_str).collect();
+        let service_ids: HashSet<&str> = service_ids.iter().map(String::as_str).collect();
+        let mut state = self.state.lock().await;
+        let matching_ids: Vec<String> = state
+            .desired
+            .values()
+            .filter(|registration| {
+                registration.plugin_id == plugin_id
+                    && ids.contains(registration.id.as_str())
+                    && service_ids.contains(registration.service_id.as_str())
+            })
+            .map(|registration| registration.id.clone())
+            .collect();
+        let mut stopped = Vec::with_capacity(matching_ids.len());
+        for id in matching_ids {
+            state.desired.remove(&id);
+            if let Some(live) = state.active.remove(&id) {
+                live.begin_stop();
+                stopped.push(live);
+            }
+        }
+        self.rebuild_published(&state);
+        for live in stopped {
+            live.join().await;
+        }
+        drop(state);
+        self.refresh_monitor().await;
+    }
+
     /// Reconcile each eligible declaration to the exact currently-ready
     /// `ServiceInputSender` generation. A scheduled/starting service, a
     /// legacy null-stdin service, and a broken/stale generation all remain
@@ -989,6 +1036,60 @@ mod tests {
             .unregister_sinks(&["inactive".to_string(), "eligible".to_string()])
             .await;
         assert!(!router.monitor_is_running());
+    }
+
+    #[tokio::test]
+    async fn service_filtered_unregister_checks_owner_and_preserves_unrelated_route() {
+        let router = router();
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("removed", &[], 4, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("retained", &[], 4, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        let removed = Arc::new(RecordingInput::new(1));
+        let retained = Arc::new(RecordingInput::new(2));
+        router
+            .install_input_for_test("removed", removed.clone())
+            .await;
+        router
+            .install_input_for_test("retained", retained.clone())
+            .await;
+
+        let prior_ids = vec!["removed".to_string(), "retained".to_string()];
+        let dropped_services = vec!["removed-service".to_string()];
+        router
+            .unregister_plugin_sinks_backed_by_services(
+                "other-plugin",
+                &prior_ids,
+                &dropped_services,
+            )
+            .await;
+        assert_eq!(
+            router.status_for_ids(&["removed".to_string()]).await[0].state,
+            ToolEventSinkState::Live,
+            "a mismatched plugin owner must not revoke the route"
+        );
+
+        router
+            .unregister_plugin_sinks_backed_by_services("plugin", &prior_ids, &dropped_services)
+            .await;
+        let statuses = router.status_for_ids(&prior_ids).await;
+        assert_eq!(statuses[0].state, ToolEventSinkState::Unavailable);
+        assert_eq!(statuses[1].state, ToolEventSinkState::Live);
+
+        router.try_publish(event("Write", "after-drop", 8)).unwrap();
+        wait_until(|| retained.calls().len() == 1).await;
+        assert!(removed.calls().is_empty());
+        assert_eq!(retained.calls(), vec!["after-drop"]);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app/bamboo-server/src/tool_event_router.rs
+++ b/crates/app/bamboo-server/src/tool_event_router.rs
@@ -1,0 +1,1223 @@
+//! Server-owned, best-effort routing from framework [`ToolEventV1`] values to
+//! supervised plugin services.
+//!
+//! The tool path is deliberately small and synchronous: it takes a
+//! non-blocking snapshot read, matches subscriptions, performs one explicit
+//! bounded-size serialization for per-sink admission, and enters each
+//! independent sink queue with `try_send`. The downstream service-input
+//! boundary serializes again off the tool path. Service discovery,
+//! process-generation changes, queue workers, and shutdown joins happen
+//! outside tool execution.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bamboo_plugin::manifest::{
+    EventSinkCapabilityState, EventSinkInactiveReason, EventSinkManifestEntry,
+    MAX_EVENT_SINKS_PER_PLUGIN, MAX_EVENT_SINK_ID_BYTES,
+};
+use bamboo_plugin::registry::EventSinkReconciliation;
+use bamboo_plugin::PluginManifest;
+use bamboo_plugin_protocol::{
+    ToolEventPublishError, ToolEventPublisher, ToolEventV1, FILE_CHANGED_SUBSCRIPTION_ID_V1,
+};
+use parking_lot::RwLock as ParkingRwLock;
+use serde::Serialize;
+use tokio::sync::{mpsc, Mutex as AsyncMutex};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::service_manager::{
+    ServiceInputHealth, ServiceInputSendError, ServiceInputSender, ServiceManager,
+};
+
+const RECONCILE_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Sanitized live state for one declared event sink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolEventSinkState {
+    /// Provenance names this bounded id, but no trustworthy live declaration
+    /// is available yet (boot still reconciling or on-disk manifest damage).
+    Unavailable,
+    Inactive,
+    WaitingForService,
+    Live,
+}
+
+/// Payload-free, bounded status exposed through the plugin API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ToolEventSinkStatusSnapshot {
+    pub id: String,
+    pub service_id: String,
+    pub state: ToolEventSinkState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inactive_reason: Option<EventSinkInactiveReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation: Option<u64>,
+    pub queue_capacity: usize,
+    pub max_event_bytes: usize,
+    /// Accepted by the exact live service-generation input queue. This is
+    /// best-effort admission, not a durable acknowledgement from the plugin.
+    pub delivered: u64,
+    pub queue_full: u64,
+    pub service_down: u64,
+    pub serialization: u64,
+    pub oversize: u64,
+}
+
+#[derive(Default)]
+struct SinkCounters {
+    delivered: AtomicU64,
+    queue_full: AtomicU64,
+    service_down: AtomicU64,
+    serialization: AtomicU64,
+    oversize: AtomicU64,
+}
+
+impl SinkCounters {
+    fn snapshot(&self) -> SinkCounterSnapshot {
+        SinkCounterSnapshot {
+            delivered: self.delivered.load(Ordering::Relaxed),
+            queue_full: self.queue_full.load(Ordering::Relaxed),
+            service_down: self.service_down.load(Ordering::Relaxed),
+            serialization: self.serialization.load(Ordering::Relaxed),
+            oversize: self.oversize.load(Ordering::Relaxed),
+        }
+    }
+}
+
+struct SinkCounterSnapshot {
+    delivered: u64,
+    queue_full: u64,
+    service_down: u64,
+    serialization: u64,
+    oversize: u64,
+}
+
+fn increment(counter: &AtomicU64) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+        Some(value.saturating_add(1))
+    });
+}
+
+#[derive(Clone)]
+struct SubscriptionFilter {
+    id: String,
+    tool_names: Vec<String>,
+}
+
+impl SubscriptionFilter {
+    fn matches(&self, event: &ToolEventV1) -> bool {
+        if self.id != event.subscription_id.as_str() {
+            return false;
+        }
+        // ToolEventV1 currently has one implemented event-type subscription.
+        // Keep the event-type check explicit rather than treating a matching
+        // subscription string as sufficient on its own.
+        if self.id == FILE_CHANGED_SUBSCRIPTION_ID_V1 && !event.event_type.is_file_changed() {
+            return false;
+        }
+        self.tool_names.is_empty()
+            || self
+                .tool_names
+                .iter()
+                .any(|name| name == &event.context.tool_name)
+    }
+}
+
+struct SinkRegistration {
+    plugin_id: String,
+    id: String,
+    service_id: String,
+    capability: EventSinkCapabilityState,
+    subscriptions: Vec<SubscriptionFilter>,
+    queue_capacity: usize,
+    max_event_bytes: usize,
+    counters: Arc<SinkCounters>,
+}
+
+impl SinkRegistration {
+    fn from_manifest(
+        plugin_id: &str,
+        manifest: &EventSinkManifestEntry,
+        capability: EventSinkCapabilityState,
+        counters: Arc<SinkCounters>,
+    ) -> Self {
+        Self {
+            plugin_id: plugin_id.to_string(),
+            id: manifest.id.clone(),
+            service_id: manifest.service_id.clone(),
+            capability,
+            subscriptions: manifest
+                .subscriptions
+                .iter()
+                .map(|subscription| SubscriptionFilter {
+                    id: subscription.id.as_str().to_string(),
+                    tool_names: subscription.tool_names.clone(),
+                })
+                .collect(),
+            // PluginManifest::validate has already enforced non-zero absolute
+            // bounds. Conversions are lossless on every supported target.
+            queue_capacity: manifest.delivery.queue_capacity as usize,
+            max_event_bytes: manifest.delivery.max_event_bytes as usize,
+            counters,
+        }
+    }
+
+    fn is_eligible(&self) -> bool {
+        matches!(self.capability, EventSinkCapabilityState::Eligible)
+    }
+
+    fn matches(&self, event: &ToolEventV1) -> bool {
+        self.subscriptions
+            .iter()
+            .any(|subscription| subscription.matches(event))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SinkInputError {
+    QueueFull,
+    ServiceDown,
+    Serialization,
+    Oversize,
+}
+
+trait SinkInput: Send + Sync {
+    fn generation(&self) -> u64;
+    fn try_send(&self, event: &ToolEventV1) -> Result<(), SinkInputError>;
+}
+
+impl SinkInput for ServiceInputSender {
+    fn generation(&self) -> u64 {
+        ServiceInputSender::generation(self)
+    }
+
+    fn try_send(&self, event: &ToolEventV1) -> Result<(), SinkInputError> {
+        ServiceInputSender::try_send(self, event).map_err(|error| match error {
+            ServiceInputSendError::QueueFull { .. } => SinkInputError::QueueFull,
+            ServiceInputSendError::StaleGeneration { .. }
+            | ServiceInputSendError::Stopped { .. }
+            | ServiceInputSendError::BrokenStdin { .. } => SinkInputError::ServiceDown,
+            ServiceInputSendError::Serialization => SinkInputError::Serialization,
+            ServiceInputSendError::Oversize { .. } => SinkInputError::Oversize,
+        })
+    }
+}
+
+struct LiveSink {
+    generation: u64,
+    active: Arc<AtomicBool>,
+    cancel: CancellationToken,
+    tx: mpsc::Sender<Arc<ToolEventV1>>,
+    task: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl LiveSink {
+    fn spawn(registration: &SinkRegistration, input: Arc<dyn SinkInput>) -> Arc<Self> {
+        let generation = input.generation();
+        let active = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
+        let (tx, rx) = mpsc::channel(registration.queue_capacity);
+        let task = tokio::spawn(run_sink_worker(
+            registration.id.clone(),
+            registration.counters.clone(),
+            input,
+            active.clone(),
+            cancel.clone(),
+            rx,
+        ));
+        Arc::new(Self {
+            generation,
+            active,
+            cancel,
+            tx,
+            task: Mutex::new(Some(task)),
+        })
+    }
+
+    fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    fn begin_stop(&self) {
+        self.active.store(false, Ordering::SeqCst);
+        self.cancel.cancel();
+    }
+
+    async fn join(&self) {
+        let task = self
+            .task
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(task) = task {
+            let _ = task.await;
+        }
+    }
+
+    fn try_enqueue(&self, event: Arc<ToolEventV1>, counters: &SinkCounters) -> Result<(), ()> {
+        if !self.is_active() {
+            increment(&counters.service_down);
+            return Err(());
+        }
+        match self.tx.try_send(event) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                increment(&counters.queue_full);
+                Err(())
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                increment(&counters.service_down);
+                Err(())
+            }
+        }
+    }
+}
+
+async fn run_sink_worker(
+    sink_id: String,
+    counters: Arc<SinkCounters>,
+    input: Arc<dyn SinkInput>,
+    active: Arc<AtomicBool>,
+    cancel: CancellationToken,
+    mut rx: mpsc::Receiver<Arc<ToolEventV1>>,
+) {
+    loop {
+        let event = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => break,
+            event = rx.recv() => match event {
+                Some(event) => event,
+                None => break,
+            }
+        };
+        if !active.load(Ordering::SeqCst) {
+            break;
+        }
+        match input.try_send(event.as_ref()) {
+            Ok(()) => increment(&counters.delivered),
+            Err(SinkInputError::QueueFull) => increment(&counters.queue_full),
+            Err(SinkInputError::Serialization) => increment(&counters.serialization),
+            Err(SinkInputError::Oversize) => increment(&counters.oversize),
+            Err(SinkInputError::ServiceDown) => {
+                increment(&counters.service_down);
+                active.store(false, Ordering::SeqCst);
+                tracing::debug!(
+                    sink_id,
+                    generation = input.generation(),
+                    "event-sink generation became unavailable"
+                );
+                break;
+            }
+        }
+    }
+    active.store(false, Ordering::SeqCst);
+}
+
+#[derive(Clone)]
+struct PublishedSink {
+    registration: Arc<SinkRegistration>,
+    live: Option<Arc<LiveSink>>,
+}
+
+#[derive(Default)]
+struct RouterState {
+    desired: BTreeMap<String, Arc<SinkRegistration>>,
+    active: HashMap<String, Arc<LiveSink>>,
+}
+
+/// AppState-owned ToolEvent publisher and plugin-sink lifecycle registry.
+pub struct ToolEventRouter {
+    service_manager: Arc<ServiceManager>,
+    state: AsyncMutex<RouterState>,
+    published: ParkingRwLock<Vec<PublishedSink>>,
+    has_routeable_sinks: AtomicBool,
+    monitor_enabled: bool,
+    reconcile_monitor: Mutex<Option<ReconcileMonitor>>,
+}
+
+struct ReconcileMonitor {
+    cancel: CancellationToken,
+    task: JoinHandle<()>,
+}
+
+impl ToolEventRouter {
+    pub fn new(service_manager: Arc<ServiceManager>) -> Arc<Self> {
+        Self::new_inner(service_manager, true)
+    }
+
+    fn new_inner(service_manager: Arc<ServiceManager>, monitor_enabled: bool) -> Arc<Self> {
+        Arc::new(Self {
+            service_manager,
+            state: AsyncMutex::new(RouterState::default()),
+            published: ParkingRwLock::new(Vec::new()),
+            has_routeable_sinks: AtomicBool::new(false),
+            monitor_enabled,
+            reconcile_monitor: Mutex::new(None),
+        })
+    }
+
+    /// Start generation polling only while at least one eligible declaration
+    /// exists. A default AppState (and an AppState with inactive-only sinks)
+    /// owns no router task at all.
+    async fn refresh_monitor(self: &Arc<Self>) {
+        if !self.monitor_enabled {
+            return;
+        }
+        let routeable = self.has_routeable_sinks.load(Ordering::SeqCst);
+        let stopped = {
+            let mut monitor = self
+                .reconcile_monitor
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if routeable {
+                if monitor.is_some() {
+                    return;
+                }
+                let weak = Arc::downgrade(self);
+                let cancel = CancellationToken::new();
+                let task_cancel = cancel.clone();
+                let task = tokio::spawn(async move {
+                    let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+                    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                    loop {
+                        tokio::select! {
+                            _ = task_cancel.cancelled() => break,
+                            _ = interval.tick() => {}
+                        }
+                        let Some(router) = weak.upgrade() else {
+                            break;
+                        };
+                        router.reconcile_once().await;
+                    }
+                });
+                *monitor = Some(ReconcileMonitor { cancel, task });
+                return;
+            }
+            monitor.take()
+        };
+        if let Some(stopped) = stopped {
+            stopped.cancel.cancel();
+            let _ = stopped.task.await;
+        }
+    }
+
+    #[cfg(test)]
+    fn monitor_is_running(&self) -> bool {
+        self.reconcile_monitor
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
+    }
+
+    /// Replace all runtime declarations owned by `plugin_id` with one pure
+    /// #903 reconciliation plan. Existing workers are removed from the hot
+    /// snapshot and joined before any replacement generation can activate.
+    pub async fn apply_plugin_plan(
+        self: &Arc<Self>,
+        plugin_id: &str,
+        manifest: &PluginManifest,
+        plan: &EventSinkReconciliation,
+    ) {
+        let mut state = self.state.lock().await;
+        let prior_counters: HashMap<String, Arc<SinkCounters>> = state
+            .desired
+            .values()
+            .filter(|registration| registration.plugin_id == plugin_id)
+            .map(|registration| (registration.id.clone(), registration.counters.clone()))
+            .collect();
+
+        let mut stopped = Vec::new();
+        let owned_ids: Vec<String> = state
+            .desired
+            .values()
+            .filter(|registration| registration.plugin_id == plugin_id)
+            .map(|registration| registration.id.clone())
+            .collect();
+        for id in owned_ids {
+            state.desired.remove(&id);
+            if let Some(live) = state.active.remove(&id) {
+                live.begin_stop();
+                stopped.push(live);
+            }
+        }
+        for id in &plan.deactivate_before_services {
+            let owned = state
+                .desired
+                .get(id)
+                .is_some_and(|registration| registration.plugin_id == plugin_id);
+            if owned {
+                state.desired.remove(id);
+                if let Some(live) = state.active.remove(id) {
+                    live.begin_stop();
+                    stopped.push(live);
+                }
+            }
+        }
+        self.rebuild_published(&state);
+        for live in stopped {
+            live.join().await;
+        }
+
+        for reconciled in &plan.sinks_after_services {
+            let Some(entry) = manifest
+                .provides
+                .event_sinks
+                .iter()
+                .find(|entry| entry.id == reconciled.id)
+            else {
+                continue;
+            };
+            if state
+                .desired
+                .get(&entry.id)
+                .is_some_and(|registration| registration.plugin_id != plugin_id)
+            {
+                tracing::warn!(
+                    plugin_id,
+                    sink_id = %entry.id,
+                    "event-sink runtime ownership conflict; refusing replacement"
+                );
+                continue;
+            }
+            let counters = prior_counters
+                .get(&entry.id)
+                .cloned()
+                .unwrap_or_else(|| Arc::new(SinkCounters::default()));
+            state.desired.insert(
+                entry.id.clone(),
+                Arc::new(SinkRegistration::from_manifest(
+                    plugin_id,
+                    entry,
+                    reconciled.state.clone(),
+                    counters,
+                )),
+            );
+        }
+        self.rebuild_published(&state);
+        drop(state);
+        self.refresh_monitor().await;
+        self.reconcile_once().await;
+    }
+
+    /// Remove exact provenance-owned ids. The hot snapshot is revoked first;
+    /// this future returns only after every matching worker has exited.
+    pub async fn unregister_sinks(self: &Arc<Self>, ids: &[String]) {
+        if ids.is_empty() {
+            return;
+        }
+        let mut state = self.state.lock().await;
+        let mut stopped = Vec::new();
+        for id in ids {
+            state.desired.remove(id);
+            if let Some(live) = state.active.remove(id) {
+                live.begin_stop();
+                stopped.push(live);
+            }
+        }
+        self.rebuild_published(&state);
+        for live in stopped {
+            live.join().await;
+        }
+        drop(state);
+        self.refresh_monitor().await;
+    }
+
+    /// Reconcile each eligible declaration to the exact currently-ready
+    /// `ServiceInputSender` generation. A scheduled/starting service, a
+    /// legacy null-stdin service, and a broken/stale generation all remain
+    /// visible as `waiting_for_service` and never receive a queue worker.
+    pub async fn reconcile_once(&self) {
+        let mut state = self.state.lock().await;
+        let desired: Vec<Arc<SinkRegistration>> = state.desired.values().cloned().collect();
+        let mut inputs: HashMap<String, Option<ServiceInputSender>> = HashMap::new();
+
+        for registration in desired {
+            let sender = if registration.is_eligible() {
+                if let Some(cached) = inputs.get(&registration.service_id) {
+                    cached.clone()
+                } else {
+                    let ready = self
+                        .service_manager
+                        .status(&registration.service_id)
+                        .await
+                        .and_then(|status| status.input)
+                        .is_some_and(|input| input.health == ServiceInputHealth::Ready);
+                    let sender = if ready {
+                        self.service_manager
+                            .input_sender(&registration.service_id)
+                            .await
+                    } else {
+                        None
+                    };
+                    inputs.insert(registration.service_id.clone(), sender.clone());
+                    sender
+                }
+            } else {
+                None
+            };
+
+            let current_matches = match (state.active.get(&registration.id), sender.as_ref()) {
+                (Some(live), Some(sender)) => {
+                    live.is_active() && live.generation == sender.generation()
+                }
+                (None, None) => true,
+                _ => false,
+            };
+            if current_matches {
+                continue;
+            }
+
+            if let Some(live) = state.active.remove(&registration.id) {
+                live.begin_stop();
+                self.rebuild_published(&state);
+                live.join().await;
+            }
+            if let Some(sender) = sender {
+                let live = LiveSink::spawn(&registration, Arc::new(sender));
+                state.active.insert(registration.id.clone(), live);
+            }
+            self.rebuild_published(&state);
+        }
+    }
+
+    /// Status is capped even if an on-disk provenance row was hand-corrupted
+    /// to contain more ids than manifest validation permits.
+    pub async fn status_for_ids(&self, ids: &[String]) -> Vec<ToolEventSinkStatusSnapshot> {
+        let state = self.state.lock().await;
+        ids.iter()
+            .take(MAX_EVENT_SINKS_PER_PLUGIN)
+            .filter(|id| !id.trim().is_empty() && id.len() <= MAX_EVENT_SINK_ID_BYTES)
+            .map(|id| {
+                let Some(registration) = state.desired.get(id) else {
+                    return ToolEventSinkStatusSnapshot {
+                        id: id.clone(),
+                        service_id: String::new(),
+                        state: ToolEventSinkState::Unavailable,
+                        inactive_reason: None,
+                        generation: None,
+                        queue_capacity: 0,
+                        max_event_bytes: 0,
+                        delivered: 0,
+                        queue_full: 0,
+                        service_down: 0,
+                        serialization: 0,
+                        oversize: 0,
+                    };
+                };
+                let live = state.active.get(id).filter(|live| live.is_active());
+                let (state_value, inactive_reason, generation) = match &registration.capability {
+                    EventSinkCapabilityState::Inactive { detail } => {
+                        (ToolEventSinkState::Inactive, Some(detail.clone()), None)
+                    }
+                    EventSinkCapabilityState::Eligible => match live {
+                        Some(live) => (ToolEventSinkState::Live, None, Some(live.generation)),
+                        None => (ToolEventSinkState::WaitingForService, None, None),
+                    },
+                };
+                let counters = registration.counters.snapshot();
+                ToolEventSinkStatusSnapshot {
+                    id: registration.id.clone(),
+                    service_id: registration.service_id.clone(),
+                    state: state_value,
+                    inactive_reason,
+                    generation,
+                    queue_capacity: registration.queue_capacity,
+                    max_event_bytes: registration.max_event_bytes,
+                    delivered: counters.delivered,
+                    queue_full: counters.queue_full,
+                    service_down: counters.service_down,
+                    serialization: counters.serialization,
+                    oversize: counters.oversize,
+                }
+            })
+            .collect()
+    }
+
+    fn rebuild_published(&self, state: &RouterState) {
+        let snapshot: Vec<PublishedSink> = state
+            .desired
+            .values()
+            .map(|registration| PublishedSink {
+                registration: registration.clone(),
+                live: state.active.get(&registration.id).cloned(),
+            })
+            .collect();
+        let has_routeable = snapshot.iter().any(|sink| sink.registration.is_eligible());
+        *self.published.write() = snapshot;
+        self.has_routeable_sinks
+            .store(has_routeable, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    async fn install_input_for_test(self: &Arc<Self>, id: &str, input: Arc<dyn SinkInput>) {
+        let mut state = self.state.lock().await;
+        let registration = state.desired.get(id).cloned().expect("test sink exists");
+        if let Some(live) = state.active.remove(id) {
+            live.begin_stop();
+            self.rebuild_published(&state);
+            live.join().await;
+        }
+        state
+            .active
+            .insert(id.to_string(), LiveSink::spawn(&registration, input));
+        self.rebuild_published(&state);
+    }
+
+    #[cfg(test)]
+    async fn configure_test_sink(
+        self: &Arc<Self>,
+        plugin_id: &str,
+        entry: EventSinkManifestEntry,
+        capability: EventSinkCapabilityState,
+    ) {
+        let mut state = self.state.lock().await;
+        state.desired.insert(
+            entry.id.clone(),
+            Arc::new(SinkRegistration::from_manifest(
+                plugin_id,
+                &entry,
+                capability,
+                Arc::new(SinkCounters::default()),
+            )),
+        );
+        self.rebuild_published(&state);
+        drop(state);
+        self.refresh_monitor().await;
+    }
+}
+
+impl ToolEventPublisher for ToolEventRouter {
+    fn is_enabled(&self) -> bool {
+        self.has_routeable_sinks.load(Ordering::SeqCst)
+    }
+
+    fn try_publish(&self, event: ToolEventV1) -> Result<(), ToolEventPublishError> {
+        event
+            .validate_bounds()
+            .map_err(ToolEventPublishError::InvalidEvent)?;
+        let snapshot = self
+            .published
+            .try_read()
+            .ok_or(ToolEventPublishError::Busy)?;
+        let matching: Vec<&PublishedSink> = snapshot
+            .iter()
+            .filter(|sink| sink.registration.is_eligible() && sink.registration.matches(&event))
+            .collect();
+        if matching.is_empty() {
+            return Ok(());
+        }
+        let serialized_len = match serde_json::to_vec(&event) {
+            Ok(serialized) => serialized.len(),
+            Err(_) => {
+                for sink in matching {
+                    increment(&sink.registration.counters.serialization);
+                }
+                return Ok(());
+            }
+        };
+        let event = Arc::new(event);
+        for sink in matching {
+            if serialized_len > sink.registration.max_event_bytes {
+                increment(&sink.registration.counters.oversize);
+                continue;
+            }
+            match &sink.live {
+                Some(live) => {
+                    let _ = live.try_enqueue(event.clone(), &sink.registration.counters);
+                }
+                None => increment(&sink.registration.counters.service_down),
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ToolEventRouter {
+    fn drop(&mut self) {
+        if let Some(monitor) = self
+            .reconcile_monitor
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+        {
+            monitor.cancel.cancel();
+            monitor.task.abort();
+        }
+        if let Ok(mut state) = self.state.try_lock() {
+            for live in state.active.values() {
+                live.begin_stop();
+            }
+            state.active.clear();
+        }
+    }
+}
+
+/// Keeps the existing injected-publisher test/embedder seam while making the
+/// AppState router the production publisher.
+pub(crate) struct CombinedToolEventPublisher {
+    router: Arc<ToolEventRouter>,
+    additional: Arc<dyn ToolEventPublisher>,
+}
+
+impl CombinedToolEventPublisher {
+    pub(crate) fn new(
+        router: Arc<ToolEventRouter>,
+        additional: Arc<dyn ToolEventPublisher>,
+    ) -> Self {
+        Self { router, additional }
+    }
+}
+
+impl ToolEventPublisher for CombinedToolEventPublisher {
+    fn is_enabled(&self) -> bool {
+        self.router.is_enabled() || self.additional.is_enabled()
+    }
+
+    fn try_publish(&self, event: ToolEventV1) -> Result<(), ToolEventPublishError> {
+        let router_enabled = self.router.is_enabled();
+        let additional_enabled = self.additional.is_enabled();
+        match (router_enabled, additional_enabled) {
+            (false, false) => Ok(()),
+            (true, false) => self.router.try_publish(event),
+            (false, true) => self.additional.try_publish(event),
+            (true, true) => {
+                let router_result = self.router.try_publish(event.clone());
+                let additional_result = self.additional.try_publish(event);
+                router_result.and(additional_result)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+    use std::sync::{Condvar, Mutex};
+
+    use bamboo_plugin::manifest::{
+        EventSinkDeliveryLimits, EventSinkProtocolManifest, EventSinkSubscriptionManifest,
+        ObservationPermissionId,
+    };
+    use bamboo_plugin_protocol::{
+        FileChangedV1, ToolEventContextV1, ToolEventSubscriptionId, TOOL_EVENT_PROTOCOL_NAME,
+        TOOL_EVENT_V1_SCHEMA_VERSION,
+    };
+
+    use super::*;
+
+    struct RecordingInput {
+        generation: u64,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl RecordingInput {
+        fn new(generation: u64) -> Self {
+            Self {
+                generation,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl SinkInput for RecordingInput {
+        fn generation(&self) -> u64 {
+            self.generation
+        }
+
+        fn try_send(&self, event: &ToolEventV1) -> Result<(), SinkInputError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(event.context.tool_call_id.clone());
+            Ok(())
+        }
+    }
+
+    struct BlockingInput {
+        generation: u64,
+        entered: AtomicBool,
+        release: (Mutex<bool>, Condvar),
+        calls: AtomicUsize,
+    }
+
+    impl BlockingInput {
+        fn new(generation: u64) -> Self {
+            Self {
+                generation,
+                entered: AtomicBool::new(false),
+                release: (Mutex::new(false), Condvar::new()),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn release(&self) {
+            let mut released = self.release.0.lock().unwrap();
+            *released = true;
+            self.release.1.notify_all();
+        }
+    }
+
+    impl SinkInput for BlockingInput {
+        fn generation(&self) -> u64 {
+            self.generation
+        }
+
+        fn try_send(&self, _event: &ToolEventV1) -> Result<(), SinkInputError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.entered.store(true, Ordering::SeqCst);
+            let mut released = self.release.0.lock().unwrap();
+            while !*released {
+                released = self.release.1.wait(released).unwrap();
+            }
+            Ok(())
+        }
+    }
+
+    fn sink(
+        id: &str,
+        tools: &[&str],
+        capacity: u32,
+        max_event_bytes: u32,
+    ) -> EventSinkManifestEntry {
+        EventSinkManifestEntry {
+            id: id.to_string(),
+            service_id: format!("{id}-service"),
+            protocol: EventSinkProtocolManifest {
+                name: TOOL_EVENT_PROTOCOL_NAME.to_string(),
+                version: TOOL_EVENT_V1_SCHEMA_VERSION,
+                extensions: BTreeMap::new(),
+            },
+            subscriptions: vec![EventSinkSubscriptionManifest {
+                id: ToolEventSubscriptionId::file_changed_v1(),
+                tool_names: tools.iter().map(|tool| (*tool).to_string()).collect(),
+                extensions: BTreeMap::new(),
+            }],
+            delivery: EventSinkDeliveryLimits {
+                queue_capacity: capacity,
+                max_event_bytes,
+                extensions: BTreeMap::new(),
+            },
+            requested_permissions: vec![ObservationPermissionId::new("metadata")],
+            platforms: None,
+            extensions: BTreeMap::new(),
+        }
+    }
+
+    fn event(tool: &str, call: &str, path_len: usize) -> ToolEventV1 {
+        ToolEventV1::file_changed(
+            ToolEventContextV1::bounded("session", "root", tool, call).unwrap(),
+            FileChangedV1::bounded(format!("/{}", "x".repeat(path_len))).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn router() -> Arc<ToolEventRouter> {
+        ToolEventRouter::new_inner(Arc::new(ServiceManager::new()), false)
+    }
+
+    async fn wait_until(mut predicate: impl FnMut() -> bool) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !predicate() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("condition reached");
+    }
+
+    #[tokio::test]
+    async fn filters_by_event_subscription_and_canonical_tool_name() {
+        let router = router();
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("write", &["Write"], 4, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("edit", &["Edit"], 4, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        let write = Arc::new(RecordingInput::new(1));
+        let edit = Arc::new(RecordingInput::new(2));
+        router.install_input_for_test("write", write.clone()).await;
+        router.install_input_for_test("edit", edit.clone()).await;
+
+        router.try_publish(event("Write", "write-1", 8)).unwrap();
+        router.try_publish(event("Edit", "edit-1", 8)).unwrap();
+        wait_until(|| write.calls().len() == 1 && edit.calls().len() == 1).await;
+        assert_eq!(write.calls(), vec!["write-1"]);
+        assert_eq!(edit.calls(), vec!["edit-1"]);
+    }
+
+    #[tokio::test]
+    async fn generation_monitor_is_lazy_and_stops_with_last_eligible_sink() {
+        let router = ToolEventRouter::new(Arc::new(ServiceManager::new()));
+        assert!(!router.monitor_is_running());
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("inactive", &[], 4, 16_384),
+                EventSinkCapabilityState::Inactive {
+                    detail: EventSinkInactiveReason::ServiceDisabled,
+                },
+            )
+            .await;
+        assert!(!router.monitor_is_running());
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("eligible", &[], 4, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        assert!(router.monitor_is_running());
+        router
+            .unregister_sinks(&["inactive".to_string(), "eligible".to_string()])
+            .await;
+        assert!(!router.monitor_is_running());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn saturated_slow_sink_isolated_from_tools_and_other_sink() {
+        let router = router();
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("slow", &[], 1, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("fast", &[], 8, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        let slow = Arc::new(BlockingInput::new(1));
+        let fast = Arc::new(RecordingInput::new(2));
+        router.install_input_for_test("slow", slow.clone()).await;
+        router.install_input_for_test("fast", fast.clone()).await;
+
+        router.try_publish(event("Write", "one", 8)).unwrap();
+        wait_until(|| slow.entered.load(Ordering::SeqCst)).await;
+        router.try_publish(event("Write", "two", 8)).unwrap();
+        router.try_publish(event("Write", "three", 8)).unwrap();
+        wait_until(|| fast.calls().len() == 3).await;
+        let status = router.status_for_ids(&["slow".to_string()]).await;
+        assert_eq!(status[0].queue_full, 1);
+        assert_eq!(fast.calls(), vec!["one", "two", "three"]);
+        slow.release();
+    }
+
+    #[tokio::test]
+    async fn outage_and_sink_event_bound_are_counted_without_payloads() {
+        let router = router();
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("down", &[], 2, 256),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        router.try_publish(event("Write", "down", 8)).unwrap();
+        router.try_publish(event("Write", "oversize", 300)).unwrap();
+
+        let status = router.status_for_ids(&["down".to_string()]).await;
+        assert_eq!(status[0].state, ToolEventSinkState::WaitingForService);
+        assert_eq!(status[0].service_down, 1);
+        assert_eq!(status[0].oversize, 1);
+        let safe = serde_json::to_string(&status).unwrap();
+        assert!(!safe.contains(&"x".repeat(32)));
+        assert!(!safe.contains("/xxxxxxxx"));
+    }
+
+    #[tokio::test]
+    async fn replacement_generation_is_ordered_and_does_not_follow_old_sender() {
+        let router = router();
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("restart", &[], 8, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        let first = Arc::new(RecordingInput::new(10));
+        router
+            .install_input_for_test("restart", first.clone())
+            .await;
+        router.try_publish(event("Write", "old-1", 8)).unwrap();
+        router.try_publish(event("Write", "old-2", 8)).unwrap();
+        wait_until(|| first.calls().len() == 2).await;
+
+        let second = Arc::new(RecordingInput::new(11));
+        router
+            .install_input_for_test("restart", second.clone())
+            .await;
+        router.try_publish(event("Write", "new-1", 8)).unwrap();
+        router.try_publish(event("Write", "new-2", 8)).unwrap();
+        wait_until(|| second.calls().len() == 2).await;
+        assert_eq!(first.calls(), vec!["old-1", "old-2"]);
+        assert_eq!(second.calls(), vec!["new-1", "new-2"]);
+        assert_eq!(
+            router.status_for_ids(&["restart".to_string()]).await[0].generation,
+            Some(11)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_unregister_revokes_snapshot_and_joins_worker() {
+        let router = router();
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("remove", &[], 64, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+        let input = Arc::new(RecordingInput::new(1));
+        router.install_input_for_test("remove", input.clone()).await;
+        let publishing = {
+            let router = router.clone();
+            tokio::spawn(async move {
+                for index in 0..500 {
+                    let _ = router.try_publish(event("Write", &format!("call-{index}"), 8));
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+        router.unregister_sinks(&["remove".to_string()]).await;
+        publishing.await.unwrap();
+        let count_after_unregister = input.calls().len();
+        for index in 0..10 {
+            router
+                .try_publish(event("Write", &format!("after-{index}"), 8))
+                .unwrap();
+        }
+        tokio::task::yield_now().await;
+        assert_eq!(input.calls().len(), count_after_unregister);
+        let status = router.status_for_ids(&["remove".to_string()]).await;
+        assert_eq!(status[0].state, ToolEventSinkState::Unavailable);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn real_service_manager_stop_start_rebinds_a_fresh_generation() {
+        use std::path::PathBuf;
+
+        use bamboo_domain::mcp_config::ReconnectConfig;
+        use bamboo_plugin::manifest::{GracefulShutdown, HealthCheckSpec, ServiceInputProtocol};
+
+        use crate::service_manager::ServiceRuntimeConfig;
+
+        let temp = tempfile::tempdir().unwrap();
+        let output = temp.path().join("events.ndjson");
+        let manager = Arc::new(ServiceManager::new());
+        let router = ToolEventRouter::new(manager.clone());
+        router
+            .configure_test_sink(
+                "plugin",
+                sink("real", &[], 8, 16_384),
+                EventSinkCapabilityState::Eligible,
+            )
+            .await;
+
+        let config = ServiceRuntimeConfig {
+            id: "real-service".to_string(),
+            plugin_id: "plugin".to_string(),
+            name: None,
+            command: PathBuf::from("/bin/sh"),
+            args: vec![
+                "-c".to_string(),
+                "while IFS= read -r line; do printf '%s\\n' \"$line\" >> \"$1\"; done".to_string(),
+                "bamboo-event-sink-test".to_string(),
+                output.to_string_lossy().into_owned(),
+            ],
+            cwd: None,
+            env: HashMap::new(),
+            health_check: HealthCheckSpec::default(),
+            restart_policy: ReconnectConfig {
+                enabled: false,
+                ..ReconnectConfig::default()
+            },
+            graceful_shutdown: GracefulShutdown::default(),
+            input_protocol: ServiceInputProtocol::NdjsonV1,
+            user_config_path: temp.path().join("config.json"),
+        };
+
+        manager.start_service(config.clone()).await.unwrap();
+        let first_generation = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = router.status_for_ids(&["real".to_string()]).await;
+                if let Some(generation) = status.first().and_then(|status| status.generation) {
+                    break generation;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("first service generation becomes routeable");
+        router.try_publish(event("Write", "first", 8)).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if tokio::fs::read_to_string(&output)
+                    .await
+                    .is_ok_and(|raw| raw.contains("first"))
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("first generation receives event");
+
+        manager.stop_service("real-service").await.unwrap();
+        manager.start_service(config).await.unwrap();
+        let second_generation = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = router.status_for_ids(&["real".to_string()]).await;
+                if let Some(generation) = status.first().and_then(|status| status.generation) {
+                    if generation > first_generation {
+                        break generation;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("replacement service generation becomes routeable");
+        assert!(second_generation > first_generation);
+        router.try_publish(event("Write", "second", 8)).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if tokio::fs::read_to_string(&output)
+                    .await
+                    .is_ok_and(|raw| raw.contains("second"))
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("replacement generation receives event");
+
+        router.unregister_sinks(&["real".to_string()]).await;
+        manager.stop_service("real-service").await.unwrap();
+    }
+}

--- a/crates/infra/bamboo-plugin/src/lib.rs
+++ b/crates/infra/bamboo-plugin/src/lib.rs
@@ -15,7 +15,7 @@
 //! | Prompt presets | `prompt-presets.json` | copied into shared store |
 //! | Legacy workflows | N/A — discovered **in place** | `~/.bamboo/plugins/*/workflows/*.md` is a read-only Skill adapter source |
 //! | Services | `ServiceManager` | supervised process owned by exact plugin provenance |
-//! | Event sinks | `installed.json` + pure reconciliation plan | runtime routing is added separately by #905 |
+//! | Event sinks | `installed.json` + pure reconciliation plan | `bamboo-server` activates the plan through its AppState-owned `ToolEventRouter` |
 //!
 //! This crate defines the shared skeleton three things build on:
 //!

--- a/crates/infra/bamboo-plugin/src/manifest.rs
+++ b/crates/infra/bamboo-plugin/src/manifest.rs
@@ -1040,17 +1040,17 @@ impl PluginManifest {
                     sink.id, MAX_EVENT_SINK_SERVICE_ID_BYTES
                 )));
             }
-            if !self
+            let Some(service) = self
                 .provides
                 .services
                 .iter()
-                .any(|service| service.id == sink.service_id)
-            {
+                .find(|service| service.id == sink.service_id)
+            else {
                 return Err(PluginError::InvalidManifest(format!(
                     "event sink '{}' references service '{}' which is not declared by the same plugin",
                     sink.id, sink.service_id
                 )));
-            }
+            };
             if sink.protocol.name != TOOL_EVENT_PROTOCOL_NAME {
                 return Err(PluginError::InvalidManifest(format!(
                     "event sink '{}' uses unknown protocol family '{}' (expected '{}')",
@@ -1064,6 +1064,12 @@ impl PluginManifest {
                 )));
             }
             let strict_v1 = sink.protocol.version == TOOL_EVENT_V1_SCHEMA_VERSION;
+            if strict_v1 && service.input_protocol != ServiceInputProtocol::NdjsonV1 {
+                return Err(PluginError::InvalidManifest(format!(
+                    "ToolEventV1 event sink '{}' requires service '{}' to declare input_protocol 'ndjson_v1'",
+                    sink.id, sink.service_id
+                )));
+            }
             validate_event_sink_extensions(&sink.id, "declaration", &sink.extensions, strict_v1)?;
             validate_event_sink_extensions(
                 &sink.id,
@@ -1768,7 +1774,8 @@ mod tests {
                 "services": [{
                     "id": "audit-service",
                     "enabled": service_enabled,
-                    "command": PLATFORM_BIN_TOKEN
+                    "command": PLATFORM_BIN_TOKEN,
+                    "input_protocol": "ndjson_v1"
                 }],
                 "event_sinks": [{
                     "id": "audit-events",
@@ -1845,6 +1852,10 @@ mod tests {
     #[test]
     fn future_tool_event_version_preserves_opaque_values_and_is_inactive() {
         let mut value = event_sink_manifest_value(TOOL_EVENT_V1_SCHEMA_VERSION + 1, true);
+        value["provides"]["services"][0]
+            .as_object_mut()
+            .expect("service object")
+            .remove("input_protocol");
         value["provides"]["event_sinks"][0]["future_sink_option"] =
             serde_json::json!({ "mode": "v2" });
         value["provides"]["event_sinks"][0]["protocol"]["negotiation"] =
@@ -1867,6 +1878,11 @@ mod tests {
             .validate()
             .expect("future version must degrade instead of failing validation");
         let sink = &manifest.provides.event_sinks[0];
+        assert_eq!(
+            manifest.provides.services[0].input_protocol,
+            ServiceInputProtocol::None,
+            "future protocols must remain installable and inactive when the current host input protocol is absent"
+        );
         assert_eq!(sink.subscriptions[0].id.as_str(), "tool.symbol_changed.v2");
         assert_eq!(sink.requested_permissions.len(), 1);
         assert_eq!(sink.requested_permissions[0].as_str(), "symbol_metadata_v2");
@@ -1984,6 +2000,20 @@ mod tests {
             .validate()
             .expect_err("duplicate sink id must fail");
         assert!(error.to_string().contains("duplicate event sink id"));
+    }
+
+    #[test]
+    fn tool_event_v1_requires_ndjson_service_input() {
+        let mut value = event_sink_manifest_value(TOOL_EVENT_V1_SCHEMA_VERSION, true);
+        value["provides"]["services"][0]
+            .as_object_mut()
+            .expect("service object")
+            .remove("input_protocol");
+
+        let error = parse_event_sink_manifest(&value)
+            .validate()
+            .expect_err("ToolEventV1 cannot route into a null-stdin service");
+        assert!(error.to_string().contains("input_protocol 'ndjson_v1'"));
     }
 
     #[test]

--- a/crates/infra/bamboo-plugin/src/registry.rs
+++ b/crates/infra/bamboo-plugin/src/registry.rs
@@ -805,7 +805,8 @@ mod tests {
                 "services": [{
                     "id": "audit-service",
                     "enabled": service_enabled,
-                    "command": "${platform_bin}"
+                    "command": "${platform_bin}",
+                    "input_protocol": "ndjson_v1"
                 }],
                 "event_sinks": [{
                     "id": "audit-events",


### PR DESCRIPTION
## Summary
- add one AppState-owned ToolEvent router with lazy reconciliation and bounded, isolated per-sink queues
- bind each sink worker to an exact service-input generation, revoke and join workers before any backing-service stop, and never replay a prior-generation backlog
- require supported ToolEventV1 sinks to reference `input_protocol: ndjson_v1` during pure manifest preflight while preserving future-version inactive compatibility
- expose bounded, sanitized sink health/counters through the plugin status API and reconcile install, update, uninstall, and boot under the plugin operation lock
- preserve retained routes when an upgrade drops an unrelated service and later aborts, while still revoking sinks tied to a dropped or replaced service before process shutdown
- preserve injected publishers while composing production routing, and leave permissions/redaction/content policy to follow-up #907

## Test Plan
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p bamboo-plugin --lib --no-fail-fast` (64 passed)
- `cargo test --locked -p bamboo-server plugin_installer::tests --lib --no-fail-fast` (29 passed)
- `cargo test --locked -p bamboo-server handlers::agent::plugin::tests --lib --no-fail-fast` (18 passed)
- `cargo test --locked -p bamboo-server tool_event_router --lib --no-fail-fast` (8 passed)
- `cargo test --locked -p bamboo-server --lib --no-fail-fast -- --quiet` (1935 passed, 1 ignored, 0 failed)
- `cargo clippy --locked --all-features -- -D warnings -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code`
- `cargo metadata --locked --all-features --format-version 1`
- `cargo audit --deny warnings`
- `cargo +1.95.0 check --locked -p bamboo-server --all-targets --all-features`
- `cargo +1.95.0 check --locked -p bamboo-server --tests --target x86_64-pc-windows-gnu`

## Screenshots
N/A — backend runtime and status API only.

Closes #905