### PR TITLE
refactor: replay OpenAI Responses discovery items (#976)

### DIFF
--- a/crates/core/bamboo-domain/src/session/provider_transcript.rs
+++ b/crates/core/bamboo-domain/src/session/provider_transcript.rs
@@ -2218,7 +2218,8 @@ fn validate_group_order(
             let mut pending_provider_calls = HashSet::<&str>::new();
             let mut pending_client_calls = HashSet::<&str>::new();
             let mut pending_unkeyed_provider_calls = 0usize;
-            let mut saw_client_search_call = false;
+            let mut has_client_search_call = false;
+            let mut has_client_search_output = false;
             let mut loaded_at = HashMap::<String, usize>::new();
             let mut function_calls = Vec::<(usize, &str)>::new();
             for (index, item) in items.iter().enumerate() {
@@ -2256,7 +2257,7 @@ fn validate_group_order(
                                 pending_client_calls.insert(call_id);
                             }
                         }
-                        saw_client_search_call |= execution == "client";
+                        has_client_search_call |= execution == "client";
                     }
                     ProviderTranscriptItemKind::OpenAiToolSearchOutput => {
                         let execution = item
@@ -2289,9 +2290,7 @@ fn validate_group_order(
                             };
                             pending.remove(call_id)
                         };
-                        if execution == "client" && saw_client_search_call {
-                            return Err(ProviderTranscriptError::InvalidGroupOrder);
-                        }
+                        has_client_search_output |= execution == "client";
                         if !matched_pending
                             && (execution == "server"
                                 || item.origin != ProviderTranscriptOrigin::HostToolSearch)
@@ -2307,9 +2306,6 @@ fn validate_group_order(
                         }
                     }
                     ProviderTranscriptItemKind::OpenAiFunctionCall => {
-                        if saw_client_search_call {
-                            return Err(ProviderTranscriptError::InvalidGroupOrder);
-                        }
                         let name = item
                             .payload
                             .get("name")
@@ -2321,6 +2317,14 @@ fn validate_group_order(
                 }
             }
             if !pending_provider_calls.is_empty() || pending_unkeyed_provider_calls != 0 {
+                return Err(ProviderTranscriptError::InvalidGroupOrder);
+            }
+            // Client execution is a suspension boundary: the provider-owned
+            // response stops at tool_search_call, and the host resumes it in a
+            // later standalone HostToolSearch output group. Express this as an
+            // order-independent group invariant so reversed malformed output
+            // cannot bypass a forward-only state check.
+            if has_client_search_call && (has_client_search_output || !function_calls.is_empty()) {
                 return Err(ProviderTranscriptError::InvalidGroupOrder);
             }
             let mut matched_loaded_call = false;
@@ -3644,11 +3648,48 @@ mod tests {
         assert_eq!(
             test_group(
                 "client-call-must-stop",
-                vec![client_call, premature_function_call],
+                vec![client_call.clone(), premature_function_call.clone()],
             )
             .unwrap_err(),
             ProviderTranscriptError::InvalidGroupOrder
         );
+        assert_eq!(
+            test_group(
+                "function-cannot-precede-client-call",
+                vec![premature_function_call, client_call.clone()],
+            )
+            .unwrap_err(),
+            ProviderTranscriptError::InvalidGroupOrder
+        );
+
+        let host_client_output = ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::HostToolSearch,
+            ProviderTranscriptAuthor::ToolResult,
+            json!({
+                "type":"tool_search_output","execution":"client",
+                "call_id":"search_1","status":"completed","tools":[]
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            test_group(
+                "client-call-cannot-contain-host-output",
+                vec![client_call.clone(), host_client_output.clone()],
+            )
+            .unwrap_err(),
+            ProviderTranscriptError::InvalidGroupOrder
+        );
+        assert_eq!(
+            test_group(
+                "host-output-cannot-precede-client-call",
+                vec![host_client_output.clone(), client_call],
+            )
+            .unwrap_err(),
+            ProviderTranscriptError::InvalidGroupOrder
+        );
+        assert!(test_group("standalone-host-output", vec![host_client_output]).is_ok());
 
         let anthropic = anthropic_items();
         let mut reordered = anthropic.clone();

--- a/crates/core/bamboo-domain/src/session/provider_transcript.rs
+++ b/crates/core/bamboo-domain/src/session/provider_transcript.rs
@@ -1660,12 +1660,17 @@ fn validate_openai_item(
                 ],
                 "tool search call fields",
             )?;
-            execution()?;
+            let execution = execution()?;
             require_nonempty_string("id")?;
+            let call_id_valid = if execution == "client" {
+                is_nonempty_string(object.get("call_id"))
+            } else {
+                is_optional_nullable_nonempty_string(object.get("call_id"))
+            };
             if author != ProviderTranscriptAuthor::Model
                 || object.get("status").and_then(Value::as_str) != Some("completed")
                 || !object.get("arguments").is_some_and(Value::is_object)
-                || !is_optional_nullable_nonempty_string(object.get("call_id"))
+                || !call_id_valid
                 || !is_optional_nullable_nonempty_string(object.get("created_by"))
             {
                 return Err(ProviderTranscriptError::InvalidItem(
@@ -2213,7 +2218,7 @@ fn validate_group_order(
             let mut pending_provider_calls = HashSet::<&str>::new();
             let mut pending_client_calls = HashSet::<&str>::new();
             let mut pending_unkeyed_provider_calls = 0usize;
-            let mut pending_unkeyed_client_calls = 0usize;
+            let mut saw_client_search_call = false;
             let mut loaded_at = HashMap::<String, usize>::new();
             let mut function_calls = Vec::<(usize, &str)>::new();
             for (index, item) in items.iter().enumerate() {
@@ -2239,8 +2244,7 @@ fn validate_group_order(
                                 pending_unkeyed_provider_calls =
                                     pending_unkeyed_provider_calls.saturating_add(1);
                             } else {
-                                pending_unkeyed_client_calls =
-                                    pending_unkeyed_client_calls.saturating_add(1);
+                                return Err(ProviderTranscriptError::InvalidGroupOrder);
                             }
                         } else {
                             if !seen_search_call_ids.insert(call_id) {
@@ -2252,6 +2256,7 @@ fn validate_group_order(
                                 pending_client_calls.insert(call_id);
                             }
                         }
+                        saw_client_search_call |= execution == "client";
                     }
                     ProviderTranscriptItemKind::OpenAiToolSearchOutput => {
                         let execution = item
@@ -2269,15 +2274,11 @@ fn validate_group_order(
                             return Err(ProviderTranscriptError::InvalidGroupOrder);
                         }
                         let matched_pending = if call_id.is_empty() {
-                            let pending = if execution == "server" {
-                                &mut pending_unkeyed_provider_calls
-                            } else {
-                                &mut pending_unkeyed_client_calls
-                            };
-                            if *pending == 0 {
+                            if execution != "server" || pending_unkeyed_provider_calls == 0 {
                                 false
                             } else {
-                                *pending = pending.saturating_sub(1);
+                                pending_unkeyed_provider_calls =
+                                    pending_unkeyed_provider_calls.saturating_sub(1);
                                 true
                             }
                         } else {
@@ -2288,6 +2289,9 @@ fn validate_group_order(
                             };
                             pending.remove(call_id)
                         };
+                        if execution == "client" && saw_client_search_call {
+                            return Err(ProviderTranscriptError::InvalidGroupOrder);
+                        }
                         if !matched_pending
                             && (execution == "server"
                                 || item.origin != ProviderTranscriptOrigin::HostToolSearch)
@@ -2303,6 +2307,9 @@ fn validate_group_order(
                         }
                     }
                     ProviderTranscriptItemKind::OpenAiFunctionCall => {
+                        if saw_client_search_call {
+                            return Err(ProviderTranscriptError::InvalidGroupOrder);
+                        }
                         let name = item
                             .payload
                             .get("name")
@@ -2844,6 +2851,8 @@ mod tests {
             additional.kind(),
             ProviderTranscriptItemKind::OpenAiAdditionalTools
         );
+        ProviderTranscriptGroup::validate_items(std::slice::from_ref(&client))
+            .expect("a client output is a standalone host-owned continuation group");
     }
 
     #[test]
@@ -3583,6 +3592,34 @@ mod tests {
         )
         .expect("the official hosted output model permits an omitted call_id");
 
+        for malformed_client in [
+            json!({
+                "type":"tool_search_call","id":"tsc_client_missing","execution":"client",
+                "status":"completed","arguments":{}
+            }),
+            json!({
+                "type":"tool_search_call","id":"tsc_client_null","execution":"client",
+                "call_id":null,"status":"completed","arguments":{}
+            }),
+            json!({
+                "type":"tool_search_call","id":"tsc_client_empty","execution":"client",
+                "call_id":"","status":"completed","arguments":{}
+            }),
+            json!({
+                "type":"tool_search_call","id":"tsc_client_typed","execution":"client",
+                "call_id":7,"status":"completed","arguments":{}
+            }),
+        ] {
+            assert!(ProviderTranscriptItem::try_from_payload(
+                ProviderFamily::OpenAi,
+                ProviderProtocol::OpenAiResponsesV1,
+                ProviderTranscriptOrigin::Provider,
+                ProviderTranscriptAuthor::Model,
+                malformed_client,
+            )
+            .is_err());
+        }
+
         // Client execution intentionally stops after the call. Its host output
         // is committed in a later input group and may therefore stand alone.
         let client_call = ProviderTranscriptItem::try_from_payload(
@@ -3596,7 +3633,22 @@ mod tests {
             }),
         )
         .unwrap();
-        assert!(test_group("client-call", vec![client_call]).is_ok());
+        assert!(test_group("client-call", vec![client_call.clone()]).is_ok());
+        let premature_function_call = hosted_item(
+            ProviderTranscriptAuthor::Model,
+            json!({
+                "type":"function_call","id":"fc_client_premature","call_id":"function_1",
+                "name":"get_weather","arguments":"{}","status":"completed"
+            }),
+        );
+        assert_eq!(
+            test_group(
+                "client-call-must-stop",
+                vec![client_call, premature_function_call],
+            )
+            .unwrap_err(),
+            ProviderTranscriptError::InvalidGroupOrder
+        );
 
         let anthropic = anthropic_items();
         let mut reordered = anthropic.clone();

--- a/crates/core/bamboo-domain/src/session/provider_transcript.rs
+++ b/crates/core/bamboo-domain/src/session/provider_transcript.rs
@@ -373,6 +373,14 @@ impl<'de> Deserialize<'de> for ProviderTranscriptGroup {
 }
 
 impl ProviderTranscriptGroup {
+    /// Validate an atomic provider-native batch before any item is exposed to
+    /// the engine stream. Provider adapters use this same admission path as
+    /// durable group construction so malformed ordering cannot fail later,
+    /// after the normalized assistant response has already been committed.
+    pub fn validate_items(items: &[ProviderTranscriptItem]) -> Result<(), ProviderTranscriptError> {
+        validated_group_identity(items).map(|_| ())
+    }
+
     fn new(
         epoch: u64,
         sequence: u64,
@@ -392,16 +400,7 @@ impl ProviderTranscriptGroup {
         if !is_sha256_hex(&provider_boundary_sha256) {
             return Err(ProviderTranscriptError::InvalidProviderBoundary);
         }
-        if items
-            .iter()
-            .any(|item| item.family != family || item.protocol != protocol)
-        {
-            return Err(ProviderTranscriptError::MixedProviderGroup);
-        }
-        if !items.iter().any(|item| item.kind.is_discovery()) {
-            return Err(ProviderTranscriptError::MissingDiscoveryItem);
-        }
-        validate_group_order(protocol, &items)?;
+        Self::validate_items(&items)?;
 
         let id = stable_group_id(
             epoch,
@@ -1275,6 +1274,16 @@ fn is_nonempty_string(value: Option<&Value>) -> bool {
         .is_some_and(|value| !value.trim().is_empty())
 }
 
+fn is_optional_nullable_nonempty_string(value: Option<&Value>) -> bool {
+    value.is_none_or(|value| {
+        value.is_null() || value.as_str().is_some_and(|value| !value.trim().is_empty())
+    })
+}
+
+fn is_optional_nullable_item_status(value: Option<&Value>) -> bool {
+    value.is_none_or(|value| value.is_null() || is_openai_item_status(Some(value)))
+}
+
 fn is_openai_item_status(value: Option<&Value>) -> bool {
     matches!(
         value.and_then(Value::as_str),
@@ -1286,6 +1295,9 @@ fn validate_openai_agent(value: Option<&Value>) -> Result<(), ProviderTranscript
     let Some(value) = value else {
         return Ok(());
     };
+    if value.is_null() {
+        return Ok(());
+    }
     let agent = value
         .as_object()
         .ok_or(ProviderTranscriptError::InvalidItem("agent shape"))?;
@@ -1378,6 +1390,9 @@ fn validate_openai_logprobs(value: Option<&Value>) -> Result<(), ProviderTranscr
     let Some(value) = value else {
         return Ok(());
     };
+    if value.is_null() {
+        return Ok(());
+    }
     let logprobs = value
         .as_array()
         .ok_or(ProviderTranscriptError::InvalidItem("output logprobs"))?;
@@ -1471,6 +1486,9 @@ fn validate_openai_reasoning_parts(
             Ok(())
         };
     };
+    if value.is_null() && !required {
+        return Ok(());
+    }
     let parts = value
         .as_array()
         .ok_or(ProviderTranscriptError::InvalidItem("reasoning parts"))?;
@@ -1492,6 +1510,9 @@ fn validate_openai_caller(value: Option<&Value>) -> Result<(), ProviderTranscrip
     let Some(value) = value else {
         return Ok(());
     };
+    if value.is_null() {
+        return Ok(());
+    }
     let caller = value
         .as_object()
         .ok_or(ProviderTranscriptError::InvalidItem("function caller"))?;
@@ -1544,7 +1565,8 @@ fn validate_openai_item(
                 || object.get("role").and_then(Value::as_str) != Some("assistant")
                 || !is_openai_item_status(object.get("status"))
                 || object.get("phase").is_some_and(|phase| {
-                    !matches!(phase.as_str(), Some("commentary" | "final_answer"))
+                    !phase.is_null()
+                        && !matches!(phase.as_str(), Some("commentary" | "final_answer"))
                 })
             {
                 return Err(ProviderTranscriptError::InvalidItem(
@@ -1573,12 +1595,10 @@ fn validate_openai_item(
             )?;
             if author != ProviderTranscriptAuthor::Model
                 || !is_nonempty_string(object.get("id"))
-                || object
+                || !object
                     .get("encrypted_content")
-                    .is_some_and(|content| !content.is_string())
-                || object
-                    .get("status")
-                    .is_some_and(|_| !is_openai_item_status(object.get("status")))
+                    .is_none_or(|content| content.is_null() || content.is_string())
+                || !is_optional_nullable_item_status(object.get("status"))
             {
                 return Err(ProviderTranscriptError::InvalidItem("reasoning shape"));
             }
@@ -1600,6 +1620,7 @@ fn validate_openai_item(
                     "caller",
                     "namespace",
                     "status",
+                    "created_by",
                 ],
                 "function call fields",
             )?;
@@ -1607,15 +1628,10 @@ fn validate_openai_item(
             require_nonempty_string("call_id")?;
             let arguments = object.get("arguments").and_then(Value::as_str);
             if author != ProviderTranscriptAuthor::Model
-                || object
-                    .get("id")
-                    .is_some_and(|_| !is_nonempty_string(object.get("id")))
-                || object
-                    .get("namespace")
-                    .is_some_and(|_| !is_nonempty_string(object.get("namespace")))
-                || object
-                    .get("status")
-                    .is_some_and(|_| !is_openai_item_status(object.get("status")))
+                || !is_optional_nullable_nonempty_string(object.get("id"))
+                || !is_optional_nullable_nonempty_string(object.get("namespace"))
+                || !is_optional_nullable_item_status(object.get("status"))
+                || !is_optional_nullable_nonempty_string(object.get("created_by"))
                 || arguments.is_none()
                 || !arguments.is_some_and(|arguments| {
                     serde_json::from_str::<Value>(arguments)
@@ -1646,13 +1662,11 @@ fn validate_openai_item(
             )?;
             execution()?;
             require_nonempty_string("id")?;
-            require_nonempty_string("call_id")?;
             if author != ProviderTranscriptAuthor::Model
                 || object.get("status").and_then(Value::as_str) != Some("completed")
                 || !object.get("arguments").is_some_and(Value::is_object)
-                || object
-                    .get("created_by")
-                    .is_some_and(|_| !is_nonempty_string(object.get("created_by")))
+                || !is_optional_nullable_nonempty_string(object.get("call_id"))
+                || !is_optional_nullable_nonempty_string(object.get("created_by"))
             {
                 return Err(ProviderTranscriptError::InvalidItem(
                     "tool search call shape",
@@ -1687,13 +1701,11 @@ fn validate_openai_item(
                         "server tool search output fields",
                     )?;
                     require_nonempty_string("id")?;
-                    require_nonempty_string("call_id")?;
-                    if object
-                        .get("created_by")
-                        .is_some_and(|_| !is_nonempty_string(object.get("created_by")))
+                    if !is_optional_nullable_nonempty_string(object.get("call_id"))
+                        || !is_optional_nullable_nonempty_string(object.get("created_by"))
                     {
                         return Err(ProviderTranscriptError::InvalidItem(
-                            "tool search output created_by",
+                            "tool search output metadata",
                         ));
                     }
                     validate_openai_agent(object.get("agent"))?;
@@ -2168,6 +2180,27 @@ fn validate_anthropic_search_result_content(
     }
 }
 
+fn validated_group_identity(
+    items: &[ProviderTranscriptItem],
+) -> Result<(ProviderFamily, ProviderProtocol), ProviderTranscriptError> {
+    let Some(first) = items.first() else {
+        return Err(ProviderTranscriptError::EmptyGroup);
+    };
+    let family = first.family;
+    let protocol = first.protocol;
+    if items
+        .iter()
+        .any(|item| item.family != family || item.protocol != protocol)
+    {
+        return Err(ProviderTranscriptError::MixedProviderGroup);
+    }
+    if !items.iter().any(|item| item.kind.is_discovery()) {
+        return Err(ProviderTranscriptError::MissingDiscoveryItem);
+    }
+    validate_group_order(protocol, items)?;
+    Ok((family, protocol))
+}
+
 fn validate_group_order(
     protocol: ProviderProtocol,
     items: &[ProviderTranscriptItem],
@@ -2179,6 +2212,8 @@ fn validate_group_order(
             let mut seen_search_outputs = HashSet::<(&str, &str)>::new();
             let mut pending_provider_calls = HashSet::<&str>::new();
             let mut pending_client_calls = HashSet::<&str>::new();
+            let mut pending_unkeyed_provider_calls = 0usize;
+            let mut pending_unkeyed_client_calls = 0usize;
             let mut loaded_at = HashMap::<String, usize>::new();
             let mut function_calls = Vec::<(usize, &str)>::new();
             for (index, item) in items.iter().enumerate() {
@@ -2199,13 +2234,23 @@ fn validate_group_order(
                             .get("call_id")
                             .and_then(Value::as_str)
                             .unwrap_or_default();
-                        if !seen_search_call_ids.insert(call_id) {
-                            return Err(ProviderTranscriptError::InvalidGroupOrder);
-                        }
-                        if execution == "server" {
-                            pending_provider_calls.insert(call_id);
+                        if call_id.is_empty() {
+                            if execution == "server" {
+                                pending_unkeyed_provider_calls =
+                                    pending_unkeyed_provider_calls.saturating_add(1);
+                            } else {
+                                pending_unkeyed_client_calls =
+                                    pending_unkeyed_client_calls.saturating_add(1);
+                            }
                         } else {
-                            pending_client_calls.insert(call_id);
+                            if !seen_search_call_ids.insert(call_id) {
+                                return Err(ProviderTranscriptError::InvalidGroupOrder);
+                            }
+                            if execution == "server" {
+                                pending_provider_calls.insert(call_id);
+                            } else {
+                                pending_client_calls.insert(call_id);
+                            }
                         }
                     }
                     ProviderTranscriptItemKind::OpenAiToolSearchOutput => {
@@ -2219,15 +2264,31 @@ fn validate_group_order(
                             .get("call_id")
                             .and_then(Value::as_str)
                             .unwrap_or_default();
-                        if !seen_search_outputs.insert((execution, call_id)) {
+                        if !call_id.is_empty() && !seen_search_outputs.insert((execution, call_id))
+                        {
                             return Err(ProviderTranscriptError::InvalidGroupOrder);
                         }
-                        let pending = if execution == "server" {
-                            &mut pending_provider_calls
+                        let matched_pending = if call_id.is_empty() {
+                            let pending = if execution == "server" {
+                                &mut pending_unkeyed_provider_calls
+                            } else {
+                                &mut pending_unkeyed_client_calls
+                            };
+                            if *pending == 0 {
+                                false
+                            } else {
+                                *pending = pending.saturating_sub(1);
+                                true
+                            }
                         } else {
-                            &mut pending_client_calls
+                            let pending = if execution == "server" {
+                                &mut pending_provider_calls
+                            } else {
+                                &mut pending_client_calls
+                            };
+                            pending.remove(call_id)
                         };
-                        if !pending.remove(call_id)
+                        if !matched_pending
                             && (execution == "server"
                                 || item.origin != ProviderTranscriptOrigin::HostToolSearch)
                         {
@@ -2252,7 +2313,7 @@ fn validate_group_order(
                     _ => {}
                 }
             }
-            if !pending_provider_calls.is_empty() {
+            if !pending_provider_calls.is_empty() || pending_unkeyed_provider_calls != 0 {
                 return Err(ProviderTranscriptError::InvalidGroupOrder);
             }
             let mut matched_loaded_call = false;
@@ -2662,6 +2723,80 @@ mod tests {
                 ProviderTranscriptItemKind::OpenAiToolSearchOutput,
                 ProviderTranscriptItemKind::OpenAiFunctionCall,
             ]
+        );
+    }
+
+    #[test]
+    fn openai_provider_output_preserves_official_nullable_fields() {
+        let payloads = [
+            (
+                ProviderTranscriptAuthor::Model,
+                json!({
+                    "type":"reasoning","id":"rs_nullable","summary":[],
+                    "agent":null,"content":null,"encrypted_content":null,"status":null
+                }),
+            ),
+            (
+                ProviderTranscriptAuthor::Model,
+                json!({
+                    "type":"message","id":"msg_nullable","role":"assistant",
+                    "status":"completed","agent":null,"phase":null,
+                    "content":[{
+                        "type":"output_text","text":"Searching",
+                        "annotations":[],"logprobs":null
+                    }]
+                }),
+            ),
+            (
+                ProviderTranscriptAuthor::Model,
+                json!({
+                    "type":"tool_search_call","id":"tsc_nullable","execution":"server",
+                    "call_id":null,"status":"completed","arguments":{"query":"orders"},
+                    "agent":null,"created_by":null
+                }),
+            ),
+            (
+                ProviderTranscriptAuthor::ToolResult,
+                json!({
+                    "type":"tool_search_output","id":"tso_nullable","execution":"server",
+                    "call_id":null,"status":"completed","agent":null,"created_by":null,
+                    "tools":[{"type":"function","name":"get_orders"}]
+                }),
+            ),
+            (
+                ProviderTranscriptAuthor::Model,
+                json!({
+                    "type":"function_call","id":null,"call_id":"call_nullable",
+                    "name":"get_orders","arguments":"{}","agent":null,"caller":null,
+                    "namespace":null,"status":null,"created_by":null
+                }),
+            ),
+        ];
+        let expected = payloads
+            .iter()
+            .map(|(_, payload)| payload.clone())
+            .collect::<Vec<_>>();
+        let items = payloads
+            .into_iter()
+            .map(|(author, payload)| {
+                ProviderTranscriptItem::try_from_payload(
+                    ProviderFamily::OpenAi,
+                    ProviderProtocol::OpenAiResponsesV1,
+                    ProviderTranscriptOrigin::Provider,
+                    author,
+                    payload,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        ProviderTranscriptGroup::validate_items(&items).unwrap();
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.payload().clone())
+                .collect::<Vec<_>>(),
+            expected
         );
     }
 
@@ -3333,6 +3468,38 @@ mod tests {
         ];
         assert!(test_group("openai-parallel", parallel).is_ok());
 
+        let unkeyed_parallel = vec![
+            hosted_item(
+                ProviderTranscriptAuthor::Model,
+                json!({
+                    "type":"tool_search_call","id":"tsc_unkeyed_1","execution":"server",
+                    "call_id":null,"status":"completed","arguments":{"query":"first"}
+                }),
+            ),
+            hosted_item(
+                ProviderTranscriptAuthor::Model,
+                json!({
+                    "type":"tool_search_call","id":"tsc_unkeyed_2","execution":"server",
+                    "status":"completed","arguments":{"query":"second"}
+                }),
+            ),
+            hosted_item(
+                ProviderTranscriptAuthor::ToolResult,
+                json!({
+                    "type":"tool_search_output","id":"tso_unkeyed_1","execution":"server",
+                    "call_id":null,"status":"completed","tools":[]
+                }),
+            ),
+            hosted_item(
+                ProviderTranscriptAuthor::ToolResult,
+                json!({
+                    "type":"tool_search_output","id":"tso_unkeyed_2","execution":"server",
+                    "status":"completed","tools":[]
+                }),
+            ),
+        ];
+        assert!(test_group("openai-unkeyed-parallel", unkeyed_parallel).is_ok());
+
         let mismatched_output = hosted_item(
             ProviderTranscriptAuthor::ToolResult,
             json!({
@@ -3380,25 +3547,41 @@ mod tests {
             .unwrap_err(),
             ProviderTranscriptError::InvalidGroupOrder
         );
-        for malformed in [
+        assert!(ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::Provider,
+            ProviderTranscriptAuthor::Model,
             json!({
                 "type":"tool_search_call","execution":"server","call_id":"search_missing_id",
                 "status":"completed","arguments":{}
             }),
-            json!({
-                "type":"tool_search_call","id":"tsc_missing_call","execution":"server",
-                "status":"completed","arguments":{}
-            }),
-        ] {
+        )
+        .is_err());
+        for call_id in [json!(""), json!(7)] {
             assert!(ProviderTranscriptItem::try_from_payload(
                 ProviderFamily::OpenAi,
                 ProviderProtocol::OpenAiResponsesV1,
                 ProviderTranscriptOrigin::Provider,
                 ProviderTranscriptAuthor::Model,
-                malformed,
+                json!({
+                    "type":"tool_search_call","id":"tsc_invalid_call","execution":"server",
+                    "call_id":call_id,"status":"completed","arguments":{}
+                }),
             )
             .is_err());
         }
+        ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::Provider,
+            ProviderTranscriptAuthor::Model,
+            json!({
+                "type":"tool_search_call","id":"tsc_missing_call","execution":"server",
+                "status":"completed","arguments":{}
+            }),
+        )
+        .expect("the official hosted output model permits an omitted call_id");
 
         // Client execution intentionally stops after the call. Its host output
         // is committed in a later input group and may therefore stand alone.

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -160,19 +160,21 @@ fn messages_to_responses_input_json_with_cache_and_native(
     let mut rendered_breakpoints = 0usize;
 
     for m in messages {
-        let mut anchored_groups = native_groups
-            .iter()
-            .filter(|group| group.anchor_message_id() == m.id)
-            .collect::<Vec<_>>();
-        anchored_groups.sort_by_key(|group| group.sequence());
-        if !anchored_groups.is_empty() {
-            out.extend(
-                anchored_groups
-                    .into_iter()
-                    .flat_map(|group| group.items())
-                    .map(|item| item.payload().clone()),
-            );
-            continue;
+        if m.role == Role::Assistant {
+            let mut anchored_groups = native_groups
+                .iter()
+                .filter(|group| group.anchor_message_id() == m.id)
+                .collect::<Vec<_>>();
+            anchored_groups.sort_by_key(|group| group.sequence());
+            if !anchored_groups.is_empty() {
+                out.extend(
+                    anchored_groups
+                        .into_iter()
+                        .flat_map(|group| group.items())
+                        .map(|item| item.payload().clone()),
+                );
+                continue;
+            }
         }
         match m.role {
             Role::Assistant => {
@@ -1321,9 +1323,19 @@ impl ResponsesSseParser {
                 );
                 return Vec::new();
             };
-            items.push(LLMChunk::ProviderTranscriptItem(item));
+            items.push(item);
+        }
+        if ProviderTranscriptGroup::validate_items(&items).is_err() {
+            tracing::warn!(
+                "{} Responses discovery transcript failed closed during atomic validation",
+                self.provider_label
+            );
+            return Vec::new();
         }
         items
+            .into_iter()
+            .map(LLMChunk::ProviderTranscriptItem)
+            .collect()
     }
 
     fn text_item_id(v: &Value) -> Option<String> {
@@ -2241,14 +2253,76 @@ mod tests {
         assert!(body.get("input").is_some());
     }
 
+    fn discovery_output_fixture() -> Value {
+        json!([
+            {
+                "type":"reasoning",
+                "id":"rs_1",
+                "status":"completed",
+                "summary":[{"type":"summary_text","text":"Search the order index"}],
+                "content":[{"type":"reasoning_text","text":"Use the loaded order tool"}],
+                "encrypted_content":"opaque-reasoning",
+                "agent":{"agent_name":"order-searcher"}
+            },
+            {
+                "type":"message",
+                "id":"msg_1",
+                "role":"assistant",
+                "phase":"commentary",
+                "status":"completed",
+                "agent":{"agent_name":"order-searcher"},
+                "content":[{
+                    "type":"output_text",
+                    "text":"Searching",
+                    "annotations":[],
+                    "logprobs":[]
+                }]
+            },
+            {
+                "type":"tool_search_call",
+                "id":"tsc_1",
+                "execution":"server",
+                "call_id":"search_1",
+                "status":"completed",
+                "arguments":{"query":"orders"},
+                "agent":{"agent_name":"order-searcher"},
+                "created_by":"openai"
+            },
+            {
+                "type":"tool_search_output",
+                "id":"tso_1",
+                "execution":"server",
+                "call_id":"search_1",
+                "status":"completed",
+                "tools":[{
+                    "type":"function",
+                    "name":"get_orders",
+                    "description":"Fetch matching orders",
+                    "parameters":{"type":"object","properties":{}},
+                    "strict":true,
+                    "allowed_callers":["direct"],
+                    "defer_loading":true,
+                    "output_schema":{"type":"object"}
+                }],
+                "agent":{"agent_name":"order-searcher"},
+                "created_by":"openai"
+            },
+            {
+                "type":"function_call",
+                "id":"fc_1",
+                "call_id":"call_1",
+                "name":"get_orders",
+                "arguments":"{}",
+                "status":"completed",
+                "agent":{"agent_name":"order-searcher"},
+                "caller":{"type":"direct"}
+            }
+        ])
+    }
+
     #[test]
     fn discovery_output_is_captured_and_replayed_at_its_message_anchor() {
-        let output = json!([
-            {"type":"message","id":"msg_1","role":"assistant","phase":"commentary","status":"completed","content":[{"type":"output_text","text":"Searching"}]},
-            {"type":"tool_search_call","execution":"server","call_id":null,"status":"completed","arguments":{"query":"orders"}},
-            {"type":"tool_search_output","execution":"server","call_id":null,"status":"completed","tools":[{"type":"function","name":"get_orders"}]},
-            {"type":"function_call","call_id":"call_1","name":"get_orders","arguments":"{}"}
-        ]);
+        let output = discovery_output_fixture();
         let mut parser = ResponsesSseParser::new_with_context("OpenAI", "gpt-5.6", None);
         let chunks = parser
             .handle_event_multi(
@@ -2263,20 +2337,41 @@ mod tests {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        assert_eq!(items.len(), 4);
-        assert_eq!(items[0].payload()["phase"], "commentary");
+        assert_eq!(items.len(), 5);
+        assert_eq!(
+            items
+                .iter()
+                .find(|item| item.payload()["type"] == "message")
+                .unwrap()
+                .payload()["phase"],
+            "commentary"
+        );
 
         let mut session = bamboo_domain::Session::new("native-openai", "gpt-5.6");
         session.add_message(Message::user("find orders"));
         let assistant = Message::assistant("normalized", None);
         let anchor = assistant.id.clone();
         session.add_message(assistant);
+        let provider_boundary =
+            bamboo_domain::provider_transcript_boundary_sha256(Some("openai-test"), Some("openai"))
+                .unwrap();
+        session
+            .activate_provider_transcript_route(
+                ProviderFamily::OpenAi,
+                ProviderProtocol::OpenAiResponsesV1,
+                &provider_boundary,
+            )
+            .unwrap();
         session
             .append_provider_transcript_group(&anchor, None, items)
             .unwrap();
         let groups = session
             .provider_transcript
-            .replayable_groups(ProviderFamily::OpenAi, ProviderProtocol::OpenAiResponsesV1)
+            .replayable_groups(
+                ProviderFamily::OpenAi,
+                ProviderProtocol::OpenAiResponsesV1,
+                &provider_boundary,
+            )
             .into_iter()
             .cloned()
             .collect::<Vec<_>>();
@@ -2289,20 +2384,204 @@ mod tests {
     }
 
     #[test]
+    fn discovery_output_preserves_official_nullable_fields_exactly() {
+        let mut output = discovery_output_fixture();
+        let items = output.as_array_mut().unwrap();
+        items[0]["agent"] = Value::Null;
+        items[0]["content"] = Value::Null;
+        items[0]["encrypted_content"] = Value::Null;
+        items[0]["status"] = Value::Null;
+        items[1]["agent"] = Value::Null;
+        items[1]["phase"] = Value::Null;
+        items[1]["content"][0]["logprobs"] = Value::Null;
+        items[2]["agent"] = Value::Null;
+        items[2]["call_id"] = Value::Null;
+        items[2]["created_by"] = Value::Null;
+        items[3]["agent"] = Value::Null;
+        items[3]["call_id"] = Value::Null;
+        items[3]["created_by"] = Value::Null;
+        items[4]["id"] = Value::Null;
+        items[4]["agent"] = Value::Null;
+        items[4]["caller"] = Value::Null;
+        items[4]["namespace"] = Value::Null;
+        items[4]["status"] = Value::Null;
+        items[4]["created_by"] = Value::Null;
+
+        let mut parser = ResponsesSseParser::new_with_context("OpenAI", "gpt-5.6", None);
+        let captured = parser
+            .handle_event_multi(
+                "response.completed",
+                &json!({"type":"response.completed","response":{"output":output}}).to_string(),
+            )
+            .unwrap()
+            .into_iter()
+            .filter_map(|chunk| match chunk {
+                LLMChunk::ProviderTranscriptItem(item) => Some(item.payload().clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(captured, output.as_array().unwrap().clone());
+    }
+
+    fn assert_discovery_output_falls_back(output: Value) {
+        let mut parser = ResponsesSseParser::new_with_context("OpenAI", "gpt-5.6", None);
+        let chunks = parser
+            .handle_event_multi(
+                "response.completed",
+                &json!({"type":"response.completed","response":{"output":output}}).to_string(),
+            )
+            .unwrap();
+
+        assert!(!chunks
+            .iter()
+            .any(|chunk| matches!(chunk, LLMChunk::ProviderTranscriptItem(_))));
+        assert!(chunks
+            .iter()
+            .any(|chunk| matches!(chunk, LLMChunk::Token(text) if text == "Searching")));
+        assert!(chunks
+            .iter()
+            .any(|chunk| matches!(chunk, LLMChunk::ToolCalls(calls) if !calls.is_empty())));
+        assert!(chunks.iter().any(|chunk| matches!(chunk, LLMChunk::Done)));
+    }
+
+    #[test]
+    fn malformed_discovery_chains_fail_closed_to_normalized_chunks_atomically() {
+        let mut unknown_item = discovery_output_fixture();
+        unknown_item.as_array_mut().unwrap().push(json!({
+            "type":"future_provider_item",
+            "id":"future_1"
+        }));
+
+        let mut malformed_item = discovery_output_fixture();
+        malformed_item[1]["content"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("annotations");
+
+        let mut output_before_call = discovery_output_fixture();
+        output_before_call.as_array_mut().unwrap().swap(2, 3);
+
+        let mut mismatched_call_id = discovery_output_fixture();
+        mismatched_call_id[3]["call_id"] = json!("search_other");
+
+        let mut duplicate_item_id = discovery_output_fixture();
+        duplicate_item_id[3]["id"] = json!("tsc_1");
+
+        let mut duplicate_search_call_id = discovery_output_fixture();
+        let mut second_call = duplicate_search_call_id[2].clone();
+        second_call["id"] = json!("tsc_2");
+        duplicate_search_call_id
+            .as_array_mut()
+            .unwrap()
+            .insert(3, second_call);
+
+        let mut function_before_output = discovery_output_fixture();
+        function_before_output.as_array_mut().unwrap().swap(3, 4);
+
+        let mut function_not_loaded = discovery_output_fixture();
+        function_not_loaded[3]["tools"][0]["name"] = json!("different_tool");
+
+        for malformed in [
+            unknown_item,
+            malformed_item,
+            output_before_call,
+            mismatched_call_id,
+            duplicate_item_id,
+            duplicate_search_call_id,
+            function_before_output,
+            function_not_loaded,
+        ] {
+            assert_discovery_output_falls_back(malformed);
+        }
+    }
+
+    #[test]
+    fn native_groups_never_replace_non_assistant_anchors() {
+        let item = ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::Provider,
+            ProviderTranscriptAuthor::Model,
+            json!({
+                "type":"tool_search_call","id":"tsc_wrong_anchor","execution":"client",
+                "call_id":"search_wrong_anchor","status":"completed","arguments":{}
+            }),
+        )
+        .unwrap();
+        let provider_boundary =
+            bamboo_domain::provider_transcript_boundary_sha256(Some("openai-test"), Some("openai"))
+                .unwrap();
+
+        for message in [
+            Message::system("stable system"),
+            Message::user("important user input"),
+            Message::tool_result("call_1", "important tool output"),
+        ] {
+            let mut session = bamboo_domain::Session::new("wrong-anchor", "gpt-5.6");
+            let anchor = message.id.clone();
+            session.add_message(message);
+            session
+                .activate_provider_transcript_route(
+                    ProviderFamily::OpenAi,
+                    ProviderProtocol::OpenAiResponsesV1,
+                    &provider_boundary,
+                )
+                .unwrap();
+            session
+                .append_provider_transcript_group(&anchor, None, vec![item.clone()])
+                .unwrap();
+
+            let (expected, _) = messages_to_responses_input_json_with_cache_and_native(
+                &session.messages,
+                None,
+                &[],
+            );
+            let (actual, _) = messages_to_responses_input_json_with_cache_and_native(
+                &session.messages,
+                None,
+                session.provider_transcript.groups(),
+            );
+            assert_eq!(actual, expected);
+            assert!(!actual
+                .iter()
+                .any(|item| item.get("id") == Some(&json!("tsc_wrong_anchor"))));
+        }
+    }
+
+    #[test]
     fn shared_responses_wire_keeps_openai_and_copilot_native_state_isolated() {
         let group = |family| {
             let mut session = bamboo_domain::Session::new("native", "model");
             let assistant = Message::assistant("", None);
             let anchor = assistant.id.clone();
             session.add_message(assistant);
+            let (provider_name, provider_type) = match family {
+                ProviderFamily::OpenAi => ("openai-test", "openai"),
+                ProviderFamily::Copilot => ("copilot-test", "copilot"),
+                _ => unreachable!("test only constructs Responses families"),
+            };
+            let provider_boundary = bamboo_domain::provider_transcript_boundary_sha256(
+                Some(provider_name),
+                Some(provider_type),
+            )
+            .unwrap();
+            session
+                .activate_provider_transcript_route(
+                    family,
+                    ProviderProtocol::OpenAiResponsesV1,
+                    &provider_boundary,
+                )
+                .unwrap();
             let item = ProviderTranscriptItem::try_from_payload(
                 family,
                 ProviderProtocol::OpenAiResponsesV1,
                 ProviderTranscriptOrigin::Provider,
                 ProviderTranscriptAuthor::Model,
                 json!({
-                    "type":"tool_search_call","execution":"client","call_id":"search_isolation",
-                    "status":"completed","arguments":{"query":"weather"}
+                    "type":"tool_search_call","id":"tsc_isolation","execution":"client",
+                    "call_id":"search_isolation","status":"completed",
+                    "arguments":{"query":"weather"}
                 }),
             )
             .unwrap();
@@ -2311,11 +2590,12 @@ mod tests {
                 .unwrap();
             session.provider_transcript.groups()[0].clone()
         };
+        let groups = vec![
+            group(ProviderFamily::OpenAi),
+            group(ProviderFamily::Copilot),
+        ];
         let mut options = ResponsesRequestOptions {
-            provider_transcript_groups: vec![
-                group(ProviderFamily::OpenAi),
-                group(ProviderFamily::Copilot),
-            ],
+            provider_transcript_groups: groups.clone(),
             ..Default::default()
         };
 
@@ -2325,6 +2605,44 @@ mod tests {
             options.provider_transcript_groups[0].family(),
             ProviderFamily::OpenAi
         );
+
+        let mut options = ResponsesRequestOptions {
+            provider_transcript_groups: groups,
+            ..Default::default()
+        };
+        retain_provider_transcript_family(&mut options, ProviderFamily::Copilot);
+        assert_eq!(options.provider_transcript_groups.len(), 1);
+        assert_eq!(
+            options.provider_transcript_groups[0].family(),
+            ProviderFamily::Copilot
+        );
+    }
+
+    #[test]
+    fn discovery_capture_uses_the_concrete_responses_provider_family() {
+        for (provider_label, expected_family) in [
+            ("OpenAI", ProviderFamily::OpenAi),
+            ("Copilot", ProviderFamily::Copilot),
+        ] {
+            let output = discovery_output_fixture();
+            let mut parser =
+                ResponsesSseParser::new_with_context(provider_label, "provider-model", None);
+            let items = parser
+                .handle_event_multi(
+                    "response.completed",
+                    &json!({"type":"response.completed","response":{"output":output}}).to_string(),
+                )
+                .unwrap()
+                .into_iter()
+                .filter_map(|chunk| match chunk {
+                    LLMChunk::ProviderTranscriptItem(item) => Some(item),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(items.len(), 5);
+            assert!(items.iter().all(|item| item.family() == expected_family));
+        }
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -11,7 +11,10 @@ use crate::types::LLMChunk;
 use bamboo_domain::MessagePart;
 use bamboo_domain::ReasoningEffort;
 use bamboo_domain::ToolSchema;
-use bamboo_domain::{Message, MessagePhase, Role};
+use bamboo_domain::{
+    Message, MessagePhase, ProviderFamily, ProviderProtocol, ProviderTranscriptAuthor,
+    ProviderTranscriptGroup, ProviderTranscriptItem, ProviderTranscriptOrigin, Role,
+};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -134,6 +137,14 @@ fn messages_to_responses_input_json_with_cache(
     messages: &[Message],
     cache_plan: Option<&PromptCachePlan>,
 ) -> (Vec<Value>, usize) {
+    messages_to_responses_input_json_with_cache_and_native(messages, cache_plan, &[])
+}
+
+fn messages_to_responses_input_json_with_cache_and_native(
+    messages: &[Message],
+    cache_plan: Option<&PromptCachePlan>,
+    native_groups: &[ProviderTranscriptGroup],
+) -> (Vec<Value>, usize) {
     // If any message contains image parts, emit a "typed" content array shape so
     // multimodal inputs have a chance to reach upstream Responses implementations.
     let has_images = messages.iter().any(|m| {
@@ -149,6 +160,20 @@ fn messages_to_responses_input_json_with_cache(
     let mut rendered_breakpoints = 0usize;
 
     for m in messages {
+        let mut anchored_groups = native_groups
+            .iter()
+            .filter(|group| group.anchor_message_id() == m.id)
+            .collect::<Vec<_>>();
+        anchored_groups.sort_by_key(|group| group.sequence());
+        if !anchored_groups.is_empty() {
+            out.extend(
+                anchored_groups
+                    .into_iter()
+                    .flat_map(|group| group.items())
+                    .map(|item| item.payload().clone()),
+            );
+            continue;
+        }
         match m.role {
             Role::Assistant => {
                 // Emit assistant text content as a message item (even if empty, for completeness).
@@ -436,6 +461,18 @@ pub fn select_responses_input_messages<'a>(
     }
 }
 
+/// Apply the final provider-family boundary before a shared Responses request
+/// is lowered. OpenAI and Copilot use the same wire protocol but must never
+/// share native loading/cache state.
+pub fn retain_provider_transcript_family(
+    options: &mut ResponsesRequestOptions,
+    family: ProviderFamily,
+) {
+    options.provider_transcript_groups.retain(|group| {
+        group.family() == family && group.protocol() == ProviderProtocol::OpenAiResponsesV1
+    });
+}
+
 /// Build a standard Responses API streaming request body.
 #[allow(clippy::too_many_arguments)]
 pub fn build_responses_body(
@@ -461,20 +498,25 @@ pub fn build_responses_body(
             responses_options.and_then(|options| options.raw_input_with_cache_breakpoints.as_ref())
         })
         .flatten();
-    let (input, rendered_breakpoints, generated_breakpoints) =
-        if let Some(raw_input) = caller_cache_input {
-            (
-                raw_input.clone(),
-                count_responses_explicit_breakpoints(raw_input),
-                false,
-            )
-        } else {
-            let (input, rendered_breakpoints) = messages_to_responses_input_json_with_cache(
-                effective_messages,
-                explicit_cache_supported.then_some(cache_plan).flatten(),
-            );
-            (Value::Array(input), rendered_breakpoints, true)
-        };
+    let (input, rendered_breakpoints, generated_breakpoints) = if let Some(raw_input) =
+        caller_cache_input
+    {
+        (
+            raw_input.clone(),
+            count_responses_explicit_breakpoints(raw_input),
+            false,
+        )
+    } else {
+        let native_groups = responses_options
+            .map(|options| options.provider_transcript_groups.as_slice())
+            .unwrap_or_default();
+        let (input, rendered_breakpoints) = messages_to_responses_input_json_with_cache_and_native(
+            effective_messages,
+            explicit_cache_supported.then_some(cache_plan).flatten(),
+            native_groups,
+        );
+        (Value::Array(input), rendered_breakpoints, true)
+    };
     let mut body = json!({
         "model": model,
         "input": input,
@@ -1232,6 +1274,56 @@ impl ResponsesSseParser {
             }
         }
         chunks
+    }
+
+    fn completed_provider_transcript_items(&self, value: &Value) -> Vec<LLMChunk> {
+        let Some(output) = value
+            .get("response")
+            .and_then(|response| response.get("output"))
+            .or_else(|| value.get("output"))
+            .and_then(Value::as_array)
+        else {
+            return Vec::new();
+        };
+        if !output.iter().any(|item| {
+            matches!(
+                item.get("type").and_then(Value::as_str),
+                Some("tool_search_call" | "tool_search_output")
+            )
+        }) {
+            return Vec::new();
+        }
+
+        let family = if self.provider_label.eq_ignore_ascii_case("copilot") {
+            ProviderFamily::Copilot
+        } else {
+            ProviderFamily::OpenAi
+        };
+        let mut items = Vec::with_capacity(output.len());
+        for payload in output {
+            let author = match payload.get("type").and_then(Value::as_str) {
+                Some("tool_search_output") => ProviderTranscriptAuthor::ToolResult,
+                Some("message" | "reasoning" | "function_call" | "tool_search_call") => {
+                    ProviderTranscriptAuthor::Model
+                }
+                _ => return Vec::new(),
+            };
+            let Ok(item) = ProviderTranscriptItem::try_from_payload(
+                family,
+                ProviderProtocol::OpenAiResponsesV1,
+                ProviderTranscriptOrigin::Provider,
+                author,
+                payload.clone(),
+            ) else {
+                tracing::warn!(
+                    "{} Responses discovery transcript failed closed during validation",
+                    self.provider_label
+                );
+                return Vec::new();
+            };
+            items.push(LLMChunk::ProviderTranscriptItem(item));
+        }
+        items
     }
 
     fn text_item_id(v: &Value) -> Option<String> {
@@ -2090,6 +2182,7 @@ impl ResponsesSseParser {
 
         if event_type == "response.completed" {
             self.terminal_seen = true;
+            chunks.extend(self.completed_provider_transcript_items(&v));
             chunks.extend(self.completed_output_chunks(&v));
             let usage = v
                 .get("response")
@@ -2146,6 +2239,92 @@ mod tests {
         assert_eq!(body["max_output_tokens"], 123);
         assert_eq!(body["store"], false);
         assert!(body.get("input").is_some());
+    }
+
+    #[test]
+    fn discovery_output_is_captured_and_replayed_at_its_message_anchor() {
+        let output = json!([
+            {"type":"message","id":"msg_1","role":"assistant","phase":"commentary","status":"completed","content":[{"type":"output_text","text":"Searching"}]},
+            {"type":"tool_search_call","execution":"server","call_id":null,"status":"completed","arguments":{"query":"orders"}},
+            {"type":"tool_search_output","execution":"server","call_id":null,"status":"completed","tools":[{"type":"function","name":"get_orders"}]},
+            {"type":"function_call","call_id":"call_1","name":"get_orders","arguments":"{}"}
+        ]);
+        let mut parser = ResponsesSseParser::new_with_context("OpenAI", "gpt-5.6", None);
+        let chunks = parser
+            .handle_event_multi(
+                "response.completed",
+                &json!({"type":"response.completed","response":{"output":output}}).to_string(),
+            )
+            .unwrap();
+        let items = chunks
+            .into_iter()
+            .filter_map(|chunk| match chunk {
+                LLMChunk::ProviderTranscriptItem(item) => Some(item),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(items.len(), 4);
+        assert_eq!(items[0].payload()["phase"], "commentary");
+
+        let mut session = bamboo_domain::Session::new("native-openai", "gpt-5.6");
+        session.add_message(Message::user("find orders"));
+        let assistant = Message::assistant("normalized", None);
+        let anchor = assistant.id.clone();
+        session.add_message(assistant);
+        session
+            .append_provider_transcript_group(&anchor, None, items)
+            .unwrap();
+        let groups = session
+            .provider_transcript
+            .replayable_groups(ProviderFamily::OpenAi, ProviderProtocol::OpenAiResponsesV1)
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let (input, _) = messages_to_responses_input_json_with_cache_and_native(
+            &session.messages,
+            None,
+            &groups,
+        );
+        assert_eq!(input[1..], output.as_array().unwrap()[..]);
+    }
+
+    #[test]
+    fn shared_responses_wire_keeps_openai_and_copilot_native_state_isolated() {
+        let group = |family| {
+            let mut session = bamboo_domain::Session::new("native", "model");
+            let assistant = Message::assistant("", None);
+            let anchor = assistant.id.clone();
+            session.add_message(assistant);
+            let item = ProviderTranscriptItem::try_from_payload(
+                family,
+                ProviderProtocol::OpenAiResponsesV1,
+                ProviderTranscriptOrigin::Provider,
+                ProviderTranscriptAuthor::Model,
+                json!({
+                    "type":"tool_search_call","execution":"server","call_id":null,
+                    "status":"completed","arguments":{"query":"weather"}
+                }),
+            )
+            .unwrap();
+            session
+                .append_provider_transcript_group(&anchor, None, vec![item])
+                .unwrap();
+            session.provider_transcript.groups()[0].clone()
+        };
+        let mut options = ResponsesRequestOptions {
+            provider_transcript_groups: vec![
+                group(ProviderFamily::OpenAi),
+                group(ProviderFamily::Copilot),
+            ],
+            ..Default::default()
+        };
+
+        retain_provider_transcript_family(&mut options, ProviderFamily::OpenAi);
+        assert_eq!(options.provider_transcript_groups.len(), 1);
+        assert_eq!(
+            options.provider_transcript_groups[0].family(),
+            ProviderFamily::OpenAi
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -2301,7 +2301,7 @@ mod tests {
                 ProviderTranscriptOrigin::Provider,
                 ProviderTranscriptAuthor::Model,
                 json!({
-                    "type":"tool_search_call","execution":"server","call_id":null,
+                    "type":"tool_search_call","execution":"client","call_id":"search_isolation",
                     "status":"completed","arguments":{"query":"weather"}
                 }),
             )

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -2320,6 +2320,19 @@ mod tests {
         ])
     }
 
+    fn client_discovery_output_fixture(call_id: Option<Value>) -> Value {
+        let mut output = discovery_output_fixture();
+        output.as_array_mut().unwrap().truncate(3);
+        output[2]["execution"] = json!("client");
+        match call_id {
+            Some(call_id) => output[2]["call_id"] = call_id,
+            None => {
+                output[2].as_object_mut().unwrap().remove("call_id");
+            }
+        }
+        output
+    }
+
     #[test]
     fn discovery_output_is_captured_and_replayed_at_its_message_anchor() {
         let output = discovery_output_fixture();
@@ -2424,7 +2437,36 @@ mod tests {
         assert_eq!(captured, output.as_array().unwrap().clone());
     }
 
+    #[test]
+    fn client_discovery_call_with_matching_id_stops_as_a_replayable_group() {
+        let output = client_discovery_output_fixture(Some(json!("search_client_1")));
+        let mut parser = ResponsesSseParser::new_with_context("OpenAI", "gpt-5.6", None);
+        let items = parser
+            .handle_event_multi(
+                "response.completed",
+                &json!({"type":"response.completed","response":{"output":output}}).to_string(),
+            )
+            .unwrap()
+            .into_iter()
+            .filter_map(|chunk| match chunk {
+                LLMChunk::ProviderTranscriptItem(item) => Some(item),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 3);
+        assert_eq!(items.last().unwrap().payload()["type"], "tool_search_call");
+        assert_eq!(
+            items.last().unwrap().payload()["call_id"],
+            "search_client_1"
+        );
+        ProviderTranscriptGroup::validate_items(&items).unwrap();
+    }
+
     fn assert_discovery_output_falls_back(output: Value) {
+        let expects_tool_call = output
+            .as_array()
+            .is_some_and(|items| items.iter().any(|item| item["type"] == "function_call"));
         let mut parser = ResponsesSseParser::new_with_context("OpenAI", "gpt-5.6", None);
         let chunks = parser
             .handle_event_multi(
@@ -2439,10 +2481,27 @@ mod tests {
         assert!(chunks
             .iter()
             .any(|chunk| matches!(chunk, LLMChunk::Token(text) if text == "Searching")));
-        assert!(chunks
-            .iter()
-            .any(|chunk| matches!(chunk, LLMChunk::ToolCalls(calls) if !calls.is_empty())));
+        if expects_tool_call {
+            assert!(chunks
+                .iter()
+                .any(|chunk| matches!(chunk, LLMChunk::ToolCalls(calls) if !calls.is_empty())));
+        }
         assert!(chunks.iter().any(|chunk| matches!(chunk, LLMChunk::Done)));
+    }
+
+    #[test]
+    fn malformed_client_discovery_stops_fail_closed_to_normalized_chunks() {
+        for call_id in [None, Some(Value::Null), Some(json!("")), Some(json!(7))] {
+            assert_discovery_output_falls_back(client_discovery_output_fixture(call_id));
+        }
+
+        let mut premature_function =
+            client_discovery_output_fixture(Some(json!("search_client_1")));
+        premature_function
+            .as_array_mut()
+            .unwrap()
+            .push(discovery_output_fixture()[4].clone());
+        assert_discovery_output_falls_back(premature_function);
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -2502,6 +2502,15 @@ mod tests {
             .unwrap()
             .push(discovery_output_fixture()[4].clone());
         assert_discovery_output_falls_back(premature_function);
+
+        let mut function_before_client =
+            client_discovery_output_fixture(Some(json!("search_client_1")));
+        let client_call_index = function_before_client.as_array().unwrap().len() - 1;
+        function_before_client
+            .as_array_mut()
+            .unwrap()
+            .insert(client_call_index, discovery_output_fixture()[4].clone());
+        assert_discovery_output_falls_back(function_before_client);
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
@@ -24,7 +24,8 @@ use super::common::openai_compat::{
     tools_to_openai_compat_json,
 };
 use super::common::openai_responses::{
-    build_responses_body, select_responses_input_messages, ResponsesInputSource, ResponsesSseParser,
+    build_responses_body, retain_provider_transcript_family, select_responses_input_messages,
+    ResponsesInputSource, ResponsesSseParser,
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
@@ -594,6 +595,10 @@ impl CopilotProvider {
         effective_responses_options.prompt_cache_key = None;
         effective_responses_options.prompt_cache_options = None;
         effective_responses_options.raw_input_with_cache_breakpoints = None;
+        retain_provider_transcript_family(
+            &mut effective_responses_options,
+            bamboo_domain::ProviderFamily::Copilot,
+        );
         let input_selection =
             select_responses_input_messages(messages, Some(&effective_responses_options));
         let input_source = match input_selection.source {

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -26,8 +26,8 @@ use super::common::openai_compat::{
     parse_openai_compat_sse_data_strict_multi,
 };
 use super::common::openai_responses::{
-    build_responses_body, select_responses_input_messages, ResponsesInputSource,
-    ResponsesSseParser, ResponsesWirePrefixTracker,
+    build_responses_body, retain_provider_transcript_family, select_responses_input_messages,
+    ResponsesInputSource, ResponsesSseParser, ResponsesWirePrefixTracker,
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
@@ -225,6 +225,11 @@ impl OpenAIProvider {
         request_purpose: &str,
         session_log_id: &str,
     ) -> Result<LLMStream> {
+        let mut effective_responses_options = responses_options.cloned();
+        if let Some(options) = effective_responses_options.as_mut() {
+            retain_provider_transcript_family(options, bamboo_domain::ProviderFamily::OpenAi);
+        }
+        let responses_options = effective_responses_options.as_ref();
         let retain_protocol_events =
             responses_options.is_some_and(|options| options.retain_protocol_events);
         let input_selection = select_responses_input_messages(messages, responses_options);


### PR DESCRIPTION
## Summary

- capture validated OpenAI Responses and Copilot hosted discovery output in exact provider order
- replay reasoning, assistant message, tool_search_call, tool_search_output, and function_call items only at their stable assistant anchor
- validate each complete native batch atomically before emitting stream sideband, so malformed chains retain normalized text and tool-call fallback
- preserve official nullable server/provider fields while requiring a nonempty correlation ID for client-executed search continuation
- enforce client discovery as an order-independent suspension boundary: a provider client tool_search_call cannot coexist with a function_call or client tool_search_output
- isolate OpenAI and Copilot families at their provider entry points while retaining the provider-instance boundary selected by the engine

## Scope

This PR is rebased directly onto dev after #967 merged. It changes four files: the shared OpenAI Responses adapter, the OpenAI and Copilot entry points, and the shared provider transcript validator required for exact hosted-output admission.

It does not serialize tool-search requests, execute client search, add defer-loading policy, rank capabilities, change the visible tool set, or modify UI behavior. Client search execution and host output orchestration remain in #969.

## Safety and fallback

- complete discovery groups are checked by the same domain validator used for durable persistence before any ProviderTranscriptItem chunk is emitted
- unknown items, malformed shapes, output-before-call, mismatched call IDs, duplicate IDs, premature function calls, and calls to unloaded names all fall back atomically to normalized chunks
- client search calls require a nonempty call_id and cannot share a group with function execution or client output in either ordering
- standalone HostToolSearch client output remains the valid later continuation shape
- native groups can replace only assistant anchors; user, system, and tool messages are preserved
- diagnostics never include provider payloads, tool schemas, arguments, or raw provider route names

## Test Plan

Validated locally on exact head 37efdd5744733f2c02de8cb8f4fbeddab25e1eac:

- cargo fmt --all -- --check
- git diff --check origin/dev...HEAD
- cargo test -p bamboo-domain provider_transcript --lib --quiet: 23 passed
- cargo test -p bamboo-domain --lib --quiet: 227 passed
- cargo test -p bamboo-llm --lib --quiet: 592 passed
- four focused bamboo-engine native persistence/replay/UI regressions: 4 passed
- cargo check --locked --workspace --all-targets --all-features
- repository CI exact Clippy command with all features and denied warnings

The prior head completed the full local all-features CI test command with every non-ignored test passing. This exact head changes only the client continuation admission invariant and its focused fixtures; fresh GitHub checks remain merge gates.

Closes #976
