### PR TITLE
fix: honor exact tool execution identities (#989)

### DIFF
--- a/crates/app/bamboo-broker/src/mcp.rs
+++ b/crates/app/bamboo-broker/src/mcp.rs
@@ -772,6 +772,17 @@ impl ToolExecutor for McpProxyExecutor {
     fn list_tools(&self) -> Vec<ToolSchema> {
         self.manifest.read().map(|m| m.clone()).unwrap_or_default()
     }
+
+    fn owns_exact_tool(&self, tool_name: &str) -> bool {
+        self.manifest
+            .read()
+            .map(|manifest| {
+                manifest
+                    .iter()
+                    .any(|schema| schema.function.name == tool_name)
+            })
+            .unwrap_or(false)
+    }
 }
 
 #[cfg(test)]
@@ -1096,6 +1107,9 @@ mod tests {
         let tools = proxy.list_tools();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].function.name, "nova_click");
+        assert!(proxy.owns_exact_tool("nova_click"));
+        assert!(!proxy.owns_exact_tool("NOVA_CLICK"));
+        assert!(!proxy.owns_exact_tool("default::nova_click"));
 
         // A call is forwarded to the orchestrator and the result comes back.
         let call = ToolCall {

--- a/crates/app/bamboo-server-tools/src/overlay_executor.rs
+++ b/crates/app/bamboo-server-tools/src/overlay_executor.rs
@@ -1,10 +1,17 @@
 use async_trait::async_trait;
 
 use bamboo_agent_core::tools::{
-    normalize_tool_name, parse_tool_args_best_effort, Tool, ToolCall, ToolError,
-    ToolExecutionContext, ToolExecutor, ToolOutcome, ToolResult, ToolSchema,
+    parse_tool_args_best_effort, Tool, ToolCall, ToolError, ToolExecutionContext, ToolExecutor,
+    ToolOutcome, ToolResult, ToolSchema,
 };
-use bamboo_tools::normalize_tool_ref;
+use bamboo_domain::resolve_tool_reference_name;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum OverlayRoute {
+    Overlay,
+    BaseExact(String),
+    BaseFallback,
+}
 
 /// Tool executor that overlays a single tool on top of an existing executor.
 ///
@@ -43,6 +50,36 @@ impl OverlayToolExecutor {
         }
         args
     }
+
+    /// Resolve against the complete overlay + base catalog. Exact base
+    /// identities are considered before any compatibility alias can select the
+    /// overlay; an intentional same-name overlay replacement retains precedence.
+    fn route(&self, reference: &str) -> OverlayRoute {
+        let resolved = resolve_tool_reference_name(reference, |candidate| {
+            candidate == self.overlay.name() || self.base.owns_exact_tool(candidate)
+        });
+        match resolved {
+            Some(execution_name) if execution_name == self.overlay.name() => OverlayRoute::Overlay,
+            Some(execution_name) => OverlayRoute::BaseExact(execution_name),
+            None => OverlayRoute::BaseFallback,
+        }
+    }
+
+    async fn execute_overlay_outcome(
+        &self,
+        call: &ToolCall,
+        ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolOutcome, ToolError> {
+        let args = self.resolve_args(call, &ctx);
+        if let Some(outcome) = self
+            .base
+            .check_permissions_for_resolved(call, self.overlay.name(), &args, &ctx)
+            .await?
+        {
+            return Ok(outcome);
+        }
+        self.overlay.invoke(args, ctx.to_tool_ctx()).await
+    }
 }
 
 #[async_trait]
@@ -57,36 +94,9 @@ impl ToolExecutor for OverlayToolExecutor {
         call: &ToolCall,
         ctx: ToolExecutionContext<'_>,
     ) -> Result<ToolResult, ToolError> {
-        let name = normalize_tool_name(&call.function.name);
-        let is_overlay_call = name == self.overlay.name()
-            || normalize_tool_ref(name)
-                .as_deref()
-                .is_some_and(|normalized| normalized == self.overlay.name());
-        if is_overlay_call {
-            // Gate the overlay tool through the base executor's real permission
-            // check BEFORE invoking it (issue #341). The permission checker lives
-            // in the base (built-in) executor, so overlay tools (`memory`,
-            // `scheduler`, `SubAgent`, …) used to bypass it entirely. `Some`
-            // is the interactive approval pause; `Err` is deny / fail-closed.
-            if let Some(outcome) = self.base.check_permissions_for(call, &ctx).await? {
-                return Ok(outcome.into_tool_result());
-            }
-            // Reuse the args the dispatching loop already parsed (threaded via the
-            // context) instead of re-parsing the raw JSON string a second time here
-            // (issue #106). The threaded value is the exact output of the same
-            // parser on the same input, so reuse is behavior-preserving — and it
-            // means the malformed-args fallback `warn!` fires at most once per call
-            // (at the dispatch site), never re-emitted here. When absent (`none()`
-            // contexts, tests, synthesized child calls), parse leniently exactly as
-            // before, including the fallback warning.
-            let args = self.resolve_args(call, &ctx);
-            return self
-                .overlay
-                .invoke(args, ctx.to_tool_ctx())
-                .await
-                .map(|outcome| outcome.into_tool_result());
-        }
-        self.base.execute_with_context(call, ctx).await
+        self.execute_with_context_outcome(call, ctx)
+            .await
+            .map(ToolOutcome::into_tool_result)
     }
 
     async fn execute_with_context_outcome(
@@ -94,23 +104,35 @@ impl ToolExecutor for OverlayToolExecutor {
         call: &ToolCall,
         ctx: ToolExecutionContext<'_>,
     ) -> Result<ToolOutcome, ToolError> {
-        let name = normalize_tool_name(&call.function.name);
-        let is_overlay_call = name == self.overlay.name()
-            || normalize_tool_ref(name)
-                .as_deref()
-                .is_some_and(|normalized| normalized == self.overlay.name());
-        if is_overlay_call {
-            // Same permission gate as `execute_with_context` (issue #341): the
-            // overlay tool is checked by the base executor before it runs.
-            if let Some(outcome) = self.base.check_permissions_for(call, &ctx).await? {
-                return Ok(outcome);
+        match self.route(&call.function.name) {
+            OverlayRoute::Overlay => self.execute_overlay_outcome(call, ctx).await,
+            OverlayRoute::BaseExact(execution_name) => {
+                self.base
+                    .execute_exact_with_context_outcome(call, &execution_name, ctx)
+                    .await
             }
-            // Reuse the dispatch-parsed args (parse-once) exactly as in
-            // `execute_with_context` above (issue #106).
-            let args = self.resolve_args(call, &ctx);
-            return self.overlay.invoke(args, ctx.to_tool_ctx()).await;
+            OverlayRoute::BaseFallback => self.base.execute_with_context_outcome(call, ctx).await,
         }
-        self.base.execute_with_context_outcome(call, ctx).await
+    }
+
+    async fn execute_exact_with_context_outcome(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolOutcome, ToolError> {
+        if execution_name == self.overlay.name() {
+            self.execute_overlay_outcome(call, ctx).await
+        } else if self.base.owns_exact_tool(execution_name) {
+            self.base
+                .execute_exact_with_context_outcome(call, execution_name, ctx)
+                .await
+        } else {
+            Err(ToolError::NotFound(format!(
+                "Tool '{}' not found",
+                execution_name
+            )))
+        }
     }
 
     /// Delegate the permission gate to the base executor so stacked overlays
@@ -121,7 +143,32 @@ impl ToolExecutor for OverlayToolExecutor {
         call: &ToolCall,
         ctx: &ToolExecutionContext<'_>,
     ) -> Result<Option<ToolOutcome>, ToolError> {
-        self.base.check_permissions_for(call, ctx).await
+        match self.route(&call.function.name) {
+            OverlayRoute::Overlay => {
+                let args = ctx
+                    .pre_parsed_args
+                    .cloned()
+                    .unwrap_or_else(|| parse_tool_args_best_effort(&call.function.arguments).0);
+                self.base
+                    .check_permissions_for_resolved(call, self.overlay.name(), &args, ctx)
+                    .await
+            }
+            OverlayRoute::BaseExact(_) | OverlayRoute::BaseFallback => {
+                self.base.check_permissions_for(call, ctx).await
+            }
+        }
+    }
+
+    async fn check_permissions_for_resolved(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        args: &serde_json::Value,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>, ToolError> {
+        self.base
+            .check_permissions_for_resolved(call, execution_name, args, ctx)
+            .await
     }
 
     fn list_tools(&self) -> Vec<ToolSchema> {
@@ -136,6 +183,59 @@ impl ToolExecutor for OverlayToolExecutor {
         tools.sort_by_key(|t| t.function.name.clone());
         tools
     }
+
+    fn owns_exact_tool(&self, tool_name: &str) -> bool {
+        tool_name == self.overlay.name() || self.base.owns_exact_tool(tool_name)
+    }
+
+    fn tool_mutability(&self, tool_name: &str) -> bamboo_agent_core::ToolMutability {
+        match self.route(tool_name) {
+            OverlayRoute::Overlay => self.overlay.classify(&serde_json::Value::Null).mutability,
+            OverlayRoute::BaseExact(execution_name) => self.base.tool_mutability(&execution_name),
+            OverlayRoute::BaseFallback => self.base.tool_mutability(tool_name),
+        }
+    }
+
+    fn call_mutability(&self, call: &ToolCall) -> bamboo_agent_core::ToolMutability {
+        self.call_parallel_classification(call).0
+    }
+
+    fn tool_concurrency_safe(&self, tool_name: &str) -> bool {
+        match self.route(tool_name) {
+            OverlayRoute::Overlay => {
+                self.overlay
+                    .classify(&serde_json::Value::Null)
+                    .parallel_safe
+            }
+            OverlayRoute::BaseExact(execution_name) => {
+                self.base.tool_concurrency_safe(&execution_name)
+            }
+            OverlayRoute::BaseFallback => self.base.tool_concurrency_safe(tool_name),
+        }
+    }
+
+    fn call_concurrency_safe(&self, call: &ToolCall) -> bool {
+        self.call_parallel_classification(call).1
+    }
+
+    fn call_parallel_classification(
+        &self,
+        call: &ToolCall,
+    ) -> (bamboo_agent_core::ToolMutability, bool) {
+        match self.route(&call.function.name) {
+            OverlayRoute::Overlay => {
+                let args = parse_tool_args_best_effort(&call.function.arguments).0;
+                let class = self.overlay.classify(&args);
+                (class.mutability, class.parallel_safe)
+            }
+            OverlayRoute::BaseExact(execution_name) => {
+                let mut exact_call = call.clone();
+                exact_call.function.name = execution_name;
+                self.base.call_parallel_classification(&exact_call)
+            }
+            OverlayRoute::BaseFallback => self.base.call_parallel_classification(call),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -144,7 +244,7 @@ mod tests {
 
     use serde_json::json;
 
-    use bamboo_agent_core::tools::{FunctionCall, ToolCtx};
+    use bamboo_agent_core::tools::{FunctionCall, FunctionSchema, ToolCtx};
 
     struct BaseExecutor;
 
@@ -184,6 +284,10 @@ mod tests {
 
         fn parameters_schema(&self) -> serde_json::Value {
             json!({"type":"object","properties":{}})
+        }
+
+        fn classify(&self, _args: &serde_json::Value) -> bamboo_agent_core::ToolClass {
+            bamboo_agent_core::ToolClass::READONLY_PARALLEL
         }
 
         async fn invoke(
@@ -242,6 +346,233 @@ mod tests {
         assert!(
             matches!(err, ToolError::Execution(msg) if msg.contains("base executor called for Read"))
         );
+    }
+
+    struct ExactBaseExecutor {
+        name: &'static str,
+        result: Result<&'static str, ToolError>,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for ExactBaseExecutor {
+        async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+            if call.function.name != self.name {
+                return Err(ToolError::NotFound(call.function.name.clone()));
+            }
+            let result = self.result.clone()?;
+            Ok(ToolResult {
+                success: true,
+                result: result.to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            vec![ToolSchema {
+                schema_type: "function".to_string(),
+                function: FunctionSchema {
+                    name: self.name.to_string(),
+                    description: "exact base tool".to_string(),
+                    parameters: json!({"type":"object"}),
+                },
+            }]
+        }
+
+        fn owns_exact_tool(&self, tool_name: &str) -> bool {
+            tool_name == self.name
+        }
+
+        fn call_parallel_classification(
+            &self,
+            call: &ToolCall,
+        ) -> (bamboo_agent_core::ToolMutability, bool) {
+            assert_eq!(call.function.name, self.name);
+            (bamboo_agent_core::ToolMutability::Mutating, false)
+        }
+    }
+
+    struct NamedOverlayTool(&'static str);
+
+    #[async_trait]
+    impl Tool for NamedOverlayTool {
+        fn name(&self) -> &str {
+            self.0
+        }
+
+        fn description(&self) -> &str {
+            "named overlay"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({"type":"object"})
+        }
+
+        async fn invoke(
+            &self,
+            _args: serde_json::Value,
+            _ctx: ToolCtx,
+        ) -> Result<ToolOutcome, ToolError> {
+            Ok(ToolOutcome::Completed(ToolResult {
+                success: true,
+                result: format!("overlay:{}", self.0),
+                display_preference: None,
+                images: Vec::new(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_base_spawn_session_beats_overlay_alias_through_stacked_overlays() {
+        let base: std::sync::Arc<dyn ToolExecutor> = std::sync::Arc::new(ExactBaseExecutor {
+            name: "spawn_session",
+            result: Ok("exact-base"),
+        });
+        let subagent: std::sync::Arc<dyn ToolExecutor> = std::sync::Arc::new(
+            OverlayToolExecutor::new(base, std::sync::Arc::new(SubAgentOverlayTool)),
+        );
+        let stacked =
+            OverlayToolExecutor::new(subagent, std::sync::Arc::new(NamedOverlayTool("memory")));
+
+        assert!(stacked.owns_exact_tool("spawn_session"));
+        let exact = stacked
+            .execute(&make_call("spawn_session"))
+            .await
+            .expect("base exact owner must win");
+        assert_eq!(exact.result, "exact-base");
+
+        let alias = stacked
+            .execute(&make_call("sub_task"))
+            .await
+            .expect("unshadowed alias must reach SubAgent overlay");
+        assert_eq!(alias.result, "overlay");
+    }
+
+    #[tokio::test]
+    async fn exact_base_not_found_is_not_reinterpreted_as_overlay_alias() {
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(ExactBaseExecutor {
+                name: "spawn_session",
+                result: Err(ToolError::NotFound("exact owner failed".to_string())),
+            }),
+            std::sync::Arc::new(SubAgentOverlayTool),
+        );
+
+        let error = overlay
+            .execute(&make_call("spawn_session"))
+            .await
+            .expect_err("exact owner error must propagate");
+        assert!(matches!(error, ToolError::NotFound(message) if message == "exact owner failed"));
+    }
+
+    #[tokio::test]
+    async fn namespace_fallback_dispatches_the_resolved_exact_base_identity() {
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(ExactBaseExecutor {
+                name: "custom_tool",
+                result: Ok("base-custom"),
+            }),
+            std::sync::Arc::new(SubAgentOverlayTool),
+        );
+        let call = make_call("default::custom_tool");
+
+        let result = overlay
+            .execute(&call)
+            .await
+            .expect("namespace fallback must execute base exact identity");
+        assert_eq!(result.result, "base-custom");
+        assert_eq!(
+            overlay.call_parallel_classification(&call),
+            (bamboo_agent_core::ToolMutability::Mutating, false)
+        );
+    }
+
+    #[tokio::test]
+    async fn same_name_overlay_replacement_keeps_overlay_precedence() {
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(ExactBaseExecutor {
+                name: "SubAgent",
+                result: Ok("base-subagent"),
+            }),
+            std::sync::Arc::new(SubAgentOverlayTool),
+        );
+
+        let result = overlay
+            .execute(&make_call("SubAgent"))
+            .await
+            .expect("same-name overlay must replace base");
+        assert_eq!(result.result, "overlay");
+        assert_eq!(
+            overlay
+                .list_tools()
+                .iter()
+                .filter(|schema| schema.function.name == "SubAgent")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn alias_classification_uses_the_selected_overlay_identity() {
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(BaseExecutor),
+            std::sync::Arc::new(SubAgentOverlayTool),
+        );
+
+        assert_eq!(
+            overlay.call_parallel_classification(&make_call("sub_task")),
+            (bamboo_agent_core::ToolMutability::ReadOnly, true)
+        );
+    }
+
+    struct ResolvedPermissionBase {
+        seen: std::sync::Arc<std::sync::Mutex<Option<(String, serde_json::Value)>>>,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for ResolvedPermissionBase {
+        async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+            Err(ToolError::NotFound(call.function.name.clone()))
+        }
+
+        async fn check_permissions_for(
+            &self,
+            _call: &ToolCall,
+            _ctx: &ToolExecutionContext<'_>,
+        ) -> Result<Option<ToolOutcome>, ToolError> {
+            panic!("overlay must use the resolved permission seam")
+        }
+
+        async fn check_permissions_for_resolved(
+            &self,
+            _call: &ToolCall,
+            execution_name: &str,
+            args: &serde_json::Value,
+            _ctx: &ToolExecutionContext<'_>,
+        ) -> Result<Option<ToolOutcome>, ToolError> {
+            *self.seen.lock().unwrap() = Some((execution_name.to_string(), args.clone()));
+            Ok(None)
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn alias_permission_gate_receives_overlay_identity_and_effective_args() {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(ResolvedPermissionBase { seen: seen.clone() }),
+            std::sync::Arc::new(SubAgentOverlayTool),
+        );
+        let call = make_call_with_args("sub_task", r#"{"prompt":"inspect"}"#);
+
+        overlay.execute(&call).await.expect("execute overlay alias");
+
+        let recorded = seen.lock().unwrap().clone().expect("permission record");
+        assert_eq!(recorded.0, "SubAgent");
+        assert_eq!(recorded.1, json!({"prompt": "inspect"}));
     }
 
     // ---- issue #341: overlay tools must hit the base permission gate ---------

--- a/crates/app/bamboo-server-tools/src/overlay_executor.rs
+++ b/crates/app/bamboo-server-tools/src/overlay_executor.rs
@@ -153,9 +153,38 @@ impl ToolExecutor for OverlayToolExecutor {
                     .check_permissions_for_resolved(call, self.overlay.name(), &args, ctx)
                     .await
             }
-            OverlayRoute::BaseExact(_) | OverlayRoute::BaseFallback => {
-                self.base.check_permissions_for(call, ctx).await
+            OverlayRoute::BaseExact(execution_name) => {
+                self.base
+                    .check_permissions_for_exact(call, &execution_name, ctx)
+                    .await
             }
+            OverlayRoute::BaseFallback => self.base.check_permissions_for(call, ctx).await,
+        }
+    }
+
+    async fn check_permissions_for_exact(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>, ToolError> {
+        if execution_name == self.overlay.name() {
+            let args = ctx
+                .pre_parsed_args
+                .cloned()
+                .unwrap_or_else(|| parse_tool_args_best_effort(&call.function.arguments).0);
+            self.base
+                .check_permissions_for_resolved(call, execution_name, &args, ctx)
+                .await
+        } else if self.base.owns_exact_tool(execution_name) {
+            self.base
+                .check_permissions_for_exact(call, execution_name, ctx)
+                .await
+        } else {
+            Err(ToolError::NotFound(format!(
+                "Tool '{}' not found",
+                execution_name
+            )))
         }
     }
 
@@ -446,6 +475,121 @@ mod tests {
             .await
             .expect("unshadowed alias must reach SubAgent overlay");
         assert_eq!(alias.result, "overlay");
+    }
+
+    struct ReResolvingPermissionBase {
+        executed: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        permission_checked: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        classified: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for ReResolvingPermissionBase {
+        async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+            if call.function.name != "spawn_session" {
+                return Err(ToolError::NotFound(call.function.name.clone()));
+            }
+            self.executed
+                .lock()
+                .unwrap()
+                .push(call.function.name.clone());
+            Ok(ToolResult {
+                success: true,
+                result: "exact-base".to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+
+        async fn check_permissions_for(
+            &self,
+            call: &ToolCall,
+            _ctx: &ToolExecutionContext<'_>,
+        ) -> Result<Option<ToolOutcome>, ToolError> {
+            let permission_name = if call.function.name == "default::spawn_session" {
+                "SubAgent"
+            } else {
+                &call.function.name
+            };
+            self.permission_checked
+                .lock()
+                .unwrap()
+                .push(permission_name.to_string());
+            Ok(None)
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            vec![ToolSchema {
+                schema_type: "function".to_string(),
+                function: FunctionSchema {
+                    name: "spawn_session".to_string(),
+                    description: "exact base tool".to_string(),
+                    parameters: json!({"type":"object"}),
+                },
+            }]
+        }
+
+        fn owns_exact_tool(&self, tool_name: &str) -> bool {
+            tool_name == "spawn_session"
+        }
+
+        fn call_parallel_classification(
+            &self,
+            call: &ToolCall,
+        ) -> (bamboo_agent_core::ToolMutability, bool) {
+            self.classified
+                .lock()
+                .unwrap()
+                .push(call.function.name.clone());
+            (bamboo_agent_core::ToolMutability::Mutating, false)
+        }
+    }
+
+    #[tokio::test]
+    async fn stacked_overlays_keep_base_exact_owner_for_permission_and_classification() {
+        let executed = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let permission_checked = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let classified = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let base = std::sync::Arc::new(ReResolvingPermissionBase {
+            executed: executed.clone(),
+            permission_checked: permission_checked.clone(),
+            classified: classified.clone(),
+        });
+        let call = make_call("default::spawn_session");
+        let ctx = ToolExecutionContext::none(&call.id);
+
+        base.check_permissions_for(&call, &ctx)
+            .await
+            .expect("raw permission mismatch repro");
+        assert_eq!(permission_checked.lock().unwrap().as_slice(), ["SubAgent"]);
+        permission_checked.lock().unwrap().clear();
+
+        let subagent: std::sync::Arc<dyn ToolExecutor> = std::sync::Arc::new(
+            OverlayToolExecutor::new(base, std::sync::Arc::new(SubAgentOverlayTool)),
+        );
+        let stacked =
+            OverlayToolExecutor::new(subagent, std::sync::Arc::new(NamedOverlayTool("memory")));
+
+        let result = stacked
+            .execute(&call)
+            .await
+            .expect("stacked exact base owner executes");
+        assert_eq!(result.result, "exact-base");
+        stacked
+            .check_permissions_for(&call, &ctx)
+            .await
+            .expect("stacked exact base owner permission check");
+        assert_eq!(
+            stacked.call_parallel_classification(&call),
+            (bamboo_agent_core::ToolMutability::Mutating, false)
+        );
+
+        assert_eq!(executed.lock().unwrap().as_slice(), ["spawn_session"]);
+        assert_eq!(
+            permission_checked.lock().unwrap().as_slice(),
+            ["spawn_session"]
+        );
+        assert_eq!(classified.lock().unwrap().as_slice(), ["spawn_session"]);
     }
 
     #[tokio::test]

--- a/crates/core/bamboo-agent-core/src/tools/executor.rs
+++ b/crates/core/bamboo-agent-core/src/tools/executor.rs
@@ -155,6 +155,25 @@ pub trait ToolExecutor: Send + Sync {
         Ok(None)
     }
 
+    /// Permission gate for an already-selected exact owner identity.
+    ///
+    /// Routing wrappers must use this seam after ownership resolution instead
+    /// of handing the original reference back to
+    /// [`check_permissions_for`](Self::check_permissions_for), where a concrete
+    /// executor may resolve it differently. The default preserves compatibility
+    /// by pinning only the function name and delegating to the existing gate;
+    /// argument bytes and the caller's pre-parsed context remain unchanged.
+    async fn check_permissions_for_exact(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>> {
+        let mut exact_call = call.clone();
+        exact_call.function.name = execution_name.to_string();
+        self.check_permissions_for(&exact_call, ctx).await
+    }
+
     /// Permission gate for a call whose exact execution identity and effective
     /// arguments have already been resolved by a wrapping executor.
     ///
@@ -545,5 +564,34 @@ mod tests {
         assert_eq!(recorded.2, effective_args);
         assert_eq!(call.function.name, "default::apply_patch");
         assert_eq!(call.function.arguments, original_args.to_string());
+    }
+
+    #[tokio::test]
+    async fn default_exact_permission_seam_pins_only_the_selected_identity() {
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let executor: Arc<dyn ToolExecutor> =
+            Arc::new(PermissionArgsExecutor { seen: seen.clone() });
+        let mut call = make_tool_call("default::custom_tool");
+        call.function.arguments = json!({"path": "original"}).to_string();
+        let original_args = json!({"path": "from-context"});
+        let ctx = ToolExecutionContext {
+            pre_parsed_args: Some(&original_args),
+            ..ToolExecutionContext::none(&call.id)
+        };
+
+        executor
+            .check_permissions_for_exact(&call, "custom_tool", &ctx)
+            .await
+            .expect("exact permission check");
+
+        let recorded = seen.lock().unwrap().clone().expect("permission record");
+        assert_eq!(recorded.0, "custom_tool");
+        assert_eq!(recorded.1, json!({"path": "original"}));
+        assert_eq!(recorded.2, original_args);
+        assert_eq!(call.function.name, "default::custom_tool");
+        assert_eq!(
+            call.function.arguments,
+            json!({"path": "original"}).to_string()
+        );
     }
 }

--- a/crates/core/bamboo-agent-core/src/tools/executor.rs
+++ b/crates/core/bamboo-agent-core/src/tools/executor.rs
@@ -104,6 +104,24 @@ pub trait ToolExecutor: Send + Sync {
             .map(ToolOutcome::Completed)
     }
 
+    /// Execute a call through an already-selected exact owner.
+    ///
+    /// `execution_name` is the complete, case-sensitive identity returned by
+    /// the shared reference resolver. The original `call` is retained so a
+    /// concrete executor can apply compatibility argument handling based on the
+    /// caller's spelling without re-running ownership selection. The default
+    /// rewrites only the function name and delegates to the outcome-aware path.
+    async fn execute_exact_with_context_outcome(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolOutcome> {
+        let mut exact_call = call.clone();
+        exact_call.function.name = execution_name.to_string();
+        self.execute_with_context_outcome(&exact_call, ctx).await
+    }
+
     /// Permission gate for a tool call, exposed on the executor trait so the
     /// check is part of the executor *chain*.
     ///
@@ -137,10 +155,50 @@ pub trait ToolExecutor: Send + Sync {
         Ok(None)
     }
 
+    /// Permission gate for a call whose exact execution identity and effective
+    /// arguments have already been resolved by a wrapping executor.
+    ///
+    /// Routing wrappers use this seam after selecting an exact owner so the
+    /// permission layer observes the same identity and arguments that the tool
+    /// will receive. The default rebuilds both the call and its pre-parsed-args
+    /// context before delegating to
+    /// [`check_permissions_for`](Self::check_permissions_for), preserving source
+    /// compatibility for executors without a specialized permission layer.
+    async fn check_permissions_for_resolved(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        args: &serde_json::Value,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>> {
+        let mut resolved_call = call.clone();
+        resolved_call.function.name = execution_name.to_string();
+        resolved_call.function.arguments = args.to_string();
+        let resolved_ctx = ToolExecutionContext {
+            pre_parsed_args: Some(args),
+            ..*ctx
+        };
+        self.check_permissions_for(&resolved_call, &resolved_ctx)
+            .await
+    }
+
     /// Lists all available tools and their schemas
     ///
     /// Returns schemas for all tools that can be executed via this executor
     fn list_tools(&self) -> Vec<ToolSchema>;
+
+    /// Returns whether this executor owns `tool_name` as a complete, exact,
+    /// case-sensitive execution identity.
+    ///
+    /// This deliberately performs no namespace stripping or alias resolution.
+    /// Wrappers use it to select an owner before applying compatibility
+    /// fallbacks. Registry/index-backed production executors should override the
+    /// source-compatible default to avoid cloning parameter schemas per query.
+    fn owns_exact_tool(&self, tool_name: &str) -> bool {
+        self.list_tools()
+            .iter()
+            .any(|schema| schema.function.name == tool_name)
+    }
 
     /// Server-level usage guidance to surface in the system prompt for whatever
     /// this executor currently exposes — e.g. the `instructions` an MCP server
@@ -430,5 +488,62 @@ mod tests {
             .expect("composition execution should succeed");
 
         assert_eq!(result.result, "from-composition");
+    }
+
+    struct PermissionArgsExecutor {
+        seen: Arc<std::sync::Mutex<Option<(String, serde_json::Value, serde_json::Value)>>>,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for PermissionArgsExecutor {
+        async fn execute(&self, call: &ToolCall) -> Result<ToolResult> {
+            Err(ToolError::NotFound(call.function.name.clone()))
+        }
+
+        async fn check_permissions_for(
+            &self,
+            call: &ToolCall,
+            ctx: &ToolExecutionContext<'_>,
+        ) -> Result<Option<ToolOutcome>> {
+            let call_args = serde_json::from_str(&call.function.arguments).expect("call args JSON");
+            let pre_parsed_args = ctx
+                .pre_parsed_args
+                .cloned()
+                .expect("resolved args must be threaded through context");
+            *self.seen.lock().unwrap() =
+                Some((call.function.name.clone(), call_args, pre_parsed_args));
+            Ok(None)
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn default_resolved_permission_seam_replaces_call_and_pre_parsed_args() {
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let executor: Arc<dyn ToolExecutor> =
+            Arc::new(PermissionArgsExecutor { seen: seen.clone() });
+        let mut call = make_tool_call("default::apply_patch");
+        call.function.arguments = json!({"path": "original"}).to_string();
+        let original_args = json!({"path": "original"});
+        let effective_args = json!({"file_path": "effective"});
+        let ctx = ToolExecutionContext {
+            pre_parsed_args: Some(&original_args),
+            ..ToolExecutionContext::none(&call.id)
+        };
+
+        executor
+            .check_permissions_for_resolved(&call, "Edit", &effective_args, &ctx)
+            .await
+            .expect("resolved permission check");
+
+        let recorded = seen.lock().unwrap().clone().expect("permission record");
+        assert_eq!(recorded.0, "Edit");
+        assert_eq!(recorded.1, effective_args);
+        assert_eq!(recorded.2, effective_args);
+        assert_eq!(call.function.name, "default::apply_patch");
+        assert_eq!(call.function.arguments, original_args.to_string());
     }
 }

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bamboo_agent_core::{
-    normalize_tool_name, parse_tool_args_best_effort, Tool, ToolCall, ToolError,
-    ToolExecutionContext, ToolExecutor, ToolOutcome, ToolResult, ToolSchema,
+    parse_tool_args_best_effort, Tool, ToolCall, ToolError, ToolExecutionContext, ToolExecutor,
+    ToolOutcome, ToolResult, ToolSchema,
 };
-use bamboo_domain::tool_names::{normalize_builtin_alias, resolve_alias};
+use bamboo_domain::{canonical_tool_name, resolve_tool_reference_name};
 
 use crate::guide::{context::GuideBuildContext, EnhancedPromptBuilder, ToolGuide};
 use crate::permission::{check_permissions, PermissionChecker, PermissionError};
@@ -83,26 +83,41 @@ fn normalize_legacy_builtin_args(
     }
 }
 
-fn resolve_registered_tool_name(registry: &ToolRegistry, raw_tool_name: &str) -> String {
-    if registry.get(raw_tool_name).is_some() {
-        return raw_tool_name.to_string();
-    }
+fn resolve_registered_tool_name(registry: &ToolRegistry, reference: &str) -> Option<String> {
+    resolve_tool_reference_name(reference, |candidate| registry.contains(candidate))
+}
 
-    let aliased = normalize_builtin_alias(raw_tool_name);
-    if registry.get(aliased).is_some() {
-        return aliased.to_string();
+/// Apply compatibility argument aliases only after the registry identity and
+/// its framework-owned implementation provenance are resolved. Exact custom
+/// tools whose names merely resemble a builtin or alias (for example an exact
+/// `Read` or `apply_patch`) must receive their original arguments.
+fn normalize_resolved_builtin_args(
+    reference: &str,
+    execution_name: &str,
+    args: &mut serde_json::Value,
+) {
+    if !matches!(execution_name, "Read" | "Write" | "Edit" | "Bash" | "Glob") {
+        return;
     }
-
-    resolve_alias(aliased).unwrap_or(aliased).to_string()
+    let unqualified = reference
+        .trim()
+        .rsplit("::")
+        .next()
+        .unwrap_or(reference)
+        .trim();
+    if let Some(args_obj) = args.as_object_mut() {
+        normalize_legacy_builtin_args(unqualified, args_obj);
+    }
 }
 
 /// Built-in tool executor that uses ToolRegistry for dynamic dispatch
 pub struct BuiltinToolExecutor {
     registry: ToolRegistry,
     permission_checker: Option<Arc<dyn PermissionChecker>>,
-    /// Framework-owned mutation tool instances keyed by canonical name. Arc
-    /// identity prevents a registry replacement from inheriting provenance.
-    builtin_mutation_tools: BTreeMap<String, Arc<dyn Tool>>,
+    /// Framework-owned tool instances whose identity affects compatibility
+    /// argument handling or file-change events. Arc identity prevents a custom
+    /// same-name registry replacement from inheriting builtin provenance.
+    framework_builtin_tools: BTreeMap<String, Arc<dyn Tool>>,
     tool_event_publisher: Arc<dyn ToolEventPublisher>,
 }
 
@@ -114,11 +129,11 @@ impl BuiltinToolExecutor {
     /// Creates a new executor with all built-in tools registered
     pub fn new() -> Self {
         let registry = ToolRegistry::new();
-        let builtin_mutation_tools = Self::register_builtin_tools(&registry, None);
+        let framework_builtin_tools = Self::register_builtin_tools(&registry, None);
         Self {
             registry,
             permission_checker: None,
-            builtin_mutation_tools,
+            framework_builtin_tools,
             tool_event_publisher: Self::default_tool_event_publisher(),
         }
     }
@@ -126,11 +141,11 @@ impl BuiltinToolExecutor {
     /// Creates a new executor with a permission checker
     pub fn new_with_permissions(permission_checker: Arc<dyn PermissionChecker>) -> Self {
         let registry = ToolRegistry::new();
-        let builtin_mutation_tools = Self::register_builtin_tools(&registry, None);
+        let framework_builtin_tools = Self::register_builtin_tools(&registry, None);
         Self {
             registry,
             permission_checker: Some(permission_checker),
-            builtin_mutation_tools,
+            framework_builtin_tools,
             tool_event_publisher: Self::default_tool_event_publisher(),
         }
     }
@@ -141,11 +156,11 @@ impl BuiltinToolExecutor {
     /// `http_request`) honor proxy settings from `config.json`.
     pub fn new_with_config(config: Arc<RwLock<Config>>) -> Self {
         let registry = ToolRegistry::new();
-        let builtin_mutation_tools = Self::register_builtin_tools(&registry, Some(config));
+        let framework_builtin_tools = Self::register_builtin_tools(&registry, Some(config));
         Self {
             registry,
             permission_checker: None,
-            builtin_mutation_tools,
+            framework_builtin_tools,
             tool_event_publisher: Self::default_tool_event_publisher(),
         }
     }
@@ -156,11 +171,11 @@ impl BuiltinToolExecutor {
         permission_checker: Arc<dyn PermissionChecker>,
     ) -> Self {
         let registry = ToolRegistry::new();
-        let builtin_mutation_tools = Self::register_builtin_tools(&registry, Some(config));
+        let framework_builtin_tools = Self::register_builtin_tools(&registry, Some(config));
         Self {
             registry,
             permission_checker: Some(permission_checker),
-            builtin_mutation_tools,
+            framework_builtin_tools,
             tool_event_publisher: Self::default_tool_event_publisher(),
         }
     }
@@ -170,7 +185,7 @@ impl BuiltinToolExecutor {
         Self {
             registry,
             permission_checker: None,
-            builtin_mutation_tools: BTreeMap::new(),
+            framework_builtin_tools: BTreeMap::new(),
             tool_event_publisher: Self::default_tool_event_publisher(),
         }
     }
@@ -188,7 +203,7 @@ impl BuiltinToolExecutor {
         Self {
             registry,
             permission_checker: Some(permission_checker),
-            builtin_mutation_tools: BTreeMap::new(),
+            framework_builtin_tools: BTreeMap::new(),
             tool_event_publisher: Self::default_tool_event_publisher(),
         }
     }
@@ -210,7 +225,7 @@ impl BuiltinToolExecutor {
         tool: &Arc<dyn Tool>,
         args: &serde_json::Value,
     ) -> Option<FileChangedV1> {
-        let builtin = self.builtin_mutation_tools.get(tool_name)?;
+        let builtin = self.framework_builtin_tools.get(tool_name)?;
         if !Arc::ptr_eq(builtin, tool) {
             return None;
         }
@@ -258,31 +273,37 @@ impl BuiltinToolExecutor {
         registry: &ToolRegistry,
         config: Option<Arc<RwLock<Config>>>,
     ) -> BTreeMap<String, Arc<dyn Tool>> {
-        let mut mutation_tools = BTreeMap::new();
+        let mut framework_tools = BTreeMap::new();
         let _ = config;
         // NOTE: apply_patch is now an alias for Edit – no separate registration.
         let _ = registry.register(ConclusionWithOptionsTool::new());
-        let _ = registry.register(BashTool::new());
+        if let Ok((name, tool)) = Self::register_tracked_builtin(registry, BashTool::new()) {
+            framework_tools.insert(name, tool);
+        }
         let _ = registry.register(BashInputTool::new());
         let _ = registry.register(BashOutputTool::new());
-        if let Ok((name, tool)) = Self::register_builtin_mutation(registry, EditTool::new()) {
-            mutation_tools.insert(name, tool);
+        if let Ok((name, tool)) = Self::register_tracked_builtin(registry, EditTool::new()) {
+            framework_tools.insert(name, tool);
         }
         let _ = registry.register(EnterPlanModeTool::new());
         let _ = registry.register(ExitPlanModeTool::new());
         // NOTE: FileExists is now an alias for GetFileInfo – no separate registration.
         let _ = registry.register(GetFileInfoTool::new());
-        let _ = registry.register(GlobTool::new());
+        if let Ok((name, tool)) = Self::register_tracked_builtin(registry, GlobTool::new()) {
+            framework_tools.insert(name, tool);
+        }
         let _ = registry.register(GrepTool::new());
         let _ = registry.register(UpdateGoalTool::new());
         let _ = registry.register(JsReplTool::new());
         let _ = registry.register(KillShellTool::new());
         let _ = registry.register(SessionNoteTool::new());
-        if let Ok((name, tool)) = Self::register_builtin_mutation(registry, NotebookEditTool::new())
+        if let Ok((name, tool)) = Self::register_tracked_builtin(registry, NotebookEditTool::new())
         {
-            mutation_tools.insert(name, tool);
+            framework_tools.insert(name, tool);
         }
-        let _ = registry.register(ReadTool::new());
+        if let Ok((name, tool)) = Self::register_tracked_builtin(registry, ReadTool::new()) {
+            framework_tools.insert(name, tool);
+        }
         let _ = registry.register(RequestPermissionsTool::new());
         let _ = registry.register(SleepTool::new());
         let _ = registry.register(TaskTool::new());
@@ -290,13 +311,13 @@ impl BuiltinToolExecutor {
         let _ = registry.register(WebSearchTool::new());
         // NOTE: GetCurrentDir + SetWorkspace are now aliases for Workspace.
         let _ = registry.register(WorkspaceTool::new());
-        if let Ok((name, tool)) = Self::register_builtin_mutation(registry, WriteTool::new()) {
-            mutation_tools.insert(name, tool);
+        if let Ok((name, tool)) = Self::register_tracked_builtin(registry, WriteTool::new()) {
+            framework_tools.insert(name, tool);
         }
-        mutation_tools
+        framework_tools
     }
 
-    fn register_builtin_mutation<T: Tool + 'static>(
+    fn register_tracked_builtin<T: Tool + 'static>(
         registry: &ToolRegistry,
         tool: T,
     ) -> Result<(String, Arc<dyn Tool>), ToolError> {
@@ -306,6 +327,24 @@ impl BuiltinToolExecutor {
             .register_shared(tool.clone())
             .map_err(|error| ToolError::Execution(error.to_string()))?;
         Ok((name, tool))
+    }
+
+    fn is_framework_builtin_instance(&self, execution_name: &str, tool: &Arc<dyn Tool>) -> bool {
+        self.framework_builtin_tools
+            .get(execution_name)
+            .is_some_and(|builtin| Arc::ptr_eq(builtin, tool))
+    }
+
+    fn normalize_registered_builtin_args(
+        &self,
+        reference: &str,
+        execution_name: &str,
+        tool: &Arc<dyn Tool>,
+        args: &mut serde_json::Value,
+    ) {
+        if self.is_framework_builtin_instance(execution_name, tool) {
+            normalize_resolved_builtin_args(reference, execution_name, args);
+        }
     }
 
     /// Returns all built-in tool schemas
@@ -336,6 +375,74 @@ impl BuiltinToolExecutor {
     /// Get guide for a tool
     pub fn get_guide(&self, tool_name: &str) -> Option<Arc<dyn ToolGuide>> {
         self.registry.get_guide(tool_name)
+    }
+
+    fn parse_execution_args(
+        &self,
+        call: &ToolCall,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> serde_json::Value {
+        if let Some(pre_parsed) = ctx.pre_parsed_args {
+            return pre_parsed.clone();
+        }
+        let args_raw = call.function.arguments.trim();
+        let (parsed, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
+        if let Some(warning) = parse_warning {
+            tracing::warn!(
+                "Builtin tool argument parsing fallback applied: session_id={:?}, tool_call_id={}, tool_name={}, args_len={}, args_preview=\"{}\", warning={}",
+                ctx.session_id,
+                call.id,
+                call.function.name,
+                args_raw.len(),
+                preview_for_log(args_raw, 180),
+                warning
+            );
+        }
+        parsed
+    }
+
+    async fn execute_registered_with_context_outcome(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolOutcome, ToolError> {
+        let tool = self
+            .registry
+            .get(execution_name)
+            .ok_or_else(|| ToolError::NotFound(format!("Tool '{}' not found", execution_name)))?;
+        let mut args = self.parse_execution_args(call, &ctx);
+        self.normalize_registered_builtin_args(
+            &call.function.name,
+            execution_name,
+            &tool,
+            &mut args,
+        );
+
+        if let Some(outcome) = self
+            .check_permissions_for_resolved(call, execution_name, &args, &ctx)
+            .await?
+        {
+            return Ok(outcome);
+        }
+
+        let publisher_enabled =
+            catch_unwind(AssertUnwindSafe(|| self.tool_event_publisher.is_enabled()))
+                .unwrap_or(false);
+        let pending_file_changed = publisher_enabled
+            .then(|| self.pending_file_changed(execution_name, &tool, &args))
+            .flatten();
+
+        let outcome = tool.invoke(args, ctx.to_tool_ctx()).await?;
+        if matches!(
+            &outcome,
+            ToolOutcome::Completed(result) if result.success
+        ) {
+            if let Some(data) = pending_file_changed {
+                self.publish_successful_file_change(&ctx, execution_name, data);
+            }
+        }
+        Ok(outcome)
     }
 
     /// Build enhanced prompt for all registered tools
@@ -379,85 +486,23 @@ impl ToolExecutor for BuiltinToolExecutor {
         call: &ToolCall,
         ctx: ToolExecutionContext<'_>,
     ) -> Result<ToolOutcome, ToolError> {
-        // Reuse the args the dispatching agent loop already parsed (for the
-        // `ToolStart` event) when it threaded them through the context, instead
-        // of re-parsing the raw JSON string here (issue #106, deferred B1 from
-        // #17). The pre-parsed value is the exact output of
-        // `parse_tool_args_best_effort` on the same input, and that loop already
-        // logged any fallback warning at parse time, so skipping the re-parse is
-        // behavior-preserving. When absent (the `execute` entry point, tests, or
-        // a loop that parsed with a different/stricter parser), fall back to
-        // parsing here exactly as before — including the fallback-warning log.
-        let mut args = if let Some(pre_parsed) = ctx.pre_parsed_args {
-            pre_parsed.clone()
-        } else {
-            let args_raw = call.function.arguments.trim();
-            let (parsed, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
-            if let Some(warning) = parse_warning {
-                tracing::warn!(
-                    "Builtin tool argument parsing fallback applied: session_id={:?}, tool_call_id={}, tool_name={}, args_len={}, args_preview=\"{}\", warning={}",
-                    ctx.session_id,
-                    call.id,
-                    call.function.name,
-                    args_raw.len(),
-                    preview_for_log(args_raw, 180),
-                    warning
-                );
-            }
-            parsed
-        };
+        let reference = call.function.name.trim();
+        let tool_name =
+            resolve_registered_tool_name(&self.registry, reference).ok_or_else(|| {
+                ToolError::NotFound(format!("Tool '{}' not found", call.function.name))
+            })?;
+        self.execute_registered_with_context_outcome(call, &tool_name, ctx)
+            .await
+    }
 
-        let raw_tool_name = normalize_tool_name(&call.function.name);
-        if let Some(args_obj) = args.as_object_mut() {
-            normalize_legacy_builtin_args(raw_tool_name, args_obj);
-        }
-
-        let tool_name = resolve_registered_tool_name(&self.registry, raw_tool_name);
-
-        // Look up the tool in the registry
-        let tool = self
-            .registry
-            .get(&tool_name)
-            .ok_or_else(|| ToolError::NotFound(format!("Tool '{}' not found", tool_name)))?;
-
-        // Permission gate. Factored onto the `ToolExecutor` trait
-        // (`check_permissions_for`) so overlay/wrapping executors can run the
-        // exact same check before invoking their own tools (issue #341). Kept
-        // AFTER the registry lookup so a `NotFound` still takes precedence,
-        // exactly as before. `Some(outcome)` is the interactive approval pause
-        // synthesized for a human sink; `Err` is deny / fail-closed.
-        if let Some(outcome) = self.check_permissions_for(call, &ctx).await? {
-            return Ok(outcome);
-        }
-
-        // Only framework-owned mutation tool instances are eligible. The hint
-        // itself is bounded before allocation and is inert until the real tool
-        // returns a successful terminal result.
-        let publisher_enabled =
-            catch_unwind(AssertUnwindSafe(|| self.tool_event_publisher.is_enabled()))
-                .unwrap_or(false);
-        let pending_file_changed = publisher_enabled
-            .then(|| self.pending_file_changed(&tool_name, &tool, &args))
-            .flatten();
-
-        // Rewritten dispatch: build the owned `ToolCtx` at this concrete seam and
-        // call the tool's single `invoke`. Unwrap the `ToolOutcome` back to a
-        // `ToolResult` so the surrounding dispatch/loop is unchanged for now:
-        // `Completed` is the result; `Running`'s synthetic ack IS a `ToolResult`
-        // (preserving background Bash's current behavior); `NeedsHuman` cannot yet
-        // be produced (no tool returns it in this phase). Phase B makes the outcome
-        // authoritative and removes this unwrap.
-        let tool_ctx = ctx.to_tool_ctx();
-        let outcome = tool.invoke(args, tool_ctx).await?;
-        if matches!(
-            &outcome,
-            ToolOutcome::Completed(result) if result.success
-        ) {
-            if let Some(data) = pending_file_changed {
-                self.publish_successful_file_change(&ctx, &tool_name, data);
-            }
-        }
-        Ok(outcome)
+    async fn execute_exact_with_context_outcome(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolOutcome, ToolError> {
+        self.execute_registered_with_context_outcome(call, execution_name, ctx)
+            .await
     }
 
     /// The real permission gate for built-in tools, extracted from the execute
@@ -488,8 +533,30 @@ impl ToolExecutor for BuiltinToolExecutor {
         call: &ToolCall,
         ctx: &ToolExecutionContext<'_>,
     ) -> Result<Option<ToolOutcome>, ToolError> {
-        let raw_tool_name = normalize_tool_name(&call.function.name);
-        let tool_name = resolve_registered_tool_name(&self.registry, raw_tool_name);
+        let reference = call.function.name.trim();
+        let tool_name = resolve_registered_tool_name(&self.registry, reference)
+            .unwrap_or_else(|| canonical_tool_name(reference));
+        let mut args = if let Some(pre_parsed) = ctx.pre_parsed_args {
+            pre_parsed.clone()
+        } else {
+            parse_tool_args_best_effort(&call.function.arguments).0
+        };
+        if let Some(tool) = self.registry.get(&tool_name) {
+            self.normalize_registered_builtin_args(reference, &tool_name, &tool, &mut args);
+        }
+        self.check_permissions_for_resolved(call, &tool_name, &args, ctx)
+            .await
+    }
+
+    async fn check_permissions_for_resolved(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        resolved_args: &serde_json::Value,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>, ToolError> {
+        let tool_name = execution_name.to_string();
+        let args = resolved_args.clone();
         if ctx.auto_approve_permissions && tool_name.eq_ignore_ascii_case("request_permissions") {
             return Err(ToolError::Execution(
                 "Auto mode cannot request expanded permissions; operate within existing hard boundaries"
@@ -505,19 +572,6 @@ impl ToolExecutor for BuiltinToolExecutor {
             return Ok(None);
         };
         let hook_permission_override = crate::current_hook_permission_override(&call.id);
-
-        // Mirror the head of `execute_with_context_outcome`: reuse the pre-parsed
-        // args when threaded, apply the legacy-arg normalization, then resolve the
-        // registered/alias tool name. This is what makes the gate see the exact
-        // `tool_name`/`args` the tool will actually run with.
-        let mut args = if let Some(pre_parsed) = ctx.pre_parsed_args {
-            pre_parsed.clone()
-        } else {
-            parse_tool_args_best_effort(&call.function.arguments).0
-        };
-        if let Some(args_obj) = args.as_object_mut() {
-            normalize_legacy_builtin_args(raw_tool_name, args_obj);
-        }
 
         if let Some(contexts) =
             check_permissions(&tool_name, &args).map_err(permission_error_to_tool_error)?
@@ -741,53 +795,56 @@ impl ToolExecutor for BuiltinToolExecutor {
         self.registry.list_tools()
     }
 
+    fn owns_exact_tool(&self, tool_name: &str) -> bool {
+        self.registry.contains(tool_name)
+    }
+
     fn tool_mutability(&self, tool_name: &str) -> crate::ToolMutability {
-        self.registry
-            .get(tool_name)
+        let resolved = resolve_registered_tool_name(&self.registry, tool_name);
+        resolved
+            .as_deref()
+            .and_then(|name| self.registry.get(name))
             .map(|tool| tool.classify(&serde_json::Value::Null).mutability)
-            .unwrap_or_else(|| crate::classify_tool(tool_name))
+            .unwrap_or_else(|| crate::classify_tool(&canonical_tool_name(tool_name)))
     }
 
     fn call_mutability(&self, call: &ToolCall) -> crate::ToolMutability {
-        let canonical = resolve_registered_tool_name(&self.registry, call.function.name.trim());
-        let args = bamboo_agent_core::parse_tool_args_best_effort(&call.function.arguments).0;
-        self.registry
-            .get(&canonical)
-            .map(|tool| tool.classify(&args).mutability)
-            .unwrap_or_else(|| self.tool_mutability(&canonical))
+        self.call_parallel_classification(call).0
     }
 
     fn tool_concurrency_safe(&self, tool_name: &str) -> bool {
-        let canonical = resolve_registered_tool_name(&self.registry, tool_name);
-        self.registry
-            .get(&canonical)
+        let resolved = resolve_registered_tool_name(&self.registry, tool_name);
+        resolved
+            .as_deref()
+            .and_then(|name| self.registry.get(name))
             .map(|tool| tool.classify(&serde_json::Value::Null).parallel_safe)
-            .unwrap_or_else(|| self.tool_mutability(&canonical) == crate::ToolMutability::ReadOnly)
+            .unwrap_or_else(|| self.tool_mutability(tool_name) == crate::ToolMutability::ReadOnly)
     }
 
     fn call_concurrency_safe(&self, call: &ToolCall) -> bool {
-        let canonical = resolve_registered_tool_name(&self.registry, call.function.name.trim());
-        let args = bamboo_agent_core::parse_tool_args_best_effort(&call.function.arguments).0;
-        self.registry
-            .get(&canonical)
-            .map(|tool| tool.classify(&args).parallel_safe)
-            .unwrap_or_else(|| self.tool_concurrency_safe(&canonical))
+        self.call_parallel_classification(call).1
     }
 
     fn call_parallel_classification(&self, call: &ToolCall) -> (crate::ToolMutability, bool) {
         // One args-aware `classify` returns the (mutability, parallel_safe) pair
         // with a single arg parse — the collapse of the former
         // `call_mutability`/`call_concurrency_safe` pair.
-        let canonical = resolve_registered_tool_name(&self.registry, call.function.name.trim());
-        let args = bamboo_agent_core::parse_tool_args_best_effort(&call.function.arguments).0;
-        match self.registry.get(&canonical) {
-            Some(tool) => {
+        let reference = call.function.name.trim();
+        let resolved = resolve_registered_tool_name(&self.registry, reference);
+        let mut args = bamboo_agent_core::parse_tool_args_best_effort(&call.function.arguments).0;
+        match resolved.as_deref().and_then(|execution_name| {
+            self.registry
+                .get(execution_name)
+                .map(|tool| (execution_name, tool))
+        }) {
+            Some((execution_name, tool)) => {
+                self.normalize_registered_builtin_args(reference, execution_name, &tool, &mut args);
                 let class = tool.classify(&args);
                 (class.mutability, class.parallel_safe)
             }
             None => (
-                self.tool_mutability(&canonical),
-                self.tool_concurrency_safe(&canonical),
+                self.tool_mutability(reference),
+                self.tool_concurrency_safe(reference),
             ),
         }
     }
@@ -797,7 +854,7 @@ impl ToolExecutor for BuiltinToolExecutor {
 pub struct BuiltinToolExecutorBuilder {
     registry: ToolRegistry,
     permission_checker: Option<Arc<dyn PermissionChecker>>,
-    builtin_mutation_tools: BTreeMap<String, Arc<dyn Tool>>,
+    framework_builtin_tools: BTreeMap<String, Arc<dyn Tool>>,
     tool_event_publisher: Arc<dyn ToolEventPublisher>,
 }
 
@@ -807,14 +864,14 @@ impl BuiltinToolExecutorBuilder {
         Self {
             registry: ToolRegistry::new(),
             permission_checker: None,
-            builtin_mutation_tools: BTreeMap::new(),
+            framework_builtin_tools: BTreeMap::new(),
             tool_event_publisher: BuiltinToolExecutor::default_tool_event_publisher(),
         }
     }
 
     /// Registers all default built-in tools
     pub fn with_default_tools(mut self) -> Self {
-        self.builtin_mutation_tools
+        self.framework_builtin_tools
             .extend(BuiltinToolExecutor::register_builtin_tools(
                 &self.registry,
                 None,
@@ -824,38 +881,36 @@ impl BuiltinToolExecutorBuilder {
 
     /// Registers a specific filesystem tool by name
     pub fn with_filesystem_tool(mut self, name: &str) -> Result<Self, ToolError> {
-        let marker = match name {
+        let (name, tool) = match name {
             "Read" => {
-                self.registry
-                    .register(ReadTool::new())
-                    .map_err(|error| ToolError::Execution(error.to_string()))?;
-                None
+                BuiltinToolExecutor::register_tracked_builtin(&self.registry, ReadTool::new())?
             }
-            "Write" => Some(BuiltinToolExecutor::register_builtin_mutation(
-                &self.registry,
-                WriteTool::new(),
-            )?),
+            "Write" => {
+                BuiltinToolExecutor::register_tracked_builtin(&self.registry, WriteTool::new())?
+            }
             // apply_patch is now an alias for Edit
-            "Edit" | "apply_patch" => Some(BuiltinToolExecutor::register_builtin_mutation(
-                &self.registry,
-                EditTool::new(),
-            )?),
-            "NotebookEdit" => Some(BuiltinToolExecutor::register_builtin_mutation(
+            "Edit" | "apply_patch" => {
+                BuiltinToolExecutor::register_tracked_builtin(&self.registry, EditTool::new())?
+            }
+            "NotebookEdit" => BuiltinToolExecutor::register_tracked_builtin(
                 &self.registry,
                 NotebookEditTool::new(),
-            )?),
+            )?,
             _ => return Err(ToolError::NotFound(format!("Unknown tool: {}", name))),
         };
-        if let Some((name, tool)) = marker {
-            self.builtin_mutation_tools.insert(name, tool);
-        }
+        self.framework_builtin_tools.insert(name, tool);
         Ok(self)
     }
 
     /// Registers a specific command tool by name
-    pub fn with_command_tool(self, name: &str) -> Result<Self, ToolError> {
+    pub fn with_command_tool(mut self, name: &str) -> Result<Self, ToolError> {
+        if name == "Bash" {
+            let (name, tool) =
+                BuiltinToolExecutor::register_tracked_builtin(&self.registry, BashTool::new())?;
+            self.framework_builtin_tools.insert(name, tool);
+            return Ok(self);
+        }
         match name {
-            "Bash" => self.registry.register(BashTool::new()),
             "BashOutput" => self.registry.register(BashOutputTool::new()),
             "KillShell" => self.registry.register(KillShellTool::new()),
             "Task" => self.registry.register(TaskTool::new()),
@@ -890,7 +945,7 @@ impl BuiltinToolExecutorBuilder {
         BuiltinToolExecutor {
             registry: self.registry,
             permission_checker: self.permission_checker,
-            builtin_mutation_tools: self.builtin_mutation_tools,
+            framework_builtin_tools: self.framework_builtin_tools,
             tool_event_publisher: self.tool_event_publisher,
         }
     }
@@ -1078,7 +1133,7 @@ mod tests {
         BuiltinToolExecutor {
             registry,
             permission_checker: None,
-            builtin_mutation_tools: BTreeMap::from([("Write".to_string(), tool)]),
+            framework_builtin_tools: BTreeMap::from([("Write".to_string(), tool)]),
             tool_event_publisher: publisher,
         }
     }
@@ -1308,6 +1363,11 @@ mod tests {
         let call = make_tool_call("Read", json!({"path": file_path}));
 
         let result = executor.execute(&call).await.unwrap();
+        assert!(result.success);
+        assert!(result.result.contains("canonical read content"));
+
+        let namespaced = make_tool_call("default::Read", json!({"path": file_path}));
+        let result = executor.execute(&namespaced).await.unwrap();
         assert!(result.success);
         assert!(result.result.contains("canonical read content"));
     }
@@ -2649,6 +2709,262 @@ mod tests {
         let result = executor.execute(&call).await.expect("execute custom tool");
         assert!(result.success);
         assert_eq!(result.result, "custom-spawn-session");
+    }
+
+    struct ExactRoutingTool {
+        name: &'static str,
+        label: &'static str,
+        args_sensitive: bool,
+    }
+
+    #[async_trait]
+    impl Tool for ExactRoutingTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn description(&self) -> &str {
+            "exact routing regression tool"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({"type":"object","properties":{}})
+        }
+
+        fn classify(&self, args: &serde_json::Value) -> bamboo_agent_core::ToolClass {
+            let has_builtin_normalized_arg = ["file_path", "command", "pattern"]
+                .iter()
+                .any(|key| args.get(key).is_some());
+            if self.args_sensitive && !has_builtin_normalized_arg {
+                bamboo_agent_core::ToolClass::READONLY_PARALLEL
+            } else {
+                bamboo_agent_core::ToolClass::MUTATING_SERIAL
+            }
+        }
+
+        async fn invoke(
+            &self,
+            args: serde_json::Value,
+            _ctx: ToolCtx,
+        ) -> Result<ToolOutcome, ToolError> {
+            Ok(ToolOutcome::Completed(ToolResult {
+                success: true,
+                result: json!({"label": self.label, "args": args}).to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_preserves_namespaced_exact_identity_and_unqualified_collision() {
+        let executor = BuiltinToolExecutorBuilder::new()
+            .with_tool(ExactRoutingTool {
+                name: "a::custom_tool",
+                label: "namespaced",
+                args_sensitive: false,
+            })
+            .expect("register namespaced tool")
+            .with_tool(ExactRoutingTool {
+                name: "custom_tool",
+                label: "unqualified",
+                args_sensitive: false,
+            })
+            .expect("register unqualified tool")
+            .build();
+
+        assert!(executor.owns_exact_tool("a::custom_tool"));
+        assert!(executor.owns_exact_tool("custom_tool"));
+        assert!(!executor.owns_exact_tool("A::custom_tool"));
+        let names: Vec<String> = executor
+            .list_tools()
+            .into_iter()
+            .map(|schema| schema.function.name)
+            .collect();
+        assert!(names.contains(&"a::custom_tool".to_string()));
+        assert!(names.contains(&"custom_tool".to_string()));
+
+        let namespaced = executor
+            .execute(&make_tool_call("a::custom_tool", json!({})))
+            .await
+            .expect("execute namespaced exact tool");
+        let unqualified = executor
+            .execute(&make_tool_call("custom_tool", json!({})))
+            .await
+            .expect("execute unqualified exact tool");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&namespaced.result).unwrap()["label"],
+            "namespaced"
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&unqualified.result).unwrap()["label"],
+            "unqualified"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_canonical_shadows_do_not_inherit_builtin_argument_provenance() {
+        let executor = BuiltinToolExecutorBuilder::new()
+            .with_tool(ExactRoutingTool {
+                name: "Read",
+                label: "exact-read",
+                args_sensitive: true,
+            })
+            .expect("register exact Read shadow")
+            .with_tool(ExactRoutingTool {
+                name: "Write",
+                label: "exact-write",
+                args_sensitive: true,
+            })
+            .expect("register exact Write shadow")
+            .with_tool(ExactRoutingTool {
+                name: "Edit",
+                label: "exact-edit",
+                args_sensitive: true,
+            })
+            .expect("register exact Edit shadow")
+            .with_tool(ExactRoutingTool {
+                name: "Bash",
+                label: "exact-bash",
+                args_sensitive: true,
+            })
+            .expect("register exact Bash shadow")
+            .with_tool(ExactRoutingTool {
+                name: "Glob",
+                label: "exact-glob",
+                args_sensitive: true,
+            })
+            .expect("register exact Glob shadow")
+            .with_default_tools()
+            .build();
+
+        let cases = [
+            ("Read", json!({"path": "/tmp/custom-read"}), "file_path"),
+            ("Write", json!({"path": "/tmp/custom-write"}), "file_path"),
+            ("Edit", json!({"path": "/tmp/custom-edit"}), "file_path"),
+            ("Bash", json!({"cmd": "custom-command"}), "command"),
+            (
+                "Glob",
+                json!({"path": "/tmp/custom-glob", "recursive": true}),
+                "pattern",
+            ),
+        ];
+
+        for (name, args, normalized_key) in cases {
+            let call = make_tool_call(name, args.clone());
+            assert_eq!(
+                executor.call_mutability(&call),
+                crate::ToolMutability::ReadOnly,
+                "custom {name} classification must see the original args"
+            );
+            assert!(
+                executor.call_concurrency_safe(&call),
+                "custom {name} classification must remain parallel-safe"
+            );
+
+            let result = executor
+                .execute(&call)
+                .await
+                .unwrap_or_else(|error| panic!("execute custom {name}: {error}"));
+            let result: serde_json::Value = serde_json::from_str(&result.result).unwrap();
+            assert_eq!(result["args"], args, "custom {name} args changed");
+            assert!(result["args"].get(normalized_key).is_none());
+        }
+
+        // Exercise the permission entry point with exact canonical shadows for
+        // which the central policy has no name-based write/execute rule. The
+        // same raw args must reach classification and invocation even when a
+        // checker is installed.
+        let permission_executor = BuiltinToolExecutorBuilder::new()
+            .with_tool(ExactRoutingTool {
+                name: "Read",
+                label: "permission-read",
+                args_sensitive: true,
+            })
+            .expect("register permission-aware Read shadow")
+            .with_tool(ExactRoutingTool {
+                name: "Glob",
+                label: "permission-glob",
+                args_sensitive: true,
+            })
+            .expect("register permission-aware Glob shadow")
+            .with_default_tools()
+            .with_permission_checker(Arc::new(crate::permission::AllowAllPermissionChecker))
+            .build();
+        for (name, args) in [
+            ("Read", json!({"path": "/tmp/permission-read"})),
+            (
+                "Glob",
+                json!({"path": "/tmp/permission-glob", "recursive": true}),
+            ),
+        ] {
+            let call = make_tool_call(name, args.clone());
+            let ctx = ToolExecutionContext::none(&call.id);
+            assert!(permission_executor
+                .check_permissions_for(&call, &ctx)
+                .await
+                .expect("permission check")
+                .is_none());
+            assert_eq!(
+                permission_executor.call_mutability(&call),
+                crate::ToolMutability::ReadOnly
+            );
+            assert!(permission_executor.call_concurrency_safe(&call));
+            let result = permission_executor.execute(&call).await.unwrap();
+            let result: serde_json::Value = serde_json::from_str(&result.result).unwrap();
+            assert_eq!(result["args"], args);
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_apply_patch_keeps_original_args_and_classification() {
+        let executor = BuiltinToolExecutorBuilder::new()
+            .with_filesystem_tool("Edit")
+            .expect("register builtin Edit")
+            .with_tool(ExactRoutingTool {
+                name: "apply_patch",
+                label: "exact-apply-patch",
+                args_sensitive: true,
+            })
+            .expect("register exact apply_patch shadow")
+            .build();
+        let call = make_tool_call("apply_patch", json!({"path": "/tmp/exact-shadow"}));
+
+        let (mutability, parallel_safe) = executor.call_parallel_classification(&call);
+        assert_eq!(mutability, crate::ToolMutability::ReadOnly);
+        assert!(parallel_safe);
+
+        let result = executor.execute(&call).await.expect("execute exact shadow");
+        let result: serde_json::Value = serde_json::from_str(&result.result).unwrap();
+        assert_eq!(result["label"], "exact-apply-patch");
+        assert_eq!(result["args"]["path"], "/tmp/exact-shadow");
+        assert!(result["args"].get("file_path").is_none());
+    }
+
+    #[tokio::test]
+    async fn unshadowed_alias_and_namespace_keep_legacy_argument_compatibility() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-alias.txt");
+        fs::write(&path, "before").await.unwrap();
+        let executor = BuiltinToolExecutorBuilder::new()
+            .with_filesystem_tool("Edit")
+            .expect("register builtin Edit")
+            .with_permission_checker(Arc::new(crate::permission::AllowAllPermissionChecker))
+            .build();
+
+        let result = executor
+            .execute(&make_tool_call(
+                "default::apply_patch",
+                json!({
+                    "path": path,
+                    "old_string": "before",
+                    "new_string": "after"
+                }),
+            ))
+            .await
+            .expect("execute unshadowed alias");
+        assert!(result.success);
+        assert_eq!(fs::read_to_string(path).await.unwrap(), "after");
     }
 
     // ---- issue #106: parse tool args once on the execute path -------------

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -548,6 +548,31 @@ impl ToolExecutor for BuiltinToolExecutor {
             .await
     }
 
+    async fn check_permissions_for_exact(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>, ToolError> {
+        let tool = self
+            .registry
+            .get(execution_name)
+            .ok_or_else(|| ToolError::NotFound(format!("Tool '{}' not found", execution_name)))?;
+        let mut args = if let Some(pre_parsed) = ctx.pre_parsed_args {
+            pre_parsed.clone()
+        } else {
+            parse_tool_args_best_effort(&call.function.arguments).0
+        };
+        self.normalize_registered_builtin_args(
+            call.function.name.trim(),
+            execution_name,
+            &tool,
+            &mut args,
+        );
+        self.check_permissions_for_resolved(call, execution_name, &args, ctx)
+            .await
+    }
+
     async fn check_permissions_for_resolved(
         &self,
         call: &ToolCall,
@@ -2939,6 +2964,36 @@ mod tests {
         assert_eq!(result["label"], "exact-apply-patch");
         assert_eq!(result["args"]["path"], "/tmp/exact-shadow");
         assert!(result["args"].get("file_path").is_none());
+    }
+
+    #[tokio::test]
+    async fn exact_permission_seam_preserves_default_apply_patch_builtin_provenance() {
+        let executor = BuiltinToolExecutorBuilder::new()
+            .with_filesystem_tool("Edit")
+            .expect("register builtin Edit")
+            .with_permission_checker(Arc::new(crate::permission::AllowAllPermissionChecker))
+            .build();
+        let raw_args = json!({
+            "path": "/tmp/exact-permission-apply-patch.txt",
+            "old_string": "before",
+            "new_string": "after"
+        });
+        let call = make_tool_call("default::apply_patch", raw_args.clone());
+        let ctx = ToolExecutionContext {
+            pre_parsed_args: Some(&raw_args),
+            ..ToolExecutionContext::none(&call.id)
+        };
+
+        assert!(executor
+            .check_permissions_for_exact(&call, "Edit", &ctx)
+            .await
+            .expect("normalized builtin permission check")
+            .is_none());
+        assert_eq!(call.function.name, "default::apply_patch");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&call.function.arguments).unwrap(),
+            raw_args
+        );
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-mcp/src/executor.rs
+++ b/crates/infra/bamboo-mcp/src/executor.rs
@@ -414,7 +414,11 @@ impl ToolExecutor for CompositeToolExecutor {
         ctx: &ToolExecutionContext<'_>,
     ) -> std::result::Result<Option<ToolOutcome>, ToolError> {
         match self.route(&call.function.name) {
-            CompositeRoute::Builtin { .. } => self.builtin.check_permissions_for(call, ctx).await,
+            CompositeRoute::Builtin { execution_name } => {
+                self.builtin
+                    .check_permissions_for_exact(call, &execution_name, ctx)
+                    .await
+            }
             CompositeRoute::Secondary { execution_name } => {
                 let args = ctx
                     .pre_parsed_args
@@ -425,6 +429,32 @@ impl ToolExecutor for CompositeToolExecutor {
                     .await
             }
             CompositeRoute::LegacyFallback => self.builtin.check_permissions_for(call, ctx).await,
+        }
+    }
+
+    async fn check_permissions_for_exact(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> std::result::Result<Option<ToolOutcome>, ToolError> {
+        if self.builtin.owns_exact_tool(execution_name) {
+            self.builtin
+                .check_permissions_for_exact(call, execution_name, ctx)
+                .await
+        } else if self.mcp.owns_exact_tool(execution_name) {
+            let args = ctx
+                .pre_parsed_args
+                .cloned()
+                .unwrap_or_else(|| parse_tool_args_best_effort(&call.function.arguments).0);
+            self.builtin
+                .check_permissions_for_resolved(call, execution_name, &args, ctx)
+                .await
+        } else {
+            Err(ToolError::NotFound(format!(
+                "Tool '{}' not found",
+                execution_name
+            )))
         }
     }
 
@@ -503,7 +533,12 @@ impl ToolExecutor for CompositeToolExecutor {
         call: &ToolCall,
     ) -> (bamboo_agent_core::ToolMutability, bool) {
         match self.route(&call.function.name) {
-            CompositeRoute::Builtin { .. } => self.builtin.call_parallel_classification(call),
+            CompositeRoute::Builtin { execution_name } => self
+                .builtin
+                .call_parallel_classification(&Self::call_with_execution_name(
+                    call,
+                    &execution_name,
+                )),
             CompositeRoute::Secondary { execution_name } => {
                 self.mcp
                     .call_parallel_classification(&Self::call_with_execution_name(
@@ -577,6 +612,8 @@ mod tests {
         classification: (bamboo_agent_core::ToolMutability, bool),
         executed: Arc<std::sync::Mutex<Vec<String>>>,
         permission_checked: Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>,
+        permission_reresolution: Option<(&'static str, &'static str)>,
+        classified: Arc<std::sync::Mutex<Vec<String>>>,
     }
 
     impl RoutingStub {
@@ -589,6 +626,8 @@ mod tests {
                 classification: (bamboo_agent_core::ToolMutability::Mutating, false),
                 executed: Arc::new(std::sync::Mutex::new(Vec::new())),
                 permission_checked: Arc::new(std::sync::Mutex::new(Vec::new())),
+                permission_reresolution: None,
+                classified: Arc::new(std::sync::Mutex::new(Vec::new())),
             }
         }
 
@@ -635,10 +674,15 @@ mod tests {
             _ctx: &ToolExecutionContext<'_>,
         ) -> std::result::Result<Option<ToolOutcome>, ToolError> {
             let args = parse_tool_args_best_effort(&call.function.arguments).0;
+            let permission_name = self
+                .permission_reresolution
+                .filter(|(reference, _)| *reference == call.function.name)
+                .map(|(_, alias)| alias)
+                .unwrap_or(&call.function.name);
             self.permission_checked
                 .lock()
                 .unwrap()
-                .push((call.function.name.clone(), args));
+                .push((permission_name.to_string(), args));
             Ok(None)
         }
 
@@ -655,8 +699,12 @@ mod tests {
 
         fn call_parallel_classification(
             &self,
-            _call: &ToolCall,
+            call: &ToolCall,
         ) -> (bamboo_agent_core::ToolMutability, bool) {
+            self.classified
+                .lock()
+                .unwrap()
+                .push(call.function.name.clone());
             self.classification
         }
     }
@@ -703,6 +751,70 @@ mod tests {
             )]
         );
         assert!(secondary_permissions.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn stacked_composites_keep_the_selected_builtin_exact_identity() {
+        let mut builtin = RoutingStub::new(vec!["custom_tool"], "builtin-custom");
+        builtin.permission_reresolution = Some(("default::custom_tool", "legacy_alias_owner"));
+        let builtin = Arc::new(builtin);
+        let builtin_executed = builtin.executed.clone();
+        let builtin_permissions = builtin.permission_checked.clone();
+        let builtin_classified = builtin.classified.clone();
+
+        let mut secondary = RoutingStub::new(vec!["legacy_alias_owner"], "secondary-alias");
+        secondary.classification = (bamboo_agent_core::ToolMutability::ReadOnly, true);
+        let secondary_executed = secondary.executed.clone();
+        let secondary_permissions = secondary.permission_checked.clone();
+        let secondary_classified = secondary.classified.clone();
+        let call = create_test_tool_call("default::custom_tool", r#"{"path":"selected-owner"}"#);
+        let ctx = ToolExecutionContext::none(&call.id);
+
+        builtin
+            .check_permissions_for(&call, &ctx)
+            .await
+            .expect("raw permission repro");
+        assert_eq!(
+            builtin_permissions.lock().unwrap().as_slice(),
+            [(
+                "legacy_alias_owner".to_string(),
+                serde_json::json!({"path": "selected-owner"})
+            )],
+            "the generic raw gate demonstrates the re-resolution mismatch"
+        );
+        builtin_permissions.lock().unwrap().clear();
+
+        let inner = Arc::new(CompositeToolExecutor::new(builtin, Arc::new(secondary)));
+        let composite = CompositeToolExecutor::new(inner, Arc::new(GuidanceStub(None)));
+        let result = composite
+            .execute(&call)
+            .await
+            .expect("selected builtin exact owner executes");
+        assert_eq!(result.result, "builtin-custom");
+        composite
+            .check_permissions_for(&call, &ctx)
+            .await
+            .expect("selected builtin exact owner permission check");
+        assert_eq!(
+            composite.call_parallel_classification(&call),
+            (bamboo_agent_core::ToolMutability::Mutating, false)
+        );
+
+        assert_eq!(builtin_executed.lock().unwrap().as_slice(), ["custom_tool"]);
+        assert_eq!(
+            builtin_permissions.lock().unwrap().as_slice(),
+            [(
+                "custom_tool".to_string(),
+                serde_json::json!({"path": "selected-owner"})
+            )]
+        );
+        assert_eq!(
+            builtin_classified.lock().unwrap().as_slice(),
+            ["custom_tool"]
+        );
+        assert!(secondary_executed.lock().unwrap().is_empty());
+        assert!(secondary_permissions.lock().unwrap().is_empty());
+        assert!(secondary_classified.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-mcp/src/executor.rs
+++ b/crates/infra/bamboo-mcp/src/executor.rs
@@ -3,6 +3,8 @@ use bamboo_agent_core::{
     parse_tool_args_best_effort, ToolCall, ToolError, ToolExecutionContext, ToolExecutor,
     ToolOutcome, ToolResult, ToolResultImage, ToolSchema,
 };
+use bamboo_domain::resolve_tool_reference_name;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{debug, error, warn};
 
@@ -231,6 +233,10 @@ impl ToolExecutor for McpToolExecutor {
             .collect()
     }
 
+    fn owns_exact_tool(&self, tool_name: &str) -> bool {
+        self.index.contains_exact_alias(tool_name)
+    }
+
     /// Each connected MCP server's `instructions`, rendered as a labeled block.
     /// Only ready servers contribute, so this guidance is automatically scoped to
     /// whatever is loaded for the run.
@@ -258,26 +264,70 @@ pub struct CompositeToolExecutor {
     mcp: Arc<dyn ToolExecutor>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CompositeRoute {
+    Builtin { execution_name: String },
+    Secondary { execution_name: String },
+    LegacyFallback,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CompositeOwner {
+    Builtin,
+    Secondary,
+    None,
+}
+
 impl CompositeToolExecutor {
     pub fn new(builtin: Arc<dyn ToolExecutor>, mcp: Arc<dyn ToolExecutor>) -> Self {
         Self { builtin, mcp }
+    }
+
+    /// Resolve once against both children. Builtin wins duplicate exact names;
+    /// the secondary wins an exact shadow before builtin alias fallback.
+    fn route(&self, reference: &str) -> CompositeRoute {
+        let mut owners = HashMap::<String, CompositeOwner>::new();
+        let mut selected_owner = CompositeOwner::None;
+        let resolved = resolve_tool_reference_name(reference, |candidate| {
+            let owner = *owners.entry(candidate.to_string()).or_insert_with(|| {
+                if self.builtin.owns_exact_tool(candidate) {
+                    CompositeOwner::Builtin
+                } else if self.mcp.owns_exact_tool(candidate) {
+                    CompositeOwner::Secondary
+                } else {
+                    CompositeOwner::None
+                }
+            });
+            if owner != CompositeOwner::None {
+                selected_owner = owner;
+                true
+            } else {
+                false
+            }
+        });
+        let Some(execution_name) = resolved else {
+            return CompositeRoute::LegacyFallback;
+        };
+        match selected_owner {
+            CompositeOwner::Builtin => CompositeRoute::Builtin { execution_name },
+            CompositeOwner::Secondary => CompositeRoute::Secondary { execution_name },
+            CompositeOwner::None => CompositeRoute::LegacyFallback,
+        }
+    }
+
+    fn call_with_execution_name(call: &ToolCall, execution_name: &str) -> ToolCall {
+        let mut resolved_call = call.clone();
+        resolved_call.function.name = execution_name.to_string();
+        resolved_call
     }
 }
 
 #[async_trait]
 impl ToolExecutor for CompositeToolExecutor {
     async fn execute(&self, call: &ToolCall) -> std::result::Result<ToolResult, ToolError> {
-        // Try built-in first
-        match self.builtin.execute(call).await {
-            Ok(result) => return Ok(result),
-            Err(ToolError::NotFound(_)) => {
-                // Fall through to MCP
-            }
-            Err(e) => return Err(e),
-        }
-
-        // Try MCP
-        self.mcp.execute(call).await
+        self.execute_with_context_outcome(call, ToolExecutionContext::none(&call.id))
+            .await
+            .map(ToolOutcome::into_tool_result)
     }
 
     async fn execute_with_context(
@@ -285,17 +335,9 @@ impl ToolExecutor for CompositeToolExecutor {
         call: &ToolCall,
         ctx: ToolExecutionContext<'_>,
     ) -> std::result::Result<ToolResult, ToolError> {
-        // Try built-in first (preserve context for streaming tools).
-        match self.builtin.execute_with_context(call, ctx).await {
-            Ok(result) => return Ok(result),
-            Err(ToolError::NotFound(_)) => {
-                // Fall through to MCP
-            }
-            Err(e) => return Err(e),
-        }
-
-        // Try MCP (context ignored by default).
-        self.mcp.execute_with_context(call, ctx).await
+        self.execute_with_context_outcome(call, ctx)
+            .await
+            .map(ToolOutcome::into_tool_result)
     }
 
     /// Outcome-aware dispatch. MUST be overridden here (not left to the trait
@@ -312,15 +354,48 @@ impl ToolExecutor for CompositeToolExecutor {
         call: &ToolCall,
         ctx: ToolExecutionContext<'_>,
     ) -> std::result::Result<ToolOutcome, ToolError> {
-        match self.builtin.execute_with_context_outcome(call, ctx).await {
-            Ok(outcome) => return Ok(outcome),
-            Err(ToolError::NotFound(_)) => {
-                // Fall through to MCP.
+        match self.route(&call.function.name) {
+            CompositeRoute::Builtin { execution_name } => {
+                self.builtin
+                    .execute_exact_with_context_outcome(call, &execution_name, ctx)
+                    .await
             }
-            Err(e) => return Err(e),
+            CompositeRoute::Secondary { execution_name } => {
+                self.mcp
+                    .execute_exact_with_context_outcome(call, &execution_name, ctx)
+                    .await
+            }
+            CompositeRoute::LegacyFallback => {
+                match self.builtin.execute_with_context_outcome(call, ctx).await {
+                    Ok(outcome) => return Ok(outcome),
+                    Err(ToolError::NotFound(_)) => {}
+                    Err(error) => return Err(error),
+                }
+                self.mcp.execute_with_context_outcome(call, ctx).await
+            }
         }
+    }
 
-        self.mcp.execute_with_context_outcome(call, ctx).await
+    async fn execute_exact_with_context_outcome(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        ctx: ToolExecutionContext<'_>,
+    ) -> std::result::Result<ToolOutcome, ToolError> {
+        if self.builtin.owns_exact_tool(execution_name) {
+            self.builtin
+                .execute_exact_with_context_outcome(call, execution_name, ctx)
+                .await
+        } else if self.mcp.owns_exact_tool(execution_name) {
+            self.mcp
+                .execute_exact_with_context_outcome(call, execution_name, ctx)
+                .await
+        } else {
+            Err(ToolError::NotFound(format!(
+                "Tool '{}' not found",
+                execution_name
+            )))
+        }
     }
 
     /// Delegate the permission gate to the built-in executor, which is where the
@@ -338,13 +413,112 @@ impl ToolExecutor for CompositeToolExecutor {
         call: &ToolCall,
         ctx: &ToolExecutionContext<'_>,
     ) -> std::result::Result<Option<ToolOutcome>, ToolError> {
-        self.builtin.check_permissions_for(call, ctx).await
+        match self.route(&call.function.name) {
+            CompositeRoute::Builtin { .. } => self.builtin.check_permissions_for(call, ctx).await,
+            CompositeRoute::Secondary { execution_name } => {
+                let args = ctx
+                    .pre_parsed_args
+                    .cloned()
+                    .unwrap_or_else(|| parse_tool_args_best_effort(&call.function.arguments).0);
+                self.builtin
+                    .check_permissions_for_resolved(call, &execution_name, &args, ctx)
+                    .await
+            }
+            CompositeRoute::LegacyFallback => self.builtin.check_permissions_for(call, ctx).await,
+        }
+    }
+
+    async fn check_permissions_for_resolved(
+        &self,
+        call: &ToolCall,
+        execution_name: &str,
+        args: &serde_json::Value,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> std::result::Result<Option<ToolOutcome>, ToolError> {
+        // The builtin executor hosts the real permission policy for every live
+        // surface, including MCP and the server overlays stacked above this
+        // composite. Preserve that architecture while forwarding the exact
+        // identity and effective arguments selected by the routing layer.
+        self.builtin
+            .check_permissions_for_resolved(call, execution_name, args, ctx)
+            .await
     }
 
     fn list_tools(&self) -> Vec<ToolSchema> {
         let mut tools = self.builtin.list_tools();
-        tools.extend(self.mcp.list_tools());
+        let mut names: HashSet<String> = tools
+            .iter()
+            .map(|schema| schema.function.name.clone())
+            .collect();
+        tools.extend(
+            self.mcp
+                .list_tools()
+                .into_iter()
+                .filter(|schema| names.insert(schema.function.name.clone())),
+        );
         tools
+    }
+
+    fn owns_exact_tool(&self, tool_name: &str) -> bool {
+        self.builtin.owns_exact_tool(tool_name) || self.mcp.owns_exact_tool(tool_name)
+    }
+
+    fn tool_mutability(&self, tool_name: &str) -> bamboo_agent_core::ToolMutability {
+        match self.route(tool_name) {
+            CompositeRoute::Builtin { execution_name } => {
+                self.builtin.tool_mutability(&execution_name)
+            }
+            CompositeRoute::Secondary { execution_name } => {
+                self.mcp.tool_mutability(&execution_name)
+            }
+            CompositeRoute::LegacyFallback => bamboo_agent_core::classify_tool(tool_name),
+        }
+    }
+
+    fn call_mutability(&self, call: &ToolCall) -> bamboo_agent_core::ToolMutability {
+        self.call_parallel_classification(call).0
+    }
+
+    fn tool_concurrency_safe(&self, tool_name: &str) -> bool {
+        match self.route(tool_name) {
+            CompositeRoute::Builtin { execution_name } => {
+                self.builtin.tool_concurrency_safe(&execution_name)
+            }
+            CompositeRoute::Secondary { execution_name } => {
+                self.mcp.tool_concurrency_safe(&execution_name)
+            }
+            CompositeRoute::LegacyFallback => {
+                bamboo_agent_core::classify_tool(tool_name)
+                    == bamboo_agent_core::ToolMutability::ReadOnly
+            }
+        }
+    }
+
+    fn call_concurrency_safe(&self, call: &ToolCall) -> bool {
+        self.call_parallel_classification(call).1
+    }
+
+    fn call_parallel_classification(
+        &self,
+        call: &ToolCall,
+    ) -> (bamboo_agent_core::ToolMutability, bool) {
+        match self.route(&call.function.name) {
+            CompositeRoute::Builtin { .. } => self.builtin.call_parallel_classification(call),
+            CompositeRoute::Secondary { execution_name } => {
+                self.mcp
+                    .call_parallel_classification(&Self::call_with_execution_name(
+                        call,
+                        &execution_name,
+                    ))
+            }
+            CompositeRoute::LegacyFallback => {
+                let mutability = bamboo_agent_core::classify_tool(&call.function.name);
+                (
+                    mutability,
+                    mutability == bamboo_agent_core::ToolMutability::ReadOnly,
+                )
+            }
+        }
     }
 
     fn tool_guidance(&self) -> Option<String> {
@@ -393,6 +567,218 @@ mod tests {
         fn tool_guidance(&self) -> Option<String> {
             self.0.map(str::to_string)
         }
+    }
+
+    struct RoutingStub {
+        exact_names: Vec<&'static str>,
+        label: &'static str,
+        apply_patch_alias: bool,
+        error: Option<ToolError>,
+        classification: (bamboo_agent_core::ToolMutability, bool),
+        executed: Arc<std::sync::Mutex<Vec<String>>>,
+        permission_checked: Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>,
+    }
+
+    impl RoutingStub {
+        fn new(exact_names: Vec<&'static str>, label: &'static str) -> Self {
+            Self {
+                exact_names,
+                label,
+                apply_patch_alias: false,
+                error: None,
+                classification: (bamboo_agent_core::ToolMutability::Mutating, false),
+                executed: Arc::new(std::sync::Mutex::new(Vec::new())),
+                permission_checked: Arc::new(std::sync::Mutex::new(Vec::new())),
+            }
+        }
+
+        fn schema(name: &str) -> ToolSchema {
+            ToolSchema {
+                schema_type: "function".to_string(),
+                function: FunctionSchema {
+                    name: name.to_string(),
+                    description: "routing stub".to_string(),
+                    parameters: serde_json::json!({"type":"object"}),
+                },
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ToolExecutor for RoutingStub {
+        async fn execute(&self, call: &ToolCall) -> std::result::Result<ToolResult, ToolError> {
+            let exact = self.owns_exact_tool(&call.function.name);
+            let accepted_alias = self.apply_patch_alias
+                && call.function.name == "apply_patch"
+                && self.owns_exact_tool("Edit");
+            if !exact && !accepted_alias {
+                return Err(ToolError::NotFound(call.function.name.clone()));
+            }
+            self.executed
+                .lock()
+                .unwrap()
+                .push(call.function.name.clone());
+            if let Some(error) = &self.error {
+                return Err(error.clone());
+            }
+            Ok(ToolResult {
+                success: true,
+                result: self.label.to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+
+        async fn check_permissions_for(
+            &self,
+            call: &ToolCall,
+            _ctx: &ToolExecutionContext<'_>,
+        ) -> std::result::Result<Option<ToolOutcome>, ToolError> {
+            let args = parse_tool_args_best_effort(&call.function.arguments).0;
+            self.permission_checked
+                .lock()
+                .unwrap()
+                .push((call.function.name.clone(), args));
+            Ok(None)
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            self.exact_names
+                .iter()
+                .map(|name| Self::schema(name))
+                .collect()
+        }
+
+        fn owns_exact_tool(&self, tool_name: &str) -> bool {
+            self.exact_names.contains(&tool_name)
+        }
+
+        fn call_parallel_classification(
+            &self,
+            _call: &ToolCall,
+        ) -> (bamboo_agent_core::ToolMutability, bool) {
+            self.classification
+        }
+    }
+
+    #[tokio::test]
+    async fn secondary_exact_apply_patch_beats_builtin_alias_across_all_routes() {
+        let mut builtin = RoutingStub::new(vec!["Edit"], "builtin-edit");
+        builtin.apply_patch_alias = true;
+        let builtin_executed = builtin.executed.clone();
+        let builtin_permissions = builtin.permission_checked.clone();
+
+        let mut secondary = RoutingStub::new(vec!["apply_patch"], "secondary-exact");
+        secondary.classification = (bamboo_agent_core::ToolMutability::ReadOnly, true);
+        let secondary_executed = secondary.executed.clone();
+        let secondary_permissions = secondary.permission_checked.clone();
+
+        let composite = CompositeToolExecutor::new(Arc::new(builtin), Arc::new(secondary));
+        let call = create_test_tool_call("apply_patch", r#"{"path":"custom"}"#);
+
+        let result = composite
+            .execute(&call)
+            .await
+            .expect("secondary exact owner must execute");
+        assert_eq!(result.result, "secondary-exact");
+        assert!(builtin_executed.lock().unwrap().is_empty());
+        assert_eq!(
+            secondary_executed.lock().unwrap().as_slice(),
+            ["apply_patch"]
+        );
+        assert_eq!(
+            composite.call_parallel_classification(&call),
+            (bamboo_agent_core::ToolMutability::ReadOnly, true)
+        );
+
+        composite
+            .check_permissions_for(&call, &ToolExecutionContext::none(&call.id))
+            .await
+            .expect("secondary permission check");
+        assert_eq!(
+            builtin_permissions.lock().unwrap().as_slice(),
+            [(
+                "apply_patch".to_string(),
+                serde_json::json!({"path": "custom"})
+            )]
+        );
+        assert!(secondary_permissions.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unshadowed_apply_patch_preserves_builtin_alias_fallback() {
+        let mut builtin = RoutingStub::new(vec!["Edit"], "builtin-edit");
+        builtin.apply_patch_alias = true;
+        let composite = CompositeToolExecutor::new(
+            Arc::new(builtin),
+            Arc::new(RoutingStub::new(Vec::new(), "secondary")),
+        );
+
+        let result = composite
+            .execute(&create_test_tool_call("apply_patch", "{}"))
+            .await
+            .expect("unshadowed alias must retain builtin behavior");
+        assert_eq!(result.result, "builtin-edit");
+    }
+
+    #[tokio::test]
+    async fn namespace_fallback_executes_the_selected_secondary_exact_identity() {
+        let secondary = RoutingStub::new(vec!["custom_tool"], "secondary-custom");
+        let composite = CompositeToolExecutor::new(
+            Arc::new(RoutingStub::new(Vec::new(), "builtin")),
+            Arc::new(secondary),
+        );
+
+        let result = composite
+            .execute(&create_test_tool_call("default::custom_tool", "{}"))
+            .await
+            .expect("namespace fallback must execute secondary exact identity");
+        assert_eq!(result.result, "secondary-custom");
+    }
+
+    #[tokio::test]
+    async fn selected_exact_owner_errors_never_fall_through() {
+        for error in [
+            ToolError::NotFound("secondary exact missing".to_string()),
+            ToolError::Execution("secondary exact denied".to_string()),
+        ] {
+            let mut builtin = RoutingStub::new(vec!["Edit"], "builtin-fallback");
+            builtin.apply_patch_alias = true;
+            let builtin_executed = builtin.executed.clone();
+            let mut secondary = RoutingStub::new(vec!["apply_patch"], "secondary");
+            secondary.error = Some(error.clone());
+            let composite = CompositeToolExecutor::new(Arc::new(builtin), Arc::new(secondary));
+
+            let actual = composite
+                .execute(&create_test_tool_call("apply_patch", "{}"))
+                .await
+                .expect_err("selected exact owner error must propagate");
+            assert_eq!(actual.to_string(), error.to_string());
+            assert!(builtin_executed.lock().unwrap().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_exact_names_are_builtin_first_and_listed_once() {
+        let builtin = RoutingStub::new(vec!["duplicate"], "builtin");
+        let secondary = RoutingStub::new(vec!["duplicate"], "secondary");
+        let secondary_executed = secondary.executed.clone();
+        let composite = CompositeToolExecutor::new(Arc::new(builtin), Arc::new(secondary));
+
+        let result = composite
+            .execute(&create_test_tool_call("duplicate", "{}"))
+            .await
+            .expect("builtin duplicate owner must win");
+        assert_eq!(result.result, "builtin");
+        assert!(secondary_executed.lock().unwrap().is_empty());
+        assert_eq!(
+            composite
+                .list_tools()
+                .iter()
+                .filter(|schema| schema.function.name == "duplicate")
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -739,7 +1125,7 @@ mod tests {
     #[tokio::test]
     async fn test_composite_executor_builtin_success() {
         let mut mock_builtin = MockToolExecutor::new();
-        let mock_mcp = MockToolExecutor::new();
+        let mut mock_mcp = MockToolExecutor::new();
 
         // Built-in succeeds, MCP should not be called
         mock_builtin.expect_execute().returning(|_| {
@@ -761,6 +1147,7 @@ mod tests {
                 },
             }]
         });
+        mock_mcp.expect_list_tools().returning(Vec::new);
 
         let composite = CompositeToolExecutor::new(Arc::new(mock_builtin), Arc::new(mock_mcp));
 
@@ -773,7 +1160,7 @@ mod tests {
     #[tokio::test]
     async fn test_composite_executor_builtin_error() {
         let mut mock_builtin = MockToolExecutor::new();
-        let mock_mcp = MockToolExecutor::new();
+        let mut mock_mcp = MockToolExecutor::new();
 
         // Built-in returns error (not NotFound), should propagate
         mock_builtin
@@ -790,6 +1177,7 @@ mod tests {
                 },
             }]
         });
+        mock_mcp.expect_list_tools().returning(Vec::new);
 
         let composite = CompositeToolExecutor::new(Arc::new(mock_builtin), Arc::new(mock_mcp));
 

--- a/crates/infra/bamboo-mcp/src/tool_index.rs
+++ b/crates/infra/bamboo-mcp/src/tool_index.rs
@@ -116,6 +116,15 @@ impl ToolIndex {
     pub fn contains(&self, alias: &str) -> bool {
         self.aliases.contains_key(alias)
     }
+
+    /// Check ownership of a complete, exact alias identity.
+    ///
+    /// Keep this separate from compatibility lookup/containment APIs: executor
+    /// routing must never treat a canonicalized or unambiguous legacy reference
+    /// as an exact owner.
+    pub fn contains_exact_alias(&self, alias: &str) -> bool {
+        self.aliases.contains_key(alias)
+    }
 }
 
 impl Default for ToolIndex {
@@ -245,5 +254,21 @@ mod tests {
 
         index.remove_server_tools("fs");
         assert!(!index.contains("mcp__fs__read_file"));
+    }
+
+    #[test]
+    fn exact_alias_membership_is_case_sensitive_and_does_not_canonicalize() {
+        let index = ToolIndex::new();
+        let tools = vec![McpTool {
+            name: "read_file".to_string(),
+            description: "Read".to_string(),
+            parameters: serde_json::json!({}),
+            output_schema: None,
+        }];
+        index.register_server_tools("fs", &tools, &[], &[]);
+
+        assert!(index.contains_exact_alias("mcp__fs__read_file"));
+        assert!(!index.contains_exact_alias("MCP__fs__read_file"));
+        assert!(!index.contains_exact_alias("read_file"));
     }
 }


### PR DESCRIPTION
## Summary

- add object-safe exact-owner execution and permission seams to `ToolExecutor`
- make builtin, overlay, composite, MCP, and broker proxy routing select exact identities before compatibility aliases
- keep execution, permission checks, argument compatibility, mutability, and concurrency classification on the same selected owner, including stacked Overlay/Composite executors
- preserve framework-builtin argument compatibility by Arc provenance so same-name custom tools retain their own schemas and raw arguments
- propagate selected-owner errors/removals fail-closed without semantic fallthrough

Closes #989

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- affected full suites after the permission-owner fix: `cargo test --locked -p bamboo-agent-core -p bamboo-tools -p bamboo-mcp -p bamboo-server-tools --no-fail-fast` (910 lib + 4 integration tests passed; doc tests clean/ignored only)
- broker full lib suite on the routing snapshot (95 passed)
- affected package `cargo check`
- affected production libraries: strict `cargo clippy --lib --no-deps -- -D warnings`
- affected all-target code passes with only the documented untouched baseline lint allowances

## Review

Independent agent review found and verified fixes for two P1 issues before merge: framework-builtin argument provenance and exact permission-owner pinning. Final reviewed patch SHA-256 matches the pushed commits; no P0/P1/P2 findings remain. Adjacent name-only custom permission-policy debt is recorded separately in #994 and remains fail-closed.

## Screenshots

Not applicable (backend routing change).