### PR TITLE
fix: make MCP tool aliases collision-safe (#990)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/usage.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/usage.rs
@@ -18,6 +18,13 @@ struct ParsedMcpAlias {
     tool_name: String,
 }
 
+fn is_v1_alias_tag(value: &str) -> bool {
+    value.len() == 26
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || matches!(byte, b'2'..=b'7'))
+}
+
 fn parse_mcp_tool_alias(value: &str) -> Option<ParsedMcpAlias> {
     let trimmed = value.trim();
     if !trimmed.starts_with("mcp__") {
@@ -25,6 +32,20 @@ fn parse_mcp_tool_alias(value: &str) -> Option<ParsedMcpAlias> {
     }
 
     let rest = &trimmed["mcp__".len()..];
+    if let Some((server_tag, owner_tag)) = rest
+        .strip_prefix("v1_")
+        .and_then(|tags| tags.split_once('_'))
+    {
+        if is_v1_alias_tag(server_tag) && is_v1_alias_tag(owner_tag) {
+            // V1 exposes only stable pseudonyms. Preserve real per-server
+            // grouping without putting raw MCP labels into metrics.
+            return Some(ParsedMcpAlias {
+                server_id: format!("v1_{server_tag}"),
+                tool_name: owner_tag.to_string(),
+            });
+        }
+    }
+
     let sep = rest.find("__")?;
     if sep == 0 {
         return None;
@@ -248,4 +269,56 @@ pub async fn usage_breakdown(
         top_mcp_servers,
         top_mcp_tools,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_mcp_tool_alias;
+
+    #[test]
+    fn parses_v1_canonical_alias_as_secret_safe_mcp_pseudonyms() {
+        let alias =
+            bamboo_mcp::ToolIndex::new().generate_alias("secret-server-label", "secret-tool-label");
+        let (server_tag, owner_tag) = alias
+            .strip_prefix("mcp__v1_")
+            .and_then(|tags| tags.split_once('_'))
+            .unwrap();
+        let parsed =
+            parse_mcp_tool_alias(&alias).expect("canonical v1 aliases remain in MCP metrics");
+
+        assert_eq!(parsed.server_id, format!("v1_{server_tag}"));
+        assert_eq!(parsed.tool_name, owner_tag);
+        assert!(!parsed.server_id.contains("secret"));
+        assert!(!parsed.tool_name.contains("secret"));
+    }
+
+    #[test]
+    fn v1_metrics_group_same_server_and_separate_distinct_servers() {
+        let index = bamboo_mcp::ToolIndex::new();
+        let first = parse_mcp_tool_alias(&index.generate_alias("server-a", "tool-one")).unwrap();
+        let sibling = parse_mcp_tool_alias(&index.generate_alias("server-a", "tool-two")).unwrap();
+        let other = parse_mcp_tool_alias(&index.generate_alias("server-b", "tool-one")).unwrap();
+
+        assert_eq!(first.server_id, sibling.server_id);
+        assert_ne!(first.tool_name, sibling.tool_name);
+        assert_ne!(first.server_id, other.server_id);
+        assert_ne!(first.tool_name, other.tool_name);
+    }
+
+    #[test]
+    fn preserves_legacy_alias_parsing_and_rejects_malformed_v1_names() {
+        let legacy = parse_mcp_tool_alias("mcp__filesystem__read_file").unwrap();
+        assert_eq!(legacy.server_id, "filesystem");
+        assert_eq!(legacy.tool_name, "read_file");
+
+        let legacy_v1_prefix = parse_mcp_tool_alias("mcp__v1_server__tool").unwrap();
+        assert_eq!(legacy_v1_prefix.server_id, "v1_server");
+        assert_eq!(legacy_v1_prefix.tool_name, "tool");
+
+        assert!(parse_mcp_tool_alias("mcp__v1_too_short").is_none());
+        assert!(
+            parse_mcp_tool_alias(&format!("mcp__v1_{}_{}", "a".repeat(26), "0".repeat(26)))
+                .is_none()
+        );
+    }
 }

--- a/crates/infra/bamboo-mcp/src/error.rs
+++ b/crates/infra/bamboo-mcp/src/error.rs
@@ -1,5 +1,41 @@
 use thiserror::Error;
 
+/// Typed failures produced while validating or publishing one MCP tool catalog.
+///
+/// These diagnostics deliberately identify positions, bounded counts, and
+/// provider-visible hashed aliases instead of echoing remote server/tool labels,
+/// which may contain sensitive or attacker-controlled text.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum ToolRegistrationError {
+    #[error("MCP tool catalog has an empty server identity")]
+    EmptyServerIdentity,
+
+    #[error("MCP tool catalog has an empty tool identity at position {position}")]
+    EmptyToolIdentity { position: usize },
+
+    #[error(
+        "MCP tool catalog has a duplicate tool identity at positions {first_position} and {duplicate_position}"
+    )]
+    DuplicateToolIdentity {
+        first_position: usize,
+        duplicate_position: usize,
+    },
+
+    #[error("MCP catalog update contains duplicate plans for one server")]
+    DuplicateServerPlan,
+
+    #[error("MCP catalog update both replaces and removes one server")]
+    ConflictingServerChange,
+
+    #[error("MCP canonical tool alias collision for '{alias}'")]
+    AliasCollision { alias: String },
+
+    #[error(
+        "MCP ownership ledger capacity exceeded: attempted {attempted} relationships with limit {limit}"
+    )]
+    OwnershipLedgerCapacityExceeded { limit: usize, attempted: usize },
+}
+
 #[derive(Error, Debug, Clone)]
 pub enum McpError {
     #[error("Transport error: {0}")]
@@ -46,6 +82,9 @@ pub enum McpError {
 
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
+
+    #[error(transparent)]
+    ToolRegistration(#[from] ToolRegistrationError),
 
     #[error("Server disconnected")]
     Disconnected,

--- a/crates/infra/bamboo-mcp/src/lib.rs
+++ b/crates/infra/bamboo-mcp/src/lib.rs
@@ -13,10 +13,10 @@ pub mod transports;
 pub mod types;
 
 pub use config::*;
-pub use error::{McpError, Result};
+pub use error::{McpError, Result, ToolRegistrationError};
 pub use executor::{CompositeToolExecutor, McpToolExecutor};
 pub use manager::McpServerManager;
 pub use protocol::*;
-pub use tool_index::ToolIndex;
+pub use tool_index::{ToolIndex, MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS};
 pub use transports::*;
 pub use types::*;

--- a/crates/infra/bamboo-mcp/src/manager/config_sync.rs
+++ b/crates/infra/bamboo-mcp/src/manager/config_sync.rs
@@ -123,6 +123,28 @@ impl McpServerManager {
             .filter(|id| !desired_enabled.contains(id.as_str()))
             .collect();
 
+        // Validate the complete resulting catalog before crossing the durable
+        // configuration boundary. This catches cross-server alias conflicts as
+        // one unit and leaves every currently published runtime/index entry
+        // untouched on failure.
+        let replacement_catalogs: Vec<_> = replacements
+            .iter()
+            .map(|prepared| prepared.catalog.clone())
+            .collect();
+        let catalog_update = match self
+            .index
+            .preflight_catalog_update(&replacement_catalogs, &removals)
+        {
+            Ok(update) => update,
+            Err(error) => {
+                for prepared in replacements {
+                    let id = prepared.runtime.config.id.clone();
+                    self.shutdown_detached_runtime(&id, prepared.runtime).await;
+                }
+                return Err(error.into());
+            }
+        };
+
         if let Err(error) = before_publish().await {
             for prepared in replacements {
                 let id = prepared.runtime.config.id.clone();
@@ -147,7 +169,7 @@ impl McpServerManager {
         }
         let mut removed = Vec::new();
         for id in removals {
-            match self.detach_runtime(&id) {
+            match self.detach_runtime_without_index(&id) {
                 Ok(runtime) => removed.push((id, runtime)),
                 Err(error) => {
                     // The reconcile lock makes this unreachable for ordinary
@@ -157,6 +179,7 @@ impl McpServerManager {
                 }
             }
         }
+        self.index.commit_catalog_update(catalog_update);
 
         // Event channel backpressure and transport shutdown are post-commit
         // cleanup. They must never delay section health publication by the

--- a/crates/infra/bamboo-mcp/src/manager/lifecycle.rs
+++ b/crates/infra/bamboo-mcp/src/manager/lifecycle.rs
@@ -28,7 +28,7 @@ impl McpServerManager {
 
         let prepared = self.prepare_server_runtime(config, "start").await?;
         debug_assert_eq!(prepared.runtime.config.id, server_id);
-        let replaced = self.install_prepared_runtime(prepared).await;
+        let replaced = self.install_prepared_runtime(prepared).await?;
         debug_assert!(replaced.is_none());
 
         Ok(())
@@ -41,9 +41,21 @@ impl McpServerManager {
     ) -> Result<PreparedServerRuntime> {
         let server_id = config.id.clone();
         let runtime_proxy_fingerprint = desired_proxy_fingerprint(self.config.as_ref()).await;
-        let (client, tools, instructions, notification_rx) = self
+        let (mut client, tools, instructions, notification_rx) = self
             .bootstrap_server_client(&server_id, &config, phase)
             .await?;
+        let catalog = match self.index.plan_server_tools(
+            &server_id,
+            &tools,
+            &config.allowed_tools,
+            &config.denied_tools,
+        ) {
+            Ok(catalog) => catalog,
+            Err(error) => {
+                let _ = client.disconnect().await;
+                return Err(error.into());
+            }
+        };
         let runtime = Arc::new(ServerRuntime {
             config,
             client: RwLock::new(client),
@@ -65,7 +77,7 @@ impl McpServerManager {
         });
         Ok(PreparedServerRuntime {
             runtime,
-            tools,
+            catalog,
             notification_rx,
         })
     }
@@ -75,11 +87,30 @@ impl McpServerManager {
     pub(super) async fn install_prepared_runtime(
         &self,
         prepared: PreparedServerRuntime,
-    ) -> Option<Arc<ServerRuntime>> {
+    ) -> Result<Option<Arc<ServerRuntime>>> {
+        let transaction = match self
+            .index
+            .preflight_catalog_update(std::slice::from_ref(&prepared.catalog), &[])
+        {
+            Ok(transaction) => transaction,
+            Err(error) => {
+                let server_id = prepared.runtime.config.id.clone();
+                self.shutdown_detached_runtime(&server_id, prepared.runtime)
+                    .await;
+                return Err(error.into());
+            }
+        };
         let (server_id, tool_names, replaced) = self.publish_prepared_runtime(prepared);
+        self.index.commit_catalog_update(transaction);
+
+        info!(
+            "Registered {} MCP tools for server '{}'",
+            tool_names.len(),
+            server_id
+        );
 
         self.emit_runtime_ready_events(server_id, tool_names).await;
-        replaced
+        Ok(replaced)
     }
 
     /// Publish a fully initialized runtime without suspending. Configuration
@@ -91,26 +122,18 @@ impl McpServerManager {
     ) -> (String, Vec<String>, Option<Arc<ServerRuntime>>) {
         let PreparedServerRuntime {
             runtime,
-            tools,
+            catalog,
             notification_rx,
         } = prepared;
         let config = &runtime.config;
         let server_id = config.id.clone();
         let healthcheck_interval_ms = config.healthcheck_interval_ms;
 
-        self.index.remove_server_tools(&server_id);
-        let aliases = self.index.register_server_tools(
-            &server_id,
-            &tools,
-            &config.allowed_tools,
-            &config.denied_tools,
-        );
-
-        info!(
-            "Registered {} MCP tools for server '{}'",
-            aliases.len(),
-            server_id
-        );
+        let tool_names = catalog
+            .aliases()
+            .into_iter()
+            .map(|alias| alias.alias)
+            .collect();
 
         // Store runtime only after its client initialized and tools were read.
         let replaced = self.runtimes.insert(server_id.clone(), runtime.clone());
@@ -130,7 +153,6 @@ impl McpServerManager {
             old.shutdown.store(true, Ordering::SeqCst);
         }
 
-        let tool_names = aliases.into_iter().map(|alias| alias.alias).collect();
         (server_id, tool_names, replaced)
     }
 
@@ -165,22 +187,35 @@ impl McpServerManager {
 
     pub(super) async fn stop_server_unlocked(&self, server_id: &str) -> Result<()> {
         info!("Stopping MCP server '{}'", server_id);
-        let runtime = self.detach_runtime(server_id)?;
+        // `stop_server` owns the reconciliation lock. Preflight the catalog
+        // removal before detaching the runtime, then publish both changes with
+        // no suspension/cancellation point. Another OS thread may briefly see
+        // the old alias after runtime removal, but execution then fails closed
+        // on the missing runtime; it can never resolve to a different owner.
+        // The checked commit is infallible under the single-writer invariant
+        // and fail-stops before swapping if violated.
+        let transaction = self
+            .index
+            .preflight_catalog_update(&[], &[server_id.to_string()])?;
+        let runtime = self.detach_runtime_without_index(server_id)?;
+        self.index.commit_catalog_update(transaction);
         self.finish_detached_stop(server_id.to_string(), runtime, true)
             .await;
         info!("MCP server '{}' stopped", server_id);
         Ok(())
     }
 
-    /// Remove a runtime and all of its externally visible tools without
-    /// suspending. The returned client can be disconnected afterward.
-    pub(super) fn detach_runtime(&self, server_id: &str) -> Result<Arc<ServerRuntime>> {
+    /// Detach only the runtime. Transactional configuration reconciliation uses
+    /// this while a preflighted whole-index replacement is waiting to commit.
+    pub(super) fn detach_runtime_without_index(
+        &self,
+        server_id: &str,
+    ) -> Result<Arc<ServerRuntime>> {
         let (_, runtime) = self
             .runtimes
             .remove(server_id)
             .ok_or_else(|| McpError::NotRunning(server_id.to_string()))?;
         runtime.shutdown.store(true, Ordering::SeqCst);
-        self.index.remove_server_tools(server_id);
         Ok(runtime)
     }
 
@@ -340,7 +375,7 @@ impl McpServerManager {
 
         if !self
             .publish_refreshed_tools_if_current(server_id, &runtime, new_tools)
-            .await
+            .await?
         {
             tracing::debug!(
                 "Discarding tool refresh for detached MCP runtime '{}'",
@@ -355,32 +390,36 @@ impl McpServerManager {
         server_id: &str,
         runtime: &Arc<ServerRuntime>,
         new_tools: Vec<McpTool>,
-    ) -> bool {
+    ) -> Result<bool> {
         // Serialize the generation check with transactional replacement. The
         // list_tools await above may span a replacement, so checking only when
         // the refresh starts is insufficient.
         let _reconcile = self.reconcile_lock.lock().await;
         if runtime.shutdown.load(Ordering::SeqCst) || !self.is_current_runtime(server_id, runtime) {
-            return false;
+            return Ok(false);
         }
 
-        // Update tools
-        let mut tools = runtime.tools.write().await;
-        *tools = new_tools.clone();
-        drop(tools);
-
-        // Update info
-        let mut info = runtime.info.write().await;
-        info.tool_count = new_tools.len();
-
-        // Re-register tools
-        self.index.remove_server_tools(server_id);
-        let aliases = self.index.register_server_tools(
+        let catalog = self.index.plan_server_tools(
             server_id,
             &new_tools,
             &runtime.config.allowed_tools,
             &runtime.config.denied_tools,
-        );
+        )?;
+        let aliases = catalog.aliases();
+        let transaction = self
+            .index
+            .preflight_catalog_update(std::slice::from_ref(&catalog), &[])?;
+
+        // Acquire every fallible/suspending guard before the publication point.
+        // From the index swap through the runtime metadata update there is no
+        // await, so a failed preflight leaves the prior catalog untouched.
+        let mut tools = runtime.tools.write().await;
+        let mut info = runtime.info.write().await;
+        self.index.commit_catalog_update(transaction);
+        *tools = new_tools.clone();
+        info.tool_count = new_tools.len();
+        drop(info);
+        drop(tools);
 
         info!(
             "Refreshed {} tools for MCP server '{}'",
@@ -399,7 +438,7 @@ impl McpServerManager {
                 .await;
         }
 
-        true
+        Ok(true)
     }
 
     fn start_health_check(&self, runtime: Arc<ServerRuntime>, interval_ms: u64) {

--- a/crates/infra/bamboo-mcp/src/manager/mod.rs
+++ b/crates/infra/bamboo-mcp/src/manager/mod.rs
@@ -10,7 +10,7 @@ use crate::config::{McpConfig, McpServerConfig, TransportConfig};
 use crate::error::{McpError, Result};
 use crate::protocol::models::JsonRpcNotification;
 use crate::protocol::{McpProtocolClient, McpTransport};
-use crate::tool_index::ToolIndex;
+use crate::tool_index::{ServerToolCatalog, ToolIndex};
 use crate::transports::{SseTransport, StdioTransport, StreamableHttpTransport};
 use crate::types::{McpEvent, McpTool, RuntimeInfo, ServerStatus};
 use bamboo_llm::Config;
@@ -161,7 +161,7 @@ struct ServerRuntime {
 /// working runtime.
 struct PreparedServerRuntime {
     runtime: Arc<ServerRuntime>,
-    tools: Vec<McpTool>,
+    catalog: ServerToolCatalog,
     notification_rx: Option<tokio::sync::mpsc::Receiver<JsonRpcNotification>>,
 }
 

--- a/crates/infra/bamboo-mcp/src/manager/reconnect.rs
+++ b/crates/infra/bamboo-mcp/src/manager/reconnect.rs
@@ -176,33 +176,24 @@ impl McpServerManager {
     }
 
     /// Internal method to reconnect a single server.
-    async fn reconnect_server(&self, runtime: Arc<ServerRuntime>) -> Result<bool> {
+    pub(super) async fn reconnect_server(&self, runtime: Arc<ServerRuntime>) -> Result<bool> {
         let server_id = runtime.config.id.clone();
 
         info!("Attempting to reconnect MCP server '{}'", server_id);
-
-        // Disconnect existing client if connected
-        {
-            let mut client = runtime.client.write().await;
-            if client.is_connected().await {
-                let _ = client.disconnect().await;
-            }
-        }
 
         let (client, tools, instructions, notification_rx) = self
             .bootstrap_server_client(&server_id, &runtime.config, "reconnect")
             .await?;
 
-        Ok(self
-            .publish_reconnected_runtime_if_current(
-                &server_id,
-                &runtime,
-                client,
-                tools,
-                instructions,
-                notification_rx,
-            )
-            .await)
+        self.publish_reconnected_runtime_if_current(
+            &server_id,
+            &runtime,
+            client,
+            tools,
+            instructions,
+            notification_rx,
+        )
+        .await
     }
 
     pub(super) async fn publish_reconnected_runtime_if_current(
@@ -213,7 +204,7 @@ impl McpServerManager {
         tools: Vec<McpTool>,
         instructions: Option<String>,
         notification_rx: Option<tokio::sync::mpsc::Receiver<JsonRpcNotification>>,
-    ) -> bool {
+    ) -> Result<bool> {
         // Bootstrap may span a replacement. Serialize this final generation
         // check with transactional commit before touching runtime state or the
         // shared tool index.
@@ -221,14 +212,50 @@ impl McpServerManager {
         if runtime.shutdown.load(Ordering::SeqCst) || !self.is_current_runtime(server_id, runtime) {
             drop(_reconcile);
             let _ = client.disconnect().await;
-            return false;
+            return Ok(false);
         }
 
-        // Update client
+        let catalog = match self.index.plan_server_tools(
+            server_id,
+            &tools,
+            &runtime.config.allowed_tools,
+            &runtime.config.denied_tools,
+        ) {
+            Ok(catalog) => catalog,
+            Err(error) => {
+                drop(_reconcile);
+                let _ = client.disconnect().await;
+                return Err(error.into());
+            }
+        };
+        let aliases = catalog.aliases();
+        let catalog_update = match self
+            .index
+            .preflight_catalog_update(std::slice::from_ref(&catalog), &[])
         {
-            let mut client_lock = runtime.client.write().await;
-            *client_lock = client;
-        }
+            Ok(update) => update,
+            Err(error) => {
+                drop(_reconcile);
+                let _ = client.disconnect().await;
+                return Err(error.into());
+            }
+        };
+
+        // Acquire every suspending guard before the publication point. Once
+        // the new client is swapped, the index and runtime metadata are updated
+        // without another await, so registration failure preserves the entire
+        // prior generation.
+        let mut client_lock = runtime.client.write().await;
+        let mut tools_lock = runtime.tools.write().await;
+        let mut info = runtime.info.write().await;
+        let mut old_client = std::mem::replace(&mut *client_lock, client);
+        self.index.commit_catalog_update(catalog_update);
+        *tools_lock = tools;
+        info.instructions = instructions;
+        info.tool_count = tools_lock.len();
+        drop(info);
+        drop(tools_lock);
+        drop(client_lock);
 
         // Spawn the notification drain only AFTER the new client is swapped in, so
         // an immediate `tools/list_changed` refreshes against the NEW connection
@@ -237,34 +264,19 @@ impl McpServerManager {
             self.spawn_notification_drain(server_id.to_string(), runtime.clone(), rx);
         }
 
-        // Update tools
-        {
-            let mut tools_lock = runtime.tools.write().await;
-            *tools_lock = tools.clone();
-        }
-
-        // Refresh the server's prompt instructions from the new init result.
-        {
-            let mut info = runtime.info.write().await;
-            info.instructions = instructions;
-        }
-
-        // Re-register tools in index
-        self.index.remove_server_tools(server_id);
-        let aliases = self.index.register_server_tools(
-            server_id,
-            &tools,
-            &runtime.config.allowed_tools,
-            &runtime.config.denied_tools,
-        );
-
         info!(
             "Re-registered {} MCP tools for server '{}'",
             aliases.len(),
             server_id
         );
 
-        // Emit tools changed event
+        // Transport shutdown and event-channel backpressure are post-commit
+        // cleanup, so cancellation cannot strand a half-published reconnect.
+        tokio::spawn(async move {
+            if old_client.disconnect().await.is_err() {
+                warn!("Failed to disconnect replaced MCP client");
+            }
+        });
         if let Some(ref tx) = self.event_tx {
             let tool_names: Vec<String> = aliases.into_iter().map(|a| a.alias).collect();
             let _ = tx
@@ -274,8 +286,9 @@ impl McpServerManager {
                 })
                 .await;
         }
+        drop(_reconcile);
 
-        true
+        Ok(true)
     }
 
     pub(super) async fn bootstrap_server_client(

--- a/crates/infra/bamboo-mcp/src/manager/tests.rs
+++ b/crates/infra/bamboo-mcp/src/manager/tests.rs
@@ -1,7 +1,10 @@
 use super::fingerprint::proxy_fingerprint;
 use super::*;
 use crate::config::{ReconnectConfig, SseConfig, StdioConfig};
+use crate::executor::McpToolExecutor;
 use async_trait::async_trait;
+use bamboo_agent_core::{FunctionCall, ToolCall, ToolExecutor};
+use bamboo_domain::ClassifiedToolIdentity;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
 
@@ -486,6 +489,17 @@ impl McpTransport for NotifyingMockTransport {
                 "result": { "tools": tools }
             });
             let _ = self.to_client_tx.send(resp.to_string()).await;
+        } else if req["method"].as_str() == Some("tools/call") {
+            let called_name = req["params"]["name"].as_str().unwrap_or_default();
+            let resp = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": req["id"].clone(),
+                "result": {
+                    "content": [{"type": "text", "text": called_name}],
+                    "isError": false
+                }
+            });
+            let _ = self.to_client_tx.send(resp.to_string()).await;
         }
         Ok(())
     }
@@ -500,16 +514,16 @@ impl McpTransport for NotifyingMockTransport {
     }
 }
 
-/// Inserts a `ServerRuntime` backed by an already-connected `client`, starting
-/// with zero registered tools. Returns the runtime so the test can take the
-/// client's notification receiver.
-fn insert_mock_runtime(
-    manager: &McpServerManager,
-    server_id: &str,
+fn mock_runtime(server_id: &str, client: McpProtocolClient) -> Arc<ServerRuntime> {
+    mock_runtime_with_config(create_test_server_config(server_id), client)
+}
+
+fn mock_runtime_with_config(
+    config: McpServerConfig,
     client: McpProtocolClient,
 ) -> Arc<ServerRuntime> {
-    let runtime = Arc::new(ServerRuntime {
-        config: create_test_server_config(server_id),
+    Arc::new(ServerRuntime {
+        config,
         client: RwLock::new(client),
         info: RwLock::new(RuntimeInfo {
             status: ServerStatus::Ready,
@@ -526,7 +540,18 @@ fn insert_mock_runtime(
         reconnecting: AtomicBool::new(false),
         qos: McpServerQos::new(McpQosConfig::default()),
         proxy_fingerprint: None,
-    });
+    })
+}
+
+/// Inserts a `ServerRuntime` backed by an already-connected `client`, starting
+/// with zero registered tools. Returns the runtime so the test can take the
+/// client's notification receiver.
+fn insert_mock_runtime(
+    manager: &McpServerManager,
+    server_id: &str,
+    client: McpProtocolClient,
+) -> Arc<ServerRuntime> {
+    let runtime = mock_runtime(server_id, client);
     manager
         .runtimes
         .insert(server_id.to_string(), runtime.clone());
@@ -550,6 +575,62 @@ fn marker_tool(name: &str) -> McpTool {
 }
 
 #[tokio::test]
+async fn install_registration_failure_preserves_existing_publication() {
+    let manager = McpServerManager::new();
+    let old_runtime = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
+    let old_tool = marker_tool("old_tool");
+    *old_runtime.tools.write().await = vec![old_tool.clone()];
+    old_runtime.info.write().await.tool_count = 1;
+    let old_aliases = manager
+        .index
+        .register_server_tools("stable", std::slice::from_ref(&old_tool), &[], &[])
+        .unwrap();
+
+    // A real 130-bit tag collision is not a practical fixture. Corrupt only the
+    // staged test catalog to exercise the runtime ownership guard and install
+    // rollback path deterministically.
+    let candidate_tool = marker_tool("candidate_tool");
+    let mut candidate_catalog = manager
+        .index
+        .plan_server_tools("candidate", std::slice::from_ref(&candidate_tool), &[], &[])
+        .unwrap();
+    candidate_catalog.replace_first_canonical_alias_for_test(old_aliases[0].alias.clone());
+    let candidate_runtime = mock_runtime("candidate", connected_mock_client().await);
+    *candidate_runtime.tools.write().await = vec![candidate_tool];
+    candidate_runtime.info.write().await.tool_count = 1;
+    let prepared = PreparedServerRuntime {
+        runtime: candidate_runtime.clone(),
+        catalog: candidate_catalog,
+        notification_rx: None,
+    };
+
+    let error = match manager.install_prepared_runtime(prepared).await {
+        Err(error) => error,
+        Ok(_) => panic!("colliding install catalog must fail"),
+    };
+
+    assert!(matches!(
+        error,
+        McpError::ToolRegistration(crate::error::ToolRegistrationError::AliasCollision {
+            ref alias
+        }) if alias == &old_aliases[0].alias
+    ));
+    assert!(Arc::ptr_eq(
+        manager.runtimes.get("stable").unwrap().value(),
+        &old_runtime
+    ));
+    assert!(!manager.runtimes.contains_key("candidate"));
+    assert_eq!(manager.index.all_aliases(), old_aliases);
+    assert!(old_runtime.client.read().await.is_connected().await);
+    assert!(candidate_runtime.shutdown.load(Ordering::SeqCst));
+    assert!(!candidate_runtime.client.read().await.is_connected().await);
+    assert_eq!(
+        candidate_runtime.info.read().await.status,
+        ServerStatus::Stopped
+    );
+}
+
+#[tokio::test]
 async fn transactional_reconcile_bootstrap_failure_keeps_old_runtime_and_tool_index() {
     let manager = McpServerManager::new();
     let transport = NotifyingMockTransport::new(&[], &[]);
@@ -564,7 +645,8 @@ async fn transactional_reconcile_bootstrap_failure_keeps_old_runtime_and_tool_in
     };
     manager
         .index
-        .register_server_tools("stable", &[old_tool], &[], &[]);
+        .register_server_tools("stable", &[old_tool], &[], &[])
+        .unwrap();
     let alias = manager.index.generate_alias("stable", "still_available");
 
     let mut replacement = create_test_server_config("stable");
@@ -708,7 +790,8 @@ async fn committed_reconcile_publishes_all_removals_before_blocked_cleanup() {
     for id in ["first", "second"] {
         manager
             .index
-            .register_server_tools(id, &[marker_tool("old")], &[], &[]);
+            .register_server_tools(id, &[marker_tool("old")], &[], &[])
+            .unwrap();
     }
 
     let durable = Arc::new(AtomicBool::new(false));
@@ -744,6 +827,52 @@ async fn committed_reconcile_publishes_all_removals_before_blocked_cleanup() {
 }
 
 #[tokio::test]
+async fn manager_stop_preserves_colliding_survivor_and_historical_legacy_ambiguity() {
+    let manager = McpServerManager::new();
+    let removed_runtime = insert_mock_runtime(&manager, "a::b", connected_mock_client().await);
+    let survivor_runtime = insert_mock_runtime(&manager, "a__b", connected_mock_client().await);
+    let remote_tool = marker_tool("c");
+    let removed_alias = manager
+        .index
+        .register_server_tools("a::b", std::slice::from_ref(&remote_tool), &[], &[])
+        .unwrap()
+        .pop()
+        .unwrap();
+    let survivor_alias = manager
+        .index
+        .register_server_tools("a__b", std::slice::from_ref(&remote_tool), &[], &[])
+        .unwrap()
+        .pop()
+        .unwrap();
+    let legacy = "mcp__a__b__c";
+    assert!(manager.index.lookup(legacy).is_none());
+
+    manager.stop_server("a::b").await.unwrap();
+
+    assert!(!manager.runtimes.contains_key("a::b"));
+    assert!(Arc::ptr_eq(
+        manager.runtimes.get("a__b").unwrap().value(),
+        &survivor_runtime
+    ));
+    assert!(removed_runtime.shutdown.load(Ordering::SeqCst));
+    assert!(manager.index.lookup(&removed_alias.alias).is_none());
+    assert_eq!(
+        manager
+            .index
+            .lookup(&survivor_alias.alias)
+            .expect("survivor canonical alias remains")
+            .server_id,
+        "a__b"
+    );
+    assert!(
+        manager.index.lookup(legacy).is_none(),
+        "a historically ambiguous legacy alias must not retarget to the survivor"
+    );
+
+    manager.stop_server("a__b").await.unwrap();
+}
+
+#[tokio::test]
 async fn detached_refresh_cannot_overwrite_replacement_tool_index() {
     let manager = McpServerManager::new();
     let old = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
@@ -751,13 +880,13 @@ async fn detached_refresh_cannot_overwrite_replacement_tool_index() {
     manager.index.remove_server_tools("stable");
     manager
         .index
-        .register_server_tools("stable", &[marker_tool("replacement")], &[], &[]);
+        .register_server_tools("stable", &[marker_tool("replacement")], &[], &[])
+        .unwrap();
 
-    assert!(
-        !manager
-            .publish_refreshed_tools_if_current("stable", &old, vec![marker_tool("stale_refresh")])
-            .await
-    );
+    assert!(!manager
+        .publish_refreshed_tools_if_current("stable", &old, vec![marker_tool("stale_refresh")])
+        .await
+        .unwrap());
     assert!(manager
         .index
         .contains(&manager.index.generate_alias("stable", "replacement")));
@@ -778,20 +907,20 @@ async fn detached_reconnect_cannot_overwrite_replacement_tool_index() {
     manager.index.remove_server_tools("stable");
     manager
         .index
-        .register_server_tools("stable", &[marker_tool("replacement")], &[], &[]);
+        .register_server_tools("stable", &[marker_tool("replacement")], &[], &[])
+        .unwrap();
 
-    assert!(
-        !manager
-            .publish_reconnected_runtime_if_current(
-                "stable",
-                &old,
-                connected_mock_client().await,
-                vec![marker_tool("stale_reconnect")],
-                Some("stale instructions".to_string()),
-                None,
-            )
-            .await
-    );
+    assert!(!manager
+        .publish_reconnected_runtime_if_current(
+            "stable",
+            &old,
+            connected_mock_client().await,
+            vec![marker_tool("stale_reconnect")],
+            Some("stale instructions".to_string()),
+            None,
+        )
+        .await
+        .unwrap());
     assert!(manager
         .index
         .contains(&manager.index.generate_alias("stable", "replacement")));
@@ -802,6 +931,203 @@ async fn detached_reconnect_cannot_overwrite_replacement_tool_index() {
         manager.runtimes.get("stable").unwrap().value(),
         &replacement
     ));
+}
+
+#[tokio::test]
+async fn refresh_registration_failure_preserves_old_catalog_and_runtime_tools() {
+    let manager = McpServerManager::new();
+    let runtime = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
+    let old_tool = marker_tool("old_tool");
+    *runtime.tools.write().await = vec![old_tool.clone()];
+    runtime.info.write().await.tool_count = 1;
+    let old_aliases = manager
+        .index
+        .register_server_tools("stable", std::slice::from_ref(&old_tool), &[], &[])
+        .unwrap();
+
+    let error = manager
+        .publish_refreshed_tools_if_current(
+            "stable",
+            &runtime,
+            vec![marker_tool("duplicate"), marker_tool("duplicate")],
+        )
+        .await
+        .expect_err("duplicate refresh catalog must fail registration");
+
+    assert!(matches!(
+        error,
+        McpError::ToolRegistration(crate::error::ToolRegistrationError::DuplicateToolIdentity {
+            first_position: 0,
+            duplicate_position: 1,
+        })
+    ));
+    assert_eq!(
+        runtime
+            .tools
+            .read()
+            .await
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>(),
+        ["old_tool"]
+    );
+    assert_eq!(runtime.info.read().await.tool_count, 1);
+    assert_eq!(manager.index.all_aliases(), old_aliases);
+    assert!(manager.index.lookup(&old_aliases[0].alias).is_some());
+    assert!(!manager
+        .index
+        .contains_exact_alias(&manager.index.generate_alias("stable", "duplicate")));
+}
+
+#[tokio::test]
+async fn reconnect_registration_failure_preserves_old_generation_and_catalog() {
+    let manager = McpServerManager::new();
+    let runtime = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
+    let old_tool = marker_tool("old_tool");
+    *runtime.tools.write().await = vec![old_tool.clone()];
+    {
+        let mut info = runtime.info.write().await;
+        info.tool_count = 1;
+        info.instructions = Some("old instructions".to_string());
+    }
+    let old_aliases = manager
+        .index
+        .register_server_tools("stable", std::slice::from_ref(&old_tool), &[], &[])
+        .unwrap();
+
+    let error = manager
+        .publish_reconnected_runtime_if_current(
+            "stable",
+            &runtime,
+            connected_mock_client().await,
+            vec![marker_tool("duplicate"), marker_tool("duplicate")],
+            Some("replacement instructions".to_string()),
+            None,
+        )
+        .await
+        .expect_err("duplicate reconnect catalog must fail registration");
+
+    assert!(matches!(
+        error,
+        McpError::ToolRegistration(crate::error::ToolRegistrationError::DuplicateToolIdentity {
+            first_position: 0,
+            duplicate_position: 1,
+        })
+    ));
+    assert!(runtime.client.read().await.is_connected().await);
+    assert_eq!(
+        runtime
+            .tools
+            .read()
+            .await
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>(),
+        ["old_tool"]
+    );
+    let info = runtime.info.read().await;
+    assert_eq!(info.tool_count, 1);
+    assert_eq!(info.instructions.as_deref(), Some("old instructions"));
+    drop(info);
+    assert_eq!(manager.index.all_aliases(), old_aliases);
+    assert!(manager.index.lookup(&old_aliases[0].alias).is_some());
+    assert!(!manager
+        .index
+        .contains_exact_alias(&manager.index.generate_alias("stable", "duplicate")));
+}
+
+#[tokio::test]
+async fn reconnect_bootstrap_failure_keeps_old_client_and_catalog_published() {
+    let manager = McpServerManager::new();
+    let mut config = create_test_server_config("stable");
+    config.transport = TransportConfig::Stdio(StdioConfig {
+        command: "definitely-not-a-real-mcp-command-990".to_string(),
+        args: Vec::new(),
+        cwd: None,
+        env: std::collections::HashMap::new(),
+        env_encrypted: std::collections::HashMap::new(),
+        env_credential_refs: std::collections::HashMap::new(),
+        startup_timeout_ms: 100,
+    });
+    let runtime = mock_runtime_with_config(config, connected_mock_client().await);
+    manager
+        .runtimes
+        .insert("stable".to_string(), runtime.clone());
+    let old_tool = marker_tool("old_tool");
+    *runtime.tools.write().await = vec![old_tool.clone()];
+    runtime.info.write().await.tool_count = 1;
+    let old_aliases = manager
+        .index
+        .register_server_tools("stable", std::slice::from_ref(&old_tool), &[], &[])
+        .unwrap();
+
+    manager
+        .reconnect_server(runtime.clone())
+        .await
+        .expect_err("candidate transport bootstrap must fail");
+
+    assert!(runtime.client.read().await.is_connected().await);
+    assert_eq!(
+        runtime
+            .tools
+            .read()
+            .await
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>(),
+        ["old_tool"]
+    );
+    assert_eq!(manager.index.all_aliases(), old_aliases);
+    assert!(manager.index.lookup(&old_aliases[0].alias).is_some());
+    assert!(Arc::ptr_eq(
+        manager.runtimes.get("stable").unwrap().value(),
+        &runtime
+    ));
+}
+
+#[tokio::test]
+async fn canonical_identity_is_exact_from_listing_through_execution() {
+    let manager = Arc::new(McpServerManager::new());
+    let transport = NotifyingMockTransport::new(&[], &[]);
+    let mut client = McpProtocolClient::new(Box::new(transport));
+    client.connect().await.expect("connect execution fixture");
+    let runtime = insert_mock_runtime(&manager, "a::b", client);
+    let remote_tool = marker_tool("c");
+    *runtime.tools.write().await = vec![remote_tool.clone()];
+    runtime.info.write().await.tool_count = 1;
+    let alias = manager
+        .index
+        .register_server_tools("a::b", std::slice::from_ref(&remote_tool), &[], &[])
+        .unwrap()
+        .pop()
+        .unwrap();
+    let executor = McpToolExecutor::new(manager.clone(), manager.tool_index());
+
+    let listed = executor.list_tools();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].function.name, alias.alias);
+    let identity = ClassifiedToolIdentity::from_schema_name(&listed[0].function.name)
+        .expect("listed canonical MCP alias is a loadable identity");
+    assert_eq!(identity.execution_name(), alias.alias);
+    assert_eq!(manager.index.lookup(&alias.alias).unwrap(), alias);
+    assert!(manager.index.contains_exact_alias(&alias.alias));
+
+    let result = executor
+        .execute(&ToolCall {
+            id: "call-exact-mcp-alias".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: alias.alias.clone(),
+                arguments: "{}".to_string(),
+            },
+        })
+        .await
+        .expect("canonical provider identity executes");
+    assert!(result.success);
+    assert_eq!(
+        result.result, remote_tool.name,
+        "transport must receive the original MCP tool name"
+    );
 }
 
 #[tokio::test]

--- a/crates/infra/bamboo-mcp/src/tool_index.rs
+++ b/crates/infra/bamboo-mcp/src/tool_index.rs
@@ -1,129 +1,501 @@
+use crate::error::ToolRegistrationError;
 use crate::types::{McpTool, ToolAlias};
-use dashmap::DashMap;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-/// Maps tool aliases to their original server/tool names
+/// OpenAI and Anthropic function names are bounded to 64 provider-safe bytes.
+pub const MAX_MCP_TOOL_ALIAS_BYTES: usize = 64;
+
+/// Maximum number of process-lifetime alias-to-owner relationships retained to
+/// prevent a removed identity from later rebinding. A normal tool consumes one
+/// canonical and one legacy relationship, so this bounds hostile catalog churn
+/// while leaving ample room for ordinary long-running managers.
+pub const MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS: usize = 65_536;
+
+// The suffix after `mcp__` deliberately contains no second `__`. Every legacy
+// alias has a `server__tool` separator, so the canonical and legacy namespaces
+// are syntactically disjoint even when remote labels are attacker-controlled.
+const CANONICAL_ALIAS_PREFIX: &str = "mcp__v1_";
+const ALIAS_TAG_BASE32_CHARS: usize = 26;
+const SERVER_ALIAS_HASH_DOMAIN: &[u8] = b"bamboo-mcp-server-alias-v1\0";
+const OWNER_ALIAS_HASH_DOMAIN: &[u8] = b"bamboo-mcp-tool-owner-alias-v1\0";
+const CANONICAL_LEDGER_ALIAS_HASH_DOMAIN: &[u8] = b"bamboo-mcp-canonical-ledger-alias-v1\0";
+const LEGACY_LEDGER_ALIAS_HASH_DOMAIN: &[u8] = b"bamboo-mcp-legacy-ledger-alias-v1\0";
+const LEDGER_OWNER_HASH_DOMAIN: &[u8] = b"bamboo-mcp-ledger-owner-v1\0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct CanonicalAliasFingerprint([u8; 32]);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct LegacyAliasFingerprint([u8; 32]);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct OwnerFingerprint([u8; 32]);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ToolOwner {
+    server_id: String,
+    original_name: String,
+}
+
+impl ToolOwner {
+    fn as_alias(&self, alias: String) -> ToolAlias {
+        ToolAlias {
+            alias,
+            server_id: self.server_id.clone(),
+            original_name: self.original_name.clone(),
+        }
+    }
+
+    fn fingerprint(&self) -> OwnerFingerprint {
+        OwnerFingerprint(fingerprint(
+            LEDGER_OWNER_HASH_DOMAIN,
+            &[self.server_id.as_bytes(), self.original_name.as_bytes()],
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CatalogEntry {
+    canonical_alias: String,
+    legacy_alias: Option<String>,
+    owner: ToolOwner,
+}
+
+/// Fully validated, mutation-free publication plan for one server catalog.
+#[derive(Debug, Clone)]
+pub(crate) struct ServerToolCatalog {
+    server_id: String,
+    entries: Vec<CatalogEntry>,
+}
+
+impl ServerToolCatalog {
+    pub(crate) fn aliases(&self) -> Vec<ToolAlias> {
+        self.entries
+            .iter()
+            .map(|entry| entry.owner.as_alias(entry.canonical_alias.clone()))
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replace_first_canonical_alias_for_test(&mut self, alias: String) {
+        self.entries
+            .first_mut()
+            .expect("test catalog must contain one tool")
+            .canonical_alias = alias;
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct IndexState {
+    /// Monotonic publication generation. Every committed replacement advances
+    /// this value exactly once while holding the state write lock.
+    revision: u64,
+    /// Canonical provider-visible alias -> exact owner.
+    aliases: BTreeMap<String, ToolOwner>,
+    /// Process-lifetime ownership ledger. Only fixed-size, domain-separated
+    /// fingerprints survive removal, so attacker-controlled labels are neither
+    /// retained nor allowed to grow one allocation without bound.
+    canonical_owners: BTreeMap<CanonicalAliasFingerprint, OwnerFingerprint>,
+    /// Legacy sanitized alias -> every candidate owner. Lookup is permitted
+    /// only when both the live and process-lifetime owner sets contain exactly
+    /// the same one owner.
+    legacy_candidates: BTreeMap<String, BTreeSet<ToolOwner>>,
+    /// Process-lifetime legacy ownership ledger. Once a lossy historical alias
+    /// has represented multiple owner fingerprints, removal cannot make an old
+    /// transcript safe to retarget to whichever owner happens to remain.
+    legacy_owners: BTreeMap<LegacyAliasFingerprint, BTreeSet<OwnerFingerprint>>,
+    /// Stored publication authority used for replacement and owner-aware
+    /// removal. Removal never regenerates an alias from caller input.
+    server_catalogs: BTreeMap<String, ServerToolCatalog>,
+}
+
+impl IndexState {
+    fn apply_catalog_update(
+        &mut self,
+        replacements: &[ServerToolCatalog],
+        removals: &[String],
+        ledger_relationship_limit: usize,
+    ) -> Result<(), ToolRegistrationError> {
+        let mut replacement_ids = BTreeSet::new();
+        for replacement in replacements {
+            if !replacement_ids.insert(replacement.server_id.clone()) {
+                return Err(ToolRegistrationError::DuplicateServerPlan);
+            }
+        }
+        let removal_ids: BTreeSet<&str> = removals.iter().map(String::as_str).collect();
+        if replacement_ids
+            .iter()
+            .any(|server_id| removal_ids.contains(server_id.as_str()))
+        {
+            return Err(ToolRegistrationError::ConflictingServerChange);
+        }
+
+        for server_id in removals {
+            self.server_catalogs.remove(server_id);
+        }
+        for replacement in replacements {
+            self.server_catalogs
+                .insert(replacement.server_id.clone(), replacement.clone());
+        }
+        self.rebuild_alias_maps(ledger_relationship_limit)
+    }
+
+    fn rebuild_alias_maps(
+        &mut self,
+        ledger_relationship_limit: usize,
+    ) -> Result<(), ToolRegistrationError> {
+        let mut aliases = BTreeMap::new();
+        let mut canonical_owners = self.canonical_owners.clone();
+        let mut legacy_candidates: BTreeMap<String, BTreeSet<ToolOwner>> = BTreeMap::new();
+        let mut legacy_owners = self.legacy_owners.clone();
+        let mut ledger_relationships = self.ledger_relationship_count();
+        if ledger_relationships > ledger_relationship_limit {
+            return Err(ToolRegistrationError::OwnershipLedgerCapacityExceeded {
+                limit: ledger_relationship_limit,
+                attempted: ledger_relationships,
+            });
+        }
+
+        for catalog in self.server_catalogs.values() {
+            for entry in &catalog.entries {
+                let canonical_fingerprint = canonical_alias_fingerprint(&entry.canonical_alias);
+                let owner_fingerprint = entry.owner.fingerprint();
+                if let Some(existing) = canonical_owners.get(&canonical_fingerprint) {
+                    if existing != &owner_fingerprint {
+                        return Err(ToolRegistrationError::AliasCollision {
+                            alias: entry.canonical_alias.clone(),
+                        });
+                    }
+                } else {
+                    reserve_ledger_relationship(
+                        &mut ledger_relationships,
+                        ledger_relationship_limit,
+                    )?;
+                    canonical_owners.insert(canonical_fingerprint, owner_fingerprint);
+                }
+                aliases.insert(entry.canonical_alias.clone(), entry.owner.clone());
+
+                if let Some(legacy_alias) = &entry.legacy_alias {
+                    legacy_candidates
+                        .entry(legacy_alias.clone())
+                        .or_default()
+                        .insert(entry.owner.clone());
+                    let historical_owners = legacy_owners
+                        .entry(legacy_alias_fingerprint(legacy_alias))
+                        .or_default();
+                    if !historical_owners.contains(&owner_fingerprint) {
+                        reserve_ledger_relationship(
+                            &mut ledger_relationships,
+                            ledger_relationship_limit,
+                        )?;
+                        historical_owners.insert(owner_fingerprint);
+                    }
+                }
+            }
+        }
+
+        self.aliases = aliases;
+        self.canonical_owners = canonical_owners;
+        self.legacy_candidates = legacy_candidates;
+        self.legacy_owners = legacy_owners;
+        Ok(())
+    }
+
+    fn ledger_relationship_count(&self) -> usize {
+        self.legacy_owners
+            .values()
+            .fold(self.canonical_owners.len(), |total, owners| {
+                total.saturating_add(owners.len())
+            })
+    }
+}
+
+/// A whole-index update that has already validated every replacement/removal.
+/// The manager holds its reconciliation lock between preflight and commit.
+#[derive(Debug)]
+pub(crate) struct ToolIndexTransaction {
+    base_revision: u64,
+    next: IndexState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+enum ToolIndexCommitError {
+    #[error(
+        "stale MCP tool-index transaction: base revision {base_revision}, current revision {current_revision}"
+    )]
+    StaleTransaction {
+        base_revision: u64,
+        current_revision: u64,
+    },
+
+    #[error("MCP tool-index publication revision exhausted at {current_revision}")]
+    RevisionExhausted { current_revision: u64 },
+}
+
+/// Atomic owner index for MCP tool identities.
+///
+/// All canonical aliases, compatibility aliases, and per-server ownership are
+/// published behind one lock so readers never observe a partially installed
+/// catalog.
 pub struct ToolIndex {
-    /// alias -> (server_id, original_name)
-    aliases: DashMap<String, (String, String)>,
-    /// server_id -> list of tool names
-    server_tools: DashMap<String, Vec<String>>,
+    state: RwLock<IndexState>,
+    ledger_relationship_limit: usize,
 }
 
 impl ToolIndex {
     pub fn new() -> Self {
         Self {
-            aliases: DashMap::new(),
-            server_tools: DashMap::new(),
+            state: RwLock::new(IndexState::default()),
+            ledger_relationship_limit: MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS,
         }
     }
 
-    /// Generate a unique alias for a tool from a specific server
-    pub fn generate_alias(&self, server_id: &str, tool_name: &str) -> String {
-        // Use format: mcp__{server_id}__{tool_name}
-        // Sanitize server_id and tool_name (replace :: with __)
-        let sanitized_server = server_id.replace("::", "__").replace(':', "_");
-        let sanitized_tool = tool_name.replace("::", "__").replace(':', "_");
-        format!("mcp__{}__{}", sanitized_server, sanitized_tool)
+    #[cfg(test)]
+    fn with_ledger_relationship_limit_for_test(ledger_relationship_limit: usize) -> Self {
+        Self {
+            state: RwLock::new(IndexState::default()),
+            ledger_relationship_limit,
+        }
     }
 
-    /// Register tools from a server
-    pub fn register_server_tools(
+    fn read_state(&self) -> RwLockReadGuard<'_, IndexState> {
+        self.state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn write_state(&self) -> RwLockWriteGuard<'_, IndexState> {
+        self.state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Generate the stable provider-visible identity for one exact owner tuple.
+    ///
+    /// The server and complete owner tuple use independent, domain-separated,
+    /// length-framed SHA-256 hashes. Each is truncated to 26 lowercase base32
+    /// characters (130 bits), keeping the complete alias within 64 bytes while
+    /// allowing secret-safe metrics to group tools by a stable server pseudonym.
+    /// The process-lifetime owner ledger rejects any realized truncation
+    /// collision instead of silently rebinding the alias.
+    pub fn generate_alias(&self, server_id: &str, tool_name: &str) -> String {
+        let server_tag = hash_tag(SERVER_ALIAS_HASH_DOMAIN, &[server_id.as_bytes()]);
+        let owner_tag = hash_tag(
+            OWNER_ALIAS_HASH_DOMAIN,
+            &[server_id.as_bytes(), tool_name.as_bytes()],
+        );
+        let alias = format!("{CANONICAL_ALIAS_PREFIX}{server_tag}_{owner_tag}");
+        debug_assert!(is_provider_safe_alias(&alias));
+        debug_assert!(alias.len() <= MAX_MCP_TOOL_ALIAS_BYTES);
+        alias
+    }
+
+    /// Validate the complete allowed/non-denied catalog without mutating live
+    /// publication. Duplicate original names are rejected explicitly.
+    pub(crate) fn plan_server_tools(
         &self,
         server_id: &str,
         tools: &[McpTool],
         allowed_tools: &[String],
         denied_tools: &[String],
-    ) -> Vec<ToolAlias> {
-        let mut aliases = Vec::new();
-        let mut tool_names = Vec::new();
+    ) -> Result<ServerToolCatalog, ToolRegistrationError> {
+        if server_id.is_empty() {
+            return Err(ToolRegistrationError::EmptyServerIdentity);
+        }
 
-        for tool in tools {
-            // Check if tool is allowed
+        let mut first_positions = BTreeMap::<String, usize>::new();
+        let mut entries = Vec::new();
+        for (position, tool) in tools.iter().enumerate() {
             if !allowed_tools.is_empty() && !allowed_tools.contains(&tool.name) {
                 continue;
             }
-
-            // Check if tool is denied
             if denied_tools.contains(&tool.name) {
                 continue;
             }
+            if tool.name.is_empty() {
+                return Err(ToolRegistrationError::EmptyToolIdentity { position });
+            }
+            if let Some(first_position) = first_positions.insert(tool.name.clone(), position) {
+                return Err(ToolRegistrationError::DuplicateToolIdentity {
+                    first_position,
+                    duplicate_position: position,
+                });
+            }
 
-            let alias = self.generate_alias(server_id, &tool.name);
-            self.aliases
-                .insert(alias.clone(), (server_id.to_string(), tool.name.clone()));
-            tool_names.push(tool.name.clone());
-
-            aliases.push(ToolAlias {
-                alias: alias.clone(),
-                server_id: server_id.to_string(),
-                original_name: tool.name.clone(),
+            let canonical_alias = self.generate_alias(server_id, &tool.name);
+            let legacy_alias =
+                legacy_alias(server_id, &tool.name).filter(|legacy| legacy != &canonical_alias);
+            entries.push(CatalogEntry {
+                canonical_alias,
+                legacy_alias,
+                owner: ToolOwner {
+                    server_id: server_id.to_string(),
+                    original_name: tool.name.clone(),
+                },
             });
         }
 
-        self.server_tools.insert(server_id.to_string(), tool_names);
-        aliases
-    }
-
-    /// Remove all tools from a server
-    pub fn remove_server_tools(&self, server_id: &str) {
-        if let Some((_, tools)) = self.server_tools.remove(server_id) {
-            for tool_name in tools {
-                let alias = self.generate_alias(server_id, &tool_name);
-                self.aliases.remove(&alias);
-            }
-        }
-    }
-
-    /// Lookup a tool by its alias
-    pub fn lookup(&self, alias: &str) -> Option<ToolAlias> {
-        self.aliases.get(alias).map(|entry| {
-            let (server_id, original_name) = entry.value();
-            ToolAlias {
-                alias: alias.to_string(),
-                server_id: server_id.clone(),
-                original_name: original_name.clone(),
-            }
+        // Event/schema/listing order is stable even when an MCP server returns
+        // its otherwise identical catalog in a different order.
+        entries.sort_by(|left, right| left.canonical_alias.cmp(&right.canonical_alias));
+        Ok(ServerToolCatalog {
+            server_id: server_id.to_string(),
+            entries,
         })
     }
 
-    /// Get all registered aliases
+    /// Preflight a complete set of catalog changes against one cloned snapshot.
+    /// No live map is touched if any plan is invalid or collides.
+    pub(crate) fn preflight_catalog_update(
+        &self,
+        replacements: &[ServerToolCatalog],
+        removals: &[String],
+    ) -> Result<ToolIndexTransaction, ToolRegistrationError> {
+        let state = self.read_state();
+        let base_revision = state.revision;
+        let mut next = state.clone();
+        drop(state);
+        next.apply_catalog_update(replacements, removals, self.ledger_relationship_limit)?;
+        Ok(ToolIndexTransaction {
+            base_revision,
+            next,
+        })
+    }
+
+    /// Commit a transaction preflighted while the manager reconciliation lock is
+    /// held. A revision mismatch is an internal writer-invariant violation, not
+    /// a recoverable post-durable CAS outcome: production has exactly one writer
+    /// behind that lock. Fail-stop before swapping in every build so a stale
+    /// snapshot can never erase a newer catalog or ownership history.
+    pub(crate) fn commit_catalog_update(&self, transaction: ToolIndexTransaction) {
+        self.try_commit_catalog_update(transaction)
+            .unwrap_or_else(|error| panic!("MCP tool-index writer invariant violated: {error}"));
+    }
+
+    fn try_commit_catalog_update(
+        &self,
+        mut transaction: ToolIndexTransaction,
+    ) -> Result<(), ToolIndexCommitError> {
+        let mut state = self.write_state();
+        let current_revision = state.revision;
+        if transaction.base_revision != current_revision {
+            return Err(ToolIndexCommitError::StaleTransaction {
+                base_revision: transaction.base_revision,
+                current_revision,
+            });
+        }
+        let next_revision = current_revision
+            .checked_add(1)
+            .ok_or(ToolIndexCommitError::RevisionExhausted { current_revision })?;
+        transaction.next.revision = next_revision;
+        *state = transaction.next;
+        Ok(())
+    }
+
+    /// Test-only direct registration seam. Production writes are owned by
+    /// `McpServerManager` and serialized by its reconciliation lock.
+    #[cfg(test)]
+    pub(crate) fn register_server_tools(
+        &self,
+        server_id: &str,
+        tools: &[McpTool],
+        allowed_tools: &[String],
+        denied_tools: &[String],
+    ) -> Result<Vec<ToolAlias>, ToolRegistrationError> {
+        let catalog = self.plan_server_tools(server_id, tools, allowed_tools, denied_tools)?;
+        let aliases = catalog.aliases();
+        let transaction = self.preflight_catalog_update(std::slice::from_ref(&catalog), &[])?;
+        self.try_commit_catalog_update(transaction)
+            .expect("test-only MCP registration must commit its current snapshot");
+        Ok(aliases)
+    }
+
+    /// Test-only direct removal seam. Production removal is one manager-owned
+    /// preflight/commit transaction under the reconciliation lock.
+    #[cfg(test)]
+    pub(crate) fn remove_server_tools(&self, server_id: &str) {
+        let transaction = self
+            .preflight_catalog_update(&[], &[server_id.to_string()])
+            .expect("removing one stored MCP catalog cannot introduce a collision");
+        self.try_commit_catalog_update(transaction)
+            .expect("test-only MCP removal must commit its current snapshot");
+    }
+
+    /// Lookup either an exact canonical alias or an unambiguous legacy alias.
+    /// Canonical identities always win. Ambiguous legacy identities fail closed.
+    pub fn lookup(&self, alias: &str) -> Option<ToolAlias> {
+        let state = self.read_state();
+        if let Some(owner) = state.aliases.get(alias) {
+            return Some(owner.as_alias(alias.to_string()));
+        }
+        let active_owners = state.legacy_candidates.get(alias)?;
+        if active_owners.len() != 1 {
+            return None;
+        }
+        let active_owner = active_owners.iter().next()?;
+        let historical_owners = state.legacy_owners.get(&legacy_alias_fingerprint(alias))?;
+        if historical_owners.len() != 1 || !historical_owners.contains(&active_owner.fingerprint())
+        {
+            return None;
+        }
+        Some(active_owner.as_alias(alias.to_string()))
+    }
+
+    /// Get every canonical provider-visible alias in stable lexical order.
+    /// Legacy compatibility names are deliberately not advertised.
     pub fn all_aliases(&self) -> Vec<ToolAlias> {
-        self.aliases
+        self.read_state()
+            .aliases
             .iter()
-            .map(|entry| {
-                let (server_id, original_name) = entry.value();
-                ToolAlias {
-                    alias: entry.key().clone(),
-                    server_id: server_id.clone(),
-                    original_name: original_name.clone(),
-                }
-            })
+            .map(|(alias, owner)| owner.as_alias(alias.clone()))
             .collect()
     }
 
-    /// Get tools for a specific server
+    /// Get exact original tool names for one server in canonical alias order.
     pub fn get_server_tools(&self, server_id: &str) -> Option<Vec<String>> {
-        self.server_tools.get(server_id).map(|entry| entry.clone())
+        self.read_state()
+            .server_catalogs
+            .get(server_id)
+            .map(|catalog| {
+                catalog
+                    .entries
+                    .iter()
+                    .map(|entry| entry.owner.original_name.clone())
+                    .collect()
+            })
     }
 
-    /// Clear all registered tools
-    pub fn clear(&self) {
-        self.aliases.clear();
-        self.server_tools.clear();
+    /// Test-only clear seam. Process-lifetime owner ledgers remain so removed
+    /// aliases cannot later bind or retarget to another tuple.
+    #[cfg(test)]
+    pub(crate) fn clear(&self) {
+        let removals = self
+            .read_state()
+            .server_catalogs
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let transaction = self
+            .preflight_catalog_update(&[], &removals)
+            .expect("clearing stored MCP catalogs cannot introduce a collision");
+        self.try_commit_catalog_update(transaction)
+            .expect("test-only MCP clear must commit its current snapshot");
     }
 
-    /// Check if an alias exists
-    pub fn contains(&self, alias: &str) -> bool {
-        self.aliases.contains_key(alias)
-    }
-
-    /// Check ownership of a complete, exact alias identity.
+    /// Check exact canonical ownership without accepting compatibility names.
     ///
-    /// Keep this separate from compatibility lookup/containment APIs: executor
-    /// routing must never treat a canonicalized or unambiguous legacy reference
-    /// as an exact owner.
+    /// Execution surfaces that promise exact tool membership must use this
+    /// method rather than the legacy-aware [`Self::contains`] seam.
     pub fn contains_exact_alias(&self, alias: &str) -> bool {
-        self.aliases.contains_key(alias)
+        self.read_state().aliases.contains_key(alias)
+    }
+
+    /// Check whether a canonical or unambiguous compatibility alias resolves.
+    /// This is intentionally broader than exact provider-visible membership.
+    pub fn contains(&self, alias: &str) -> bool {
+        self.lookup(alias).is_some()
     }
 }
 
@@ -133,23 +505,173 @@ impl Default for ToolIndex {
     }
 }
 
+fn update_len_prefixed(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}
+
+fn fingerprint(domain: &[u8], components: &[&[u8]]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    for component in components {
+        update_len_prefixed(&mut hasher, component);
+    }
+    hasher.finalize().into()
+}
+
+fn hash_tag(domain: &[u8], components: &[&[u8]]) -> String {
+    let digest = fingerprint(domain, components);
+    let encoded = base32_lower_no_pad(&digest);
+    encoded[..ALIAS_TAG_BASE32_CHARS].to_string()
+}
+
+fn canonical_alias_fingerprint(alias: &str) -> CanonicalAliasFingerprint {
+    CanonicalAliasFingerprint(fingerprint(
+        CANONICAL_LEDGER_ALIAS_HASH_DOMAIN,
+        &[alias.as_bytes()],
+    ))
+}
+
+fn legacy_alias_fingerprint(alias: &str) -> LegacyAliasFingerprint {
+    LegacyAliasFingerprint(fingerprint(
+        LEGACY_LEDGER_ALIAS_HASH_DOMAIN,
+        &[alias.as_bytes()],
+    ))
+}
+
+fn reserve_ledger_relationship(
+    current: &mut usize,
+    limit: usize,
+) -> Result<(), ToolRegistrationError> {
+    let attempted = current.saturating_add(1);
+    if attempted > limit {
+        return Err(ToolRegistrationError::OwnershipLedgerCapacityExceeded { limit, attempted });
+    }
+    *current = attempted;
+    Ok(())
+}
+
+fn base32_lower_no_pad(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
+    let mut output = String::with_capacity(bytes.len().div_ceil(5) * 8);
+    let mut accumulator = 0u16;
+    let mut bits = 0u8;
+    for byte in bytes {
+        accumulator = (accumulator << 8) | u16::from(*byte);
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            let index = ((accumulator >> bits) & 0x1f) as usize;
+            output.push(ALPHABET[index] as char);
+        }
+        accumulator &= (1u16 << bits).wrapping_sub(1);
+    }
+    if bits > 0 {
+        let index = ((accumulator << (5 - bits)) & 0x1f) as usize;
+        output.push(ALPHABET[index] as char);
+    }
+    output
+}
+
+fn is_provider_safe_alias(alias: &str) -> bool {
+    !alias.is_empty()
+        && alias.len() <= MAX_MCP_TOOL_ALIAS_BYTES
+        && alias
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn legacy_alias(server_id: &str, tool_name: &str) -> Option<String> {
+    let sanitized_server = server_id.replace("::", "__").replace(':', "_");
+    let sanitized_tool = tool_name.replace("::", "__").replace(':', "_");
+    let alias = format!("mcp__{sanitized_server}__{sanitized_tool}");
+    (!sanitized_server.is_empty() && !sanitized_tool.is_empty()).then_some(alias)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use bamboo_domain::{canonical_tool_name, CapabilityLoadingClass, ClassifiedToolIdentity};
 
-    #[test]
-    fn test_generate_alias() {
-        let index = ToolIndex::new();
-        let alias = index.generate_alias("filesystem", "read_file");
-        assert_eq!(alias, "mcp__filesystem__read_file");
+    fn tool(name: &str) -> McpTool {
+        McpTool {
+            name: name.to_string(),
+            description: format!("{name} description"),
+            parameters: serde_json::json!({"type": "object"}),
+            output_schema: None,
+        }
     }
 
     #[test]
-    fn test_generate_alias_sanitizes() {
+    fn canonical_codec_is_stable_bounded_and_provider_safe() {
+        let server = "服务器::".repeat(100);
+        let name = "tool:name with punctuation/秘密".repeat(100);
+        let first = ToolIndex::new().generate_alias(&server, &name);
+        let second = ToolIndex::new().generate_alias(&server, &name);
+
+        assert_eq!(first, second);
+        assert!(first.starts_with(CANONICAL_ALIAS_PREFIX));
+        assert_eq!(first.len(), 61);
+        assert!(first.len() <= MAX_MCP_TOOL_ALIAS_BYTES);
+        assert!(is_provider_safe_alias(&first));
+    }
+
+    #[test]
+    fn former_sanitize_collisions_have_distinct_canonical_aliases() {
         let index = ToolIndex::new();
-        let alias = index.generate_alias("my::server", "tool::name");
-        assert_eq!(alias, "mcp__my__server__tool__name");
+        for ((left_server, left_tool), (right_server, right_tool)) in [
+            (("a::b", "c"), ("a__b", "c")),
+            (("a:b", "c"), ("a_b", "c")),
+            (("a", "b__c"), ("a__b", "c")),
+        ] {
+            assert_ne!(
+                index.generate_alias(left_server, left_tool),
+                index.generate_alias(right_server, right_tool)
+            );
+            assert_eq!(
+                legacy_alias(left_server, left_tool),
+                legacy_alias(right_server, right_tool)
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_namespace_cannot_be_constructed_by_the_legacy_codec() {
+        let index = ToolIndex::new();
+        let canonical = index.generate_alias("target", "tool");
+        let hash = canonical
+            .strip_prefix(CANONICAL_ALIAS_PREFIX)
+            .expect("canonical prefix");
+        let attacker_controlled_legacy = legacy_alias("v1", hash).unwrap();
+
+        assert_eq!(attacker_controlled_legacy, format!("mcp__v1__{hash}"));
+        assert_ne!(canonical, attacker_controlled_legacy);
+        assert!(!canonical["mcp__".len()..].contains("__"));
+    }
+
+    #[test]
+    fn canonical_codec_exposes_stable_distinct_server_and_owner_pseudonyms() {
+        fn tags(alias: &str) -> (&str, &str) {
+            alias
+                .strip_prefix(CANONICAL_ALIAS_PREFIX)
+                .and_then(|value| value.split_once('_'))
+                .expect("canonical server and owner tags")
+        }
+
+        let index = ToolIndex::new();
+        let first = index.generate_alias("server-a", "tool-one");
+        let sibling = index.generate_alias("server-a", "tool-two");
+        let other_server = index.generate_alias("server-b", "tool-one");
+        let (first_server, first_owner) = tags(&first);
+        let (sibling_server, sibling_owner) = tags(&sibling);
+        let (other_server_tag, other_owner) = tags(&other_server);
+
+        assert_eq!(first_server.len(), ALIAS_TAG_BASE32_CHARS);
+        assert_eq!(first_owner.len(), ALIAS_TAG_BASE32_CHARS);
+        assert_eq!(first_server, sibling_server);
+        assert_ne!(first_owner, sibling_owner);
+        assert_ne!(first_server, other_server_tag);
+        assert_ne!(first_owner, other_owner);
     }
 
     #[test]
@@ -166,109 +688,429 @@ mod tests {
     }
 
     #[test]
-    fn test_register_and_lookup() {
+    fn registration_filtering_and_lookup_preserve_exact_owner() {
         let index = ToolIndex::new();
-        let tools = vec![
-            McpTool {
-                name: "read_file".to_string(),
-                description: "Read a file".to_string(),
-                parameters: serde_json::json!({}),
-                output_schema: None,
-            },
-            McpTool {
-                name: "write_file".to_string(),
-                description: "Write a file".to_string(),
-                parameters: serde_json::json!({}),
-                output_schema: None,
-            },
-        ];
-
-        let aliases = index.register_server_tools("fs", &tools, &[], &[]);
-        assert_eq!(aliases.len(), 2);
-
-        let lookup = index.lookup("mcp__fs__read_file");
-        assert!(lookup.is_some());
-        let lookup = lookup.unwrap();
+        let aliases = index
+            .register_server_tools(
+                "fs",
+                &[tool("read_file"), tool("delete_file")],
+                &["read_file".to_string()],
+                &["delete_file".to_string()],
+            )
+            .unwrap();
+        assert_eq!(aliases.len(), 1);
+        let alias = &aliases[0].alias;
+        let lookup = index.lookup(alias).unwrap();
+        assert_eq!(lookup.alias, *alias);
         assert_eq!(lookup.server_id, "fs");
         assert_eq!(lookup.original_name, "read_file");
+        assert_eq!(index.get_server_tools("fs").unwrap(), ["read_file"]);
     }
 
     #[test]
-    fn test_allowed_tools_filter() {
+    fn duplicate_catalog_fails_before_replacing_prior_publication() {
         let index = ToolIndex::new();
-        let tools = vec![
-            McpTool {
-                name: "read_file".to_string(),
-                description: "Read".to_string(),
-                parameters: serde_json::json!({}),
-                output_schema: None,
-            },
-            McpTool {
-                name: "delete_file".to_string(),
-                description: "Delete".to_string(),
-                parameters: serde_json::json!({}),
-                output_schema: None,
-            },
-        ];
-
-        let aliases = index.register_server_tools("fs", &tools, &["read_file".to_string()], &[]);
-        assert_eq!(aliases.len(), 1);
-        assert_eq!(aliases[0].original_name, "read_file");
+        let old = index
+            .register_server_tools("fs", &[tool("old")], &[], &[])
+            .unwrap();
+        let error = index
+            .register_server_tools(
+                "fs",
+                &[tool("new"), tool("duplicate"), tool("duplicate")],
+                &[],
+                &[],
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            ToolRegistrationError::DuplicateToolIdentity {
+                first_position: 1,
+                duplicate_position: 2
+            }
+        );
+        assert_eq!(index.all_aliases(), old);
+        assert!(index.lookup(&old[0].alias).is_some());
+        assert!(index.lookup(&index.generate_alias("fs", "new")).is_none());
     }
 
     #[test]
-    fn test_denied_tools_filter() {
+    fn registration_diagnostics_do_not_echo_remote_identities() {
         let index = ToolIndex::new();
-        let tools = vec![
-            McpTool {
-                name: "read_file".to_string(),
-                description: "Read".to_string(),
-                parameters: serde_json::json!({}),
-                output_schema: None,
-            },
-            McpTool {
-                name: "delete_file".to_string(),
-                description: "Delete".to_string(),
-                parameters: serde_json::json!({}),
-                output_schema: None,
-            },
-        ];
+        let secret_server = "https://user:password@example.invalid/private";
+        let secret_tool = "Bearer highly-sensitive-remote-label";
+        let error = index
+            .plan_server_tools(
+                secret_server,
+                &[tool(secret_tool), tool(secret_tool)],
+                &[],
+                &[],
+            )
+            .unwrap_err();
+        let diagnostic = error.to_string();
 
-        let aliases = index.register_server_tools("fs", &tools, &[], &["delete_file".to_string()]);
-        assert_eq!(aliases.len(), 1);
-        assert_eq!(aliases[0].original_name, "read_file");
+        assert!(!diagnostic.contains(secret_server));
+        assert!(!diagnostic.contains(secret_tool));
+        assert!(diagnostic.contains("positions 0 and 1"));
     }
 
     #[test]
-    fn test_remove_server_tools() {
+    fn removed_catalog_history_retains_only_fixed_size_fingerprints() {
         let index = ToolIndex::new();
-        let tools = vec![McpTool {
-            name: "read_file".to_string(),
-            description: "Read".to_string(),
-            parameters: serde_json::json!({}),
-            output_schema: None,
-        }];
+        let secret_server = "https://user:password@example.invalid/private";
+        let secret_tool = "Bearer highly-sensitive-remote-label";
+        let legacy = legacy_alias(secret_server, secret_tool).unwrap();
+        index
+            .register_server_tools(secret_server, &[tool(secret_tool)], &[], &[])
+            .unwrap();
+        index.remove_server_tools(secret_server);
 
-        index.register_server_tools("fs", &tools, &[], &[]);
-        assert!(index.contains("mcp__fs__read_file"));
-
-        index.remove_server_tools("fs");
-        assert!(!index.contains("mcp__fs__read_file"));
+        let state = index.read_state();
+        assert!(state.aliases.is_empty());
+        assert!(state.legacy_candidates.is_empty());
+        assert!(state.server_catalogs.is_empty());
+        assert_eq!(state.ledger_relationship_count(), 2);
+        assert!(state
+            .canonical_owners
+            .keys()
+            .all(|fingerprint| std::mem::size_of_val(fingerprint) == 32));
+        assert!(state
+            .canonical_owners
+            .values()
+            .all(|fingerprint| std::mem::size_of_val(fingerprint) == 32));
+        assert!(state
+            .legacy_owners
+            .keys()
+            .all(|fingerprint| std::mem::size_of_val(fingerprint) == 32));
+        let historical_debug = format!("{:?}{:?}", state.canonical_owners, state.legacy_owners);
+        assert!(!historical_debug.contains(secret_server));
+        assert!(!historical_debug.contains(secret_tool));
+        assert!(!historical_debug.contains(&legacy));
     }
 
     #[test]
-    fn exact_alias_membership_is_case_sensitive_and_does_not_canonicalize() {
-        let index = ToolIndex::new();
-        let tools = vec![McpTool {
-            name: "read_file".to_string(),
-            description: "Read".to_string(),
-            parameters: serde_json::json!({}),
-            output_schema: None,
-        }];
-        index.register_server_tools("fs", &tools, &[], &[]);
+    fn ledger_fingerprints_are_domain_separated_and_length_framed() {
+        let owner_left = ToolOwner {
+            server_id: "a".to_string(),
+            original_name: "bc".to_string(),
+        };
+        let owner_right = ToolOwner {
+            server_id: "ab".to_string(),
+            original_name: "c".to_string(),
+        };
+        assert_ne!(owner_left.fingerprint(), owner_right.fingerprint());
 
-        assert!(index.contains_exact_alias("mcp__fs__read_file"));
-        assert!(!index.contains_exact_alias("MCP__fs__read_file"));
-        assert!(!index.contains_exact_alias("read_file"));
+        let same_input = "mcp__same__bytes";
+        assert_ne!(
+            canonical_alias_fingerprint(same_input).0,
+            legacy_alias_fingerprint(same_input).0,
+            "canonical and legacy ledgers must not share a hash domain"
+        );
+    }
+
+    #[test]
+    fn ledger_capacity_failure_rolls_back_and_same_owner_does_not_consume_capacity() {
+        // One owner normally consumes one canonical and one legacy relationship.
+        // The limit of three lets the colliding candidate reserve its canonical
+        // relationship in the cloned snapshot, then fail on its fourth total
+        // relationship without poisoning live history.
+        let index = ToolIndex::with_ledger_relationship_limit_for_test(3);
+        let old = index
+            .register_server_tools("a::b", &[tool("c")], &[], &[])
+            .unwrap();
+        assert_eq!(index.read_state().ledger_relationship_count(), 2);
+
+        for _ in 0..3 {
+            assert_eq!(
+                index
+                    .register_server_tools("a::b", &[tool("c")], &[], &[])
+                    .unwrap(),
+                old
+            );
+            assert_eq!(index.read_state().ledger_relationship_count(), 2);
+        }
+
+        let error = index
+            .register_server_tools("a__b", &[tool("c")], &[], &[])
+            .unwrap_err();
+        assert_eq!(
+            error,
+            ToolRegistrationError::OwnershipLedgerCapacityExceeded {
+                limit: 3,
+                attempted: 4,
+            }
+        );
+        assert_eq!(index.read_state().ledger_relationship_count(), 2);
+        assert_eq!(index.all_aliases(), old);
+        assert!(index.lookup(&old[0].alias).is_some());
+        assert!(index.lookup("mcp__a__b__c").is_some());
+        assert!(index.lookup(&index.generate_alias("a__b", "c")).is_none());
+    }
+
+    #[test]
+    fn whole_catalog_preflight_detects_bounded_alias_collision_without_mutation() {
+        let index = ToolIndex::new();
+        let old = index
+            .register_server_tools("stable", &[tool("old")], &[], &[])
+            .unwrap();
+        let first = index
+            .plan_server_tools("first", &[tool("one")], &[], &[])
+            .unwrap();
+        let mut second = index
+            .plan_server_tools("second", &[tool("two")], &[], &[])
+            .unwrap();
+        second.entries[0].canonical_alias = first.entries[0].canonical_alias.clone();
+
+        let error = index
+            .preflight_catalog_update(&[first.clone(), second], &["stable".to_string()])
+            .unwrap_err();
+        assert_eq!(
+            error,
+            ToolRegistrationError::AliasCollision {
+                alias: first.entries[0].canonical_alias.clone()
+            }
+        );
+        assert_eq!(index.all_aliases(), old);
+        assert!(index.lookup(&old[0].alias).is_some());
+        assert!(index.get_server_tools("stable").is_some());
+    }
+
+    #[test]
+    fn stale_transaction_is_rejected_before_swap_and_preserves_newer_history() {
+        let index = ToolIndex::new();
+        let first = index
+            .register_server_tools("a::b", &[tool("c")], &[], &[])
+            .unwrap();
+        let legacy = legacy_alias("a::b", "c").unwrap();
+        assert_eq!(index.lookup(&legacy).unwrap().server_id, "a::b");
+
+        // Preflight A from revision 1. Its cloned snapshot contains only the
+        // first owner and would therefore make the lossy legacy alias resolve
+        // to that owner if it could overwrite a later publication.
+        let planned = index
+            .plan_server_tools("planned", &[tool("unrelated")], &[], &[])
+            .unwrap();
+        let stale = index
+            .preflight_catalog_update(std::slice::from_ref(&planned), &[])
+            .unwrap();
+        let stale_fail_stop = index
+            .preflight_catalog_update(std::slice::from_ref(&planned), &[])
+            .unwrap();
+        assert_eq!(stale.base_revision, 1);
+
+        // Test-only direct mutation B publishes the second owner of the same
+        // legacy alias and permanently records the resulting ambiguity.
+        let second = index
+            .register_server_tools("a__b", &[tool("c")], &[], &[])
+            .unwrap();
+        assert!(index.lookup(&legacy).is_none());
+        assert_eq!(index.read_state().revision, 2);
+
+        let error = index.try_commit_catalog_update(stale).unwrap_err();
+        assert_eq!(
+            error,
+            ToolIndexCommitError::StaleTransaction {
+                base_revision: 1,
+                current_revision: 2,
+            }
+        );
+        let fail_stop = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            index.commit_catalog_update(stale_fail_stop);
+        }));
+        assert!(
+            fail_stop.is_err(),
+            "the production commit seam must fail-stop on an impossible stale writer"
+        );
+
+        // The stale snapshot is rejected before the state swap: B's canonical
+        // publication and fixed-size historical owner fingerprint both remain,
+        // while A's unrelated planned catalog never appears.
+        assert_eq!(index.read_state().revision, 2);
+        assert!(index.lookup(&first[0].alias).is_some());
+        assert!(index.lookup(&second[0].alias).is_some());
+        assert!(index
+            .lookup(&index.generate_alias("planned", "unrelated"))
+            .is_none());
+        assert!(index.lookup(&legacy).is_none());
+        let state = index.read_state();
+        let historical = state
+            .legacy_owners
+            .get(&legacy_alias_fingerprint(&legacy))
+            .expect("legacy history remains published");
+        assert_eq!(historical.len(), 2);
+        assert!(historical.contains(
+            &ToolOwner {
+                server_id: "a__b".to_string(),
+                original_name: "c".to_string(),
+            }
+            .fingerprint()
+        ));
+    }
+
+    #[test]
+    fn removed_canonical_alias_cannot_rebind_to_another_owner() {
+        let index = ToolIndex::new();
+        let first = index
+            .plan_server_tools("first", &[tool("one")], &[], &[])
+            .unwrap();
+        let canonical_alias = first.entries[0].canonical_alias.clone();
+        let transaction = index
+            .preflight_catalog_update(std::slice::from_ref(&first), &[])
+            .unwrap();
+        index.commit_catalog_update(transaction);
+        index.remove_server_tools("first");
+        assert!(index.all_aliases().is_empty());
+
+        let mut second = index
+            .plan_server_tools("second", &[tool("two")], &[], &[])
+            .unwrap();
+        second.replace_first_canonical_alias_for_test(canonical_alias.clone());
+        let error = index.preflight_catalog_update(&[second], &[]).unwrap_err();
+
+        assert_eq!(
+            error,
+            ToolRegistrationError::AliasCollision {
+                alias: canonical_alias
+            }
+        );
+        assert!(index.all_aliases().is_empty());
+    }
+
+    #[test]
+    fn ambiguous_legacy_alias_fails_closed_in_both_registration_orders() {
+        for order in [
+            [("a::b", "c"), ("a__b", "c")],
+            [("a__b", "c"), ("a::b", "c")],
+        ] {
+            let index = ToolIndex::new();
+            let first = index
+                .register_server_tools(order[0].0, &[tool(order[0].1)], &[], &[])
+                .unwrap();
+            let second = index
+                .register_server_tools(order[1].0, &[tool(order[1].1)], &[], &[])
+                .unwrap();
+            let legacy = legacy_alias("a::b", "c").unwrap();
+            assert!(index.lookup(&legacy).is_none());
+            assert_eq!(first[0].alias, index.generate_alias(order[0].0, order[0].1));
+            assert_eq!(
+                second[0].alias,
+                index.generate_alias(order[1].0, order[1].1)
+            );
+            assert_eq!(index.lookup(&first[0].alias).unwrap().server_id, order[0].0);
+            assert_eq!(
+                index.lookup(&second[0].alias).unwrap().server_id,
+                order[1].0
+            );
+            assert_eq!(index.all_aliases().len(), 2);
+        }
+    }
+
+    #[test]
+    fn owner_aware_removal_preserves_other_owner_and_keeps_legacy_fail_closed() {
+        for registration_order in [
+            [("a::b", "c"), ("a__b", "c")],
+            [("a__b", "c"), ("a::b", "c")],
+        ] {
+            for removed_server in ["a::b", "a__b"] {
+                let index = ToolIndex::new();
+                for (server_id, tool_name) in registration_order {
+                    index
+                        .register_server_tools(server_id, &[tool(tool_name)], &[], &[])
+                        .unwrap();
+                }
+                let legacy = legacy_alias("a::b", "c").unwrap();
+                assert!(index.lookup(&legacy).is_none());
+                assert_eq!(index.read_state().ledger_relationship_count(), 4);
+
+                let survivor_server = if removed_server == "a::b" {
+                    "a__b"
+                } else {
+                    "a::b"
+                };
+                let removed_alias = index.generate_alias(removed_server, "c");
+                let survivor_alias = index.generate_alias(survivor_server, "c");
+                index.remove_server_tools(removed_server);
+
+                assert!(index.lookup(&removed_alias).is_none());
+                assert_eq!(
+                    index.lookup(&survivor_alias).unwrap().server_id,
+                    survivor_server
+                );
+                assert!(
+                    index.lookup(&legacy).is_none(),
+                    "a historically ambiguous alias must not retarget after removal"
+                );
+                assert_eq!(
+                    index.read_state().ledger_relationship_count(),
+                    4,
+                    "removal must retain fixed-size historical ambiguity"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn publication_and_listing_order_are_independent_of_catalog_order() {
+        let index = ToolIndex::new();
+        let first = index
+            .register_server_tools("stable", &[tool("zeta"), tool("alpha")], &[], &[])
+            .unwrap();
+        let first_listing = index.all_aliases();
+        let second = index
+            .register_server_tools("stable", &[tool("alpha"), tool("zeta")], &[], &[])
+            .unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first_listing, index.all_aliases());
+    }
+
+    #[test]
+    fn unambiguous_provider_safe_legacy_alias_remains_lookup_only() {
+        let index = ToolIndex::new();
+        let canonical = index
+            .register_server_tools("filesystem", &[tool("read_file")], &[], &[])
+            .unwrap();
+        let legacy = "mcp__filesystem__read_file";
+        let lookup = index.lookup(legacy).unwrap();
+        assert_eq!(lookup.alias, legacy);
+        assert_eq!(lookup.server_id, "filesystem");
+        assert_eq!(lookup.original_name, "read_file");
+        assert_eq!(index.all_aliases(), canonical);
+        assert_ne!(canonical[0].alias, legacy);
+        assert!(index.contains_exact_alias(&canonical[0].alias));
+        assert!(!index.contains_exact_alias(legacy));
+        assert!(index.contains(legacy));
+    }
+
+    #[test]
+    fn unambiguous_legacy_history_lookup_does_not_require_provider_safe_text() {
+        let index = ToolIndex::new();
+        let canonical = index
+            .register_server_tools("server/with path", &[tool("tool/with path")], &[], &[])
+            .unwrap();
+        let legacy = "mcp__server/with path__tool/with path";
+
+        let lookup = index.lookup(legacy).unwrap();
+        assert_eq!(lookup.server_id, "server/with path");
+        assert_eq!(lookup.original_name, "tool/with path");
+        assert!(!index.contains_exact_alias(legacy));
+        assert_eq!(index.all_aliases(), canonical);
+        assert!(is_provider_safe_alias(&canonical[0].alias));
+    }
+
+    #[test]
+    fn clear_removes_catalog_and_every_lookup_form_atomically() {
+        let index = ToolIndex::new();
+        let canonical = index
+            .register_server_tools("filesystem", &[tool("read_file")], &[], &[])
+            .unwrap();
+        let legacy = "mcp__filesystem__read_file";
+        assert!(index.contains_exact_alias(&canonical[0].alias));
+        assert!(index.contains(legacy));
+
+        index.clear();
+
+        assert!(index.all_aliases().is_empty());
+        assert!(index.get_server_tools("filesystem").is_none());
+        assert!(!index.contains_exact_alias(&canonical[0].alias));
+        assert!(!index.contains(legacy));
     }
 }

--- a/crates/infra/bamboo-mcp/src/types.rs
+++ b/crates/infra/bamboo-mcp/src/types.rs
@@ -488,19 +488,23 @@ impl Default for RuntimeInfo {
     }
 }
 
-/// Tool alias mapping for namespaced tool access.
+/// Tool alias mapping for collision-safe MCP tool access.
 ///
-/// Maps a fully-qualified tool name (with server prefix) to the original
-/// tool name on a specific server. This enables multiple servers to provide
-/// tools with the same name without conflicts.
+/// Maps a deterministic provider-visible identity to the exact original tool
+/// and server tuple. This enables multiple servers to provide identical or
+/// punctuation-heavy names without collisions.
 ///
 /// # Format
 ///
-/// The alias format is: `mcp__<server_id>__<original_name>`
+/// Canonical aliases use `mcp__v1_<server-tag>_<owner-tag>`. Both tags are
+/// domain-separated, length-framed SHA-256 pseudonyms truncated to 130 bits,
+/// and the complete alias is bounded to provider function-name limits.
+/// Historical `mcp__<server>__<tool>` names are compatibility lookup inputs
+/// only when they resolve to exactly one owner.
 ///
 /// # Fields
 ///
-/// * `alias` - Fully-qualified tool name with server prefix
+/// * `alias` - Canonical provider-visible tool identity
 /// * `server_id` - Identifier of the server providing this tool
 /// * `original_name` - Original tool name on the server
 ///
@@ -508,17 +512,16 @@ impl Default for RuntimeInfo {
 ///
 /// ```ignore
 /// let alias = ToolAlias {
-///     alias: "mcp__filesystem__read_file".to_string(),
+///     alias: "mcp__v1_<server-tag>_<owner-tag>".to_string(),
 ///     server_id: "filesystem".to_string(),
 ///     original_name: "read_file".to_string(),
 /// };
 ///
-/// // When the user calls "mcp__filesystem__read_file",
-/// // it maps to the "read_file" tool on the "filesystem" server
+/// // The canonical alias maps to the exact "read_file" owner tuple.
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolAlias {
-    /// Fully-qualified tool name (mcp__<server>__<tool>)
+    /// Canonical provider-visible identity (or a resolved legacy lookup input).
     pub alias: String,
     /// Server providing this tool
     pub server_id: String,


### PR DESCRIPTION
## Summary

- replace lossy MCP aliases with deterministic provider-safe canonical identities and retain legacy names only as unambiguous lookup inputs
- publish complete per-server catalog changes through typed preflight/commit transactions with owner-aware removal and stale-generation rejection
- preserve the old runtime/catalog on install, refresh, reconnect, or registration failure
- keep listing, classified deferred identity, lookup, metrics pseudonyms, and execution on the same canonical alias
- bound process-lifetime ownership ledgers and keep registration diagnostics free of raw remote identities

The independent exact-head review found no P0/P1/P2 issues. Coherent runtime-plus-schema snapshots and broader operational log redaction remain intentionally split to #995 and #996.

Closes #990

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p bamboo-mcp --all-features --no-fail-fast` (236 passed; 14 doc tests ignored)
- `cargo test --locked -p bamboo-agent-core -p bamboo-tools -p bamboo-server-tools --lib --no-fail-fast` (692 passed)
- `cargo test --locked -p bamboo-server handlers::agent::metrics::core_handlers::usage::tests -- --nocapture` (3 passed)
- `cargo clippy --locked -p bamboo-mcp --all-targets --all-features -- -D warnings`
- `cargo check --locked --release -p bamboo-mcp`
- post-rebase exact-routing checks: 7 bamboo-tools tests and 1 canonical MCP metrics parser test
