### PR TITLE
[bamboo-domain] refactor: define typed capability loading policy

### DIFF
--- a/crates/app/bamboo-server/src/app_state/tests.rs
+++ b/crates/app/bamboo-server/src/app_state/tests.rs
@@ -242,37 +242,37 @@ async fn root_tools_include_server_overlays_and_session_note() {
 }
 
 #[tokio::test]
-async fn default_first_round_tool_surface_is_smaller_than_full_root_tool_catalog() {
+async fn root_catalog_classifies_exactly_five_callable_core_functions() {
     let temp_dir = tempfile::tempdir().unwrap();
     let state = AppState::new(temp_dir.path().to_path_buf())
         .await
         .expect("app state should initialize");
 
     let full = state.get_all_tool_schemas();
-    let visible: Vec<_> = full
+    let core_names = full
         .iter()
-        .filter(|schema| bamboo_tools::exposure::is_core_tool(&schema.function.name))
-        .collect();
-    let visible_names: std::collections::HashSet<&str> = visible
-        .iter()
-        .map(|schema| schema.function.name.as_str())
-        .collect();
-    eprintln!(
-        "tool_surface_metrics: full={}, visible={}, hidden={}",
-        full.len(),
-        visible.len(),
-        full.len().saturating_sub(visible.len())
-    );
+        .filter_map(|schema| {
+            bamboo_domain::ClassifiedToolIdentity::from_schema_name(&schema.function.name)
+        })
+        .filter(|identity| identity.loading_class() == bamboo_domain::CapabilityLoadingClass::Core)
+        .map(|identity| identity.execution_name().to_string())
+        .collect::<std::collections::BTreeSet<_>>();
 
-    assert!(
-        visible.len() < full.len(),
-        "expected reduced first-round surface: visible={}, full={}",
-        visible.len(),
-        full.len()
+    assert_eq!(
+        core_names,
+        std::collections::BTreeSet::from([
+            "Bash".to_string(),
+            "Edit".to_string(),
+            "Grep".to_string(),
+            "Read".to_string(),
+            "Write".to_string(),
+        ])
     );
-    assert!(!visible_names.contains("scheduler"));
-    assert!(!visible_names.contains("sub_session_manager"));
-    assert!(!visible_names.contains("session_history"));
+    assert_eq!(
+        bamboo_domain::DISCOVERY_CONTROL_GATEWAY.logical_name(),
+        "discover"
+    );
+    assert!(bamboo_domain::DISCOVERY_CONTROL_GATEWAY.is_initially_visible());
 }
 
 #[tokio::test]

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -101,8 +101,10 @@ pub async fn handle_execute(
         }
     };
 
-    let disabled_tools_vec: Vec<String> =
-        config_snapshot.disabled_tool_names().into_iter().collect();
+    let disabled_tools_vec: Vec<String> = config_snapshot
+        .disabled_tool_references()
+        .into_iter()
+        .collect();
     let disabled_skill_ids_vec: Vec<String> =
         config_snapshot.disabled_skill_ids().into_iter().collect();
     let explicit_provider = req

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
@@ -145,7 +145,10 @@ pub(crate) fn make_disabled_filter_resolver(
     Arc::new(move || {
         let config_snapshot = read_config_snapshot(&config, cached_config.as_ref());
         (
-            config_snapshot.disabled_tool_names().into_iter().collect(),
+            config_snapshot
+                .disabled_tool_references()
+                .into_iter()
+                .collect(),
             config_snapshot.disabled_skill_ids().into_iter().collect(),
         )
     })

--- a/crates/core/bamboo-domain/src/capability_loading.rs
+++ b/crates/core/bamboo-domain/src/capability_loading.rs
@@ -1,0 +1,543 @@
+//! Provider-neutral capability loading policy and classified tool catalogs.
+//!
+//! Provider adapters lower these logical classes to their own wire protocols.
+//! The schema itself deliberately stays free of Anthropic/OpenAI fields.
+
+use crate::{canonical_tool_name, ToolSchema, DISCOVER_CAPABILITY_NAME};
+
+/// The loading class of a callable function schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CapabilityLoadingClass {
+    /// Always present in the initial callable function set.
+    Core,
+    /// Eligible for discovery/loading; legacy providers may still receive it.
+    Deferred,
+    /// Retained for host compatibility but never advertised to a model.
+    HostOnly,
+}
+
+/// The complete and intentionally small always-resident function surface.
+pub const CORE_TOOL_NAMES: [&str; 5] = ["Bash", "Read", "Grep", "Edit", "Write"];
+
+/// Host protocol helpers that must not enter model catalogs or discovery.
+pub const HOST_ONLY_TOOL_NAMES: [&str; 3] = [
+    "Workspace",
+    "conclusion_with_options",
+    "request_permissions",
+];
+
+/// Examples whose deferred status is part of the public migration contract.
+pub const EXPLICIT_DEFERRED_TOOL_NAMES: [&str; 5] = [
+    "Glob",
+    "GetFileInfo",
+    "load_skill",
+    "workflow_run",
+    "update_goal",
+];
+
+/// Reserved provider-safe function name used only by Bamboo's compatibility
+/// fallback adapter. Native provider search items map to the logical gateway
+/// directly and do not use this function identity.
+pub const DISCOVERY_CONTROL_FALLBACK_TOOL_NAME: &str = "discover_capabilities";
+
+/// Trusted marker for Bamboo's separate, always-resident discovery gateway.
+///
+/// It is intentionally not constructed from a function schema or inferred by
+/// name: a custom function called `discover` must remain ordinary Deferred
+/// input and must not gain control-plane privileges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DiscoveryControlGateway {
+    _private: (),
+}
+
+impl DiscoveryControlGateway {
+    pub const fn logical_name(self) -> &'static str {
+        DISCOVER_CAPABILITY_NAME
+    }
+
+    pub const fn fallback_tool_name(self) -> &'static str {
+        DISCOVERY_CONTROL_FALLBACK_TOOL_NAME
+    }
+
+    pub const fn is_initially_visible(self) -> bool {
+        true
+    }
+}
+
+pub const DISCOVERY_CONTROL_GATEWAY: DiscoveryControlGateway =
+    DiscoveryControlGateway { _private: () };
+
+/// Classify a host/model reference after canonical alias resolution.
+///
+/// This function is intentionally reference-oriented: callers that classify a
+/// registered schema, build a logical catalog, or make admission decisions must
+/// use [`ClassifiedToolIdentity`] / [`ClassifiedToolSchema`] instead. Their
+/// exact-first registration semantics prevent a custom exact `bash` or
+/// `apply_patch` registration from inheriting Core policy from a builtin alias.
+/// Unknown references deliberately remain Deferred so a new builtin, server
+/// overlay, plugin, desktop, MCP, or custom tool cannot silently expand the
+/// always-resident surface.
+pub fn capability_loading_class_for_reference(name: &str) -> CapabilityLoadingClass {
+    let canonical = canonical_tool_name(name);
+    if CORE_TOOL_NAMES
+        .iter()
+        .any(|core| core.eq_ignore_ascii_case(&canonical))
+    {
+        CapabilityLoadingClass::Core
+    } else if HOST_ONLY_TOOL_NAMES
+        .iter()
+        .any(|host_only| host_only.eq_ignore_ascii_case(&canonical))
+    {
+        CapabilityLoadingClass::HostOnly
+    } else {
+        CapabilityLoadingClass::Deferred
+    }
+}
+
+/// Immutable policy identity derived from a registered schema name.
+///
+/// Logical catalog identity, and the intended executor key, follow the
+/// registered schema name exactly. Concrete executor routing is migrated in a
+/// follow-up slice before loaded-state admission is enabled.
+/// Alias fallback is retained separately because the shared resolution contract
+/// is exact-first. Thus a custom exact `apply_patch` is a Deferred custom tool,
+/// while an unshadowed invocation reference `apply_patch` may still resolve to
+/// builtin `Edit`.
+///
+/// Classification is lexical policy, not implementation provenance: exact
+/// reserved spellings select Bamboo's reserved loading class, but this wrapper
+/// does not attest that the underlying implementation is a framework builtin.
+/// Current registrars are host-trusted; any future untrusted registrar needs an
+/// authoritative origin boundary before it may claim reserved names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassifiedToolIdentity {
+    execution_name: String,
+    alias_fallback_name: String,
+    loading_class: CapabilityLoadingClass,
+}
+
+impl ClassifiedToolIdentity {
+    pub fn from_schema_name(schema_name: &str) -> Option<Self> {
+        let registered_name = schema_name.trim();
+        if registered_name.is_empty() || registered_name != schema_name {
+            return None;
+        }
+        let alias_fallback_name = canonical_tool_name(registered_name);
+        if alias_fallback_name == DISCOVERY_CONTROL_FALLBACK_TOOL_NAME {
+            return None;
+        }
+        let exact_framework_identity = crate::BUILTIN_TOOL_NAMES
+            .iter()
+            .chain(crate::SERVER_CAPABILITY_NAMES.iter())
+            .any(|known| *known == registered_name);
+        let loading_class = if exact_framework_identity {
+            capability_loading_class_for_reference(registered_name)
+        } else if capability_loading_class_for_reference(&alias_fallback_name)
+            == CapabilityLoadingClass::HostOnly
+        {
+            // Host protocol identities and their legacy aliases stay outside
+            // every model catalog even when an exact custom registration would
+            // otherwise shadow alias fallback.
+            CapabilityLoadingClass::HostOnly
+        } else {
+            CapabilityLoadingClass::Deferred
+        };
+        Some(Self {
+            execution_name: registered_name.to_string(),
+            alias_fallback_name,
+            loading_class,
+        })
+    }
+
+    /// Exact registered name used as the logical catalog and executor key.
+    /// This is deliberately not alias-canonicalized.
+    pub fn execution_name(&self) -> &str {
+        &self.execution_name
+    }
+
+    pub fn loading_class(&self) -> CapabilityLoadingClass {
+        self.loading_class
+    }
+
+    pub fn alias_fallback_name(&self) -> &str {
+        &self.alias_fallback_name
+    }
+}
+
+/// Resolve a reference against the exact registered execution identities in a
+/// catalog. Exact registrations win; only a missing exact name may fall back to
+/// the shared legacy/builtin alias resolver.
+///
+/// The caller supplies the catalog membership predicate so config, discovery,
+/// provider projection, and later admission can share these semantics without
+/// coupling the domain policy to one collection type.
+pub fn resolve_tool_reference_name(
+    reference: &str,
+    mut contains_registered_name: impl FnMut(&str) -> bool,
+) -> Option<String> {
+    let exact = reference.trim();
+    if exact.is_empty() {
+        return None;
+    }
+    if contains_registered_name(exact) {
+        return Some(exact.to_string());
+    }
+
+    let unqualified = exact.rsplit("::").next().unwrap_or(exact).trim();
+    if unqualified != exact && contains_registered_name(unqualified) {
+        return Some(unqualified.to_string());
+    }
+
+    let legacy_normalized = crate::normalize_builtin_alias(unqualified);
+    if legacy_normalized != unqualified && contains_registered_name(legacy_normalized) {
+        return Some(legacy_normalized.to_string());
+    }
+
+    let fallback = canonical_tool_name(exact);
+    (!fallback.is_empty() && contains_registered_name(&fallback)).then_some(fallback)
+}
+
+/// A logical catalog entry carrying provider-neutral loading policy alongside
+/// an otherwise unchanged function schema.
+#[derive(Clone)]
+pub struct ClassifiedToolSchema {
+    identity: ClassifiedToolIdentity,
+    schema: ToolSchema,
+}
+
+impl std::fmt::Debug for ClassifiedToolSchema {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ClassifiedToolSchema")
+            .field("execution_name", &self.execution_name())
+            .field("loading_class", &self.loading_class())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ClassifiedToolSchema {
+    /// Classify one non-empty function schema. Blank names fail closed rather
+    /// than entering a provider or discovery catalog.
+    pub fn new(schema: ToolSchema) -> Option<Self> {
+        let identity = ClassifiedToolIdentity::from_schema_name(&schema.function.name)?;
+        Some(Self { identity, schema })
+    }
+
+    pub fn execution_name(&self) -> &str {
+        self.identity.execution_name()
+    }
+
+    pub fn loading_class(&self) -> CapabilityLoadingClass {
+        self.identity.loading_class()
+    }
+
+    pub fn alias_fallback_name(&self) -> &str {
+        self.identity.alias_fallback_name()
+    }
+
+    pub fn schema(&self) -> &ToolSchema {
+        &self.schema
+    }
+
+    pub fn into_schema(self) -> ToolSchema {
+        self.schema
+    }
+
+    pub fn is_model_visible(&self) -> bool {
+        self.loading_class() != CapabilityLoadingClass::HostOnly
+    }
+
+    pub fn is_initially_visible(&self) -> bool {
+        self.loading_class() == CapabilityLoadingClass::Core
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        FunctionSchema, BUILTIN_TOOL_ALIASES, BUILTIN_TOOL_NAMES, LEGACY_TOOL_NAME_ALIASES,
+        SERVER_CAPABILITY_NAMES,
+    };
+    use serde_json::json;
+
+    fn schema(name: &str) -> ToolSchema {
+        ToolSchema {
+            schema_type: "function".to_string(),
+            function: FunctionSchema {
+                name: name.to_string(),
+                description: format!("{name} description"),
+                parameters: json!({"type": "object"}),
+            },
+        }
+    }
+
+    #[test]
+    fn locks_exact_core_and_separate_discovery_gateway() {
+        assert_eq!(CORE_TOOL_NAMES, ["Bash", "Read", "Grep", "Edit", "Write"]);
+        for name in CORE_TOOL_NAMES {
+            assert_eq!(
+                capability_loading_class_for_reference(name),
+                CapabilityLoadingClass::Core
+            );
+        }
+        assert_eq!(DISCOVERY_CONTROL_GATEWAY.logical_name(), "discover");
+        assert_eq!(
+            DISCOVERY_CONTROL_GATEWAY.fallback_tool_name(),
+            "discover_capabilities"
+        );
+        assert_ne!(
+            DISCOVERY_CONTROL_GATEWAY.logical_name(),
+            DISCOVERY_CONTROL_GATEWAY.fallback_tool_name()
+        );
+        assert!(DISCOVERY_CONTROL_GATEWAY.is_initially_visible());
+        assert_eq!(
+            capability_loading_class_for_reference(DISCOVER_CAPABILITY_NAME),
+            CapabilityLoadingClass::Deferred,
+            "the control gateway is outside the function Core set"
+        );
+        let ordinary_function = ClassifiedToolSchema::new(schema(DISCOVER_CAPABILITY_NAME))
+            .expect("ordinary function schema");
+        assert_eq!(
+            ordinary_function.loading_class(),
+            CapabilityLoadingClass::Deferred
+        );
+        assert!(!ordinary_function.is_initially_visible());
+        assert!(ClassifiedToolSchema::new(schema(DISCOVERY_CONTROL_FALLBACK_TOOL_NAME)).is_none());
+        assert!(ClassifiedToolSchema::new(schema("default::discover_capabilities")).is_none());
+    }
+
+    #[test]
+    fn every_known_function_has_fail_closed_loading_policy() {
+        for name in BUILTIN_TOOL_NAMES {
+            let expected = if CORE_TOOL_NAMES.contains(&name) {
+                CapabilityLoadingClass::Core
+            } else if HOST_ONLY_TOOL_NAMES.contains(&name) {
+                CapabilityLoadingClass::HostOnly
+            } else {
+                CapabilityLoadingClass::Deferred
+            };
+            assert_eq!(
+                capability_loading_class_for_reference(name),
+                expected,
+                "{name}"
+            );
+        }
+        for name in SERVER_CAPABILITY_NAMES {
+            assert_eq!(
+                capability_loading_class_for_reference(name),
+                CapabilityLoadingClass::Deferred,
+                "server overlay {name} must not become Core"
+            );
+        }
+    }
+
+    #[test]
+    fn locks_required_deferred_and_host_only_names() {
+        for name in EXPLICIT_DEFERRED_TOOL_NAMES {
+            assert_eq!(
+                capability_loading_class_for_reference(name),
+                CapabilityLoadingClass::Deferred
+            );
+        }
+        for name in HOST_ONLY_TOOL_NAMES {
+            assert_eq!(
+                capability_loading_class_for_reference(name),
+                CapabilityLoadingClass::HostOnly
+            );
+        }
+    }
+
+    #[test]
+    fn all_declared_aliases_share_their_target_classification() {
+        for (alias, target) in BUILTIN_TOOL_ALIASES {
+            assert_eq!(
+                canonical_tool_name(alias),
+                canonical_tool_name(target),
+                "{alias}"
+            );
+            assert_eq!(
+                capability_loading_class_for_reference(alias),
+                capability_loading_class_for_reference(target),
+                "{alias} -> {target}"
+            );
+        }
+        assert_eq!(
+            capability_loading_class_for_reference("applyPatch"),
+            CapabilityLoadingClass::Core
+        );
+        assert_eq!(
+            capability_loading_class_for_reference("default::getCurrentDir"),
+            CapabilityLoadingClass::HostOnly
+        );
+        assert_eq!(
+            capability_loading_class_for_reference("default::sub_task"),
+            CapabilityLoadingClass::Deferred
+        );
+        for (alias, normalized) in LEGACY_TOOL_NAME_ALIASES {
+            assert_eq!(
+                canonical_tool_name(alias),
+                canonical_tool_name(normalized),
+                "legacy spelling {alias}"
+            );
+            assert_eq!(
+                capability_loading_class_for_reference(alias),
+                capability_loading_class_for_reference(normalized),
+                "legacy spelling {alias}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_dynamic_and_namespaced_mcp_tools_default_deferred() {
+        for name in [
+            "future_builtin",
+            "default::desktop_capture",
+            "plugin_custom_tool",
+            "mcp__alpha__read_file",
+            "mcp__beta__read_file",
+        ] {
+            assert_eq!(
+                capability_loading_class_for_reference(name),
+                CapabilityLoadingClass::Deferred
+            );
+        }
+    }
+
+    #[test]
+    fn exact_custom_alias_registrations_remain_deferred_execution_identities() {
+        for name in [
+            "apply_patch",
+            "applyPatch",
+            "read_file",
+            "execute_command",
+            "bash",
+            "default::Bash",
+        ] {
+            let identity = ClassifiedToolIdentity::from_schema_name(name)
+                .expect("exact custom registration remains catalogued");
+            assert_eq!(identity.execution_name(), name);
+            assert_eq!(
+                identity.loading_class(),
+                CapabilityLoadingClass::Deferred,
+                "custom exact registration {name} must not gain reserved policy"
+            );
+        }
+        let host_alias =
+            ClassifiedToolIdentity::from_schema_name("GetCurrentDir").expect("host alias identity");
+        assert_eq!(host_alias.execution_name(), "GetCurrentDir");
+        assert_eq!(host_alias.loading_class(), CapabilityLoadingClass::HostOnly);
+        assert_eq!(
+            ClassifiedToolIdentity::from_schema_name("Bash")
+                .expect("canonical builtin")
+                .loading_class(),
+            CapabilityLoadingClass::Core
+        );
+    }
+
+    #[test]
+    fn namespaced_custom_registration_stays_exact_and_reference_fallback_is_catalog_aware() {
+        let classified = ClassifiedToolSchema::new(schema("default::custom_tool"))
+            .expect("generic executors may expose exact namespaced schemas");
+        assert_eq!(classified.execution_name(), "default::custom_tool");
+        assert_eq!(classified.schema().function.name, "default::custom_tool");
+        assert_eq!(classified.alias_fallback_name(), "custom_tool");
+        assert_eq!(classified.loading_class(), CapabilityLoadingClass::Deferred);
+
+        let registered = ["Bash", "custom_tool"];
+        assert_eq!(
+            resolve_tool_reference_name("default::Bash", |name| registered.contains(&name)),
+            Some("Bash".to_string())
+        );
+        assert_eq!(
+            resolve_tool_reference_name("default::custom_tool", |name| registered.contains(&name)),
+            Some("custom_tool".to_string())
+        );
+    }
+
+    #[test]
+    fn catalog_reference_resolution_is_exact_first_then_alias_fallback() {
+        let shadowed = ["Edit", "apply_patch", "default::applyPatch"];
+        assert_eq!(
+            resolve_tool_reference_name("Edit", |name| shadowed.contains(&name)),
+            Some("Edit".to_string())
+        );
+        assert_eq!(
+            resolve_tool_reference_name("apply_patch", |name| shadowed.contains(&name)),
+            Some("apply_patch".to_string())
+        );
+        assert_eq!(
+            resolve_tool_reference_name("applyPatch", |name| shadowed.contains(&name)),
+            Some("apply_patch".to_string())
+        );
+        assert_eq!(
+            resolve_tool_reference_name("default::applyPatch", |name| shadowed.contains(&name)),
+            Some("default::applyPatch".to_string())
+        );
+
+        let shadowed_without_namespaced_exact = ["Edit", "apply_patch"];
+        assert_eq!(
+            resolve_tool_reference_name("default::applyPatch", |name| {
+                shadowed_without_namespaced_exact.contains(&name)
+            }),
+            Some("apply_patch".to_string())
+        );
+
+        let unshadowed = ["Edit"];
+        assert_eq!(
+            resolve_tool_reference_name("apply_patch", |name| unshadowed.contains(&name)),
+            Some("Edit".to_string())
+        );
+        assert_eq!(
+            resolve_tool_reference_name("default::applyPatch", |name| unshadowed.contains(&name)),
+            Some("Edit".to_string())
+        );
+        assert_eq!(
+            resolve_tool_reference_name("unknown", |name| unshadowed.contains(&name)),
+            None
+        );
+    }
+
+    #[test]
+    fn classified_wrapper_keeps_schema_provider_neutral() {
+        let classified = ClassifiedToolSchema::new(schema("Edit")).expect("classified schema");
+        assert_eq!(classified.execution_name(), "Edit");
+        assert_eq!(classified.loading_class(), CapabilityLoadingClass::Core);
+        assert!(classified.is_model_visible());
+        assert!(classified.is_initially_visible());
+
+        let serialized = serde_json::to_value(classified.schema()).expect("serialize schema");
+        assert_eq!(serialized["function"]["name"], "Edit");
+        assert!(serialized.get("loading_class").is_none());
+        assert!(serialized.get("defer_loading").is_none());
+    }
+
+    #[test]
+    fn host_only_wrapper_is_not_model_visible() {
+        let classified = ClassifiedToolSchema::new(schema("Workspace")).expect("classified schema");
+        assert_eq!(classified.execution_name(), "Workspace");
+        assert_eq!(classified.loading_class(), CapabilityLoadingClass::HostOnly);
+        assert!(!classified.is_model_visible());
+        assert!(!classified.is_initially_visible());
+    }
+
+    #[test]
+    fn blank_schema_names_fail_closed() {
+        assert!(ClassifiedToolSchema::new(schema("  ")).is_none());
+    }
+
+    #[test]
+    fn classified_debug_never_emits_schema_content() {
+        const SECRET: &str = "private-classified-schema-sentinel";
+        let mut sensitive = schema("custom_tool");
+        sensitive.schema_type = SECRET.to_string();
+        sensitive.function.description = SECRET.to_string();
+        sensitive.function.parameters = json!({"secret": SECRET});
+        let classified = ClassifiedToolSchema::new(sensitive).expect("classified schema");
+        let debug = format!("{classified:?}");
+
+        assert!(!debug.contains(SECRET));
+        assert!(debug.contains("custom_tool"));
+        assert!(debug.contains("Deferred"));
+    }
+}

--- a/crates/core/bamboo-domain/src/lib.rs
+++ b/crates/core/bamboo-domain/src/lib.rs
@@ -3,6 +3,7 @@
 // From bamboo-shared-types
 pub mod bounded_dedup;
 pub mod capability_discovery;
+pub mod capability_loading;
 pub mod poison;
 pub mod reasoning;
 pub mod token_usage;
@@ -37,6 +38,7 @@ pub mod prompt_markers;
 
 // Flat re-exports for backward-compatible access
 pub use capability_discovery::*;
+pub use capability_loading::*;
 pub use ledger::*;
 pub use mcp_config::*;
 pub use project::*;

--- a/crates/core/bamboo-domain/src/tool_names.rs
+++ b/crates/core/bamboo-domain/src/tool_names.rs
@@ -59,6 +59,46 @@ pub const BUILTIN_TOOL_ALIASES: [(&str, &str); 10] = [
     ("SubSession", "SubAgent"),
 ];
 
+/// Legacy spellings normalized before canonical alias resolution.
+///
+/// This table is public so classification, compatibility tests, and future
+/// admission code can prove that every accepted spelling shares one resolver.
+pub const LEGACY_TOOL_NAME_ALIASES: [(&str, &str); 33] = [
+    ("conclusionWithOptions", "conclusion_with_options"),
+    ("execute_command", "Bash"),
+    ("file_exists", "FileExists"),
+    ("fileExists", "FileExists"),
+    ("get_current_dir", "GetCurrentDir"),
+    ("getCurrentDir", "GetCurrentDir"),
+    ("get_file_info", "GetFileInfo"),
+    ("getFileInfo", "GetFileInfo"),
+    ("list_directory", "Glob"),
+    ("memory_note", "memory_note"),
+    ("read_file", "Read"),
+    ("set_workspace", "SetWorkspace"),
+    ("setWorkspace", "SetWorkspace"),
+    ("sleep", "Sleep"),
+    ("applyPatch", "apply_patch"),
+    ("spawn_session", "SubAgent"),
+    ("spawnSession", "SubAgent"),
+    ("sub_session", "SubAgent"),
+    ("subSession", "SubAgent"),
+    ("sub_task", "SubAgent"),
+    ("subTask", "SubAgent"),
+    ("team_agent", "SubAgent"),
+    ("teamAgent", "SubAgent"),
+    ("child_session", "SubAgent"),
+    ("childSession", "SubAgent"),
+    ("sub_session_manager", "SubAgent"),
+    ("sub_agent", "SubAgent"),
+    ("subAgent", "SubAgent"),
+    ("SubSession", "SubAgent"),
+    ("subsession", "SubAgent"),
+    ("write_file", "Write"),
+    ("sessionInspector", "session_inspector"),
+    ("scheduleTasks", "schedule_tasks"),
+];
+
 pub const SERVER_TOOL_NAMES: [&str; 8] = [
     "SubAgent",
     "compact_context",
@@ -69,6 +109,54 @@ pub const SERVER_TOOL_NAMES: [&str; 8] = [
     "load_skill",
     "read_skill_resource",
 ];
+
+/// Canonical capability names supplied by Bamboo's server-side overlays.
+///
+/// This superset is used by catalogs and discovery without broadening the
+/// legacy `normalize_tool_ref`/`is_builtin_tool` acceptance surface above.
+pub const SERVER_CAPABILITY_NAMES: [&str; 14] = [
+    "SubAgent",
+    "Project",
+    "ask_agent",
+    "cluster",
+    "compact_context",
+    "deploy_agent",
+    "ledger",
+    "load_skill",
+    "memory",
+    "notify",
+    "read_skill_resource",
+    "scheduler",
+    "session_history",
+    "workflow_run",
+];
+
+/// Resolve any model- or host-facing tool reference to one canonical identity.
+///
+/// Legacy `namespace::tool` references use the executable name after the last
+/// separator. MCP aliases already encode their namespace as
+/// `mcp__server__function`, so they remain distinct. Known builtin/server names
+/// are also restored to their declared case. Unknown registrations are kept as
+/// executable names and are classified fail-closed elsewhere. Registered schema
+/// execution identities remain exact and are carried separately by
+/// `ClassifiedToolIdentity`; this function must not be used to rename schemas.
+pub fn canonical_tool_name(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let unqualified = trimmed.rsplit("::").next().unwrap_or(trimmed).trim();
+    let normalized = normalize_builtin_alias(unqualified);
+    let canonical = resolve_alias(normalized).unwrap_or(normalized);
+
+    BUILTIN_TOOL_NAMES
+        .iter()
+        .chain(SERVER_CAPABILITY_NAMES.iter())
+        .find(|known| known.eq_ignore_ascii_case(canonical))
+        .map(|known| (*known).to_string())
+        .unwrap_or_else(|| canonical.to_string())
+}
 
 /// Normalizes a tool reference to a standard tool name.
 ///
@@ -108,43 +196,11 @@ pub fn resolve_alias(name: &str) -> Option<&'static str> {
 }
 
 pub fn normalize_builtin_alias(name: &str) -> &str {
-    match name {
-        // Backward compatibility for earlier camelCase and snake_case names.
-        "conclusionWithOptions" => "conclusion_with_options",
-        "execute_command" => "Bash",
-        "file_exists" => "FileExists",
-        "fileExists" => "FileExists",
-        "get_current_dir" => "GetCurrentDir",
-        "getCurrentDir" => "GetCurrentDir",
-        "get_file_info" => "GetFileInfo",
-        "getFileInfo" => "GetFileInfo",
-        "list_directory" => "Glob",
-        "memory_note" => "memory_note",
-        "read_file" => "Read",
-        "set_workspace" => "SetWorkspace",
-        "setWorkspace" => "SetWorkspace",
-        "sleep" => "Sleep",
-        "applyPatch" => "apply_patch",
-        "spawn_session" => "SubAgent",
-        "spawnSession" => "SubAgent",
-        "sub_session" => "SubAgent",
-        "subSession" => "SubAgent",
-        "sub_task" => "SubAgent",
-        "subTask" => "SubAgent",
-        "team_agent" => "SubAgent",
-        "teamAgent" => "SubAgent",
-        "child_session" => "SubAgent",
-        "childSession" => "SubAgent",
-        "sub_session_manager" => "SubAgent",
-        "sub_agent" => "SubAgent",
-        "subAgent" => "SubAgent",
-        "SubSession" => "SubAgent",
-        "subsession" => "SubAgent",
-        "write_file" => "Write",
-        "sessionInspector" => "session_inspector",
-        "scheduleTasks" => "schedule_tasks",
-        _ => name,
-    }
+    LEGACY_TOOL_NAME_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == name)
+        .map(|(_, normalized)| *normalized)
+        .unwrap_or(name)
 }
 
 /// Checks if a tool reference is a built-in tool
@@ -272,5 +328,41 @@ mod tests {
         assert_eq!(resolve_alias("apply_patch"), Some("Edit"));
         assert_eq!(resolve_alias("FileExists"), Some("GetFileInfo"));
         assert_eq!(resolve_alias("Bash"), None);
+    }
+
+    #[test]
+    fn canonical_name_resolves_aliases_namespaces_and_known_case() {
+        assert_eq!(canonical_tool_name(" default::applyPatch "), "Edit");
+        assert_eq!(canonical_tool_name("DEFAULT::read"), "Read");
+        assert_eq!(canonical_tool_name("default::set_workspace"), "Workspace");
+        assert_eq!(canonical_tool_name("DEFAULT::WORKFLOW_RUN"), "workflow_run");
+    }
+
+    #[test]
+    fn canonical_reference_name_unqualifies_dynamic_refs_and_preserves_mcp_aliases() {
+        assert_eq!(canonical_tool_name("default::custom_tool"), "custom_tool");
+        assert_eq!(
+            canonical_tool_name("mcp__alpha__read_file"),
+            "mcp__alpha__read_file"
+        );
+        assert_eq!(
+            canonical_tool_name("mcp__beta__read_file"),
+            "mcp__beta__read_file"
+        );
+        assert_ne!(
+            canonical_tool_name("mcp__alpha__read_file"),
+            canonical_tool_name("mcp__beta__read_file")
+        );
+        assert!(canonical_tool_name("  ").is_empty());
+    }
+
+    #[test]
+    fn legacy_server_names_are_a_subset_of_the_classified_server_catalog() {
+        for name in SERVER_TOOL_NAMES {
+            assert!(
+                SERVER_CAPABILITY_NAMES.contains(&name),
+                "legacy server tool {name} must remain classifiable"
+            );
+        }
     }
 }

--- a/crates/engine/bamboo-engine/src/capability_discovery.rs
+++ b/crates/engine/bamboo-engine/src/capability_discovery.rs
@@ -8,9 +8,11 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use bamboo_agent_core::ToolSchema;
 use bamboo_domain::{
-    CapabilityInvocationPolicy, CapabilityInvocationTarget, CapabilityKind, CapabilityMatch,
-    CapabilitySource, CapabilityStatus, DiscoverCapabilitiesRequest, DiscoverCapabilitiesResult,
-    DISCOVER_CAPABILITY_NAME, MAX_DISCOVERY_QUERY_CHARS, MAX_DISCOVERY_RESULTS,
+    canonical_tool_name as canonical_registry_tool_name, resolve_tool_reference_name,
+    CapabilityInvocationPolicy, CapabilityInvocationTarget, CapabilityKind, CapabilityLoadingClass,
+    CapabilityMatch, CapabilitySource, CapabilityStatus, ClassifiedToolIdentity,
+    ClassifiedToolSchema, DiscoverCapabilitiesRequest, DiscoverCapabilitiesResult,
+    MAX_DISCOVERY_QUERY_CHARS, MAX_DISCOVERY_RESULTS,
 };
 use bamboo_skills::{
     WorkflowCatalogEntry, WorkflowCatalogSnapshot, WorkflowKind, WorkflowSource, WorkflowStatus,
@@ -20,23 +22,6 @@ use thiserror::Error;
 /// Discovery summaries are bounded independently of the source description so
 /// one verbose registry entry cannot dominate a bounded result.
 pub const MAX_CAPABILITY_SUMMARY_CHARS: usize = 240;
-
-const SERVER_CAPABILITY_NAMES: &[&str] = &[
-    "Project",
-    "ask_agent",
-    "cluster",
-    "compact_context",
-    "deploy_agent",
-    "ledger",
-    "load_skill",
-    "memory",
-    "notify",
-    "read_skill_resource",
-    "scheduler",
-    "session_history",
-    "SubAgent",
-    "workflow_run",
-];
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum InvocationEligibility {
@@ -66,7 +51,8 @@ impl InvocationEligibility {
 pub struct CapabilityDiscoveryEligibility {
     pub disabled_tool_names: BTreeSet<String>,
     /// `None` means the caller already supplied a surface-scoped registry.
-    /// `Some(empty)` exposes no tools. Names are canonicalized before matching.
+    /// `Some(empty)` exposes no tools. References resolve exact-first against
+    /// the projected catalog, then through legacy/builtin aliases.
     pub allowed_tool_names: Option<BTreeSet<String>>,
     pub disabled_skill_ids: BTreeSet<String>,
     /// `None` means no additional allowlist. `Some(empty)` exposes no Skills.
@@ -108,17 +94,36 @@ pub fn project_tool_capability_metadata(schemas: &[ToolSchema]) -> Vec<ToolCapab
     schemas
         .iter()
         .filter_map(|schema| {
-            let canonical_name = canonical_registry_tool_name(&schema.function.name);
-            if canonical_name.is_empty() {
+            let identity = ClassifiedToolIdentity::from_schema_name(&schema.function.name)?;
+            if identity.loading_class() == CapabilityLoadingClass::HostOnly {
                 return None;
             }
             Some(ToolCapabilityMetadata {
-                source: source_for_tool(&canonical_name),
-                aliases: aliases_for_tool(&canonical_name),
-                canonical_name,
+                source: source_for_tool(identity.execution_name()),
+                aliases: aliases_for_tool(identity.execution_name()),
+                canonical_name: identity.execution_name().to_string(),
                 summary: bounded_summary(&schema.function.description),
                 available: true,
             })
+        })
+        .collect()
+}
+
+/// Project a classified logical catalog into metadata-only discovery entries.
+/// HostOnly schemas never enter the searchable index, while Core and Deferred
+/// share the exact execution identity and policy used by provider projection.
+pub fn project_classified_tool_capability_metadata(
+    catalog: &[ClassifiedToolSchema],
+) -> Vec<ToolCapabilityMetadata> {
+    catalog
+        .iter()
+        .filter(|entry| entry.loading_class() != CapabilityLoadingClass::HostOnly)
+        .map(|entry| ToolCapabilityMetadata {
+            source: source_for_tool(entry.execution_name()),
+            aliases: aliases_for_tool(entry.execution_name()),
+            canonical_name: entry.execution_name().to_string(),
+            summary: bounded_summary(&entry.schema().function.description),
+            available: true,
         })
         .collect()
 }
@@ -138,10 +143,31 @@ pub struct CapabilityDiscoveryIndex {
 }
 
 impl CapabilityDiscoveryIndex {
-    /// Capture both command catalogs under the store's publication read lock and
-    /// build one immutable index. `command_catalog_snapshots` is the atomic
-    /// counterpart of `skill_catalog_snapshot` + `workflow_catalog_snapshot`;
-    /// it returns the same metadata-only entries without opening bundle files.
+    /// Build discovery from the exact classified catalog already resolved for
+    /// the current session/round, while capturing both command catalogs under
+    /// the store's publication read lock. Tool allow/disable references are not
+    /// applied twice; Skill/Workflow eligibility is still resolved here.
+    pub async fn from_resolved_classified_store(
+        tool_catalog: &[ClassifiedToolSchema],
+        store: &bamboo_skills::SkillStore,
+        eligibility: &CapabilityDiscoveryEligibility,
+    ) -> Self {
+        let (skill_catalog, workflow_catalog) = store.command_catalog_snapshots().await;
+        let mut non_tool_eligibility = eligibility.clone();
+        non_tool_eligibility.disabled_tool_names.clear();
+        non_tool_eligibility.allowed_tool_names = None;
+        Self::from_snapshots(
+            project_classified_tool_capability_metadata(tool_catalog),
+            &skill_catalog,
+            &workflow_catalog,
+            &non_tool_eligibility,
+        )
+    }
+
+    /// Legacy compatibility facade for callers that do not yet have a
+    /// session-resolved classified catalog. New agent-loop code must use
+    /// [`Self::from_resolved_classified_store`] so goal/Skill/disabled eligibility
+    /// and provider projection cannot drift from discovery.
     pub async fn from_store(
         tool_schemas: &[ToolSchema],
         store: &bamboo_skills::SkillStore,
@@ -162,37 +188,18 @@ impl CapabilityDiscoveryIndex {
         workflow_catalog: &WorkflowCatalogSnapshot,
         eligibility: &CapabilityDiscoveryEligibility,
     ) -> Self {
-        let disabled_tools = eligibility
-            .disabled_tool_names
-            .iter()
-            .map(|name| canonical_registry_tool_name(name).to_lowercase())
-            .collect::<BTreeSet<_>>();
-        let allowed_tools = eligibility.allowed_tool_names.as_ref().map(|names| {
-            names
-                .iter()
-                .map(|name| canonical_registry_tool_name(name).to_lowercase())
-                .collect::<BTreeSet<_>>()
-        });
         let mut projected_tools = BTreeMap::<String, ToolCapabilityMetadata>::new();
 
         for mut tool in tools {
-            tool.canonical_name = canonical_registry_tool_name(&tool.canonical_name);
-            if tool.canonical_name.is_empty()
-                || tool
-                    .canonical_name
-                    .eq_ignore_ascii_case(DISCOVER_CAPABILITY_NAME)
-                || !tool.available
-            {
+            let Some(identity) = ClassifiedToolIdentity::from_schema_name(&tool.canonical_name)
+            else {
+                continue;
+            };
+            tool.canonical_name = identity.execution_name().to_string();
+            if identity.loading_class() == CapabilityLoadingClass::HostOnly || !tool.available {
                 continue;
             }
-            let key = tool.canonical_name.to_lowercase();
-            if disabled_tools.contains(&key)
-                || allowed_tools
-                    .as_ref()
-                    .is_some_and(|allowed| !allowed.contains(&key))
-            {
-                continue;
-            }
+            let key = tool.canonical_name.clone();
             tool.summary = bounded_summary(&tool.summary);
             tool.aliases.sort();
             tool.aliases.dedup();
@@ -203,6 +210,30 @@ impl CapabilityDiscoveryIndex {
                 }
             }
         }
+
+        let disabled_execution_names = eligibility
+            .disabled_tool_names
+            .iter()
+            .filter_map(|reference| {
+                resolve_tool_reference_name(reference, |name| projected_tools.contains_key(name))
+            })
+            .collect::<BTreeSet<_>>();
+        let allowed_execution_names = eligibility.allowed_tool_names.as_ref().map(|references| {
+            references
+                .iter()
+                .filter_map(|reference| {
+                    resolve_tool_reference_name(reference, |name| {
+                        projected_tools.contains_key(name)
+                    })
+                })
+                .collect::<BTreeSet<_>>()
+        });
+        projected_tools.retain(|name, _| {
+            !disabled_execution_names.contains(name)
+                && allowed_execution_names
+                    .as_ref()
+                    .is_none_or(|allowed| allowed.contains(name))
+        });
 
         let mut candidates = projected_tools
             .into_values()
@@ -288,6 +319,18 @@ impl CapabilityDiscoveryIndex {
         if normalized_query.is_empty() || query_tokens.is_empty() {
             return Ok(empty());
         }
+        let tool_query = query
+            .strip_prefix("tool:")
+            .or_else(|| query.strip_prefix("tool/"))
+            .unwrap_or(&query);
+        let resolved_tool_query = resolve_tool_reference_name(tool_query, |name| {
+            self.candidates.iter().any(|candidate| {
+                matches!(
+                    &candidate.value.invocation_target,
+                    CapabilityInvocationTarget::Tool { name: registered } if registered == name
+                )
+            })
+        });
 
         let mut ranked = self
             .candidates
@@ -298,8 +341,14 @@ impl CapabilityDiscoveryIndex {
                     .is_none_or(|kinds| kinds.contains(&candidate.value.kind))
             })
             .filter_map(|candidate| {
-                rank_candidate(candidate, &query, &normalized_query, &query_tokens)
-                    .map(|rank| (rank, candidate))
+                rank_candidate(
+                    candidate,
+                    &query,
+                    &normalized_query,
+                    &query_tokens,
+                    resolved_tool_query.as_deref(),
+                )
+                .map(|rank| (rank, candidate))
             })
             .collect::<Vec<_>>();
 
@@ -333,6 +382,7 @@ pub enum CapabilityDiscoveryError {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct SearchRank {
+    exact_registered_identity: bool,
     exact_identity: bool,
     name_phrase: bool,
     name_token_hits: usize,
@@ -346,7 +396,12 @@ fn rank_candidate(
     raw_query: &str,
     normalized_query: &str,
     query_tokens: &BTreeSet<String>,
+    resolved_tool_query: Option<&str>,
 ) -> Option<SearchRank> {
+    let exact_registered_identity = matches!(
+        (&candidate.value.invocation_target, resolved_tool_query),
+        (CapabilityInvocationTarget::Tool { name }, Some(resolved)) if name == resolved
+    );
     let exact_identity = candidate
         .normalized_names
         .iter()
@@ -369,7 +424,8 @@ fn rank_candidate(
     let summary_phrase = candidate.normalized_summary.contains(normalized_query);
     let summary_token_hits = token_hits(&candidate.normalized_summary, query_tokens);
 
-    if !exact_identity
+    if !exact_registered_identity
+        && !exact_identity
         && !name_phrase
         && name_token_hits == 0
         && !summary_phrase
@@ -379,6 +435,7 @@ fn rank_candidate(
     }
 
     Some(SearchRank {
+        exact_registered_identity,
         exact_identity,
         name_phrase,
         name_token_hits,
@@ -399,7 +456,7 @@ fn tool_alias_exact_match(candidate: &IndexedCapability, raw_query: &str) -> boo
     let canonical = canonical_registry_tool_name(query);
     matches!(
         &candidate.value.invocation_target,
-        CapabilityInvocationTarget::Tool { name } if name.eq_ignore_ascii_case(&canonical)
+        CapabilityInvocationTarget::Tool { name } if name == &canonical
     )
 }
 
@@ -577,44 +634,21 @@ fn prefer_tool_projection(
 }
 
 fn source_for_tool(name: &str) -> CapabilitySource {
-    if bamboo_domain::BUILTIN_TOOL_NAMES
-        .iter()
-        .any(|builtin| builtin.eq_ignore_ascii_case(name))
-    {
+    if bamboo_domain::BUILTIN_TOOL_NAMES.contains(&name) {
         CapabilitySource::Builtin
-    } else if SERVER_CAPABILITY_NAMES
-        .iter()
-        .any(|server| server.eq_ignore_ascii_case(name))
-    {
+    } else if bamboo_domain::SERVER_CAPABILITY_NAMES.contains(&name) {
         CapabilitySource::Server
-    } else if name.to_ascii_lowercase().starts_with("mcp__") {
+    } else if name.starts_with("mcp__") {
         CapabilitySource::Mcp
     } else {
         CapabilitySource::Custom
     }
 }
 
-fn canonical_registry_tool_name(name: &str) -> String {
-    let trimmed = name.trim();
-    if trimmed.is_empty() {
-        return String::new();
-    }
-    let unqualified = trimmed.split("::").last().unwrap_or(trimmed);
-    let normalized = bamboo_domain::normalize_builtin_alias(unqualified);
-    let canonical = bamboo_domain::resolve_alias(normalized).unwrap_or(normalized);
-    bamboo_domain::BUILTIN_TOOL_NAMES
-        .iter()
-        .chain(bamboo_domain::SERVER_TOOL_NAMES.iter())
-        .chain(SERVER_CAPABILITY_NAMES.iter())
-        .find(|known| known.eq_ignore_ascii_case(canonical))
-        .map(|known| (*known).to_string())
-        .unwrap_or_else(|| trimmed.to_string())
-}
-
 fn aliases_for_tool(canonical_name: &str) -> Vec<String> {
     bamboo_domain::BUILTIN_TOOL_ALIASES
         .iter()
-        .filter(|(_, canonical)| canonical.eq_ignore_ascii_case(canonical_name))
+        .filter(|(_, canonical)| *canonical == canonical_name)
         .map(|(alias, _)| (*alias).to_string())
         .collect()
 }
@@ -933,6 +967,35 @@ mod tests {
             serde_json::to_string(&first).expect("serialize"),
             serde_json::to_string(&second).expect("serialize")
         );
+    }
+
+    #[test]
+    fn exact_registered_identity_ranks_ahead_of_alias_and_case_fallbacks() {
+        let index = index(
+            &[
+                schema("Edit", "builtin edit", json!({})),
+                schema("apply_patch", "custom exact patch", json!({})),
+                schema("Foo", "upper custom", json!({})),
+                schema("foo", "lower custom", json!({})),
+            ],
+            Vec::new(),
+            Vec::new(),
+            CapabilityDiscoveryEligibility::default(),
+        );
+
+        let patch = index
+            .discover(&request("apply_patch"))
+            .expect("exact custom alias query");
+        assert_eq!(patch.matches[0].capability_ref, "tool:apply_patch");
+        let legacy_patch = index
+            .discover(&request("applyPatch"))
+            .expect("legacy spelling resolves through exact custom alias");
+        assert_eq!(legacy_patch.matches[0].capability_ref, "tool:apply_patch");
+
+        let lower = index.discover(&request("foo")).expect("exact case query");
+        assert_eq!(lower.matches[0].capability_ref, "tool:foo");
+        let upper = index.discover(&request("Foo")).expect("exact case query");
+        assert_eq!(upper.matches[0].capability_ref, "tool:Foo");
     }
 
     #[test]
@@ -1364,12 +1427,25 @@ mod tests {
     }
 
     #[test]
-    fn tool_projection_deduplicates_canonical_aliases_and_bounds_summaries() {
+    fn tool_projection_keeps_exact_alias_shadow_separate_and_bounds_summaries() {
         let long = "x".repeat(MAX_CAPABILITY_SUMMARY_CHARS + 40);
         let metadata = project_tool_capability_metadata(&[
             schema("Edit", &long, json!({})),
             schema("apply_patch", "short alias", json!({})),
         ]);
+        assert_eq!(metadata.len(), 2);
+        let edit = metadata
+            .iter()
+            .find(|entry| entry.canonical_name == "Edit")
+            .expect("builtin Edit projection");
+        assert_eq!(edit.source, CapabilitySource::Builtin);
+        assert_eq!(edit.aliases, vec!["apply_patch"]);
+        let custom_alias = metadata
+            .iter()
+            .find(|entry| entry.canonical_name == "apply_patch")
+            .expect("exact custom alias projection");
+        assert_eq!(custom_alias.source, CapabilitySource::Custom);
+        assert!(custom_alias.aliases.is_empty());
         let result = CapabilityDiscoveryIndex::from_snapshots(
             metadata,
             &WorkflowCatalogSnapshot::default(),
@@ -1384,15 +1460,313 @@ mod tests {
         assert!(result.matches[0].summary.chars().count() <= MAX_CAPABILITY_SUMMARY_CHARS);
     }
 
+    #[test]
+    fn framework_source_and_alias_metadata_require_exact_registered_identity() {
+        let metadata = project_tool_capability_metadata(&[
+            schema("Bash", "canonical builtin", json!({})),
+            schema("bash", "custom lowercase", json!({})),
+            schema("Project", "canonical server", json!({})),
+            schema("project", "custom lowercase", json!({})),
+            schema("Edit", "canonical edit", json!({})),
+            schema("edit", "custom lowercase", json!({})),
+            schema("mcp__alpha__inspect", "canonical mcp alias", json!({})),
+            schema("MCP__alpha__inspect", "custom uppercase prefix", json!({})),
+        ]);
+        let entry = |name: &str| {
+            metadata
+                .iter()
+                .find(|entry| entry.canonical_name == name)
+                .unwrap_or_else(|| panic!("missing {name}"))
+        };
+
+        assert_eq!(entry("Bash").source, CapabilitySource::Builtin);
+        assert_eq!(entry("bash").source, CapabilitySource::Custom);
+        assert_eq!(entry("Project").source, CapabilitySource::Server);
+        assert_eq!(entry("project").source, CapabilitySource::Custom);
+        assert_eq!(entry("Edit").aliases, vec!["apply_patch"]);
+        assert!(entry("edit").aliases.is_empty());
+        assert_eq!(entry("mcp__alpha__inspect").source, CapabilitySource::Mcp);
+        assert_eq!(
+            entry("MCP__alpha__inspect").source,
+            CapabilitySource::Custom
+        );
+    }
+
+    #[test]
+    fn raw_and_classified_projections_exclude_host_only_and_keep_deferred_tools() {
+        let schemas = [
+            schema("Bash", "inspect core", json!({})),
+            schema("Glob", "inspect deferred", json!({})),
+            schema("custom_tool", "inspect custom", json!({})),
+            schema("mcp__alpha__inspect", "inspect mcp", json!({})),
+            schema("Workspace", "inspect host", json!({})),
+            schema("conclusion_with_options", "inspect host", json!({})),
+            schema("request_permissions", "inspect host", json!({})),
+        ];
+        let raw = project_tool_capability_metadata(&schemas);
+        let classified = schemas
+            .iter()
+            .cloned()
+            .filter_map(ClassifiedToolSchema::new)
+            .collect::<Vec<_>>();
+        let typed = project_classified_tool_capability_metadata(&classified);
+        let names = |items: &[ToolCapabilityMetadata]| {
+            items
+                .iter()
+                .map(|item| item.canonical_name.clone())
+                .collect::<BTreeSet<_>>()
+        };
+
+        assert_eq!(names(&raw), names(&typed));
+        assert_eq!(
+            names(&raw),
+            BTreeSet::from([
+                "Bash".to_string(),
+                "Glob".to_string(),
+                "custom_tool".to_string(),
+                "mcp__alpha__inspect".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn snapshot_boundary_rejects_forged_host_only_metadata() {
+        let mut metadata = [
+            "Workspace",
+            "conclusion_with_options",
+            "request_permissions",
+            "GetCurrentDir",
+            "SetWorkspace",
+        ]
+        .into_iter()
+        .map(|name| ToolCapabilityMetadata {
+            canonical_name: name.to_string(),
+            summary: "inspect host".to_string(),
+            source: CapabilitySource::Custom,
+            aliases: Vec::new(),
+            available: true,
+        })
+        .collect::<Vec<_>>();
+        metadata.push(ToolCapabilityMetadata {
+            canonical_name: "VisibleTool".to_string(),
+            summary: "inspect visible".to_string(),
+            source: CapabilitySource::Custom,
+            aliases: Vec::new(),
+            available: true,
+        });
+        let result = CapabilityDiscoveryIndex::from_snapshots(
+            metadata,
+            &WorkflowCatalogSnapshot::default(),
+            &WorkflowCatalogSnapshot::default(),
+            &CapabilityDiscoveryEligibility::default(),
+        )
+        .discover(&request("inspect"))
+        .expect("host-only boundary");
+
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].capability_ref, "tool:VisibleTool");
+    }
+
+    #[test]
+    fn disabled_aliases_use_the_same_canonical_identity_as_discovery() {
+        let eligibility = CapabilityDiscoveryEligibility {
+            disabled_tool_names: BTreeSet::from([
+                "apply_patch".to_string(),
+                "FileExists".to_string(),
+                "sub_session_manager".to_string(),
+            ]),
+            ..Default::default()
+        };
+        let result = index(
+            &[
+                schema("Edit", "inspect edit", json!({})),
+                schema("GetFileInfo", "inspect file", json!({})),
+                schema("SubAgent", "inspect agent", json!({})),
+                schema("VisibleTool", "inspect visible", json!({})),
+            ],
+            Vec::new(),
+            Vec::new(),
+            eligibility,
+        )
+        .discover(&request("inspect"))
+        .expect("canonical disabled filter");
+
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].capability_ref, "tool:VisibleTool");
+    }
+
+    #[test]
+    fn eligibility_resolves_exact_shadow_before_alias_fallback() {
+        let schemas = [
+            schema("Edit", "builtin edit", json!({})),
+            schema("apply_patch", "custom exact patch", json!({})),
+        ];
+        let allowed_builtin = index(
+            &schemas,
+            Vec::new(),
+            Vec::new(),
+            CapabilityDiscoveryEligibility {
+                allowed_tool_names: Some(BTreeSet::from(["Edit".to_string()])),
+                ..Default::default()
+            },
+        )
+        .discover(&request("patch"))
+        .expect("exact allowed builtin");
+        assert_eq!(allowed_builtin.matches.len(), 1);
+        assert_eq!(allowed_builtin.matches[0].capability_ref, "tool:Edit");
+
+        let allowed_shadow = index(
+            &schemas,
+            Vec::new(),
+            Vec::new(),
+            CapabilityDiscoveryEligibility {
+                allowed_tool_names: Some(BTreeSet::from(["apply_patch".to_string()])),
+                ..Default::default()
+            },
+        )
+        .discover(&request("patch"))
+        .expect("exact allowed custom shadow");
+        assert_eq!(allowed_shadow.matches.len(), 1);
+        assert_eq!(allowed_shadow.matches[0].capability_ref, "tool:apply_patch");
+
+        let alias_fallback = index(
+            &[schema("Edit", "builtin edit", json!({}))],
+            Vec::new(),
+            Vec::new(),
+            CapabilityDiscoveryEligibility {
+                allowed_tool_names: Some(BTreeSet::from(["apply_patch".to_string()])),
+                ..Default::default()
+            },
+        )
+        .discover(&request("patch"))
+        .expect("unshadowed alias fallback");
+        assert_eq!(alias_fallback.matches.len(), 1);
+        assert_eq!(alias_fallback.matches[0].capability_ref, "tool:Edit");
+
+        let disabled_shadow = index(
+            &schemas,
+            Vec::new(),
+            Vec::new(),
+            CapabilityDiscoveryEligibility {
+                disabled_tool_names: BTreeSet::from(["apply_patch".to_string()]),
+                ..Default::default()
+            },
+        )
+        .discover(&request("edit"))
+        .expect("exact disabled custom shadow");
+        assert_eq!(disabled_shadow.matches.len(), 1);
+        assert_eq!(disabled_shadow.matches[0].capability_ref, "tool:Edit");
+    }
+
+    #[test]
+    fn case_distinct_dynamic_and_mcp_identities_do_not_collapse() {
+        let metadata = project_tool_capability_metadata(&[
+            schema("Foo", "inspect custom", json!({})),
+            schema("foo", "inspect custom", json!({})),
+            schema("mcp__Alpha__inspect", "inspect mcp", json!({})),
+            schema("mcp__alpha__inspect", "inspect mcp", json!({})),
+        ]);
+        assert_eq!(metadata.len(), 4);
+
+        let eligibility = CapabilityDiscoveryEligibility {
+            disabled_tool_names: BTreeSet::from(["mcp__Alpha__inspect".to_string()]),
+            ..Default::default()
+        };
+        let result = CapabilityDiscoveryIndex::from_snapshots(
+            metadata,
+            &WorkflowCatalogSnapshot::default(),
+            &WorkflowCatalogSnapshot::default(),
+            &eligibility,
+        )
+        .discover(&request("inspect"))
+        .expect("case-preserving discovery");
+        let refs = result
+            .matches
+            .iter()
+            .map(|entry| entry.capability_ref.as_str())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(refs.len(), 3);
+        assert!(refs.contains("tool:Foo"));
+        assert!(refs.contains("tool:foo"));
+        assert!(refs.contains("tool:mcp__alpha__inspect"));
+        assert!(!refs.contains("tool:mcp__Alpha__inspect"));
+
+        let allowed = CapabilityDiscoveryIndex::from_snapshots(
+            project_tool_capability_metadata(&[
+                schema("Foo", "inspect custom", json!({})),
+                schema("foo", "inspect custom", json!({})),
+                schema("mcp__Alpha__inspect", "inspect mcp", json!({})),
+                schema("mcp__alpha__inspect", "inspect mcp", json!({})),
+            ]),
+            &WorkflowCatalogSnapshot::default(),
+            &WorkflowCatalogSnapshot::default(),
+            &CapabilityDiscoveryEligibility {
+                allowed_tool_names: Some(BTreeSet::from([
+                    "Foo".to_string(),
+                    "mcp__alpha__inspect".to_string(),
+                ])),
+                ..Default::default()
+            },
+        )
+        .discover(&request("inspect"))
+        .expect("case-preserving allowlist");
+        let allowed_refs = allowed
+            .matches
+            .iter()
+            .map(|entry| entry.capability_ref.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            allowed_refs,
+            BTreeSet::from(["tool:Foo", "tool:mcp__alpha__inspect"])
+        );
+    }
+
+    #[test]
+    fn ordinary_discover_named_function_is_searchable_and_disableable() {
+        let schemas = [schema(
+            "discover",
+            "discover a custom data source",
+            json!({}),
+        )];
+        let visible = index(
+            &schemas,
+            Vec::new(),
+            Vec::new(),
+            CapabilityDiscoveryEligibility::default(),
+        )
+        .discover(&request("discover custom"))
+        .expect("ordinary discover-named function");
+        assert_eq!(visible.matches.len(), 1);
+        assert_eq!(visible.matches[0].capability_ref, "tool:discover");
+
+        let hidden = index(
+            &schemas,
+            Vec::new(),
+            Vec::new(),
+            CapabilityDiscoveryEligibility {
+                disabled_tool_names: BTreeSet::from(["discover".to_string()]),
+                ..Default::default()
+            },
+        )
+        .discover(&request("discover custom"))
+        .expect("disabled ordinary function");
+        assert!(hidden.matches.is_empty());
+    }
+
     #[tokio::test]
     async fn store_facade_builds_from_atomic_metadata_snapshots() {
         let store = bamboo_skills::SkillStore::default();
-        let index = CapabilityDiscoveryIndex::from_store(
-            &[schema(
-                "SafeTool",
-                "Inspect safely",
-                json!({"private_schema": "must-not-be-read"}),
-            )],
+        let catalog = [schema(
+            "SafeTool",
+            "Inspect safely",
+            json!({"private_schema": "must-not-be-read"}),
+        )]
+        .into_iter()
+        .filter_map(ClassifiedToolSchema::new)
+        .collect::<Vec<_>>();
+        let index = CapabilityDiscoveryIndex::from_resolved_classified_store(
+            &catalog,
             &store,
             &CapabilityDiscoveryEligibility::default(),
         )
@@ -1403,5 +1777,30 @@ mod tests {
             .expect("metadata-only store projection");
         assert_eq!(result.matches.len(), 1);
         assert_eq!(result.matches[0].capability_ref, "tool:SafeTool");
+
+        let edit_schema = schema("Edit", "Edit safely", json!({}));
+        let resolved_catalog = [edit_schema.clone()]
+            .into_iter()
+            .filter_map(ClassifiedToolSchema::new)
+            .collect::<Vec<_>>();
+        let disabled_alias = CapabilityDiscoveryEligibility {
+            disabled_tool_names: BTreeSet::from(["apply_patch".to_string()]),
+            ..Default::default()
+        };
+        let resolved = CapabilityDiscoveryIndex::from_resolved_classified_store(
+            &resolved_catalog,
+            &store,
+            &disabled_alias,
+        )
+        .await
+        .discover(&request("edit"))
+        .expect("resolved catalogs must not be filtered twice");
+        assert_eq!(resolved.matches[0].capability_ref, "tool:Edit");
+
+        let legacy = CapabilityDiscoveryIndex::from_store(&[edit_schema], &store, &disabled_alias)
+            .await
+            .discover(&request("edit"))
+            .expect("raw schemas still resolve tool eligibility");
+        assert!(legacy.matches.is_empty());
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -1165,6 +1165,8 @@ fn session_eligibility_is_shared_by_model_and_discovery_projections() {
         schemas: vec![
             schema("update_goal"),
             schema("load_skill"),
+            schema("default::update_goal"),
+            schema("default::load_skill"),
             schema("Glob"),
             schema("Workspace"),
         ],
@@ -1190,7 +1192,12 @@ fn session_eligibility_is_shared_by_model_and_discovery_projections() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(
         catalog_names,
-        std::collections::BTreeSet::from(["Glob", "Workspace"])
+        std::collections::BTreeSet::from([
+            "Glob",
+            "Workspace",
+            "default::load_skill",
+            "default::update_goal",
+        ])
     );
 
     let model_names = resolve_available_tool_schemas_for_session(&config, &tools, &session)
@@ -1204,7 +1211,11 @@ fn session_eligibility_is_shared_by_model_and_discovery_projections() {
             .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(
         model_names,
-        std::collections::BTreeSet::from(["Glob".to_string()])
+        std::collections::BTreeSet::from([
+            "Glob".to_string(),
+            "default::load_skill".to_string(),
+            "default::update_goal".to_string(),
+        ])
     );
     assert_eq!(discovery_names, model_names);
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -2,13 +2,15 @@ use async_trait::async_trait;
 
 use super::prompt_envelope::StablePromptFrame;
 use super::prompt_setup::build_stable_prompt_frame_with_sections;
-use super::tool_schemas::resolve_available_tool_schemas_for_session;
+use super::tool_schemas::{
+    resolve_available_tool_schemas_for_session, resolve_classified_tool_catalog_for_session,
+};
 use bamboo_agent_core::agent::types::{TaskItem, TaskItemStatus, TaskList};
 use bamboo_agent_core::tools::{
     FunctionSchema, ToolCall, ToolExecutionContext, ToolExecutor, ToolResult, ToolSchema,
 };
 use bamboo_agent_core::{Message, Session};
-use bamboo_domain::RuntimeSessionPersistence;
+use bamboo_domain::{CapabilityLoadingClass, RuntimeSessionPersistence};
 use bamboo_skills::runtime_metadata::{
     SKILL_RUNTIME_ACTIVATION_GENERATION_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
     SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY,
@@ -873,13 +875,22 @@ fn explicit_activation_state_becomes_current_only_after_successful_model_load() 
 #[test]
 fn resolve_available_tool_schemas_excludes_canonicalized_disabled_tool_aliases() {
     let config = crate::runtime::config::AgentLoopConfig {
-        disabled_tools: ["Bash".to_string(), "Read".to_string()]
-            .into_iter()
-            .collect(),
+        disabled_tools: [
+            "apply_patch".to_string(),
+            "FileExists".to_string(),
+            "sub_session_manager".to_string(),
+        ]
+        .into_iter()
+        .collect(),
         ..Default::default()
     };
     let tools = StaticToolExecutor {
-        schemas: vec![schema("Bash"), schema("Read"), schema("Write")],
+        schemas: vec![
+            schema("Edit"),
+            schema("GetFileInfo"),
+            schema("SubAgent"),
+            schema("Write"),
+        ],
     };
     let session = Session::new("session-1", "model");
 
@@ -893,7 +904,7 @@ fn resolve_available_tool_schemas_excludes_canonicalized_disabled_tool_aliases()
 }
 
 #[test]
-fn resolve_available_tool_schemas_hides_discoverable_tools_by_default() {
+fn legacy_projection_keeps_deferred_tools_with_short_guide_descriptions() {
     let config = crate::runtime::config::AgentLoopConfig::default();
     let tools = StaticToolExecutor {
         schemas: vec![schema("Read"), schema("Sleep"), schema("scheduler")],
@@ -919,6 +930,283 @@ fn resolve_available_tool_schemas_hides_discoverable_tools_by_default() {
         .find(|s| s.function.name == "scheduler")
         .unwrap();
     assert!(scheduler.function.description.contains("Discoverable"));
+}
+
+#[test]
+fn classified_catalog_drives_legacy_projection_without_hiding_deferred_tools() {
+    let config = crate::runtime::config::AgentLoopConfig::default();
+    let tools = StaticToolExecutor {
+        schemas: [
+            "Bash",
+            "Read",
+            "Grep",
+            "Edit",
+            "Write",
+            "Glob",
+            "GetFileInfo",
+            "load_skill",
+            "workflow_run",
+            "custom_tool",
+            "mcp__alpha__inspect",
+            "mcp__beta__inspect",
+            "Workspace",
+            "conclusion_with_options",
+            "request_permissions",
+        ]
+        .into_iter()
+        .map(schema)
+        .collect(),
+    };
+    let session = Session::new("classified-catalog", "model");
+
+    let catalog = resolve_classified_tool_catalog_for_session(&config, &tools, &session);
+    let classes = catalog
+        .iter()
+        .map(|entry| (entry.execution_name(), entry.loading_class()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+
+    for name in ["Bash", "Read", "Grep", "Edit", "Write"] {
+        assert_eq!(classes[name], CapabilityLoadingClass::Core, "{name}");
+    }
+    for name in [
+        "Glob",
+        "GetFileInfo",
+        "load_skill",
+        "workflow_run",
+        "custom_tool",
+        "mcp__alpha__inspect",
+        "mcp__beta__inspect",
+    ] {
+        assert_eq!(classes[name], CapabilityLoadingClass::Deferred, "{name}");
+    }
+    for name in [
+        "Workspace",
+        "conclusion_with_options",
+        "request_permissions",
+    ] {
+        assert_eq!(classes[name], CapabilityLoadingClass::HostOnly, "{name}");
+    }
+
+    let model_names = resolve_available_tool_schemas_for_session(&config, &tools, &session)
+        .into_iter()
+        .map(|schema| schema.function.name)
+        .collect::<std::collections::BTreeSet<_>>();
+    for name in [
+        "Glob",
+        "GetFileInfo",
+        "load_skill",
+        "workflow_run",
+        "custom_tool",
+        "mcp__alpha__inspect",
+        "mcp__beta__inspect",
+    ] {
+        assert!(model_names.contains(name), "legacy projection lost {name}");
+    }
+    for name in [
+        "Workspace",
+        "conclusion_with_options",
+        "request_permissions",
+    ] {
+        assert!(!model_names.contains(name), "HostOnly leaked: {name}");
+    }
+
+    let discovery_names =
+        crate::capability_discovery::project_classified_tool_capability_metadata(&catalog)
+            .into_iter()
+            .map(|entry| entry.canonical_name)
+            .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        discovery_names, model_names,
+        "legacy provider projection and discovery must consume one classified catalog"
+    );
+}
+
+#[test]
+fn ordinary_discover_named_function_is_deferred_and_disableable() {
+    let config = crate::runtime::config::AgentLoopConfig {
+        disabled_tools: ["discover".to_string()].into_iter().collect(),
+        ..Default::default()
+    };
+    let tools = StaticToolExecutor {
+        schemas: vec![schema("discover")],
+    };
+    let session = Session::new("custom-discover", "model");
+
+    assert!(resolve_classified_tool_catalog_for_session(&config, &tools, &session).is_empty());
+    assert!(resolve_available_tool_schemas_for_session(&config, &tools, &session).is_empty());
+}
+
+#[test]
+fn exact_custom_alias_registrations_remain_deferred_and_keep_execution_names() {
+    let config = crate::runtime::config::AgentLoopConfig::default();
+    let tools = StaticToolExecutor {
+        schemas: vec![
+            schema("Edit"),
+            schema("apply_patch"),
+            schema("read_file"),
+            schema("execute_command"),
+            schema("bash"),
+            schema("a::custom_tool"),
+            schema("custom_tool"),
+        ],
+    };
+    let session = Session::new("reserved-alias-collision", "model");
+
+    let catalog = resolve_classified_tool_catalog_for_session(&config, &tools, &session);
+    let entries = catalog
+        .iter()
+        .map(|entry| {
+            (
+                entry.execution_name().to_string(),
+                entry.schema().function.name.clone(),
+                entry.loading_class(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        entries,
+        vec![
+            (
+                "Edit".to_string(),
+                "Edit".to_string(),
+                CapabilityLoadingClass::Core
+            ),
+            (
+                "a::custom_tool".to_string(),
+                "a::custom_tool".to_string(),
+                CapabilityLoadingClass::Deferred
+            ),
+            (
+                "apply_patch".to_string(),
+                "apply_patch".to_string(),
+                CapabilityLoadingClass::Deferred
+            ),
+            (
+                "bash".to_string(),
+                "bash".to_string(),
+                CapabilityLoadingClass::Deferred
+            ),
+            (
+                "custom_tool".to_string(),
+                "custom_tool".to_string(),
+                CapabilityLoadingClass::Deferred
+            ),
+            (
+                "execute_command".to_string(),
+                "execute_command".to_string(),
+                CapabilityLoadingClass::Deferred
+            ),
+            (
+                "read_file".to_string(),
+                "read_file".to_string(),
+                CapabilityLoadingClass::Deferred
+            ),
+        ]
+    );
+
+    let model_names = resolve_available_tool_schemas_for_session(&config, &tools, &session)
+        .into_iter()
+        .map(|schema| schema.function.name)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        model_names,
+        vec![
+            "Edit",
+            "a::custom_tool",
+            "apply_patch",
+            "bash",
+            "custom_tool",
+            "execute_command",
+            "read_file"
+        ]
+    );
+    assert_eq!(
+        catalog
+            .iter()
+            .find(|entry| entry.execution_name() == "custom_tool")
+            .expect("exact custom execution entry")
+            .schema()
+            .function
+            .description,
+        "custom_tool tool"
+    );
+}
+
+#[test]
+fn session_disabled_filter_resolves_exact_shadow_before_alias_fallback() {
+    let config = crate::runtime::config::AgentLoopConfig {
+        disabled_tools: std::collections::BTreeSet::from(["default::applyPatch".to_string()]),
+        ..Default::default()
+    };
+    let session = Session::new("disabled-exact-shadow", "model");
+
+    let shadowed = StaticToolExecutor {
+        schemas: vec![schema("Edit"), schema("apply_patch")],
+    };
+    let shadowed_names = resolve_classified_tool_catalog_for_session(&config, &shadowed, &session)
+        .into_iter()
+        .map(|entry| entry.execution_name().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(shadowed_names, vec!["Edit"]);
+
+    let unshadowed = StaticToolExecutor {
+        schemas: vec![schema("Edit")],
+    };
+    assert!(
+        resolve_classified_tool_catalog_for_session(&config, &unshadowed, &session).is_empty(),
+        "without an exact custom shadow, applyPatch must fall back to Edit"
+    );
+}
+
+#[test]
+fn session_eligibility_is_shared_by_model_and_discovery_projections() {
+    let config = crate::runtime::config::AgentLoopConfig::default();
+    let tools = StaticToolExecutor {
+        schemas: vec![
+            schema("update_goal"),
+            schema("load_skill"),
+            schema("Glob"),
+            schema("Workspace"),
+        ],
+    };
+    let mut session = Session::new("shared-session-eligibility", "model");
+    session.metadata.insert(
+        "skill_runtime_loaded_skill_ids".to_string(),
+        "[\"review\"]".to_string(),
+    );
+    session.metadata.insert(
+        "skill_runtime_selected_skill_ids".to_string(),
+        "[\"review\"]".to_string(),
+    );
+    session.metadata.insert(
+        "skill_runtime_selection_source".to_string(),
+        "explicit".to_string(),
+    );
+
+    let catalog = resolve_classified_tool_catalog_for_session(&config, &tools, &session);
+    let catalog_names = catalog
+        .iter()
+        .map(|entry| entry.execution_name())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        catalog_names,
+        std::collections::BTreeSet::from(["Glob", "Workspace"])
+    );
+
+    let model_names = resolve_available_tool_schemas_for_session(&config, &tools, &session)
+        .into_iter()
+        .map(|schema| schema.function.name)
+        .collect::<std::collections::BTreeSet<_>>();
+    let discovery_names =
+        crate::capability_discovery::project_classified_tool_capability_metadata(&catalog)
+            .into_iter()
+            .map(|entry| entry.canonical_name)
+            .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        model_names,
+        std::collections::BTreeSet::from(["Glob".to_string()])
+    );
+    assert_eq!(discovery_names, model_names);
 }
 
 #[test]
@@ -983,8 +1271,7 @@ fn resolve_available_tool_schemas_does_not_mutate_session_metadata() {
 }
 
 #[test]
-fn resolve_available_tool_schemas_keeps_conclusion_with_options_description_neutral_when_flag_disabled(
-) {
+fn model_catalog_excludes_conclusion_with_options_when_enhancement_flag_is_disabled() {
     let config = crate::runtime::config::AgentLoopConfig::default();
     let tools = StaticToolExecutor {
         schemas: vec![schema("conclusion_with_options")],
@@ -992,24 +1279,29 @@ fn resolve_available_tool_schemas_keeps_conclusion_with_options_description_neut
     let session = Session::new("session-1", "model");
 
     let resolved = resolve_available_tool_schemas_for_session(&config, &tools, &session);
-    let conclusion_with_options_schema = resolved
+    assert!(resolved
         .iter()
-        .find(|schema| schema.function.name == "conclusion_with_options")
-        .expect("conclusion_with_options schema should exist");
+        .all(|schema| schema.function.name != "conclusion_with_options"));
 
+    let catalog = resolve_classified_tool_catalog_for_session(&config, &tools, &session);
+    let host_entry = catalog
+        .iter()
+        .find(|entry| entry.execution_name() == "conclusion_with_options")
+        .expect("host catalog keeps compatibility entry");
     assert_eq!(
-        conclusion_with_options_schema.function.description,
+        host_entry.schema().function.description,
         "conclusion_with_options tool"
     );
-    assert!(!conclusion_with_options_schema
+    assert_eq!(host_entry.loading_class(), CapabilityLoadingClass::HostOnly);
+    assert!(!host_entry
+        .schema()
         .function
         .description
         .contains(ASK_USER_ENHANCED_DESCRIPTION_FRAGMENT));
 }
 
 #[test]
-fn resolve_available_tool_schemas_strengthens_conclusion_with_options_description_when_flag_enabled(
-) {
+fn model_catalog_excludes_conclusion_with_options_when_enhancement_flag_is_enabled() {
     let config = crate::runtime::config::AgentLoopConfig::default();
     let tools = StaticToolExecutor {
         schemas: vec![schema("conclusion_with_options")],
@@ -1021,23 +1313,27 @@ fn resolve_available_tool_schemas_strengthens_conclusion_with_options_descriptio
     );
 
     let resolved = resolve_available_tool_schemas_for_session(&config, &tools, &session);
-    let conclusion_with_options_schema = resolved
+    assert!(resolved
         .iter()
-        .find(|schema| schema.function.name == "conclusion_with_options")
-        .expect("conclusion_with_options schema should exist");
+        .all(|schema| schema.function.name != "conclusion_with_options"));
 
-    assert!(conclusion_with_options_schema
+    let catalog = resolve_classified_tool_catalog_for_session(&config, &tools, &session);
+    let host_entry = catalog
+        .iter()
+        .find(|entry| entry.execution_name() == "conclusion_with_options")
+        .expect("host catalog keeps compatibility entry");
+    assert_eq!(host_entry.loading_class(), CapabilityLoadingClass::HostOnly);
+    assert!(host_entry
+        .schema()
         .function
         .description
         .contains(ASK_USER_ENHANCED_DESCRIPTION_FRAGMENT));
-    assert!(conclusion_with_options_schema
+    assert!(host_entry
+        .schema()
         .function
         .description
         .contains("conclusion"));
-    assert!(conclusion_with_options_schema
-        .function
-        .description
-        .contains("OK"));
+    assert!(host_entry.schema().function.description.contains("OK"));
 }
 
 #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
@@ -1,14 +1,15 @@
 use crate::runtime::config::AgentLoopConfig;
 use bamboo_agent_core::tools::{ToolExecutor, ToolSchema};
 use bamboo_agent_core::Session;
+use bamboo_domain::{
+    canonical_tool_name, resolve_tool_reference_name, CapabilityLoadingClass,
+    ClassifiedToolIdentity, ClassifiedToolSchema,
+};
 use bamboo_skills::runtime_metadata::{
     LOADED_SKILL_IDS_METADATA_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
     SKILL_RUNTIME_SELECTION_SOURCE_KEY,
 };
-use bamboo_tools::exposure::{
-    activated_discoverable_tools, canonical_tool_name, discoverable_tool_short_description,
-    is_core_tool,
-};
+use bamboo_tools::exposure::{activated_discoverable_tools, expandable_tool_short_description};
 
 const COPILOT_CONCLUSION_WITH_OPTIONS_ENHANCEMENT_METADATA_KEY: &str =
     "copilot_conclusion_with_options_enhancement_enabled";
@@ -41,6 +42,25 @@ pub(crate) fn resolve_available_tool_schemas_for_session(
     tools: &dyn ToolExecutor,
     session: &Session,
 ) -> Vec<ToolSchema> {
+    resolve_classified_tool_catalog_for_session(config, tools, session)
+        .into_iter()
+        .filter(ClassifiedToolSchema::is_model_visible)
+        .map(ClassifiedToolSchema::into_schema)
+        .collect()
+}
+
+/// Resolve the provider-neutral logical catalog for one round.
+///
+/// Legacy providers project every model-visible Deferred entry from this
+/// catalog. Native/fallback progressive-loading adapters later consume the same
+/// classification and may project only initially visible entries. HostOnly
+/// entries remain represented for host compatibility but never cross the model
+/// catalog projection above.
+pub(crate) fn resolve_classified_tool_catalog_for_session(
+    config: &AgentLoopConfig,
+    tools: &dyn ToolExecutor,
+    session: &Session,
+) -> Vec<ClassifiedToolSchema> {
     let mut tool_schemas = config.tool_registry.list_tools();
     if tool_schemas.is_empty() {
         tool_schemas = tools.list_tools();
@@ -54,16 +74,13 @@ pub(crate) fn resolve_available_tool_schemas_for_session(
     // round, because this list is rebuilt unfiltered every round; with no resolver
     // (SDK/tests) this is the frozen per-run snapshot (#44), unchanged.
     let (disabled_tools, _disabled_skill_ids) = config.resolve_disabled_filters();
-    if !disabled_tools.is_empty() {
-        tool_schemas.retain(|schema| !disabled_tools.contains(&schema.function.name));
-    }
-
     // The `update_goal` self-report tool is only meaningful while the autonomous
     // goal loop is active; hide it from every ordinary session so it never
     // tempts the model when no goal is set.
     if !config.goal_loop_active() {
         tool_schemas.retain(|schema| {
-            schema.function.name != bamboo_tools::tools::goal::UPDATE_GOAL_TOOL_NAME
+            !canonical_tool_name(&schema.function.name)
+                .eq_ignore_ascii_case(bamboo_tools::tools::goal::UPDATE_GOAL_TOOL_NAME)
         });
     }
 
@@ -95,18 +112,24 @@ pub(crate) fn resolve_available_tool_schemas_for_session(
             .metadata
             .contains_key(bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY);
     if explicit_activation_is_current || explicit_activation_degraded {
-        tool_schemas.retain(|schema| schema.function.name != "load_skill");
+        tool_schemas.retain(|schema| {
+            !canonical_tool_name(&schema.function.name).eq_ignore_ascii_case("load_skill")
+        });
     }
 
     let activated = activated_discoverable_tools(session);
 
-    // Replace descriptions for inactive discoverable tools with short summaries.
-    // All tools remain available to the LLM; activation only controls the
-    // depth of guidance (short vs full) shown in the tool guide.
+    // Legacy providers keep Deferred schemas visible during migration;
+    // activation only controls the depth of the existing tool-guide summaries.
     for schema in &mut tool_schemas {
-        let canonical = canonical_tool_name(&schema.function.name);
-        if !is_core_tool(&canonical) && !activated.contains(&canonical) {
-            if let Some(short) = discoverable_tool_short_description(&canonical) {
+        let Some(identity) = ClassifiedToolIdentity::from_schema_name(&schema.function.name) else {
+            continue;
+        };
+        let guide_name = identity.alias_fallback_name();
+        if identity.loading_class() == CapabilityLoadingClass::Deferred
+            && !activated.contains(guide_name)
+        {
+            if let Some(short) = expandable_tool_short_description(guide_name) {
                 schema.function.description =
                     format!("[Discoverable — not fully activated] {}", short);
             }
@@ -115,7 +138,36 @@ pub(crate) fn resolve_available_tool_schemas_for_session(
 
     apply_session_tool_schema_overrides(session, &mut tool_schemas);
 
-    tool_schemas
+    let mut by_execution_name = std::collections::BTreeMap::<String, ClassifiedToolSchema>::new();
+    for entry in tool_schemas
+        .into_iter()
+        .filter_map(ClassifiedToolSchema::new)
+    {
+        let key = entry.execution_name().to_string();
+        match by_execution_name.entry(key) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(entry);
+            }
+            std::collections::btree_map::Entry::Occupied(_) => {}
+        }
+    }
+    let disabled_execution_names = disabled_tools
+        .iter()
+        .filter_map(|reference| {
+            resolve_tool_reference_name(reference, |name| by_execution_name.contains_key(name))
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    by_execution_name.retain(|name, _| !disabled_execution_names.contains(name));
+
+    let mut catalog = by_execution_name.into_values().collect::<Vec<_>>();
+    catalog.sort_by(|left, right| {
+        left.schema()
+            .function
+            .name
+            .cmp(&right.schema().function.name)
+    });
+
+    catalog
 }
 
 #[cfg(test)]

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
@@ -2,8 +2,8 @@ use crate::runtime::config::AgentLoopConfig;
 use bamboo_agent_core::tools::{ToolExecutor, ToolSchema};
 use bamboo_agent_core::Session;
 use bamboo_domain::{
-    canonical_tool_name, resolve_tool_reference_name, CapabilityLoadingClass,
-    ClassifiedToolIdentity, ClassifiedToolSchema,
+    resolve_tool_reference_name, CapabilityLoadingClass, ClassifiedToolIdentity,
+    ClassifiedToolSchema,
 };
 use bamboo_skills::runtime_metadata::{
     LOADED_SKILL_IDS_METADATA_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
@@ -79,8 +79,7 @@ pub(crate) fn resolve_classified_tool_catalog_for_session(
     // tempts the model when no goal is set.
     if !config.goal_loop_active() {
         tool_schemas.retain(|schema| {
-            !canonical_tool_name(&schema.function.name)
-                .eq_ignore_ascii_case(bamboo_tools::tools::goal::UPDATE_GOAL_TOOL_NAME)
+            schema.function.name != bamboo_tools::tools::goal::UPDATE_GOAL_TOOL_NAME
         });
     }
 
@@ -112,9 +111,7 @@ pub(crate) fn resolve_classified_tool_catalog_for_session(
             .metadata
             .contains_key(bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY);
     if explicit_activation_is_current || explicit_activation_degraded {
-        tool_schemas.retain(|schema| {
-            !canonical_tool_name(&schema.function.name).eq_ignore_ascii_case("load_skill")
-        });
+        tool_schemas.retain(|schema| schema.function.name != "load_skill");
     }
 
     let activated = activated_discoverable_tools(session);

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -298,7 +298,7 @@ pub struct ExecuteRequest {
     /// Optional per-round live resolver for the disabled tool/skill sets (#136).
     /// When `None`, the snapshotted `disabled_tools`/`disabled_skill_ids` are used.
     pub disabled_filter_resolver: Option<DisabledFilterResolver>,
-    /// When `None`, falls back to `Config::disabled_tool_names()`.
+    /// When `None`, falls back to `Config::disabled_tool_references()`.
     pub disabled_tools: Option<BTreeSet<String>>,
     /// When `None`, falls back to `Config::disabled_skill_ids()`.
     pub disabled_skill_ids: Option<BTreeSet<String>>,
@@ -809,7 +809,7 @@ impl AgentRuntime {
             auxiliary_model_resolver,
             disabled_filter_resolver,
             disabled_tools: {
-                let mut merged = config.disabled_tool_names();
+                let mut merged = config.disabled_tool_references();
                 if let Some(dt) = disabled_tools {
                     merged.extend(dt);
                 }

--- a/crates/engine/bamboo-engine/src/session_app/resolution.rs
+++ b/crates/engine/bamboo-engine/src/session_app/resolution.rs
@@ -62,7 +62,7 @@ pub fn resolve_resume_config_snapshot(
             .map(|model| model.model_name.clone()),
         summarization_model_ref: areas.summarization_ref.clone(),
         summarization_model_provider: areas.summarization.map(|model| model.provider),
-        disabled_tools: config.disabled_tool_names(),
+        disabled_tools: config.disabled_tool_references(),
         disabled_skill_ids: config.disabled_skill_ids(),
         image_fallback: resolve_image_fallback(config).ok().flatten(),
         gold_config: gold_config_override.or_else(|| {

--- a/crates/engine/bamboo-tools/src/exposure.rs
+++ b/crates/engine/bamboo-tools/src/exposure.rs
@@ -1,12 +1,24 @@
 use std::collections::{BTreeSet, HashMap};
 
-use bamboo_agent_core::normalize_tool_name;
 use bamboo_agent_core::Session;
-use bamboo_domain::tool_names::resolve_alias;
 
 pub const ACTIVATED_DISCOVERABLE_TOOLS_METADATA_KEY: &str = "activated_discoverable_tools";
 const MAX_ACTIVATED_DISCOVERABLE_TOOLS: usize = 12;
 
+/// Legacy tool-guide detail policy. This controls expandable guidance and
+/// session metadata only; it is not callable Core/Deferred loading policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolGuideExposure {
+    Full,
+    Expandable,
+}
+
+/// Deprecated names for the legacy guide-detail policy.
+///
+/// `Core` here never meant the callable loading class introduced by #986.
+#[deprecated(
+    note = "use ToolGuideExposure::{Full, Expandable}; callable loading policy lives in bamboo_domain::CapabilityLoadingClass"
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolExposure {
     Core,
@@ -14,27 +26,48 @@ pub enum ToolExposure {
 }
 
 pub fn canonical_tool_name(name: &str) -> String {
-    let normalized = normalize_tool_name(name.trim());
-    resolve_alias(normalized).unwrap_or(normalized).to_string()
+    bamboo_domain::canonical_tool_name(name)
 }
 
-pub fn exposure_for_tool_name(name: &str) -> ToolExposure {
+pub fn guide_exposure_for_tool_name(name: &str) -> ToolGuideExposure {
     match canonical_tool_name(name).as_str() {
         // Lower-frequency or specialized tools stay discoverable by default.
         "Sleep" | "NotebookEdit" | "js_repl" | "WebFetch" | "WebSearch" | "memory"
         | "scheduler" | "SubAgent" | "session_history" | "ExitPlanMode" => {
-            ToolExposure::Discoverable
+            ToolGuideExposure::Expandable
         }
-        _ => ToolExposure::Core,
+        _ => ToolGuideExposure::Full,
     }
 }
 
-pub fn is_core_tool(name: &str) -> bool {
-    matches!(exposure_for_tool_name(name), ToolExposure::Core)
+#[allow(deprecated)]
+#[deprecated(note = "use guide_exposure_for_tool_name for legacy guide detail policy")]
+pub fn exposure_for_tool_name(name: &str) -> ToolExposure {
+    match guide_exposure_for_tool_name(name) {
+        ToolGuideExposure::Full => ToolExposure::Core,
+        ToolGuideExposure::Expandable => ToolExposure::Discoverable,
+    }
 }
 
+pub fn has_full_tool_guide(name: &str) -> bool {
+    matches!(guide_exposure_for_tool_name(name), ToolGuideExposure::Full)
+}
+
+#[deprecated(note = "use has_full_tool_guide; this predicate is not callable Core policy")]
+pub fn is_core_tool(name: &str) -> bool {
+    has_full_tool_guide(name)
+}
+
+pub fn has_expandable_tool_guide(name: &str) -> bool {
+    matches!(
+        guide_exposure_for_tool_name(name),
+        ToolGuideExposure::Expandable
+    )
+}
+
+#[deprecated(note = "use has_expandable_tool_guide for legacy guide detail policy")]
 pub fn is_discoverable_tool(name: &str) -> bool {
-    matches!(exposure_for_tool_name(name), ToolExposure::Discoverable)
+    has_expandable_tool_guide(name)
 }
 
 pub fn activated_discoverable_tools_from_metadata(
@@ -46,7 +79,7 @@ pub fn activated_discoverable_tools_from_metadata(
         .unwrap_or_default()
         .into_iter()
         .map(|name| canonical_tool_name(&name))
-        .filter(|name| is_discoverable_tool(name))
+        .filter(|name| has_expandable_tool_guide(name))
         .collect()
 }
 
@@ -62,7 +95,7 @@ where
     let mut activated = activated_discoverable_tools(session);
     for tool_name in tool_names {
         let canonical = canonical_tool_name(tool_name.as_ref());
-        if is_discoverable_tool(&canonical) {
+        if has_expandable_tool_guide(&canonical) {
             activated.insert(canonical);
         }
     }
@@ -113,8 +146,8 @@ where
     }
 }
 
-/// Short description for discoverable tools shown when not activated.
-pub fn discoverable_tool_short_description(name: &str) -> Option<&'static str> {
+/// Short summary for a legacy expandable guide shown before activation.
+pub fn expandable_tool_short_description(name: &str) -> Option<&'static str> {
     match canonical_tool_name(name).as_str() {
         "Sleep" => Some("Pause briefly when waiting for an external state change before polling again."),
         "NotebookEdit" => Some("Edit notebook cells by replace/insert/delete."),
@@ -130,7 +163,13 @@ pub fn discoverable_tool_short_description(name: &str) -> Option<&'static str> {
     }
 }
 
-/// Return the canonical names of all discoverable tools.
+#[deprecated(note = "use expandable_tool_short_description for legacy guide summaries")]
+pub fn discoverable_tool_short_description(name: &str) -> Option<&'static str> {
+    expandable_tool_short_description(name)
+}
+
+/// Return the legacy expandable-guide names used by the compatibility API.
+/// This is not the complete typed capability discovery catalog.
 pub fn list_discoverable_tools() -> Vec<&'static str> {
     vec![
         "Sleep",
@@ -153,22 +192,27 @@ mod tests {
     #[test]
     fn canonical_name_resolves_builtin_aliases() {
         assert_eq!(canonical_tool_name("FileExists"), "GetFileInfo");
+        assert_eq!(canonical_tool_name("default::set_workspace"), "Workspace");
+        assert_eq!(canonical_tool_name("default::applyPatch"), "Edit");
         assert_eq!(
-            canonical_tool_name("default::set_workspace"),
-            "set_workspace"
+            canonical_tool_name("mcp__filesystem__read_file"),
+            "mcp__filesystem__read_file"
         );
     }
 
     #[test]
-    fn discoverable_exposure_includes_memory_and_subagent() {
-        assert!(is_discoverable_tool("memory"));
-        assert!(is_discoverable_tool("SubAgent"));
-        assert!(is_discoverable_tool("sub_session_manager"));
+    fn expandable_guides_include_memory_and_subagent() {
+        assert!(has_full_tool_guide("Bash"));
+        assert!(has_expandable_tool_guide("memory"));
+        assert!(has_expandable_tool_guide("SubAgent"));
+        assert!(has_expandable_tool_guide("sub_session_manager"));
+        assert!(!has_expandable_tool_guide("future_dynamic_tool"));
         assert!(list_discoverable_tools().contains(&"memory"));
         assert!(list_discoverable_tools().contains(&"SubAgent"));
-        assert!(discoverable_tool_short_description("memory").is_some());
-        assert!(discoverable_tool_short_description("SubAgent").is_some());
-        assert!(discoverable_tool_short_description("sub_session_manager").is_some());
+        assert!(!list_discoverable_tools().contains(&"Workspace"));
+        assert!(expandable_tool_short_description("memory").is_some());
+        assert!(expandable_tool_short_description("SubAgent").is_some());
+        assert!(expandable_tool_short_description("sub_session_manager").is_some());
     }
 
     #[test]

--- a/crates/engine/bamboo-tools/src/guide/mod.rs
+++ b/crates/engine/bamboo-tools/src/guide/mod.rs
@@ -28,7 +28,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::exposure::{canonical_tool_name, is_core_tool};
+use crate::exposure::{canonical_tool_name, has_full_tool_guide};
 use bamboo_agent_core::ToolSchema;
 use serde::{Deserialize, Serialize};
 
@@ -397,16 +397,16 @@ impl EnhancedPromptBuilder {
     ) -> String {
         let guides = Self::collect_guides(registry, tool_names);
 
-        // Split into core, activated-discoverable, and inactive-discoverable.
+        // Split legacy guide detail independently of callable loading policy.
         let activated = &context.activated_discoverable_tools;
-        let mut core_guides: Vec<ToolGuideSpec> = Vec::new();
+        let mut full_guides: Vec<ToolGuideSpec> = Vec::new();
         let mut activated_discoverable: Vec<ToolGuideSpec> = Vec::new();
         let mut inactive_discoverable: Vec<ToolGuideSpec> = Vec::new();
 
         for guide in guides {
             let canonical = canonical_tool_name(&guide.tool_name);
-            if is_core_tool(&canonical) {
-                core_guides.push(guide);
+            if has_full_tool_guide(&canonical) {
+                full_guides.push(guide);
             } else if activated.contains(&canonical) {
                 activated_discoverable.push(guide);
             } else {
@@ -417,11 +417,11 @@ impl EnhancedPromptBuilder {
         let mut output = String::from("## Tool Usage Guidelines\n");
         let mut rendered_any = false;
 
-        // Render core tools (always full detail).
-        if !core_guides.is_empty() {
+        // Render legacy full-detail guides.
+        if !full_guides.is_empty() {
             rendered_any = true;
             let mut grouped: BTreeMap<ToolCategory, Vec<&ToolGuideSpec>> = BTreeMap::new();
-            for guide in &core_guides {
+            for guide in &full_guides {
                 grouped.entry(guide.category).or_default().push(guide);
             }
 
@@ -488,7 +488,7 @@ impl EnhancedPromptBuilder {
             ));
         }
 
-        let guided_names: BTreeSet<String> = core_guides
+        let guided_names: BTreeSet<String> = full_guides
             .iter()
             .chain(activated_discoverable.iter())
             .chain(inactive_discoverable.iter())
@@ -995,7 +995,7 @@ mod tests {
     }
 
     #[test]
-    fn build_separates_core_and_discoverable_tools_correctly() {
+    fn build_separates_full_and_expandable_tool_guides_correctly() {
         let registry = ToolRegistry::new();
         registry.register(ReadTool::new()).unwrap();
         registry.register(crate::tools::SleepTool::new()).unwrap();
@@ -1008,14 +1008,14 @@ mod tests {
 
         let prompt = EnhancedPromptBuilder::build(Some(&registry), &schemas, &context);
 
-        // Core tool (Read) should appear in its category section with full detail
+        // Full-guide tool (Read) appears in its category section.
         assert!(
             prompt.contains("### File Reading Tools"),
-            "core tools should appear in category section"
+            "full guides should appear in category section"
         );
         assert!(
             prompt.contains("**Read**"),
-            "core Read should show full guide"
+            "Read should show its full guide"
         );
 
         // Activated discoverable should appear in activated section

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -66,7 +66,7 @@ use std::sync::{OnceLock, RwLock};
 
 use crate::keyword_masking::KeywordMaskingConfig;
 use crate::model_mapping::{AnthropicModelMapping, GeminiModelMapping};
-use bamboo_domain::tool_names::normalize_tool_ref;
+use bamboo_domain::normalize_tool_ref;
 use bamboo_domain::ReasoningEffort;
 
 /// Minimum accepted watchdog deadline. Zero would turn scheduling jitter into
@@ -4352,20 +4352,36 @@ impl Config {
         }
     }
 
-    /// Get normalized disabled tool names.
-    pub fn disabled_tool_names(&self) -> BTreeSet<String> {
+    /// Get exact disabled tool references for catalog-aware resolution.
+    ///
+    /// References remain exact here: catalog-aware filtering resolves an exact
+    /// registered name before applying legacy/builtin alias fallback. Eagerly
+    /// rewriting `apply_patch` to `Edit`, for example, would make an exact
+    /// custom `apply_patch` registration indistinguishable from the builtin.
+    pub fn disabled_tool_references(&self) -> BTreeSet<String> {
         self.tools
             .disabled
             .iter()
             .map(|name| name.trim())
             .filter(|name| !name.is_empty())
-            .map(|name| normalize_tool_ref(name).unwrap_or_else(|| name.to_string()))
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Legacy normalized-name facade retained for source compatibility.
+    ///
+    /// New execution/catalog code must use [`Self::disabled_tool_references`]
+    /// so an exact registered alias can be resolved before fallback.
+    pub fn disabled_tool_names(&self) -> BTreeSet<String> {
+        self.disabled_tool_references()
+            .into_iter()
+            .map(|reference| normalize_tool_ref(&reference).unwrap_or(reference))
             .collect()
     }
 
     /// Normalize tool settings (trim / dedupe / sort).
     pub fn normalize_tool_settings(&mut self) {
-        self.tools.disabled = self.disabled_tool_names().into_iter().collect();
+        self.tools.disabled = self.disabled_tool_references().into_iter().collect();
     }
 
     /// Get normalized disabled skill IDs.
@@ -8495,7 +8511,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_tool_settings_trims_dedupes_canonicalizes_and_sorts() {
+    fn normalize_tool_settings_trims_dedupes_and_sorts_raw_references() {
         let mut config = Config::default();
         config.tools.disabled = vec![
             "  read_file  ".to_string(),
@@ -8503,15 +8519,28 @@ mod tests {
             "read_file".to_string(),
             "bash".to_string(),
             "default::getCurrentDir".to_string(),
+            "default::applyPatch".to_string(),
+            "default::custom_tool".to_string(),
+            "mcp__alpha__inspect".to_string(),
         ];
 
         config.normalize_tool_settings();
 
-        assert_eq!(config.tools.disabled, vec!["Bash", "GetCurrentDir", "Read"]);
+        assert_eq!(
+            config.tools.disabled,
+            vec![
+                "bash",
+                "default::applyPatch",
+                "default::custom_tool",
+                "default::getCurrentDir",
+                "mcp__alpha__inspect",
+                "read_file"
+            ]
+        );
     }
 
     #[test]
-    fn config_load_reads_disabled_tools_as_canonical_names() {
+    fn config_load_preserves_disabled_references_for_catalog_resolution() {
         let _lock = env_lock_acquire();
         let temp_home = TempHome::new();
         temp_home.set_config_json(
@@ -8523,10 +8552,23 @@ mod tests {
         );
 
         let config = Config::from_data_dir(Some(temp_home.path.clone()));
-        assert_eq!(config.tools.disabled, vec!["Bash", "GetCurrentDir", "Read"]);
-        assert!(config.disabled_tool_names().contains("Bash"));
-        assert!(config.disabled_tool_names().contains("Read"));
-        assert!(config.disabled_tool_names().contains("GetCurrentDir"));
+        assert_eq!(
+            config.tools.disabled,
+            vec!["bash", "default::getCurrentDir", "read_file"]
+        );
+        assert!(config.disabled_tool_references().contains("bash"));
+        assert!(config.disabled_tool_references().contains("read_file"));
+        assert!(config
+            .disabled_tool_references()
+            .contains("default::getCurrentDir"));
+        assert_eq!(
+            config.disabled_tool_names(),
+            BTreeSet::from([
+                "Bash".to_string(),
+                "GetCurrentDir".to_string(),
+                "Read".to_string()
+            ])
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-mcp/src/tool_index.rs
+++ b/crates/infra/bamboo-mcp/src/tool_index.rs
@@ -127,6 +127,7 @@ impl Default for ToolIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bamboo_domain::{canonical_tool_name, CapabilityLoadingClass, ClassifiedToolIdentity};
 
     #[test]
     fn test_generate_alias() {
@@ -140,6 +141,19 @@ mod tests {
         let index = ToolIndex::new();
         let alias = index.generate_alias("my::server", "tool::name");
         assert_eq!(alias, "mcp__my__server__tool__name");
+    }
+
+    #[test]
+    fn generated_alias_is_an_exact_deferred_capability_identity() {
+        let index = ToolIndex::new();
+        let alias = index.generate_alias("filesystem", "read_file");
+        let identity = ClassifiedToolIdentity::from_schema_name(&alias)
+            .expect("generated MCP alias must be a valid registration identity");
+
+        assert_eq!(canonical_tool_name(&alias), alias);
+        assert_eq!(identity.execution_name(), alias);
+        assert_eq!(identity.alias_fallback_name(), alias);
+        assert_eq!(identity.loading_class(), CapabilityLoadingClass::Deferred);
     }
 
     #[test]

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -2266,7 +2266,11 @@ mod tests {
             value["mcpServers"]["stdio-server"]["env"]["TOKEN"],
             "****...****"
         );
-        assert_eq!(value["tools"]["disabled"], json!(["Bash", "Read"]));
+        assert_eq!(
+            value["tools"]["disabled"],
+            json!(["bash", "read_file"]),
+            "CLI serialization must preserve exact references for catalog-aware resolution"
+        );
     }
 
     #[test]
@@ -2283,7 +2287,11 @@ mod tests {
             value["mcpServers"]["stdio-server"]["env"]["TOKEN"],
             "super-secret"
         );
-        assert_eq!(value["tools"]["disabled"], json!(["Bash", "Read"]));
+        assert_eq!(
+            value["tools"]["disabled"],
+            json!(["bash", "read_file"]),
+            "including secrets must not change exact disabled-tool references"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add provider-neutral `CapabilityLoadingClass::{Core, Deferred, HostOnly}` and a classified `ToolSchema` wrapper
- lock the callable Core set to exactly `Bash`, `Read`, `Grep`, `Edit`, and `Write`, with `discover` represented as a separate always-visible control gateway
- preserve exact registered execution identities and add a shared exact-first reference resolver for classification, disabled filters, discovery, and later admission
- build model and discovery projections from the same session-classified catalog; exclude HostOnly tools while keeping Deferred tools visible for legacy providers
- preserve raw disabled references until the catalog is known and retain deprecated source-compatible guide exposure APIs
- cover real server overlays and generated MCP aliases without adding provider wire fields or enabling loaded-state admission

## Test Plan

- `cargo test --locked -p bamboo-domain -p bamboo-config -p bamboo-tools -p bamboo-engine -p bamboo-mcp -p bamboo-server`
  - domain 244, config 694, tools 387 plus integration, engine 1417 plus doc-test, MCP 211, server 1958 plus integration/doc tests: all non-ignored tests passed
- `cargo check --locked -p bamboo-domain -p bamboo-config -p bamboo-tools -p bamboo-engine -p bamboo-mcp -p bamboo-server`
- final focused policy/discovery/session/guide/MCP/server tests after the lint-only patch
- `cargo fmt --all -- --check`
- `git diff --check`
- strict Clippy audit for all six affected packages: no warning introduced by this diff; the raw repository command still reports pre-existing `too_many_arguments` and test-target lint in untouched files, while `-D warnings` passes after allowing only those independently verified baseline categories

## Scope and follow-ups

This is the provider-neutral foundation only. It does not enable Anthropic/OpenAI wire lowering, loaded-state admission, provider transcript parsing, or cache invalidation.

- #989 owns concrete executor exact-routing before admission is enabled
- #990 owns collision-safe, ownership-aware MCP aliases
- #991 tracks future origin-aware registration hardening for untrusted registrars

## Screenshots

Not applicable; no UI changes.

Closes #986
