### PR TITLE
refactor: move workspace context out of system prompt (#972)

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/builder.rs
+++ b/crates/app/bamboo-sdk/src/agent/builder.rs
@@ -2114,14 +2114,12 @@ mod tests {
         assert!(error
             .to_string()
             .contains("test provider must not be called"));
+        let canonical_display = bamboo_config::paths::path_to_display_string(
+            &project_path.path().canonicalize().unwrap(),
+        );
         assert_eq!(
             session.workspace_path_meta().as_deref(),
-            Some(
-                bamboo_config::paths::path_to_display_string(
-                    &project_path.path().canonicalize().unwrap()
-                )
-                .as_str()
-            )
+            Some(canonical_display.as_str())
         );
         assert_eq!(
             session
@@ -2130,16 +2128,33 @@ mod tests {
                 .map(String::as_str),
             Some("project_default")
         );
-        let prompt = session
+        assert!(session
             .messages
             .iter()
-            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
-            .expect("runtime system prompt")
-            .content
-            .as_str();
-        assert!(prompt.contains("Project path:"));
-        assert!(prompt.contains("Project home (Bamboo data):"));
-        assert!(prompt.contains("Workspace source: project_default"));
+            .filter(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .all(|message| {
+                !message.content.contains(&canonical_display)
+                    && !message.content.contains("BAMBOO_PROJECT_CONTEXT_START")
+                    && !message.content.contains("BAMBOO_WORKSPACE_CONTEXT_START")
+            }));
+        let snapshot = session.prompt_snapshot.as_ref().expect("prompt snapshot");
+        let project_context = snapshot
+            .project_context
+            .as_deref()
+            .expect("typed Project context");
+        assert!(project_context.contains(project.id.as_str()));
+        assert!(!project_context.contains(&canonical_display));
+        assert!(!project_context.contains("Project home (Bamboo data):"));
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed Workspace context");
+        assert!(workspace_context.contains(&canonical_display));
+        assert!(workspace_context.contains("Workspace source: project_default"));
+        assert!(workspace_context.contains("Binding status: registered"));
+        assert!(!snapshot
+            .effective_system_prompt
+            .contains(&canonical_display));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -1715,14 +1715,30 @@ mod tests {
                 .map(String::as_str),
             Some(bamboo_engine::project_context::WorkspaceSource::ProjectDefault.as_str())
         );
+        let project_path_display = project.project_path.as_deref().expect("Project path");
         let system_prompt = session
             .messages
             .iter()
             .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
             .expect("Connect system prompt");
-        assert!(system_prompt
+        assert!(!system_prompt.content.contains(project_path_display));
+        assert!(!system_prompt
             .content
-            .contains("Workspace source: project_default"));
+            .contains("BAMBOO_WORKSPACE_CONTEXT_START"));
+        assert!(!system_prompt
+            .content
+            .contains("BAMBOO_PROJECT_CONTEXT_START"));
+        let snapshot = session.prompt_snapshot.as_ref().expect("prompt snapshot");
+        assert!(snapshot
+            .workspace_context
+            .as_deref()
+            .is_some_and(|value| value.contains(project_path_display)));
+        assert!(!snapshot
+            .effective_system_prompt
+            .contains(project_path_display));
+        assert!(!snapshot
+            .effective_system_prompt
+            .contains("BAMBOO_WORKSPACE_CONTEXT_START"));
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -1066,6 +1066,9 @@ mod optional_model_e2e {
             .await
             .expect("load")
             .expect("session");
+        let workspace_display = session
+            .workspace_path_meta()
+            .expect("persisted workspace path");
         let resolved = state
             .project_context_resolver
             .resolve(&session, None)
@@ -1076,26 +1079,47 @@ mod optional_model_e2e {
             resolved.binding_status,
             bamboo_engine::project_context::WorkspaceBindingStatus::Registered
         );
+        assert!(session
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .all(|message| {
+                !message.content.contains("BAMBOO_PROJECT_CONTEXT_START")
+                    && !message.content.contains("BAMBOO_WORKSPACE_CONTEXT_START")
+                    && !message.content.contains(&workspace_display)
+            }));
         let snapshot = session.prompt_snapshot.expect("immediate prompt snapshot");
-        assert!(snapshot
+        let project_context = snapshot
             .project_context
             .as_deref()
-            .is_some_and(|context| context.contains(owner.id.as_str())));
+            .expect("typed Project context");
+        assert!(project_context.contains(owner.id.as_str()));
+        assert!(!project_context.contains(&workspace_display));
+        assert!(!project_context.contains("Project home (Bamboo data):"));
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed Workspace context");
+        assert!(workspace_context.contains(&workspace_display));
+        assert!(workspace_context.contains("Workspace source: explicit"));
+        assert!(workspace_context.contains("Binding status: registered"));
         assert_eq!(
             snapshot
                 .effective_system_prompt
                 .matches("<!-- BAMBOO_PROJECT_CONTEXT_START -->")
                 .count(),
-            1
+            0
         );
-        assert!(
+        assert_eq!(
             snapshot
-                .workspace_context
-                .as_deref()
-                .is_some_and(|context| context.contains("Binding status: registered")),
-            "unexpected workspace context: {:?}",
-            snapshot.workspace_context
+                .effective_system_prompt
+                .matches("<!-- BAMBOO_WORKSPACE_CONTEXT_START -->")
+                .count(),
+            0
         );
+        assert!(!snapshot
+            .effective_system_prompt
+            .contains(&workspace_display));
     }
 
     #[actix_web::test]
@@ -1413,7 +1437,7 @@ mod optional_model_e2e {
     }
 
     #[actix_web::test]
-    async fn chat_persists_same_project_configured_default_and_prompt_marker() {
+    async fn chat_persists_same_project_configured_default_and_dynamic_context() {
         let state = new_state().await;
         let workspace = tempdir().expect("default workspace");
         let foreign_default = tempdir().expect("foreign global default");
@@ -1466,18 +1490,47 @@ mod optional_model_e2e {
             bamboo_agent_core::workspace_state::get_workspace("chat-default-owned").as_deref(),
             Some(canonical.as_path())
         );
+        assert!(session
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .all(|message| {
+                !message.content.contains("BAMBOO_PROJECT_CONTEXT_START")
+                    && !message.content.contains("BAMBOO_WORKSPACE_CONTEXT_START")
+                    && !message.content.contains(&canonical_display)
+            }));
         let snapshot = session.prompt_snapshot.expect("prompt snapshot");
-        assert!(snapshot.workspace_context.as_deref().is_some_and(|value| {
-            value.contains("Binding status: registered")
-                && value.contains("Workspace source: project_default")
-        }));
+        let project_context = snapshot
+            .project_context
+            .as_deref()
+            .expect("typed Project context");
+        assert!(project_context.contains(project.id.as_str()));
+        assert!(!project_context.contains(&canonical_display));
+        assert!(!project_context.contains("Project home (Bamboo data):"));
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed Workspace context");
+        assert!(workspace_context.contains(&canonical_display));
+        assert!(workspace_context.contains("Binding status: registered"));
+        assert!(workspace_context.contains("Workspace source: project_default"));
+        assert_eq!(
+            snapshot
+                .effective_system_prompt
+                .matches("BAMBOO_PROJECT_CONTEXT_START")
+                .count(),
+            0
+        );
         assert_eq!(
             snapshot
                 .effective_system_prompt
                 .matches("BAMBOO_WORKSPACE_CONTEXT_START")
                 .count(),
-            1
+            0
         );
+        assert!(!snapshot
+            .effective_system_prompt
+            .contains(&canonical_display));
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -2780,6 +2780,17 @@ mod tests {
         assert!(prompt["project_context"]
             .as_str()
             .is_some_and(|value| value.contains(owner.id.as_str())));
+        let project_context = prompt["project_context"]
+            .as_str()
+            .expect("typed Project context");
+        assert!(!project_context.contains(&nested_workspace_display));
+        assert!(!project_context.contains("Project home (Bamboo data):"));
+        let workspace_context = prompt["workspace_context"]
+            .as_str()
+            .expect("typed Workspace context");
+        assert!(workspace_context.contains(&nested_workspace_display));
+        assert!(workspace_context.contains("Workspace source: explicit"));
+        assert!(workspace_context.contains("Binding status: registered"));
         let effective = prompt["effective_system_prompt"]
             .as_str()
             .expect("effective prompt");
@@ -2787,15 +2798,15 @@ mod tests {
             effective
                 .matches("<!-- BAMBOO_PROJECT_CONTEXT_START -->")
                 .count(),
-            1
+            0
         );
         assert_eq!(
             effective
                 .matches("<!-- BAMBOO_WORKSPACE_CONTEXT_START -->")
                 .count(),
-            1
+            0
         );
-        assert!(effective.contains("Binding status: registered"));
+        assert!(!effective.contains(&nested_workspace_display));
     }
 
     #[actix_web::test]
@@ -2917,7 +2928,7 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn same_project_default_workspace_is_persisted_with_prompt_marker() {
+    async fn same_project_default_workspace_is_persisted_with_dynamic_context() {
         let state = new_state().await;
         let workspace = tempdir().expect("default workspace");
         let foreign_default = tempdir().expect("foreign global default");
@@ -2998,22 +3009,33 @@ mod tests {
             .project_context
             .as_deref()
             .expect("Project context");
-        assert!(project_context.contains(&format!("Project path: {canonical_display}")));
-        assert!(project_context.contains("Project home (Bamboo data):"));
+        assert!(project_context.contains(project.id.as_str()));
+        assert!(!project_context.contains(&canonical_display));
+        assert!(!project_context.contains("Project home (Bamboo data):"));
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("Workspace context");
+        assert!(workspace_context.contains(&canonical_display));
+        assert!(workspace_context.contains("Binding status: registered"));
+        assert!(workspace_context.contains("Workspace source: project_default"));
         assert_eq!(
             snapshot
                 .effective_system_prompt
                 .matches("BAMBOO_PROJECT_CONTEXT_START")
                 .count(),
-            1
+            0
         );
         assert_eq!(
             snapshot
                 .effective_system_prompt
                 .matches("BAMBOO_WORKSPACE_CONTEXT_START")
                 .count(),
-            1
+            0
         );
+        assert!(!snapshot
+            .effective_system_prompt
+            .contains(&canonical_display));
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
@@ -264,7 +264,6 @@ mod tests {
                 .as_str()
                 .expect("typed Workspace context");
             assert!(workspace_context.contains(workspace.to_string_lossy().as_ref()));
-            assert!(workspace_context.contains("Workspace source: session"));
             assert!(workspace_context.contains("Binding status: registered"));
             assert!(!effective.contains(workspace.to_string_lossy().as_ref()));
 

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
@@ -249,17 +249,24 @@ mod tests {
             let effective = snapshot["effective_system_prompt"]
                 .as_str()
                 .expect("effective prompt");
-            assert_eq!(effective.matches("BAMBOO_PROJECT_CONTEXT_START").count(), 1);
+            assert_eq!(effective.matches("BAMBOO_PROJECT_CONTEXT_START").count(), 0);
             assert_eq!(
                 effective.matches("BAMBOO_WORKSPACE_CONTEXT_START").count(),
-                1
+                0
             );
-            assert!(snapshot["project_context"]
+            let project_context = snapshot["project_context"]
                 .as_str()
-                .is_some_and(|value| value.contains(project.id.as_str())));
-            assert!(snapshot["workspace_context"]
+                .expect("typed Project context");
+            assert!(project_context.contains(project.id.as_str()));
+            assert!(!project_context.contains(workspace.to_string_lossy().as_ref()));
+            assert!(!project_context.contains("Project home (Bamboo data):"));
+            let workspace_context = snapshot["workspace_context"]
                 .as_str()
-                .is_some_and(|value| value.contains(workspace.to_string_lossy().as_ref())));
+                .expect("typed Workspace context");
+            assert!(workspace_context.contains(workspace.to_string_lossy().as_ref()));
+            assert!(workspace_context.contains("Workspace source: session"));
+            assert!(workspace_context.contains("Binding status: registered"));
+            assert!(!effective.contains(workspace.to_string_lossy().as_ref()));
 
             let persisted = state
                 .storage

--- a/crates/engine/bamboo-engine/src/project_context.rs
+++ b/crates/engine/bamboo-engine/src/project_context.rs
@@ -14,7 +14,9 @@ use bamboo_domain::{ProjectId, ProjectResourceKind, ProjectResourceSummary, Work
 use serde::{Deserialize, Serialize};
 
 pub const PROJECT_ID_METADATA_KEY: &str = "project_id";
+pub const PROJECT_CONTEXT_RENDERED_KEY: &str = "project_context_rendered";
 pub const PROJECT_RESOURCES_RENDERED_KEY: &str = "project_resources_rendered";
+pub const WORKSPACE_BINDING_STATUS_METADATA_KEY: &str = "workspace_binding_status";
 pub const WORKSPACE_SOURCE_METADATA_KEY: &str = "workspace_source";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,6 +31,13 @@ impl WorkspaceBindingStatus {
         match self {
             Self::Registered => "registered",
             Self::Unregistered => "unregistered",
+        }
+    }
+
+    pub fn from_metadata(value: Option<&str>) -> Self {
+        match value {
+            Some("registered") => Self::Registered,
+            _ => Self::Unregistered,
         }
     }
 }
@@ -74,6 +83,14 @@ impl WorkspaceSource {
             Self::Explicit => "explicit",
             Self::Session => "session",
             Self::ProjectDefault => "project_default",
+        }
+    }
+
+    pub fn from_metadata(value: Option<&str>) -> Self {
+        match value {
+            Some("explicit") => Self::Explicit,
+            Some("project_default") => Self::ProjectDefault,
+            _ => Self::Session,
         }
     }
 }
@@ -542,13 +559,15 @@ impl ProjectContextResolver {
         self.source.find_workspace_owner(workspace).await
     }
 
-    /// Resolve and persist the stable Project and mutable Workspace prompt
-    /// markers immediately.
+    /// Resolve and persist stable Project identity plus mutable Workspace
+    /// metadata immediately.
     ///
     /// Session-create and chat APIs call this before their first response so a
     /// freshly-created assigned session is already self-describing when read
     /// back, rather than waiting for the first execution round. The round
-    /// prelude calls the same helper to keep the markers current.
+    /// prelude calls the same helper to keep the metadata current. Provider
+    /// context is rendered later from this authority; this method never injects
+    /// Project or Workspace markers into a System message.
     pub async fn refresh_session_prompt(
         &self,
         session: &mut Session,
@@ -556,7 +575,7 @@ impl ProjectContextResolver {
         self.refresh_session_prompt_inner(session, true).await
     }
 
-    /// Resolve Project/Workspace prompt markers on an in-memory snapshot
+    /// Resolve Project/Workspace metadata on an in-memory snapshot
     /// without changing runtime workspace state.
     ///
     /// Read APIs use this for sessions that have never entered the runner
@@ -575,6 +594,9 @@ impl ProjectContextResolver {
         session: &mut Session,
         sync_runtime_workspace: bool,
     ) -> Result<Option<ResolvedProjectContext>, ProjectContextError> {
+        // Legacy prompt text is compatibility input only. Recover a path when
+        // metadata is absent, then remove the marker before normal resolution.
+        crate::runtime::runner::session_setup::migrate_legacy_workspace_prompt(session);
         let resolved = self.resolve(session, None).await?;
         let workspace = if let Some(context) = resolved.as_ref() {
             context.workspace.clone()
@@ -600,50 +622,38 @@ impl ProjectContextResolver {
                 WORKSPACE_SOURCE_METADATA_KEY.to_string(),
                 context.workspace_source.as_str().to_string(),
             );
+            session.metadata.insert(
+                WORKSPACE_BINDING_STATUS_METADATA_KEY.to_string(),
+                context.binding_status.as_str().to_string(),
+            );
+        } else if workspace.is_some() {
+            session
+                .metadata
+                .entry(WORKSPACE_SOURCE_METADATA_KEY.to_string())
+                .or_insert_with(|| WorkspaceSource::Session.as_str().to_string());
+            session.metadata.insert(
+                WORKSPACE_BINDING_STATUS_METADATA_KEY.to_string(),
+                WorkspaceBindingStatus::Unregistered.as_str().to_string(),
+            );
         } else {
             session.metadata.remove(WORKSPACE_SOURCE_METADATA_KEY);
+            session
+                .metadata
+                .remove(WORKSPACE_BINDING_STATUS_METADATA_KEY);
         }
-        let current = session
-            .messages
-            .iter()
-            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
-            .map(|message| message.content.clone())
-            .or_else(|| session.metadata.get("base_system_prompt").cloned())
-            .unwrap_or_default();
-        let mut updated =
-            crate::runtime::context::upsert_project_prompt_context(&current, resolved.as_ref());
 
         if let Some(context) = resolved.as_ref() {
+            session.metadata.insert(
+                PROJECT_CONTEXT_RENDERED_KEY.to_string(),
+                crate::runtime::context::build_project_model_context(context),
+            );
             session.metadata.insert(
                 PROJECT_RESOURCES_RENDERED_KEY.to_string(),
                 context.render_resource_inventory(),
             );
         } else {
+            session.metadata.remove(PROJECT_CONTEXT_RENDERED_KEY);
             session.metadata.remove(PROJECT_RESOURCES_RENDERED_KEY);
-        }
-        let workspace_display = workspace
-            .as_deref()
-            .map(bamboo_config::paths::path_to_display_string);
-        updated = crate::runtime::context::upsert_workspace_prompt_context_with_source(
-            &updated,
-            workspace_display.as_deref(),
-            resolved
-                .as_ref()
-                .map(|context| context.binding_status)
-                .unwrap_or(WorkspaceBindingStatus::Unregistered),
-            resolved.as_ref().map(|context| context.workspace_source),
-        );
-
-        if let Some(system_message) = session
-            .messages
-            .iter_mut()
-            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
-        {
-            system_message.content = updated;
-        } else if !updated.trim().is_empty() {
-            session
-                .messages
-                .insert(0, bamboo_agent_core::Message::system(updated));
         }
         crate::runner::refresh_prompt_snapshot(session);
 
@@ -1085,12 +1095,20 @@ mod tests {
             )
         );
         let prompt = &session.messages[0].content;
-        assert_eq!(prompt.matches("Project path:").count(), 1);
-        assert_eq!(prompt.matches("Project home (Bamboo data):").count(), 1);
-        assert_eq!(prompt.matches("Workspace path:").count(), 1);
+        assert_eq!(prompt, "base");
+        let project_context = session
+            .metadata
+            .get(PROJECT_CONTEXT_RENDERED_KEY)
+            .expect("redacted Project context");
+        assert!(project_context.contains("Project ID: project-default"));
+        assert!(!project_context.contains("Project path:"));
+        assert!(!project_context.contains("Project home"));
         assert_eq!(
-            prompt.matches("Workspace source: project_default").count(),
-            1
+            session
+                .metadata
+                .get(WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some("project_default")
         );
         assert!(!prompt.contains(foreign_default.to_string_lossy().as_ref()));
         assert!(!workspace_root.join(&session.id).exists());
@@ -1365,7 +1383,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prompt_refresh_removes_stale_project_and_updates_unassigned_workspace() {
+    async fn metadata_refresh_updates_project_and_unassigned_workspace_without_system_mutation() {
         let directory = tempfile::tempdir().expect("tempdir");
         let workspace = directory.path().join("workspace");
         std::fs::create_dir_all(&workspace).expect("workspace");
@@ -1406,8 +1424,18 @@ mod tests {
             .await
             .expect("assigned refresh");
         let assigned = &session.messages[0].content;
-        assert_eq!(assigned.matches("BAMBOO_PROJECT_CONTEXT_START").count(), 1);
-        assert!(assigned.contains("Binding status: registered"));
+        assert_eq!(assigned, "base");
+        assert!(session
+            .metadata
+            .get(PROJECT_CONTEXT_RENDERED_KEY)
+            .is_some_and(|context| context.contains("Project ID: project-prompt-refresh")));
+        assert_eq!(
+            session
+                .metadata
+                .get(WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some("registered")
+        );
 
         session.clear_project_id_meta();
         resolver
@@ -1415,15 +1443,15 @@ mod tests {
             .await
             .expect("unassigned refresh");
         let unassigned = &session.messages[0].content;
+        assert_eq!(unassigned, "base");
+        assert!(!session.metadata.contains_key(PROJECT_CONTEXT_RENDERED_KEY));
         assert_eq!(
-            unassigned.matches("BAMBOO_PROJECT_CONTEXT_START").count(),
-            0
+            session
+                .metadata
+                .get(WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some("unregistered")
         );
-        assert_eq!(
-            unassigned.matches("BAMBOO_WORKSPACE_CONTEXT_START").count(),
-            1
-        );
-        assert!(unassigned.contains("Binding status: unregistered"));
         assert!(!session
             .metadata
             .contains_key(PROJECT_RESOURCES_RENDERED_KEY));

--- a/crates/engine/bamboo-engine/src/runtime/context/instruction.rs
+++ b/crates/engine/bamboo-engine/src/runtime/context/instruction.rs
@@ -23,21 +23,24 @@ fn read_trimmed_file(path: &Path) -> Option<String> {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
         Err(error) => {
-            tracing::warn!("Failed to inspect instruction file {:?}: {}", path, error);
+            tracing::warn!(
+                error_kind = ?error.kind(),
+                "failed to inspect workspace instruction file"
+            );
             return None;
         }
     };
     if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
-        tracing::warn!(
-            "Ignoring non-regular or symlinked instruction file: {:?}",
-            path
-        );
+        tracing::warn!("ignoring non-regular or symlinked workspace instruction file");
         return None;
     }
     let bytes = match std::fs::read(path) {
         Ok(bytes) => bytes,
         Err(error) => {
-            tracing::warn!("Failed to read instruction file {:?}: {}", path, error);
+            tracing::warn!(
+                error_kind = ?error.kind(),
+                "failed to read workspace instruction file"
+            );
             return None;
         }
     };
@@ -128,14 +131,33 @@ pub fn build_instruction_prompt_context(workspace_path: &str) -> Option<String> 
         "Repository instruction layer loaded from workspace policy files. Treat these as authoritative project guardrails and follow them in addition to the base system prompt. When a request in this conversation conflicts with them, the repository policy takes precedence: do not override it just because the user asks in passing — surface the conflict and keep following the policy unless the user explicitly and knowingly directs you to override a specific rule. Only the base system prompt and higher-priority system/developer/safety directives outrank these files.".to_string(),
     );
 
+    // Provider-visible source identities are workspace-relative. Absolute host
+    // paths belong only to the dedicated Workspace block and must not be
+    // duplicated by the instruction overlay.
+    let source_root = files
+        .first()
+        .and_then(|file| file.path.parent())
+        .map(Path::to_path_buf);
     for file in files {
+        let source = source_root
+            .as_deref()
+            .and_then(|root| file.path.strip_prefix(root).ok())
+            .filter(|relative| !relative.as_os_str().is_empty())
+            .unwrap_or_else(|| {
+                Path::new(
+                    file.path
+                        .file_name()
+                        .and_then(|value| value.to_str())
+                        .unwrap_or("INSTRUCTION.md"),
+                )
+            });
         sections.push(format!(
             "## {}\nSource: {}\n\n{}",
             file.path
                 .file_name()
                 .and_then(|value| value.to_str())
                 .unwrap_or("INSTRUCTION.md"),
-            file.display_path,
+            paths::path_to_display_string(source),
             file.content
         ));
     }

--- a/crates/engine/bamboo-engine/src/runtime/context/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/context/mod.rs
@@ -140,6 +140,65 @@ pub fn build_workspace_prompt_context_with_binding_and_source(
     ))
 }
 
+/// Locate a complete unwrapped Workspace block emitted by legacy Bamboo builds.
+///
+/// Some persisted sessions predate the marker wrapper, but an ordinary custom
+/// System prompt is also allowed to discuss a `Workspace path:`. Treat the
+/// prefix as host authority only when it appears at the start of a line and is
+/// followed by the exact generated guidance, with only known generated
+/// metadata lines in between. Otherwise migration must leave the text alone.
+pub(crate) fn legacy_unwrapped_workspace_context_bounds(prompt: &str) -> Option<(usize, usize)> {
+    let guidance = workspace_prompt_guidance();
+
+    for (start_idx, _) in prompt.match_indices(WORKSPACE_CONTEXT_PREFIX) {
+        if start_idx > 0 && prompt.as_bytes()[start_idx - 1] != b'\n' {
+            continue;
+        }
+
+        let path_start = start_idx + WORKSPACE_CONTEXT_PREFIX.len();
+        let Some(path_end_rel) = prompt[path_start..].find('\n') else {
+            continue;
+        };
+        let path_end = path_start + path_end_rel;
+        if prompt[path_start..path_end].trim().is_empty() {
+            continue;
+        }
+
+        let metadata_start = path_end + 1;
+        let Some(guidance_rel) = prompt[metadata_start..].find(&guidance) else {
+            continue;
+        };
+        let guidance_start = metadata_start + guidance_rel;
+        if guidance_start > 0 && prompt.as_bytes()[guidance_start - 1] != b'\n' {
+            continue;
+        }
+
+        let metadata_is_generated = prompt[metadata_start..guidance_start]
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .all(|line| {
+                matches!(
+                    line,
+                    "Workspace source: explicit"
+                        | "Workspace source: project_default"
+                        | "Workspace source: session"
+                        | "Binding status: registered"
+                        | "Binding status: unregistered"
+                        | "Workspace-local resources may override Project-shared resources."
+                        | "Changing the workspace changes only the filesystem execution context; it does not change Project membership or Project memory."
+                )
+            });
+        if !metadata_is_generated {
+            continue;
+        }
+
+        return Some((start_idx, guidance_start + guidance.len()));
+    }
+
+    None
+}
+
 /// Build the stable Project identity block.
 ///
 /// Resource counts and revisions are intentionally excluded: they belong to

--- a/crates/engine/bamboo-engine/src/runtime/context/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/context/mod.rs
@@ -163,6 +163,21 @@ pub fn build_project_prompt_context(context: &ResolvedProjectContext) -> String 
     format!("{PROJECT_CONTEXT_START_MARKER}\n{body}\n{PROJECT_CONTEXT_END_MARKER}")
 }
 
+/// Build provider-visible Project identity without filesystem locations.
+///
+/// The active workspace path is rendered exactly once by the sibling Workspace
+/// context. Project roots and Bamboo-owned data paths are host details and must
+/// not duplicate that path or leak into provider-visible diagnostics.
+pub fn build_project_model_context(context: &ResolvedProjectContext) -> String {
+    let project = &context.project;
+    let body = format!(
+        "{PROJECT_CONTEXT_PREFIX}{}\nProject name: {}\nThis session belongs to this Project.\nWorkspace is mutable execution context; changing it does not change Project membership, sidebar grouping, Project memory, or Project-shared resources.\nProject-shared resource inventory is supplied separately as per-round dynamic context.\nThe host owns workspace selection and reports the active execution context separately.",
+        prompt_safe_scalar(project.id.as_str()),
+        prompt_safe_scalar(&project.name),
+    );
+    format!("{PROJECT_CONTEXT_START_MARKER}\n{body}\n{PROJECT_CONTEXT_END_MARKER}")
+}
+
 /// Replace every existing Project block with exactly one current block.
 ///
 /// Workspace blocks are deliberately outside the removed marker range.
@@ -259,25 +274,22 @@ fn replace_prompt_block(
 /// Assemble a full system prompt from base prompt, optional enhancement, and context segments.
 ///
 /// This is the shared prompt assembly logic used by both the HTTP handler and the schedule
-/// manager. It layers:
-/// 1. Base system prompt (required)
-/// 2. Optional enhancement text
-/// 3. Workspace context (if workspace_path is provided)
-/// 4. Instruction layer context (AGENTS.md / CLAUDE.md from workspace)
-/// 5. Environment variable context
+/// manager. System text contains only the caller-owned base plus optional
+/// enhancement. Project, Workspace, instruction, and environment context are
+/// assembled later as typed model-context blocks.
 pub fn assemble_system_prompt(
     base: &str,
     enhance: Option<&str>,
-    workspace_path: Option<&str>,
+    _workspace_path: Option<&str>,
 ) -> String {
-    assemble_system_prompt_with_project(base, enhance, None, workspace_path)
+    assemble_system_prompt_with_project(base, enhance, None, None)
 }
 
 pub fn assemble_system_prompt_with_project(
     base: &str,
     enhance: Option<&str>,
-    project_context: Option<&ResolvedProjectContext>,
-    workspace_path: Option<&str>,
+    _project_context: Option<&ResolvedProjectContext>,
+    _workspace_path: Option<&str>,
 ) -> String {
     let mut prompt = base.trim().to_string();
     if let Some(extra) = enhance.map(str::trim).filter(|v| !v.is_empty()) {
@@ -285,40 +297,6 @@ pub fn assemble_system_prompt_with_project(
             prompt.push_str("\n\n");
         }
         prompt.push_str(extra);
-    }
-    if let Some(context) = project_context {
-        let segment = build_project_prompt_context(context);
-        if !prompt.is_empty() {
-            prompt.push_str("\n\n");
-        }
-        prompt.push_str(&segment);
-    }
-    if let Some(path) = workspace_path.map(str::trim).filter(|v| !v.is_empty()) {
-        let binding_status = project_context
-            .map(|context| context.binding_status)
-            .unwrap_or(WorkspaceBindingStatus::Unregistered);
-        if let Some(segment) = build_workspace_prompt_context_with_binding_and_source(
-            path,
-            binding_status,
-            project_context.map(|context| context.workspace_source),
-        ) {
-            if !prompt.is_empty() {
-                prompt.push_str("\n\n");
-            }
-            prompt.push_str(&segment);
-        }
-        if let Some(instruction_segment) = instruction::build_instruction_prompt_context(path) {
-            if !prompt.is_empty() {
-                prompt.push_str("\n\n");
-            }
-            prompt.push_str(&instruction_segment);
-        }
-    }
-    if let Some(segment) = build_env_prompt_context() {
-        if !prompt.is_empty() {
-            prompt.push_str("\n\n");
-        }
-        prompt.push_str(&segment);
     }
     prompt
 }
@@ -383,31 +361,37 @@ mod project_context_tests {
     }
 
     #[test]
-    fn scoped_prompt_contains_exactly_one_project_and_workspace_block() {
-        let context = project_context("/workspace/main");
+    fn system_assembly_ignores_legacy_dynamic_context_arguments() {
+        let context = project_context("/workspace/private");
         let prompt = assemble_system_prompt_with_project(
             "base",
             None,
             Some(&context),
-            Some("/workspace/main"),
+            Some("/workspace/private"),
         );
-        assert_eq!(prompt.matches(PROJECT_CONTEXT_START_MARKER).count(), 1);
-        assert_eq!(prompt.matches(PROJECT_CONTEXT_END_MARKER).count(), 1);
-        assert_eq!(prompt.matches(WORKSPACE_CONTEXT_START_MARKER).count(), 1);
-        assert_eq!(prompt.matches(WORKSPACE_CONTEXT_END_MARKER).count(), 1);
-        assert!(prompt.contains("Binding status: registered"));
+        assert_eq!(prompt, "base");
+        assert!(!prompt.contains("/workspace/private"));
+        assert!(!prompt.contains("/data/projects"));
+        assert!(!prompt.contains(PROJECT_CONTEXT_START_MARKER));
+        assert!(!prompt.contains(WORKSPACE_CONTEXT_START_MARKER));
+        assert!(!prompt.contains(WORKSPACE_CONTEXT_END_MARKER));
+        assert!(!prompt.contains(ENV_CONTEXT_START_MARKER));
+    }
+
+    #[test]
+    fn provider_project_context_contains_no_host_paths() {
+        let context = project_context("/workspace/main");
+        let prompt = build_project_model_context(&context);
+        assert!(prompt.contains("Project ID:"));
+        assert!(!prompt.contains("/workspace/main"));
+        assert!(!prompt.contains("/data/projects"));
     }
 
     #[test]
     fn workspace_upsert_preserves_project_block_byte_for_byte() {
         let context = project_context("/workspace/main");
-        let prompt = assemble_system_prompt_with_project(
-            "base",
-            None,
-            Some(&context),
-            Some("/workspace/main"),
-        );
         let project_block = build_project_prompt_context(&context);
+        let prompt = format!("base\n\n{project_block}");
         let updated = upsert_workspace_prompt_context(
             &prompt,
             Some("/workspace/worktree"),

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -788,7 +788,7 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                 Some(&model),
             );
 
-            let system_prompt = system_prompt_for_session(&session);
+            let system_prompt = system_prompt_for_debug_log(&mut session);
             if let Some(prompt) = system_prompt.as_ref() {
                 log_base_system_prompt_snapshot(&session_id, prompt);
             }
@@ -1105,6 +1105,14 @@ fn system_prompt_for_session(session: &Session) -> Option<String> {
         .map(|message| message.content.clone())
 }
 
+/// Normalize legacy host-owned prompt sections before the debug logger can
+/// observe persisted System text. The runner repeats this migration
+/// idempotently before workspace-scoped setup.
+fn system_prompt_for_debug_log(session: &mut Session) -> Option<String> {
+    crate::runtime::runner::session_setup::migrate_legacy_workspace_prompt(session);
+    system_prompt_for_session(session)
+}
+
 fn initial_user_message_for_session(session: &Session) -> String {
     session
         .messages
@@ -1138,6 +1146,46 @@ fn selected_skill_mode_for_session(session: &Session) -> Option<String> {
 mod reservation_tests {
     use super::*;
     use crate::runtime::execution::runner_state::AgentStatus;
+
+    #[test]
+    fn debug_prompt_snapshot_migrates_legacy_host_paths_before_logging() {
+        let legacy_project = format!(
+            "{}\nProject ID: legacy-project\nProject path: /private/legacy-project\nProject home: /private/legacy-home\n{}",
+            crate::runtime::context::PROJECT_CONTEXT_START_MARKER,
+            crate::runtime::context::PROJECT_CONTEXT_END_MARKER,
+        );
+        let legacy_workspace =
+            crate::runtime::context::build_workspace_prompt_context("/private/legacy-workspace")
+                .expect("legacy workspace context");
+        let legacy_instruction = format!(
+            "{}\nSource: /private/legacy-workspace/AGENTS.md\nlegacy policy\n{}",
+            crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER,
+            crate::runtime::context::instruction::INSTRUCTION_CONTEXT_END_MARKER,
+        );
+        let mut session = Session::new("legacy-debug-log", "model");
+        session.add_message(bamboo_agent_core::Message::system(format!(
+            "Base prompt\n\n{legacy_project}\n\n{legacy_workspace}\n\n{legacy_instruction}"
+        )));
+
+        let prompt = system_prompt_for_debug_log(&mut session).expect("normalized System");
+
+        assert_eq!(prompt, "Base prompt");
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some("/private/legacy-workspace")
+        );
+        for private_path in [
+            "/private/legacy-project",
+            "/private/legacy-home",
+            "/private/legacy-workspace",
+        ] {
+            assert!(!prompt.contains(private_path));
+        }
+        assert!(!prompt.contains(crate::runtime::context::PROJECT_CONTEXT_START_MARKER));
+        assert!(!prompt.contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
+        assert!(!prompt
+            .contains(crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER));
+    }
 
     #[test]
     fn reservation_target_requires_domain_id_and_exact_runner_registry() {

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
@@ -956,13 +956,16 @@ async fn projected_relocation_does_not_double_reserve_large_system_env_context()
         ..Default::default()
     };
     let mut session = Session::new("session-cp-relocated-env", "test-model");
-    let (stable_frame, _) =
+    let (stable_frame, sections) =
         crate::runtime::runner::session_setup::prompt_setup::build_stable_prompt_frame_with_sections(
             &session,
             &config,
             &[],
             &Default::default(),
         );
+    assert!(!stable_frame
+        .stable_instructions
+        .contains("stable environment inventory"));
     session
         .messages
         .push(Message::system(stable_frame.stable_instructions));
@@ -971,9 +974,22 @@ async fn projected_relocation_does_not_double_reserve_large_system_env_context()
         .push(Message::user("inspect the environment"));
 
     let counter = TiktokenTokenCounter::default();
-    let fitted_system_tokens = counter.count_messages(&session.messages[..1]);
+    let env_context = sections
+        .iter()
+        .find(|section| section.name == "env")
+        .map(|section| section.content.clone())
+        .expect("relocated environment section");
+    let env_message = bamboo_agent_core::ContextBlock::new(
+        ContextBlockType::EnvSnapshot,
+        bamboo_agent_core::ContextBlockPriority::High,
+        bamboo_agent_core::ContextBlockStability::SessionStable,
+        "Environment Snapshot",
+        env_context,
+    )
+    .render_runtime_context_message();
+    let fitted_prefix_tokens = counter.count_messages(&[session.messages[0].clone(), env_message]);
     let max_output_tokens = 256;
-    let request_input_limit = fitted_system_tokens.saturating_add(768);
+    let request_input_limit = fitted_prefix_tokens.saturating_add(768);
     session.token_budget = Some(TokenBudget::with_safety_margin(
         request_input_limit.saturating_add(max_output_tokens),
         max_output_tokens,

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use super::{
     build_compression_context_blocks, emit_context_pressure_notification,
@@ -22,6 +22,13 @@ use bamboo_llm::provider::{LLMProvider, LLMRequestOptions, LLMStream, ProviderMo
 use bamboo_llm::{LLMChunk, LLMError};
 use futures::stream;
 use tokio::sync::mpsc;
+
+fn isolate_prompt_safe_env_cache() -> MutexGuard<'static, ()> {
+    let guard = crate::runtime::tests::env_cache_lock_acquire();
+    let empty_data_dir = tempfile::tempdir().expect("temp dir for empty config");
+    let _ = bamboo_config::Config::from_data_dir(Some(empty_data_dir.path().to_path_buf()));
+    guard
+}
 
 /// A no-op LLM provider for tests that returns an empty stream.
 struct NoopLlmProvider;
@@ -944,8 +951,10 @@ async fn prepare_round_context_applies_placeholder_fallback_only_to_prepared_con
     assert!(persisted_user.content_parts.is_some());
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn projected_relocation_does_not_double_reserve_large_system_env_context() {
+    let _env_lock = isolate_prompt_safe_env_cache();
     let large_env = "stable environment inventory and capability detail ".repeat(900);
     let configured_system = format!(
         "system\n\n<!-- BAMBOO_ENV_CONTEXT_START -->\n{large_env}\n<!-- BAMBOO_ENV_CONTEXT_END -->"
@@ -1024,8 +1033,10 @@ async fn projected_relocation_does_not_double_reserve_large_system_env_context()
     );
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn projected_compression_reseed_does_not_double_reserve_large_summary() {
+    let _env_lock = isolate_prompt_safe_env_cache();
     let summary_content =
         "compressed decisions requirements and verification evidence ".repeat(900);
     let mut session = Session::new("session-cp-relocated-summary", "test-model");
@@ -1098,8 +1109,10 @@ async fn projected_compression_reseed_does_not_double_reserve_large_summary() {
     );
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn projected_refit_handles_over_limit_vision_transform_exactly_once() {
+    let _env_lock = isolate_prompt_safe_env_cache();
     let mut session = Session::new("session-cp-vision-refit", "test-model");
     session.messages.push(Message::system("system"));
     for index in 0..20 {

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -7,16 +7,14 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::runtime::config::AgentLoopConfig;
-use crate::runtime::runner::prompt_context::{
-    append_core_agent_directives, strip_existing_core_directives, strip_existing_external_memory,
-    strip_existing_goal, strip_existing_plan_mode_instructions,
-    strip_existing_plan_runtime_context, strip_existing_task_list,
-};
+use crate::runtime::runner::prompt_context::append_core_agent_directives;
 use crate::runtime::runner::session_setup::prompt_envelope::{
     build_active_workflow_context_block, build_agent_hook_context_block,
     build_conversation_summary_context_block, build_external_memory_context_block,
-    build_goal_context_block, build_plan_mode_context_block, build_plan_runtime_context_block,
+    build_goal_context_block, build_instruction_overlay_context_block,
+    build_plan_mode_context_block, build_plan_runtime_context_block,
     build_project_resources_context_block, build_task_list_context_block,
+    build_workspace_context_block,
 };
 use crate::runtime::runner::session_setup::prompt_setup::{
     build_stable_prompt_frame_with_sections, StablePrefixSection,
@@ -304,33 +302,23 @@ fn derive_system_remainder_message(
         return None;
     }
 
-    let without_external_memory = strip_existing_external_memory(&message.content);
-    let without_task_list = strip_existing_task_list(&without_external_memory);
-    let without_plan_mode = strip_existing_plan_mode_instructions(&without_task_list);
-    let without_plan_runtime = strip_existing_plan_runtime_context(&without_plan_mode);
-    // Strip a legacy goal block too: the goal now rides the volatile tail (built from
-    // the active goal), so a stale `<!-- BAMBOO_GOAL_START -->` left in an old
-    // persisted System message must not resurface as a duplicate in the remainder.
-    let without_goal = strip_existing_goal(&without_plan_runtime);
-    // Framework directives always live in the assembled system field and are not
-    // part of the persisted base, so strip them from both sides before comparing.
-    // The directives are inserted INTO the `base` section (between the base text
-    // and the skill/tool-guide/workspace/env contexts) — not as a leading prefix
-    // of the whole frame — so stripping them from both the persisted message and
-    // the reference makes the comparison apples-to-apples (base+contexts vs
-    // base+contexts). Without it, the directive-bearing reference no longer equals
-    // the directive-free persisted base, so the dedup falls through and re-emits
-    // the entire base as a redundant system message. Stripping both sides also
-    // discards a STALE directive block in an old persisted message, so the current
-    // directives (already in the system field) win.
-    let without_directives = strip_existing_core_directives(&without_goal);
-    let trimmed = without_directives.trim();
+    // Compare only the normalized user base. Every host-owned section — including
+    // legacy workspace/instruction markers — is either in the canonical system
+    // blocks or the typed model-context ledger and must never leak as a second
+    // System remainder.
+    let normalized = crate::runtime::runner::session_setup::prompt_setup::normalize_base_prompt(
+        &message.content,
+    );
+    let trimmed = normalized.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    let stable_without_directives = strip_existing_core_directives(stable_instructions);
-    let stable_trimmed = stable_without_directives.trim();
+    let stable_normalized =
+        crate::runtime::runner::session_setup::prompt_setup::normalize_base_prompt(
+            stable_instructions,
+        );
+    let stable_trimmed = stable_normalized.trim();
     if stable_trimmed.is_empty() {
         return Some(Message::system(trimmed.to_string()));
     }
@@ -648,54 +636,37 @@ fn build_request_envelope_reconciled(
         system_blocks.clear();
     }
 
-    // Session-variable context (workspace path, project instruction overlay,
-    // loaded skills), relocated to ride AFTER the invariant tool guide so it never
-    // shifts the cached head. Each block is session-stable and emitted only when
-    // present; keeping them as separate blocks lets an unchanged block stay inside
-    // the shared prefix even when a sibling changes. The instruction overlay keeps
-    // Critical priority so its authority survives the move out of the system field.
+    // Session-variable context rides AFTER the invariant tool guide so it never
+    // shifts the cached head. Workspace and instructions are added below from
+    // authoritative session metadata, not from these diagnostic sections.
     [
-        (
-            ContextBlockType::Workspace,
-            ContextBlockPriority::High,
-            "Project & Workspace",
-            [section("project"), section("workspace")]
-                .into_iter()
-                .filter(|value| !value.trim().is_empty())
-                .collect::<Vec<_>>()
-                .join("\n\n"),
-        ),
-        (
-            ContextBlockType::InstructionOverlay,
-            ContextBlockPriority::Critical,
-            "Project Instructions",
-            section("instruction"),
-        ),
         (
             ContextBlockType::SkillContext,
             ContextBlockPriority::High,
+            ContextBlockStability::RoundDynamic,
             "Loaded Skills",
             section("skill"),
         ),
         (
             ContextBlockType::EnvSnapshot,
             ContextBlockPriority::High,
+            ContextBlockStability::SessionStable,
             "Environment Snapshot",
             section("env"),
         ),
     ]
     .into_iter()
-    .filter(|(_, _, _, content)| !content.trim().is_empty())
-    .map(|(block_type, priority, title, content)| {
-        ContextBlock::new(
-            block_type,
-            priority,
-            ContextBlockStability::SessionStable,
-            title,
-            content,
-        )
+    .filter(|(_, _, _, _, content)| !content.trim().is_empty())
+    .map(|(block_type, priority, stability, title, content)| {
+        ContextBlock::new(block_type, priority, stability, title, content)
     })
     .for_each(|block| context_blocks.push(block));
+    if let Some(block) = build_workspace_context_block(session) {
+        context_blocks.push(block);
+    }
+    if let Some(block) = build_instruction_overlay_context_block(session) {
+        context_blocks.push(block);
+    }
 
     // The Responses-API view (instructions = stable system, guide leading the input
     // array) is no longer pre-baked here: the IR carries the system field + the
@@ -782,6 +753,15 @@ fn build_request_envelope_reconciled(
         cache: cache_plan,
         continuation: None,
     };
+
+    // Prefix-drift diagnostics must observe only bytes that actually participate
+    // in the cacheable head. Keeping dynamic assembly sections here would both
+    // report false cache drift and persist raw workspace paths in diagnostic
+    // snapshots.
+    let stable_prefix_sections = stable_prefix_sections
+        .into_iter()
+        .filter(|section| matches!(section.name, "base" | "core_directives" | "tool_guide"))
+        .collect();
 
     PreparedRequestEnvelope {
         ir,

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -1747,12 +1747,28 @@ fn build_request_envelope_relocates_session_context_after_tool_guide() {
     // system field and ride as a typed context-block message positioned AFTER the
     // large invariant tool guide — so it never shifts the cached head.
     let _env_lock = isolate_prompt_safe_env_cache();
+    let mut env_config = Config::default();
+    env_config.env_vars = vec![bamboo_config::EnvVarEntry {
+        name: "ENV_AUTHORITY_MARKER".to_string(),
+        value: "dynamic environment".to_string(),
+        secret: false,
+        value_encrypted: None,
+        credential_ref: None,
+        configured: true,
+        description: Some("authority-owned environment context".to_string()),
+    }];
+    env_config.publish_env_vars();
     let mut session = Session::new("session-sessionctx", "test-model");
     session.metadata.insert(
         "skill.context".to_string(),
         "SKILL_CONTEXT_MARKER loaded skill body".to_string(),
     );
     let mut config = test_config("BASE_SYSTEM_IDENTITY");
+    config.system_prompt = Some(format!(
+        "BASE_SYSTEM_IDENTITY\n\n{}\nSTALE_SYSTEM_ENV_MARKER\n{}",
+        crate::runtime::context::ENV_CONTEXT_START_MARKER,
+        crate::runtime::context::ENV_CONTEXT_END_MARKER,
+    ));
     config.mcp_tool_guidance = Some("NOVA_GUIDANCE_MARKER targeting workflow".to_string());
     let prepared_context = PreparedContext {
         messages: vec![Message::system("BASE_SYSTEM_IDENTITY"), Message::user("go")],
@@ -1771,6 +1787,7 @@ fn build_request_envelope_relocates_session_context_after_tool_guide() {
         !envelope.ir.system_text.contains("SKILL_CONTEXT_MARKER"),
         "session-variable skill context must leave the system prompt"
     );
+    assert!(!envelope.ir.system_text.contains("STALE_SYSTEM_ENV_MARKER"));
 
     // The immutable guide remains the stable prefix; mutable skill state is a
     // typed event in the chronological ledger.
@@ -1783,7 +1800,19 @@ fn build_request_envelope_relocates_session_context_after_tool_guide() {
     assert!(transcript[skill_pos]
         .content
         .contains("context_type: skill_context"));
+    assert!(transcript[skill_pos]
+        .content
+        .contains("scope: round_dynamic"));
     assert!(!transcript[skill_pos].never_compress);
+    let env = transcript
+        .iter()
+        .find(|message| message.content.contains("ENV_AUTHORITY_MARKER"))
+        .expect("environment context reconciled into the model transcript");
+    assert!(env.content.contains("context_type: env_snapshot"));
+    assert!(env.content.contains("scope: session_stable"));
+    assert!(!transcript
+        .iter()
+        .any(|message| message.content.contains("STALE_SYSTEM_ENV_MARKER")));
 
     // Provider lowering places the stable guide before the ledger event.
     let guide_pos = stable
@@ -1805,6 +1834,246 @@ fn build_request_envelope_relocates_session_context_after_tool_guide() {
         .messages
         .iter()
         .all(|message| !message.content.contains("BAMBOO_MODEL_CONTEXT_EVENT_START")));
+}
+
+fn workspace_session(id: &str, workspace: &std::path::Path) -> Session {
+    let mut session = Session::new(id, "test-model");
+    session.set_workspace_path_meta(bamboo_config::paths::path_to_display_string(workspace));
+    session.metadata.insert(
+        crate::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
+        crate::project_context::WorkspaceSource::Explicit
+            .as_str()
+            .to_string(),
+    );
+    session.metadata.insert(
+        crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY.to_string(),
+        crate::project_context::WorkspaceBindingStatus::Registered
+            .as_str()
+            .to_string(),
+    );
+    session
+}
+
+fn workspace_prepared_context() -> PreparedContext {
+    PreparedContext {
+        messages: vec![Message::system("BASE_IDENTITY"), Message::user("go")],
+        token_usage: usage(0, 24),
+        truncation_occurred: false,
+        segments_removed: 0,
+        compressed_message_ids: Vec::new(),
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+    }
+}
+
+#[test]
+fn openai_responses_places_one_workspace_block_after_stable_prefix() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::create_dir_all(workspace.path().join(".git")).expect("git marker");
+    std::fs::write(
+        workspace.path().join("AGENTS.md"),
+        "WORKSPACE_POLICY_MARKER",
+    )
+    .expect("workspace policy");
+    let workspace_path = bamboo_config::paths::path_to_display_string(workspace.path());
+    let session = workspace_session("workspace-openai", workspace.path());
+    let mut config = test_config("BASE_IDENTITY");
+    config.provider_type = Some("openai".to_string());
+    config.mcp_tool_guidance = Some("STABLE_GUIDE_MARKER".to_string());
+
+    let envelope =
+        super::build_request_envelope(&session, &workspace_prepared_context(), &config, &[]);
+    assert!(envelope.stable_prefix_sections.iter().all(|section| {
+        matches!(section.name, "base" | "core_directives" | "tool_guide")
+            && !section.content.contains(&workspace_path)
+    }));
+    let responses = envelope.ir.responses_request_options(None);
+    let instructions = responses.instructions.expect("Responses instructions");
+    assert!(!instructions.contains(&workspace_path));
+    assert!(!instructions.contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
+    let input = responses.input_messages.expect("Responses input");
+    assert_eq!(
+        input
+            .iter()
+            .filter(|message| message.content.contains("context_type: workspace"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        input
+            .iter()
+            .map(|message| message.content.matches(&workspace_path).count())
+            .sum::<usize>(),
+        1,
+        "the absolute active path appears only in the Workspace block"
+    );
+    let guide = input
+        .iter()
+        .position(|message| message.content.contains("STABLE_GUIDE_MARKER"))
+        .expect("stable guide");
+    let workspace_position = input
+        .iter()
+        .position(|message| message.content.contains("context_type: workspace"))
+        .expect("workspace block");
+    let conversation = input
+        .iter()
+        .position(|message| message.content == "go")
+        .expect("conversation");
+    assert!(guide < workspace_position && workspace_position < conversation);
+    let instruction = input
+        .iter()
+        .find(|message| message.content.contains("WORKSPACE_POLICY_MARKER"))
+        .expect("instruction overlay");
+    assert!(instruction.content.contains("Source: AGENTS.md"));
+    assert!(!instruction.content.contains(&workspace_path));
+}
+
+#[test]
+fn anthropic_body_places_workspace_after_stable_prefix_not_system() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let workspace = tempfile::tempdir().expect("workspace");
+    let workspace_path = bamboo_config::paths::path_to_display_string(workspace.path());
+    let session = workspace_session("workspace-anthropic", workspace.path());
+    let mut config = test_config("BASE_IDENTITY");
+    config.provider_type = Some("anthropic".to_string());
+    config.mcp_tool_guidance = Some("STABLE_GUIDE_MARKER".to_string());
+
+    let envelope =
+        super::build_request_envelope(&session, &workspace_prepared_context(), &config, &[]);
+    assert!(!envelope.ir.system_text.contains(&workspace_path));
+    assert!(!envelope
+        .ir
+        .system_text
+        .contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
+    let body = envelope.ir.body_chat();
+    assert_eq!(
+        body.iter()
+            .filter(|message| message.content.contains("context_type: workspace"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        body.iter()
+            .map(|message| message.content.matches(&workspace_path).count())
+            .sum::<usize>(),
+        1
+    );
+    let guide = body
+        .iter()
+        .position(|message| message.content.contains("STABLE_GUIDE_MARKER"))
+        .expect("stable guide");
+    let workspace_position = body
+        .iter()
+        .position(|message| message.content.contains("context_type: workspace"))
+        .expect("workspace block");
+    assert!(guide < workspace_position);
+}
+
+#[test]
+fn no_workspace_emits_no_workspace_context_block() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let session = Session::new("workspace-none", "test-model");
+    let envelope = super::build_request_envelope(
+        &session,
+        &workspace_prepared_context(),
+        &test_config("BASE_IDENTITY"),
+        &[],
+    );
+    assert!(envelope
+        .ir
+        .body_chat()
+        .iter()
+        .all(|message| !message.content.contains("context_type: workspace")));
+}
+
+#[test]
+fn workspace_switch_supersedes_dynamic_context_without_resetting_cache_prefix() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let first_workspace = tempfile::tempdir().expect("first workspace");
+    let second_workspace = tempfile::tempdir().expect("second workspace");
+    let first_path = bamboo_config::paths::path_to_display_string(first_workspace.path());
+    let second_path = bamboo_config::paths::path_to_display_string(second_workspace.path());
+    let mut session = workspace_session("workspace-switch", first_workspace.path());
+    let mut config = test_config("BASE_IDENTITY");
+    config.provider_type = Some("openai".to_string());
+    config.mcp_tool_guidance = Some("STABLE_GUIDE_MARKER".to_string());
+    let prepared = workspace_prepared_context();
+
+    let first = super::build_request_envelope_reconciled(
+        &mut session,
+        &prepared,
+        &config,
+        &[],
+        "test-model",
+    );
+    let first_cache_scope = session
+        .model_context_state
+        .as_ref()
+        .and_then(|state| state.cache_scope_sha256.clone())
+        .expect("first cache scope");
+    let first_state_revision = session
+        .model_context_state
+        .as_ref()
+        .map(|state| state.state_revision)
+        .expect("first state revision");
+    let first_next_sequence = session
+        .model_context_state
+        .as_ref()
+        .map(|state| state.next_sequence)
+        .expect("first context sequence");
+
+    session.set_workspace_path_meta(&second_path);
+    let switched = super::build_request_envelope_reconciled(
+        &mut session,
+        &prepared,
+        &config,
+        &[],
+        "test-model",
+    );
+    let state = session.model_context_state.as_ref().expect("context state");
+    let workspace_events = state
+        .events
+        .iter()
+        .filter(|event| event.block_type == bamboo_domain::ContextBlockType::Workspace)
+        .collect::<Vec<_>>();
+
+    assert_eq!(switched.ir.system_text, first.ir.system_text);
+    assert_eq!(
+        message_shape(switched.ir.run(bamboo_llm::SegmentRole::StablePrefix)),
+        message_shape(first.ir.run(bamboo_llm::SegmentRole::StablePrefix))
+    );
+    assert_eq!(switched.prefix_epoch, first.prefix_epoch);
+    assert!(switched.prefix_reset_reason.is_none());
+    assert_eq!(
+        state.cache_scope_sha256.as_deref(),
+        Some(first_cache_scope.as_str())
+    );
+    assert!(state.state_revision > first_state_revision);
+    assert!(state.next_sequence > first_next_sequence);
+    assert!(switched.ledger_changed);
+    assert_eq!(workspace_events.len(), 2);
+    assert_eq!(workspace_events[0].revision, 1);
+    assert_eq!(workspace_events[1].revision, 2);
+    assert_eq!(workspace_events[1].supersedes_revision, Some(1));
+    assert!(workspace_events[1].anchor_message_id.is_some());
+    assert!(workspace_events
+        .iter()
+        .all(|event| event.rendered_text.contains("scope: round_dynamic")));
+    assert_eq!(
+        switched
+            .ir
+            .body_chat()
+            .iter()
+            .map(|message| message.content.matches(&second_path).count())
+            .sum::<usize>(),
+        1
+    );
+    assert!(first
+        .ir
+        .body_chat()
+        .iter()
+        .any(|message| message.content.contains(&first_path)));
 }
 
 #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
@@ -197,17 +197,20 @@ fn persist_round_prompt_metadata(session: &mut Session, prompt: &str) {
                 .cloned()
                 .unwrap_or_default(),
             enhancement_prompt: session.enhance_prompt(),
-            project_context: super::session_setup::prompt_setup::extract_project_context(prompt),
-            workspace_context: session.workspace_path_meta().and_then(|workspace_path| {
-                crate::runtime::context::build_workspace_prompt_context(&workspace_path)
-            }),
+            project_context: session
+                .metadata
+                .get(crate::project_context::PROJECT_CONTEXT_RENDERED_KEY)
+                .cloned(),
+            workspace_context: super::session_setup::prompt_setup::workspace_context_from_session(
+                session,
+            ),
             instruction_context: session.workspace_path_meta().and_then(|workspace_path| {
                 crate::runtime::context::instruction::build_instruction_prompt_context(
                     &workspace_path,
                 )
             }),
-            env_context: None,
-            skill_context: None,
+            env_context: crate::runtime::context::build_env_prompt_context(),
+            skill_context: session.metadata.get("skill.context").cloned(),
             tool_guide_context: None,
             dream_notebook: None,
             session_memory_note: None,
@@ -374,7 +377,7 @@ mod project_prompt_tests {
     }
 
     #[tokio::test]
-    async fn per_round_resolution_injects_project_once_and_refreshes_only_workspace() {
+    async fn per_round_resolution_preserves_system_and_refreshes_workspace_metadata() {
         let directory = tempfile::tempdir().expect("tempdir");
         let first = directory.path().join("main");
         let second = directory.path().join("worktree");
@@ -413,45 +416,60 @@ mod project_prompt_tests {
         session.set_project_id_meta(project_id.to_string());
         session.set_workspace_path_meta(first.to_string_lossy().to_string());
         session.add_message(Message::system("Base"));
+        let system_id = session.messages[0].id.clone();
 
         super::refresh_project_context(&mut session, Some(&resolver))
             .await
             .expect("first Project refresh");
-        let first_prompt = session.messages[0].content.clone();
-        let project_block = first_prompt
-            .split(crate::runtime::context::PROJECT_CONTEXT_START_MARKER)
-            .nth(1)
-            .and_then(|tail| {
-                tail.split(crate::runtime::context::PROJECT_CONTEXT_END_MARKER)
-                    .next()
-            })
-            .expect("project body")
-            .to_string();
+        assert_eq!(session.messages[0].id, system_id);
+        assert_eq!(session.messages[0].content, "Base");
+        let project_context = session
+            .metadata
+            .get(crate::project_context::PROJECT_CONTEXT_RENDERED_KEY)
+            .expect("path-free Project model context")
+            .clone();
+        assert!(project_context.contains("Project ID: project-1"));
+        assert!(!project_context.contains(directory.path().to_string_lossy().as_ref()));
 
         session.set_workspace_path_meta(second.to_string_lossy().to_string());
         super::refresh_project_context(&mut session, Some(&resolver))
             .await
             .expect("second Project refresh");
-        let second_prompt = &session.messages[0].content;
-        assert_eq!(
-            second_prompt
-                .matches(crate::runtime::context::PROJECT_CONTEXT_START_MARKER)
-                .count(),
-            1
-        );
-        assert_eq!(
-            second_prompt
-                .matches(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER)
-                .count(),
-            1
-        );
-        assert!(second_prompt.contains(&project_block));
-        let second = bamboo_config::paths::path_to_display_string(
+        let second_workspace = bamboo_config::paths::path_to_display_string(
             &second.canonicalize().expect("canonical second workspace"),
         );
-        assert!(
-            second_prompt.contains(&format!("Workspace path: {second}")),
-            "second workspace was not refreshed in prompt: {second_prompt}"
+        assert_eq!(session.messages[0].id, system_id);
+        assert_eq!(session.messages[0].content, "Base");
+        assert_eq!(
+            session
+                .metadata
+                .get(crate::project_context::PROJECT_CONTEXT_RENDERED_KEY),
+            Some(&project_context)
+        );
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some(second_workspace.as_str())
+        );
+        assert!(session
+            .prompt_snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.workspace_context.as_deref())
+            .is_some_and(|context| context.contains(&second_workspace)));
+        assert!(session.messages.iter().all(|message| {
+            !message
+                .content
+                .contains(crate::runtime::context::PROJECT_CONTEXT_START_MARKER)
+                && !message
+                    .content
+                    .contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER)
+                && !message.content.contains(&second_workspace)
+        }));
+        assert_eq!(
+            session
+                .metadata
+                .get(crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(crate::project_context::WorkspaceBindingStatus::Unregistered.as_str())
         );
     }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
@@ -383,6 +383,8 @@ mod project_prompt_tests {
         let second = directory.path().join("worktree");
         std::fs::create_dir_all(&first).expect("first");
         std::fs::create_dir_all(&second).expect("second");
+        let first = first.canonicalize().expect("canonical first workspace");
+        let second = second.canonicalize().expect("canonical second workspace");
         let project_id = ProjectId::parse("project-1").expect("project id");
         let descriptor = ProjectDescriptor {
             id: project_id.clone(),
@@ -469,7 +471,7 @@ mod project_prompt_tests {
                 .metadata
                 .get(crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
                 .map(String::as_str),
-            Some(crate::project_context::WorkspaceBindingStatus::Unregistered.as_str())
+            Some(crate::project_context::WorkspaceBindingStatus::Registered.as_str())
         );
     }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
@@ -32,6 +32,10 @@ pub fn refresh_prompt_snapshot(session: &mut Session) {
     prompt_setup::refresh_prompt_snapshot_from_session(session)
 }
 
+pub(crate) fn migrate_legacy_workspace_prompt(session: &mut Session) -> bool {
+    prompt_setup::migrate_legacy_workspace_prompt(session)
+}
+
 async fn publish_pending_workflow_lifecycle_event(
     session: &mut Session,
     config: &AgentLoopConfig,
@@ -127,6 +131,9 @@ pub(crate) async fn prepare_session_for_loop(
     must_resume_pinned_activation: bool,
     event_tx: &tokio::sync::mpsc::Sender<AgentEvent>,
 ) -> super::Result<Option<TaskLoopContext>> {
+    // Resume compatibility: recover metadata before any workspace-scoped skill
+    // or instruction lookup, then permanently remove the legacy prompt marker.
+    migrate_legacy_workspace_prompt(session);
     publish_pending_workflow_lifecycle_event(session, config, event_tx).await?;
     let skill_result = match skill_context::load_skill_context(
         config,

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/prompt_envelope.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/prompt_envelope.rs
@@ -32,6 +32,47 @@ impl StablePromptFrame {
     }
 }
 
+/// Build the single provider-visible Workspace block from authoritative
+/// session metadata. Project identity is included only in its redacted,
+/// path-free form so the active workspace path appears exactly once.
+pub(crate) fn build_workspace_context_block(session: &Session) -> Option<ContextBlock> {
+    let workspace = super::prompt_setup::workspace_context_from_session(session)?;
+    let project = session
+        .metadata
+        .get(crate::project_context::PROJECT_CONTEXT_RENDERED_KEY)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let content = project
+        .into_iter()
+        .chain(std::iter::once(workspace.trim()))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    Some(ContextBlock::new(
+        ContextBlockType::Workspace,
+        ContextBlockPriority::High,
+        ContextBlockStability::RoundDynamic,
+        "Project & Workspace",
+        content,
+    ))
+}
+
+/// Build repository instructions from the authoritative workspace metadata,
+/// never from a marker parsed out of System text.
+pub(crate) fn build_instruction_overlay_context_block(session: &Session) -> Option<ContextBlock> {
+    let workspace = session.workspace_path_meta()?;
+    let content =
+        crate::runtime::context::instruction::build_instruction_prompt_context(workspace.trim())?;
+    Some(ContextBlock::new(
+        ContextBlockType::InstructionOverlay,
+        ContextBlockPriority::Critical,
+        ContextBlockStability::RoundDynamic,
+        "Project Instructions",
+        content,
+    ))
+}
+
 #[cfg(test)]
 pub(crate) fn render_context_block_message(block: &ContextBlock) -> Message {
     block.render_runtime_context_message()
@@ -328,6 +369,30 @@ mod tests {
         assert!(envelope.dynamic_context_messages[0]
             .content
             .contains("BAMBOO_CONTEXT_BLOCK_START"));
+    }
+
+    #[test]
+    fn workspace_block_uses_authoritative_path_once_and_path_free_project_metadata() {
+        let workspace = "/private/workspace/current";
+        let mut session = Session::new("session-workspace-block", "model");
+        session.set_workspace_path_meta(workspace);
+        session.metadata.insert(
+            crate::project_context::PROJECT_CONTEXT_RENDERED_KEY.to_string(),
+            format!(
+                "{}\nProject ID: project-1\nProject name: Zenith\n{}",
+                crate::runtime::context::PROJECT_CONTEXT_START_MARKER,
+                crate::runtime::context::PROJECT_CONTEXT_END_MARKER,
+            ),
+        );
+
+        let block = build_workspace_context_block(&session).expect("workspace block");
+
+        assert_eq!(block.block_type, ContextBlockType::Workspace);
+        assert_eq!(block.stability, ContextBlockStability::RoundDynamic);
+        assert_eq!(block.content.matches(workspace).count(), 1);
+        assert!(block.content.contains("Project ID: project-1"));
+        assert!(!block.content.contains("Project path:"));
+        assert!(!block.content.contains("Project home"));
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/prompt_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/prompt_setup.rs
@@ -13,7 +13,7 @@ use super::super::prompt_context::{
     append_core_agent_directives, merge_system_prompt_with_contexts,
     strip_existing_core_directives, strip_existing_external_memory, strip_existing_goal,
     strip_existing_plan_mode_instructions, strip_existing_plan_runtime_context,
-    strip_existing_task_list,
+    strip_existing_skill_context, strip_existing_task_list, strip_existing_tool_guide_context,
 };
 
 const RUNTIME_PROMPT_COMPOSER_VERSION: &str = "bamboo.runtime-system-prompt.v3";
@@ -268,19 +268,61 @@ pub(crate) fn resolve_base_prompt_for_language<'a>(
         .unwrap_or_default()
 }
 
-/// One labeled segment of the cacheable stable prefix, captured alongside the
-/// assembled frame purely for prompt-cache drift diagnostics. The segment order
-/// mirrors the order they are merged into `stable_instructions`.
+pub(crate) fn workspace_context_from_session(session: &Session) -> Option<String> {
+    let workspace_path = session
+        .workspace_path_meta()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())?;
+    let source = crate::project_context::WorkspaceSource::from_metadata(
+        session
+            .metadata
+            .get(crate::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+            .map(String::as_str),
+    );
+    let binding = crate::project_context::WorkspaceBindingStatus::from_metadata(
+        session
+            .metadata
+            .get(crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+            .map(String::as_str),
+    );
+    crate::runtime::context::build_workspace_prompt_context_with_binding_and_source(
+        &workspace_path,
+        binding,
+        Some(source),
+    )
+}
+
+fn project_context_from_session(session: &Session) -> Option<String> {
+    session
+        .metadata
+        .get(crate::project_context::PROJECT_CONTEXT_RENDERED_KEY)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn instruction_context_from_session(session: &Session) -> Option<String> {
+    session
+        .workspace_path_meta()
+        .as_deref()
+        .and_then(crate::runtime::context::instruction::build_instruction_prompt_context)
+}
+
+/// One labeled assembly segment captured alongside the stable frame.
+///
+/// The runner relocates session-variable segments into typed context blocks and
+/// retains only the actual cacheable segments for prefix-drift diagnostics.
 #[derive(Debug, Clone)]
 pub(crate) struct StablePrefixSection {
     pub name: &'static str,
     pub content: String,
 }
 
-/// Build the cacheable stable prompt frame and the per-section breakdown of the
-/// prefix, so callers can diff which section changed between rounds without
-/// re-deriving the contexts. The section order mirrors the merge order in
-/// `stable_instructions`.
+/// Build the invariant prompt frame plus the per-section material used by the
+/// typed request assembler. `StablePromptFrame::stable_instructions` contains
+/// only base identity and core directives; mutable project/workspace/instruction
+/// material never enters that string, even as an intermediate representation.
 pub(crate) fn build_stable_prompt_frame_with_sections(
     session: &Session,
     config: &AgentLoopConfig,
@@ -288,20 +330,15 @@ pub(crate) fn build_stable_prompt_frame_with_sections(
     activated_discoverable_tools: &BTreeSet<String>,
 ) -> (StablePromptFrame, Vec<StablePrefixSection>) {
     let raw_base_prompt = resolve_base_prompt_for_language(config, session).to_string();
-    let project_context = extract_project_context(&raw_base_prompt);
-    let workspace_context = extract_workspace_context(&raw_base_prompt);
-    let instruction_context = workspace_context
-        .as_deref()
-        .and_then(workspace_path_from_context)
-        .and_then(crate::runtime::context::instruction::build_instruction_prompt_context);
-    let env_context = extract_env_context(&raw_base_prompt)
-        .or_else(crate::runtime::context::build_env_prompt_context);
+    let project_context = project_context_from_session(session);
+    let workspace_context = workspace_context_from_session(session);
+    let instruction_context = instruction_context_from_session(session);
+    let env_context = crate::runtime::context::build_env_prompt_context();
     // Base identity and the framework-invariant operating directives are kept as
     // SEPARATE structured sections (`base` / `core_directives`) so downstream
     // assembly can emit them as discrete content blocks instead of one glued
-    // string. `base_prompt` (the two folded together, the way it shipped before)
-    // is still produced for the legacy `stable_instructions` string consumed by
-    // the non-relocate fallback path.
+    // string. Their folded form is the only content allowed in the legacy
+    // `stable_instructions` compatibility field.
     let base_only = normalize_base_prompt(&raw_base_prompt);
     let core_directives = crate::runtime::context::CORE_AGENT_DIRECTIVES.to_string();
     let base_prompt = append_core_agent_directives(&base_only, &core_directives);
@@ -320,15 +357,7 @@ pub(crate) fn build_stable_prompt_frame_with_sections(
         activated_discoverable_tools,
     );
 
-    let stable_instructions = merge_with_optional_contexts(
-        &base_prompt,
-        project_context.as_deref(),
-        workspace_context.as_deref(),
-        instruction_context.as_deref(),
-        env_context.as_deref(),
-        skill_context,
-        &tool_guide_context,
-    );
+    let stable_instructions = base_prompt;
 
     let sections = vec![
         StablePrefixSection {
@@ -413,88 +442,52 @@ pub(crate) fn apply_system_prompt_contexts(
     skill_context: &str,
     tool_guide_context: &str,
 ) -> PromptAssemblyReport {
-    let (
-        base_prompt,
-        project_context,
-        workspace_context,
-        instruction_context,
-        env_context,
-        merged_prompt,
-    ) = if let Some(system_message) = session
+    migrate_legacy_workspace_prompt(session);
+    let raw_base_prompt = config
+        .system_prompt
+        .clone()
+        .or_else(|| {
+            session
+                .messages
+                .iter()
+                .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+                .map(|message| message.content.clone())
+        })
+        .unwrap_or_default();
+    let project_context = project_context_from_session(session);
+    let workspace_context = workspace_context_from_session(session);
+    let instruction_context = instruction_context_from_session(session);
+    let env_context = crate::runtime::context::build_env_prompt_context();
+    let base_prompt = normalize_base_prompt(&raw_base_prompt);
+
+    // Workspace, Project identity, and repository instructions are model-context
+    // blocks. They are reported in the structured snapshot below but never
+    // persisted back into System text.
+    // Dynamic assembly inputs live in the typed snapshot/ledger, never in the
+    // persisted System message. Preserve the loaded skill body under its
+    // existing metadata authority so the round assembler can build a typed
+    // SkillContext block after this setup phase.
+    if skill_context.trim().is_empty() {
+        session.metadata.remove("skill.context");
+    } else {
+        session
+            .metadata
+            .insert("skill.context".to_string(), skill_context.to_string());
+    }
+    let merged_prompt = base_prompt.clone();
+    if let Some(system_message) = session
         .messages
         .iter_mut()
         .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
     {
-        let raw_base_prompt = config
-            .system_prompt
-            .as_deref()
-            .unwrap_or(&system_message.content)
-            .to_string();
-        let project_context = extract_project_context(&raw_base_prompt);
-        let workspace_context = extract_workspace_context(&raw_base_prompt);
-        let instruction_context = workspace_context
-            .as_deref()
-            .and_then(workspace_path_from_context)
-            .and_then(crate::runtime::context::instruction::build_instruction_prompt_context);
-        let env_context = extract_env_context(&raw_base_prompt)
-            .or_else(crate::runtime::context::build_env_prompt_context);
-        let base_prompt = normalize_base_prompt(&raw_base_prompt);
-        let merged_prompt = merge_with_optional_contexts(
-            &base_prompt,
-            project_context.as_deref(),
-            workspace_context.as_deref(),
-            instruction_context.as_deref(),
-            env_context.as_deref(),
-            skill_context,
-            tool_guide_context,
-        );
-        system_message.content = merged_prompt.clone();
-        (
-            base_prompt,
-            project_context,
-            workspace_context,
-            instruction_context,
-            env_context,
-            merged_prompt,
-        )
-    } else {
-        let raw_base_prompt = config
-            .system_prompt
-            .as_deref()
-            .unwrap_or_default()
-            .to_string();
-        let project_context = extract_project_context(&raw_base_prompt);
-        let workspace_context = extract_workspace_context(&raw_base_prompt);
-        let instruction_context = workspace_context
-            .as_deref()
-            .and_then(workspace_path_from_context)
-            .and_then(crate::runtime::context::instruction::build_instruction_prompt_context);
-        let env_context = extract_env_context(&raw_base_prompt)
-            .or_else(crate::runtime::context::build_env_prompt_context);
-        let base_prompt = normalize_base_prompt(&raw_base_prompt);
-        let merged_prompt = merge_with_optional_contexts(
-            &base_prompt,
-            project_context.as_deref(),
-            workspace_context.as_deref(),
-            instruction_context.as_deref(),
-            env_context.as_deref(),
-            skill_context,
-            tool_guide_context,
-        );
-        if !merged_prompt.is_empty() {
-            session
-                .messages
-                .insert(0, Message::system(merged_prompt.clone()));
+        if system_message.content != merged_prompt {
+            system_message.content = merged_prompt.clone();
         }
-        (
-            base_prompt,
-            project_context,
-            workspace_context,
-            instruction_context,
-            env_context,
-            merged_prompt,
-        )
-    };
+    } else if !merged_prompt.is_empty() {
+        session
+            .messages
+            .insert(0, Message::system(merged_prompt.clone()));
+    }
 
     let sections = build_prompt_sections(
         base_prompt.as_str(),
@@ -541,6 +534,7 @@ fn read_prompt_memory_observability(session: &Session) -> Option<PromptMemoryObs
 }
 
 pub fn refresh_prompt_snapshot_from_session(session: &mut Session) {
+    migrate_legacy_workspace_prompt(session);
     let effective_system_prompt = session
         .messages
         .iter()
@@ -549,42 +543,11 @@ pub fn refresh_prompt_snapshot_from_session(session: &mut Session) {
         .filter(|value| !value.is_empty())
         .unwrap_or_default();
 
-    let project_context = extract_project_context(&effective_system_prompt);
-    let persisted_workspace = session.metadata.get("workspace_path").map(String::as_str);
-    let extracted_workspace_context = extract_workspace_context(&effective_system_prompt);
-    let workspace_context = match persisted_workspace {
-        Some(workspace_path)
-            if extracted_workspace_context
-                .as_deref()
-                .and_then(workspace_path_from_context)
-                == Some(workspace_path) =>
-        {
-            extracted_workspace_context
-        }
-        Some(workspace_path) => {
-            crate::runtime::context::build_workspace_prompt_context(workspace_path)
-        }
-        None => extracted_workspace_context,
-    };
-    let instruction_context = session
-        .metadata
-        .get("workspace_path")
-        .and_then(|workspace_path| {
-            crate::runtime::context::instruction::build_instruction_prompt_context(workspace_path)
-        })
-        .or_else(|| {
-            workspace_context
-                .as_deref()
-                .and_then(workspace_path_from_context)
-                .and_then(crate::runtime::context::instruction::build_instruction_prompt_context)
-        });
-    let env_context = extract_env_context(&effective_system_prompt)
-        .or_else(crate::runtime::context::build_env_prompt_context);
-    let skill_context = extract_wrapped_section(
-        &effective_system_prompt,
-        "<!-- BAMBOO_SKILL_CONTEXT_START -->",
-        "<!-- BAMBOO_SKILL_CONTEXT_END -->",
-    );
+    let project_context = project_context_from_session(session);
+    let workspace_context = workspace_context_from_session(session);
+    let instruction_context = instruction_context_from_session(session);
+    let env_context = crate::runtime::context::build_env_prompt_context();
+    let skill_context = session.metadata.get("skill.context").cloned();
     let tool_guide_context = extract_wrapped_section(
         &effective_system_prompt,
         "<!-- BAMBOO_TOOL_GUIDE_START -->",
@@ -703,10 +666,80 @@ fn build_prompt_sections(
     ]
 }
 
-fn normalize_base_prompt(prompt: &str) -> String {
+/// Recover a legacy persisted workspace marker once, then remove legacy
+/// host-owned sections from every persisted System message.
+///
+/// Existing metadata always wins. Marker parsing exists only at this migration
+/// boundary and is never used by normal round assembly.
+pub(crate) fn migrate_legacy_workspace_prompt(session: &mut Session) -> bool {
+    let authoritative_path = session
+        .workspace_path_meta()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let mut recovered_path = None;
+    let mut changed = false;
+
+    for message in session
+        .messages
+        .iter_mut()
+        .filter(|message| matches!(message.role, bamboo_agent_core::Role::System))
+    {
+        if authoritative_path.is_none() && recovered_path.is_none() {
+            recovered_path = extract_workspace_context(&message.content)
+                .as_deref()
+                .and_then(workspace_path_from_context)
+                .map(ToString::to_string);
+        }
+        let without_project = strip_project_context(&message.content);
+        let without_workspace = strip_workspace_context(&without_project);
+        let without_instruction = strip_all_instruction_context(&without_workspace);
+        let without_env = strip_env_context(&without_instruction);
+        let without_skill = strip_existing_skill_context(&without_env);
+        let cleaned = strip_existing_tool_guide_context(&without_skill);
+        if cleaned != message.content {
+            message.content = cleaned;
+            changed = true;
+        }
+    }
+
+    if changed {
+        session.messages.retain(|message| {
+            !matches!(message.role, bamboo_agent_core::Role::System)
+                || !message.content.trim().is_empty()
+        });
+        session.prompt_snapshot = None;
+        session.metadata.remove(RUNTIME_PROMPT_SNAPSHOT_KEY);
+    }
+
+    if authoritative_path.is_none() {
+        if let Some(path) = recovered_path
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+        {
+            session.set_workspace_path_meta(path);
+            session.metadata.insert(
+                crate::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
+                crate::project_context::WorkspaceSource::Session
+                    .as_str()
+                    .to_string(),
+            );
+            session.metadata.insert(
+                crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY.to_string(),
+                crate::project_context::WorkspaceBindingStatus::Unregistered
+                    .as_str()
+                    .to_string(),
+            );
+            changed = true;
+        }
+    }
+
+    changed
+}
+
+pub(crate) fn normalize_base_prompt(prompt: &str) -> String {
     let without_project = strip_project_context(prompt);
     let without_workspace = strip_workspace_context(&without_project);
-    let without_instruction = strip_instruction_context(&without_workspace);
+    let without_instruction = strip_all_instruction_context(&without_workspace);
     let without_env = strip_env_context(&without_instruction);
     let without_external_memory = strip_existing_external_memory(&without_env);
     let without_task_list = strip_existing_task_list(&without_external_memory);
@@ -716,52 +749,14 @@ fn normalize_base_prompt(prompt: &str) -> String {
     // field. Strip any goal left in a legacy persisted System message so it can't
     // re-leak into the cached `base` block (the goal-leak fix).
     let without_goal = strip_existing_goal(&without_plan_runtime);
+    let without_skill = strip_existing_skill_context(&without_goal);
+    let without_tool_guide = strip_existing_tool_guide_context(&without_skill);
     // Strip framework directives too, so normalize yields a clean base uniformly
     // with every other framework-injected section. They are re-added (idempotent)
     // by `append_core_agent_directives` during assembly; stripping here keeps a
     // clean base even if directives ever leak into a persisted System message.
-    let without_directives = strip_existing_core_directives(&without_goal);
+    let without_directives = strip_existing_core_directives(&without_tool_guide);
     merge_system_prompt_with_contexts(&without_directives, "", "")
-}
-
-pub(crate) fn merge_with_optional_contexts(
-    base_prompt: &str,
-    project_context: Option<&str>,
-    workspace_context: Option<&str>,
-    instruction_context: Option<&str>,
-    env_context: Option<&str>,
-    skill_context: &str,
-    tool_guide_context: &str,
-) -> String {
-    let merged = merge_system_prompt_with_contexts(base_prompt, skill_context, tool_guide_context);
-    let mut sections = Vec::new();
-    if let Some(project_context) = project_context
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        sections.push(project_context.to_string());
-    }
-    if let Some(workspace_context) = workspace_context
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        sections.push(workspace_context.to_string());
-    }
-    if let Some(instruction_context) = instruction_context
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        sections.push(instruction_context.to_string());
-    }
-    if let Some(env_context) = env_context.map(str::trim).filter(|value| !value.is_empty()) {
-        sections.push(env_context.to_string());
-    }
-
-    if sections.is_empty() {
-        merged
-    } else {
-        format!("{}\n\n{}", merged.trim_end(), sections.join("\n\n"))
-    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -807,14 +802,6 @@ fn derive_enhancement_prompt(
     }
 }
 
-pub(crate) fn extract_project_context(prompt: &str) -> Option<String> {
-    extract_wrapped_section(
-        prompt,
-        PROJECT_CONTEXT_START_MARKER,
-        PROJECT_CONTEXT_END_MARKER,
-    )
-}
-
 fn extract_workspace_context(prompt: &str) -> Option<String> {
     extract_wrapped_section(
         prompt,
@@ -824,28 +811,72 @@ fn extract_workspace_context(prompt: &str) -> Option<String> {
     .or_else(|| extract_legacy_workspace_context(prompt))
 }
 
-fn extract_env_context(prompt: &str) -> Option<String> {
-    extract_wrapped_section(prompt, ENV_CONTEXT_START_MARKER, ENV_CONTEXT_END_MARKER)
-}
-
 fn strip_workspace_context(prompt: &str) -> String {
-    strip_wrapped_section(
-        prompt,
+    let had_generated_workspace = prompt.contains(WORKSPACE_CONTEXT_START_MARKER)
+        || prompt.contains(WORKSPACE_CONTEXT_PREFIX);
+    let mut current = prompt.trim().to_string();
+    while let Some(stripped) = strip_wrapped_section(
+        &current,
         WORKSPACE_CONTEXT_START_MARKER,
         WORKSPACE_CONTEXT_END_MARKER,
-    )
-    .map(|stripped| stripped.trim().to_string())
-    .unwrap_or_else(|| strip_legacy_workspace_context(prompt).trim().to_string())
+    ) {
+        if stripped == current {
+            break;
+        }
+        current = stripped.trim().to_string();
+    }
+    loop {
+        let stripped = strip_legacy_workspace_context(&current).trim().to_string();
+        if stripped == current {
+            break;
+        }
+        current = stripped;
+    }
+    if had_generated_workspace {
+        current = strip_exact_generated_section(
+            &current,
+            &crate::runtime::context::workspace_prompt_guidance(),
+        );
+    }
+    current
+}
+
+fn strip_exact_generated_section(prompt: &str, section: &str) -> String {
+    let mut current = prompt.trim().to_string();
+    let section = section.trim();
+    if section.is_empty() {
+        return current;
+    }
+    while let Some(start_idx) = current.find(section) {
+        let end_idx = start_idx + section.len();
+        let before = current[..start_idx].trim_end();
+        let after = current[end_idx..].trim_start();
+        current = match (before.is_empty(), after.is_empty()) {
+            (true, true) => String::new(),
+            (true, false) => after.to_string(),
+            (false, true) => before.to_string(),
+            (false, false) => format!("{before}\n\n{after}"),
+        };
+    }
+    current
 }
 
 fn strip_project_context(prompt: &str) -> String {
-    strip_wrapped_section(
-        prompt,
-        PROJECT_CONTEXT_START_MARKER,
-        PROJECT_CONTEXT_END_MARKER,
-    )
-    .map(|stripped| stripped.trim().to_string())
-    .unwrap_or_else(|| prompt.trim().to_string())
+    let mut current = prompt.trim().to_string();
+    loop {
+        let Some(stripped) = strip_wrapped_section(
+            &current,
+            PROJECT_CONTEXT_START_MARKER,
+            PROJECT_CONTEXT_END_MARKER,
+        ) else {
+            return current;
+        };
+        let stripped = stripped.trim().to_string();
+        if stripped == current {
+            return current;
+        }
+        current = stripped;
+    }
 }
 
 fn strip_instruction_context(prompt: &str) -> String {
@@ -858,10 +889,31 @@ fn strip_instruction_context(prompt: &str) -> String {
     .unwrap_or_else(|| prompt.trim().to_string())
 }
 
+fn strip_all_instruction_context(prompt: &str) -> String {
+    let mut current = prompt.trim().to_string();
+    loop {
+        let stripped = strip_instruction_context(&current);
+        if stripped == current {
+            return current;
+        }
+        current = stripped;
+    }
+}
+
 fn strip_env_context(prompt: &str) -> String {
-    strip_wrapped_section(prompt, ENV_CONTEXT_START_MARKER, ENV_CONTEXT_END_MARKER)
-        .map(|stripped| stripped.trim().to_string())
-        .unwrap_or_else(|| prompt.trim().to_string())
+    let mut current = prompt.trim().to_string();
+    loop {
+        let Some(stripped) =
+            strip_wrapped_section(&current, ENV_CONTEXT_START_MARKER, ENV_CONTEXT_END_MARKER)
+        else {
+            return current;
+        };
+        let stripped = stripped.trim().to_string();
+        if stripped == current {
+            return current;
+        }
+        current = stripped;
+    }
 }
 
 fn workspace_path_from_context(context: &str) -> Option<&str> {

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/prompt_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/prompt_setup.rs
@@ -813,7 +813,7 @@ fn extract_workspace_context(prompt: &str) -> Option<String> {
 
 fn strip_workspace_context(prompt: &str) -> String {
     let had_generated_workspace = prompt.contains(WORKSPACE_CONTEXT_START_MARKER)
-        || prompt.contains(WORKSPACE_CONTEXT_PREFIX);
+        || crate::runtime::context::legacy_unwrapped_workspace_context_bounds(prompt).is_some();
     let mut current = prompt.trim().to_string();
     while let Some(stripped) = strip_wrapped_section(
         &current,
@@ -951,25 +951,18 @@ fn strip_wrapped_section(prompt: &str, start_marker: &str, end_marker: &str) -> 
 }
 
 fn extract_legacy_workspace_context(prompt: &str) -> Option<String> {
-    let start_idx = prompt.find(WORKSPACE_CONTEXT_PREFIX)?;
-    let guidance = crate::runtime::context::workspace_prompt_guidance();
-    let end_idx = prompt[start_idx..]
-        .find(&guidance)
-        .map(|guidance_rel_idx| start_idx + guidance_rel_idx + guidance.len())
-        .unwrap_or(prompt.len());
+    let (start_idx, end_idx) =
+        crate::runtime::context::legacy_unwrapped_workspace_context_bounds(prompt)?;
     let section = prompt[start_idx..end_idx].trim();
     (!section.is_empty()).then(|| section.to_string())
 }
 
 fn strip_legacy_workspace_context(prompt: &str) -> String {
-    let Some(start_idx) = prompt.find(WORKSPACE_CONTEXT_PREFIX) else {
+    let Some((start_idx, end_idx)) =
+        crate::runtime::context::legacy_unwrapped_workspace_context_bounds(prompt)
+    else {
         return prompt.to_string();
     };
-    let guidance = crate::runtime::context::workspace_prompt_guidance();
-    let end_idx = prompt[start_idx..]
-        .find(&guidance)
-        .map(|guidance_rel_idx| start_idx + guidance_rel_idx + guidance.len())
-        .unwrap_or(prompt.len());
 
     let before = prompt[..start_idx].trim_end();
     let after = prompt[end_idx..].trim_start();

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -522,16 +522,18 @@ async fn session_setup_requires_model_issued_load_for_one_explicit_skill() {
     assert!(!session
         .metadata
         .contains_key("skill_runtime_loaded_skill_ids"));
-    let system_prompt = session
-        .messages
-        .iter()
-        .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
-        .expect("system prompt")
-        .content
-        .as_str();
-    assert!(system_prompt.contains("## Required Explicit Workflow Activation"));
-    assert!(system_prompt.contains("first response step MUST be exactly one `load_skill` call"));
-    assert!(system_prompt.contains("review"));
+    let skill_context = session
+        .metadata
+        .get("skill.context")
+        .expect("required activation context");
+    assert!(skill_context.contains("## Required Explicit Workflow Activation"));
+    assert!(skill_context.contains("first response step MUST be exactly one `load_skill` call"));
+    assert!(skill_context.contains("review"));
+    assert!(session.messages.iter().all(|message| {
+        !message
+            .content
+            .contains("## Required Explicit Workflow Activation")
+    }));
 
     let saved = persistence.sessions.lock().expect("recording lock");
     assert!(saved.iter().all(|saved_session| !saved_session
@@ -603,18 +605,20 @@ async fn permission_style_second_prepare_preserves_unchanged_explicit_activation
         Some("[\"review\"]")
     );
     assert!(!super::skill_context::explicit_activation_pending(&session));
-    let system_prompt = session
-        .messages
-        .iter()
-        .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
-        .expect("system prompt")
-        .content
-        .as_str();
-    assert!(!system_prompt.contains("## Required Explicit Workflow Activation"));
-    assert!(system_prompt.contains("## Explicit Workflow Already Activated"));
+    let skill_context = session
+        .metadata
+        .get("skill.context")
+        .expect("restored activation context");
+    assert!(!skill_context.contains("## Required Explicit Workflow Activation"));
+    assert!(skill_context.contains("## Explicit Workflow Already Activated"));
     assert!(
-        system_prompt.contains("Do not call `load_skill` again solely because execution resumed")
+        skill_context.contains("Do not call `load_skill` again solely because execution resumed")
     );
+    assert!(session.messages.iter().all(|message| {
+        !message
+            .content
+            .contains("## Explicit Workflow Already Activated")
+    }));
     assert!(tools.calls.lock().expect("recording tool lock").is_empty());
 }
 
@@ -1392,6 +1396,119 @@ fn apply_system_prompt_contexts_persists_shared_prompt_snapshot() {
 }
 
 #[test]
+fn legacy_workspace_prompt_migration_recovers_metadata_and_strips_derived_sections_once() {
+    let legacy_project = format!(
+        "{}\nProject ID: legacy-project\nProject path: /legacy/workspace\nProject home: /private/project-home\n{}",
+        crate::runtime::context::PROJECT_CONTEXT_START_MARKER,
+        crate::runtime::context::PROJECT_CONTEXT_END_MARKER,
+    );
+    let legacy_workspace =
+        crate::runtime::context::build_workspace_prompt_context("/legacy/workspace")
+            .expect("legacy workspace block");
+    let legacy_instruction = format!(
+        "{}\nlegacy policy\n{}",
+        crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER,
+        crate::runtime::context::instruction::INSTRUCTION_CONTEXT_END_MARKER,
+    );
+    let legacy_env = format!(
+        "{}\nlegacy env /private/env-path\n{}",
+        crate::runtime::context::ENV_CONTEXT_START_MARKER,
+        crate::runtime::context::ENV_CONTEXT_END_MARKER,
+    );
+    let legacy_skill = "<!-- BAMBOO_SKILL_CONTEXT_START -->\nlegacy skill /private/skill-path\n<!-- BAMBOO_SKILL_CONTEXT_END -->";
+    let legacy_tool_guide = "<!-- BAMBOO_TOOL_GUIDE_START -->\nlegacy guide /private/tool-path\n<!-- BAMBOO_TOOL_GUIDE_END -->";
+    let mut session = Session::new("legacy-workspace-migration", "model");
+    session.add_message(Message::system(format!(
+        "Base prompt\n\n{legacy_project}\n\n{legacy_workspace}\n\n{legacy_instruction}\n\n{legacy_env}\n\n{legacy_skill}\n\n{legacy_tool_guide}"
+    )));
+
+    assert!(super::prompt_setup::migrate_legacy_workspace_prompt(
+        &mut session
+    ));
+    assert_eq!(
+        session.workspace_path_meta().as_deref(),
+        Some("/legacy/workspace")
+    );
+    assert_eq!(session.messages.len(), 1);
+    assert_eq!(session.messages[0].content, "Base prompt");
+    assert!(!session.messages[0]
+        .content
+        .contains(crate::runtime::context::PROJECT_CONTEXT_START_MARKER));
+    for marker in [
+        crate::runtime::context::PROJECT_CONTEXT_START_MARKER,
+        crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER,
+        crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER,
+        crate::runtime::context::ENV_CONTEXT_START_MARKER,
+        "<!-- BAMBOO_SKILL_CONTEXT_START -->",
+        "<!-- BAMBOO_TOOL_GUIDE_START -->",
+    ] {
+        assert!(!session.messages[0].content.contains(marker));
+    }
+    assert!(!session.messages[0]
+        .content
+        .contains(crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER));
+    assert!(!session.messages[0].content.contains("/legacy/workspace"));
+    assert!(!session.messages[0]
+        .content
+        .contains("/private/project-home"));
+    assert!(!session.messages[0].content.contains("/private/env-path"));
+    assert!(!session.messages[0].content.contains("/private/skill-path"));
+    assert!(!session.messages[0].content.contains("/private/tool-path"));
+    assert!(!super::prompt_setup::migrate_legacy_workspace_prompt(
+        &mut session
+    ));
+}
+
+#[test]
+fn legacy_workspace_prompt_migration_preserves_authoritative_metadata() {
+    let stale = crate::runtime::context::build_workspace_prompt_context("/stale/workspace")
+        .expect("stale workspace block");
+    let mut session = Session::new("legacy-workspace-authority", "model");
+    session.set_workspace_path_meta("/authoritative/workspace");
+    session.add_message(Message::system(format!("Base prompt\n\n{stale}")));
+
+    assert!(super::prompt_setup::migrate_legacy_workspace_prompt(
+        &mut session
+    ));
+    assert_eq!(
+        session.workspace_path_meta().as_deref(),
+        Some("/authoritative/workspace")
+    );
+    assert_eq!(session.messages[0].content, "Base prompt");
+}
+
+#[test]
+fn normalize_base_prompt_strips_repeated_instruction_and_environment_sections() {
+    let instruction = |path: &str| {
+        format!(
+            "{}\n## AGENTS.md\nSource: {path}\nlegacy policy\n{}",
+            crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER,
+            crate::runtime::context::instruction::INSTRUCTION_CONTEXT_END_MARKER,
+        )
+    };
+    let prompt = format!(
+        "Base prompt\n\n{}\n\n{}\n\n{}\nenv one\n{}\n\n{}\nenv two\n{}",
+        instruction("/private/workspace-one/AGENTS.md"),
+        instruction("/private/workspace-two/AGENTS.md"),
+        crate::runtime::context::ENV_CONTEXT_START_MARKER,
+        crate::runtime::context::ENV_CONTEXT_END_MARKER,
+        crate::runtime::context::ENV_CONTEXT_START_MARKER,
+        crate::runtime::context::ENV_CONTEXT_END_MARKER,
+    );
+
+    let normalized = super::prompt_setup::normalize_base_prompt(&prompt);
+
+    assert_eq!(normalized, "Base prompt");
+    assert!(!normalized.contains("/private/workspace-one"));
+    assert!(!normalized.contains("/private/workspace-two"));
+    assert!(!normalized.contains("env one"));
+    assert!(!normalized.contains("env two"));
+    assert!(!normalized
+        .contains(crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER));
+    assert!(!normalized.contains(crate::runtime::context::ENV_CONTEXT_START_MARKER));
+}
+
+#[test]
 fn refresh_prompt_snapshot_from_session_preserves_multi_topic_memory_split_fields() {
     let mut session = Session::new("snapshot-memory-topics", "gpt-test");
     session
@@ -1614,6 +1731,27 @@ fn apply_system_prompt_contexts_persists_runtime_prompt_metadata() {
     assert!(session
         .metadata
         .contains_key("runtime_prompt_section_layout"));
+    assert_eq!(session.messages.len(), 1);
+    assert_eq!(session.messages[0].content, "Base prompt");
+    assert_eq!(
+        session.metadata.get("skill.context").map(String::as_str),
+        Some(skill_context)
+    );
+    for marker in [
+        crate::runtime::context::PROJECT_CONTEXT_START_MARKER,
+        crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER,
+        crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER,
+        crate::runtime::context::ENV_CONTEXT_START_MARKER,
+        "<!-- BAMBOO_SKILL_CONTEXT_START -->",
+        "<!-- BAMBOO_TOOL_GUIDE_START -->",
+    ] {
+        assert!(!session.messages[0].content.contains(marker));
+    }
+    assert!(!session.messages[0]
+        .content
+        .contains(workspace.to_string_lossy().as_ref()));
+    assert!(!session.messages[0].content.contains("Skill details"));
+    assert!(!session.messages[0].content.contains("Guide details"));
 
     let base_prompt = report
         .section("base_prompt")
@@ -1756,7 +1894,7 @@ fn prompt_assembly_report_component_values_match_sections() {
 }
 
 #[test]
-fn build_stable_prompt_frame_includes_base_and_stable_contexts() {
+fn build_stable_prompt_frame_contains_only_invariant_system_content() {
     let _lock = crate::runtime::tests::env_cache_lock_acquire();
     let mut config_with_env = bamboo_llm::Config::default();
     config_with_env.env_vars = vec![bamboo_config::EnvVarEntry {
@@ -1784,6 +1922,7 @@ fn build_stable_prompt_frame_includes_base_and_stable_contexts() {
         ..Default::default()
     };
     let mut session = Session::new("session-stable-frame-1", "model");
+    session.set_workspace_path_meta(workspace.to_string_lossy().into_owned());
     session.metadata.insert(
         "skill.context".to_string(),
         "## Skill\nUse the skill".to_string(),
@@ -1798,10 +1937,23 @@ fn build_stable_prompt_frame_includes_base_and_stable_contexts() {
     .0;
 
     assert!(stable.stable_instructions.contains("Base system"));
-    assert!(stable.stable_instructions.contains("Workspace path:"));
-    assert!(stable
+    assert!(!stable.stable_instructions.contains("Workspace path:"));
+    assert!(!stable
+        .stable_instructions
+        .contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
+    assert!(!stable
+        .stable_instructions
+        .contains(crate::runtime::context::PROJECT_CONTEXT_START_MARKER));
+    assert!(!stable
+        .stable_instructions
+        .contains(crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER));
+    assert!(!stable
         .stable_instructions
         .contains("environment variables were explicitly configured by the user inside Bodhi"));
+    assert!(!stable.stable_instructions.contains("## Skill"));
+    assert!(!stable
+        .stable_instructions
+        .contains("BAMBOO_TOOL_GUIDE_START"));
     // Framework-invariant directives ride on top of even a fully custom override
     // base (`config.system_prompt`), so they are present regardless of the user's
     // base prompt.
@@ -1829,6 +1981,7 @@ fn build_stable_prompt_frame_strips_round_dynamic_prompt_blocks() {
         ..Default::default()
     };
     let mut session = Session::new("session-stable-frame-2", "model");
+    session.set_workspace_path_meta(workspace.to_string_lossy().into_owned());
     session.metadata.insert(
         "skill.context".to_string(),
         "## Skill\nUse the skill".to_string(),
@@ -1860,7 +2013,13 @@ fn build_stable_prompt_frame_strips_round_dynamic_prompt_blocks() {
     .0;
 
     assert!(stable.stable_instructions.contains("Base system"));
-    assert!(stable.stable_instructions.contains("Workspace path:"));
+    assert!(!stable.stable_instructions.contains("Workspace path:"));
+    assert!(!stable
+        .stable_instructions
+        .contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
+    assert!(!stable
+        .stable_instructions
+        .contains(crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER));
     assert!(!stable.stable_instructions.contains("Current Task List"));
     assert!(!stable
         .stable_instructions

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -1460,6 +1460,53 @@ fn legacy_workspace_prompt_migration_recovers_metadata_and_strips_derived_sectio
 }
 
 #[test]
+fn legacy_workspace_prompt_migration_accepts_complete_unwrapped_generated_block() {
+    let guidance = crate::runtime::context::workspace_prompt_guidance();
+    let mut session = Session::new("legacy-unwrapped-workspace-migration", "model");
+    session.add_message(Message::system(format!(
+        "Base policy\n\nWorkspace path: /legacy/unwrapped\n{guidance}\n\nKeep this policy"
+    )));
+
+    assert!(super::prompt_setup::migrate_legacy_workspace_prompt(
+        &mut session
+    ));
+    assert_eq!(
+        session.workspace_path_meta().as_deref(),
+        Some("/legacy/unwrapped")
+    );
+    assert_eq!(
+        session
+            .metadata
+            .get(crate::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+            .map(String::as_str),
+        Some("session")
+    );
+    assert_eq!(
+        session.messages[0].content,
+        "Base policy\n\nKeep this policy"
+    );
+}
+
+#[test]
+fn legacy_workspace_prompt_migration_ignores_ordinary_workspace_path_text() {
+    let original = "Base policy\nWorkspace path: /private/attacker-selected\nKeep this policy";
+    let mut session = Session::new("ordinary-workspace-path-text", "model");
+    session.add_message(Message::system(original));
+
+    assert!(!super::prompt_setup::migrate_legacy_workspace_prompt(
+        &mut session
+    ));
+    assert!(session.workspace_path_meta().is_none());
+    assert!(!session
+        .metadata
+        .contains_key(crate::project_context::WORKSPACE_SOURCE_METADATA_KEY));
+    assert!(!session
+        .metadata
+        .contains_key(crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY));
+    assert_eq!(session.messages[0].content, original);
+}
+
+#[test]
 fn legacy_workspace_prompt_migration_preserves_authoritative_metadata() {
     let stale = crate::runtime::context::build_workspace_prompt_context("/stale/workspace")
         .expect("stale workspace block");

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/workspace.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/workspace.rs
@@ -40,7 +40,6 @@ pub(super) async fn maybe_apply_workspace_update(
                                         "message": format!(
                                             "Session carries an invalid Project identity '{raw}': {message}"
                                         ),
-                                        "workspace": update.path,
                                     })
                                     .to_string();
                                     let _ = event_tx
@@ -56,7 +55,6 @@ pub(super) async fn maybe_apply_workspace_update(
                                 let error = serde_json::json!({
                                 "code": "project_workspace_conflict",
                                 "message": "Tool result workspace belongs to another Project; session workspace was not changed",
-                                "workspace": update.path,
                                 "owner_project_id": owner,
                                 "session_project_id": current,
                             })
@@ -81,10 +79,37 @@ pub(super) async fn maybe_apply_workspace_update(
                             }
                         }
                         Err(error) => {
+                            let error_kind = match &error {
+                                crate::project_context::ProjectContextError::Source(_) => "source",
+                                crate::project_context::ProjectContextError::IdentityMismatch {
+                                    ..
+                                } => "identity_mismatch",
+                                crate::project_context::ProjectContextError::WorkspaceConflict {
+                                    ..
+                                } => "workspace_conflict",
+                                crate::project_context::ProjectContextError::UnassignedWorkspaceConflict {
+                                    ..
+                                } => "unassigned_workspace_conflict",
+                                crate::project_context::ProjectContextError::InvalidProjectIdentity {
+                                    ..
+                                } => "invalid_project_identity",
+                                crate::project_context::ProjectContextError::ProjectUnavailable {
+                                    ..
+                                } => "project_unavailable",
+                                crate::project_context::ProjectContextError::ProjectPathMissing {
+                                    ..
+                                } => "project_path_missing",
+                                crate::project_context::ProjectContextError::ProjectPathUnavailable {
+                                    ..
+                                } => "project_path_unavailable",
+                                crate::project_context::ProjectContextError::WorkspaceInvalid {
+                                    ..
+                                } => "workspace_invalid",
+                            };
                             tracing::warn!(
                                 session_id,
                                 tool = %tool_call.function.name,
-                                %error,
+                                error_kind,
                                 "failed closed while checking implicit workspace ownership"
                             );
                             return;
@@ -98,10 +123,10 @@ pub(super) async fn maybe_apply_workspace_update(
                 update.binding_status,
             );
             tracing::info!(
-                "[{}] Updated session workspace_path via {}: {}",
                 session_id,
-                tool_call.function.name,
-                update.path
+                tool = %tool_call.function.name,
+                workspace_changed = true,
+                "updated session workspace metadata"
             );
         }
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/workspace_context/prompt.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/workspace_context/prompt.rs
@@ -1,23 +1,14 @@
-use crate::project_context::WorkspaceBindingStatus;
-use bamboo_agent_core::{Message, Session};
+use crate::project_context::{
+    WorkspaceBindingStatus, WorkspaceSource, WORKSPACE_BINDING_STATUS_METADATA_KEY,
+    WORKSPACE_SOURCE_METADATA_KEY,
+};
+use bamboo_agent_core::Session;
 
-use super::super::prompt_context::{strip_existing_external_memory, strip_existing_task_list};
-
-const WORKSPACE_CONTEXT_START_MARKER: &str =
-    crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER;
-const WORKSPACE_CONTEXT_END_MARKER: &str = crate::runtime::context::WORKSPACE_CONTEXT_END_MARKER;
-const SKILL_CONTEXT_START_MARKER: &str = "<!-- BAMBOO_SKILL_CONTEXT_START -->";
-const TOOL_GUIDE_START_MARKER: &str = "<!-- BAMBOO_TOOL_GUIDE_START -->";
-const EXTERNAL_MEMORY_START_MARKER: &str = "<!-- BAMBOO_EXTERNAL_MEMORY_START -->";
-const TASK_LIST_START_MARKER: &str = "<!-- BAMBOO_TASK_LIST_START -->";
-use bamboo_domain::LEGACY_TODO_LIST_START_MARKER;
-const LEGACY_WORKSPACE_CONTEXT_MARKER: &str = "\n\nWorkspace path: ";
-const LEGACY_SKILL_CONTEXT_MARKERS: [&str; 2] =
-    ["\n\n## Skill System\n", "\n\n## Available Skills\n"];
-const LEGACY_TOOL_GUIDE_MARKER: &str = "## Tool Usage Guidelines\n";
-const LEGACY_EXTERNAL_MEMORY_MARKER: &str = "<!-- BAMBOO_EXTERNAL_MEMORY_START -->\n";
-const LEGACY_TASK_LIST_MARKER: &str = "\n\n## Current Task List:";
-
+/// Commit a host-selected workspace to the authoritative session metadata.
+///
+/// Provider-visible context is rebuilt from this state during round assembly.
+/// Assigning or switching a workspace never creates or edits a persisted
+/// System message.
 pub(super) fn apply_workspace_path_to_session(
     session: &mut Session,
     workspace_path: &str,
@@ -30,132 +21,15 @@ pub(super) fn apply_workspace_path_to_session(
 
     session.set_workspace_path_meta(workspace_path);
     session.metadata.insert(
-        crate::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
-        crate::project_context::WorkspaceSource::Explicit
-            .as_str()
-            .to_string(),
+        WORKSPACE_SOURCE_METADATA_KEY.to_string(),
+        WorkspaceSource::Explicit.as_str().to_string(),
+    );
+    session.metadata.insert(
+        WORKSPACE_BINDING_STATUS_METADATA_KEY.to_string(),
+        binding_status.as_str().to_string(),
     );
 
-    if let Some(system_message) = session
-        .messages
-        .iter_mut()
-        .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
-    {
-        // Drop dynamic round sections first. They will be re-injected by the loop.
-        let base_prompt =
-            strip_existing_task_list(&strip_existing_external_memory(&system_message.content));
-        system_message.content =
-            upsert_workspace_context(&base_prompt, workspace_path, binding_status);
-        crate::runtime::runner::refresh_prompt_snapshot(session);
-    } else {
-        session.messages.insert(
-            0,
-            Message::system(upsert_workspace_context("", workspace_path, binding_status)),
-        );
-        crate::runtime::runner::refresh_prompt_snapshot(session);
-    }
-}
-
-pub(super) fn upsert_workspace_context(
-    prompt: &str,
-    workspace_path: &str,
-    binding_status: WorkspaceBindingStatus,
-) -> String {
-    let workspace_path = workspace_path.trim();
-    if workspace_path.is_empty() {
-        return strip_existing_workspace_context(prompt);
-    }
-
-    let Some(segment) =
-        crate::runtime::context::build_workspace_prompt_context_with_binding_and_source(
-            workspace_path,
-            binding_status,
-            Some(crate::project_context::WorkspaceSource::Explicit),
-        )
-    else {
-        return strip_existing_workspace_context(prompt);
-    };
-    let stripped = strip_existing_workspace_context(prompt);
-
-    if stripped.trim().is_empty() {
-        segment
-    } else {
-        format!("{}\n\n{}", stripped.trim_end(), segment)
-    }
-}
-
-fn strip_existing_workspace_context(prompt: &str) -> String {
-    let prompt = strip_wrapped_workspace_context(prompt);
-    strip_legacy_workspace_context(&prompt)
-}
-
-fn strip_wrapped_workspace_context(prompt: &str) -> String {
-    let mut current = prompt.to_string();
-    while let Some(start_idx) = current.find(WORKSPACE_CONTEXT_START_MARKER) {
-        let search_from = start_idx + WORKSPACE_CONTEXT_START_MARKER.len();
-        let Some(end_rel_idx) = current[search_from..].find(WORKSPACE_CONTEXT_END_MARKER) else {
-            break;
-        };
-        let end_idx = search_from + end_rel_idx + WORKSPACE_CONTEXT_END_MARKER.len();
-
-        let before = current[..start_idx].trim_end();
-        let after = current[end_idx..].trim_start();
-        current = match (before.is_empty(), after.is_empty()) {
-            (true, true) => String::new(),
-            (true, false) => after.to_string(),
-            (false, true) => before.to_string(),
-            (false, false) => format!("{before}\n\n{after}"),
-        };
-    }
-    current
-}
-
-fn strip_legacy_workspace_context(prompt: &str) -> String {
-    let Some(start_idx) = prompt.find(LEGACY_WORKSPACE_CONTEXT_MARKER) else {
-        return prompt.to_string();
-    };
-
-    let guidance = crate::runtime::context::workspace_prompt_guidance();
-    if let Some(guidance_rel_idx) = prompt[start_idx..].find(&guidance) {
-        let guidance_end_idx = start_idx + guidance_rel_idx + guidance.len();
-        let mut out = String::new();
-        out.push_str(prompt[..start_idx].trim_end());
-        out.push_str(&prompt[guidance_end_idx..]);
-        return out.trim_end().to_string();
-    }
-
-    let after_marker_idx = start_idx + LEGACY_WORKSPACE_CONTEXT_MARKER.len();
-    let remainder = &prompt[after_marker_idx..];
-    let mut next_section_idx = [
-        remainder.find(WORKSPACE_CONTEXT_START_MARKER),
-        remainder.find(SKILL_CONTEXT_START_MARKER),
-        remainder.find(TOOL_GUIDE_START_MARKER),
-        remainder.find(EXTERNAL_MEMORY_START_MARKER),
-        remainder.find(TASK_LIST_START_MARKER),
-        remainder.find(LEGACY_TODO_LIST_START_MARKER),
-    ]
-    .into_iter()
-    .flatten()
-    .map(|idx| after_marker_idx + idx)
-    .min();
-
-    if next_section_idx.is_none() {
-        next_section_idx = [
-            remainder.find(LEGACY_SKILL_CONTEXT_MARKERS[0]),
-            remainder.find(LEGACY_SKILL_CONTEXT_MARKERS[1]),
-            remainder.find(LEGACY_TOOL_GUIDE_MARKER),
-            remainder.find(LEGACY_EXTERNAL_MEMORY_MARKER),
-            remainder.find(LEGACY_TASK_LIST_MARKER),
-        ]
-        .into_iter()
-        .flatten()
-        .map(|idx| after_marker_idx + idx)
-        .min();
-    }
-    let next_section_idx = next_section_idx.unwrap_or(prompt.len());
-
-    let mut out = String::new();
-    out.push_str(prompt[..start_idx].trim_end());
-    out.push_str(&prompt[next_section_idx..]);
-    out.trim_end().to_string()
+    // Keep the diagnostic snapshot current without making it authoritative
+    // and without touching Session.messages.
+    crate::runtime::runner::refresh_prompt_snapshot(session);
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/workspace_context/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/workspace_context/tests.rs
@@ -1,4 +1,3 @@
-use super::prompt::upsert_workspace_context;
 use super::{
     apply_workspace_path_to_session, extract_workspace_path_from_tool_result,
     should_apply_workspace_update,
@@ -122,53 +121,10 @@ fn should_apply_workspace_update_when_target_is_outside_workspace() {
 }
 
 #[test]
-fn upsert_workspace_context_replaces_existing_segment() {
-    let guidance = crate::runtime::context::workspace_prompt_guidance();
-    let old = format!(
-        "Base prompt\n\nWorkspace path: /old/path\n{}\n\n## Tool Usage Guidelines\nX",
-        guidance
-    );
-    let updated = upsert_workspace_context(&old, "/new/path", WorkspaceBindingStatus::Unregistered);
-
-    assert!(updated.contains("Workspace path: /new/path"));
-    assert!(!updated.contains("Workspace path: /old/path"));
-    assert!(updated.contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
-    assert!(updated.contains(crate::runtime::context::WORKSPACE_CONTEXT_END_MARKER));
-    assert!(updated.contains("## Tool Usage Guidelines"));
-}
-
-#[test]
-fn workspace_upsert_preserves_stable_project_block() {
-    let project_block = format!(
-        "{}\nProject ID: project-1\nProject name: Zenith\n{}",
-        crate::runtime::context::PROJECT_CONTEXT_START_MARKER,
-        crate::runtime::context::PROJECT_CONTEXT_END_MARKER,
-    );
-    let old_workspace = crate::runtime::context::build_workspace_prompt_context("/old/path")
-        .expect("workspace context");
-    let prompt = format!("Base prompt\n\n{project_block}\n\n{old_workspace}");
-
-    let updated =
-        upsert_workspace_context(&prompt, "/new/path", WorkspaceBindingStatus::Unregistered);
-    assert!(updated.contains(&project_block));
-    assert_eq!(
-        updated
-            .matches(crate::runtime::context::PROJECT_CONTEXT_START_MARKER)
-            .count(),
-        1
-    );
-    assert_eq!(
-        updated
-            .matches(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER)
-            .count(),
-        1
-    );
-}
-
-#[test]
-fn apply_workspace_path_to_session_updates_metadata_and_prompt() {
+fn apply_workspace_path_to_session_updates_metadata_without_mutating_system() {
     let mut session = Session::new("session-1", "test-model");
     session.add_message(Message::system("Base prompt".to_string()));
+    let message_id_before = session.messages[0].id.clone();
 
     apply_workspace_path_to_session(
         &mut session,
@@ -187,29 +143,44 @@ fn apply_workspace_path_to_session_updates_metadata_and_prompt() {
             .map(String::as_str),
         Some("explicit")
     );
-    let system_content = session
-        .messages
-        .iter()
-        .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
-        .map(|message| message.content.clone())
-        .unwrap_or_default();
-    assert!(system_content.contains("Workspace path: /tmp/workspace"));
-    assert!(system_content.contains("Workspace source: explicit"));
-    assert!(system_content.contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
-    assert!(system_content.contains(crate::runtime::context::WORKSPACE_CONTEXT_END_MARKER));
+    assert_eq!(
+        session
+            .metadata
+            .get(crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+            .map(String::as_str),
+        Some("unregistered")
+    );
+    assert_eq!(session.messages.len(), 1);
+    assert_eq!(session.messages[0].id, message_id_before);
+    assert_eq!(session.messages[0].content, "Base prompt");
     let snapshot = crate::runtime::runner::read_prompt_snapshot(&session)
         .expect("prompt snapshot should exist after workspace update");
     assert!(snapshot
         .workspace_context
         .as_deref()
         .is_some_and(|value| value.contains("/tmp/workspace")));
-    assert!(snapshot
-        .effective_system_prompt
-        .contains("Workspace path: /tmp/workspace"));
+    assert_eq!(snapshot.effective_system_prompt, "Base prompt");
 }
 
 #[test]
-fn registered_workspace_update_preserves_project_block_byte_for_byte() {
+fn apply_workspace_path_to_session_without_system_creates_no_message() {
+    let mut session = Session::new("session-no-system", "test-model");
+
+    apply_workspace_path_to_session(
+        &mut session,
+        "/tmp/workspace",
+        WorkspaceBindingStatus::Unregistered,
+    );
+
+    assert!(session.messages.is_empty());
+    assert_eq!(
+        session.workspace_path_meta().as_deref(),
+        Some("/tmp/workspace")
+    );
+}
+
+#[test]
+fn registered_workspace_update_strips_legacy_project_host_paths_once() {
     let project_block = format!(
         "{}\nProject ID: project-1\nProject name: Zenith\nProject home: /data/projects/project-1\n{}",
         crate::runtime::context::PROJECT_CONTEXT_START_MARKER,
@@ -217,6 +188,7 @@ fn registered_workspace_update_preserves_project_block_byte_for_byte() {
     );
     let mut session = Session::new("session-registered", "test-model");
     session.add_message(Message::system(format!("Base\n\n{project_block}")));
+    let message_id_before = session.messages[0].id.clone();
 
     apply_workspace_path_to_session(
         &mut session,
@@ -224,22 +196,19 @@ fn registered_workspace_update_preserves_project_block_byte_for_byte() {
         WorkspaceBindingStatus::Registered,
     );
 
-    let system = session
-        .messages
-        .iter()
-        .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
-        .unwrap();
-    assert!(system.content.contains(&project_block));
-    assert!(system.content.contains("Binding status: registered"));
-    assert_eq!(
-        system
-            .content
-            .matches(crate::runtime::context::PROJECT_CONTEXT_START_MARKER)
-            .count(),
-        1
-    );
+    assert_eq!(session.messages.len(), 1);
+    assert_eq!(session.messages[0].id, message_id_before);
+    assert_eq!(session.messages[0].content, "Base");
+    assert!(!session.messages[0].content.contains("/data/projects"));
     assert_eq!(
         session.workspace_path_meta(),
         Some("/tmp/registered".to_string())
+    );
+    assert_eq!(
+        session
+            .metadata
+            .get(crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+            .map(String::as_str),
+        Some("registered")
     );
 }

--- a/crates/engine/bamboo-engine/src/session_app/chat.rs
+++ b/crates/engine/bamboo-engine/src/session_app/chat.rs
@@ -1,6 +1,6 @@
 //! Chat use case: prepare a chat turn for execution.
 
-use crate::context::{build_env_prompt_context, build_workspace_prompt_context};
+use crate::context::build_env_prompt_context;
 use crate::runner::refresh_prompt_snapshot;
 use bamboo_agent_core::{Role, Session};
 use bamboo_config::paths::path_to_display_string;
@@ -29,7 +29,7 @@ const PROMPT_FINGERPRINT_KEY: &str = "prompt_fingerprint";
 const PROMPT_COMPONENT_FLAGS_KEY: &str = "prompt_component_flags";
 const PROMPT_COMPONENT_LENGTHS_KEY: &str = "prompt_component_lengths";
 
-const PROMPT_COMPOSER_VERSION: &str = "bamboo.prompt-composer.v2";
+const PROMPT_COMPOSER_VERSION: &str = "bamboo.prompt-composer.v3";
 pub const SESSION_START_SOURCE_METADATA_KEY: &str = "runtime.session_start_source";
 
 /// Prepare a chat turn: load/create session, resolve prompts, update metadata,
@@ -160,6 +160,7 @@ pub fn prepare_chat_turn_from_authoritative_session_with_workspace_policy(
         crate::project_context::SessionProjectIdentity::Assigned(_)
         | crate::project_context::SessionProjectIdentity::Unassigned => {}
     }
+    crate::runtime::runner::session_setup::migrate_legacy_workspace_prompt(&mut session);
     session.metadata.insert(
         SESSION_START_SOURCE_METADATA_KEY.to_string(),
         session_start_source.to_string(),
@@ -242,10 +243,25 @@ pub fn prepare_chat_turn_from_authoritative_session_with_workspace_policy(
     );
 
     // ---- Upsert system prompt message ----
-    session
+    // A workspace-only switch leaves this stable text byte-identical and must
+    // not rewrite Session.messages.
+    let system_messages = session
         .messages
-        .retain(|message| !matches!(message.role, Role::System));
-    session.messages.insert(0, Message::system(system_prompt));
+        .iter()
+        .filter(|message| matches!(message.role, Role::System))
+        .collect::<Vec<_>>();
+    let system_is_current = system_messages.len() == 1
+        && system_messages[0].content == system_prompt
+        && session
+            .messages
+            .first()
+            .is_some_and(|message| matches!(message.role, Role::System));
+    if !system_is_current {
+        session
+            .messages
+            .retain(|message| !matches!(message.role, Role::System));
+        session.messages.insert(0, Message::system(system_prompt));
+    }
     refresh_prompt_snapshot(&mut session);
 
     // ---- Persist model/provider selection ----
@@ -302,6 +318,8 @@ pub fn resolve_base_prompt(
                 trimmed.to_string()
             }
         });
+    let resolved =
+        crate::runtime::runner::session_setup::prompt_setup::normalize_base_prompt(&resolved);
 
     session
         .metadata
@@ -353,25 +371,21 @@ fn resolve_workspace_path_with_default(
     data_dir: Option<&Path>,
     allow_legacy_fallback: bool,
 ) -> Option<String> {
-    if let Some(path) = workspace_path_from_request {
-        session.set_workspace_path_meta(path);
-        session.metadata.insert(
-            crate::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
-            crate::project_context::WorkspaceSource::Explicit
-                .as_str()
-                .to_string(),
-        );
-    }
-
-    let resolved = workspace_path_from_request
-        .map(ToString::to_string)
-        .or_else(|| session.workspace_path_meta())
-        .or_else(|| {
-            allow_legacy_fallback
-                .then(|| default_workspace_path.map(ToString::to_string))
-                .flatten()
+    let explicit = workspace_path_from_request
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    let persisted = session.workspace_path_meta();
+    let configured_default = allow_legacy_fallback
+        .then(|| {
+            default_workspace_path
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
         })
-        .or_else(|| {
+        .flatten();
+    let fallback = (explicit.is_none() && persisted.is_none() && configured_default.is_none())
+        .then(|| {
             allow_legacy_fallback
                 .then(|| {
                     resolve_workspace_fallback_with(fallback_policy, || {
@@ -379,13 +393,56 @@ fn resolve_workspace_path_with_default(
                     })
                 })
                 .flatten()
-        });
+        })
+        .flatten();
+    let (resolved, source, binding_reset) = if let Some(workspace) = explicit {
+        (
+            Some(workspace),
+            crate::project_context::WorkspaceSource::Explicit,
+            true,
+        )
+    } else if let Some(workspace) = persisted {
+        (
+            Some(workspace),
+            crate::project_context::WorkspaceSource::from_metadata(
+                session
+                    .metadata
+                    .get(crate::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                    .map(String::as_str),
+            ),
+            false,
+        )
+    } else if let Some(workspace) = configured_default {
+        (
+            Some(workspace),
+            crate::project_context::WorkspaceSource::Session,
+            true,
+        )
+    } else {
+        (
+            fallback,
+            crate::project_context::WorkspaceSource::Session,
+            true,
+        )
+    };
     if let Some(workspace) = resolved.as_ref() {
         // Persist the effective post-lock choice, including a live-config or
         // session-root fallback. Otherwise the subsequent Project resolver
         // would see no metadata and independently pick a different global
         // fallback.
         session.set_workspace_path_meta(workspace.clone());
+        session.metadata.insert(
+            crate::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
+            source.as_str().to_string(),
+        );
+        if binding_reset {
+            session.metadata.insert(
+                crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY.to_string(),
+                crate::project_context::WorkspaceBindingStatus::Unregistered
+                    .as_str()
+                    .to_string(),
+            );
+        }
     }
     resolved
 }
@@ -697,22 +754,13 @@ impl PromptCompositionProfile {
     }
 }
 
-fn build_prompt_fingerprint(
-    base_prompt: &str,
-    enhancement: Option<&str>,
-    workspace: Option<&str>,
-    env_context: Option<&str>,
-) -> String {
+fn build_prompt_fingerprint(base_prompt: &str, enhancement: Option<&str>) -> String {
     let mut hasher = Sha256::new();
     hasher.update(PROMPT_COMPOSER_VERSION.as_bytes());
     hasher.update([0u8]);
     hasher.update(base_prompt.as_bytes());
     hasher.update([0u8]);
     hasher.update(enhancement.unwrap_or_default().as_bytes());
-    hasher.update([0u8]);
-    hasher.update(workspace.unwrap_or_default().as_bytes());
-    hasher.update([0u8]);
-    hasher.update(env_context.unwrap_or_default().as_bytes());
     hex::encode(hasher.finalize())
 }
 
@@ -732,36 +780,25 @@ fn build_enhanced_system_prompt_with_profile(
         merged_prompt.push_str(enhancement.as_str());
     }
 
-    let workspace_context = workspace_path
+    let has_workspace_context = workspace_path
         .map(str::trim)
-        .filter(|workspace_path| !workspace_path.is_empty())
-        .and_then(build_workspace_prompt_context);
-    if let Some(workspace_context) = workspace_context.as_ref() {
-        merged_prompt.push_str("\n\n");
-        merged_prompt.push_str(workspace_context.as_str());
-    }
+        .is_some_and(|workspace_path| !workspace_path.is_empty());
 
-    let env_context = build_env_prompt_context();
-    if let Some(env_context) = env_context.as_ref() {
-        merged_prompt.push_str("\n\n");
-        merged_prompt.push_str(env_context.as_str());
-    }
+    // Environment details are discovered from the same authority during round
+    // assembly and emitted as a typed EnvSnapshot. Keep the compatibility flag
+    // observable without copying those details into System or its fingerprint.
+    let has_env_context = build_env_prompt_context().is_some();
 
     let profile = PromptCompositionProfile {
         version: PROMPT_COMPOSER_VERSION,
-        fingerprint: build_prompt_fingerprint(
-            base_prompt,
-            enhancement.as_deref(),
-            workspace_context.as_deref(),
-            env_context.as_deref(),
-        ),
+        fingerprint: build_prompt_fingerprint(base_prompt, enhancement.as_deref()),
         has_enhancement: enhancement.is_some(),
-        has_workspace_context: workspace_context.is_some(),
-        has_env_context: env_context.is_some(),
+        has_workspace_context,
+        has_env_context,
         base_len: base_prompt.len(),
         enhancement_len: enhancement.as_ref().map(|s| s.len()).unwrap_or(0),
-        workspace_context_len: workspace_context.as_ref().map(|s| s.len()).unwrap_or(0),
-        env_context_len: env_context.as_ref().map(|s| s.len()).unwrap_or(0),
+        workspace_context_len: 0,
+        env_context_len: 0,
         final_len: merged_prompt.len(),
     };
 
@@ -1144,6 +1181,13 @@ mod tests {
         let system_prompt = system_message_content(&session);
         assert!(system_prompt.starts_with("Base prompt"));
         assert!(system_prompt.contains("Extra enhancement guidance"));
+        assert!(!system_prompt.contains(crate::runtime::context::PROJECT_CONTEXT_START_MARKER));
+        assert!(!system_prompt.contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
+        assert!(!system_prompt
+            .contains(crate::runtime::context::instruction::INSTRUCTION_CONTEXT_START_MARKER));
+        assert!(!system_prompt.contains(crate::runtime::context::ENV_CONTEXT_START_MARKER));
+        assert!(!system_prompt.contains("BAMBOO_SKILL_CONTEXT_START"));
+        assert!(!system_prompt.contains("BAMBOO_TOOL_GUIDE_START"));
         assert_eq!(
             session.enhance_prompt().as_deref(),
             Some("Extra enhancement guidance")
@@ -1172,6 +1216,68 @@ mod tests {
             .metadata
             .get(PROMPT_COMPONENT_FLAGS_KEY)
             .is_some_and(|flags| flags.contains("enhance=0")));
+    }
+
+    #[test]
+    fn workspace_switch_preserves_system_identity_and_prompt_fingerprint() {
+        let first_workspace = "/workspace/first-private";
+        let second_workspace = "/workspace/second-private";
+        let mut first_input = chat_turn_input(Some("Stable enhancement"));
+        first_input.workspace_path = Some(first_workspace.to_string());
+        let first = prepare_chat_turn_from_authoritative_session(
+            None,
+            first_input,
+            "Global prompt",
+            "Builtin prompt",
+        )
+        .expect("first workspace turn");
+        let first_system = first
+            .messages
+            .iter()
+            .find(|message| matches!(message.role, Role::System))
+            .expect("first system message")
+            .clone();
+        let first_fingerprint = first
+            .metadata
+            .get(PROMPT_FINGERPRINT_KEY)
+            .expect("first prompt fingerprint")
+            .clone();
+
+        let mut switched_input = chat_turn_input(Some("Stable enhancement"));
+        switched_input.workspace_path = Some(second_workspace.to_string());
+        let switched = prepare_chat_turn_from_authoritative_session(
+            Some(first),
+            switched_input,
+            "Global prompt",
+            "Builtin prompt",
+        )
+        .expect("switched workspace turn");
+        let switched_system = switched
+            .messages
+            .iter()
+            .find(|message| matches!(message.role, Role::System))
+            .expect("switched system message");
+
+        assert_eq!(switched_system.id, first_system.id);
+        assert_eq!(switched_system.content, first_system.content);
+        assert_eq!(
+            switched.metadata.get(PROMPT_FINGERPRINT_KEY),
+            Some(&first_fingerprint)
+        );
+        assert_eq!(
+            switched.workspace_path_meta().as_deref(),
+            Some(second_workspace)
+        );
+        assert!(!switched_system.content.contains(first_workspace));
+        assert!(!switched_system.content.contains(second_workspace));
+        assert!(!switched_system
+            .content
+            .contains(crate::runtime::context::WORKSPACE_CONTEXT_START_MARKER));
+        assert!(switched
+            .prompt_snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.workspace_context.as_deref())
+            .is_some_and(|context| context.contains(second_workspace)));
     }
 
     #[test]
@@ -1211,8 +1317,8 @@ mod tests {
         );
         let system_prompt = system_message_content(&session);
         assert!(
-            system_prompt.contains(&session_fallback_display),
-            "session fallback must participate in prepare-stage prompt composition"
+            !system_prompt.contains(&session_fallback_display),
+            "workspace path must stay out of the persisted System message"
         );
         assert!(
             !system_prompt.contains(foreign_default.to_string_lossy().as_ref()),
@@ -1270,6 +1376,18 @@ mod tests {
                 .canonicalize()
                 .expect("configured canonical")
         );
+        assert_eq!(
+            session
+                .metadata
+                .get(crate::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(crate::project_context::WorkspaceSource::Session.as_str())
+        );
+        assert!(session
+            .prompt_snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.workspace_context.as_deref())
+            .is_some_and(|context| context.contains("Workspace source: session")));
     }
 
     // The non-server disk fallback (`default_workspace_from_data_dir`) tested

--- a/crates/engine/bamboo-engine/src/session_app/session_create.rs
+++ b/crates/engine/bamboo-engine/src/session_app/session_create.rs
@@ -68,6 +68,18 @@ pub fn build_new_session(input: &CreateSessionInput, config: &CreateSessionConfi
     }
     if let Some(workspace_path) = trimmed_non_empty(input.workspace_path.as_deref()) {
         session.set_workspace_path_meta(workspace_path);
+        session.metadata.insert(
+            crate::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
+            crate::project_context::WorkspaceSource::Explicit
+                .as_str()
+                .to_string(),
+        );
+        session.metadata.insert(
+            crate::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY.to_string(),
+            crate::project_context::WorkspaceBindingStatus::Unregistered
+                .as_str()
+                .to_string(),
+        );
     }
     if let Some(project_id) = input.project_id.as_ref() {
         session.set_project_id_meta(project_id.to_string());

--- a/crates/engine/bamboo-engine/src/session_app/system_prompt.rs
+++ b/crates/engine/bamboo-engine/src/session_app/system_prompt.rs
@@ -24,7 +24,6 @@ use bamboo_domain::{LEGACY_TODO_LIST_END_MARKER, LEGACY_TODO_LIST_START_MARKER};
 
 const WORKSPACE_CONTEXT_START_MARKER: &str = crate::context::WORKSPACE_CONTEXT_START_MARKER;
 const WORKSPACE_CONTEXT_END_MARKER: &str = crate::context::WORKSPACE_CONTEXT_END_MARKER;
-const WORKSPACE_CONTEXT_PREFIX: &str = crate::context::WORKSPACE_CONTEXT_PREFIX;
 const PROJECT_CONTEXT_START_MARKER: &str = crate::context::PROJECT_CONTEXT_START_MARKER;
 const PROJECT_CONTEXT_END_MARKER: &str = crate::context::PROJECT_CONTEXT_END_MARKER;
 
@@ -301,14 +300,10 @@ fn split_env_context(prompt: &str) -> (String, Option<String>) {
 }
 
 fn split_legacy_workspace_context(prompt: &str) -> (String, Option<String>) {
-    let Some(start_idx) = prompt.find(WORKSPACE_CONTEXT_PREFIX) else {
+    let Some((start_idx, end_idx)) =
+        crate::runtime::context::legacy_unwrapped_workspace_context_bounds(prompt)
+    else {
         return (prompt.trim().to_string(), None);
-    };
-    let guidance = crate::context::workspace_prompt_guidance();
-    let end_idx = if let Some(guidance_rel_idx) = prompt[start_idx..].find(&guidance) {
-        start_idx + guidance_rel_idx + guidance.len()
-    } else {
-        prompt.len()
     };
 
     let workspace_context = prompt[start_idx..end_idx].trim().to_string();
@@ -505,6 +500,19 @@ mod tests {
             .workspace_context
             .as_deref()
             .is_some_and(|value| value.contains("/tmp/legacy-workspace")));
+    }
+
+    #[test]
+    fn snapshot_preserves_ordinary_workspace_path_text_as_operator_policy() {
+        let original = "Base policy\nWorkspace path: /private/operator-example\nKeep this policy";
+        let mut session = Session::new("session-ordinary-workspace-text", "gpt-5");
+        session.add_message(Message::system(original));
+
+        let snapshot = build_system_prompt_snapshot(&session, TEST_DEFAULT_PROMPT);
+
+        assert_eq!(snapshot.base_system_prompt, original);
+        assert_eq!(snapshot.effective_system_prompt, original);
+        assert!(snapshot.workspace_context.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- move Project and Workspace host-owned context out of the persisted/cacheable System prompt and into typed round-dynamic context blocks
- keep Project identity path-free for the model while rendering the active Workspace path exactly once from authoritative session metadata
- preserve stable-prefix cache reuse across Workspace changes while advancing the model-context state revision
- migrate only recognizable legacy Bamboo-generated Workspace blocks; ordinary operator text containing `Workspace path:` remains byte-identical and cannot become workspace authority
- align chat, session-create, system-prompt, Connect, and SDK tests with the metadata-only prompt contract

This is the core #972 foundation. Schedule, Connect, and SDK external-entrypoint handoff ordering remains intentionally isolated in #998; therefore this PR references #972 but does not close it.

## Scope

Affected submodule: Bamboo (`bamboo-engine`, plus server/SDK contract tests).

Non-goals:

- no Schedule/Connect factory signature changes
- no SDK pending-approved-tool replay ordering change
- no provider tool-discovery or MCP lifecycle changes
- no workspace configuration/API changes

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- exact regressions for the six server and one SDK legacy prompt assertions
- legacy migration positive/negative regressions, including ordinary `Workspace path:` operator text
- `cargo test --locked -p bamboo-engine --quiet` — 1430 passed; doc test passed
- `cargo test --locked -p bamboo-sdk --quiet` — 53 passed; integration/doc groups passed
- `cargo test --locked -p bamboo-server --lib -- --nocapture` — 1961 passed, 1 ignored
- Bamboo server integration targets: chat isolation 1/1, create isolation 1/1, WebSocket 16/16, env-cache isolation 1/1
- `cargo test --locked -p bamboo-server --doc --quiet` — 9 passed, 3 ignored
- `cargo check --locked -p bamboo-engine -p bamboo-sdk -p bamboo-server --all-targets`
- production `cargo clippy` for engine/SDK/server with `-D warnings`; only the repository's existing `too_many_arguments` lint is allowed

One quiet server-suite run aborted inside the Rust test harness with `failed to initiate panic, error 5` and no named assertion. The immediately repeated full named run completed all 1961 tests successfully; CI remains the independent merge gate.

## Review

- independent exact-head review: APPROVE, no remaining P0/P1
- reviewed head: `ee565b8cb2f9c4d5fa24af55bc8be675e84ea7ca`
- review specifically covered provider ordering, cache behavior, path leakage, legacy migration authority, and the #998 scope boundary

Refs #972
Follow-up: #998
