### PR TITLE
[bamboo-plugin] feat: enforce ToolEvent permissions, redaction, and payload bounds

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
@@ -7,8 +7,9 @@
 //! re-syncing both sides:
 //!
 //! - `GET /api/v1/plugins` -> `200 { "plugins": [InstalledPluginView, ...] }`
-//! - `POST /api/v1/plugins/install` body `{ "source": SourceSpec }` -> `201 InstalledPluginView`
-//! - `POST /api/v1/plugins/{id}/update` body `{ "source": SourceSpec }` -> `200 InstalledPluginView`
+//! - `POST /api/v1/plugins/install` body `{ "source": SourceSpec,
+//!   "event_sink_grants"?: GrantRecord[] }` -> `201 InstalledPluginView`
+//! - `POST /api/v1/plugins/{id}/update` uses the same body -> `200 InstalledPluginView`
 //! - `DELETE /api/v1/plugins/{id}` -> `200 { "id", "removed": true }`
 //!
 //! `SourceSpec` reuses [`bamboo_plugin::PluginSource`]'s own
@@ -64,19 +65,27 @@
 use serde::{Deserialize, Serialize};
 
 use bamboo_plugin::{
-    EventSinkInactiveReason, InstalledPlugin, PluginInstallStatus, PluginManifest, PluginSource,
-    RegisteredCapabilities, ServiceInputProtocol,
+    EventSinkInactiveReason, InstalledPlugin, ObservationPermissionId, PluginInstallStatus,
+    PluginManifest, PluginSource, RegisteredCapabilities, ServiceInputProtocol,
 };
 
 use crate::service_manager::{
     ServiceInputHealth, ServiceInputStatusSnapshot, ServiceManager, ServiceState,
 };
+use crate::tool_event_policy::{canonicalize_persisted_event_sink_grants, EventSinkGrantRequest};
 use crate::tool_event_router::{ToolEventRouter, ToolEventSinkState, ToolEventSinkStatusSnapshot};
 
 /// Shared body for `POST /install` and `POST /{id}/update`.
 #[derive(Debug, Deserialize)]
 pub struct InstallPluginRequest {
     pub source: PluginSource,
+    /// Optional complete ToolEventV1 host-grant target. `Some` means every
+    /// listed sink receives exactly its listed permissions and every omitted
+    /// v1 sink falls back to metadata-only. On update, omission of this field
+    /// preserves only the intersection of prior grants and new requests.
+    /// A list (not a JSON map) keeps duplicate sink ids detectable.
+    #[serde(default)]
+    pub event_sink_grants: Option<Vec<EventSinkGrantRequest>>,
 }
 
 /// `GET /plugins` element, and the body of a successful install/update
@@ -121,6 +130,10 @@ pub struct ToolEventSinkStatusView {
     pub inactive_reason: Option<EventSinkInactiveReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generation: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_generation: Option<u64>,
+    pub requested_permissions: Vec<ObservationPermissionId>,
+    pub granted_permissions: Vec<ObservationPermissionId>,
     pub queue_capacity: usize,
     pub max_event_bytes: usize,
     pub delivered: u64,
@@ -138,6 +151,9 @@ impl From<ToolEventSinkStatusSnapshot> for ToolEventSinkStatusView {
             state: snapshot.state,
             inactive_reason: snapshot.inactive_reason,
             generation: snapshot.generation,
+            policy_generation: snapshot.policy_generation,
+            requested_permissions: snapshot.requested_permissions,
+            granted_permissions: snapshot.granted_permissions,
             queue_capacity: snapshot.queue_capacity,
             max_event_bytes: snapshot.max_event_bytes,
             delivered: snapshot.delivered,
@@ -230,9 +246,21 @@ pub async fn to_view(
     service_manager: &ServiceManager,
     tool_event_router: &ToolEventRouter,
 ) -> InstalledPluginView {
-    let name = read_manifest_name(&entry.plugin_dir).await;
-    let mut service_status = Vec::with_capacity(entry.registered.service_ids.len());
-    for service_id in &entry.registered.service_ids {
+    let manifest = read_manifest(&entry.plugin_dir).await;
+    let name = manifest.as_ref().map(|manifest| manifest.name.clone());
+    let mut registered = entry.registered;
+    // `installed.json` is durable authority, not a trusted wire DTO. Only
+    // expose a manifest-validated canonical map; a hand-corrupt value is
+    // omitted here and represented by unavailable sink status instead of
+    // reflecting arbitrary strings back to API callers.
+    registered.event_sink_grants = manifest
+        .as_ref()
+        .and_then(|manifest| {
+            canonicalize_persisted_event_sink_grants(manifest, &registered.event_sink_grants).ok()
+        })
+        .unwrap_or_default();
+    let mut service_status = Vec::with_capacity(registered.service_ids.len());
+    for service_id in &registered.service_ids {
         let view = match service_manager.status(service_id).await {
             Some(snapshot) => ServiceStatusView {
                 id: snapshot.id,
@@ -258,7 +286,7 @@ pub async fn to_view(
         service_status.push(view);
     }
     let event_sink_status = tool_event_router
-        .status_for_ids(&entry.registered.event_sink_ids)
+        .status_for_ids(&registered.event_sink_ids)
         .await
         .into_iter()
         .map(Into::into)
@@ -269,16 +297,15 @@ pub async fn to_view(
         version: entry.version,
         source: entry.source,
         status: entry.status,
-        registered: entry.registered,
+        registered,
         service_status,
         event_sink_status,
     }
 }
 
-async fn read_manifest_name(plugin_dir: &std::path::Path) -> Option<String> {
+async fn read_manifest(plugin_dir: &std::path::Path) -> Option<PluginManifest> {
     let raw = tokio::fs::read_to_string(plugin_dir.join("plugin.json"))
         .await
         .ok()?;
-    let manifest = PluginManifest::parse_str(&raw).ok()?;
-    Some(manifest.name)
+    PluginManifest::parse_str(&raw).ok()
 }

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
@@ -14,7 +14,9 @@ use bamboo_plugin::{InstallDisposition, PluginInstaller, PluginSource};
 
 use crate::app_state::AppState;
 use crate::plugin_installer::ServerPluginInstaller;
-use crate::plugin_source::{install_server_plugin_from_source, PluginSourceInput};
+use crate::plugin_source::{
+    install_server_plugin_from_source_with_event_sink_grants, PluginSourceInput,
+};
 
 use super::api_types::{to_view, InstallPluginRequest, PluginListResponse};
 use super::errors::plugin_error_response;
@@ -86,16 +88,19 @@ pub async fn install_plugin(
 ) -> impl Responder {
     let installer = ServerPluginInstaller::new(state.clone());
     let root = plugins_root(&state);
-    let input = to_source_input(body.into_inner().source);
+    let request = body.into_inner();
+    let grants = request.event_sink_grants;
+    let input = to_source_input(request.source);
     let trust = state.config.read().await.plugin_trust.clone();
 
-    match install_server_plugin_from_source(
+    match install_server_plugin_from_source_with_event_sink_grants(
         &installer,
         input,
         &root,
         &trust,
         InstallDisposition::FailIfInstalled,
         None,
+        grants.as_deref(),
     )
     .await
     {
@@ -122,16 +127,19 @@ pub async fn update_plugin(
     let path_id = path.into_inner();
     let installer = ServerPluginInstaller::new(state.clone());
     let root = plugins_root(&state);
-    let input = to_source_input(body.into_inner().source);
+    let request = body.into_inner();
+    let grants = request.event_sink_grants;
+    let input = to_source_input(request.source);
     let trust = state.config.read().await.plugin_trust.clone();
 
-    match install_server_plugin_from_source(
+    match install_server_plugin_from_source_with_event_sink_grants(
         &installer,
         input,
         &root,
         &trust,
         InstallDisposition::Upgrade,
         Some(&path_id),
+        grants.as_deref(),
     )
     .await
     {

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
@@ -153,6 +153,22 @@ async fn write_event_sink_plugin_dir(
     dir
 }
 
+async fn configure_event_sink_fixture(
+    source: &Path,
+    requested_permissions: &[&str],
+    enabled: bool,
+) {
+    let manifest_path = source.join("plugin.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&tokio::fs::read_to_string(&manifest_path).await.unwrap()).unwrap();
+    manifest["provides"]["services"][0]["enabled"] = serde_json::json!(enabled);
+    manifest["provides"]["event_sinks"][0]["requested_permissions"] =
+        serde_json::json!(requested_permissions);
+    tokio::fs::write(manifest_path, manifest.to_string())
+        .await
+        .unwrap();
+}
+
 async fn body_json(response: actix_web::dev::ServiceResponse) -> serde_json::Value {
     let bytes = test::read_body(response).await;
     serde_json::from_slice(&bytes).expect("valid json body")
@@ -280,6 +296,188 @@ async fn installed_event_sink_exposes_bounded_sanitized_status() {
     let safe = serde_json::to_string(status).unwrap();
     assert!(!safe.contains("payload-must-not-enter-status"));
     assert!(!safe.contains(source.to_string_lossy().as_ref()));
+}
+
+#[actix_web::test]
+async fn corrupt_persisted_grant_strings_are_not_reflected_by_plugin_status() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let source_root = tempfile::tempdir().unwrap();
+    let source = write_event_sink_plugin_dir(
+        source_root.path(),
+        "corrupt-status-source",
+        "corrupt-status-plugin",
+        "1.0.0",
+        "fixture",
+    )
+    .await;
+    configure_event_sink_fixture(&source, &["metadata", "paths"], false).await;
+
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state)).await;
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/v1/plugins/install")
+            .set_json(local_dir_source(&source))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let installed_json = data_dir.path().join("plugins").join("installed.json");
+    let mut store = InstalledPlugins::load(&installed_json).await.unwrap();
+    store.plugins[0].registered.event_sink_grants.insert(
+        "shared-sink".to_string(),
+        vec![
+            bamboo_plugin::ObservationPermissionId::new("metadata"),
+            bamboo_plugin::ObservationPermissionId::new("credential-sentinel"),
+        ],
+    );
+    store.save(&installed_json).await.unwrap();
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/api/v1/plugins").to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let listed = body_json(response).await;
+    assert!(
+        listed["plugins"][0]["registered"]
+            .get("event_sink_grants")
+            .is_none(),
+        "a corrupt authority map must fail closed instead of being reflected"
+    );
+    assert!(!listed.to_string().contains("credential-sentinel"));
+}
+
+#[actix_web::test]
+async fn install_and_update_surface_exact_requested_and_persisted_grants() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let source_root = tempfile::tempdir().unwrap();
+    let initial = write_event_sink_plugin_dir(
+        source_root.path(),
+        "grant-v1-source",
+        "grant-plugin",
+        "1.0.0",
+        "v1",
+    )
+    .await;
+    configure_event_sink_fixture(
+        &initial,
+        &["content", "metadata", "tool_name", "paths"],
+        false,
+    )
+    .await;
+
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+    let mut body = local_dir_source(&initial);
+    body["event_sink_grants"] = serde_json::json!([{
+        "sink_id": "shared-sink",
+        "granted_permissions": ["content", "paths", "metadata", "tool_name"]
+    }]);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/v1/plugins/install")
+            .set_json(body)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let installed = body_json(response).await;
+    assert_eq!(
+        installed["registered"]["event_sink_grants"]["shared-sink"],
+        serde_json::json!(["metadata", "tool_name", "paths", "content"])
+    );
+    assert_eq!(
+        installed["event_sink_status"][0]["requested_permissions"],
+        serde_json::json!(["content", "metadata", "tool_name", "paths"])
+    );
+    assert_eq!(
+        installed["event_sink_status"][0]["granted_permissions"],
+        serde_json::json!(["metadata", "tool_name", "paths", "content"])
+    );
+    assert!(installed["event_sink_status"][0]["policy_generation"]
+        .as_u64()
+        .is_some_and(|generation| generation > 0));
+
+    let update = write_event_sink_plugin_dir(
+        source_root.path(),
+        "grant-v2-source",
+        "grant-plugin",
+        "2.0.0",
+        "v2",
+    )
+    .await;
+    configure_event_sink_fixture(
+        &update,
+        &["diff", "metadata", "paths", "content", "tool_name"],
+        false,
+    )
+    .await;
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/v1/plugins/grant-plugin/update")
+            .set_json(local_dir_source(&update))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let updated = body_json(response).await;
+    assert_eq!(
+        updated["registered"]["event_sink_grants"]["shared-sink"],
+        serde_json::json!(["metadata", "tool_name", "paths", "content"]),
+        "an omitted update grant target must not auto-authorize the newly requested diff field"
+    );
+    assert_eq!(
+        updated["event_sink_status"][0]["granted_permissions"],
+        serde_json::json!(["metadata", "tool_name", "paths", "content"])
+    );
+}
+
+#[actix_web::test]
+async fn duplicate_sink_grant_request_is_rejected_before_install_mutation() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let source_root = tempfile::tempdir().unwrap();
+    let source = write_event_sink_plugin_dir(
+        source_root.path(),
+        "duplicate-grant-source",
+        "duplicate-grant-plugin",
+        "1.0.0",
+        "must-not-activate",
+    )
+    .await;
+    configure_event_sink_fixture(&source, &["metadata", "paths"], false).await;
+
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+    let mut body = local_dir_source(&source);
+    body["event_sink_grants"] = serde_json::json!([
+        {"sink_id": "shared-sink", "granted_permissions": ["metadata"]},
+        {"sink_id": "shared-sink", "granted_permissions": ["metadata", "paths"]}
+    ]);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/v1/plugins/install")
+            .set_json(body)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error = body_json(response).await;
+    assert!(error_message(&error).contains("repeats sink"), "{error}");
+    assert!(!data_dir
+        .path()
+        .join("plugins/duplicate-grant-plugin")
+        .exists());
+    let store = InstalledPlugins::load(&data_dir.path().join("plugins/installed.json"))
+        .await
+        .unwrap();
+    assert!(store.list().is_empty());
 }
 
 // ---------------------------------------------------------------------

--- a/crates/app/bamboo-server/src/lib.rs
+++ b/crates/app/bamboo-server/src/lib.rs
@@ -127,6 +127,7 @@ pub mod server;
 pub mod service_manager;
 pub mod services;
 pub mod session_app;
+pub mod tool_event_policy;
 pub mod tool_event_router;
 
 // Re-export shims: these modules were relocated to bamboo-engine; keep the

--- a/crates/app/bamboo-server/src/plugin_installer.rs
+++ b/crates/app/bamboo-server/src/plugin_installer.rs
@@ -144,8 +144,8 @@ use bamboo_plugin::registry::{
     RegisteredCapabilities,
 };
 use bamboo_plugin::{
-    InstallDisposition, InstalledPlugin, InstalledPlugins, PluginError, PluginInstallStatus,
-    PluginInstaller, PluginManifest, PluginResult, PluginSource,
+    EventSinkPermissionGrants, InstallDisposition, InstalledPlugin, InstalledPlugins, PluginError,
+    PluginInstallStatus, PluginInstaller, PluginManifest, PluginResult, PluginSource,
 };
 
 use crate::app_state::{AppState, ConfigUpdateEffects};
@@ -155,6 +155,9 @@ use crate::handlers::agent::prompt_presets::{
     ensure_unique_preset_id, load_store, save_store, store_file_path, StoredPromptPreset,
 };
 use crate::service_manager::{ServiceManager, ServiceRuntimeConfig};
+use crate::tool_event_policy::{
+    canonicalize_persisted_event_sink_grants, resolve_event_sink_grants,
+};
 use crate::tool_event_router::ToolEventRouter;
 
 /// Process-wide serialization of plugin install/uninstall operations.
@@ -981,6 +984,34 @@ impl ServerPluginInstaller {
             disposition,
             installed_at,
             _guard,
+            None,
+            InstallFailureInjection::default(),
+        )
+        .await
+    }
+
+    /// Prepared-source install seam carrying a preflighted, canonical host
+    /// grant target. The inner transaction validates it again while holding
+    /// the plugin operation lock and before any journal/shared-store/runtime
+    /// mutation.
+    pub(crate) async fn install_with_operation_and_event_sink_grants(
+        &self,
+        manifest: &PluginManifest,
+        plugin_dir: &Path,
+        source: PluginSource,
+        disposition: InstallDisposition,
+        installed_at: DateTime<Utc>,
+        grants: &EventSinkPermissionGrants,
+        guard: &PluginOperationGuard,
+    ) -> PluginResult<InstalledPlugin> {
+        self.install_with_operation_inner(
+            manifest,
+            plugin_dir,
+            source,
+            disposition,
+            installed_at,
+            guard,
+            Some(grants),
             InstallFailureInjection::default(),
         )
         .await
@@ -1006,6 +1037,7 @@ impl ServerPluginInstaller {
             disposition,
             installed_at,
             guard,
+            None,
             InstallFailureInjection {
                 before_service_replacement: true,
                 ..InstallFailureInjection::default()
@@ -1025,6 +1057,7 @@ impl ServerPluginInstaller {
         source: PluginSource,
         disposition: InstallDisposition,
         installed_at: DateTime<Utc>,
+        prepared_event_sink_grants: Option<&EventSinkPermissionGrants>,
         guard: &PluginOperationGuard,
     ) -> PluginResult<InstalledPlugin> {
         self.install_with_operation_inner(
@@ -1034,6 +1067,7 @@ impl ServerPluginInstaller {
             disposition,
             installed_at,
             guard,
+            prepared_event_sink_grants,
             InstallFailureInjection {
                 final_provenance_commit: true,
                 ..InstallFailureInjection::default()
@@ -1050,6 +1084,7 @@ impl ServerPluginInstaller {
         disposition: InstallDisposition,
         installed_at: DateTime<Utc>,
         _guard: &PluginOperationGuard,
+        prepared_event_sink_grants: Option<&EventSinkPermissionGrants>,
         failure_injection: InstallFailureInjection,
     ) -> PluginResult<InstalledPlugin> {
         let installed_json_path = self.installed_json_path();
@@ -1062,6 +1097,14 @@ impl ServerPluginInstaller {
         let previous =
             load_previous_for_disposition(&installed_json_path, &manifest.id, disposition).await?;
         let resolved_mcp_servers = preflight_install(manifest, plugin_dir).await?;
+        let event_sink_grants = match prepared_event_sink_grants {
+            Some(grants) => canonicalize_persisted_event_sink_grants(manifest, grants)?,
+            None => resolve_event_sink_grants(
+                manifest,
+                previous.as_ref().map(|entry| &entry.registered),
+                None,
+            )?,
+        };
 
         // Re-run under the held operation guard as defense in depth. The HTTP
         // prepared-source path performs the same audit before bundle swap or
@@ -1097,6 +1140,7 @@ impl ServerPluginInstaller {
                 .map(|entry| entry.id.clone())
                 .collect(),
             event_sink_ids: declared_event_sink_ids,
+            event_sink_grants: event_sink_grants.clone(),
         };
 
         // Step 0: upgrade drop-diff. Computed from the NEW manifest's plain
@@ -1250,6 +1294,7 @@ impl ServerPluginInstaller {
             workflow_filenames,
             service_ids,
             event_sink_ids: event_sink_reconciliation.to_register,
+            event_sink_grants,
         };
         let runtime_sink_plan = reconcile_event_sinks(
             manifest,
@@ -1283,10 +1328,28 @@ impl ServerPluginInstaller {
         // Provenance is committed before runtime publication. The router
         // records eligible/inactive declarations now, but only creates a live
         // queue after ServiceManager exposes a Ready exact-generation sender.
-        self.state
+        if let Err(error) = self
+            .state
             .tool_event_router
-            .apply_plugin_plan(&manifest.id, manifest, &runtime_sink_plan)
-            .await;
+            .apply_plugin_plan(
+                &manifest.id,
+                manifest,
+                &runtime_sink_plan,
+                &entry.registered.event_sink_grants,
+            )
+            .await
+        {
+            // The same canonical map was validated before any mutation under
+            // the operation guard. A mismatch here therefore indicates an
+            // internal invariant failure; keep delivery fail-closed without
+            // misreporting the already committed plugin transaction as rolled
+            // back.
+            tracing::error!(
+                plugin_id = %manifest.id,
+                %error,
+                "committed plugin event sinks could not be published"
+            );
+        }
 
         Ok(entry)
     }
@@ -1470,6 +1533,24 @@ pub async fn boot_reconcile_services(
             continue;
         };
 
+        // Durable grants are executable authority. Validate the complete map
+        // before starting any plugin-owned process so a corrupt nonempty row
+        // cannot run code while its observation policy remains unavailable.
+        let event_sink_grants = match canonicalize_persisted_event_sink_grants(
+            manifest,
+            &plugin.registered.event_sink_grants,
+        ) {
+            Ok(grants) => grants,
+            Err(error) => {
+                tracing::warn!(
+                    plugin_id = %plugin.id,
+                    %error,
+                    "service boot-reconcile: invalid persisted event-sink grants kept plugin capabilities unavailable"
+                );
+                continue;
+            }
+        };
+
         let to_start: HashSet<&str> = plan
             .service_ids_to_start
             .iter()
@@ -1513,9 +1594,16 @@ pub async fn boot_reconcile_services(
                 ),
             }
         }
-        tool_event_router
-            .apply_plugin_plan(&plugin.id, manifest, &plan.event_sinks)
-            .await;
+        if let Err(error) = tool_event_router
+            .apply_plugin_plan(&plugin.id, manifest, &plan.event_sinks, &event_sink_grants)
+            .await
+        {
+            tracing::warn!(
+                plugin_id = %plugin.id,
+                %error,
+                "service boot-reconcile: event-sink grants failed router preflight"
+            );
+        }
     }
 }
 

--- a/crates/app/bamboo-server/src/plugin_installer/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_installer/tests.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use actix_web::web;
 use bamboo_plugin::{
     InstallDisposition, InstalledPlugin, InstalledPlugins, McpServerManifestEntry,
-    McpTransportManifest, Platform, PluginError, PluginInstallStatus, PluginInstaller,
-    PluginManifest, PluginSource, RegisteredCapabilities,
+    McpTransportManifest, ObservationPermissionId, Platform, PluginError, PluginInstallStatus,
+    PluginInstaller, PluginManifest, PluginSource, RegisteredCapabilities,
 };
 use bamboo_plugin_protocol::{
     FILE_CHANGED_SUBSCRIPTION_ID_V1, TOOL_EVENT_PROTOCOL_NAME, TOOL_EVENT_V1_SCHEMA_VERSION,
@@ -14,6 +14,7 @@ use chrono::Utc;
 
 use super::{boot_reconcile_services, ServerPluginInstaller, PLUGIN_OP_LOCK};
 use crate::app_state::AppState;
+use crate::tool_event_policy::canonicalize_persisted_event_sink_grants;
 use crate::tool_event_router::ToolEventSinkState;
 
 /// A never-resolves stdio command: `Command::spawn` fails immediately (ENOENT)
@@ -997,6 +998,15 @@ async fn install_recovers_from_a_crashed_installing_leftover() {
         status: PluginInstallStatus::Installing,
         registered: RegisteredCapabilities {
             mcp_server_ids: vec!["leftover-mcp".to_string()],
+            service_ids: vec!["leftover-event-service".to_string()],
+            event_sink_ids: vec!["leftover-event-sink".to_string()],
+            event_sink_grants: std::collections::BTreeMap::from([(
+                "leftover-event-sink".to_string(),
+                vec![
+                    ObservationPermissionId::new("metadata"),
+                    ObservationPermissionId::new("paths"),
+                ],
+            )]),
             ..Default::default()
         },
     });
@@ -1007,6 +1017,24 @@ async fn install_recovers_from_a_crashed_installing_leftover() {
     // and must NOT false-Conflict on `leftover-mcp` (recorded as the plugin's
     // own intended entry).
     let manifest_json = mcp_manifest_json("crashed-plugin", "1.0.0", &["leftover-mcp"]);
+    let mut manifest_value: serde_json::Value = serde_json::from_str(&manifest_json).unwrap();
+    manifest_value["provides"]["services"] = serde_json::json!([{
+        "id": "leftover-event-service",
+        "enabled": false,
+        "command": "${platform_bin}",
+        "input_protocol": "ndjson_v1"
+    }]);
+    manifest_value["provides"]["event_sinks"] = serde_json::json!([{
+        "id": "leftover-event-sink",
+        "service_id": "leftover-event-service",
+        "protocol": {
+            "name": TOOL_EVENT_PROTOCOL_NAME,
+            "version": TOOL_EVENT_V1_SCHEMA_VERSION
+        },
+        "subscriptions": [{"id": FILE_CHANGED_SUBSCRIPTION_ID_V1}],
+        "requested_permissions": ["metadata", "paths"]
+    }]);
+    let manifest_json = manifest_value.to_string();
     tokio::fs::write(plugin_dir.join("plugin.json"), &manifest_json)
         .await
         .unwrap();
@@ -1029,6 +1057,14 @@ async fn install_recovers_from_a_crashed_installing_leftover() {
     assert_eq!(
         entry.registered.mcp_server_ids,
         vec!["leftover-mcp".to_string()]
+    );
+    assert_eq!(
+        entry.registered.event_sink_grants["leftover-event-sink"]
+            .iter()
+            .map(ObservationPermissionId::as_str)
+            .collect::<Vec<_>>(),
+        vec!["metadata", "paths"],
+        "Installing recovery must preserve only the exact still-requested host authority"
     );
 
     // Provenance flipped to `installed`; the mcp entry is still owned.
@@ -1903,10 +1939,14 @@ async fn changed_backing_service_revokes_retained_sink_before_old_service_stop()
         Platform::current(),
     )
     .unwrap();
+    let grants =
+        canonicalize_persisted_event_sink_grants(&old_manifest, &previous.event_sink_grants)
+            .unwrap();
     state
         .tool_event_router
-        .apply_plugin_plan("changed-service-plugin", &old_manifest, &plan)
-        .await;
+        .apply_plugin_plan("changed-service-plugin", &old_manifest, &plan, &grants)
+        .await
+        .unwrap();
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let status = state
@@ -2045,10 +2085,21 @@ async fn failed_upgrade_dropping_unrelated_service_preserves_retained_live_route
         Platform::current(),
     )
     .unwrap();
+    let old_grants = canonicalize_persisted_event_sink_grants(
+        &old_manifest,
+        &previous_registered.event_sink_grants,
+    )
+    .unwrap();
     state
         .tool_event_router
-        .apply_plugin_plan("rollback-route-plugin", &old_manifest, &old_plan)
-        .await;
+        .apply_plugin_plan(
+            "rollback-route-plugin",
+            &old_manifest,
+            &old_plan,
+            &old_grants,
+        )
+        .await
+        .unwrap();
     let prior_generation = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let status = state
@@ -2191,10 +2242,16 @@ async fn boot_reconcile_takes_plugin_op_lock_before_reading_its_generation_plan(
         "generation-service",
         &[("new-sink", TOOL_EVENT_V1_SCHEMA_VERSION)],
     );
-    tokio::fs::write(old_dir.join("plugin.json"), old_manifest)
+    let add_paths_request = |raw: String| {
+        let mut value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        value["provides"]["event_sinks"][0]["requested_permissions"] =
+            serde_json::json!(["metadata", "paths"]);
+        value.to_string()
+    };
+    tokio::fs::write(old_dir.join("plugin.json"), add_paths_request(old_manifest))
         .await
         .unwrap();
-    tokio::fs::write(new_dir.join("plugin.json"), new_manifest)
+    tokio::fs::write(new_dir.join("plugin.json"), add_paths_request(new_manifest))
         .await
         .unwrap();
 
@@ -2210,6 +2267,13 @@ async fn boot_reconcile_takes_plugin_op_lock_before_reading_its_generation_plan(
         registered: RegisteredCapabilities {
             service_ids: vec!["generation-service".to_string()],
             event_sink_ids: vec![sink_id.to_string()],
+            event_sink_grants: std::collections::BTreeMap::from([(
+                sink_id.to_string(),
+                vec![
+                    ObservationPermissionId::new("metadata"),
+                    ObservationPermissionId::new("paths"),
+                ],
+            )]),
             ..Default::default()
         },
     };
@@ -2245,4 +2309,78 @@ async fn boot_reconcile_takes_plugin_op_lock_before_reading_its_generation_plan(
         .await;
     assert_eq!(status[0].state, ToolEventSinkState::Unavailable);
     assert_eq!(status[1].state, ToolEventSinkState::Inactive);
+    assert_eq!(
+        status[1]
+            .granted_permissions
+            .iter()
+            .map(ObservationPermissionId::as_str)
+            .collect::<Vec<_>>(),
+        vec!["metadata", "paths"]
+    );
+    assert!(status[1].policy_generation.is_some());
+}
+
+#[tokio::test]
+async fn boot_rejects_corrupt_nonempty_grants_before_starting_plugin_service() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugins_root = data_dir.path().join("plugins");
+    let plugin_dir = plugins_root.join("corrupt-grants-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+
+    let raw = event_sink_manifest_json(
+        "corrupt-grants-plugin",
+        "1.0.0",
+        "must-not-start-service",
+        &[("must-not-route-sink", TOOL_EVENT_V1_SCHEMA_VERSION)],
+    );
+    let mut manifest: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    manifest["provides"]["services"][0]["enabled"] = serde_json::json!(true);
+    manifest["provides"]["event_sinks"][0]["requested_permissions"] =
+        serde_json::json!(["metadata", "paths"]);
+    tokio::fs::write(plugin_dir.join("plugin.json"), manifest.to_string())
+        .await
+        .unwrap();
+
+    let mut store = InstalledPlugins::default();
+    store.plugins.push(InstalledPlugin {
+        id: "corrupt-grants-plugin".to_string(),
+        version: "1.0.0".to_string(),
+        source: PluginSource::LocalDir {
+            path: plugin_dir.clone(),
+        },
+        plugin_dir,
+        installed_at: Utc::now(),
+        status: PluginInstallStatus::Installed,
+        registered: RegisteredCapabilities {
+            service_ids: vec!["must-not-start-service".to_string()],
+            event_sink_ids: vec!["must-not-route-sink".to_string()],
+            event_sink_grants: std::collections::BTreeMap::from([(
+                "must-not-route-sink".to_string(),
+                vec![
+                    ObservationPermissionId::new("metadata"),
+                    ObservationPermissionId::new("content"),
+                ],
+            )]),
+            ..Default::default()
+        },
+    });
+    store
+        .save(&plugins_root.join("installed.json"))
+        .await
+        .unwrap();
+
+    let state = AppState::new(data_dir.path().to_path_buf())
+        .await
+        .expect("app state");
+    state.wait_for_boot_reconcile_services().await;
+    assert!(
+        !state.service_manager.is_running("must-not-start-service"),
+        "grant authority must validate before any plugin-owned process starts"
+    );
+    let status = state
+        .tool_event_router
+        .status_for_ids(&["must-not-route-sink".to_string()])
+        .await;
+    assert_eq!(status[0].state, ToolEventSinkState::Unavailable);
+    assert!(status[0].granted_permissions.is_empty());
 }

--- a/crates/app/bamboo-server/src/plugin_source.rs
+++ b/crates/app/bamboo-server/src/plugin_source.rs
@@ -192,11 +192,13 @@ use bamboo_plugin::manifest::Platform;
 #[cfg(test)]
 use bamboo_plugin::PluginInstaller;
 use bamboo_plugin::{
-    InstallDisposition, InstalledPlugin, PluginError, PluginManifest, PluginResult, PluginSource,
+    EventSinkPermissionGrants, InstallDisposition, InstalledPlugin, PluginError, PluginManifest,
+    PluginResult, PluginSource,
 };
 use ed25519_dalek::Verifier;
 
 use crate::plugin_installer::ServerPluginInstaller;
+use crate::tool_event_policy::{resolve_event_sink_grants, EventSinkGrantRequest};
 
 /// What the caller pointed the installer at.
 #[derive(Debug, Clone)]
@@ -1230,6 +1232,32 @@ pub async fn install_server_plugin_from_source(
     disposition: InstallDisposition,
     expected_plugin_id: Option<&str>,
 ) -> PluginResult<InstalledPlugin> {
+    install_server_plugin_from_source_with_event_sink_grants(
+        installer,
+        input,
+        plugins_root,
+        trust,
+        disposition,
+        expected_plugin_id,
+        None,
+    )
+    .await
+}
+
+/// Source transaction with an optional complete per-sink host grant target.
+/// Resolution happens against the prepared manifest and prior durable
+/// provenance before service shutdown or bundle activation. The installer
+/// receives the canonical map and validates it again under the same operation
+/// guard before writing the Installing journal row.
+pub async fn install_server_plugin_from_source_with_event_sink_grants(
+    installer: &ServerPluginInstaller,
+    input: PluginSourceInput,
+    plugins_root: &Path,
+    trust: &PluginTrustConfig,
+    disposition: InstallDisposition,
+    expected_plugin_id: Option<&str>,
+    requested_grants: Option<&[EventSinkGrantRequest]>,
+) -> PluginResult<InstalledPlugin> {
     install_server_plugin_from_source_inner(
         installer,
         input,
@@ -1237,6 +1265,7 @@ pub async fn install_server_plugin_from_source(
         trust,
         disposition,
         expected_plugin_id,
+        requested_grants,
         ServerSourceFault::None,
     )
     .await
@@ -1345,6 +1374,7 @@ async fn install_server_plugin_from_source_with_fault(
         trust,
         disposition,
         expected_plugin_id,
+        None,
         fault,
     )
     .await
@@ -1357,6 +1387,7 @@ async fn install_server_plugin_from_source_inner(
     trust: &PluginTrustConfig,
     disposition: InstallDisposition,
     expected_plugin_id: Option<&str>,
+    requested_grants: Option<&[EventSinkGrantRequest]>,
     fault: ServerSourceFault,
 ) -> PluginResult<InstalledPlugin> {
     let prepared = prepare_plugin_source(input, plugins_root, trust).await?;
@@ -1387,8 +1418,19 @@ async fn install_server_plugin_from_source_inner(
             return Err(error);
         }
     };
+    let event_sink_grants: EventSinkPermissionGrants = match resolve_event_sink_grants(
+        &prepared.manifest,
+        previous.as_ref().map(|entry| &entry.registered),
+        requested_grants,
+    ) {
+        Ok(grants) => grants,
+        Err(error) => {
+            prepared.discard().await;
+            return Err(error);
+        }
+    };
     if disposition == InstallDisposition::Upgrade {
-        let Some(previous) = previous else {
+        let Some(previous) = previous.as_ref() else {
             prepared.discard().await;
             return Err(PluginError::Registration(format!(
                 "upgrade for '{plugin_id}' has no unique previous provenance row"
@@ -1475,17 +1517,19 @@ async fn install_server_plugin_from_source_inner(
                             source,
                             disposition,
                             chrono::Utc::now(),
+                            Some(&event_sink_grants),
                             &guard,
                         )
                         .await
                 } else {
                     installer
-                        .install_with_operation(
+                        .install_with_operation_and_event_sink_grants(
                             &manifest,
                             &plugin_dir,
                             source,
                             disposition,
                             chrono::Utc::now(),
+                            &event_sink_grants,
                             &guard,
                         )
                         .await
@@ -1494,12 +1538,13 @@ async fn install_server_plugin_from_source_inner(
             #[cfg(not(test))]
             {
                 installer
-                    .install_with_operation(
+                    .install_with_operation_and_event_sink_grants(
                         &manifest,
                         &plugin_dir,
                         source,
                         disposition,
                         chrono::Utc::now(),
+                        &event_sink_grants,
                         &guard,
                     )
                     .await

--- a/crates/app/bamboo-server/src/plugin_source/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_source/tests.rs
@@ -4,8 +4,9 @@ use actix_web::web;
 use async_trait::async_trait;
 use bamboo_config::{PluginTrustConfig, PluginTrustEnforcement, TrustedKey};
 use bamboo_plugin::{
-    InstallDisposition, InstalledPlugin, InstalledPlugins, PluginError, PluginInstallStatus,
-    PluginInstaller, PluginManifest, PluginResult, PluginSource,
+    EventSinkPermissionGrants, InstallDisposition, InstalledPlugin, InstalledPlugins,
+    ObservationPermissionId, PluginError, PluginInstallStatus, PluginInstaller, PluginManifest,
+    PluginResult, PluginSource,
 };
 use bamboo_plugin_protocol::{
     FILE_CHANGED_SUBSCRIPTION_ID_V1, TOOL_EVENT_PROTOCOL_NAME, TOOL_EVENT_V1_SCHEMA_VERSION,
@@ -1889,7 +1890,7 @@ fn event_sink_service_plugin_manifest_json(version: &str, sink_id: &str) -> Stri
                     "version": TOOL_EVENT_V1_SCHEMA_VERSION
                 },
                 "subscriptions": [{"id": FILE_CHANGED_SUBSCRIPTION_ID_V1}],
-                "requested_permissions": ["metadata"]
+                "requested_permissions": ["metadata", "paths"]
             }]
         }
     })
@@ -1980,8 +1981,16 @@ async fn server_final_commit_upgrade_fixture(
         .await
         .unwrap();
     let old_manifest = PluginManifest::parse_str(&old_manifest_json).unwrap();
+    let old_grants = EventSinkPermissionGrants::from([(
+        "old-sink".to_string(),
+        vec![
+            ObservationPermissionId::new("metadata"),
+            ObservationPermissionId::new("paths"),
+        ],
+    )]);
+    let guard = installer.begin_operation().await;
     installer
-        .install(
+        .install_with_operation_and_event_sink_grants(
             &old_manifest,
             &live_dir,
             PluginSource::LocalDir {
@@ -1989,9 +1998,12 @@ async fn server_final_commit_upgrade_fixture(
             },
             InstallDisposition::FailIfInstalled,
             Utc::now(),
+            &old_grants,
+            &guard,
         )
         .await
         .expect("install old event-sink service plugin");
+    drop(guard);
     assert!(state.service_manager.is_running("svc"));
     let previous = InstalledPlugins::load(&plugins_root.join("installed.json"))
         .await
@@ -2332,6 +2344,13 @@ async fn final_provenance_commit_failure_aborts_registration_and_restores_exact_
         previous.registered.event_sink_ids,
         vec!["old-sink".to_string()]
     );
+    assert_eq!(
+        previous.registered.event_sink_grants["old-sink"]
+            .iter()
+            .map(|permission| permission.as_str())
+            .collect::<Vec<_>>(),
+        vec!["metadata", "paths"]
+    );
 
     let error = install_server_plugin_from_source_with_fault(
         &installer,
@@ -2389,6 +2408,10 @@ async fn final_provenance_commit_failure_aborts_registration_and_restores_exact_
     assert_eq!(
         restored.registered.event_sink_ids,
         vec!["old-sink".to_string()]
+    );
+    assert_eq!(
+        restored.registered.event_sink_grants, previous.registered.event_sink_grants,
+        "rollback must restore exact host grant authority"
     );
 }
 

--- a/crates/app/bamboo-server/src/tool_event_policy.rs
+++ b/crates/app/bamboo-server/src/tool_event_policy.rs
@@ -1,0 +1,1212 @@
+//! Pure, host-owned projection policy for plugin [`ToolEventV1`] delivery.
+//!
+//! This module deliberately performs no filesystem or async I/O. Tool
+//! publication is a synchronous hot path, so path handling is lexical and
+//! fail-closed: relative, traversal, control-character, drive-relative, and
+//! extended-device paths are redacted. The mutation tools separately prove
+//! filesystem provenance before they publish a successful event.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use bamboo_plugin::{
+    EventSinkPermissionGrants, ObservationPermissionId, PluginError, PluginManifest, PluginResult,
+    RegisteredCapabilities, MAX_EVENT_SINKS_PER_PLUGIN, MAX_EVENT_SINK_ID_BYTES,
+    MAX_EVENT_SINK_PERMISSIONS, MAX_EVENT_SINK_PERMISSION_ID_BYTES, OBSERVE_CONTENT_PERMISSION,
+    OBSERVE_DIFF_PERMISSION, OBSERVE_METADATA_PERMISSION, OBSERVE_PATHS_PERMISSION,
+    OBSERVE_TOOL_NAME_PERMISSION,
+};
+use bamboo_plugin_protocol::{
+    ProjectedFileChangedV1, ProjectedToolEventContextV1, ProjectedToolEventV1, ToolEventBuildError,
+    ToolEventV1, MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES, MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES,
+    TOOL_EVENT_PATH_REDACTION_PERMISSION_NOT_GRANTED, TOOL_EVENT_PATH_REDACTION_SENSITIVE,
+    TOOL_EVENT_PATH_REDACTION_UNSAFE, TOOL_EVENT_V1_SCHEMA_VERSION,
+};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+pub const TOOL_EVENT_DIFF_FIELD: &str = "diff";
+pub const TOOL_EVENT_CONTENT_FIELD: &str = "content";
+pub const TOOL_EVENT_DIFF_TRUNCATED_FIELD: &str = "diff_truncated";
+pub const TOOL_EVENT_CONTENT_TRUNCATED_FIELD: &str = "content_truncated";
+pub const TOOL_EVENT_PATH_REDACTION_REASON_FIELD: &str = "path_redaction_reason";
+pub const TOOL_EVENT_POLICY_GENERATION_FIELD: &str = "observation_policy_generation";
+
+pub const PATH_REDACTION_PERMISSION_NOT_GRANTED: &str =
+    TOOL_EVENT_PATH_REDACTION_PERMISSION_NOT_GRANTED;
+pub const PATH_REDACTION_SENSITIVE: &str = TOOL_EVENT_PATH_REDACTION_SENSITIVE;
+pub const PATH_REDACTION_UNSAFE: &str = TOOL_EVENT_PATH_REDACTION_UNSAFE;
+
+const TRUNCATION_MARKER: &str = "\u{2026}";
+
+const KNOWN_PERMISSIONS: &[&str] = &[
+    OBSERVE_METADATA_PERMISSION,
+    OBSERVE_TOOL_NAME_PERMISSION,
+    OBSERVE_PATHS_PERMISSION,
+    OBSERVE_DIFF_PERMISSION,
+    OBSERVE_CONTENT_PERMISSION,
+];
+
+/// Runtime host policy. Manifest permissions are requests only; a field is
+/// projected when its request and this grant set both contain the permission.
+/// Metadata is always retained as the minimum routable/safe envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolEventObservationPolicy {
+    granted: BTreeSet<String>,
+}
+
+impl Default for ToolEventObservationPolicy {
+    fn default() -> Self {
+        Self::metadata_only()
+    }
+}
+
+impl ToolEventObservationPolicy {
+    pub fn metadata_only() -> Self {
+        Self {
+            granted: BTreeSet::from([OBSERVE_METADATA_PERMISSION.to_string()]),
+        }
+    }
+
+    /// Construct a policy from an already validated, exact host grant set.
+    /// This intentionally does not add metadata: corrupt persisted authority
+    /// must fail closed in the resolver instead of being silently repaired on
+    /// the delivery hot path.
+    pub(crate) fn from_validated_permission_ids<I, S>(permissions: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut policy = Self {
+            granted: BTreeSet::new(),
+        };
+        for permission in permissions {
+            let permission = permission.as_ref();
+            if KNOWN_PERMISSIONS.contains(&permission) {
+                policy.granted.insert(permission.to_string());
+            }
+        }
+        policy
+    }
+
+    #[cfg(test)]
+    pub(crate) fn all_v1() -> Self {
+        Self::from_validated_permission_ids(KNOWN_PERMISSIONS.iter().copied())
+    }
+
+    fn grants(&self, permission: &str) -> bool {
+        self.granted.contains(permission)
+    }
+
+    pub(crate) fn grant_requested(
+        &self,
+        requested: &[ObservationPermissionId],
+    ) -> GrantedObservation {
+        let requested: BTreeSet<&str> = requested.iter().map(|id| id.as_str()).collect();
+        let has = |permission| requested.contains(permission) && self.grants(permission);
+        GrantedObservation {
+            metadata: has(OBSERVE_METADATA_PERMISSION),
+            tool_name: has(OBSERVE_TOOL_NAME_PERMISSION),
+            paths: has(OBSERVE_PATHS_PERMISSION),
+            diff: has(OBSERVE_DIFF_PERMISSION),
+            content: has(OBSERVE_CONTENT_PERMISSION),
+        }
+    }
+}
+
+/// One explicit request-side grant record. HTTP deliberately uses a list,
+/// rather than a JSON object, so duplicate sink ids are observable and can be
+/// rejected instead of silently taking a parser's last value.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EventSinkGrantRequest {
+    pub sink_id: String,
+    pub granted_permissions: Vec<ObservationPermissionId>,
+}
+
+/// Resolve request authority into the canonical map persisted in both the
+/// Installing and Installed rows.
+///
+/// `Some(records)` is a complete target for all ToolEventV1 sinks: listed
+/// sinks receive exactly the validated permissions, while omitted v1 sinks
+/// receive metadata only. `None` is context-sensitive by design: a fresh
+/// install starts metadata-only; an update preserves only prior grants that
+/// the new manifest still requests. Newly requested permissions are never
+/// granted implicitly.
+pub(crate) fn resolve_event_sink_grants(
+    manifest: &PluginManifest,
+    previous: Option<&RegisteredCapabilities>,
+    requested: Option<&[EventSinkGrantRequest]>,
+) -> PluginResult<EventSinkPermissionGrants> {
+    manifest.validate()?;
+
+    if let Some(records) = requested {
+        if records.len() > MAX_EVENT_SINKS_PER_PLUGIN {
+            return invalid_grants(format!(
+                "event sink grant request exceeds the per-plugin limit of {MAX_EVENT_SINKS_PER_PLUGIN}"
+            ));
+        }
+        for record in records {
+            validate_external_grant_record(record)?;
+        }
+        let mut explicit = BTreeMap::new();
+        for record in records {
+            if explicit
+                .insert(record.sink_id.clone(), record.granted_permissions.clone())
+                .is_some()
+            {
+                return invalid_grants(format!(
+                    "event sink grant request repeats sink '{}'",
+                    record.sink_id
+                ));
+            }
+            let Some(sink) = manifest
+                .provides
+                .event_sinks
+                .iter()
+                .find(|sink| sink.id == record.sink_id)
+            else {
+                return invalid_grants(format!(
+                    "event sink grant request names unknown sink '{}'",
+                    record.sink_id
+                ));
+            };
+            if !is_v1_sink(sink) {
+                return invalid_grants(format!(
+                    "event sink '{}' uses an unsupported protocol version for host grants",
+                    record.sink_id
+                ));
+            }
+        }
+
+        let mut resolved = BTreeMap::new();
+        for sink in manifest
+            .provides
+            .event_sinks
+            .iter()
+            .filter(|sink| is_v1_sink(sink))
+        {
+            let fallback = [ObservationPermissionId::new(OBSERVE_METADATA_PERMISSION)];
+            let candidate = explicit
+                .get(&sink.id)
+                .map(Vec::as_slice)
+                .unwrap_or(&fallback);
+            resolved.insert(sink.id.clone(), canonicalize_sink_grants(sink, candidate)?);
+        }
+        return Ok(resolved);
+    }
+
+    validate_previous_grant_shape(previous)?;
+    let previous_is_legacy =
+        previous.is_none_or(|registered| registered.event_sink_grants.is_empty());
+    let mut resolved = BTreeMap::new();
+    for sink in manifest
+        .provides
+        .event_sinks
+        .iter()
+        .filter(|sink| is_v1_sink(sink))
+    {
+        let retained = previous
+            .is_some_and(|registered| registered.event_sink_ids.iter().any(|id| id == &sink.id));
+        let candidate = if retained && !previous_is_legacy {
+            let Some(grants) =
+                previous.and_then(|registered| registered.event_sink_grants.get(&sink.id))
+            else {
+                return invalid_grants(format!(
+                    "persisted host grants omit retained ToolEventV1 sink '{}'",
+                    sink.id
+                ));
+            };
+            grants
+                .iter()
+                .filter(|permission| {
+                    sink.requested_permissions
+                        .iter()
+                        .any(|requested| requested == *permission)
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        } else {
+            vec![ObservationPermissionId::new(OBSERVE_METADATA_PERMISSION)]
+        };
+        resolved.insert(sink.id.clone(), canonicalize_sink_grants(sink, &candidate)?);
+    }
+    Ok(resolved)
+}
+
+/// Validate/canonicalize durable authority at the boot/router boundary.
+/// Only an entirely empty legacy map is migrated to metadata-only. Once any
+/// grant is persisted, every ToolEventV1 sink must have an exact entry.
+pub(crate) fn canonicalize_persisted_event_sink_grants(
+    manifest: &PluginManifest,
+    persisted: &EventSinkPermissionGrants,
+) -> PluginResult<EventSinkPermissionGrants> {
+    manifest.validate()?;
+    if persisted.is_empty() {
+        return resolve_event_sink_grants(manifest, None, None);
+    }
+
+    let mut resolved = BTreeMap::new();
+    for (sink_id, permissions) in persisted {
+        validate_permission_set_shape(sink_id, permissions)?;
+        let Some(sink) = manifest
+            .provides
+            .event_sinks
+            .iter()
+            .find(|sink| &sink.id == sink_id)
+        else {
+            return invalid_grants(format!(
+                "persisted host grants name unknown sink '{sink_id}'"
+            ));
+        };
+        if !is_v1_sink(sink) {
+            return invalid_grants(format!(
+                "persisted host grants target unsupported sink '{sink_id}'"
+            ));
+        }
+        resolved.insert(
+            sink_id.clone(),
+            canonicalize_sink_grants(sink, permissions)?,
+        );
+    }
+    for sink in manifest
+        .provides
+        .event_sinks
+        .iter()
+        .filter(|sink| is_v1_sink(sink))
+    {
+        if !resolved.contains_key(&sink.id) {
+            return invalid_grants(format!(
+                "persisted host grants omit ToolEventV1 sink '{}'",
+                sink.id
+            ));
+        }
+    }
+    Ok(resolved)
+}
+
+fn validate_previous_grant_shape(previous: Option<&RegisteredCapabilities>) -> PluginResult<()> {
+    let Some(previous) = previous else {
+        return Ok(());
+    };
+    if previous.event_sink_grants.is_empty() {
+        return Ok(());
+    }
+    let owned: HashSet<&str> = previous.event_sink_ids.iter().map(String::as_str).collect();
+    for (sink_id, permissions) in &previous.event_sink_grants {
+        validate_permission_set_shape(sink_id, permissions)?;
+        if !owned.contains(sink_id.as_str()) {
+            return invalid_grants(format!(
+                "persisted host grants name sink '{sink_id}' outside registered event-sink provenance"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_sink_grants(
+    sink: &bamboo_plugin::EventSinkManifestEntry,
+    permissions: &[ObservationPermissionId],
+) -> PluginResult<Vec<ObservationPermissionId>> {
+    validate_permission_set_shape(&sink.id, permissions)?;
+    for permission in permissions {
+        if !sink
+            .requested_permissions
+            .iter()
+            .any(|requested| requested == permission)
+        {
+            return invalid_grants(format!(
+                "event sink '{}' host grant '{}' was not requested by its manifest",
+                sink.id,
+                permission.as_str()
+            ));
+        }
+    }
+    Ok(KNOWN_PERMISSIONS
+        .iter()
+        .filter(|known| {
+            permissions
+                .iter()
+                .any(|granted| granted.as_str() == **known)
+        })
+        .map(|known| ObservationPermissionId::new(*known))
+        .collect())
+}
+
+fn validate_permission_set_shape(
+    sink_id: &str,
+    permissions: &[ObservationPermissionId],
+) -> PluginResult<()> {
+    if sink_id.trim().is_empty() || sink_id.len() > MAX_EVENT_SINK_ID_BYTES {
+        return invalid_grants("event sink host grant has an invalid bounded sink id".to_string());
+    }
+    if permissions.is_empty() || permissions.len() > MAX_EVENT_SINK_PERMISSIONS {
+        return invalid_grants(format!(
+            "event sink '{sink_id}' host grants must contain 1..={MAX_EVENT_SINK_PERMISSIONS} permissions"
+        ));
+    }
+    let mut seen = HashSet::new();
+    for permission in permissions {
+        let value = permission.as_str();
+        if value.trim().is_empty() || value.len() > MAX_EVENT_SINK_PERMISSION_ID_BYTES {
+            return invalid_grants(format!(
+                "event sink '{sink_id}' has an invalid bounded host grant id"
+            ));
+        }
+        if !KNOWN_PERMISSIONS.contains(&value) {
+            return invalid_grants(format!(
+                "event sink '{sink_id}' has an unknown ToolEventV1 host grant"
+            ));
+        }
+        if !seen.insert(value) {
+            return invalid_grants(format!(
+                "event sink '{sink_id}' repeats host grant '{value}'"
+            ));
+        }
+    }
+    if !seen.contains(OBSERVE_METADATA_PERMISSION) {
+        return invalid_grants(format!(
+            "event sink '{sink_id}' host grants must include '{OBSERVE_METADATA_PERMISSION}'"
+        ));
+    }
+    if (seen.contains(OBSERVE_DIFF_PERMISSION) || seen.contains(OBSERVE_CONTENT_PERMISSION))
+        && !seen.contains(OBSERVE_PATHS_PERMISSION)
+    {
+        return invalid_grants(format!(
+            "event sink '{sink_id}' grants diff/content without the required paths grant"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_external_grant_record(record: &EventSinkGrantRequest) -> PluginResult<()> {
+    if record.sink_id.trim().is_empty() || record.sink_id.len() > MAX_EVENT_SINK_ID_BYTES {
+        return invalid_grants(
+            "event sink grant request contains an invalid bounded sink id".to_string(),
+        );
+    }
+    if record.granted_permissions.is_empty()
+        || record.granted_permissions.len() > MAX_EVENT_SINK_PERMISSIONS
+    {
+        return invalid_grants(format!(
+            "event sink grant request permissions must contain 1..={MAX_EVENT_SINK_PERMISSIONS} entries"
+        ));
+    }
+    for permission in &record.granted_permissions {
+        let value = permission.as_str();
+        if value.trim().is_empty() || value.len() > MAX_EVENT_SINK_PERMISSION_ID_BYTES {
+            return invalid_grants(
+                "event sink grant request contains an invalid bounded permission id".to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn is_v1_sink(sink: &bamboo_plugin::EventSinkManifestEntry) -> bool {
+    sink.protocol.version == TOOL_EVENT_V1_SCHEMA_VERSION
+}
+
+fn invalid_grants<T>(message: String) -> PluginResult<T> {
+    Err(PluginError::InvalidManifest(message))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GrantedObservation {
+    metadata: bool,
+    tool_name: bool,
+    paths: bool,
+    diff: bool,
+    content: bool,
+}
+
+impl GrantedObservation {
+    pub(crate) fn can_observe_tool_name(self) -> bool {
+        self.tool_name
+    }
+
+    pub(crate) fn permission_ids(self) -> Vec<ObservationPermissionId> {
+        [
+            (self.metadata, OBSERVE_METADATA_PERMISSION),
+            (self.tool_name, OBSERVE_TOOL_NAME_PERMISSION),
+            (self.paths, OBSERVE_PATHS_PERMISSION),
+            (self.diff, OBSERVE_DIFF_PERMISSION),
+            (self.content, OBSERVE_CONTENT_PERMISSION),
+        ]
+        .into_iter()
+        .filter(|(granted, _)| *granted)
+        .map(|(_, permission)| ObservationPermissionId::new(permission))
+        .collect()
+    }
+}
+
+/// Build the only object that may cross a per-sink queue. Producer extensions
+/// are deny-by-default: v1 copies only the two explicitly permissioned payload
+/// fields and synthesizes bounded host metadata/redaction markers.
+pub(crate) fn project_tool_event(
+    event: &ToolEventV1,
+    grants: GrantedObservation,
+    policy_generation: u64,
+) -> Result<ProjectedToolEventV1, ToolEventBuildError> {
+    let source = event
+        .data
+        .as_object()
+        .ok_or(ToolEventBuildError::DataMustBeObject)?;
+    let source_path = source.get("path").and_then(Value::as_str).ok_or_else(|| {
+        ToolEventBuildError::InvalidKnownPayload(
+            "file_changed data.path must be a string".to_string(),
+        )
+    })?;
+
+    // Validated v1 manifests must request metadata. Keep this explicit and
+    // fail closed if a corrupt/runtime-constructed registration bypasses that
+    // invariant rather than projecting authority-bearing ids unexpectedly.
+    if !grants.metadata {
+        return Err(ToolEventBuildError::InvalidKnownPayload(
+            "metadata permission is required for ToolEventV1 projection".to_string(),
+        ));
+    }
+
+    let context = ProjectedToolEventContextV1 {
+        session_id: event.context.session_id.clone(),
+        root_session_id: event.context.root_session_id.clone(),
+        tool_name: grants.tool_name.then(|| event.context.tool_name.clone()),
+        tool_call_id: event.context.tool_call_id.clone(),
+    };
+
+    let path = project_path(source_path, grants.paths);
+    let mut data = ProjectedFileChangedV1 {
+        path: path.value,
+        path_redaction_reason: path.redaction_reason.map(str::to_string),
+        ..ProjectedFileChangedV1::default()
+    };
+
+    // Sensitive/unsafe paths never carry payload, even if a caller grants
+    // content. This ordering prevents the path policy and payload policy from
+    // being evaluated as independent, accidentally leaky decisions.
+    if path.redaction_reason.is_none() {
+        (data.diff, data.diff_truncated) = project_bounded_string_extension(
+            source,
+            TOOL_EVENT_DIFF_FIELD,
+            grants.diff,
+            MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES,
+        )?;
+        (data.content, data.content_truncated) = project_bounded_string_extension(
+            source,
+            TOOL_EVENT_CONTENT_FIELD,
+            grants.content,
+            MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES,
+        )?;
+    }
+
+    Ok(ProjectedToolEventV1::file_changed(
+        context,
+        data,
+        policy_generation,
+    ))
+}
+
+fn project_bounded_string_extension(
+    source: &Map<String, Value>,
+    field: &str,
+    granted: bool,
+    max_bytes: usize,
+) -> Result<(Option<String>, bool), ToolEventBuildError> {
+    if !granted {
+        return Ok((None, false));
+    }
+    let Some(value) = source.get(field) else {
+        return Ok((None, false));
+    };
+    let value = value.as_str().ok_or_else(|| {
+        ToolEventBuildError::InvalidKnownPayload(format!(
+            "file_changed data.{field} must be a string"
+        ))
+    })?;
+    let (value, truncated) = truncate_utf8(value, max_bytes);
+    Ok((Some(value), truncated))
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> (String, bool) {
+    if value.len() <= max_bytes {
+        return (value.to_string(), false);
+    }
+    let budget = max_bytes.saturating_sub(TRUNCATION_MARKER.len());
+    let mut end = budget.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut bounded = String::with_capacity(max_bytes);
+    bounded.push_str(&value[..end]);
+    if TRUNCATION_MARKER.len() <= max_bytes {
+        bounded.push_str(TRUNCATION_MARKER);
+    }
+    (bounded, true)
+}
+
+#[derive(Debug)]
+struct ProjectedPath {
+    value: Option<String>,
+    redaction_reason: Option<&'static str>,
+}
+
+fn project_path(raw: &str, granted: bool) -> ProjectedPath {
+    if !granted {
+        return redacted_path(PATH_REDACTION_PERMISSION_NOT_GRANTED);
+    }
+    let Some(normalized) = normalize_absolute_path(raw) else {
+        return redacted_path(PATH_REDACTION_UNSAFE);
+    };
+    if is_sensitive_normalized_path(&normalized) {
+        return redacted_path(PATH_REDACTION_SENSITIVE);
+    }
+    ProjectedPath {
+        value: Some(normalized),
+        redaction_reason: None,
+    }
+}
+
+fn redacted_path(reason: &'static str) -> ProjectedPath {
+    ProjectedPath {
+        value: None,
+        redaction_reason: Some(reason),
+    }
+}
+
+/// Pure cross-platform lexical normalization. Ambiguity is redacted rather
+/// than guessed: `..`, relative/drive-relative paths, device namespaces, and
+/// control characters return `None`.
+fn normalize_absolute_path(raw: &str) -> Option<String> {
+    if raw.is_empty() || raw.chars().any(char::is_control) {
+        return None;
+    }
+    if raw.starts_with('\\') && !raw.starts_with("\\\\") {
+        // A single leading backslash is Windows drive-relative/rooted syntax
+        // (and also covers NT object-manager spellings such as `\Device` and
+        // `\??`). It is not an absolute, portable identity and must not be
+        // reinterpreted as a Unix path after separator normalization.
+        return None;
+    }
+    let slash = raw.replace('\\', "/");
+    let raw = slash.as_str();
+    let lower = raw.to_ascii_lowercase();
+    let namespace = lower.trim_start_matches('/');
+    if lower.starts_with("//?/")
+        || lower.starts_with("//./")
+        || namespace.starts_with("??/")
+        || namespace.starts_with("device/")
+        || namespace.starts_with("global??/")
+    {
+        // Windows device/extended namespaces can change path interpretation
+        // (including component normalization); never reinterpret them here.
+        return None;
+    }
+
+    #[derive(Clone, Copy)]
+    enum Root<'a> {
+        Unix(&'a str),
+        Drive(char, &'a str),
+        Unc(&'a str),
+    }
+
+    let root = if raw.starts_with("//") {
+        Root::Unc(raw.trim_start_matches('/'))
+    } else if let Some(rest) = raw.strip_prefix('/') {
+        Root::Unix(rest)
+    } else if raw.len() >= 3
+        && raw.as_bytes()[0].is_ascii_alphabetic()
+        && raw.as_bytes()[1] == b':'
+        && raw.as_bytes()[2] == b'/'
+    {
+        Root::Drive(
+            char::from(raw.as_bytes()[0]).to_ascii_uppercase(),
+            &raw[3..],
+        )
+    } else {
+        return None;
+    };
+
+    let rest = match root {
+        Root::Unix(rest) | Root::Drive(_, rest) | Root::Unc(rest) => rest,
+    };
+    if let Root::Unc(rest) = root {
+        let mut authority = rest.split('/');
+        let server = authority.next()?;
+        let share = authority.next()?;
+        if server.is_empty()
+            || share.is_empty()
+            || matches!(server, "." | "..")
+            || matches!(share, "." | "..")
+            || windows_component_is_ambiguous(server)
+            || windows_component_is_ambiguous(share)
+        {
+            return None;
+        }
+    }
+    let windows_semantics = matches!(root, Root::Drive(..) | Root::Unc(..));
+    let mut components = Vec::new();
+    for component in rest.split('/') {
+        if windows_semantics && windows_component_is_ambiguous(component) {
+            return None;
+        }
+        match component {
+            "" | "." => {}
+            ".." => return None,
+            value => components.push(value),
+        }
+    }
+
+    match root {
+        Root::Unix(_) => Some(if components.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", components.join("/"))
+        }),
+        Root::Drive(drive, _) => Some(if components.is_empty() {
+            format!("{drive}:/")
+        } else {
+            format!("{drive}:/{}", components.join("/"))
+        }),
+        Root::Unc(_) => {
+            // A UNC authority needs both server and share. Anything shorter is
+            // ambiguous and therefore not observable.
+            (components.len() >= 2).then(|| format!("//{}", components.join("/")))
+        }
+    }
+}
+
+fn windows_component_is_ambiguous(component: &str) -> bool {
+    if component.is_empty() || matches!(component, "." | "..") {
+        return false;
+    }
+    if component.contains(':') || component.ends_with([' ', '.']) {
+        return true;
+    }
+    let basename = component
+        .split('.')
+        .next()
+        .unwrap_or(component)
+        .to_ascii_uppercase();
+    matches!(basename.as_str(), "CON" | "PRN" | "AUX" | "NUL" | "CLOCK$")
+        || basename
+            .strip_prefix("COM")
+            .or_else(|| basename.strip_prefix("LPT"))
+            .is_some_and(|number| number.len() == 1 && matches!(number.as_bytes()[0], b'1'..=b'9'))
+}
+
+fn is_sensitive_normalized_path(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    let is_unc = lower.starts_with("//");
+    let mut components: Vec<&str> = lower
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .collect();
+    if components
+        .first()
+        .is_some_and(|component| component.ends_with(':'))
+    {
+        components.remove(0);
+    }
+    if components.is_empty() {
+        return false;
+    }
+
+    // Windows administrative shares (`C$`, `ADMIN$`, `IPC$`) and other
+    // hidden shares intentionally expose privileged/hidden namespaces. Once
+    // a UNC path names one, never project its authority, descendants, or
+    // payload even when paths/content were explicitly granted.
+    if is_unc && components.get(1).is_some_and(|share| share.ends_with('$')) {
+        return true;
+    }
+
+    // System credential/config namespaces on Unix and Windows.
+    if matches!(
+        components.as_slice(),
+        ["etc", ..] | ["proc", ..] | ["sys", ..] | ["dev", ..] | ["boot", ..]
+    ) || matches!(components.as_slice(), ["private", "etc", ..])
+        || matches!(components.as_slice(), ["windows", "system32", ..])
+        || matches!(components.as_slice(), ["programdata", ..])
+    {
+        return true;
+    }
+
+    const SENSITIVE_COMPONENTS: &[&str] = &[
+        ".ssh",
+        ".aws",
+        ".gnupg",
+        ".kube",
+        ".bamboo",
+        ".codex",
+        ".claude",
+        ".agents",
+        ".config",
+        ".git",
+        "appdata",
+        "keychains",
+        "secrets",
+    ];
+    if components
+        .iter()
+        .any(|component| SENSITIVE_COMPONENTS.contains(component))
+    {
+        return true;
+    }
+    let basename = components.last().copied().unwrap_or_default();
+    basename == ".env"
+        || basename.starts_with(".env.")
+        || matches!(
+            basename,
+            ".netrc"
+                | ".npmrc"
+                | ".pypirc"
+                | ".git-credentials"
+                | "credentials"
+                | "credentials.json"
+                | "secrets.json"
+                | "id_rsa"
+                | "id_ed25519"
+                | "authorized_keys"
+                | "agents.md"
+                | "claude.md"
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_plugin_protocol::{
+        FileChangedV1, ToolEventContextV1, FILE_CHANGED_SUBSCRIPTION_ID_V1,
+        TOOL_EVENT_PROTOCOL_NAME,
+    };
+    use serde_json::json;
+
+    fn event(path: &str) -> ToolEventV1 {
+        let mut data = FileChangedV1::bounded(path).unwrap();
+        for (key, value) in [
+            (TOOL_EVENT_DIFF_FIELD, "diff-sentinel"),
+            (TOOL_EVENT_CONTENT_FIELD, "content-sentinel"),
+            ("config", "config-sentinel"),
+            ("prompt", "prompt-sentinel"),
+            ("credentials", "credential-sentinel"),
+        ] {
+            data.extensions.insert(key.to_string(), json!(value));
+        }
+        let mut event = ToolEventV1::file_changed(
+            ToolEventContextV1::bounded("session-safe", "root-safe", "Write", "call-safe").unwrap(),
+            data,
+        )
+        .unwrap();
+        event
+            .extensions
+            .insert("prompt_dump".to_string(), json!("envelope-prompt-sentinel"));
+        event.context.extensions.insert(
+            "credential_dump".to_string(),
+            json!("context-credential-sentinel"),
+        );
+        event
+    }
+
+    fn requested_all() -> Vec<ObservationPermissionId> {
+        KNOWN_PERMISSIONS
+            .iter()
+            .map(|permission| ObservationPermissionId::new(*permission))
+            .collect()
+    }
+
+    fn grant_manifest(sinks: &[(&str, &[&str])]) -> PluginManifest {
+        let sinks: Vec<Value> = sinks
+            .iter()
+            .map(|(sink_id, permissions)| {
+                json!({
+                    "id": sink_id,
+                    "service_id": "events-service",
+                    "protocol": {
+                        "name": TOOL_EVENT_PROTOCOL_NAME,
+                        "version": TOOL_EVENT_V1_SCHEMA_VERSION
+                    },
+                    "subscriptions": [{"id": FILE_CHANGED_SUBSCRIPTION_ID_V1}],
+                    "requested_permissions": permissions
+                })
+            })
+            .collect();
+        serde_json::from_value(json!({
+            "id": "grant-test-plugin",
+            "name": "Grant Test Plugin",
+            "version": "1.0.0",
+            "provides": {
+                "services": [{
+                    "id": "events-service",
+                    "enabled": false,
+                    "command": "${platform_bin}",
+                    "input_protocol": "ndjson_v1"
+                }],
+                "event_sinks": sinks
+            }
+        }))
+        .unwrap()
+    }
+
+    fn ids(values: &[&str]) -> Vec<ObservationPermissionId> {
+        values
+            .iter()
+            .map(|value| ObservationPermissionId::new(*value))
+            .collect()
+    }
+
+    #[test]
+    fn fresh_and_explicit_grants_are_metadata_safe_and_canonical() {
+        let manifest = grant_manifest(&[
+            (
+                "first",
+                &["content", "tool_name", "metadata", "paths", "diff"],
+            ),
+            ("second", &["paths", "metadata"]),
+        ]);
+        let fresh = resolve_event_sink_grants(&manifest, None, None).unwrap();
+        assert_eq!(fresh.get("first"), Some(&ids(&["metadata"])));
+        assert_eq!(fresh.get("second"), Some(&ids(&["metadata"])));
+
+        let explicit = resolve_event_sink_grants(
+            &manifest,
+            None,
+            Some(&[EventSinkGrantRequest {
+                sink_id: "first".to_string(),
+                granted_permissions: ids(&["content", "paths", "metadata"]),
+            }]),
+        )
+        .unwrap();
+        assert_eq!(
+            explicit.get("first"),
+            Some(&ids(&["metadata", "paths", "content"]))
+        );
+        assert_eq!(explicit.get("second"), Some(&ids(&["metadata"])));
+    }
+
+    #[test]
+    fn update_omission_preserves_only_prior_requested_intersection() {
+        let manifest = grant_manifest(&[
+            (
+                "retained",
+                &["metadata", "paths", "diff", "content", "tool_name"],
+            ),
+            ("new", &["metadata", "paths", "content"]),
+        ]);
+        let previous = RegisteredCapabilities {
+            event_sink_ids: vec!["retained".to_string(), "removed".to_string()],
+            event_sink_grants: BTreeMap::from([
+                ("retained".to_string(), ids(&["metadata", "paths", "diff"])),
+                ("removed".to_string(), ids(&["metadata", "tool_name"])),
+            ]),
+            ..RegisteredCapabilities::default()
+        };
+
+        let resolved = resolve_event_sink_grants(&manifest, Some(&previous), None).unwrap();
+        assert_eq!(
+            resolved.get("retained"),
+            Some(&ids(&["metadata", "paths", "diff"]))
+        );
+        assert_eq!(resolved.get("new"), Some(&ids(&["metadata"])));
+        assert!(!resolved.contains_key("removed"));
+        assert!(!resolved["new"]
+            .iter()
+            .any(|permission| permission.as_str() == "content"));
+    }
+
+    #[test]
+    fn explicit_grants_reject_duplicate_sink_permission_and_escalation() {
+        let manifest = grant_manifest(&[("sink", &["metadata", "paths", "content"])]);
+        let duplicate_sink = [
+            EventSinkGrantRequest {
+                sink_id: "sink".to_string(),
+                granted_permissions: ids(&["metadata"]),
+            },
+            EventSinkGrantRequest {
+                sink_id: "sink".to_string(),
+                granted_permissions: ids(&["metadata"]),
+            },
+        ];
+        assert!(resolve_event_sink_grants(&manifest, None, Some(&duplicate_sink)).is_err());
+        assert!(resolve_event_sink_grants(
+            &manifest,
+            None,
+            Some(&[EventSinkGrantRequest {
+                sink_id: "sink".to_string(),
+                granted_permissions: ids(&["metadata", "metadata"]),
+            }]),
+        )
+        .is_err());
+
+        let oversized = "x".repeat(MAX_EVENT_SINK_ID_BYTES + 1);
+        let error = resolve_event_sink_grants(
+            &manifest,
+            None,
+            Some(&[EventSinkGrantRequest {
+                sink_id: oversized.clone(),
+                granted_permissions: ids(&["metadata"]),
+            }]),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(!error.contains(&oversized));
+        let oversized_permission = "p".repeat(MAX_EVENT_SINK_PERMISSION_ID_BYTES + 1);
+        let error = resolve_event_sink_grants(
+            &manifest,
+            None,
+            Some(&[EventSinkGrantRequest {
+                sink_id: "sink".to_string(),
+                granted_permissions: vec![ObservationPermissionId::new(
+                    oversized_permission.clone(),
+                )],
+            }]),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(!error.contains(&oversized_permission));
+        assert!(resolve_event_sink_grants(
+            &manifest,
+            None,
+            Some(&[EventSinkGrantRequest {
+                sink_id: "sink".to_string(),
+                granted_permissions: ids(&["metadata", "tool_name"]),
+            }]),
+        )
+        .is_err());
+        let unknown_permission = "credential-value-must-not-enter-error";
+        let error = resolve_event_sink_grants(
+            &manifest,
+            None,
+            Some(&[EventSinkGrantRequest {
+                sink_id: "sink".to_string(),
+                granted_permissions: ids(&["metadata", unknown_permission]),
+            }]),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(!error.contains(unknown_permission));
+        assert!(resolve_event_sink_grants(
+            &manifest,
+            None,
+            Some(&[EventSinkGrantRequest {
+                sink_id: "sink".to_string(),
+                granted_permissions: ids(&["metadata", "content"]),
+            }]),
+        )
+        .is_err());
+        assert!(resolve_event_sink_grants(
+            &manifest,
+            None,
+            Some(&[EventSinkGrantRequest {
+                sink_id: "unknown".to_string(),
+                granted_permissions: ids(&["metadata"]),
+            }]),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn boot_accepts_only_whole_map_legacy_or_exact_v1_authority() {
+        let manifest =
+            grant_manifest(&[("first", &["metadata", "paths"]), ("second", &["metadata"])]);
+        let legacy = canonicalize_persisted_event_sink_grants(&manifest, &BTreeMap::new()).unwrap();
+        assert_eq!(legacy.len(), 2);
+        assert_eq!(legacy["first"], ids(&["metadata"]));
+
+        let missing = BTreeMap::from([("first".to_string(), ids(&["metadata"]))]);
+        assert!(canonicalize_persisted_event_sink_grants(&manifest, &missing).is_err());
+        let unknown = BTreeMap::from([
+            ("first".to_string(), ids(&["metadata"])),
+            ("second".to_string(), ids(&["metadata"])),
+            ("unknown".to_string(), ids(&["metadata"])),
+        ]);
+        assert!(canonicalize_persisted_event_sink_grants(&manifest, &unknown).is_err());
+    }
+
+    #[test]
+    fn metadata_only_is_safe_and_unknown_fields_never_enter_projection() {
+        let source = event("/workspace/src/lib.rs");
+        let policy = ToolEventObservationPolicy::default();
+        let projected =
+            project_tool_event(&source, policy.grant_requested(&requested_all()), 1).unwrap();
+        let wire = serde_json::to_string(&projected).unwrap();
+
+        assert_eq!(projected.context.tool_name, None);
+        assert_eq!(projected.data.path, None);
+        assert_eq!(
+            projected.data.path_redaction_reason.as_deref(),
+            Some(PATH_REDACTION_PERMISSION_NOT_GRANTED)
+        );
+        for sentinel in [
+            "diff-sentinel",
+            "content-sentinel",
+            "config-sentinel",
+            "prompt-sentinel",
+            "credential-sentinel",
+            "envelope-prompt-sentinel",
+            "context-credential-sentinel",
+        ] {
+            assert!(!wire.contains(sentinel), "leaked sentinel: {sentinel}");
+        }
+    }
+
+    #[test]
+    fn requested_and_granted_permissions_are_both_required() {
+        let source = event("C:\\workspace\\src\\lib.rs");
+        let policy = ToolEventObservationPolicy::all_v1();
+        let requested = vec![
+            ObservationPermissionId::new(OBSERVE_METADATA_PERMISSION),
+            ObservationPermissionId::new(OBSERVE_PATHS_PERMISSION),
+        ];
+        let projected = project_tool_event(&source, policy.grant_requested(&requested), 7).unwrap();
+
+        assert_eq!(projected.context.tool_name, None);
+        assert_eq!(
+            projected.data.path.as_deref(),
+            Some("C:/workspace/src/lib.rs")
+        );
+        assert_eq!(projected.data.diff, None);
+        assert_eq!(projected.data.content, None);
+        assert_eq!(projected.observation_policy_generation, Some(7));
+    }
+
+    #[test]
+    fn sensitive_unix_and_windows_paths_have_one_stable_reason_and_no_payload() {
+        let policy = ToolEventObservationPolicy::all_v1();
+        let grants = policy.grant_requested(&requested_all());
+        for path in [
+            "/home/alice/.ssh/id_ed25519",
+            "/workspace/.env.production",
+            "/Users/alice/.bamboo/config.json",
+            "/workspace/.codex/config.toml",
+            "/workspace/.claude/settings.json",
+            "/workspace/.agents/skills/private.md",
+            "/home/alice/.config/gh/hosts.yml",
+            "/workspace/AGENTS.md",
+            "/workspace/CLAUDE.md",
+            r"C:\Users\alice\.aws\credentials",
+            r"C:\Users\alice\AppData\Roaming\Codex\config.json",
+            r"C:\Windows\System32\config\SAM",
+            r"\\server\C$\Windows\System32\config\SAM",
+            r"\\server\ADMIN$\System32\config\SAM",
+            r"\\server\IPC$\pipe",
+        ] {
+            let projected = project_tool_event(&event(path), grants, 2).unwrap();
+            assert_eq!(projected.data.path, None, "{path}");
+            assert_eq!(
+                projected.data.path_redaction_reason.as_deref(),
+                Some(PATH_REDACTION_SENSITIVE),
+                "{path}"
+            );
+            assert_eq!(projected.data.diff, None);
+            assert_eq!(projected.data.content, None);
+        }
+    }
+
+    #[test]
+    fn traversal_relative_and_ambiguous_paths_fail_closed_without_io() {
+        let policy = ToolEventObservationPolicy::all_v1();
+        let grants = policy.grant_requested(&requested_all());
+        for path in [
+            "relative/file.rs",
+            "/workspace/src/../secret.txt",
+            r"C:relative\file.rs",
+            r"C:\workspace\src\..\secret.txt",
+            r"\\?\C:\workspace\file.rs",
+            r"C:\workspace\file.txt:secret",
+            "C:\\workspace\\.ssh \\id_rsa",
+            r"C:\workspace\NUL",
+            r"\\server\share\COM1.txt",
+            r"\workspace\file.rs",
+            r"\Device\HarddiskVolume1\workspace\file.rs",
+            r"\??\C:\workspace\file.rs",
+            "/??/C:/workspace/file.rs",
+            "/Device/HarddiskVolume1/workspace/file.rs",
+            "/GLOBAL??/C:/workspace/file.rs",
+            r"\\server\.\share\file.rs",
+            r"\\server\\share\file.rs",
+            "//server-only",
+        ] {
+            let projected = project_tool_event(&event(path), grants, 2).unwrap();
+            assert_eq!(projected.data.path, None, "{path}");
+            assert_eq!(
+                projected.data.path_redaction_reason.as_deref(),
+                Some(PATH_REDACTION_UNSAFE),
+                "{path}"
+            );
+            assert_eq!(projected.data.content, None);
+        }
+    }
+
+    #[test]
+    fn path_normalization_is_stable_across_supported_syntaxes() {
+        assert_eq!(
+            normalize_absolute_path("/workspace//src/./lib.rs"),
+            Some("/workspace/src/lib.rs".to_string())
+        );
+        assert_eq!(
+            normalize_absolute_path(r"c:\workspace\src\.\lib.rs"),
+            Some("C:/workspace/src/lib.rs".to_string())
+        );
+        assert_eq!(
+            normalize_absolute_path(r"\\server\share\dir\file.rs"),
+            Some("//server/share/dir/file.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn diff_and_content_truncate_on_utf8_boundaries_with_explicit_markers() {
+        let mut source = event("/workspace/src/lib.rs");
+        let data = source.data.as_object_mut().unwrap();
+        data.insert(
+            TOOL_EVENT_DIFF_FIELD.to_string(),
+            json!("é".repeat(MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES)),
+        );
+        data.insert(
+            TOOL_EVENT_CONTENT_FIELD.to_string(),
+            json!("界".repeat(MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES)),
+        );
+        // Rebuild through serde so flattened data fields become extensions in
+        // the same form as a producer-created event.
+        let source: ToolEventV1 =
+            serde_json::from_value(serde_json::to_value(source).unwrap()).unwrap();
+        let policy = ToolEventObservationPolicy::all_v1();
+        let projected =
+            project_tool_event(&source, policy.grant_requested(&requested_all()), 4).unwrap();
+
+        let diff = projected.data.diff.as_deref().unwrap();
+        let content = projected.data.content.as_deref().unwrap();
+        assert!(diff.len() <= MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES);
+        assert!(content.len() <= MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES);
+        assert!(diff.ends_with(TRUNCATION_MARKER));
+        assert!(content.ends_with(TRUNCATION_MARKER));
+        assert!(projected.data.diff_truncated);
+        assert!(projected.data.content_truncated);
+    }
+
+    #[test]
+    fn malformed_authorized_payload_is_rejected_but_unauthorized_payload_is_never_read() {
+        for field in [TOOL_EVENT_DIFF_FIELD, TOOL_EVENT_CONTENT_FIELD] {
+            let mut source = event("/workspace/src/lib.rs");
+            source.data.as_object_mut().unwrap().insert(
+                field.to_string(),
+                json!({"secret": "malformed-payload-sentinel"}),
+            );
+
+            let metadata_only = ToolEventObservationPolicy::default();
+            let projected =
+                project_tool_event(&source, metadata_only.grant_requested(&requested_all()), 9)
+                    .expect("an unauthorized extension is omitted without inspecting its value");
+            assert!(!serde_json::to_string(&projected)
+                .unwrap()
+                .contains("malformed-payload-sentinel"));
+
+            let error = project_tool_event(
+                &source,
+                ToolEventObservationPolicy::all_v1().grant_requested(&requested_all()),
+                9,
+            )
+            .expect_err("an authorized known field must retain its string contract");
+            assert!(matches!(error, ToolEventBuildError::InvalidKnownPayload(_)));
+            assert!(!error.to_string().contains("malformed-payload-sentinel"));
+        }
+    }
+}

--- a/crates/app/bamboo-server/src/tool_event_router.rs
+++ b/crates/app/bamboo-server/src/tool_event_router.rs
@@ -16,12 +16,14 @@ use std::time::Duration;
 
 use bamboo_plugin::manifest::{
     EventSinkCapabilityState, EventSinkInactiveReason, EventSinkManifestEntry,
-    MAX_EVENT_SINKS_PER_PLUGIN, MAX_EVENT_SINK_ID_BYTES,
+    ObservationPermissionId, MAX_EVENT_SINKS_PER_PLUGIN, MAX_EVENT_SINK_ID_BYTES,
+    OBSERVE_TOOL_NAME_PERMISSION,
 };
 use bamboo_plugin::registry::EventSinkReconciliation;
-use bamboo_plugin::PluginManifest;
+use bamboo_plugin::{EventSinkPermissionGrants, PluginManifest};
 use bamboo_plugin_protocol::{
-    ToolEventPublishError, ToolEventPublisher, ToolEventV1, FILE_CHANGED_SUBSCRIPTION_ID_V1,
+    ProjectedToolEventV1, ToolEventPublishError, ToolEventPublisher, ToolEventV1,
+    FILE_CHANGED_SUBSCRIPTION_ID_V1, MAX_TOOL_EVENT_JSON_BYTES,
 };
 use parking_lot::RwLock as ParkingRwLock;
 use serde::Serialize;
@@ -31,6 +33,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::service_manager::{
     ServiceInputHealth, ServiceInputSendError, ServiceInputSender, ServiceManager,
+};
+use crate::tool_event_policy::{
+    canonicalize_persisted_event_sink_grants, project_tool_event, GrantedObservation,
+    ToolEventObservationPolicy,
 };
 
 const RECONCILE_INTERVAL: Duration = Duration::from_millis(100);
@@ -57,6 +63,14 @@ pub struct ToolEventSinkStatusSnapshot {
     pub inactive_reason: Option<EventSinkInactiveReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generation: Option<u64>,
+    /// Immutable host-policy generation used by every event projected through
+    /// this registration snapshot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_generation: Option<u64>,
+    /// Bounded manifest requests. These ids carry no payload or credential.
+    pub requested_permissions: Vec<ObservationPermissionId>,
+    /// Host grants intersected with this sink's requests.
+    pub granted_permissions: Vec<ObservationPermissionId>,
     pub queue_capacity: usize,
     pub max_event_bytes: usize,
     /// Accepted by the exact live service-generation input queue. This is
@@ -110,7 +124,7 @@ struct SubscriptionFilter {
 }
 
 impl SubscriptionFilter {
-    fn matches(&self, event: &ToolEventV1) -> bool {
+    fn matches(&self, event: &ToolEventV1, can_observe_tool_name: bool) -> bool {
         if self.id != event.subscription_id.as_str() {
             return false;
         }
@@ -120,8 +134,15 @@ impl SubscriptionFilter {
         if self.id == FILE_CHANGED_SUBSCRIPTION_ID_V1 && !event.event_type.is_file_changed() {
             return false;
         }
-        self.tool_names.is_empty()
-            || self
+        if self.tool_names.is_empty() {
+            return true;
+        }
+        // A tool-name filter is itself an observation of the raw tool name:
+        // delivery versus non-delivery would otherwise reveal the name even
+        // when the projected field is omitted. Fail closed until the host has
+        // granted the same permission required to expose that field.
+        can_observe_tool_name
+            && self
                 .tool_names
                 .iter()
                 .any(|name| name == &event.context.tool_name)
@@ -134,6 +155,10 @@ struct SinkRegistration {
     service_id: String,
     capability: EventSinkCapabilityState,
     subscriptions: Vec<SubscriptionFilter>,
+    requested_permissions: Vec<ObservationPermissionId>,
+    granted_permissions: Vec<ObservationPermissionId>,
+    grants: GrantedObservation,
+    policy_generation: u64,
     queue_capacity: usize,
     max_event_bytes: usize,
     counters: Arc<SinkCounters>,
@@ -145,7 +170,30 @@ impl SinkRegistration {
         manifest: &EventSinkManifestEntry,
         capability: EventSinkCapabilityState,
         counters: Arc<SinkCounters>,
+        granted_permissions: &[ObservationPermissionId],
+        policy_generation: u64,
     ) -> Self {
+        let policy = ToolEventObservationPolicy::from_validated_permission_ids(
+            granted_permissions
+                .iter()
+                .map(ObservationPermissionId::as_str),
+        );
+        let grants = policy.grant_requested(&manifest.requested_permissions);
+        let capability = if matches!(capability, EventSinkCapabilityState::Eligible)
+            && !grants.can_observe_tool_name()
+            && manifest
+                .subscriptions
+                .iter()
+                .any(|subscription| !subscription.tool_names.is_empty())
+        {
+            EventSinkCapabilityState::Inactive {
+                detail: EventSinkInactiveReason::ObservationPermissionNotGranted {
+                    permission: ObservationPermissionId::new(OBSERVE_TOOL_NAME_PERMISSION),
+                },
+            }
+        } else {
+            capability
+        };
         Self {
             plugin_id: plugin_id.to_string(),
             id: manifest.id.clone(),
@@ -159,6 +207,10 @@ impl SinkRegistration {
                     tool_names: subscription.tool_names.clone(),
                 })
                 .collect(),
+            requested_permissions: manifest.requested_permissions.clone(),
+            granted_permissions: grants.permission_ids(),
+            grants,
+            policy_generation,
             // PluginManifest::validate has already enforced non-zero absolute
             // bounds. Conversions are lossless on every supported target.
             queue_capacity: manifest.delivery.queue_capacity as usize,
@@ -174,7 +226,7 @@ impl SinkRegistration {
     fn matches(&self, event: &ToolEventV1) -> bool {
         self.subscriptions
             .iter()
-            .any(|subscription| subscription.matches(event))
+            .any(|subscription| subscription.matches(event, self.grants.can_observe_tool_name()))
     }
 }
 
@@ -188,7 +240,7 @@ enum SinkInputError {
 
 trait SinkInput: Send + Sync {
     fn generation(&self) -> u64;
-    fn try_send(&self, event: &ToolEventV1) -> Result<(), SinkInputError>;
+    fn try_send(&self, event: &ProjectedToolEventV1) -> Result<(), SinkInputError>;
 }
 
 impl SinkInput for ServiceInputSender {
@@ -196,7 +248,7 @@ impl SinkInput for ServiceInputSender {
         ServiceInputSender::generation(self)
     }
 
-    fn try_send(&self, event: &ToolEventV1) -> Result<(), SinkInputError> {
+    fn try_send(&self, event: &ProjectedToolEventV1) -> Result<(), SinkInputError> {
         ServiceInputSender::try_send(self, event).map_err(|error| match error {
             ServiceInputSendError::QueueFull { .. } => SinkInputError::QueueFull,
             ServiceInputSendError::StaleGeneration { .. }
@@ -212,7 +264,7 @@ struct LiveSink {
     generation: u64,
     active: Arc<AtomicBool>,
     cancel: CancellationToken,
-    tx: mpsc::Sender<Arc<ToolEventV1>>,
+    tx: mpsc::Sender<Arc<ProjectedToolEventV1>>,
     task: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -259,7 +311,11 @@ impl LiveSink {
         }
     }
 
-    fn try_enqueue(&self, event: Arc<ToolEventV1>, counters: &SinkCounters) -> Result<(), ()> {
+    fn try_enqueue(
+        &self,
+        event: Arc<ProjectedToolEventV1>,
+        counters: &SinkCounters,
+    ) -> Result<(), ()> {
         if !self.is_active() {
             increment(&counters.service_down);
             return Err(());
@@ -284,7 +340,7 @@ async fn run_sink_worker(
     input: Arc<dyn SinkInput>,
     active: Arc<AtomicBool>,
     cancel: CancellationToken,
-    mut rx: mpsc::Receiver<Arc<ToolEventV1>>,
+    mut rx: mpsc::Receiver<Arc<ProjectedToolEventV1>>,
 ) {
     loop {
         let event = tokio::select! {
@@ -328,6 +384,7 @@ struct PublishedSink {
 struct RouterState {
     desired: BTreeMap<String, Arc<SinkRegistration>>,
     active: HashMap<String, Arc<LiveSink>>,
+    next_policy_generation: u64,
 }
 
 /// AppState-owned ToolEvent publisher and plugin-sink lifecycle registry.
@@ -422,7 +479,13 @@ impl ToolEventRouter {
         plugin_id: &str,
         manifest: &PluginManifest,
         plan: &EventSinkReconciliation,
-    ) {
+        event_sink_grants: &EventSinkPermissionGrants,
+    ) -> bamboo_plugin::PluginResult<()> {
+        // Pure preflight precedes snapshot revocation. Only the whole-map
+        // legacy empty case is migrated; any nonempty partial/corrupt map is
+        // rejected before router state changes.
+        let event_sink_grants =
+            canonicalize_persisted_event_sink_grants(manifest, event_sink_grants)?;
         let mut state = self.state.lock().await;
         let prior_counters: HashMap<String, Arc<SinkCounters>> = state
             .desired
@@ -458,10 +521,13 @@ impl ToolEventRouter {
                 }
             }
         }
-        self.rebuild_published(&state);
-        for live in stopped {
-            live.join().await;
-        }
+        // One immutable generation is allocated for the complete replacement
+        // plan. `rebuild_published` performs one old-to-new write-lock swap,
+        // so a publisher can observe either the complete prior generation or
+        // the complete replacement generation, never an intermediate empty or
+        // partially rebuilt plugin registration set.
+        state.next_policy_generation = state.next_policy_generation.wrapping_add(1).max(1);
+        let policy_generation = state.next_policy_generation;
 
         for reconciled in &plan.sinks_after_services {
             let Some(entry) = manifest
@@ -488,6 +554,14 @@ impl ToolEventRouter {
                 .get(&entry.id)
                 .cloned()
                 .unwrap_or_else(|| Arc::new(SinkCounters::default()));
+            // The installer/boot reconciliation validates exact grants before
+            // entering the router. A missing value here remains fail-closed:
+            // inactive future sinks report no grants, while a corrupt v1
+            // registration cannot project its required metadata envelope.
+            let granted_permissions = event_sink_grants
+                .get(&entry.id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
             state.desired.insert(
                 entry.id.clone(),
                 Arc::new(SinkRegistration::from_manifest(
@@ -495,13 +569,23 @@ impl ToolEventRouter {
                     entry,
                     reconciled.state.clone(),
                     counters,
+                    granted_permissions,
+                    policy_generation,
                 )),
             );
         }
         self.rebuild_published(&state);
+        // Old workers were marked inactive before the snapshot swap, and the
+        // swap removes their senders from the hot path. Join them before this
+        // policy update returns so pre-linearization backlog cannot outlive
+        // revocation. Replacement registrations reconcile after the join.
+        for live in stopped {
+            live.join().await;
+        }
         drop(state);
         self.refresh_monitor().await;
         self.reconcile_once().await;
+        Ok(())
     }
 
     /// Remove exact provenance-owned ids. The hot snapshot is revoked first;
@@ -647,6 +731,9 @@ impl ToolEventRouter {
                         state: ToolEventSinkState::Unavailable,
                         inactive_reason: None,
                         generation: None,
+                        policy_generation: None,
+                        requested_permissions: Vec::new(),
+                        granted_permissions: Vec::new(),
                         queue_capacity: 0,
                         max_event_bytes: 0,
                         delivered: 0,
@@ -673,6 +760,9 @@ impl ToolEventRouter {
                     state: state_value,
                     inactive_reason,
                     generation,
+                    policy_generation: Some(registration.policy_generation),
+                    requested_permissions: registration.requested_permissions.clone(),
+                    granted_permissions: registration.granted_permissions.clone(),
                     queue_capacity: registration.queue_capacity,
                     max_event_bytes: registration.max_event_bytes,
                     delivered: counters.delivered,
@@ -722,7 +812,26 @@ impl ToolEventRouter {
         entry: EventSinkManifestEntry,
         capability: EventSinkCapabilityState,
     ) {
+        self.configure_test_sink_with_grants(
+            plugin_id,
+            entry,
+            capability,
+            vec![ObservationPermissionId::new("metadata")],
+        )
+        .await;
+    }
+
+    #[cfg(test)]
+    async fn configure_test_sink_with_grants(
+        self: &Arc<Self>,
+        plugin_id: &str,
+        entry: EventSinkManifestEntry,
+        capability: EventSinkCapabilityState,
+        granted_permissions: Vec<ObservationPermissionId>,
+    ) {
         let mut state = self.state.lock().await;
+        state.next_policy_generation = state.next_policy_generation.wrapping_add(1).max(1);
+        let policy_generation = state.next_policy_generation;
         state.desired.insert(
             entry.id.clone(),
             Arc::new(SinkRegistration::from_manifest(
@@ -730,6 +839,8 @@ impl ToolEventRouter {
                 &entry,
                 capability,
                 Arc::new(SinkCounters::default()),
+                &granted_permissions,
+                policy_generation,
             )),
         );
         self.rebuild_published(&state);
@@ -745,7 +856,7 @@ impl ToolEventPublisher for ToolEventRouter {
 
     fn try_publish(&self, event: ToolEventV1) -> Result<(), ToolEventPublishError> {
         event
-            .validate_bounds()
+            .validate_projection_input_bounds()
             .map_err(ToolEventPublishError::InvalidEvent)?;
         let snapshot = self
             .published
@@ -758,24 +869,36 @@ impl ToolEventPublisher for ToolEventRouter {
         if matching.is_empty() {
             return Ok(());
         }
-        let serialized_len = match serde_json::to_vec(&event) {
-            Ok(serialized) => serialized.len(),
-            Err(_) => {
-                for sink in matching {
-                    increment(&sink.registration.counters.serialization);
-                }
-                return Ok(());
-            }
-        };
-        let event = Arc::new(event);
         for sink in matching {
-            if serialized_len > sink.registration.max_event_bytes {
+            let projected = match project_tool_event(
+                &event,
+                sink.registration.grants,
+                sink.registration.policy_generation,
+            ) {
+                Ok(projected) => projected,
+                Err(_) => {
+                    increment(&sink.registration.counters.serialization);
+                    continue;
+                }
+            };
+            // This is the sole exact serialization before the per-sink queue,
+            // and it operates only on the irreversible host projection.
+            let serialized_len = match serde_json::to_vec(&projected) {
+                Ok(serialized) => serialized.len(),
+                Err(_) => {
+                    increment(&sink.registration.counters.serialization);
+                    continue;
+                }
+            };
+            if serialized_len > MAX_TOOL_EVENT_JSON_BYTES
+                || serialized_len > sink.registration.max_event_bytes
+            {
                 increment(&sink.registration.counters.oversize);
                 continue;
             }
             match &sink.live {
                 Some(live) => {
-                    let _ = live.try_enqueue(event.clone(), &sink.registration.counters);
+                    let _ = live.try_enqueue(Arc::new(projected), &sink.registration.counters);
                 }
                 None => increment(&sink.registration.counters.service_down),
             }
@@ -850,9 +973,13 @@ mod tests {
         EventSinkDeliveryLimits, EventSinkProtocolManifest, EventSinkSubscriptionManifest,
         ObservationPermissionId,
     };
+    use bamboo_plugin::{
+        reconcile_event_sinks, Platform, PluginInstallStatus, RegisteredCapabilities,
+    };
     use bamboo_plugin_protocol::{
-        FileChangedV1, ToolEventContextV1, ToolEventSubscriptionId, TOOL_EVENT_PROTOCOL_NAME,
-        TOOL_EVENT_V1_SCHEMA_VERSION,
+        FileChangedV1, ToolEventContextV1, ToolEventSubscriptionId,
+        MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES, MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES,
+        TOOL_EVENT_PROTOCOL_NAME, TOOL_EVENT_V1_SCHEMA_VERSION,
     };
 
     use super::*;
@@ -880,7 +1007,7 @@ mod tests {
             self.generation
         }
 
-        fn try_send(&self, event: &ToolEventV1) -> Result<(), SinkInputError> {
+        fn try_send(&self, event: &ProjectedToolEventV1) -> Result<(), SinkInputError> {
             self.calls
                 .lock()
                 .unwrap()
@@ -894,6 +1021,35 @@ mod tests {
         entered: AtomicBool,
         release: (Mutex<bool>, Condvar),
         calls: AtomicUsize,
+    }
+
+    struct ProjectedRecordingInput {
+        generation: u64,
+        events: Mutex<Vec<ProjectedToolEventV1>>,
+    }
+
+    impl ProjectedRecordingInput {
+        fn new(generation: u64) -> Self {
+            Self {
+                generation,
+                events: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn events(&self) -> Vec<ProjectedToolEventV1> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl SinkInput for ProjectedRecordingInput {
+        fn generation(&self) -> u64 {
+            self.generation
+        }
+
+        fn try_send(&self, event: &ProjectedToolEventV1) -> Result<(), SinkInputError> {
+            self.events.lock().unwrap().push(event.clone());
+            Ok(())
+        }
     }
 
     impl BlockingInput {
@@ -918,7 +1074,7 @@ mod tests {
             self.generation
         }
 
-        fn try_send(&self, _event: &ToolEventV1) -> Result<(), SinkInputError> {
+        fn try_send(&self, _event: &ProjectedToolEventV1) -> Result<(), SinkInputError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.entered.store(true, Ordering::SeqCst);
             let mut released = self.release.0.lock().unwrap();
@@ -967,6 +1123,93 @@ mod tests {
         .unwrap()
     }
 
+    fn event_with_payload(
+        tool: &str,
+        call: &str,
+        path: &str,
+        diff: &str,
+        content: &str,
+    ) -> ToolEventV1 {
+        let mut event = ToolEventV1::file_changed(
+            ToolEventContextV1::bounded("session", "root", tool, call).unwrap(),
+            FileChangedV1::bounded(path).unwrap(),
+        )
+        .unwrap();
+        let data = event.data.as_object_mut().unwrap();
+        data.insert(
+            "diff".to_string(),
+            serde_json::Value::String(diff.to_string()),
+        );
+        data.insert(
+            "content".to_string(),
+            serde_json::Value::String(content.to_string()),
+        );
+        data.insert(
+            "unknown_secret".to_string(),
+            serde_json::Value::String("unknown-extension-sentinel".to_string()),
+        );
+        event
+    }
+
+    fn permissions(values: &[&str]) -> Vec<ObservationPermissionId> {
+        values
+            .iter()
+            .map(|value| ObservationPermissionId::new(*value))
+            .collect()
+    }
+
+    fn manifest_for_sinks(entries: &[EventSinkManifestEntry]) -> PluginManifest {
+        let service_ids: BTreeMap<String, ()> = entries
+            .iter()
+            .map(|entry| (entry.service_id.clone(), ()))
+            .collect();
+        serde_json::from_value(serde_json::json!({
+            "id": "router-policy-plugin",
+            "name": "Router Policy Plugin",
+            "version": "1.0.0",
+            "provides": {
+                "services": service_ids.keys().map(|id| serde_json::json!({
+                    "id": id,
+                    "enabled": true,
+                    "command": "${platform_bin}",
+                    "input_protocol": "ndjson_v1"
+                })).collect::<Vec<_>>(),
+                "event_sinks": entries
+            }
+        }))
+        .unwrap()
+    }
+
+    fn plan_for(
+        manifest: &PluginManifest,
+        grants: EventSinkPermissionGrants,
+    ) -> (EventSinkReconciliation, RegisteredCapabilities) {
+        let registered = RegisteredCapabilities {
+            service_ids: manifest
+                .provides
+                .services
+                .iter()
+                .map(|service| service.id.clone())
+                .collect(),
+            event_sink_ids: manifest
+                .provides
+                .event_sinks
+                .iter()
+                .map(|sink| sink.id.clone())
+                .collect(),
+            event_sink_grants: grants,
+            ..RegisteredCapabilities::default()
+        };
+        let plan = reconcile_event_sinks(
+            manifest,
+            &registered,
+            PluginInstallStatus::Installed,
+            Platform::current(),
+        )
+        .unwrap();
+        (plan, registered)
+    }
+
     fn router() -> Arc<ToolEventRouter> {
         ToolEventRouter::new_inner(Arc::new(ServiceManager::new()), false)
     }
@@ -984,30 +1227,81 @@ mod tests {
     #[tokio::test]
     async fn filters_by_event_subscription_and_canonical_tool_name() {
         let router = router();
+        let mut write_sink = sink("write", &["Write"], 4, 16_384);
+        write_sink.requested_permissions = permissions(&["metadata", "tool_name"]);
         router
-            .configure_test_sink(
+            .configure_test_sink_with_grants(
                 "plugin",
-                sink("write", &["Write"], 4, 16_384),
+                write_sink,
                 EventSinkCapabilityState::Eligible,
+                permissions(&["metadata", "tool_name"]),
+            )
+            .await;
+        let mut edit_sink = sink("edit", &["Edit"], 4, 16_384);
+        edit_sink.requested_permissions = permissions(&["metadata", "tool_name"]);
+        router
+            .configure_test_sink_with_grants(
+                "plugin",
+                edit_sink,
+                EventSinkCapabilityState::Eligible,
+                permissions(&["metadata", "tool_name"]),
+            )
+            .await;
+        let mut ungranted_filter = sink("ungranted-filter", &["Write"], 4, 16_384);
+        ungranted_filter.requested_permissions = permissions(&["metadata", "tool_name"]);
+        router
+            .configure_test_sink_with_grants(
+                "plugin",
+                ungranted_filter,
+                EventSinkCapabilityState::Eligible,
+                permissions(&["metadata"]),
             )
             .await;
         router
             .configure_test_sink(
                 "plugin",
-                sink("edit", &["Edit"], 4, 16_384),
+                sink("unfiltered-metadata", &[], 4, 16_384),
                 EventSinkCapabilityState::Eligible,
             )
             .await;
         let write = Arc::new(RecordingInput::new(1));
         let edit = Arc::new(RecordingInput::new(2));
+        let ungranted_filter_input = Arc::new(RecordingInput::new(3));
+        let unfiltered_metadata = Arc::new(RecordingInput::new(4));
         router.install_input_for_test("write", write.clone()).await;
         router.install_input_for_test("edit", edit.clone()).await;
+        router
+            .install_input_for_test("ungranted-filter", ungranted_filter_input.clone())
+            .await;
+        router
+            .install_input_for_test("unfiltered-metadata", unfiltered_metadata.clone())
+            .await;
 
         router.try_publish(event("Write", "write-1", 8)).unwrap();
         router.try_publish(event("Edit", "edit-1", 8)).unwrap();
-        wait_until(|| write.calls().len() == 1 && edit.calls().len() == 1).await;
+        wait_until(|| {
+            write.calls().len() == 1
+                && edit.calls().len() == 1
+                && unfiltered_metadata.calls().len() == 2
+        })
+        .await;
         assert_eq!(write.calls(), vec!["write-1"]);
         assert_eq!(edit.calls(), vec!["edit-1"]);
+        assert!(
+            ungranted_filter_input.calls().is_empty(),
+            "tool-filter delivery must not become a tool-name side channel without a grant"
+        );
+        let ungranted_status = router
+            .status_for_ids(&["ungranted-filter".to_string()])
+            .await;
+        assert_eq!(ungranted_status[0].state, ToolEventSinkState::Inactive);
+        assert_eq!(
+            ungranted_status[0].inactive_reason,
+            Some(EventSinkInactiveReason::ObservationPermissionNotGranted {
+                permission: ObservationPermissionId::new(OBSERVE_TOOL_NAME_PERMISSION),
+            })
+        );
+        assert_eq!(unfiltered_metadata.calls(), vec!["write-1", "edit-1"]);
     }
 
     #[tokio::test]
@@ -1128,11 +1422,14 @@ mod tests {
     #[tokio::test]
     async fn outage_and_sink_event_bound_are_counted_without_payloads() {
         let router = router();
+        let mut entry = sink("down", &[], 2, 256);
+        entry.requested_permissions = permissions(&["metadata", "paths"]);
         router
-            .configure_test_sink(
+            .configure_test_sink_with_grants(
                 "plugin",
-                sink("down", &[], 2, 256),
+                entry,
                 EventSinkCapabilityState::Eligible,
+                permissions(&["metadata", "paths"]),
             )
             .await;
         router.try_publish(event("Write", "down", 8)).unwrap();
@@ -1145,6 +1442,206 @@ mod tests {
         let safe = serde_json::to_string(&status).unwrap();
         assert!(!safe.contains(&"x".repeat(32)));
         assert!(!safe.contains("/xxxxxxxx"));
+    }
+
+    #[tokio::test]
+    async fn one_raw_event_is_independently_projected_for_metadata_and_full_sinks() {
+        let router = router();
+        let requested = permissions(&["metadata", "tool_name", "paths", "diff", "content"]);
+        let mut metadata_entry = sink("metadata", &[], 4, 16_384);
+        metadata_entry.requested_permissions = requested.clone();
+        let mut full_entry = sink("full", &[], 4, 16_384);
+        full_entry.requested_permissions = requested;
+        router
+            .configure_test_sink_with_grants(
+                "plugin",
+                metadata_entry,
+                EventSinkCapabilityState::Eligible,
+                permissions(&["metadata"]),
+            )
+            .await;
+        router
+            .configure_test_sink_with_grants(
+                "plugin",
+                full_entry,
+                EventSinkCapabilityState::Eligible,
+                permissions(&["metadata", "tool_name", "paths", "diff", "content"]),
+            )
+            .await;
+        let metadata = Arc::new(ProjectedRecordingInput::new(1));
+        let full = Arc::new(ProjectedRecordingInput::new(2));
+        router
+            .install_input_for_test("metadata", metadata.clone())
+            .await;
+        router.install_input_for_test("full", full.clone()).await;
+
+        router
+            .try_publish(event_with_payload(
+                "Write",
+                "same-raw",
+                "/workspace/src/lib.rs",
+                "diff-sentinel",
+                "content-sentinel",
+            ))
+            .unwrap();
+        wait_until(|| metadata.events().len() == 1 && full.events().len() == 1).await;
+        let metadata_wire = serde_json::to_value(&metadata.events()[0]).unwrap();
+        assert!(metadata_wire["context"].get("tool_name").is_none());
+        assert!(metadata_wire["data"].get("path").is_none());
+        assert!(metadata_wire["data"].get("diff").is_none());
+        assert!(metadata_wire["data"].get("content").is_none());
+        assert_eq!(
+            metadata_wire["data"]["path_redaction_reason"],
+            "permission_not_granted"
+        );
+        let metadata_text = metadata_wire.to_string();
+        for sentinel in [
+            "diff-sentinel",
+            "content-sentinel",
+            "unknown-extension-sentinel",
+        ] {
+            assert!(!metadata_text.contains(sentinel));
+        }
+
+        let full_wire = serde_json::to_value(&full.events()[0]).unwrap();
+        assert_eq!(full_wire["context"]["tool_name"], "Write");
+        assert_eq!(full_wire["data"]["path"], "/workspace/src/lib.rs");
+        assert_eq!(full_wire["data"]["diff"], "diff-sentinel");
+        assert_eq!(full_wire["data"]["content"], "content-sentinel");
+        assert!(!full_wire.to_string().contains("unknown-extension-sentinel"));
+    }
+
+    #[tokio::test]
+    async fn json_escaping_amplification_is_rejected_after_projection_before_queue() {
+        let router = router();
+        let requested = permissions(&["metadata", "paths", "diff", "content"]);
+        let mut entry = sink("escaped", &[], 4, 16_384);
+        entry.requested_permissions = requested.clone();
+        router
+            .configure_test_sink_with_grants(
+                "plugin",
+                entry,
+                EventSinkCapabilityState::Eligible,
+                requested,
+            )
+            .await;
+        let input = Arc::new(ProjectedRecordingInput::new(1));
+        router
+            .install_input_for_test("escaped", input.clone())
+            .await;
+
+        router
+            .try_publish(event_with_payload(
+                "Write",
+                "escaped",
+                "/workspace/file.rs",
+                &"\"".repeat(MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES),
+                &"\"".repeat(MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES),
+            ))
+            .unwrap();
+        tokio::task::yield_now().await;
+        assert!(input.events().is_empty());
+        let status = router.status_for_ids(&["escaped".to_string()]).await;
+        assert_eq!(status[0].oversize, 1);
+        assert_eq!(status[0].delivered, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn per_sink_policy_replacement_is_atomic_and_never_queues_raw_authority() {
+        let router = router();
+        let mut first = sink("first", &[], 256, 16_384);
+        first.requested_permissions =
+            permissions(&["content", "tool_name", "metadata", "diff", "paths"]);
+        let mut second = sink("second", &[], 256, 16_384);
+        second.requested_permissions = first.requested_permissions.clone();
+        let manifest = manifest_for_sinks(&[first, second]);
+        let old_grants = EventSinkPermissionGrants::from([
+            ("first".to_string(), permissions(&["metadata"])),
+            ("second".to_string(), permissions(&["metadata"])),
+        ]);
+        let (old_plan, old_registered) = plan_for(&manifest, old_grants);
+        router
+            .apply_plugin_plan(
+                "router-policy-plugin",
+                &manifest,
+                &old_plan,
+                &old_registered.event_sink_grants,
+            )
+            .await
+            .unwrap();
+        let old_status = router
+            .status_for_ids(&["first".to_string(), "second".to_string()])
+            .await;
+        let old_policy_generation = old_status[0].policy_generation.unwrap();
+        assert_eq!(old_status[1].policy_generation, Some(old_policy_generation));
+        let old_input = Arc::new(ProjectedRecordingInput::new(1));
+        router
+            .install_input_for_test("first", old_input.clone())
+            .await;
+
+        let publishing = {
+            let router = router.clone();
+            tokio::spawn(async move {
+                for index in 0..500 {
+                    let _ = router.try_publish(event("Write", &format!("race-{index}"), 12));
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+        wait_until(|| !old_input.events().is_empty()).await;
+
+        let all = permissions(&["metadata", "tool_name", "paths", "diff", "content"]);
+        let new_grants = EventSinkPermissionGrants::from([
+            ("first".to_string(), all.clone()),
+            ("second".to_string(), all),
+        ]);
+        let (new_plan, new_registered) = plan_for(&manifest, new_grants);
+        router
+            .apply_plugin_plan(
+                "router-policy-plugin",
+                &manifest,
+                &new_plan,
+                &new_registered.event_sink_grants,
+            )
+            .await
+            .unwrap();
+        let new_input = Arc::new(ProjectedRecordingInput::new(2));
+        router
+            .install_input_for_test("first", new_input.clone())
+            .await;
+        for index in 0..10 {
+            router
+                .try_publish(event("Write", &format!("after-{index}"), 12))
+                .unwrap();
+        }
+        publishing.await.unwrap();
+        wait_until(|| new_input.events().len() >= 10).await;
+
+        let new_status = router
+            .status_for_ids(&["first".to_string(), "second".to_string()])
+            .await;
+        let new_policy_generation = new_status[0].policy_generation.unwrap();
+        assert!(new_policy_generation > old_policy_generation);
+        assert_eq!(new_status[1].policy_generation, Some(new_policy_generation));
+        for projected in old_input.events() {
+            assert_eq!(
+                projected.observation_policy_generation,
+                Some(old_policy_generation)
+            );
+            assert_eq!(projected.context.tool_name, None);
+            assert_eq!(projected.data.path, None);
+            let wire = serde_json::to_string(&projected).unwrap();
+            assert!(!wire.contains("tool_name"));
+            assert!(!wire.contains("/xxxxxxxxxxxx"));
+        }
+        for projected in new_input.events() {
+            assert_eq!(
+                projected.observation_policy_generation,
+                Some(new_policy_generation)
+            );
+            assert_eq!(projected.context.tool_name.as_deref(), Some("Write"));
+            assert_eq!(projected.data.path.as_deref(), Some("/xxxxxxxxxxxx"));
+        }
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -2964,6 +2964,129 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_through_intermediate_symlink_fails_and_emits_zero_events() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        let linked_dir = workspace.path().join("linked");
+        symlink(external.path(), &linked_dir).unwrap();
+        let target = linked_dir.join("write.txt");
+        let recorder = Arc::new(InMemoryToolEventRecorder::new(4).unwrap());
+        let executor = BuiltinToolExecutorBuilder::new()
+            .with_filesystem_tool("Write")
+            .unwrap()
+            .with_tool_event_publisher(recorder.clone())
+            .build();
+        let call = make_tool_call_with_id(
+            "symlink-write",
+            "Write",
+            json!({"file_path": target, "content": "must-not-write"}),
+        );
+
+        let result = executor
+            .execute_with_context(
+                &call,
+                tool_event_context(&call, Some("symlink-session"), Some("symlink-root")),
+            )
+            .await;
+        assert!(
+            result.is_err() || result.as_ref().is_ok_and(|result| !result.success),
+            "Write must fail closed through an intermediate symlink"
+        );
+        assert!(!external.path().join("write.txt").exists());
+        assert!(recorder.try_snapshot().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn edit_of_symlinked_file_fails_and_emits_zero_events() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.txt");
+        let linked = dir.path().join("linked.txt");
+        fs::write(&real, "before\n").await.unwrap();
+        symlink(&real, &linked).unwrap();
+        let recorder = Arc::new(InMemoryToolEventRecorder::new(4).unwrap());
+        let executor = BuiltinToolExecutor::new().with_tool_event_publisher(recorder.clone());
+        let read =
+            make_tool_call_with_id("symlink-edit-read", "Read", json!({"file_path": linked}));
+        let _ = executor
+            .execute_with_context(
+                &read,
+                tool_event_context(&read, Some("symlink-session"), Some("symlink-root")),
+            )
+            .await;
+        let edit = make_tool_call_with_id(
+            "symlink-edit",
+            "Edit",
+            json!({
+                "file_path": linked,
+                "old_string": "before",
+                "new_string": "after"
+            }),
+        );
+
+        let result = executor
+            .execute_with_context(
+                &edit,
+                tool_event_context(&edit, Some("symlink-session"), Some("symlink-root")),
+            )
+            .await;
+        assert!(
+            result.is_err() || result.as_ref().is_ok_and(|result| !result.success),
+            "Edit must fail closed for a symlinked final file"
+        );
+        assert_eq!(fs::read_to_string(&real).await.unwrap(), "before\n");
+        assert!(recorder.try_snapshot().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn notebook_edit_through_intermediate_symlink_fails_and_emits_zero_events() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        let real_notebook = external.path().join("real.ipynb");
+        let original = r#"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
+        fs::write(&real_notebook, original).await.unwrap();
+        let linked_dir = workspace.path().join("linked");
+        symlink(external.path(), &linked_dir).unwrap();
+        let recorder = Arc::new(InMemoryToolEventRecorder::new(4).unwrap());
+        let executor = BuiltinToolExecutorBuilder::new()
+            .with_filesystem_tool("NotebookEdit")
+            .unwrap()
+            .with_tool_event_publisher(recorder.clone())
+            .build();
+        let call = make_tool_call_with_id(
+            "symlink-notebook",
+            "NotebookEdit",
+            json!({
+                "notebook_path": linked_dir.join("real.ipynb"),
+                "new_source": "print('must not write')",
+                "cell_type": "code",
+                "edit_mode": "insert"
+            }),
+        );
+
+        let result = executor
+            .execute_with_context(
+                &call,
+                tool_event_context(&call, Some("symlink-session"), Some("symlink-root")),
+            )
+            .await;
+        assert!(
+            result.is_err() || result.as_ref().is_ok_and(|result| !result.success),
+            "NotebookEdit must fail closed through an intermediate symlink"
+        );
+        assert_eq!(fs::read_to_string(&real_notebook).await.unwrap(), original);
+        assert!(recorder.try_snapshot().unwrap().is_empty());
+    }
+
     #[tokio::test]
     async fn failed_and_non_successful_mutations_emit_no_event() {
         let recorder = Arc::new(InMemoryToolEventRecorder::new(4).unwrap());

--- a/crates/engine/bamboo-tools/src/tools/file_change.rs
+++ b/crates/engine/bamboo-tools/src/tools/file_change.rs
@@ -522,4 +522,32 @@ mod tests {
         );
         assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), "external");
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn atomic_write_rejects_intermediate_and_final_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        let linked_dir = workspace.path().join("linked-dir");
+        symlink(external.path(), &linked_dir).unwrap();
+        let intermediate_target = linked_dir.join("intermediate.txt");
+        let intermediate = atomic_write_text(&intermediate_target, "nope").await;
+        assert!(
+            matches!(intermediate, Err(ToolError::Execution(message)) if message.contains("symlinked"))
+        );
+        assert!(!external.path().join("intermediate.txt").exists());
+
+        let real = workspace.path().join("real.txt");
+        let linked_file = workspace.path().join("linked-file.txt");
+        tokio::fs::write(&real, "external").await.unwrap();
+        symlink(&real, &linked_file).unwrap();
+        let final_component = atomic_write_text(&linked_file, "nope").await;
+        assert!(matches!(
+            final_component,
+            Err(ToolError::Execution(message)) if message.contains("symlink")
+        ));
+        assert_eq!(tokio::fs::read_to_string(&real).await.unwrap(), "external");
+    }
 }

--- a/crates/infra/bamboo-plugin-protocol/src/lib.rs
+++ b/crates/infra/bamboo-plugin-protocol/src/lib.rs
@@ -4,9 +4,16 @@
 //! server, plugin-manifest, process-supervision, and tool-result types do not
 //! cross this boundary.
 
+mod projected_tool_event_v1;
 mod publisher;
 mod tool_event_v1;
 
+pub use projected_tool_event_v1::{
+    ProjectedFileChangedV1, ProjectedToolEventContextV1, ProjectedToolEventV1,
+    MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES, MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES,
+    TOOL_EVENT_PATH_REDACTION_PERMISSION_NOT_GRANTED, TOOL_EVENT_PATH_REDACTION_SENSITIVE,
+    TOOL_EVENT_PATH_REDACTION_UNSAFE,
+};
 pub use publisher::{
     InMemoryToolEventRecorder, NoopToolEventPublisher, ToolEventPublishError, ToolEventPublisher,
 };

--- a/crates/infra/bamboo-plugin-protocol/src/projected_tool_event_v1.rs
+++ b/crates/infra/bamboo-plugin-protocol/src/projected_tool_event_v1.rs
@@ -1,0 +1,264 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ToolEventBuildError, ToolEventSubscriptionId, ToolEventTypeV1, MAX_TOOL_EVENT_CALL_ID_BYTES,
+    MAX_TOOL_EVENT_JSON_BYTES, MAX_TOOL_EVENT_PATH_BYTES, MAX_TOOL_EVENT_ROOT_SESSION_ID_BYTES,
+    MAX_TOOL_EVENT_SESSION_ID_BYTES, MAX_TOOL_EVENT_TOOL_NAME_BYTES, TOOL_EVENT_V1_SCHEMA_VERSION,
+};
+
+/// Per-field payload bounds applied by the host projection before it performs
+/// the exact complete-event serialization/limit check.
+pub const MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES: usize = 4 * 1024;
+pub const MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES: usize = 8 * 1024;
+pub const TOOL_EVENT_PATH_REDACTION_PERMISSION_NOT_GRANTED: &str = "permission_not_granted";
+pub const TOOL_EVENT_PATH_REDACTION_SENSITIVE: &str = "sensitive_path";
+pub const TOOL_EVENT_PATH_REDACTION_UNSAFE: &str = "unsafe_path";
+
+/// Permission-aware context delivered to plugin services. Metadata is the
+/// safe baseline; `tool_name` is absent unless both requested and host-granted.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectedToolEventContextV1 {
+    pub session_id: String,
+    pub root_session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    pub tool_call_id: String,
+}
+
+/// Permission-aware `file_changed` data. An absent/redacted path never leaves
+/// a placeholder path field; the stable reason is safe metadata. Diff/content
+/// are bounded strings and carry an explicit truncation bit when shortened.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectedFileChangedV1 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_redaction_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub diff_truncated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub content_truncated: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+/// Irreversible host projection admitted to a plugin sink queue. This is
+/// intentionally a distinct type from producer [`crate::ToolEventV1`], making
+/// raw-event queueing a type error.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectedToolEventV1 {
+    pub schema_version: u16,
+    pub event_type: ToolEventTypeV1,
+    pub subscription_id: ToolEventSubscriptionId,
+    pub context: ProjectedToolEventContextV1,
+    pub data: ProjectedFileChangedV1,
+    /// Present on host-projected delivery. Optional during deserialization so
+    /// the original full-observation v1 golden remains backward compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observation_policy_generation: Option<u64>,
+}
+
+impl ProjectedToolEventV1 {
+    pub fn file_changed(
+        context: ProjectedToolEventContextV1,
+        data: ProjectedFileChangedV1,
+        observation_policy_generation: u64,
+    ) -> Self {
+        Self {
+            schema_version: TOOL_EVENT_V1_SCHEMA_VERSION,
+            event_type: ToolEventTypeV1::file_changed(),
+            subscription_id: ToolEventSubscriptionId::file_changed_v1(),
+            context,
+            data,
+            observation_policy_generation: Some(observation_policy_generation),
+        }
+    }
+
+    /// Revalidate a received projection against the public v1 contract.
+    pub fn validate_bounds(&self) -> Result<(), ToolEventBuildError> {
+        if self.schema_version != TOOL_EVENT_V1_SCHEMA_VERSION {
+            return Err(ToolEventBuildError::UnsupportedSchemaVersion {
+                actual: self.schema_version,
+                supported: TOOL_EVENT_V1_SCHEMA_VERSION,
+            });
+        }
+        if !self.event_type.is_file_changed() || !self.subscription_id.is_file_changed_v1() {
+            return Err(ToolEventBuildError::KnownVariantMismatch);
+        }
+        validate_projected_field(
+            "context.session_id",
+            &self.context.session_id,
+            MAX_TOOL_EVENT_SESSION_ID_BYTES,
+        )?;
+        validate_projected_field(
+            "context.root_session_id",
+            &self.context.root_session_id,
+            MAX_TOOL_EVENT_ROOT_SESSION_ID_BYTES,
+        )?;
+        validate_projected_field(
+            "context.tool_call_id",
+            &self.context.tool_call_id,
+            MAX_TOOL_EVENT_CALL_ID_BYTES,
+        )?;
+        if let Some(tool_name) = &self.context.tool_name {
+            validate_projected_field(
+                "context.tool_name",
+                tool_name,
+                MAX_TOOL_EVENT_TOOL_NAME_BYTES,
+            )?;
+        }
+        match (&self.data.path, &self.data.path_redaction_reason) {
+            (Some(path), None) => {
+                validate_projected_field("data.path", path, MAX_TOOL_EVENT_PATH_BYTES)?;
+            }
+            (None, Some(reason))
+                if matches!(
+                    reason.as_str(),
+                    TOOL_EVENT_PATH_REDACTION_PERMISSION_NOT_GRANTED
+                        | TOOL_EVENT_PATH_REDACTION_SENSITIVE
+                        | TOOL_EVENT_PATH_REDACTION_UNSAFE
+                ) =>
+            {
+                if self.data.diff.is_some()
+                    || self.data.content.is_some()
+                    || self.data.diff_truncated
+                    || self.data.content_truncated
+                {
+                    return Err(ToolEventBuildError::InvalidKnownPayload(
+                        "redacted path projection must not carry diff/content".to_string(),
+                    ));
+                }
+            }
+            _ => {
+                return Err(ToolEventBuildError::InvalidKnownPayload(
+                    "file_changed projection requires exactly one of path or path_redaction_reason"
+                        .to_string(),
+                ));
+            }
+        }
+        if let Some(diff) = &self.data.diff {
+            validate_projected_field("data.diff", diff, MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES)?;
+        } else if self.data.diff_truncated {
+            return Err(ToolEventBuildError::InvalidKnownPayload(
+                "diff_truncated requires diff".to_string(),
+            ));
+        }
+        if let Some(content) = &self.data.content {
+            validate_projected_field(
+                "data.content",
+                content,
+                MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES,
+            )?;
+        } else if self.data.content_truncated {
+            return Err(ToolEventBuildError::InvalidKnownPayload(
+                "content_truncated requires content".to_string(),
+            ));
+        }
+        if self.observation_policy_generation == Some(0) {
+            return Err(ToolEventBuildError::InvalidKnownPayload(
+                "observation_policy_generation must be positive".to_string(),
+            ));
+        }
+        let actual = serde_json::to_vec(self)
+            .map_err(|error| ToolEventBuildError::Serialization(error.to_string()))?
+            .len();
+        if actual > MAX_TOOL_EVENT_JSON_BYTES {
+            return Err(ToolEventBuildError::EventTooLarge {
+                actual,
+                max: MAX_TOOL_EVENT_JSON_BYTES,
+            });
+        }
+        Ok(())
+    }
+}
+
+fn validate_projected_field(
+    field: &'static str,
+    value: &str,
+    max: usize,
+) -> Result<(), ToolEventBuildError> {
+    if value.trim().is_empty() {
+        return Err(ToolEventBuildError::EmptyField { field });
+    }
+    if value.len() > max {
+        return Err(ToolEventBuildError::FieldTooLarge {
+            field,
+            actual: value.len(),
+            max,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ToolEventSubscriptionId;
+
+    #[test]
+    fn absent_observation_fields_are_absent_on_the_wire() {
+        let projected = ProjectedToolEventV1::file_changed(
+            ProjectedToolEventContextV1 {
+                session_id: "session".to_string(),
+                root_session_id: "root".to_string(),
+                tool_name: None,
+                tool_call_id: "call".to_string(),
+            },
+            ProjectedFileChangedV1 {
+                path_redaction_reason: Some("permission_not_granted".to_string()),
+                ..ProjectedFileChangedV1::default()
+            },
+            1,
+        );
+        let value = serde_json::to_value(&projected).unwrap();
+        assert!(value["context"].get("tool_name").is_none());
+        assert!(value["data"].get("path").is_none());
+        assert_eq!(
+            value["data"]["path_redaction_reason"],
+            "permission_not_granted"
+        );
+        projected.validate_bounds().unwrap();
+    }
+
+    #[test]
+    fn original_full_observation_golden_remains_deserializable() {
+        let projected: ProjectedToolEventV1 = serde_json::from_str(include_str!(
+            "../tests/golden/tool_event_v1.file_changed.json"
+        ))
+        .unwrap();
+        assert_eq!(projected.context.tool_name.as_deref(), Some("Write"));
+        assert_eq!(
+            projected.data.path.as_deref(),
+            Some("/workspace/zenith/src/lib.rs")
+        );
+        assert_eq!(projected.observation_policy_generation, None);
+        projected.validate_bounds().unwrap();
+    }
+
+    #[test]
+    fn invalid_identifier_and_mixed_path_projection_are_rejected() {
+        let mut projected: ProjectedToolEventV1 = serde_json::from_str(include_str!(
+            "../tests/golden/tool_event_v1.file_changed.json"
+        ))
+        .unwrap();
+        projected.subscription_id = ToolEventSubscriptionId::new("tool.future.v1");
+        assert_eq!(
+            projected.validate_bounds(),
+            Err(ToolEventBuildError::KnownVariantMismatch)
+        );
+
+        projected.subscription_id = ToolEventSubscriptionId::file_changed_v1();
+        projected.data.path_redaction_reason =
+            Some(TOOL_EVENT_PATH_REDACTION_SENSITIVE.to_string());
+        assert!(matches!(
+            projected.validate_bounds(),
+            Err(ToolEventBuildError::InvalidKnownPayload(_))
+        ));
+    }
+}

--- a/crates/infra/bamboo-plugin-protocol/src/tool_event_v1.rs
+++ b/crates/infra/bamboo-plugin-protocol/src/tool_event_v1.rs
@@ -1,8 +1,14 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use thiserror::Error;
+
+use crate::projected_tool_event_v1::{
+    MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES, MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES,
+    TOOL_EVENT_PATH_REDACTION_PERMISSION_NOT_GRANTED, TOOL_EVENT_PATH_REDACTION_SENSITIVE,
+    TOOL_EVENT_PATH_REDACTION_UNSAFE,
+};
 
 /// Wire schema carried by every [`ToolEventV1`].
 pub const TOOL_EVENT_V1_SCHEMA_VERSION: u16 = 1;
@@ -229,20 +235,25 @@ impl ToolEventV1 {
         context: ToolEventContextV1,
         data: FileChangedV1,
     ) -> Result<Self, ToolEventBuildError> {
-        // Validate before flatten serialization so a programmatically supplied
-        // extension cannot create a duplicate reserved JSON key.
+        // Validate borrowed/owned fields before moving them into the raw
+        // producer envelope. Build the Value directly: host projection must
+        // get the first and only serialization opportunity for fields that a
+        // plugin may not be authorized to observe.
         context.validate_bounds()?;
         data.validate_bounds()?;
+        let FileChangedV1 { path, extensions } = data;
+        let mut data = Map::new();
+        data.insert("path".to_string(), Value::String(path));
+        data.extend(extensions);
         let event = Self {
             schema_version: TOOL_EVENT_V1_SCHEMA_VERSION,
             event_type: ToolEventTypeV1::file_changed(),
             subscription_id: ToolEventSubscriptionId::file_changed_v1(),
             context,
-            data: serde_json::to_value(data)
-                .map_err(|error| ToolEventBuildError::Serialization(error.to_string()))?,
+            data: Value::Object(data),
             extensions: BTreeMap::new(),
         };
-        event.validate_bounds()?;
+        event.validate_projection_input_bounds()?;
         Ok(event)
     }
 
@@ -257,6 +268,32 @@ impl ToolEventV1 {
 
     /// Revalidate an event before crossing a bounded publisher boundary.
     pub fn validate_bounds(&self) -> Result<(), ToolEventBuildError> {
+        self.validate_projection_input_bounds()?;
+
+        // The complete protocol boundary retains an exact serialized-byte
+        // check. Host policy routers may instead call the field-only method
+        // below, discard unknown/unauthorized extensions without cloning or
+        // serializing them, and size the resulting projection exactly once.
+        let actual = serde_json::to_vec(self)
+            .map_err(|error| ToolEventBuildError::Serialization(error.to_string()))?
+            .len();
+        if actual > MAX_TOOL_EVENT_JSON_BYTES {
+            return Err(ToolEventBuildError::EventTooLarge {
+                actual,
+                max: MAX_TOOL_EVENT_JSON_BYTES,
+            });
+        }
+        Ok(())
+    }
+
+    /// Validate authority-bearing fields and the known payload shape without
+    /// serializing or deep-cloning producer extensions.
+    ///
+    /// This is the input half of a host projection boundary: callers MUST
+    /// construct a new deny-by-default DTO and apply an exact total-byte bound
+    /// to that projection before queueing it. It is intentionally not a
+    /// replacement for [`Self::validate_bounds`] at general wire boundaries.
+    pub fn validate_projection_input_bounds(&self) -> Result<(), ToolEventBuildError> {
         if self.schema_version != TOOL_EVENT_V1_SCHEMA_VERSION {
             return Err(ToolEventBuildError::UnsupportedSchemaVersion {
                 actual: self.schema_version,
@@ -296,19 +333,17 @@ impl ToolEventV1 {
             return Err(ToolEventBuildError::KnownVariantMismatch);
         }
         if event_known {
-            let data: FileChangedV1 = serde_json::from_value(self.data.clone())
-                .map_err(|error| ToolEventBuildError::InvalidKnownPayload(error.to_string()))?;
-            data.validate_bounds()?;
-        }
-
-        let actual = serde_json::to_vec(self)
-            .map_err(|error| ToolEventBuildError::Serialization(error.to_string()))?
-            .len();
-        if actual > MAX_TOOL_EVENT_JSON_BYTES {
-            return Err(ToolEventBuildError::EventTooLarge {
-                actual,
-                max: MAX_TOOL_EVENT_JSON_BYTES,
-            });
+            let path = self
+                .data
+                .as_object()
+                .and_then(|data| data.get("path"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    ToolEventBuildError::InvalidKnownPayload(
+                        "file_changed data.path must be a string".to_string(),
+                    )
+                })?;
+            validate_required("data.path", path, MAX_TOOL_EVENT_PATH_BYTES)?;
         }
         Ok(())
     }
@@ -388,7 +423,7 @@ pub fn tool_event_v1_schema() -> Value {
             "subscription_id": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": MAX_TOOL_EVENT_SUBSCRIPTION_ID_BYTES },
             "context": {
                 "type": "object",
-                "required": ["session_id", "root_session_id", "tool_name", "tool_call_id"],
+                "required": ["session_id", "root_session_id", "tool_call_id"],
                 "properties": {
                     "session_id": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": MAX_TOOL_EVENT_SESSION_ID_BYTES },
                     "root_session_id": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": MAX_TOOL_EVENT_ROOT_SESSION_ID_BYTES },
@@ -397,7 +432,8 @@ pub fn tool_event_v1_schema() -> Value {
                 },
                 "additionalProperties": true
             },
-            "data": { "type": "object" }
+            "data": { "type": "object" },
+            "observation_policy_generation": { "type": "integer", "minimum": 1 }
         },
         "allOf": [{
             "if": {
@@ -411,10 +447,45 @@ pub fn tool_event_v1_schema() -> Value {
                     "subscription_id": { "const": FILE_CHANGED_SUBSCRIPTION_ID_V1 },
                     "data": {
                         "type": "object",
-                        "required": ["path"],
                         "properties": {
-                            "path": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": MAX_TOOL_EVENT_PATH_BYTES }
+                            "path": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": MAX_TOOL_EVENT_PATH_BYTES },
+                            "path_redaction_reason": {
+                                "type": "string",
+                                "enum": [
+                                    TOOL_EVENT_PATH_REDACTION_PERMISSION_NOT_GRANTED,
+                                    TOOL_EVENT_PATH_REDACTION_SENSITIVE,
+                                    TOOL_EVENT_PATH_REDACTION_UNSAFE
+                                ]
+                            },
+                            "diff": { "type": "string", "x-bamboo-maxUtf8Bytes": MAX_PROJECTED_TOOL_EVENT_DIFF_BYTES },
+                            "diff_truncated": { "type": "boolean" },
+                            "content": { "type": "string", "x-bamboo-maxUtf8Bytes": MAX_PROJECTED_TOOL_EVENT_CONTENT_BYTES },
+                            "content_truncated": { "type": "boolean" }
                         },
+                        "oneOf": [{
+                            "required": ["path"],
+                            "not": { "required": ["path_redaction_reason"] }
+                        }, {
+                            "required": ["path_redaction_reason"],
+                            "not": { "required": ["path"] }
+                        }],
+                        "allOf": [{
+                            "if": {
+                                "anyOf": [
+                                    { "required": ["diff"] },
+                                    { "required": ["diff_truncated"] },
+                                    { "required": ["content"] },
+                                    { "required": ["content_truncated"] }
+                                ]
+                            },
+                            "then": { "required": ["path"] }
+                        }, {
+                            "if": { "required": ["diff_truncated"] },
+                            "then": { "required": ["diff"] }
+                        }, {
+                            "if": { "required": ["content_truncated"] },
+                            "then": { "required": ["content"] }
+                        }],
                         "additionalProperties": true
                     }
                 }
@@ -478,6 +549,44 @@ mod tests {
         let mut mismatched = fixture;
         mismatched["subscription_id"] = json!("tool.future.v1");
         assert!(validator.validate(&mismatched).is_err());
+    }
+
+    #[test]
+    fn metadata_only_host_projection_round_trips_and_validates_against_public_schema() {
+        let projection = crate::ProjectedToolEventV1::file_changed(
+            crate::ProjectedToolEventContextV1 {
+                session_id: "session-1".to_string(),
+                root_session_id: "root-session-1".to_string(),
+                tool_name: None,
+                tool_call_id: "call-1".to_string(),
+            },
+            crate::ProjectedFileChangedV1 {
+                path_redaction_reason: Some(
+                    crate::TOOL_EVENT_PATH_REDACTION_PERMISSION_NOT_GRANTED.to_string(),
+                ),
+                ..crate::ProjectedFileChangedV1::default()
+            },
+            3,
+        );
+        let value = serde_json::to_value(&projection).unwrap();
+        assert!(value["context"].get("tool_name").is_none());
+        assert!(value["data"].get("path").is_none());
+        let validator = jsonschema::validator_for(&tool_event_v1_schema()).unwrap();
+        assert!(validator.validate(&value).is_ok());
+        assert_eq!(
+            serde_json::from_value::<crate::ProjectedToolEventV1>(value.clone()).unwrap(),
+            projection
+        );
+
+        let mut path_and_reason = value.clone();
+        path_and_reason["data"]["path"] = json!("/workspace/file.rs");
+        assert!(validator.validate(&path_and_reason).is_err());
+        let mut redacted_payload = value.clone();
+        redacted_payload["data"]["content"] = json!("must-not-be-accepted");
+        assert!(validator.validate(&redacted_payload).is_err());
+        let mut empty_data = value;
+        empty_data["data"] = json!({});
+        assert!(validator.validate(&empty_data).is_err());
     }
 
     #[test]
@@ -558,6 +667,28 @@ mod tests {
             json!("x".repeat(MAX_TOOL_EVENT_JSON_BYTES)),
         );
 
+        assert!(matches!(
+            event.validate_bounds(),
+            Err(ToolEventBuildError::EventTooLarge {
+                actual,
+                max: MAX_TOOL_EVENT_JSON_BYTES,
+            }) if actual > MAX_TOOL_EVENT_JSON_BYTES
+        ));
+    }
+
+    #[test]
+    fn raw_constructor_does_not_serialize_unknown_payload_before_projection() {
+        let mut data = FileChangedV1::bounded("/workspace/file.rs").unwrap();
+        data.extensions.insert(
+            "future_secret".to_string(),
+            json!("secret".repeat(MAX_TOOL_EVENT_JSON_BYTES)),
+        );
+
+        let event = ToolEventV1::file_changed(
+            ToolEventContextV1::bounded("session", "root", "Write", "call").unwrap(),
+            data,
+        )
+        .expect("field-valid raw input is assembled without whole-event serialization");
         assert!(matches!(
             event.validate_bounds(),
             Err(ToolEventBuildError::EventTooLarge {

--- a/crates/infra/bamboo-plugin-protocol/tests/golden/tool_event_v1.schema.json
+++ b/crates/infra/bamboo-plugin-protocol/tests/golden/tool_event_v1.schema.json
@@ -11,7 +11,7 @@
     "subscription_id": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": 128 },
     "context": {
       "type": "object",
-      "required": ["session_id", "root_session_id", "tool_name", "tool_call_id"],
+      "required": ["session_id", "root_session_id", "tool_call_id"],
       "properties": {
         "session_id": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": 256 },
         "root_session_id": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": 256 },
@@ -20,7 +20,8 @@
       },
       "additionalProperties": true
     },
-    "data": { "type": "object" }
+    "data": { "type": "object" },
+    "observation_policy_generation": { "type": "integer", "minimum": 1 }
   },
   "allOf": [
     {
@@ -35,10 +36,48 @@
           "subscription_id": { "const": "tool.file_changed.v1" },
           "data": {
             "type": "object",
-            "required": ["path"],
             "properties": {
-              "path": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": 4096 }
+              "path": { "type": "string", "minLength": 1, "x-bamboo-maxUtf8Bytes": 4096 },
+              "path_redaction_reason": {
+                "type": "string",
+                "enum": ["permission_not_granted", "sensitive_path", "unsafe_path"]
+              },
+              "diff": { "type": "string", "x-bamboo-maxUtf8Bytes": 4096 },
+              "diff_truncated": { "type": "boolean" },
+              "content": { "type": "string", "x-bamboo-maxUtf8Bytes": 8192 },
+              "content_truncated": { "type": "boolean" }
             },
+            "oneOf": [
+              {
+                "required": ["path"],
+                "not": { "required": ["path_redaction_reason"] }
+              },
+              {
+                "required": ["path_redaction_reason"],
+                "not": { "required": ["path"] }
+              }
+            ],
+            "allOf": [
+              {
+                "if": {
+                  "anyOf": [
+                    { "required": ["diff"] },
+                    { "required": ["diff_truncated"] },
+                    { "required": ["content"] },
+                    { "required": ["content_truncated"] }
+                  ]
+                },
+                "then": { "required": ["path"] }
+              },
+              {
+                "if": { "required": ["diff_truncated"] },
+                "then": { "required": ["diff"] }
+              },
+              {
+                "if": { "required": ["content_truncated"] },
+                "then": { "required": ["content"] }
+              }
+            ],
             "additionalProperties": true
           }
         }

--- a/crates/infra/bamboo-plugin/src/lib.rs
+++ b/crates/infra/bamboo-plugin/src/lib.rs
@@ -63,7 +63,8 @@ pub use manifest::{
 };
 pub use registry::{
     classify_ownership, reconcile_event_sinks, reconcile_exclusive, reconcile_plugin_boot,
-    EventSinkReconciliation, EventSinkRemovalOrder, ExclusiveReconciliation, InstalledPlugin,
-    InstalledPlugins, Ownership, PluginBootCandidate, PluginBootIssue, PluginBootReconciliation,
-    PluginInstallStatus, PluginSource, ReconciledEventSink, RegisteredCapabilities,
+    EventSinkPermissionGrants, EventSinkReconciliation, EventSinkRemovalOrder,
+    ExclusiveReconciliation, InstalledPlugin, InstalledPlugins, Ownership, PluginBootCandidate,
+    PluginBootIssue, PluginBootReconciliation, PluginInstallStatus, PluginSource,
+    ReconciledEventSink, RegisteredCapabilities,
 };

--- a/crates/infra/bamboo-plugin/src/manifest.rs
+++ b/crates/infra/bamboo-plugin/src/manifest.rs
@@ -604,10 +604,19 @@ pub struct EventSinkManifestEntry {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "reason", rename_all = "snake_case")]
 pub enum EventSinkInactiveReason {
-    UnsupportedProtocolVersion { requested: u16, supported: u16 },
+    UnsupportedProtocolVersion {
+        requested: u16,
+        supported: u16,
+    },
     InstallIncomplete,
     PlatformIneligible,
     ServiceDisabled,
+    /// The manifest narrows delivery using a field that the host has not
+    /// granted this sink permission to observe. Keeping the sink inactive
+    /// avoids turning delivery versus non-delivery into a side channel.
+    ObservationPermissionNotGranted {
+        permission: ObservationPermissionId,
+    },
 }
 
 /// Eligibility emitted by pure reconciliation. `Eligible` intentionally does

--- a/crates/infra/bamboo-plugin/src/registry.rs
+++ b/crates/infra/bamboo-plugin/src/registry.rs
@@ -12,7 +12,7 @@
 //! deregistering capabilities (MCP servers, prompt presets, workflow files)
 //! is the installer's job (see [`crate::installer`] and `PLUGIN_PLAN.md`).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -20,7 +20,10 @@ use serde::{Deserialize, Serialize};
 use tokio::fs;
 
 use crate::error::{PluginError, PluginResult};
-use crate::manifest::{EventSinkCapabilityState, EventSinkManifestEntry, Platform, PluginManifest};
+use crate::manifest::{
+    EventSinkCapabilityState, EventSinkManifestEntry, ObservationPermissionId, Platform,
+    PluginManifest,
+};
 
 /// Where a plugin's installed bundle came from. Recorded verbatim so
 /// `update`/reinstall can re-fetch from the same place.
@@ -115,6 +118,10 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
+/// Exact host-authorized observation permissions keyed by declared sink id.
+/// This is provenance/policy state, never inferred from manifest requests.
+pub type EventSinkPermissionGrants = BTreeMap<String, Vec<ObservationPermissionId>>;
+
 /// Exactly what an installed plugin registered into Bamboo's shared capability
 /// stores. Every id/name here MUST have actually been written by the
 /// installer for THIS plugin — never a superset (that would risk clobbering
@@ -147,6 +154,10 @@ pub struct RegisteredCapabilities {
     /// is exact manifest/lifecycle provenance for the later router.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub event_sink_ids: Vec<String>,
+    /// Host grants persisted in both Installing and Installed journal rows.
+    /// A legacy absent field is interpreted as metadata-only per v1 sink.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub event_sink_grants: EventSinkPermissionGrants,
 }
 
 impl RegisteredCapabilities {
@@ -177,6 +188,9 @@ impl RegisteredCapabilities {
             workflow_filenames: subtract(&old.workflow_filenames, &self.workflow_filenames),
             service_ids: subtract(&old.service_ids, &self.service_ids),
             event_sink_ids: subtract(&old.event_sink_ids, &self.event_sink_ids),
+            // Grants are policy provenance for retained/replaced declarations,
+            // not independently deregistered capabilities.
+            event_sink_grants: BTreeMap::new(),
         }
     }
 
@@ -792,6 +806,7 @@ mod tests {
                 workflow_filenames: vec![],
                 service_ids: vec![],
                 event_sink_ids: vec![],
+                event_sink_grants: BTreeMap::new(),
             },
         }
     }
@@ -1010,6 +1025,10 @@ mod tests {
             workflow_filenames: vec!["wf-a.md".to_string()],
             service_ids: vec!["svc-a".to_string(), "svc-b".to_string()],
             event_sink_ids: vec!["sink-a".to_string(), "sink-b".to_string()],
+            event_sink_grants: BTreeMap::from([(
+                "sink-a".to_string(),
+                vec![ObservationPermissionId::new("metadata")],
+            )]),
         };
         // New version drops srv-b, preset-a, and svc-b; keeps the rest; adds srv-c.
         let new = RegisteredCapabilities {
@@ -1019,6 +1038,13 @@ mod tests {
             workflow_filenames: vec!["wf-a.md".to_string()],
             service_ids: vec!["svc-a".to_string()],
             event_sink_ids: vec!["sink-a".to_string()],
+            event_sink_grants: BTreeMap::from([(
+                "sink-a".to_string(),
+                vec![
+                    ObservationPermissionId::new("metadata"),
+                    ObservationPermissionId::new("paths"),
+                ],
+            )]),
         };
 
         let removed = new.removed_since(&old);
@@ -1028,6 +1054,39 @@ mod tests {
         assert!(removed.workflow_filenames.is_empty());
         assert_eq!(removed.service_ids, vec!["svc-b".to_string()]);
         assert_eq!(removed.event_sink_ids, vec!["sink-b".to_string()]);
+        assert!(removed.event_sink_grants.is_empty());
+        assert!(RegisteredCapabilities {
+            event_sink_grants: BTreeMap::from([(
+                "sink-a".to_string(),
+                vec![ObservationPermissionId::new("metadata")],
+            )]),
+            ..Default::default()
+        }
+        .is_empty());
+    }
+
+    #[test]
+    fn event_sink_grants_round_trip_and_legacy_absence_defaults_empty() {
+        let legacy: RegisteredCapabilities = serde_json::from_value(serde_json::json!({
+            "event_sink_ids": ["audit-events"]
+        }))
+        .unwrap();
+        assert!(legacy.event_sink_grants.is_empty());
+
+        let exact = RegisteredCapabilities {
+            event_sink_ids: vec!["audit-events".to_string()],
+            event_sink_grants: BTreeMap::from([(
+                "audit-events".to_string(),
+                vec![
+                    ObservationPermissionId::new("metadata"),
+                    ObservationPermissionId::new("paths"),
+                ],
+            )]),
+            ..Default::default()
+        };
+        let round_trip: RegisteredCapabilities =
+            serde_json::from_value(serde_json::to_value(&exact).unwrap()).unwrap();
+        assert_eq!(round_trip, exact);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- introduce an irreversible ProjectedToolEventV1 boundary so raw tool names, paths, diffs, content, and producer extensions cannot enter plugin queues without host grants
- persist canonical per-sink observation grants across install, update, crash recovery, boot reconciliation, and rollback; metadata-only remains the safe default
- normalize Unix, Windows drive, NT namespace, and UNC paths lexically, with stable redaction for sensitive locations and hidden or administrative shares
- bound fields and projected wire bytes, truncate authorized UTF-8 diff/content explicitly, and reject malformed or escaping-amplified payloads before queueing
- expose bounded requested/granted policy status and atomically replace complete policy generations
- verify Write, Edit, and NotebookEdit symlink failures emit zero ToolEvents

## Security invariants

- manifest requests never create authority; projection is request intersected with persisted host grant
- unauthorized values are not serialized, copied into the projected DTO, or queued
- a tool-name filter without tool_name authority is explicitly inactive, preventing delivery timing from becoming a side channel
- corrupt nonempty durable grant maps fail closed before plugin-owned services start and are not reflected through status
- policy replacement publishes either the complete old generation or complete new generation

## Test Plan

- cargo test --locked -p bamboo-plugin-protocol: 17 passed
- cargo test --locked -p bamboo-plugin: 65 unit and 2 integration passed
- cargo test --locked -p bamboo-tools: 387 unit and 1 integration passed; 9 existing doctests ignored
- cargo test --locked -p bamboo-server --lib --no-fail-fast -- --quiet: 1953 passed, 1 existing ignored
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --locked --all-features -- -D warnings with the repository CI allowlist

## Screenshots

N/A; backend protocol, policy, lifecycle, and security behavior only.

Closes #907