### PR TITLE
refactor: publish coherent MCP runtime generations (#995)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/mcp/server_handlers/query.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mcp/server_handlers/query.rs
@@ -10,15 +10,13 @@ use super::super::api_types::{to_api_config, McpServerApiRecord, ServerListRespo
 /// `GET /mcp/servers`
 pub async fn list_servers(state: web::Data<AppState>) -> impl Responder {
     let config = state.config.read().await.clone();
+    let snapshot = state.mcp_manager.snapshot();
     let servers: Vec<McpServerApiRecord> = config
         .mcp
         .servers
         .iter()
         .map(|server_cfg| {
-            let runtime = state
-                .mcp_manager
-                .get_server_info(&server_cfg.id)
-                .unwrap_or_default();
+            let runtime = snapshot.server_info(&server_cfg.id).unwrap_or_default();
             McpServerApiRecord {
                 id: server_cfg.id.clone(),
                 name: server_cfg.name.clone(),
@@ -55,10 +53,8 @@ pub async fn get_server(state: web::Data<AppState>, path: web::Path<String>) -> 
         }));
     };
 
-    let runtime = state
-        .mcp_manager
-        .get_server_info(&server_id)
-        .unwrap_or_default();
+    let snapshot = state.mcp_manager.snapshot();
+    let runtime = snapshot.server_info(&server_id).unwrap_or_default();
     let server_info = McpServerApiRecord {
         id: server_cfg.id.clone(),
         name: server_cfg.name.clone(),

--- a/crates/app/bamboo-server/src/handlers/agent/mcp/tool_handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mcp/tool_handlers.rs
@@ -8,14 +8,14 @@ use crate::app_state::AppState;
 /// # HTTP Route
 /// `GET /mcp/tools`
 pub async fn list_tools(state: web::Data<AppState>) -> impl Responder {
-    let aliases = state.mcp_manager.tool_index().all_aliases();
+    let snapshot = state.mcp_manager.snapshot();
+    let aliases = snapshot.aliases();
 
     let tools: Vec<ToolInfo> = aliases
         .into_iter()
         .filter_map(|alias| {
-            state
-                .mcp_manager
-                .get_tool_info(&alias.server_id, &alias.original_name)
+            snapshot
+                .tool(&alias.server_id, &alias.original_name)
                 .map(|tool| ToolInfo {
                     alias: alias.alias,
                     server_id: alias.server_id,
@@ -38,19 +38,17 @@ pub async fn get_server_tools(
     path: web::Path<String>,
 ) -> impl Responder {
     let server_id = path.into_inner();
+    let snapshot = state.mcp_manager.snapshot();
 
-    match state.mcp_manager.get_server_info(&server_id) {
+    match snapshot.server_info(&server_id) {
         Some(_) => {
-            let tools: Vec<ToolInfo> = state
-                .mcp_manager
-                .tool_index()
-                .all_aliases()
+            let tools: Vec<ToolInfo> = snapshot
+                .aliases()
                 .into_iter()
                 .filter(|alias| alias.server_id == server_id)
                 .filter_map(|alias| {
-                    state
-                        .mcp_manager
-                        .get_tool_info(&alias.server_id, &alias.original_name)
+                    snapshot
+                        .tool(&alias.server_id, &alias.original_name)
                         .map(|tool| ToolInfo {
                             alias: alias.alias,
                             server_id: alias.server_id,

--- a/crates/app/bamboo-server/src/handlers/command/sources.rs
+++ b/crates/app/bamboo-server/src/handlers/command/sources.rs
@@ -271,13 +271,13 @@ pub(super) fn legacy_workflow_catalog_entry_to_command(
 pub(super) async fn list_mcp_tools_as_commands(
     state: &AppState,
 ) -> Result<Vec<CommandItem>, AppError> {
-    let aliases = state.mcp_manager.tool_index().all_aliases();
+    let snapshot = state.mcp_manager.snapshot();
+    let aliases = snapshot.aliases();
     let commands = aliases
         .into_iter()
         .filter_map(|alias| {
-            state
-                .mcp_manager
-                .get_tool_info(&alias.server_id, &alias.original_name)
+            snapshot
+                .tool(&alias.server_id, &alias.original_name)
                 .map(|tool| CommandItem {
                     id: format!("mcp-{}-{}", alias.server_id, alias.original_name),
                     name: alias.alias.clone(),

--- a/crates/infra/bamboo-mcp/src/error.rs
+++ b/crates/infra/bamboo-mcp/src/error.rs
@@ -34,6 +34,12 @@ pub enum ToolRegistrationError {
         "MCP ownership ledger capacity exceeded: attempted {attempted} relationships with limit {limit}"
     )]
     OwnershipLedgerCapacityExceeded { limit: usize, attempted: usize },
+
+    #[error("MCP publication revision exhausted")]
+    PublicationRevisionExhausted,
+
+    #[error("MCP provider schema is unavailable for a published catalog entry")]
+    ProviderSchemaUnavailable,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -94,6 +100,21 @@ pub enum McpError {
 
     #[error("Server not running: {0}")]
     NotRunning(String),
+
+    #[error("MCP publication is stale (publication_id={publication_id}, runtime_id={runtime_id})")]
+    StalePublication {
+        publication_id: u64,
+        runtime_id: u64,
+    },
+
+    #[error("MCP resolved call belongs to a different runtime authority")]
+    ForeignRuntimeAuthority,
+
+    #[error("MCP publication identity space exhausted")]
+    PublicationIdentityExhausted,
+
+    #[error("MCP runtime identity space exhausted")]
+    RuntimeIdentityExhausted,
 }
 
 impl From<serde_json::Error> for McpError {

--- a/crates/infra/bamboo-mcp/src/executor.rs
+++ b/crates/infra/bamboo-mcp/src/executor.rs
@@ -16,12 +16,23 @@ use crate::types::{McpContentItem, McpContentMetadata, McpStructuredContent};
 /// MCP tool executor that delegates to the MCP server manager
 pub struct McpToolExecutor {
     manager: Arc<McpServerManager>,
-    index: Arc<ToolIndex>,
+    authority_matches: bool,
 }
 
 impl McpToolExecutor {
     pub fn new(manager: Arc<McpServerManager>, index: Arc<ToolIndex>) -> Self {
-        Self { manager, index }
+        let authority_matches = manager.has_same_authority(&index);
+        Self {
+            manager,
+            authority_matches,
+        }
+    }
+
+    pub fn from_manager(manager: Arc<McpServerManager>) -> Self {
+        Self {
+            manager,
+            authority_matches: true,
+        }
     }
 
     fn preview_for_log(value: &str, max_chars: usize) -> String {
@@ -141,10 +152,14 @@ impl McpToolExecutor {
 impl ToolExecutor for McpToolExecutor {
     async fn execute(&self, call: &ToolCall) -> std::result::Result<ToolResult, ToolError> {
         let tool_name = &call.function.name;
-
-        // Lookup the tool alias
-        let alias = match self.index.lookup(tool_name) {
-            Some(alias) => alias,
+        if !self.authority_matches {
+            return Err(ToolError::NotFound(
+                "MCP executor uses a detached tool-index authority".to_string(),
+            ));
+        }
+        let snapshot = self.manager.snapshot();
+        let resolved = match snapshot.resolve_call(tool_name) {
+            Some(resolved) => resolved,
             None => {
                 return Err(ToolError::NotFound(format!(
                     "MCP tool '{}' not found",
@@ -155,7 +170,9 @@ impl ToolExecutor for McpToolExecutor {
 
         debug!(
             "Executing MCP tool: {} (server: {}, original: {})",
-            tool_name, alias.server_id, alias.original_name
+            tool_name,
+            resolved.server_id(),
+            resolved.original_name()
         );
 
         // Parse arguments
@@ -166,7 +183,7 @@ impl ToolExecutor for McpToolExecutor {
                 "MCP tool argument parsing fallback applied: tool_call_id={}, tool_name={}, server_id={}, args_len={}, args_preview=\"{}\", warning={}",
                 call.id,
                 tool_name,
-                alias.server_id,
+                resolved.server_id(),
                 args_raw.len(),
                 Self::preview_for_log(args_raw, 180),
                 warning
@@ -174,11 +191,7 @@ impl ToolExecutor for McpToolExecutor {
         }
 
         // Execute via manager
-        match self
-            .manager
-            .call_tool(&alias.server_id, &alias.original_name, args)
-            .await
-        {
+        match self.manager.call_resolved_tool(&resolved, args).await {
             Ok(result) => {
                 let (text, images) = Self::format_result_content(&result.content);
                 let text = Self::append_structured_content(text, &result.structured_content);
@@ -214,34 +227,25 @@ impl ToolExecutor for McpToolExecutor {
     }
 
     fn list_tools(&self) -> Vec<ToolSchema> {
-        self.index
-            .all_aliases()
-            .into_iter()
-            .filter_map(|alias| {
-                // Get tool info from manager
-                self.manager
-                    .get_tool_info(&alias.server_id, &alias.original_name)
-                    .map(|tool| ToolSchema {
-                        schema_type: "function".to_string(),
-                        function: bamboo_agent_core::FunctionSchema {
-                            name: alias.alias,
-                            description: tool.description,
-                            parameters: tool.parameters,
-                        },
-                    })
-            })
-            .collect()
+        if self.authority_matches {
+            self.manager.snapshot().list_tools()
+        } else {
+            Vec::new()
+        }
     }
 
     fn owns_exact_tool(&self, tool_name: &str) -> bool {
-        self.index.contains_exact_alias(tool_name)
+        self.authority_matches && self.manager.snapshot().contains_exact_alias(tool_name)
     }
 
     /// Each connected MCP server's `instructions`, rendered as a labeled block.
     /// Only ready servers contribute, so this guidance is automatically scoped to
     /// whatever is loaded for the run.
     fn tool_guidance(&self) -> Option<String> {
-        let servers = self.manager.connected_server_instructions();
+        if !self.authority_matches {
+            return None;
+        }
+        let servers = self.manager.snapshot().connected_server_instructions();
         if servers.is_empty() {
             return None;
         }

--- a/crates/infra/bamboo-mcp/src/lib.rs
+++ b/crates/infra/bamboo-mcp/src/lib.rs
@@ -15,7 +15,9 @@ pub mod types;
 pub use config::*;
 pub use error::{McpError, Result, ToolRegistrationError};
 pub use executor::{CompositeToolExecutor, McpToolExecutor};
-pub use manager::McpServerManager;
+pub use manager::{
+    McpRuntimeSnapshot, McpServerManager, PublicationId, ResolvedMcpCall, RuntimeId,
+};
 pub use protocol::*;
 pub use tool_index::{ToolIndex, MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS};
 pub use transports::*;

--- a/crates/infra/bamboo-mcp/src/manager/config_sync.rs
+++ b/crates/infra/bamboo-mcp/src/manager/config_sync.rs
@@ -1,35 +1,28 @@
 use super::fingerprint::{effective_server_config, manager_proxy_fingerprint};
+use super::lifecycle::RetiredRuntimeCleanup;
 use super::*;
 use std::collections::HashSet;
 
 impl McpServerManager {
     /// Reconcile running MCP servers with the desired configuration.
     ///
-    /// This is best-effort and will:
-    /// - Stop servers that are running but removed/disabled in config.
-    /// - Start enabled servers that are not running.
-    /// - Restart servers whose effective runtime config changed.
-    ///
-    /// Secrets are compared by their hydrated plaintext (env/header values), not by the
-    /// encrypted-at-rest blobs (which can change on every save due to random nonces).
+    /// New and changed runtimes are fully staged before one immutable
+    /// generation replaces the complete live catalog/runtime view.
     pub async fn reconcile_from_config(&self, config: &McpConfig) {
         if let Err(error) = self.reconcile_from_config_transactional(config).await {
             error!("Failed to reconcile MCP configuration transactionally: {error}");
         }
     }
 
-    /// Reconcile configuration without evicting any working runtime until all
-    /// new and changed servers have completed transport connection, protocol
-    /// initialization, and tool discovery.
+    /// Reconcile without evicting any working publication until every new or
+    /// changed server has connected, initialized, and published its tool schema.
     pub async fn reconcile_from_config_transactional(&self, config: &McpConfig) -> Result<()> {
         self.reconcile_from_config_transactional_after(config, || async { Ok(()) })
             .await
     }
 
-    /// Stage every new/changed runtime, then run `before_publish`, and only
-    /// publish the prepared runtimes when that durable boundary succeeds.
-    /// This lets a section store place its CAS commit exactly between runtime
-    /// validation and runtime/tool-index publication.
+    /// Stage the next generation, run `before_publish` as the durable boundary,
+    /// then complete the already-prevalidated publication in the same poll.
     pub async fn reconcile_from_config_transactional_after<F, Fut>(
         &self,
         config: &McpConfig,
@@ -47,10 +40,8 @@ impl McpServerManager {
         .await
     }
 
-    /// Transactional reconcile with explicit runtime replacements even when
-    /// their effective configuration is unchanged. Legacy reconnect/update
-    /// endpoints use this to preserve their restart contract without doing an
-    /// out-of-transaction stop/start after the durable boundary.
+    /// Transactional reconcile with explicit replacements even when effective
+    /// runtime configuration is unchanged.
     pub async fn reconcile_from_config_transactional_after_forcing<F, Fut>(
         &self,
         config: &McpConfig,
@@ -61,7 +52,8 @@ impl McpServerManager {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<()>>,
     {
-        let _reconcile = self.reconcile_lock.lock().await;
+        let sequence = self.event_sequence_lock.clone().lock_owned().await;
+        let reconcile = self.reconcile_lock.lock().await;
         let mut seen = HashSet::new();
         for server in &config.servers {
             if server.id.trim().is_empty() {
@@ -77,14 +69,16 @@ impl McpServerManager {
             }
         }
 
+        let base = self.authority.generation();
         let desired_proxy_fingerprint = manager_proxy_fingerprint(self.config.as_ref()).await;
-        let mut replacements = Vec::new();
+        let mut prepared = Vec::new();
         for desired in config.servers.iter().filter(|server| server.enabled) {
             let needs_replacement = force_replacements.contains(&desired.id)
-                || self
-                    .runtimes
+                || base
+                    .servers
                     .get(&desired.id)
-                    .map(|runtime| {
+                    .map(|publication| {
+                        let runtime = &publication.runtime.runtime;
                         effective_server_config(&runtime.config) != effective_server_config(desired)
                             || matches!(
                                 runtime.config.transport,
@@ -92,22 +86,11 @@ impl McpServerManager {
                             ) && runtime.proxy_fingerprint != desired_proxy_fingerprint
                     })
                     .unwrap_or(true);
-            if !needs_replacement {
-                continue;
-            }
-
-            match self
-                .prepare_server_runtime(desired.clone(), "config reload")
-                .await
-            {
-                Ok(prepared) => replacements.push(prepared),
-                Err(error) => {
-                    for prepared in replacements {
-                        let id = prepared.runtime.config.id.clone();
-                        self.shutdown_detached_runtime(&id, prepared.runtime).await;
-                    }
-                    return Err(error);
-                }
+            if needs_replacement {
+                prepared.push(
+                    self.prepare_server_runtime(desired.clone(), "config reload")
+                        .await?,
+                );
             }
         }
 
@@ -117,104 +100,100 @@ impl McpServerManager {
             .filter(|server| server.enabled)
             .map(|server| server.id.as_str())
             .collect();
-        let removals: Vec<String> = self
-            .list_servers()
-            .into_iter()
-            .filter(|id| !desired_enabled.contains(id.as_str()))
-            .collect();
-
-        // Validate the complete resulting catalog before crossing the durable
-        // configuration boundary. This catches cross-server alias conflicts as
-        // one unit and leaves every currently published runtime/index entry
-        // untouched on failure.
-        let replacement_catalogs: Vec<_> = replacements
+        let removals = base
+            .servers
+            .keys()
+            .filter(|server_id| !desired_enabled.contains(server_id.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        let replacements = prepared
             .iter()
-            .map(|prepared| prepared.catalog.clone())
+            .map(|prepared| prepared.publication().clone())
+            .collect::<Vec<_>>();
+
+        // Collision/history/capacity/schema/revision validation and full next
+        // generation allocation all precede the durable callback.
+        let next = McpRuntimeGeneration::plan(
+            &base,
+            &replacements,
+            &removals,
+            self.authority.ledger_relationship_limit,
+            true,
+        )?;
+        let retirements = base
+            .servers
+            .values()
+            .filter_map(|publication| {
+                let replaced = replacements
+                    .iter()
+                    .any(|replacement| replacement.server_id == publication.server_id);
+                let removed = removals.contains(&publication.server_id);
+                (replaced || removed).then(|| (publication.clone(), removed))
+            })
+            .collect::<Vec<_>>();
+        if !self.authority.is_current(&base) {
+            return Err(McpError::Connection(
+                "stale MCP reconcile base generation".to_string(),
+            ));
+        }
+
+        let mut events = Vec::new();
+        for publication in &replacements {
+            events.extend(self.runtime_ready_events(publication));
+        }
+        for (publication, removed) in &retirements {
+            if *removed {
+                events.push(McpEvent::ServerStatusChanged {
+                    server_id: publication.server_id.clone(),
+                    status: ServerStatus::Stopped,
+                    error: None,
+                });
+            }
+        }
+        let retired = retirements
+            .iter()
+            .map(|(publication, _)| RetiredRuntimeCleanup {
+                runtime: publication.runtime.clone(),
+            })
             .collect();
-        let catalog_update = match self
-            .index
-            .preflight_catalog_update(&replacement_catalogs, &removals)
-        {
-            Ok(update) => update,
-            Err(error) => {
-                for prepared in replacements {
-                    let id = prepared.runtime.config.id.clone();
-                    self.shutdown_detached_runtime(&id, prepared.runtime).await;
-                }
-                return Err(error.into());
-            }
-        };
+        let event_batch = self.prepare_event_batch(sequence, events, retired);
+        let mut commits = prepared
+            .into_iter()
+            .map(PreparedServerRuntime::into_commit)
+            .collect::<Vec<_>>();
 
-        if let Err(error) = before_publish().await {
-            for prepared in replacements {
-                let id = prepared.runtime.config.id.clone();
-                self.shutdown_detached_runtime(&id, prepared.runtime).await;
-            }
-            return Err(error);
-        }
+        before_publish().await?;
 
-        // From the durable boundary through the end of these loops there must
-        // be no suspension point: cancellation must observe either the old
-        // section or every committed runtime/tool-index publication.
-        let mut published = Vec::new();
-        let mut replaced = Vec::new();
-        for prepared in replacements {
-            let (id, tool_names, old) = self.publish_prepared_runtime(prepared);
-            if let Some(old) = old {
-                // publish_prepared_runtime sets shutdown synchronously before
-                // returning, but keep the old generation for deferred cleanup.
-                replaced.push((id.clone(), old));
+        // No await or fallible operation is permitted after the durable
+        // boundary. The reconcile lock proves the prevalidated base is current.
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::BeforeFenceAndSwap);
+        self.authority.replace_prevalidated_with(&base, next, || {
+            for (publication, _) in &retirements {
+                publication.retire_with_runtime();
             }
-            published.push((id, tool_names));
-        }
-        let mut removed = Vec::new();
-        for id in removals {
-            match self.detach_runtime_without_index(&id) {
-                Ok(runtime) => removed.push((id, runtime)),
-                Err(error) => {
-                    // The reconcile lock makes this unreachable for ordinary
-                    // manager callers, but a commit must remain best-effort and
-                    // infallible once replacements are published.
-                    warn!("Failed to detach removed MCP server '{}': {}", id, error);
-                }
-            }
-        }
-        self.index.commit_catalog_update(catalog_update);
+            #[cfg(test)]
+            self.observe_publish(PublishProbePhase::AfterFencesBeforeSwap);
+        });
 
-        // Event channel backpressure and transport shutdown are post-commit
-        // cleanup. They must never delay section health publication by the
-        // caller or make a committed reconcile cancellable halfway through.
-        for (id, tool_names) in published {
-            let manager = self.clone();
-            tokio::spawn(async move {
-                manager.emit_runtime_ready_events(id, tool_names).await;
-            });
+        for commit in &mut commits {
+            commit.mark_published();
         }
-        for (id, runtime) in removed {
-            let manager = self.clone();
-            tokio::spawn(async move {
-                manager.finish_detached_stop(id, runtime, true).await;
-            });
+        for commit in &mut commits {
+            commit.activate();
         }
-        for (id, old) in replaced {
-            let manager = self.clone();
-            tokio::spawn(async move {
-                manager.finish_detached_stop(id, old, false).await;
-            });
-        }
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::AfterTransferAndSwapBeforeUnlock);
+        drop(reconcile);
+        event_batch.activate();
         Ok(())
     }
 
-    /// Initialize from configuration.
+    /// Initialize the enabled configuration as one generation instead of
+    /// exposing a partial server-by-server prefix.
     pub async fn initialize_from_config(&self, config: &McpConfig) {
-        for server_config in &config.servers {
-            if !server_config.enabled {
-                continue;
-            }
-
-            if let Err(e) = self.start_server(server_config.clone()).await {
-                error!("Failed to start MCP server '{}': {}", server_config.id, e);
-            }
+        if let Err(error) = self.reconcile_from_config_transactional(config).await {
+            error!("Failed to initialize MCP configuration: {error}");
         }
     }
 }

--- a/crates/infra/bamboo-mcp/src/manager/generation.rs
+++ b/crates/infra/bamboo-mcp/src/manager/generation.rs
@@ -1,0 +1,743 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use bamboo_agent_core::{FunctionSchema, ToolSchema};
+
+use super::ServerRuntime;
+use crate::error::{McpError, Result, ToolRegistrationError};
+use crate::protocol::McpProtocolClient;
+use crate::tool_index::{IndexState, ResolvedIndexAlias, ServerToolCatalog};
+use crate::types::{McpTool, RuntimeInfo, ToolAlias};
+
+/// Monotonic identity of one structural server publication.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PublicationId(u64);
+
+impl PublicationId {
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    pub(super) fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Monotonic identity of one transport connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RuntimeId(u64);
+
+impl RuntimeId {
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    pub(super) fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FenceState {
+    Open,
+    Retiring,
+    Closed,
+}
+
+#[derive(Debug)]
+struct PublicationFence {
+    state: FenceState,
+    active_calls: usize,
+}
+
+struct RuntimeFence {
+    state: FenceState,
+    active_calls: usize,
+    client: Option<Arc<McpProtocolClient>>,
+}
+
+fn mutex_lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// One exact transport connection. Passive snapshots may retain this allocation,
+/// but retirement removes its client and aborts owned tasks synchronously, so a
+/// snapshot never keeps transport resources alive.
+pub(super) struct TransportRuntime {
+    pub(super) runtime_id: RuntimeId,
+    pub(super) runtime: ServerRuntime,
+    fence: Mutex<RuntimeFence>,
+    tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
+}
+
+impl fmt::Debug for TransportRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TransportRuntime")
+            .field("runtime_id", &self.runtime_id)
+            .field("server_id", &self.runtime.config.id)
+            .field("state", &mutex_lock(&self.fence).state)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TransportRuntime {
+    pub(super) fn new(
+        runtime_id: RuntimeId,
+        runtime: ServerRuntime,
+        client: McpProtocolClient,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            runtime_id,
+            runtime,
+            fence: Mutex::new(RuntimeFence {
+                state: FenceState::Open,
+                active_calls: 0,
+                client: Some(Arc::new(client)),
+            }),
+            tasks: Mutex::new(Vec::new()),
+        })
+    }
+
+    pub(super) fn client_if_open(&self) -> Result<Arc<McpProtocolClient>> {
+        let fence = mutex_lock(&self.fence);
+        if fence.state != FenceState::Open {
+            return Err(McpError::StalePublication {
+                publication_id: 0,
+                runtime_id: self.runtime_id.get(),
+            });
+        }
+        fence.client.clone().ok_or(McpError::StalePublication {
+            publication_id: 0,
+            runtime_id: self.runtime_id.get(),
+        })
+    }
+
+    pub(super) fn install_tasks(
+        &self,
+        handles: impl IntoIterator<Item = tokio::task::JoinHandle<()>>,
+    ) {
+        let mut tasks = mutex_lock(&self.tasks);
+        debug_assert!(tasks.is_empty(), "one task set is owned by each runtime");
+        tasks.extend(handles);
+    }
+
+    /// Close transport admission, synchronously detach transport ownership, and
+    /// abort every generation-specific background task. Active execution leases
+    /// retain their exact client until they finish.
+    pub(super) fn retire(&self) {
+        let detached_client = {
+            let mut fence = mutex_lock(&self.fence);
+            if fence.state == FenceState::Closed {
+                return;
+            }
+            fence.state = FenceState::Retiring;
+            let client = fence.client.take();
+            if fence.active_calls == 0 {
+                fence.state = FenceState::Closed;
+            }
+            client
+        };
+        for handle in mutex_lock(&self.tasks).drain(..) {
+            handle.abort();
+        }
+        drop(detached_client);
+    }
+
+    #[cfg(test)]
+    pub(super) fn fence_state(&self) -> FenceState {
+        mutex_lock(&self.fence).state
+    }
+
+    #[cfg(test)]
+    pub(super) fn active_calls(&self) -> usize {
+        mutex_lock(&self.fence).active_calls
+    }
+}
+
+/// Immutable catalog publication for one server.
+pub(crate) struct ServerPublication {
+    pub(super) publication_id: PublicationId,
+    pub(super) server_id: String,
+    pub(super) runtime: Arc<TransportRuntime>,
+    pub(super) catalog: ServerToolCatalog,
+    tools: BTreeMap<String, McpTool>,
+    schemas: Vec<ToolSchema>,
+    fence: Mutex<PublicationFence>,
+}
+
+impl fmt::Debug for ServerPublication {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ServerPublication")
+            .field("publication_id", &self.publication_id)
+            .field("runtime_id", &self.runtime.runtime_id)
+            .field("server_id", &self.server_id)
+            .field("tool_count", &self.tools.len())
+            .field("state", &mutex_lock(&self.fence).state)
+            .finish()
+    }
+}
+
+impl ServerPublication {
+    pub(super) fn new(
+        publication_id: PublicationId,
+        runtime: Arc<TransportRuntime>,
+        catalog: ServerToolCatalog,
+        discovered_tools: &[McpTool],
+    ) -> Result<Arc<Self>> {
+        let mut discovered = BTreeMap::new();
+        for tool in discovered_tools {
+            discovered.insert(tool.name.clone(), tool.clone());
+        }
+
+        let mut tools = BTreeMap::new();
+        let mut schemas = Vec::new();
+        for alias in catalog.aliases() {
+            let tool = discovered
+                .get(&alias.original_name)
+                .ok_or(ToolRegistrationError::ProviderSchemaUnavailable)?;
+            tools.insert(alias.original_name.clone(), tool.clone());
+            schemas.push(ToolSchema {
+                schema_type: "function".to_string(),
+                function: FunctionSchema {
+                    name: alias.alias,
+                    description: tool.description.clone(),
+                    parameters: tool.parameters.clone(),
+                },
+            });
+        }
+
+        Ok(Arc::new(Self {
+            publication_id,
+            server_id: catalog.server_id().to_string(),
+            runtime,
+            catalog,
+            tools,
+            schemas,
+            fence: Mutex::new(PublicationFence {
+                state: FenceState::Open,
+                active_calls: 0,
+            }),
+        }))
+    }
+
+    pub(super) fn tool(&self, original_name: &str) -> Option<McpTool> {
+        self.tools.get(original_name).cloned()
+    }
+
+    pub(super) fn tool_count(&self) -> usize {
+        self.tools.len()
+    }
+
+    pub(super) fn schemas(&self) -> &[ToolSchema] {
+        &self.schemas
+    }
+
+    pub(super) fn close_admission(&self) {
+        let mut fence = mutex_lock(&self.fence);
+        if fence.state == FenceState::Open {
+            fence.state = FenceState::Retiring;
+            if fence.active_calls == 0 {
+                fence.state = FenceState::Closed;
+            }
+        }
+    }
+
+    pub(super) fn retire_with_runtime(&self) {
+        // Admission always locks publication before runtime. Preserve that order
+        // while closing both fences so check+increment cannot race retirement.
+        let detached_client = {
+            let mut publication = mutex_lock(&self.fence);
+            let mut runtime = mutex_lock(&self.runtime.fence);
+            publication.state = FenceState::Retiring;
+            runtime.state = FenceState::Retiring;
+            let client = runtime.client.take();
+            if runtime.active_calls == 0 {
+                runtime.state = FenceState::Closed;
+            }
+            if publication.active_calls == 0 {
+                publication.state = FenceState::Closed;
+            }
+            client
+        };
+        for handle in mutex_lock(&self.runtime.tasks).drain(..) {
+            handle.abort();
+        }
+        drop(detached_client);
+    }
+
+    fn admit(self: &Arc<Self>) -> Result<AdmissionLease> {
+        let mut publication = mutex_lock(&self.fence);
+        let mut runtime = mutex_lock(&self.runtime.fence);
+        if publication.state != FenceState::Open || runtime.state != FenceState::Open {
+            return Err(McpError::StalePublication {
+                publication_id: self.publication_id.get(),
+                runtime_id: self.runtime.runtime_id.get(),
+            });
+        }
+        let client = runtime.client.clone().ok_or(McpError::StalePublication {
+            publication_id: self.publication_id.get(),
+            runtime_id: self.runtime.runtime_id.get(),
+        })?;
+        publication.active_calls = publication.active_calls.saturating_add(1);
+        runtime.active_calls = runtime.active_calls.saturating_add(1);
+        drop(runtime);
+        drop(publication);
+        Ok(AdmissionLease {
+            publication: self.clone(),
+            client,
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn fence_state(&self) -> FenceState {
+        mutex_lock(&self.fence).state
+    }
+
+    #[cfg(test)]
+    pub(super) fn active_calls(&self) -> usize {
+        mutex_lock(&self.fence).active_calls
+    }
+}
+
+struct AdmissionLease {
+    publication: Arc<ServerPublication>,
+    client: Arc<McpProtocolClient>,
+}
+
+impl Drop for AdmissionLease {
+    fn drop(&mut self) {
+        let mut publication = mutex_lock(&self.publication.fence);
+        let mut runtime = mutex_lock(&self.publication.runtime.fence);
+        publication.active_calls = publication.active_calls.saturating_sub(1);
+        runtime.active_calls = runtime.active_calls.saturating_sub(1);
+        if publication.state == FenceState::Retiring && publication.active_calls == 0 {
+            publication.state = FenceState::Closed;
+        }
+        if runtime.state == FenceState::Retiring && runtime.active_calls == 0 {
+            runtime.state = FenceState::Closed;
+        }
+    }
+}
+
+/// A passive, generation-pinned exact MCP dispatch ticket.
+#[derive(Clone)]
+pub struct ResolvedMcpCall {
+    canonical_name: String,
+    original_name: String,
+    authority: Arc<GenerationAuthority>,
+    publication: Arc<ServerPublication>,
+}
+
+impl fmt::Debug for ResolvedMcpCall {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResolvedMcpCall")
+            .field("canonical_name", &self.canonical_name)
+            .field("publication_id", &self.publication.publication_id)
+            .field("runtime_id", &self.publication.runtime.runtime_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResolvedMcpCall {
+    pub fn canonical_name(&self) -> &str {
+        &self.canonical_name
+    }
+
+    pub fn original_name(&self) -> &str {
+        &self.original_name
+    }
+
+    pub fn server_id(&self) -> &str {
+        &self.publication.server_id
+    }
+
+    pub fn publication_id(&self) -> PublicationId {
+        self.publication.publication_id
+    }
+
+    pub fn runtime_id(&self) -> RuntimeId {
+        self.publication.runtime.runtime_id
+    }
+
+    pub(super) fn expected(&self) -> ExpectedPublication {
+        ExpectedPublication {
+            publication: self.publication.clone(),
+        }
+    }
+
+    pub(super) fn belongs_to(&self, authority: &Arc<GenerationAuthority>) -> bool {
+        GenerationAuthority::same_authority(&self.authority, authority)
+    }
+
+    pub(super) fn admit(&self) -> Result<AdmittedMcpCall> {
+        let lease = self.publication.admit()?;
+        Ok(AdmittedMcpCall {
+            resolved: self.clone(),
+            lease,
+        })
+    }
+}
+
+/// Internal active lease for one generation-pinned MCP call. It is
+/// intentionally non-cloneable: consuming execution or Drop releases exactly
+/// one admission.
+pub(super) struct AdmittedMcpCall {
+    pub(super) resolved: ResolvedMcpCall,
+    lease: AdmissionLease,
+}
+
+impl AdmittedMcpCall {
+    pub(super) fn client(&self) -> &McpProtocolClient {
+        &self.lease.client
+    }
+
+    pub(super) fn runtime(&self) -> &Arc<TransportRuntime> {
+        &self.resolved.publication.runtime
+    }
+}
+
+/// Opaque authority carried by notification, health, QoS and reconnect work.
+#[derive(Clone)]
+pub(super) struct ExpectedPublication {
+    pub(super) publication: Arc<ServerPublication>,
+}
+
+impl ExpectedPublication {
+    pub(super) fn server_id(&self) -> &str {
+        &self.publication.server_id
+    }
+
+    pub(super) fn runtime(&self) -> &Arc<TransportRuntime> {
+        &self.publication.runtime
+    }
+}
+
+pub(crate) struct McpRuntimeGeneration {
+    pub(crate) revision: u64,
+    pub(crate) servers: BTreeMap<String, Arc<ServerPublication>>,
+    pub(crate) index: Arc<IndexState>,
+    schemas: Arc<[ToolSchema]>,
+}
+
+impl fmt::Debug for McpRuntimeGeneration {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("McpRuntimeGeneration")
+            .field("revision", &self.revision)
+            .field("server_count", &self.servers.len())
+            .field("schema_count", &self.schemas.len())
+            .finish()
+    }
+}
+
+impl McpRuntimeGeneration {
+    pub(crate) fn empty() -> Arc<Self> {
+        Arc::new(Self {
+            revision: 0,
+            servers: BTreeMap::new(),
+            index: Arc::new(IndexState::default()),
+            schemas: Arc::from([]),
+        })
+    }
+
+    pub(crate) fn plan(
+        base: &Arc<Self>,
+        replacements: &[Arc<ServerPublication>],
+        removals: &[String],
+        ledger_relationship_limit: usize,
+        require_runtime: bool,
+    ) -> Result<Arc<Self>> {
+        let catalogs = replacements
+            .iter()
+            .map(|publication| publication.catalog.clone())
+            .collect::<Vec<_>>();
+        let index =
+            base.index
+                .plan_catalog_update(&catalogs, removals, ledger_relationship_limit)?;
+        Self::with_index(base, replacements, removals, index, require_runtime)
+    }
+
+    pub(crate) fn with_index(
+        base: &Arc<Self>,
+        replacements: &[Arc<ServerPublication>],
+        removals: &[String],
+        index: IndexState,
+        require_runtime: bool,
+    ) -> Result<Arc<Self>> {
+        let mut servers = base.servers.clone();
+        for server_id in removals {
+            servers.remove(server_id);
+        }
+        for publication in replacements {
+            servers.insert(publication.server_id.clone(), publication.clone());
+        }
+
+        let mut schemas = Vec::new();
+        for alias in index.all_aliases() {
+            let Some(publication) = servers.get(&alias.server_id) else {
+                if require_runtime {
+                    return Err(ToolRegistrationError::ProviderSchemaUnavailable.into());
+                }
+                continue;
+            };
+            let Some(schema) = publication
+                .schemas()
+                .iter()
+                .find(|schema| schema.function.name == alias.alias)
+            else {
+                return Err(ToolRegistrationError::ProviderSchemaUnavailable.into());
+            };
+            schemas.push(schema.clone());
+        }
+
+        Ok(Arc::new(Self {
+            revision: index.revision(),
+            servers,
+            index: Arc::new(index),
+            schemas: schemas.into(),
+        }))
+    }
+
+    fn resolve(
+        &self,
+        authority: &Arc<GenerationAuthority>,
+        reference: &str,
+    ) -> Option<ResolvedMcpCall> {
+        let ResolvedIndexAlias {
+            canonical_alias,
+            server_id,
+            original_name,
+        } = self.index.resolve(reference)?;
+        let publication = self.servers.get(&server_id)?.clone();
+        publication.tool(&original_name)?;
+        Some(ResolvedMcpCall {
+            canonical_name: canonical_alias,
+            original_name,
+            authority: authority.clone(),
+            publication,
+        })
+    }
+
+    fn resolve_server_tool(
+        &self,
+        authority: &Arc<GenerationAuthority>,
+        server_id: &str,
+        original_name: &str,
+    ) -> Option<ResolvedMcpCall> {
+        let publication = self.servers.get(server_id)?.clone();
+        publication.tool(original_name)?;
+        let canonical_name = publication
+            .catalog
+            .aliases()
+            .into_iter()
+            .find(|alias| alias.original_name == original_name)?
+            .alias;
+        Some(ResolvedMcpCall {
+            canonical_name,
+            original_name: original_name.to_string(),
+            authority: authority.clone(),
+            publication,
+        })
+    }
+}
+
+pub(crate) struct GenerationAuthority {
+    cell: RwLock<Arc<McpRuntimeGeneration>>,
+    pub(crate) ledger_relationship_limit: usize,
+}
+
+impl GenerationAuthority {
+    pub(crate) fn new(ledger_relationship_limit: usize) -> Arc<Self> {
+        Arc::new(Self {
+            cell: RwLock::new(McpRuntimeGeneration::empty()),
+            ledger_relationship_limit,
+        })
+    }
+
+    fn read(&self) -> RwLockReadGuard<'_, Arc<McpRuntimeGeneration>> {
+        self.cell
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, Arc<McpRuntimeGeneration>> {
+        self.cell
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    pub(crate) fn generation(&self) -> Arc<McpRuntimeGeneration> {
+        self.read().clone()
+    }
+
+    pub(crate) fn same_authority(left: &Arc<Self>, right: &Arc<Self>) -> bool {
+        Arc::ptr_eq(left, right)
+    }
+
+    pub(crate) fn is_current(&self, expected: &Arc<McpRuntimeGeneration>) -> bool {
+        Arc::ptr_eq(&self.read(), expected)
+    }
+
+    /// The reconcile lock proves exclusivity and callers validate the base before
+    /// a durable boundary. Replacement is therefore intentionally infallible.
+    #[cfg(test)]
+    pub(crate) fn replace_prevalidated(
+        &self,
+        expected: &Arc<McpRuntimeGeneration>,
+        next: Arc<McpRuntimeGeneration>,
+    ) {
+        self.replace_prevalidated_with(expected, next, || {});
+    }
+
+    /// Run fence retirement and the Arc swap while snapshot acquisition is
+    /// excluded. Readers therefore pin either an open old generation or the
+    /// complete new generation, never a listed old alias after its fence closed.
+    pub(crate) fn replace_prevalidated_with(
+        &self,
+        expected: &Arc<McpRuntimeGeneration>,
+        next: Arc<McpRuntimeGeneration>,
+        before_swap: impl FnOnce(),
+    ) {
+        let mut current = self.write();
+        assert!(
+            Arc::ptr_eq(&current, expected),
+            "MCP generation writer invariant violated"
+        );
+        before_swap();
+        *current = next;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_replace(
+        &self,
+        expected: &Arc<McpRuntimeGeneration>,
+        next: Arc<McpRuntimeGeneration>,
+    ) -> bool {
+        let mut current = self.write();
+        if !Arc::ptr_eq(&current, expected) {
+            return false;
+        }
+        *current = next;
+        true
+    }
+}
+
+/// One immutable generation pin. All multi-field reads and exact resolution are
+/// served from this Arc without consulting live manager state again.
+#[derive(Clone)]
+pub struct McpRuntimeSnapshot {
+    authority: Arc<GenerationAuthority>,
+    generation: Arc<McpRuntimeGeneration>,
+}
+
+impl McpRuntimeSnapshot {
+    pub(crate) fn new(
+        authority: Arc<GenerationAuthority>,
+        generation: Arc<McpRuntimeGeneration>,
+    ) -> Self {
+        Self {
+            authority,
+            generation,
+        }
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.generation.revision
+    }
+
+    pub fn list_tools(&self) -> Vec<ToolSchema> {
+        self.generation.schemas.to_vec()
+    }
+
+    pub fn aliases(&self) -> Vec<ToolAlias> {
+        self.generation.index.all_aliases()
+    }
+
+    pub fn contains_exact_alias(&self, alias: &str) -> bool {
+        self.generation.index.contains_exact(alias)
+    }
+
+    pub fn lookup(&self, alias: &str) -> Option<ToolAlias> {
+        self.generation.index.lookup(alias)
+    }
+
+    pub fn resolve_call(&self, reference: &str) -> Option<ResolvedMcpCall> {
+        self.generation.resolve(&self.authority, reference)
+    }
+
+    pub fn server_ids(&self) -> Vec<String> {
+        self.generation.servers.keys().cloned().collect()
+    }
+
+    pub fn contains_server(&self, server_id: &str) -> bool {
+        self.generation.servers.contains_key(server_id)
+    }
+
+    pub fn server_info(&self, server_id: &str) -> Option<RuntimeInfo> {
+        let publication = self.generation.servers.get(server_id)?;
+        let mut info = publication.runtime.runtime.info.try_read().ok()?.clone();
+        info.tool_count = publication.tool_count();
+        Some(info)
+    }
+
+    pub fn tool(&self, server_id: &str, original_name: &str) -> Option<McpTool> {
+        self.generation.servers.get(server_id)?.tool(original_name)
+    }
+
+    pub fn connected_server_instructions(&self) -> Vec<(String, String)> {
+        self.generation
+            .servers
+            .iter()
+            .filter_map(|(server_id, publication)| {
+                let info = publication.runtime.runtime.info.try_read().ok()?;
+                (info.status == crate::types::ServerStatus::Ready)
+                    .then(|| info.instructions.clone())
+                    .flatten()
+                    .map(|instructions| (server_id.clone(), instructions))
+            })
+            .collect()
+    }
+
+    pub(super) fn expected_server(&self, server_id: &str) -> Option<ExpectedPublication> {
+        Some(ExpectedPublication {
+            publication: self.generation.servers.get(server_id)?.clone(),
+        })
+    }
+
+    pub(super) fn expected_runtime(
+        &self,
+        runtime: &Arc<TransportRuntime>,
+    ) -> Option<ExpectedPublication> {
+        self.generation
+            .servers
+            .values()
+            .find(|publication| Arc::ptr_eq(&publication.runtime, runtime))
+            .cloned()
+            .map(|publication| ExpectedPublication { publication })
+    }
+
+    pub(super) fn resolve_server_tool(
+        &self,
+        server_id: &str,
+        original_name: &str,
+    ) -> Option<ResolvedMcpCall> {
+        self.generation
+            .resolve_server_tool(&self.authority, server_id, original_name)
+    }
+}
+
+pub(super) fn admit_resolved(
+    authority: &Arc<GenerationAuthority>,
+    resolved: &ResolvedMcpCall,
+) -> Result<AdmittedMcpCall> {
+    if !resolved.belongs_to(authority) {
+        return Err(McpError::ForeignRuntimeAuthority);
+    }
+    resolved.admit()
+}

--- a/crates/infra/bamboo-mcp/src/manager/lifecycle.rs
+++ b/crates/infra/bamboo-mcp/src/manager/lifecycle.rs
@@ -1,37 +1,101 @@
+use tokio::sync::{oneshot, OwnedMutexGuard};
 use tokio::time::{interval, Duration};
 
 use super::fingerprint::desired_proxy_fingerprint;
+use super::generation::{admit_resolved, AdmittedMcpCall};
 use super::*;
 use crate::protocol::models::JsonRpcNotification;
 
-/// MCP methods a server sends when its tool list changes. Per the MCP spec the
-/// wire method is `notifications/tools/list_changed`; the bare `tools/list_changed`
-/// is accepted defensively for servers that omit the `notifications/` prefix. #366.
 const TOOLS_LIST_CHANGED_METHODS: [&str; 2] =
     ["notifications/tools/list_changed", "tools/list_changed"];
 
+pub(super) struct RetiredRuntimeCleanup {
+    pub(super) runtime: Arc<TransportRuntime>,
+}
+
+/// One already-validated event batch. The task owns the global publication
+/// sequencer before it can observe the activation gate. Generation writers can
+/// therefore finish without waiting for bounded output capacity, while a
+/// successor cannot publish until every event in this batch has been delivered.
+pub(super) struct PreparedEventBatch {
+    gate: Option<oneshot::Sender<()>>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl PreparedEventBatch {
+    pub(super) fn activate(mut self) {
+        if let Some(gate) = self.gate.take() {
+            let _ = gate.send(());
+        }
+        // Dropping a JoinHandle detaches rather than aborts the activated task.
+        self.task = None;
+    }
+}
+
+impl Drop for PreparedEventBatch {
+    fn drop(&mut self) {
+        self.gate = None;
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
 impl McpServerManager {
-    /// Start a new MCP server connection.
+    /// Start and publish one fully initialized MCP server.
     pub async fn start_server(&self, config: McpServerConfig) -> Result<()> {
-        let _reconcile = self.reconcile_lock.lock().await;
-        self.start_server_unlocked(config).await
+        let sequence = self.event_sequence_lock.clone().lock_owned().await;
+        let reconcile = self.reconcile_lock.lock().await;
+        let events = self.start_server_unlocked(config, sequence).await;
+        drop(reconcile);
+        match events {
+            Ok(events) => {
+                events.activate();
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
     }
 
-    pub(super) async fn start_server_unlocked(&self, config: McpServerConfig) -> Result<()> {
+    async fn start_server_unlocked(
+        &self,
+        config: McpServerConfig,
+        sequence: OwnedMutexGuard<()>,
+    ) -> Result<PreparedEventBatch> {
         let server_id = config.id.clone();
-
-        if self.runtimes.contains_key(&server_id) {
+        if self.is_server_running(&server_id) {
             return Err(McpError::AlreadyRunning(server_id));
         }
 
         info!("Starting MCP server '{}'", server_id);
-
         let prepared = self.prepare_server_runtime(config, "start").await?;
-        debug_assert_eq!(prepared.runtime.config.id, server_id);
-        let replaced = self.install_prepared_runtime(prepared).await?;
-        debug_assert!(replaced.is_none());
-
-        Ok(())
+        let publication = prepared.publication().clone();
+        let base = self.authority.generation();
+        let next = McpRuntimeGeneration::plan(
+            &base,
+            std::slice::from_ref(&publication),
+            &[],
+            self.authority.ledger_relationship_limit,
+            true,
+        )?;
+        let events = self.prepare_event_batch(
+            sequence,
+            self.runtime_ready_events(&publication),
+            Vec::new(),
+        );
+        let mut commit = prepared.into_commit();
+        debug_assert!(self.authority.is_current(&base));
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::BeforeFenceAndSwap);
+        self.authority.replace_prevalidated_with(&base, next, || {
+            #[cfg(test)]
+            self.observe_publish(PublishProbePhase::AfterFencesBeforeSwap);
+        });
+        commit.mark_published();
+        commit.activate();
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::AfterTransferAndSwapBeforeUnlock);
+        Ok(events)
     }
 
     pub(super) async fn prepare_server_runtime(
@@ -39,584 +103,572 @@ impl McpServerManager {
         config: McpServerConfig,
         phase: &'static str,
     ) -> Result<PreparedServerRuntime> {
+        self.prepare_server_runtime_with_restart(config, phase, 0)
+            .await
+    }
+
+    pub(super) async fn prepare_server_runtime_with_restart(
+        &self,
+        config: McpServerConfig,
+        phase: &'static str,
+        restart_count: u32,
+    ) -> Result<PreparedServerRuntime> {
         let server_id = config.id.clone();
         let runtime_proxy_fingerprint = desired_proxy_fingerprint(self.config.as_ref()).await;
-        let (mut client, tools, instructions, notification_rx) = self
+        let (client, tools, instructions, notification_rx) = self
             .bootstrap_server_client(&server_id, &config, phase)
             .await?;
-        let catalog = match self.index.plan_server_tools(
+        let catalog = self.index.plan_server_tools(
             &server_id,
             &tools,
             &config.allowed_tools,
             &config.denied_tools,
-        ) {
-            Ok(catalog) => catalog,
-            Err(error) => {
-                let _ = client.disconnect().await;
-                return Err(error.into());
-            }
-        };
-        let runtime = Arc::new(ServerRuntime {
+        )?;
+        #[cfg(test)]
+        let mut catalog = catalog;
+        #[cfg(test)]
+        if let Some(probe) = &self.catalog_plan_probe {
+            probe(&server_id, &mut catalog);
+        }
+        let tool_count = catalog.aliases().len();
+        let runtime = ServerRuntime {
             config,
-            client: RwLock::new(client),
-            info: RwLock::new(RuntimeInfo {
+            info: tokio::sync::RwLock::new(RuntimeInfo {
                 status: ServerStatus::Ready,
                 last_error: None,
                 connected_at: Some(Utc::now()),
                 disconnected_at: None,
-                tool_count: tools.len(),
-                restart_count: 0,
+                tool_count,
+                restart_count,
                 last_ping_at: Some(Utc::now()),
                 instructions,
             }),
-            tools: RwLock::new(tools.clone()),
-            shutdown: AtomicBool::new(false),
             reconnecting: AtomicBool::new(false),
             qos: McpServerQos::new(McpQosConfig::default()),
             proxy_fingerprint: runtime_proxy_fingerprint,
-        });
+        };
+        let runtime = TransportRuntime::new(self.allocate_runtime_id()?, runtime, client);
+        let publication =
+            ServerPublication::new(self.allocate_publication_id()?, runtime, catalog, &tools)?;
+        let activation = self.prepare_runtime_tasks(publication.clone(), notification_rx);
         Ok(PreparedServerRuntime {
-            runtime,
-            catalog,
-            notification_rx,
+            publication: Some(publication),
+            activation: Some(activation),
         })
     }
 
-    /// Publish a fully initialized runtime. No fallible initialization remains
-    /// in this method, so callers can stage all candidates before committing.
-    pub(super) async fn install_prepared_runtime(
+    pub(super) fn prepare_runtime_tasks(
         &self,
-        prepared: PreparedServerRuntime,
-    ) -> Result<Option<Arc<ServerRuntime>>> {
-        let transaction = match self
-            .index
-            .preflight_catalog_update(std::slice::from_ref(&prepared.catalog), &[])
-        {
-            Ok(transaction) => transaction,
-            Err(error) => {
-                let server_id = prepared.runtime.config.id.clone();
-                self.shutdown_detached_runtime(&server_id, prepared.runtime)
-                    .await;
-                return Err(error.into());
-            }
+        publication: Arc<ServerPublication>,
+        notification_rx: Option<tokio::sync::mpsc::Receiver<JsonRpcNotification>>,
+    ) -> RuntimeActivation {
+        let (gate, health_gate) = tokio::sync::watch::channel(false);
+        let runtime = publication.runtime.clone();
+        let mut handles = vec![self.spawn_health_check(runtime.clone(), health_gate)];
+        if let Some(receiver) = notification_rx {
+            handles.push(self.spawn_notification_drain(
+                runtime.clone(),
+                receiver,
+                gate.subscribe(),
+            ));
+        }
+        #[cfg(test)]
+        let task_count = handles.len();
+        runtime.install_tasks(handles);
+        let activation = RuntimeActivation {
+            gate: Some(gate),
+            #[cfg(test)]
+            task_count,
+            #[cfg(test)]
+            probe: self.task_probe.clone(),
         };
-        let (server_id, tool_names, replaced) = self.publish_prepared_runtime(prepared);
-        self.index.commit_catalog_update(transaction);
-
-        info!(
-            "Registered {} MCP tools for server '{}'",
-            tool_names.len(),
-            server_id
-        );
-
-        self.emit_runtime_ready_events(server_id, tool_names).await;
-        Ok(replaced)
+        #[cfg(test)]
+        activation.observe(TaskProbePhase::PreparedAndGated);
+        activation
     }
 
-    /// Publish a fully initialized runtime without suspending. Configuration
-    /// reconciliation uses this after its durable CAS boundary so cancellation
-    /// cannot leave only part of a committed runtime set visible.
-    pub(super) fn publish_prepared_runtime(
+    pub(super) fn runtime_ready_events(
         &self,
-        prepared: PreparedServerRuntime,
-    ) -> (String, Vec<String>, Option<Arc<ServerRuntime>>) {
-        let PreparedServerRuntime {
-            runtime,
-            catalog,
-            notification_rx,
-        } = prepared;
-        let config = &runtime.config;
-        let server_id = config.id.clone();
-        let healthcheck_interval_ms = config.healthcheck_interval_ms;
-
-        let tool_names = catalog
-            .aliases()
-            .into_iter()
-            .map(|alias| alias.alias)
-            .collect();
-
-        // Store runtime only after its client initialized and tools were read.
-        let replaced = self.runtimes.insert(server_id.clone(), runtime.clone());
-
-        // Spawn the notification drain only AFTER the runtime is registered, so an
-        // immediate `tools/list_changed` resolves via `refresh_tools` instead of
-        // racing `ServerNotFound`. (#420)
-        if let Some(rx) = notification_rx {
-            self.spawn_notification_drain(server_id.clone(), runtime.clone(), rx);
-        }
-
-        // The new generation's health task and the old generation's shutdown
-        // flag are part of the synchronous publication boundary. Event delivery
-        // and client disconnection may suspend and happen afterward.
-        self.start_health_check(runtime, healthcheck_interval_ms);
-        if let Some(ref old) = replaced {
-            old.shutdown.store(true, Ordering::SeqCst);
-        }
-
-        (server_id, tool_names, replaced)
+        publication: &Arc<ServerPublication>,
+    ) -> Vec<McpEvent> {
+        vec![
+            McpEvent::ServerStatusChanged {
+                server_id: publication.server_id.clone(),
+                status: ServerStatus::Ready,
+                error: None,
+            },
+            McpEvent::ToolsChanged {
+                server_id: publication.server_id.clone(),
+                tools: publication
+                    .catalog
+                    .aliases()
+                    .into_iter()
+                    .map(|alias| alias.alias)
+                    .collect(),
+            },
+        ]
     }
 
-    pub(super) async fn emit_runtime_ready_events(
+    pub(super) fn prepare_event_batch(
         &self,
-        server_id: String,
-        tool_names: Vec<String>,
-    ) {
-        if let Some(ref tx) = self.event_tx {
-            let _ = tx
-                .send(McpEvent::ServerStatusChanged {
-                    server_id: server_id.clone(),
-                    status: ServerStatus::Ready,
-                    error: None,
-                })
-                .await;
-
-            let _ = tx
-                .send(McpEvent::ToolsChanged {
-                    server_id,
-                    tools: tool_names,
-                })
-                .await;
-        }
-    }
-
-    /// Stop an MCP server connection.
-    pub async fn stop_server(&self, server_id: &str) -> Result<()> {
-        let _reconcile = self.reconcile_lock.lock().await;
-        self.stop_server_unlocked(server_id).await
-    }
-
-    pub(super) async fn stop_server_unlocked(&self, server_id: &str) -> Result<()> {
-        info!("Stopping MCP server '{}'", server_id);
-        // `stop_server` owns the reconciliation lock. Preflight the catalog
-        // removal before detaching the runtime, then publish both changes with
-        // no suspension/cancellation point. Another OS thread may briefly see
-        // the old alias after runtime removal, but execution then fails closed
-        // on the missing runtime; it can never resolve to a different owner.
-        // The checked commit is infallible under the single-writer invariant
-        // and fail-stops before swapping if violated.
-        let transaction = self
-            .index
-            .preflight_catalog_update(&[], &[server_id.to_string()])?;
-        let runtime = self.detach_runtime_without_index(server_id)?;
-        self.index.commit_catalog_update(transaction);
-        self.finish_detached_stop(server_id.to_string(), runtime, true)
-            .await;
-        info!("MCP server '{}' stopped", server_id);
-        Ok(())
-    }
-
-    /// Detach only the runtime. Transactional configuration reconciliation uses
-    /// this while a preflighted whole-index replacement is waiting to commit.
-    pub(super) fn detach_runtime_without_index(
-        &self,
-        server_id: &str,
-    ) -> Result<Arc<ServerRuntime>> {
-        let (_, runtime) = self
-            .runtimes
-            .remove(server_id)
-            .ok_or_else(|| McpError::NotRunning(server_id.to_string()))?;
-        runtime.shutdown.store(true, Ordering::SeqCst);
-        Ok(runtime)
-    }
-
-    pub(super) async fn finish_detached_stop(
-        &self,
-        server_id: String,
-        runtime: Arc<ServerRuntime>,
-        emit_stopped: bool,
-    ) {
-        self.shutdown_detached_runtime(&server_id, runtime).await;
-        if emit_stopped {
-            if let Some(ref tx) = self.event_tx {
-                let _ = tx
-                    .send(McpEvent::ServerStatusChanged {
-                        server_id,
-                        status: ServerStatus::Stopped,
-                        error: None,
-                    })
-                    .await;
+        sequence: OwnedMutexGuard<()>,
+        events: Vec<McpEvent>,
+        retired: Vec<RetiredRuntimeCleanup>,
+    ) -> PreparedEventBatch {
+        #[cfg(test)]
+        self.observe_event(EventProbePhase::BeforeBatchValidation);
+        let tx = self.event_tx.clone();
+        #[cfg(test)]
+        let event_probe = self.event_probe.clone();
+        let (gate, activated) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _sequence = sequence;
+            if activated.await.is_err() {
+                return;
             }
+            #[cfg(test)]
+            if let Some(probe) = &event_probe {
+                probe(EventProbePhase::AcceptedBatchBeforeFirstDelivery);
+            }
+            for cleanup in retired {
+                cleanup.runtime.retire();
+                let mut info = cleanup.runtime.runtime.info.write().await;
+                info.status = ServerStatus::Stopped;
+                info.disconnected_at = Some(Utc::now());
+            }
+            let Some(tx) = tx else {
+                return;
+            };
+            for event in events {
+                #[cfg(test)]
+                if let Some(probe) = &event_probe {
+                    probe(EventProbePhase::BeforeOutputSend);
+                }
+                if tx.send(event).await.is_err() {
+                    return;
+                }
+            }
+        });
+        PreparedEventBatch {
+            gate: Some(gate),
+            task: Some(task),
         }
     }
 
-    /// Stop a runtime that has already been detached/replaced. This deliberately
-    /// does not touch the runtime map or tool index, which now belong to its
-    /// successfully committed replacement.
-    pub(super) async fn shutdown_detached_runtime(
+    /// Remove one server publication and retire its exact transport runtime.
+    pub async fn stop_server(&self, server_id: &str) -> Result<()> {
+        let sequence = self.event_sequence_lock.clone().lock_owned().await;
+        let reconcile = self.reconcile_lock.lock().await;
+        let events = self.stop_server_unlocked(server_id, sequence);
+        drop(reconcile);
+        match events {
+            Ok(events) => {
+                events.activate();
+                info!("MCP server '{}' stopped", server_id);
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn stop_server_unlocked(
         &self,
         server_id: &str,
-        runtime: Arc<ServerRuntime>,
-    ) {
-        runtime.shutdown.store(true, Ordering::SeqCst);
-        let mut client = runtime.client.write().await;
-        if let Err(error) = client.disconnect().await {
-            warn!(
-                "Error disconnecting replaced MCP server '{}': {}",
-                server_id, error
-            );
-        }
-        let mut info = runtime.info.write().await;
-        info.status = ServerStatus::Stopped;
-        info.disconnected_at = Some(Utc::now());
+        sequence: OwnedMutexGuard<()>,
+    ) -> Result<PreparedEventBatch> {
+        info!("Stopping MCP server '{}'", server_id);
+        let base = self.authority.generation();
+        let publication = base
+            .servers
+            .get(server_id)
+            .cloned()
+            .ok_or_else(|| McpError::NotRunning(server_id.to_string()))?;
+        let next = McpRuntimeGeneration::plan(
+            &base,
+            &[],
+            &[server_id.to_string()],
+            self.authority.ledger_relationship_limit,
+            true,
+        )?;
+        let events = self.prepare_event_batch(
+            sequence,
+            vec![McpEvent::ServerStatusChanged {
+                server_id: server_id.to_string(),
+                status: ServerStatus::Stopped,
+                error: None,
+            }],
+            vec![RetiredRuntimeCleanup {
+                runtime: publication.runtime.clone(),
+            }],
+        );
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::BeforeFenceAndSwap);
+        self.authority.replace_prevalidated_with(&base, next, || {
+            publication.retire_with_runtime();
+            #[cfg(test)]
+            self.observe_publish(PublishProbePhase::AfterFencesBeforeSwap);
+        });
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::AfterTransferAndSwapBeforeUnlock);
+        Ok(events)
     }
 
-    /// Call a tool on a specific server.
+    /// Execute an original server tool name through one resolved generation.
     pub async fn call_tool(
         &self,
         server_id: &str,
         tool_name: &str,
         args: serde_json::Value,
     ) -> Result<crate::types::McpCallResult> {
-        let runtime = self
-            .runtimes
-            .get(server_id)
-            .ok_or_else(|| McpError::ServerNotFound(server_id.to_string()))?;
+        let snapshot = self.snapshot();
+        let resolved = snapshot
+            .resolve_server_tool(server_id, tool_name)
+            .ok_or_else(|| {
+                if snapshot.contains_server(server_id) {
+                    McpError::ToolNotFound(tool_name.to_string())
+                } else {
+                    McpError::ServerNotFound(server_id.to_string())
+                }
+            })?;
+        self.call_resolved_tool(&resolved, args).await
+    }
 
-        runtime.qos.check_circuit(server_id, tool_name).await?;
-        let _permit = runtime.qos.acquire_permit().await?;
+    /// Execute a passive exact ticket after linearizable admission.
+    pub async fn call_resolved_tool(
+        &self,
+        resolved: &ResolvedMcpCall,
+        args: serde_json::Value,
+    ) -> Result<crate::types::McpCallResult> {
+        let admitted = admit_resolved(&self.authority, resolved)?;
+        self.call_admitted_tool(admitted, args).await
+    }
 
-        let client = runtime.client.read().await;
-        let timeout = runtime.config.request_timeout_ms;
-        let result = client.call_tool(tool_name, args, timeout).await;
-        drop(client);
+    /// Execute one already-admitted exact lease without any live name lookup.
+    async fn call_admitted_tool(
+        &self,
+        admitted: AdmittedMcpCall,
+        args: serde_json::Value,
+    ) -> Result<crate::types::McpCallResult> {
+        if !admitted.resolved.belongs_to(&self.authority) {
+            return Err(McpError::ForeignRuntimeAuthority);
+        }
+        let server_id = admitted.resolved.server_id().to_string();
+        let tool_name = admitted.resolved.original_name().to_string();
+        let runtime = admitted.runtime().clone();
+        runtime
+            .runtime
+            .qos
+            .check_circuit(&server_id, &tool_name)
+            .await?;
+        let _permit = runtime.runtime.qos.acquire_permit().await?;
+        let timeout = runtime.runtime.config.request_timeout_ms;
+        let result = admitted.client().call_tool(&tool_name, args, timeout).await;
 
         let result = match result {
-            // A tool that RAN but reported failure (`is_error`) is still `Ok` at
-            // the protocol level — so without this the QoS/health path would count
-            // it as a success and a server with a wedged capability (e.g. nova when
-            // its capture pipeline is stuck: it answers pings and returns an error
-            // RESULT well within request_timeout_ms, so it never trips a protocol
-            // timeout) would fail forever without ever being recycled.
             Ok(result) if result.is_error => {
                 let synthetic =
                     McpError::ToolExecution(format!("tool '{tool_name}' returned an error result"));
                 let should_recycle = runtime
+                    .runtime
                     .qos
-                    .record_failure(server_id, tool_name, &synthetic)
+                    .record_failure(&server_id, &tool_name, &synthetic)
                     .await;
-                self.maybe_recycle_server(runtime.value(), should_recycle);
+                self.maybe_recycle_server(admitted.resolved.expected(), should_recycle);
                 result
             }
             Ok(result) => {
-                runtime.qos.record_success().await;
+                runtime.runtime.qos.record_success().await;
                 result
             }
             Err(error) => {
                 let should_recycle = runtime
+                    .runtime
                     .qos
-                    .record_failure(server_id, tool_name, &error)
+                    .record_failure(&server_id, &tool_name, &error)
                     .await;
-                self.maybe_recycle_server(runtime.value(), should_recycle);
+                self.maybe_recycle_server(admitted.resolved.expected(), should_recycle);
                 return Err(error);
             }
         };
 
-        // Emit event
-        if let Some(ref tx) = self.event_tx {
-            let _ = tx
-                .send(McpEvent::ToolExecuted {
-                    server_id: server_id.to_string(),
-                    tool_name: tool_name.to_string(),
+        let expected = admitted.resolved.expected();
+        let sequence = self.event_sequence_lock.clone().lock_owned().await;
+        let reconcile = self.reconcile_lock.lock().await;
+        let events = self.is_current_publication(&expected).then(|| {
+            self.prepare_event_batch(
+                sequence,
+                vec![McpEvent::ToolExecuted {
+                    server_id,
+                    tool_name,
                     success: !result.is_error,
-                })
-                .await;
+                }],
+                Vec::new(),
+            )
+        });
+        drop(reconcile);
+        if let Some(events) = events {
+            events.activate();
         }
-
         Ok(result)
     }
 
-    /// Recycle a server that has failed too many times in a row — disconnect (the
-    /// existing child process is killed) and reconnect (a fresh one is spawned).
-    /// Non-blocking: runs in its own task with its own backoff, guarded against
-    /// concurrent runs by `ServerRuntime::reconnecting`. Skipped when recycling
-    /// isn't warranted, reconnect is disabled for the server, or it's shutting down.
-    fn maybe_recycle_server(&self, runtime: &Arc<ServerRuntime>, should_recycle: bool) {
+    pub(super) fn maybe_recycle_server(&self, expected: ExpectedPublication, should_recycle: bool) {
+        let runtime = expected.runtime();
         if !should_recycle
-            || !runtime.config.reconnect.enabled
-            || runtime.shutdown.load(Ordering::SeqCst)
+            || !runtime.runtime.config.reconnect.enabled
+            || !self.is_current_publication(&expected)
         {
             return;
         }
         let manager = self.clone();
-        let runtime = runtime.clone();
-        let server_id = runtime.config.id.clone();
+        let server_id = expected.server_id().to_string();
         warn!(
             "Recycling MCP server '{}' after repeated tool failures (disconnect + reconnect)",
             server_id
         );
         tokio::spawn(async move {
-            if let Err(e) = manager.attempt_reconnection(runtime).await {
-                warn!("MCP server '{}' recycle failed: {}", server_id, e);
+            if let Err(error) = manager.attempt_reconnection(expected).await {
+                warn!("MCP server '{}' recycle failed: {}", server_id, error);
             }
         });
     }
 
-    /// Get tool info for a specific tool.
+    /// Return one published tool's immutable provider metadata.
     pub fn get_tool_info(&self, server_id: &str, tool_name: &str) -> Option<McpTool> {
-        self.runtimes.get(server_id).and_then(|runtime| {
-            let tools = runtime.tools.try_read().ok()?;
-            tools.iter().find(|t| t.name == tool_name).cloned()
-        })
+        self.snapshot().tool(server_id, tool_name)
     }
 
-    /// Refresh tools from a server.
+    /// Refresh a server's catalog using its exact currently-published runtime.
     pub async fn refresh_tools(&self, server_id: &str) -> Result<()> {
-        let runtime = self
-            .runtimes
-            .get(server_id)
-            .map(|runtime| runtime.value().clone())
+        let expected = self
+            .current_expected(server_id)
             .ok_or_else(|| McpError::ServerNotFound(server_id.to_string()))?;
+        self.refresh_tools_for_expected(expected).await.map(|_| ())
+    }
 
+    async fn refresh_tools_for_expected(&self, expected: ExpectedPublication) -> Result<bool> {
+        let server_id = expected.server_id().to_string();
         info!("Refreshing tools for MCP server '{}'", server_id);
-
-        let client = runtime.client.read().await;
-        let new_tools = client.list_tools(runtime.config.request_timeout_ms).await?;
-        drop(client);
-
-        if !self
-            .publish_refreshed_tools_if_current(server_id, &runtime, new_tools)
-            .await?
-        {
-            tracing::debug!(
-                "Discarding tool refresh for detached MCP runtime '{}'",
-                server_id
-            );
-        }
-        Ok(())
+        let client = expected.runtime().client_if_open()?;
+        let new_tools = client
+            .list_tools(expected.runtime().runtime.config.request_timeout_ms)
+            .await?;
+        self.publish_refreshed_tools_if_current(expected, new_tools)
+            .await
     }
 
     pub(super) async fn publish_refreshed_tools_if_current(
         &self,
-        server_id: &str,
-        runtime: &Arc<ServerRuntime>,
+        expected: ExpectedPublication,
         new_tools: Vec<McpTool>,
     ) -> Result<bool> {
-        // Serialize the generation check with transactional replacement. The
-        // list_tools await above may span a replacement, so checking only when
-        // the refresh starts is insufficient.
-        let _reconcile = self.reconcile_lock.lock().await;
-        if runtime.shutdown.load(Ordering::SeqCst) || !self.is_current_runtime(server_id, runtime) {
+        let sequence = self.event_sequence_lock.clone().lock_owned().await;
+        let reconcile = self.reconcile_lock.lock().await;
+        if !self.is_current_publication(&expected) {
             return Ok(false);
         }
-
+        let server_id = expected.server_id().to_string();
+        let config = &expected.runtime().runtime.config;
         let catalog = self.index.plan_server_tools(
-            server_id,
+            &server_id,
             &new_tools,
-            &runtime.config.allowed_tools,
-            &runtime.config.denied_tools,
+            &config.allowed_tools,
+            &config.denied_tools,
         )?;
-        let aliases = catalog.aliases();
-        let transaction = self
-            .index
-            .preflight_catalog_update(std::slice::from_ref(&catalog), &[])?;
-
-        // Acquire every fallible/suspending guard before the publication point.
-        // From the index swap through the runtime metadata update there is no
-        // await, so a failed preflight leaves the prior catalog untouched.
-        let mut tools = runtime.tools.write().await;
-        let mut info = runtime.info.write().await;
-        self.index.commit_catalog_update(transaction);
-        *tools = new_tools.clone();
-        info.tool_count = new_tools.len();
-        drop(info);
-        drop(tools);
-
-        info!(
-            "Refreshed {} tools for MCP server '{}'",
-            aliases.len(),
-            server_id
-        );
-
-        // Emit event
-        if let Some(ref tx) = self.event_tx {
-            let tool_names: Vec<String> = aliases.into_iter().map(|a| a.alias).collect();
-            let _ = tx
-                .send(McpEvent::ToolsChanged {
-                    server_id: server_id.to_string(),
-                    tools: tool_names,
-                })
-                .await;
+        let replacement = ServerPublication::new(
+            self.allocate_publication_id()?,
+            expected.runtime().clone(),
+            catalog,
+            &new_tools,
+        )?;
+        let base = self.authority.generation();
+        if !Arc::ptr_eq(
+            base.servers
+                .get(&server_id)
+                .expect("validated current server"),
+            &expected.publication,
+        ) {
+            return Ok(false);
         }
-
+        let next = McpRuntimeGeneration::plan(
+            &base,
+            std::slice::from_ref(&replacement),
+            &[],
+            self.authority.ledger_relationship_limit,
+            true,
+        )?;
+        let events = self.prepare_event_batch(
+            sequence,
+            vec![McpEvent::ToolsChanged {
+                server_id,
+                tools: replacement
+                    .catalog
+                    .aliases()
+                    .into_iter()
+                    .map(|alias| alias.alias)
+                    .collect(),
+            }],
+            Vec::new(),
+        );
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::BeforeFenceAndSwap);
+        self.authority.replace_prevalidated_with(&base, next, || {
+            expected.publication.close_admission();
+            #[cfg(test)]
+            self.observe_publish(PublishProbePhase::AfterFencesBeforeSwap);
+        });
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::AfterTransferAndSwapBeforeUnlock);
+        drop(reconcile);
+        events.activate();
         Ok(true)
     }
 
-    fn start_health_check(&self, runtime: Arc<ServerRuntime>, interval_ms: u64) {
-        let server_id = runtime.config.id.clone();
-        let manager = Arc::new(self.clone());
-
+    fn spawn_health_check(
+        &self,
+        runtime: Arc<TransportRuntime>,
+        mut activation: tokio::sync::watch::Receiver<bool>,
+    ) -> tokio::task::JoinHandle<()> {
+        let manager = self.clone();
         tokio::spawn(async move {
-            let mut interval = interval(Duration::from_millis(interval_ms));
-
+            if !Self::wait_for_runtime_activation(&mut activation).await {
+                return;
+            }
+            let mut ticker = interval(Duration::from_millis(
+                runtime.runtime.config.healthcheck_interval_ms,
+            ));
             loop {
-                interval.tick().await;
-
-                if runtime.shutdown.load(Ordering::SeqCst)
-                    || !manager.is_current_runtime(&server_id, &runtime)
-                {
+                ticker.tick().await;
+                let Some(expected) = manager.current_expected_for_runtime(&runtime) else {
                     break;
-                }
-
-                // Skip health check if currently reconnecting
-                if runtime.reconnecting.load(Ordering::SeqCst) {
+                };
+                if runtime.runtime.reconnecting.load(Ordering::SeqCst) {
                     continue;
                 }
-
-                let ping_result = {
-                    let client = runtime.client.read().await;
-                    client.ping(runtime.config.request_timeout_ms).await
+                let result = match runtime.client_if_open() {
+                    Ok(client) => client
+                        .ping(runtime.runtime.config.request_timeout_ms)
+                        .await
+                        .map_err(|error| error.to_string()),
+                    Err(_) => break,
                 };
-
                 let Some(should_reconnect) = manager
-                    .publish_health_result_if_current(
-                        &server_id,
-                        &runtime,
-                        ping_result.map_err(|error| error.to_string()),
-                    )
+                    .publish_health_result_if_current(expected.clone(), result)
                     .await
                 else {
-                    break;
+                    continue;
                 };
-
                 if should_reconnect {
-                    if let Err(reconnect_err) = manager.attempt_reconnection(runtime.clone()).await
-                    {
-                        error!(
-                            "Reconnection failed for MCP server '{}': {}",
-                            server_id, reconnect_err
-                        );
+                    if let Err(error) = manager.attempt_reconnection(expected).await {
+                        error!("MCP health-triggered reconnection failed: {}", error);
                     }
                 }
             }
-        });
+        })
     }
 
     pub(super) async fn publish_health_result_if_current(
         &self,
-        server_id: &str,
-        runtime: &Arc<ServerRuntime>,
+        expected: ExpectedPublication,
         result: std::result::Result<(), String>,
     ) -> Option<bool> {
-        // A ping may span a transactional replacement. Keep this generation
-        // check and all status/event publication serialized with replacement.
-        let _reconcile = self.reconcile_lock.lock().await;
-        if runtime.shutdown.load(Ordering::SeqCst) || !self.is_current_runtime(server_id, runtime) {
+        let sequence = self.event_sequence_lock.clone().lock_owned().await;
+        let reconcile = self.reconcile_lock.lock().await;
+        if !self.is_current_publication(&expected) {
             return None;
         }
-
-        match result {
+        let runtime = expected.runtime();
+        let (should_reconnect, event) = match result {
             Ok(()) => {
-                let mut info = runtime.info.write().await;
+                let mut info = runtime.runtime.info.write().await;
                 info.last_ping_at = Some(Utc::now());
                 let recovered = info.status == ServerStatus::Degraded;
                 if recovered {
                     info.status = ServerStatus::Ready;
                 }
                 drop(info);
-                if recovered {
-                    if let Some(ref tx) = self.event_tx {
-                        let _ = tx
-                            .send(McpEvent::ServerStatusChanged {
-                                server_id: server_id.to_string(),
-                                status: ServerStatus::Ready,
-                                error: None,
-                            })
-                            .await;
-                    }
-                }
-                Some(false)
+                let event = recovered.then(|| McpEvent::ServerStatusChanged {
+                    server_id: expected.server_id().to_string(),
+                    status: ServerStatus::Ready,
+                    error: None,
+                });
+                (false, event)
             }
             Err(error) => {
                 warn!(
                     "Health check failed for MCP server '{}': {}",
-                    server_id, error
+                    expected.server_id(),
+                    error
                 );
                 {
-                    let mut info = runtime.info.write().await;
+                    let mut info = runtime.runtime.info.write().await;
                     info.status = ServerStatus::Degraded;
                     info.last_error = Some(error.clone());
                 }
-                if let Some(ref tx) = self.event_tx {
-                    let _ = tx
-                        .send(McpEvent::ServerStatusChanged {
-                            server_id: server_id.to_string(),
-                            status: ServerStatus::Degraded,
-                            error: Some(error),
-                        })
-                        .await;
-                }
-                Some(runtime.config.reconnect.enabled)
+                (
+                    runtime.runtime.config.reconnect.enabled,
+                    Some(McpEvent::ServerStatusChanged {
+                        server_id: expected.server_id().to_string(),
+                        status: ServerStatus::Degraded,
+                        error: Some(error),
+                    }),
+                )
             }
+        };
+        let events = event.map(|event| self.prepare_event_batch(sequence, vec![event], Vec::new()));
+        drop(reconcile);
+        if let Some(events) = events {
+            events.activate();
         }
+        Some(should_reconnect)
     }
 
-    /// Spawns the per-connection task that DRAINS this client's server-notification
-    /// queue and dispatches each notification. #366.
-    ///
-    /// The task owns the receiver (taken from the client) so it parks on
-    /// `recv().await` with zero wakeups while idle — no client lock held across the
-    /// await, no polling. It exits cleanly when every notification sender closes
-    /// (the client is disconnected/replaced on reconnect, or dropped on shutdown),
-    /// mirroring the message-handler's channel-close contract.
-    ///
-    /// Without this consumer the queue would silently fill to capacity and drop
-    /// every later notification (the #363 non-blocking send is a safety valve, not
-    /// a drain), so any capability driven by server notifications — here,
-    /// `tools/list_changed` -> tool-list refresh — would be inert.
-    pub(super) fn spawn_notification_drain(
+    fn spawn_notification_drain(
         &self,
-        server_id: String,
-        expected_runtime: Arc<ServerRuntime>,
+        runtime: Arc<TransportRuntime>,
         mut receiver: tokio::sync::mpsc::Receiver<JsonRpcNotification>,
-    ) {
+        mut activation: tokio::sync::watch::Receiver<bool>,
+    ) -> tokio::task::JoinHandle<()> {
         let manager = self.clone();
         tokio::spawn(async move {
-            while let Some(notification) = receiver.recv().await {
-                let still_current = manager
-                    .runtimes
-                    .get(&server_id)
-                    .is_some_and(|runtime| Arc::ptr_eq(runtime.value(), &expected_runtime));
-                if !still_current {
+            if !Self::wait_for_runtime_activation(&mut activation).await {
+                return;
+            }
+            loop {
+                let Some(expected) = manager.current_expected_for_runtime(&runtime) else {
                     break;
-                }
+                };
+                let Some(notification) = receiver.recv().await else {
+                    break;
+                };
                 manager
-                    .dispatch_server_notification(&server_id, notification)
+                    .dispatch_server_notification(expected, notification)
                     .await;
             }
-            tracing::trace!(
-                "MCP notification drain for server '{}' exited (channel closed)",
-                server_id
-            );
-        });
+        })
     }
 
-    /// Dispatches a single server-initiated notification. Handles
-    /// `tools/list_changed` by refreshing the server's tool list (re-registering
-    /// the tool index + emitting `ToolsChanged`); all other methods are drained and
-    /// traced so the queue can never saturate. #366.
-    async fn dispatch_server_notification(
+    async fn wait_for_runtime_activation(
+        activation: &mut tokio::sync::watch::Receiver<bool>,
+    ) -> bool {
+        if *activation.borrow() {
+            return true;
+        }
+        activation.changed().await.is_ok() && *activation.borrow()
+    }
+
+    pub(super) async fn dispatch_server_notification(
         &self,
-        server_id: &str,
+        expected: ExpectedPublication,
         notification: JsonRpcNotification,
     ) {
         let method = notification.method.as_str();
         if TOOLS_LIST_CHANGED_METHODS.contains(&method) {
-            info!(
-                "MCP server '{}' announced '{}'; refreshing tool list",
-                server_id, method
-            );
-            if let Err(e) = self.refresh_tools(server_id).await {
-                warn!(
-                    "Failed to refresh tools for MCP server '{}' after '{}': {}",
-                    server_id, method, e
-                );
+            if let Err(error) = self.refresh_tools_for_expected(expected).await {
+                warn!("Failed to refresh MCP tools after notification: {}", error);
             }
         } else {
-            tracing::trace!(
-                "MCP server '{}' notification '{}' drained (no dispatcher)",
-                server_id,
-                method
-            );
+            tracing::trace!("MCP notification '{}' drained (no dispatcher)", method);
         }
     }
 }

--- a/crates/infra/bamboo-mcp/src/manager/mod.rs
+++ b/crates/infra/bamboo-mcp/src/manager/mod.rs
@@ -1,24 +1,31 @@
 use chrono::Utc;
-use dashmap::DashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration as StdDuration, Instant};
-use tokio::sync::{Mutex, OwnedSemaphorePermit, RwLock, Semaphore};
+use tokio::sync::{watch, Mutex, OwnedSemaphorePermit, Semaphore};
 use tracing::{error, info, warn};
 
 use crate::config::{McpConfig, McpServerConfig, TransportConfig};
 use crate::error::{McpError, Result};
-use crate::protocol::models::JsonRpcNotification;
 use crate::protocol::{McpProtocolClient, McpTransport};
-use crate::tool_index::{ServerToolCatalog, ToolIndex};
+#[cfg(test)]
+use crate::tool_index::ServerToolCatalog;
+use crate::tool_index::{ToolIndex, MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS};
 use crate::transports::{SseTransport, StdioTransport, StreamableHttpTransport};
 use crate::types::{McpEvent, McpTool, RuntimeInfo, ServerStatus};
 use bamboo_llm::Config;
 
 mod config_sync;
 mod fingerprint;
+pub(crate) mod generation;
 mod lifecycle;
 mod reconnect;
+
+use generation::{
+    ExpectedPublication, GenerationAuthority, McpRuntimeGeneration, ServerPublication,
+    TransportRuntime,
+};
+pub use generation::{McpRuntimeSnapshot, PublicationId, ResolvedMcpCall, RuntimeId};
 
 #[cfg(test)]
 mod tests;
@@ -34,6 +41,40 @@ const DEFAULT_CIRCUIT_OPEN_MS: u64 = 5_000;
 /// replayd pipeline is stuck. A single success resets the counter, so a tool that
 /// merely errors occasionally never trips it.
 const DEFAULT_RECONNECT_FAILURE_THRESHOLD: u32 = 3;
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PublishProbePhase {
+    BeforeFenceAndSwap,
+    AfterFencesBeforeSwap,
+    AfterTransferAndSwapBeforeUnlock,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum EventProbePhase {
+    BeforeBatchValidation,
+    AcceptedBatchBeforeFirstDelivery,
+    BeforeOutputSend,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum TaskProbePhase {
+    PreparedAndGated,
+    Transferred,
+    Activated,
+    Dropped,
+}
+
+#[cfg(test)]
+type PublishProbe = Arc<dyn Fn(PublishProbePhase) + Send + Sync>;
+#[cfg(test)]
+type EventProbe = Arc<dyn Fn(EventProbePhase) + Send + Sync>;
+#[cfg(test)]
+type TaskProbe = Arc<dyn Fn(TaskProbePhase, usize) + Send + Sync>;
+#[cfg(test)]
+type CatalogPlanProbe = Arc<dyn Fn(&str, &mut ServerToolCatalog) + Send + Sync>;
 
 #[derive(Debug, Clone, Copy)]
 struct McpQosConfig {
@@ -61,7 +102,7 @@ struct McpQosState {
 }
 
 #[derive(Debug)]
-struct McpServerQos {
+pub(super) struct McpServerQos {
     config: McpQosConfig,
     permits: Arc<Semaphore>,
     state: Mutex<McpQosState>,
@@ -142,17 +183,14 @@ impl McpServerQos {
 }
 
 /// Runtime state for a connected MCP server.
-struct ServerRuntime {
-    config: McpServerConfig,
-    client: RwLock<McpProtocolClient>,
-    info: RwLock<RuntimeInfo>,
-    tools: RwLock<Vec<McpTool>>,
-    shutdown: AtomicBool,
-    reconnecting: AtomicBool,
-    qos: McpServerQos,
+pub(super) struct ServerRuntime {
+    pub(super) config: McpServerConfig,
+    pub(super) info: tokio::sync::RwLock<RuntimeInfo>,
+    pub(super) reconnecting: AtomicBool,
+    pub(super) qos: McpServerQos,
     // Fingerprint of the global proxy settings at the time this runtime was started.
     // Used to force-restart SSE transports when proxy settings change.
-    proxy_fingerprint: Option<String>,
+    pub(super) proxy_fingerprint: Option<String>,
 }
 
 /// Fully bootstrapped candidate that has not yet been published into the
@@ -160,51 +198,212 @@ struct ServerRuntime {
 /// every replacement first, so a later bootstrap failure cannot evict a
 /// working runtime.
 struct PreparedServerRuntime {
-    runtime: Arc<ServerRuntime>,
-    catalog: ServerToolCatalog,
-    notification_rx: Option<tokio::sync::mpsc::Receiver<JsonRpcNotification>>,
+    publication: Option<Arc<ServerPublication>>,
+    activation: Option<RuntimeActivation>,
+}
+
+impl PreparedServerRuntime {
+    fn publication(&self) -> &Arc<ServerPublication> {
+        self.publication
+            .as_ref()
+            .expect("staged publication is present until commit")
+    }
+
+    fn into_commit(mut self) -> PreparedRuntimeCommit {
+        let publication = self
+            .publication
+            .take()
+            .expect("staged publication commits once");
+        let activation = self
+            .activation
+            .take()
+            .expect("staged runtime activation commits once");
+        PreparedRuntimeCommit {
+            publication,
+            activation: Some(activation),
+            published: false,
+        }
+    }
+}
+
+/// Candidate ownership after all fallible publication planning is complete.
+/// Until `mark_published`, Drop retires the candidate synchronously. After the
+/// generation swap, all candidates are marked first and only then are their
+/// pre-owned background tasks activated, so a panic cannot retire a runtime
+/// already reachable from the published generation.
+struct PreparedRuntimeCommit {
+    publication: Arc<ServerPublication>,
+    activation: Option<RuntimeActivation>,
+    published: bool,
+}
+
+impl PreparedRuntimeCommit {
+    #[cfg(test)]
+    fn publication(&self) -> &Arc<ServerPublication> {
+        &self.publication
+    }
+
+    fn mark_published(&mut self) {
+        self.published = true;
+    }
+
+    fn activate(&mut self) {
+        if let Some(activation) = self.activation.take() {
+            activation.activate();
+        }
+    }
+
+    #[cfg(test)]
+    fn discard_activation(&mut self) {
+        self.activation = None;
+    }
+}
+
+impl Drop for PreparedRuntimeCommit {
+    fn drop(&mut self) {
+        if !self.published {
+            self.publication.close_admission();
+            self.publication.runtime.retire();
+        }
+    }
+}
+
+impl Drop for PreparedServerRuntime {
+    fn drop(&mut self) {
+        if let Some(publication) = self.publication.take() {
+            publication.close_admission();
+            publication.runtime.retire();
+        }
+        self.activation = None;
+    }
+}
+
+/// Synchronous activation handle for background tasks that were spawned,
+/// gated, and attached to a candidate runtime before its publication became
+/// durable. Dropping the sender keeps those tasks behind the gate until the
+/// candidate runtime retires and aborts them.
+struct RuntimeActivation {
+    gate: Option<watch::Sender<bool>>,
+    #[cfg(test)]
+    task_count: usize,
+    #[cfg(test)]
+    probe: Option<TaskProbe>,
+}
+
+impl RuntimeActivation {
+    fn activate(mut self) {
+        #[cfg(test)]
+        self.observe(TaskProbePhase::Transferred);
+        if let Some(gate) = self.gate.take() {
+            gate.send_replace(true);
+        }
+        #[cfg(test)]
+        self.observe(TaskProbePhase::Activated);
+    }
+
+    #[cfg(test)]
+    fn observe(&self, phase: TaskProbePhase) {
+        if let Some(probe) = &self.probe {
+            probe(phase, self.task_count);
+        }
+    }
+}
+
+impl Drop for RuntimeActivation {
+    fn drop(&mut self) {
+        #[cfg(test)]
+        if self.gate.is_some() {
+            self.observe(TaskProbePhase::Dropped);
+        }
+    }
 }
 
 /// Manages MCP server connections and tool execution.
 pub struct McpServerManager {
-    runtimes: Arc<DashMap<String, Arc<ServerRuntime>>>,
+    authority: Arc<GenerationAuthority>,
     index: Arc<ToolIndex>,
     event_tx: Option<tokio::sync::mpsc::Sender<McpEvent>>,
     config: Option<Arc<tokio::sync::RwLock<Config>>>,
+    event_sequence_lock: Arc<Mutex<()>>,
     reconcile_lock: Arc<Mutex<()>>,
+    next_publication_id: Arc<AtomicU64>,
+    next_runtime_id: Arc<AtomicU64>,
+    #[cfg(test)]
+    publish_probe: Option<PublishProbe>,
+    #[cfg(test)]
+    event_probe: Option<EventProbe>,
+    #[cfg(test)]
+    task_probe: Option<TaskProbe>,
+    #[cfg(test)]
+    catalog_plan_probe: Option<CatalogPlanProbe>,
 }
 
 impl Clone for McpServerManager {
     fn clone(&self) -> Self {
         Self {
-            runtimes: self.runtimes.clone(),
+            authority: self.authority.clone(),
             index: self.index.clone(),
             event_tx: self.event_tx.clone(),
             config: self.config.clone(),
+            event_sequence_lock: self.event_sequence_lock.clone(),
             reconcile_lock: self.reconcile_lock.clone(),
+            next_publication_id: self.next_publication_id.clone(),
+            next_runtime_id: self.next_runtime_id.clone(),
+            #[cfg(test)]
+            publish_probe: self.publish_probe.clone(),
+            #[cfg(test)]
+            event_probe: self.event_probe.clone(),
+            #[cfg(test)]
+            task_probe: self.task_probe.clone(),
+            #[cfg(test)]
+            catalog_plan_probe: self.catalog_plan_probe.clone(),
         }
     }
 }
 
 impl McpServerManager {
     pub fn new() -> Self {
+        let authority = GenerationAuthority::new(MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS);
         Self {
-            runtimes: Arc::new(DashMap::new()),
-            index: Arc::new(ToolIndex::new()),
+            index: Arc::new(ToolIndex::from_authority(authority.clone())),
+            authority,
             event_tx: None,
             config: None,
+            event_sequence_lock: Arc::new(Mutex::new(())),
             reconcile_lock: Arc::new(Mutex::new(())),
+            next_publication_id: Arc::new(AtomicU64::new(1)),
+            next_runtime_id: Arc::new(AtomicU64::new(1)),
+            #[cfg(test)]
+            publish_probe: None,
+            #[cfg(test)]
+            event_probe: None,
+            #[cfg(test)]
+            task_probe: None,
+            #[cfg(test)]
+            catalog_plan_probe: None,
         }
     }
 
     /// Create a manager that can respect global proxy settings when connecting SSE transports.
     pub fn new_with_config(config: Arc<tokio::sync::RwLock<Config>>) -> Self {
+        let authority = GenerationAuthority::new(MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS);
         Self {
-            runtimes: Arc::new(DashMap::new()),
-            index: Arc::new(ToolIndex::new()),
+            index: Arc::new(ToolIndex::from_authority(authority.clone())),
+            authority,
             event_tx: None,
             config: Some(config),
+            event_sequence_lock: Arc::new(Mutex::new(())),
             reconcile_lock: Arc::new(Mutex::new(())),
+            next_publication_id: Arc::new(AtomicU64::new(1)),
+            next_runtime_id: Arc::new(AtomicU64::new(1)),
+            #[cfg(test)]
+            publish_probe: None,
+            #[cfg(test)]
+            event_probe: None,
+            #[cfg(test)]
+            task_probe: None,
+            #[cfg(test)]
+            catalog_plan_probe: None,
         }
     }
 
@@ -217,19 +416,56 @@ impl McpServerManager {
         self.index.clone()
     }
 
+    /// Freeze one coherent MCP generation for multi-field reads or exact
+    /// execution resolution.
+    pub fn snapshot(&self) -> McpRuntimeSnapshot {
+        McpRuntimeSnapshot::new(self.authority.clone(), self.authority.generation())
+    }
+
+    pub(crate) fn has_same_authority(&self, index: &ToolIndex) -> bool {
+        GenerationAuthority::same_authority(&self.authority, index.authority())
+    }
+
+    #[cfg(test)]
+    fn observe_publish(&self, phase: PublishProbePhase) {
+        if let Some(probe) = &self.publish_probe {
+            probe(phase);
+        }
+    }
+
+    #[cfg(test)]
+    fn observe_event(&self, phase: EventProbePhase) {
+        if let Some(probe) = &self.event_probe {
+            probe(phase);
+        }
+    }
+
+    fn allocate_publication_id(&self) -> Result<PublicationId> {
+        self.next_publication_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .map(PublicationId::new)
+            .map_err(|_| McpError::PublicationIdentityExhausted)
+    }
+
+    fn allocate_runtime_id(&self) -> Result<RuntimeId> {
+        self.next_runtime_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .map(RuntimeId::new)
+            .map_err(|_| McpError::RuntimeIdentityExhausted)
+    }
+
     /// Get all server IDs.
     pub fn list_servers(&self) -> Vec<String> {
-        self.runtimes
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect()
+        self.snapshot().server_ids()
     }
 
     /// Get runtime info for a server.
     pub fn get_server_info(&self, server_id: &str) -> Option<RuntimeInfo> {
-        self.runtimes
-            .get(server_id)
-            .and_then(|runtime| runtime.info.try_read().ok().map(|info| info.clone()))
+        self.snapshot().server_info(server_id)
     }
 
     /// `(server_id, instructions)` for every currently-ready server that returned
@@ -237,31 +473,28 @@ impl McpServerManager {
     /// own usage guidance into the system prompt — so guidance appears only while
     /// the server is actually loaded. Sorted by server id for a stable prompt.
     pub fn connected_server_instructions(&self) -> Vec<(String, String)> {
-        let mut out: Vec<(String, String)> = self
-            .runtimes
-            .iter()
-            .filter_map(|entry| {
-                let info = entry.value().info.try_read().ok()?;
-                if info.status != ServerStatus::Ready {
-                    return None;
-                }
-                let instructions = info.instructions.clone()?;
-                Some((entry.key().clone(), instructions))
-            })
-            .collect();
-        out.sort_by(|a, b| a.0.cmp(&b.0));
-        out
+        self.snapshot().connected_server_instructions()
     }
 
     /// Check if a server is running.
     pub fn is_server_running(&self, server_id: &str) -> bool {
-        self.runtimes.contains_key(server_id)
+        self.snapshot().contains_server(server_id)
     }
 
-    fn is_current_runtime(&self, server_id: &str, expected: &Arc<ServerRuntime>) -> bool {
-        self.runtimes
-            .get(server_id)
-            .is_some_and(|runtime| Arc::ptr_eq(runtime.value(), expected))
+    fn current_expected(&self, server_id: &str) -> Option<ExpectedPublication> {
+        self.snapshot().expected_server(server_id)
+    }
+
+    fn current_expected_for_runtime(
+        &self,
+        runtime: &Arc<TransportRuntime>,
+    ) -> Option<ExpectedPublication> {
+        self.snapshot().expected_runtime(runtime)
+    }
+
+    fn is_current_publication(&self, expected: &ExpectedPublication) -> bool {
+        self.current_expected(expected.server_id())
+            .is_some_and(|current| Arc::ptr_eq(&current.publication, &expected.publication))
     }
 
     /// Shutdown all servers.

--- a/crates/infra/bamboo-mcp/src/manager/reconnect.rs
+++ b/crates/infra/bamboo-mcp/src/manager/reconnect.rs
@@ -5,289 +5,158 @@ use crate::protocol::models::JsonRpcNotification;
 use super::*;
 
 impl McpServerManager {
-    /// Attempt to reconnect a degraded server with exponential backoff.
-    pub(super) async fn attempt_reconnection(&self, runtime: Arc<ServerRuntime>) -> Result<()> {
-        let server_id = runtime.config.id.clone();
-
-        // Check if already reconnecting
+    /// Health and QoS share this runtime-local singleflight. Every attempt is
+    /// affine to the exact expected publication/runtime and can never reconnect
+    /// a successor selected only by server id.
+    pub(super) async fn attempt_reconnection(&self, expected: ExpectedPublication) -> Result<()> {
+        let runtime = expected.runtime().clone();
         if runtime
+            .runtime
             .reconnecting
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
             .is_err()
         {
-            info!(
-                "Reconnection already in progress for MCP server '{}'",
-                server_id
-            );
             return Ok(());
         }
 
-        let reconnect_config = &runtime.config.reconnect;
-        let mut current_backoff = reconnect_config.initial_backoff_ms;
+        let reconnect = runtime.runtime.config.reconnect.clone();
+        let mut backoff = reconnect.initial_backoff_ms;
         let mut attempt = 0u32;
-
-        info!(
-            "Starting reconnection attempts for MCP server '{}' (max_attempts: {})",
-            server_id,
-            if reconnect_config.max_attempts == 0 {
-                "unlimited".to_string()
-            } else {
-                reconnect_config.max_attempts.to_string()
-            }
-        );
-
         loop {
-            // Check if shutdown was requested
-            if runtime.shutdown.load(Ordering::SeqCst)
-                || !self.is_current_runtime(&server_id, &runtime)
-            {
-                info!(
-                    "Reconnection cancelled due to shutdown or replacement for MCP server '{}'",
-                    server_id
-                );
-                runtime.reconnecting.store(false, Ordering::SeqCst);
+            if !self.is_current_publication(&expected) {
+                runtime.runtime.reconnecting.store(false, Ordering::SeqCst);
                 return Ok(());
             }
-
-            // Check max attempts
-            if reconnect_config.max_attempts > 0 && attempt >= reconnect_config.max_attempts {
+            if reconnect.max_attempts > 0 && attempt >= reconnect.max_attempts {
+                let sequence = self.event_sequence_lock.clone().lock_owned().await;
                 let reconcile = self.reconcile_lock.lock().await;
-                if runtime.shutdown.load(Ordering::SeqCst)
-                    || !self.is_current_runtime(&server_id, &runtime)
-                {
-                    runtime.reconnecting.store(false, Ordering::SeqCst);
+                if !self.is_current_publication(&expected) {
+                    runtime.runtime.reconnecting.store(false, Ordering::SeqCst);
                     return Ok(());
                 }
-                error!(
-                    "Max reconnection attempts ({}) reached for MCP server '{}'",
-                    reconnect_config.max_attempts, server_id
-                );
-
-                // Update status to Error
-                let mut info = runtime.info.write().await;
-                info.status = ServerStatus::Error;
-                info.last_error = Some("Max reconnection attempts reached".to_string());
-                info.disconnected_at = Some(Utc::now());
-                drop(info);
-
-                // Emit error event
-                if let Some(ref tx) = self.event_tx {
-                    let _ = tx
-                        .send(McpEvent::ServerStatusChanged {
-                            server_id: server_id.clone(),
-                            status: ServerStatus::Error,
-                            error: Some("Max reconnection attempts reached".to_string()),
-                        })
-                        .await;
+                {
+                    let mut info = runtime.runtime.info.write().await;
+                    info.status = ServerStatus::Error;
+                    info.last_error = Some("Max reconnection attempts reached".to_string());
+                    info.disconnected_at = Some(Utc::now());
                 }
+                let events = self.prepare_event_batch(
+                    sequence,
+                    vec![McpEvent::ServerStatusChanged {
+                        server_id: expected.server_id().to_string(),
+                        status: ServerStatus::Error,
+                        error: Some("Max reconnection attempts reached".to_string()),
+                    }],
+                    Vec::new(),
+                );
+                runtime.runtime.reconnecting.store(false, Ordering::SeqCst);
                 drop(reconcile);
-
-                runtime.reconnecting.store(false, Ordering::SeqCst);
-                return Err(McpError::Connection(format!(
-                    "Max reconnection attempts reached for server '{}'",
-                    server_id
-                )));
+                events.activate();
+                return Err(McpError::Connection(
+                    "maximum MCP reconnection attempts reached".to_string(),
+                ));
             }
 
-            attempt += 1;
-            info!(
-                "Reconnection attempt {} for MCP server '{}' (backoff: {}ms)",
-                attempt, server_id, current_backoff
-            );
-
-            // Wait for backoff period
-            tokio::time::sleep(Duration::from_millis(current_backoff)).await;
-            if runtime.shutdown.load(Ordering::SeqCst)
-                || !self.is_current_runtime(&server_id, &runtime)
-            {
-                runtime.reconnecting.store(false, Ordering::SeqCst);
+            attempt = attempt.saturating_add(1);
+            tokio::time::sleep(Duration::from_millis(backoff)).await;
+            if !self.is_current_publication(&expected) {
+                runtime.runtime.reconnecting.store(false, Ordering::SeqCst);
                 return Ok(());
             }
 
-            // Attempt reconnection
-            match self.reconnect_server(runtime.clone()).await {
+            match self.reconnect_server(expected.clone()).await {
                 Ok(false) => {
-                    runtime.reconnecting.store(false, Ordering::SeqCst);
+                    runtime.runtime.reconnecting.store(false, Ordering::SeqCst);
                     return Ok(());
                 }
                 Ok(true) => {
-                    let reconcile = self.reconcile_lock.lock().await;
-                    if runtime.shutdown.load(Ordering::SeqCst)
-                        || !self.is_current_runtime(&server_id, &runtime)
-                    {
-                        runtime.reconnecting.store(false, Ordering::SeqCst);
-                        return Ok(());
-                    }
-                    info!(
-                        "Successfully reconnected MCP server '{}' after {} attempt(s)",
-                        server_id, attempt
-                    );
-
-                    // Update runtime info
-                    let mut info = runtime.info.write().await;
-                    info.status = ServerStatus::Ready;
-                    info.last_error = None;
-                    info.restart_count += 1;
-                    info.disconnected_at = None;
-                    drop(info);
-
-                    // Emit recovery event
-                    if let Some(ref tx) = self.event_tx {
-                        let _ = tx
-                            .send(McpEvent::ServerStatusChanged {
-                                server_id: server_id.clone(),
-                                status: ServerStatus::Ready,
-                                error: None,
-                            })
-                            .await;
-                    }
-                    drop(reconcile);
-
-                    runtime.reconnecting.store(false, Ordering::SeqCst);
+                    runtime.runtime.reconnecting.store(false, Ordering::SeqCst);
                     return Ok(());
                 }
-                Err(e) => {
-                    let reconcile = self.reconcile_lock.lock().await;
-                    if runtime.shutdown.load(Ordering::SeqCst)
-                        || !self.is_current_runtime(&server_id, &runtime)
-                    {
-                        runtime.reconnecting.store(false, Ordering::SeqCst);
+                Err(error) => {
+                    let _sequence = self.event_sequence_lock.lock().await;
+                    let _reconcile = self.reconcile_lock.lock().await;
+                    if !self.is_current_publication(&expected) {
+                        runtime.runtime.reconnecting.store(false, Ordering::SeqCst);
                         return Ok(());
                     }
-                    warn!(
-                        "Reconnection attempt {} failed for MCP server '{}': {}",
-                        attempt, server_id, e
-                    );
-
-                    // Update error info
-                    let mut info = runtime.info.write().await;
-                    info.last_error = Some(e.to_string());
-                    drop(info);
-                    drop(reconcile);
-
-                    // Calculate next backoff with exponential increase
-                    if reconnect_config.max_backoff_ms > current_backoff {
-                        current_backoff =
-                            std::cmp::min(current_backoff * 2, reconnect_config.max_backoff_ms);
+                    runtime.runtime.info.write().await.last_error = Some(error.to_string());
+                    if reconnect.max_backoff_ms > backoff {
+                        backoff = backoff.saturating_mul(2).min(reconnect.max_backoff_ms);
                     }
                 }
             }
         }
     }
 
-    /// Internal method to reconnect a single server.
-    pub(super) async fn reconnect_server(&self, runtime: Arc<ServerRuntime>) -> Result<bool> {
-        let server_id = runtime.config.id.clone();
-
-        info!("Attempting to reconnect MCP server '{}'", server_id);
-
-        let (client, tools, instructions, notification_rx) = self
-            .bootstrap_server_client(&server_id, &runtime.config, "reconnect")
+    pub(super) async fn reconnect_server(&self, expected: ExpectedPublication) -> Result<bool> {
+        let restart_count = expected
+            .runtime()
+            .runtime
+            .info
+            .read()
+            .await
+            .restart_count
+            .saturating_add(1);
+        let prepared = self
+            .prepare_server_runtime_with_restart(
+                expected.runtime().runtime.config.clone(),
+                "reconnect",
+                restart_count,
+            )
             .await?;
-
-        self.publish_reconnected_runtime_if_current(
-            &server_id,
-            &runtime,
-            client,
-            tools,
-            instructions,
-            notification_rx,
-        )
-        .await
+        self.publish_reconnected_runtime_if_current(expected, prepared)
+            .await
     }
 
     pub(super) async fn publish_reconnected_runtime_if_current(
         &self,
-        server_id: &str,
-        runtime: &Arc<ServerRuntime>,
-        mut client: McpProtocolClient,
-        tools: Vec<McpTool>,
-        instructions: Option<String>,
-        notification_rx: Option<tokio::sync::mpsc::Receiver<JsonRpcNotification>>,
+        expected: ExpectedPublication,
+        prepared: PreparedServerRuntime,
     ) -> Result<bool> {
-        // Bootstrap may span a replacement. Serialize this final generation
-        // check with transactional commit before touching runtime state or the
-        // shared tool index.
-        let _reconcile = self.reconcile_lock.lock().await;
-        if runtime.shutdown.load(Ordering::SeqCst) || !self.is_current_runtime(server_id, runtime) {
-            drop(_reconcile);
-            let _ = client.disconnect().await;
+        let sequence = self.event_sequence_lock.clone().lock_owned().await;
+        let reconcile = self.reconcile_lock.lock().await;
+        if !self.is_current_publication(&expected) {
             return Ok(false);
         }
-
-        let catalog = match self.index.plan_server_tools(
-            server_id,
-            &tools,
-            &runtime.config.allowed_tools,
-            &runtime.config.denied_tools,
+        let replacement = prepared.publication().clone();
+        let base = self.authority.generation();
+        if !Arc::ptr_eq(
+            base.servers
+                .get(expected.server_id())
+                .expect("validated current server"),
+            &expected.publication,
         ) {
-            Ok(catalog) => catalog,
-            Err(error) => {
-                drop(_reconcile);
-                let _ = client.disconnect().await;
-                return Err(error.into());
-            }
-        };
-        let aliases = catalog.aliases();
-        let catalog_update = match self
-            .index
-            .preflight_catalog_update(std::slice::from_ref(&catalog), &[])
-        {
-            Ok(update) => update,
-            Err(error) => {
-                drop(_reconcile);
-                let _ = client.disconnect().await;
-                return Err(error.into());
-            }
-        };
-
-        // Acquire every suspending guard before the publication point. Once
-        // the new client is swapped, the index and runtime metadata are updated
-        // without another await, so registration failure preserves the entire
-        // prior generation.
-        let mut client_lock = runtime.client.write().await;
-        let mut tools_lock = runtime.tools.write().await;
-        let mut info = runtime.info.write().await;
-        let mut old_client = std::mem::replace(&mut *client_lock, client);
-        self.index.commit_catalog_update(catalog_update);
-        *tools_lock = tools;
-        info.instructions = instructions;
-        info.tool_count = tools_lock.len();
-        drop(info);
-        drop(tools_lock);
-        drop(client_lock);
-
-        // Spawn the notification drain only AFTER the new client is swapped in, so
-        // an immediate `tools/list_changed` refreshes against the NEW connection
-        // (not the old, disconnected one). (#420)
-        if let Some(rx) = notification_rx {
-            self.spawn_notification_drain(server_id.to_string(), runtime.clone(), rx);
+            return Ok(false);
         }
+        let next = McpRuntimeGeneration::plan(
+            &base,
+            std::slice::from_ref(&replacement),
+            &[],
+            self.authority.ledger_relationship_limit,
+            true,
+        )?;
 
-        info!(
-            "Re-registered {} MCP tools for server '{}'",
-            aliases.len(),
-            server_id
+        let events = self.prepare_event_batch(
+            sequence,
+            self.runtime_ready_events(&replacement),
+            Vec::new(),
         );
+        let mut commit = prepared.into_commit();
 
-        // Transport shutdown and event-channel backpressure are post-commit
-        // cleanup, so cancellation cannot strand a half-published reconnect.
-        tokio::spawn(async move {
-            if old_client.disconnect().await.is_err() {
-                warn!("Failed to disconnect replaced MCP client");
-            }
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::BeforeFenceAndSwap);
+        self.authority.replace_prevalidated_with(&base, next, || {
+            expected.publication.retire_with_runtime();
+            #[cfg(test)]
+            self.observe_publish(PublishProbePhase::AfterFencesBeforeSwap);
         });
-        if let Some(ref tx) = self.event_tx {
-            let tool_names: Vec<String> = aliases.into_iter().map(|a| a.alias).collect();
-            let _ = tx
-                .send(McpEvent::ToolsChanged {
-                    server_id: server_id.to_string(),
-                    tools: tool_names,
-                })
-                .await;
-        }
-        drop(_reconcile);
-
+        commit.mark_published();
+        commit.activate();
+        #[cfg(test)]
+        self.observe_publish(PublishProbePhase::AfterTransferAndSwapBeforeUnlock);
+        drop(reconcile);
+        events.activate();
         Ok(true)
     }
 
@@ -304,56 +173,29 @@ impl McpServerManager {
     )> {
         let transport = self.build_transport(&config.transport).await?;
         let mut client = McpProtocolClient::new(transport);
-
-        client.connect().await.map_err(|e| {
+        client.connect().await.map_err(|error| {
             error!(
                 "Failed to connect MCP server '{}' during {}: {}",
-                server_id, phase, e
+                server_id, phase, error
             );
-            e
+            error
         })?;
-
         let init_result = client
             .initialize(config.request_timeout_ms)
             .await
-            .map_err(|e| {
+            .map_err(|error| {
                 error!(
                     "Failed to initialize MCP server '{}' during {}: {}",
-                    server_id, phase, e
+                    server_id, phase, error
                 );
-                e
+                error
             })?;
-
-        info!(
-            "MCP server '{}' initialized during {}: {} v{}",
-            server_id, phase, init_result.server_info.name, init_result.server_info.version
-        );
-
-        // The server's optional `instructions` (how-to-use guidance) — surfaced
-        // into the system prompt while this server is connected.
         let instructions = init_result
             .instructions
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
-
+            .map(|instructions| instructions.trim().to_string())
+            .filter(|instructions| !instructions.is_empty());
         let tools = client.list_tools(config.request_timeout_ms).await?;
-        info!(
-            "MCP server '{}' has {} tools during {}",
-            server_id,
-            tools.len(),
-            phase
-        );
-
-        // Take this client's server-notification receiver (#366) and hand it BACK
-        // to the caller rather than spawning the drain here. The drain dispatches
-        // `tools/list_changed` -> `refresh_tools`, which resolves the runtime by
-        // `server_id` and reads `runtime.client` — so it must not start until the
-        // caller has REGISTERED the runtime (`start`) / SWAPPED in the new client
-        // (`reconnect`). Spawning it inside bootstrap raced those: an immediate
-        // notification could hit `ServerNotFound` (start) or read the old,
-        // disconnected client (reconnect). (#420)
         let notification_rx = client.take_notification_receiver().await;
-
         Ok((client, tools, instructions, notification_rx))
     }
 
@@ -363,14 +205,14 @@ impl McpServerManager {
                 Ok(Box::new(StdioTransport::new(stdio_config.clone())))
             }
             TransportConfig::Sse(sse_config) => {
-                // SSE uses HTTP; ensure it respects user-configured proxy settings when available.
-                if let Some(cfg_handle) = self.config.as_ref() {
-                    let cfg = cfg_handle.read().await.clone();
-                    let client = bamboo_llm::http_client::build_http_client(&cfg).map_err(|e| {
-                        McpError::InvalidConfig(format!(
-                            "Failed to build HTTP client for MCP SSE transport: {e}"
-                        ))
-                    })?;
+                if let Some(config_handle) = self.config.as_ref() {
+                    let config = config_handle.read().await.clone();
+                    let client =
+                        bamboo_llm::http_client::build_http_client(&config).map_err(|error| {
+                            McpError::InvalidConfig(format!(
+                                "Failed to build HTTP client for MCP SSE transport: {error}"
+                            ))
+                        })?;
                     Ok(Box::new(SseTransport::new_with_client(
                         sse_config.clone(),
                         client,
@@ -379,21 +221,22 @@ impl McpServerManager {
                     Ok(Box::new(SseTransport::new(sse_config.clone())))
                 }
             }
-            TransportConfig::StreamableHttp(sh_config) => {
-                // Streamable HTTP uses HTTP; respect user-configured proxy settings.
-                if let Some(cfg_handle) = self.config.as_ref() {
-                    let cfg = cfg_handle.read().await.clone();
-                    let client = bamboo_llm::http_client::build_http_client(&cfg).map_err(|e| {
-                        McpError::InvalidConfig(format!(
-                            "Failed to build HTTP client for MCP StreamableHTTP transport: {e}"
-                        ))
-                    })?;
+            TransportConfig::StreamableHttp(http_config) => {
+                if let Some(config_handle) = self.config.as_ref() {
+                    let config = config_handle.read().await.clone();
+                    let client = bamboo_llm::http_client::build_http_client(&config).map_err(
+                        |error| {
+                            McpError::InvalidConfig(format!(
+                                "Failed to build HTTP client for MCP StreamableHTTP transport: {error}"
+                            ))
+                        },
+                    )?;
                     Ok(Box::new(StreamableHttpTransport::new_with_client(
-                        sh_config.clone(),
+                        http_config.clone(),
                         client,
                     )))
                 } else {
-                    Ok(Box::new(StreamableHttpTransport::new(sh_config.clone())))
+                    Ok(Box::new(StreamableHttpTransport::new(http_config.clone())))
                 }
             }
         }

--- a/crates/infra/bamboo-mcp/src/manager/tests.rs
+++ b/crates/infra/bamboo-mcp/src/manager/tests.rs
@@ -1,215 +1,516 @@
 use super::fingerprint::proxy_fingerprint;
 use super::*;
 use crate::config::{ReconnectConfig, SseConfig, StdioConfig};
+use crate::error::ToolRegistrationError;
 use crate::executor::McpToolExecutor;
+use crate::manager::generation::FenceState;
+use crate::protocol::models::JsonRpcNotification;
 use async_trait::async_trait;
 use bamboo_agent_core::{FunctionCall, ToolCall, ToolExecutor};
 use bamboo_domain::ClassifiedToolIdentity;
-use tokio::sync::mpsc;
+use std::collections::{BTreeSet, HashMap};
+use std::future::pending;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::{Barrier, Mutex as StdMutex};
+use tokio::sync::{mpsc, Semaphore};
 use tokio::time::{sleep, Duration};
 
-fn create_test_server_config(id: &str) -> McpServerConfig {
+fn test_config(id: &str) -> McpServerConfig {
     McpServerConfig {
         id: id.to_string(),
-        name: Some(format!("Test Server {}", id)),
+        name: Some(format!("Test {id}")),
         enabled: true,
         transport: TransportConfig::Stdio(StdioConfig {
             command: "echo".to_string(),
-            args: vec![],
+            args: Vec::new(),
             cwd: None,
-            env: std::collections::HashMap::new(),
-            env_encrypted: std::collections::HashMap::new(),
-            env_credential_refs: std::collections::HashMap::new(),
-            startup_timeout_ms: 5000,
+            env: HashMap::new(),
+            env_encrypted: HashMap::new(),
+            env_credential_refs: HashMap::new(),
+            startup_timeout_ms: 2_000,
         }),
-        request_timeout_ms: 5000,
-        healthcheck_interval_ms: 1000,
+        request_timeout_ms: 5_000,
+        healthcheck_interval_ms: 60_000,
         reconnect: ReconnectConfig {
-            enabled: false, // Disable for most tests
-            initial_backoff_ms: 100,
-            max_backoff_ms: 1000,
-            max_attempts: 3,
+            enabled: false,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 2,
+            max_attempts: 1,
         },
-        allowed_tools: vec![],
-        denied_tools: vec![],
+        allowed_tools: Vec::new(),
+        denied_tools: Vec::new(),
     }
 }
 
+fn tool(name: &str, description: &str) -> McpTool {
+    McpTool {
+        name: name.to_string(),
+        description: description.to_string(),
+        parameters: serde_json::json!({"type": "object"}),
+        output_schema: None,
+    }
+}
+
+struct MockTransport {
+    connected: AtomicBool,
+    message_rx: tokio::sync::Mutex<Option<mpsc::Receiver<String>>>,
+    message_tx: mpsc::Sender<String>,
+    tools: Arc<StdMutex<Vec<McpTool>>>,
+    marker: String,
+    call_started: Option<mpsc::UnboundedSender<()>>,
+    call_release: Option<Arc<Semaphore>>,
+    call_is_error: bool,
+    calls: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+}
+
+struct MockControls {
+    tools: Arc<StdMutex<Vec<McpTool>>>,
+    message_tx: mpsc::Sender<String>,
+    call_started: Option<mpsc::UnboundedReceiver<()>>,
+    call_release: Option<Arc<Semaphore>>,
+    calls: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl MockTransport {
+    fn new(tools: Vec<McpTool>, marker: &str) -> (Self, MockControls) {
+        Self::new_with_call_gate(tools, marker, false, false)
+    }
+
+    fn new_with_call_gate(
+        tools: Vec<McpTool>,
+        marker: &str,
+        block_call: bool,
+        call_is_error: bool,
+    ) -> (Self, MockControls) {
+        let (message_tx, message_rx) = mpsc::channel(64);
+        let tools = Arc::new(StdMutex::new(tools));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let (call_started_tx, call_started_rx) = block_call
+            .then(mpsc::unbounded_channel)
+            .map_or((None, None), |(tx, rx)| (Some(tx), Some(rx)));
+        let call_release = block_call.then(|| Arc::new(Semaphore::new(0)));
+        (
+            Self {
+                connected: AtomicBool::new(false),
+                message_rx: tokio::sync::Mutex::new(Some(message_rx)),
+                message_tx: message_tx.clone(),
+                tools: tools.clone(),
+                marker: marker.to_string(),
+                call_started: call_started_tx,
+                call_release: call_release.clone(),
+                call_is_error,
+                calls: calls.clone(),
+                drops: drops.clone(),
+            },
+            MockControls {
+                tools,
+                message_tx,
+                call_started: call_started_rx,
+                call_release,
+                calls,
+                drops,
+            },
+        )
+    }
+
+    async fn respond(&self, request: &serde_json::Value, result: serde_json::Value) {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": request["id"].clone(),
+            "result": result,
+        });
+        let _ = self.message_tx.send(response.to_string()).await;
+    }
+}
+
+impl Drop for MockTransport {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl McpTransport for MockTransport {
+    async fn connect(&mut self) -> Result<()> {
+        self.connected.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn disconnect(&mut self) -> Result<()> {
+        self.connected.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn send(&self, message: String) -> Result<()> {
+        let request: serde_json::Value = serde_json::from_str(&message)?;
+        match request["method"].as_str() {
+            Some("tools/list") => {
+                let tools = self
+                    .tools
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .iter()
+                    .map(|tool| {
+                        serde_json::json!({
+                            "name": tool.name,
+                            "description": tool.description,
+                            "inputSchema": tool.parameters,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                self.respond(&request, serde_json::json!({"tools": tools}))
+                    .await;
+            }
+            Some("tools/call") => {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                if let Some(started) = &self.call_started {
+                    let _ = started.send(());
+                }
+                if let Some(release) = &self.call_release {
+                    let permit = release.acquire().await.expect("call gate stays open");
+                    permit.forget();
+                }
+                self.respond(
+                    &request,
+                    serde_json::json!({
+                        "content": [{"type": "text", "text": self.marker}],
+                        "isError": self.call_is_error,
+                    }),
+                )
+                .await;
+            }
+            Some("ping") => self.respond(&request, serde_json::json!({})).await,
+            _ => self.respond(&request, serde_json::json!({})).await,
+        }
+        Ok(())
+    }
+
+    async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
+        self.message_rx.lock().await.take()
+    }
+
+    async fn receive(&self) -> Result<Option<String>> {
+        Err(McpError::Disconnected)
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::SeqCst)
+    }
+}
+
+async fn prepare_mock(
+    manager: &McpServerManager,
+    server_id: &str,
+    tools: Vec<McpTool>,
+    transport: MockTransport,
+) -> PreparedServerRuntime {
+    prepare_mock_with_config(manager, test_config(server_id), tools, transport).await
+}
+
+async fn prepare_mock_with_config(
+    manager: &McpServerManager,
+    config: McpServerConfig,
+    tools: Vec<McpTool>,
+    transport: MockTransport,
+) -> PreparedServerRuntime {
+    let mut client = McpProtocolClient::new(Box::new(transport));
+    client.connect().await.expect("connect mock transport");
+    let notification_rx = client.take_notification_receiver().await;
+    let server_id = config.id.clone();
+    let catalog = manager
+        .index
+        .plan_server_tools(&server_id, &tools, &[], &[])
+        .expect("valid mock catalog");
+    let runtime = ServerRuntime {
+        config,
+        info: tokio::sync::RwLock::new(RuntimeInfo {
+            status: ServerStatus::Ready,
+            connected_at: Some(Utc::now()),
+            last_ping_at: Some(Utc::now()),
+            tool_count: tools.len(),
+            ..RuntimeInfo::default()
+        }),
+        reconnecting: AtomicBool::new(false),
+        qos: McpServerQos::new(McpQosConfig::default()),
+        proxy_fingerprint: None,
+    };
+    let runtime = TransportRuntime::new(
+        manager.allocate_runtime_id().expect("runtime id"),
+        runtime,
+        client,
+    );
+    let publication = ServerPublication::new(
+        manager.allocate_publication_id().expect("publication id"),
+        runtime,
+        catalog,
+        &tools,
+    )
+    .expect("coherent mock publication");
+    let activation = manager.prepare_runtime_tasks(publication.clone(), notification_rx);
+    PreparedServerRuntime {
+        publication: Some(publication),
+        activation: Some(activation),
+    }
+}
+
+async fn publish_mock(
+    manager: &McpServerManager,
+    prepared: PreparedServerRuntime,
+) -> Arc<ServerPublication> {
+    publish_mock_inner(manager, prepared, false).await
+}
+
+async fn publish_mock_with_tasks(
+    manager: &McpServerManager,
+    prepared: PreparedServerRuntime,
+) -> Arc<ServerPublication> {
+    publish_mock_inner(manager, prepared, true).await
+}
+
+async fn publish_mock_inner(
+    manager: &McpServerManager,
+    prepared: PreparedServerRuntime,
+    start_tasks: bool,
+) -> Arc<ServerPublication> {
+    let _reconcile = manager.reconcile_lock.lock().await;
+    let replacement = prepared.publication().clone();
+    let base = manager.authority.generation();
+    let next = McpRuntimeGeneration::plan(
+        &base,
+        std::slice::from_ref(&replacement),
+        &[],
+        manager.authority.ledger_relationship_limit,
+        true,
+    )
+    .expect("mock generation plan");
+    let old = base.servers.get(&replacement.server_id).cloned();
+    manager
+        .authority
+        .replace_prevalidated_with(&base, next, || {
+            if let Some(old) = &old {
+                if Arc::ptr_eq(&old.runtime, &replacement.runtime) {
+                    old.close_admission();
+                } else {
+                    old.retire_with_runtime();
+                }
+            }
+        });
+    let mut commit = prepared.into_commit();
+    let publication = commit.publication().clone();
+    commit.mark_published();
+    if start_tasks {
+        commit.activate();
+    } else {
+        commit.discard_activation();
+    }
+    publication
+}
+
+fn expected(manager: &McpServerManager, server_id: &str) -> ExpectedPublication {
+    manager
+        .current_expected(server_id)
+        .expect("published expected server")
+}
+
+fn assert_snapshot_coherent(snapshot: &McpRuntimeSnapshot) {
+    let aliases = snapshot.aliases();
+    let schemas = snapshot.list_tools();
+    assert_eq!(aliases.len(), schemas.len());
+    for alias in aliases {
+        assert!(snapshot.contains_exact_alias(&alias.alias));
+        assert!(snapshot
+            .tool(&alias.server_id, &alias.original_name)
+            .is_some());
+        let resolved = snapshot
+            .resolve_call(&alias.alias)
+            .expect("advertised alias resolves in the same generation");
+        assert_eq!(resolved.server_id(), alias.server_id);
+        assert_eq!(resolved.original_name(), alias.original_name);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SnapshotShape {
+    servers: Vec<String>,
+    aliases: Vec<(String, String, String)>,
+    schemas: Vec<String>,
+}
+
+fn snapshot_shape(snapshot: &McpRuntimeSnapshot) -> SnapshotShape {
+    assert_snapshot_coherent(snapshot);
+    SnapshotShape {
+        servers: snapshot.server_ids(),
+        aliases: snapshot
+            .aliases()
+            .into_iter()
+            .map(|alias| (alias.alias, alias.server_id, alias.original_name))
+            .collect(),
+        schemas: snapshot
+            .list_tools()
+            .into_iter()
+            .map(|schema| schema.function.name)
+            .collect(),
+    }
+}
+
+async fn assert_old_or_new_during_writer<F, T>(manager: Arc<McpServerManager>, writer: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    let old = snapshot_shape(&manager.snapshot());
+    let start = Arc::new(Barrier::new(2));
+    let done = Arc::new(AtomicBool::new(false));
+    let reader_manager = manager.clone();
+    let reader_start = start.clone();
+    let reader_done = done.clone();
+    let reader = std::thread::spawn(move || {
+        let mut observed = Vec::new();
+        reader_start.wait();
+        while !reader_done.load(Ordering::SeqCst) {
+            observed.push(snapshot_shape(&reader_manager.snapshot()));
+            std::thread::yield_now();
+        }
+        observed.push(snapshot_shape(&reader_manager.snapshot()));
+        observed
+    });
+    start.wait();
+    let output = tokio::time::timeout(Duration::from_secs(5), writer)
+        .await
+        .expect("generation writer must complete under concurrent snapshot reads");
+    done.store(true, Ordering::SeqCst);
+    let observed = reader.join().unwrap();
+    let new = snapshot_shape(&manager.snapshot());
+    assert!(
+        observed.iter().all(|shape| shape == &old || shape == &new),
+        "observed mixed generation: old={old:?} new={new:?} observed={observed:?}"
+    );
+    output
+}
+
 #[test]
-fn test_manager_new() {
+fn manager_and_tool_index_share_one_authority() {
     let manager = McpServerManager::new();
     assert!(manager.list_servers().is_empty());
+    assert!(manager.tool_index().all_aliases().is_empty());
+    assert!(manager.has_same_authority(&manager.tool_index()));
 }
 
 #[test]
-fn test_manager_clone() {
-    let manager = McpServerManager::new();
-    let cloned = manager.clone();
-    assert!(cloned.list_servers().is_empty());
-}
-
-#[test]
-fn test_manager_with_event_channel() {
+fn manager_clone_and_event_channel_preserve_shared_authority() {
     let (tx, _rx) = mpsc::channel(100);
     let manager = McpServerManager::new().with_event_channel(tx);
+    let cloned = manager.clone();
+
     assert!(manager.event_tx.is_some());
-}
-
-#[test]
-fn test_tool_index_accessor() {
-    let manager = McpServerManager::new();
-    let index = manager.tool_index();
-    assert!(index.all_aliases().is_empty());
+    assert!(cloned.event_tx.is_some());
+    assert!(manager.has_same_authority(&cloned.tool_index()));
 }
 
 #[tokio::test]
-async fn test_list_servers_empty() {
+async fn resolved_calls_are_affine_to_their_manager_authority() {
     let manager = McpServerManager::new();
-    let servers = manager.list_servers();
-    assert!(servers.is_empty());
-}
+    let (transport, controls) = MockTransport::new(vec![tool("echo", "owned")], "owned");
+    let publication = publish_mock(
+        &manager,
+        prepare_mock(&manager, "owned", vec![tool("echo", "owned")], transport).await,
+    )
+    .await;
+    let snapshot = manager.snapshot();
+    let ticket = snapshot
+        .resolve_call(&snapshot.aliases()[0].alias)
+        .expect("owned ticket");
 
-#[tokio::test]
-async fn test_is_server_running() {
-    let manager = McpServerManager::new();
-    assert!(!manager.is_server_running("nonexistent"));
-}
+    let (foreign_events, mut foreign_event_rx) = mpsc::channel(4);
+    let foreign = McpServerManager::new().with_event_channel(foreign_events);
+    let error = foreign
+        .call_resolved_tool(&ticket, serde_json::json!({}))
+        .await
+        .expect_err("independent manager must reject a foreign ticket before admission");
+    assert!(matches!(error, McpError::ForeignRuntimeAuthority));
+    assert_eq!(controls.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(publication.active_calls(), 0);
+    assert_eq!(publication.runtime.active_calls(), 0);
+    assert!(!publication
+        .runtime
+        .runtime
+        .reconnecting
+        .load(Ordering::SeqCst));
+    assert_eq!(
+        publication
+            .runtime
+            .runtime
+            .qos
+            .state
+            .lock()
+            .await
+            .consecutive_failures,
+        0
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), foreign_event_rx.recv())
+            .await
+            .is_err()
+    );
 
-#[tokio::test]
-async fn test_get_server_info_nonexistent() {
-    let manager = McpServerManager::new();
-    let info = manager.get_server_info("nonexistent");
-    assert!(info.is_none());
-}
-
-#[tokio::test]
-async fn test_get_tool_info_nonexistent() {
-    let manager = McpServerManager::new();
-    let tool = manager.get_tool_info("nonexistent", "tool");
-    assert!(tool.is_none());
-}
-
-#[tokio::test]
-async fn test_stop_server_nonexistent() {
-    let manager = McpServerManager::new();
-    let result = manager.stop_server("nonexistent").await;
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        McpError::NotRunning(id) => assert_eq!(id, "nonexistent"),
-        _ => panic!("Expected NotRunning error"),
-    }
-}
-
-#[tokio::test]
-async fn test_call_tool_nonexistent_server() {
-    let manager = McpServerManager::new();
     let result = manager
-        .call_tool("nonexistent", "tool", serde_json::json!({}))
-        .await;
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        McpError::ServerNotFound(id) => assert_eq!(id, "nonexistent"),
-        _ => panic!("Expected ServerNotFound error"),
-    }
+        .clone()
+        .call_resolved_tool(&ticket, serde_json::json!({}))
+        .await
+        .expect("a manager clone shares the ticket authority");
+    assert!(matches!(
+        &result.content[0],
+        crate::types::McpContentItem::Text { text, .. } if text == "owned"
+    ));
+    assert_eq!(controls.calls.load(Ordering::SeqCst), 1);
+    manager.stop_server("owned").await.unwrap();
 }
 
 #[tokio::test]
-async fn test_refresh_tools_nonexistent() {
+async fn empty_manager_public_lifecycle_is_stable() {
     let manager = McpServerManager::new();
-    let result = manager.refresh_tools("nonexistent").await;
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        McpError::ServerNotFound(id) => assert_eq!(id, "nonexistent"),
-        _ => panic!("Expected ServerNotFound error"),
-    }
-}
-
-#[tokio::test]
-async fn test_shutdown_all_empty() {
-    let manager = McpServerManager::new();
-    // Should not panic
+    assert!(manager.list_servers().is_empty());
+    assert!(!manager.is_server_running("nonexistent"));
+    assert!(manager.get_server_info("nonexistent").is_none());
+    assert!(manager.get_tool_info("nonexistent", "tool").is_none());
+    assert!(matches!(
+        manager.stop_server("nonexistent").await,
+        Err(McpError::NotRunning(id)) if id == "nonexistent"
+    ));
+    assert!(matches!(
+        manager
+            .call_tool("nonexistent", "tool", serde_json::json!({}))
+            .await,
+        Err(McpError::ServerNotFound(id)) if id == "nonexistent"
+    ));
+    assert!(matches!(
+        manager.refresh_tools("nonexistent").await,
+        Err(McpError::ServerNotFound(id)) if id == "nonexistent"
+    ));
     manager.shutdown_all().await;
 }
 
 #[test]
-fn test_reconnect_config_default() {
-    let config = ReconnectConfig::default();
-    assert!(config.enabled);
-    assert_eq!(config.initial_backoff_ms, 1000);
-    assert_eq!(config.max_backoff_ms, 30000);
-    assert_eq!(config.max_attempts, 0);
-}
+fn reconnect_config_and_runtime_defaults_remain_compatible() {
+    let default = ReconnectConfig::default();
+    assert!(default.enabled);
+    assert_eq!(default.initial_backoff_ms, 1_000);
+    assert_eq!(default.max_backoff_ms, 30_000);
+    assert_eq!(default.max_attempts, 0);
 
-#[test]
-fn test_reconnect_config_custom() {
-    let config = ReconnectConfig {
-        enabled: true,
+    let custom = ReconnectConfig {
+        enabled: false,
         initial_backoff_ms: 500,
-        max_backoff_ms: 10000,
+        max_backoff_ms: 10_000,
         max_attempts: 5,
     };
-    assert!(config.enabled);
-    assert_eq!(config.initial_backoff_ms, 500);
-    assert_eq!(config.max_backoff_ms, 10000);
-    assert_eq!(config.max_attempts, 5);
-}
+    assert!(!custom.enabled);
+    assert_eq!(custom.initial_backoff_ms, 500);
+    assert_eq!(custom.max_backoff_ms, 10_000);
+    assert_eq!(custom.max_attempts, 5);
 
-#[tokio::test]
-async fn test_start_server_already_running() {
-    let manager = McpServerManager::new();
-    let config = create_test_server_config("test-server");
-
-    // Start server (will fail because echo doesn't implement MCP protocol)
-    let _ = manager.start_server(config.clone()).await;
-
-    // Try to start again - should fail with AlreadyRunning
-    // Note: This test may not work if the first start fails
-    // In that case, we're testing the logic path
-}
-
-#[tokio::test]
-async fn test_initialize_from_config_disabled_server() {
-    let manager = McpServerManager::new();
-
-    let mut config = create_test_server_config("disabled-server");
-    config.enabled = false;
-
-    let mcp_config = McpConfig {
-        version: 1,
-        servers: vec![config],
-    };
-
-    manager.initialize_from_config(&mcp_config).await;
-
-    // Should not have started the disabled server
-    assert!(!manager.is_server_running("disabled-server"));
-}
-
-#[tokio::test]
-async fn test_event_channel_server_status() {
-    let (tx, rx) = mpsc::channel(100);
-    let manager = McpServerManager::new().with_event_channel(tx);
-
-    // Events are sent during server operations
-    // This test verifies the channel is properly set up
-    assert!(manager.event_tx.is_some());
-
-    // Clean up
-    drop(manager);
-    drop(rx);
-}
-
-#[test]
-fn test_server_status_display() {
-    assert_eq!(format!("{}", ServerStatus::Ready), "ready");
-    assert_eq!(format!("{}", ServerStatus::Degraded), "degraded");
-    assert_eq!(format!("{}", ServerStatus::Error), "error");
-    assert_eq!(format!("{}", ServerStatus::Stopped), "stopped");
-    assert_eq!(format!("{}", ServerStatus::Connecting), "connecting");
-}
-
-#[test]
-fn test_runtime_info_default() {
     let info = RuntimeInfo::default();
     assert_eq!(info.status, ServerStatus::Stopped);
     assert!(info.last_error.is_none());
@@ -218,138 +519,79 @@ fn test_runtime_info_default() {
     assert_eq!(info.tool_count, 0);
     assert_eq!(info.restart_count, 0);
     assert!(info.last_ping_at.is_none());
-}
-
-// Test exponential backoff calculation (indirectly through manager behavior)
-#[test]
-fn test_exponential_backoff_calculation() {
-    let initial = 1000u64;
-    let max = 30000u64;
-    let mut current = initial;
-
-    // First backoff
-    current = std::cmp::min(current * 2, max);
-    assert_eq!(current, 2000);
-
-    // Second backoff
-    current = std::cmp::min(current * 2, max);
-    assert_eq!(current, 4000);
-
-    // Third backoff
-    current = std::cmp::min(current * 2, max);
-    assert_eq!(current, 8000);
-
-    // Fourth backoff
-    current = std::cmp::min(current * 2, max);
-    assert_eq!(current, 16000);
-
-    // Fifth backoff
-    current = std::cmp::min(current * 2, max);
-    assert_eq!(current, 30000); // Capped at max
-
-    // Try again - should stay at max
-    current = std::cmp::min(current * 2, max);
-    assert_eq!(current, 30000);
+    assert_eq!(ServerStatus::Ready.to_string(), "ready");
+    assert_eq!(ServerStatus::Degraded.to_string(), "degraded");
+    assert_eq!(ServerStatus::Error.to_string(), "error");
+    assert_eq!(ServerStatus::Stopped.to_string(), "stopped");
+    assert_eq!(ServerStatus::Connecting.to_string(), "connecting");
 }
 
 #[test]
-fn test_exponential_backoff_max_zero() {
-    // Test that max_attempts = 0 means unlimited
-    let config = ReconnectConfig {
-        enabled: true,
-        initial_backoff_ms: 100,
-        max_backoff_ms: 1000,
-        max_attempts: 0,
-    };
-
-    assert_eq!(config.max_attempts, 0);
-    // In the actual code, max_attempts == 0 bypasses the attempt limit check
-}
-
-// Test that reconnection logic is properly gated by enabled flag
-#[test]
-fn test_reconnect_disabled() {
-    let config = ReconnectConfig {
-        enabled: false,
-        initial_backoff_ms: 100,
-        max_backoff_ms: 1000,
-        max_attempts: 3,
-    };
-
-    assert!(!config.enabled);
-    // In the actual health check code, reconnection is only attempted if enabled
+fn exponential_backoff_remains_bounded_and_zero_attempts_means_unlimited() {
+    let mut current = 1_000u64;
+    let max = 30_000u64;
+    for expected in [2_000, 4_000, 8_000, 16_000, 30_000, 30_000] {
+        current = current.saturating_mul(2).min(max);
+        assert_eq!(current, expected);
+    }
+    assert_eq!(ReconnectConfig::default().max_attempts, 0);
 }
 
 #[test]
-fn test_proxy_fingerprint_changes_on_proxy_or_auth_change() {
-    let mut cfg = Config::default();
-    // Config::default() loads from the runtime data dir, so make this test
-    // deterministic regardless of local proxy settings.
-    cfg.http_proxy.clear();
-    cfg.https_proxy.clear();
-    cfg.proxy_auth = None;
-    assert_eq!(proxy_fingerprint(&cfg), None);
+fn proxy_fingerprint_changes_on_proxy_or_auth_change() {
+    let mut config = Config::default();
+    config.http_proxy.clear();
+    config.https_proxy.clear();
+    config.proxy_auth = None;
+    assert_eq!(proxy_fingerprint(&config), None);
 
-    cfg.http_proxy = "http://proxy:8080".to_string();
-    let fp1 = proxy_fingerprint(&cfg).expect("fingerprint expected");
+    config.http_proxy = "http://proxy:8080".to_string();
+    let first = proxy_fingerprint(&config).expect("proxy fingerprint");
+    config.http_proxy = "http://proxy2:8080".to_string();
+    assert_ne!(first, proxy_fingerprint(&config).unwrap());
 
-    cfg.http_proxy = "http://proxy2:8080".to_string();
-    let fp2 = proxy_fingerprint(&cfg).expect("fingerprint expected");
-    assert_ne!(fp1, fp2);
-
-    cfg.http_proxy = "http://proxy:8080".to_string();
-    cfg.proxy_auth = Some(bamboo_config::ProxyAuth {
+    config.http_proxy = "http://proxy:8080".to_string();
+    config.proxy_auth = Some(bamboo_config::ProxyAuth {
         username: "user".to_string(),
         password: "pass".to_string(),
     });
-    let fp3 = proxy_fingerprint(&cfg).expect("fingerprint expected");
-    assert_ne!(fp1, fp3);
-
-    cfg.proxy_auth = Some(bamboo_config::ProxyAuth {
-        username: "user".to_string(),
-        password: "pass2".to_string(),
-    });
-    let fp4 = proxy_fingerprint(&cfg).expect("fingerprint expected");
-    assert_ne!(fp3, fp4);
+    let authenticated = proxy_fingerprint(&config).unwrap();
+    assert_ne!(first, authenticated);
+    config.proxy_auth.as_mut().unwrap().password = "pass2".to_string();
+    assert_ne!(authenticated, proxy_fingerprint(&config).unwrap());
 }
 
 #[tokio::test]
-async fn test_sse_transport_respects_proxy_settings_when_available() {
-    // If the manager has access to global config, SSE client creation should
-    // fail early when proxy URL is invalid (proving it attempted to apply proxy).
-    let mut cfg = Config::default();
-    cfg.http_proxy = "http://".to_string(); // invalid URL
-    let manager = McpServerManager::new_with_config(Arc::new(tokio::sync::RwLock::new(cfg)));
-
+async fn sse_transport_respects_proxy_settings_when_available() {
+    let mut config = Config::default();
+    config.http_proxy = "http://".to_string();
+    let manager = McpServerManager::new_with_config(Arc::new(tokio::sync::RwLock::new(config)));
     let server = McpServerConfig {
         id: "sse-test".to_string(),
         name: Some("SSE test".to_string()),
         enabled: true,
         transport: TransportConfig::Sse(SseConfig {
             url: "http://localhost:9999/sse".to_string(),
-            headers: vec![],
+            headers: Vec::new(),
             connect_timeout_ms: 100,
         }),
-        request_timeout_ms: 1000,
-        healthcheck_interval_ms: 1000,
+        request_timeout_ms: 1_000,
+        healthcheck_interval_ms: 1_000,
         reconnect: ReconnectConfig {
             enabled: false,
             initial_backoff_ms: 100,
-            max_backoff_ms: 1000,
+            max_backoff_ms: 1_000,
             max_attempts: 1,
         },
-        allowed_tools: vec![],
-        denied_tools: vec![],
+        allowed_tools: Vec::new(),
+        denied_tools: Vec::new(),
     };
 
-    let err = manager.start_server(server).await.unwrap_err();
-    match err {
-        McpError::InvalidConfig(msg) => {
-            assert!(
-                msg.to_lowercase().contains("proxy") || msg.to_lowercase().contains("http"),
-                "unexpected error message: {msg}"
-            );
-        }
+    match manager.start_server(server).await.unwrap_err() {
+        McpError::InvalidConfig(message) => assert!(
+            message.to_lowercase().contains("proxy") || message.to_lowercase().contains("http"),
+            "unexpected error message: {message}"
+        ),
         other => panic!("expected InvalidConfig, got {other:?}"),
     }
 }
@@ -360,23 +602,16 @@ async fn qos_circuit_opens_after_consecutive_failures() {
         max_concurrent_calls: 2,
         circuit_failure_threshold: 2,
         circuit_open_ms: 60_000,
-        // High so the recycle path doesn't reset the counter mid-test.
         reconnect_failure_threshold: u32::MAX,
     });
-
-    let err = McpError::Connection("boom".to_string());
-    qos.record_failure("server-a", "tool-a", &err).await;
+    let error = McpError::Connection("boom".to_string());
+    assert!(!qos.record_failure("server-a", "tool-a", &error).await);
     assert!(qos.check_circuit("server-a", "tool-a").await.is_ok());
-
-    qos.record_failure("server-a", "tool-a", &err).await;
-    let blocked = qos.check_circuit("server-a", "tool-a").await;
-    assert!(blocked.is_err());
-    match blocked.unwrap_err() {
-        McpError::ToolExecution(message) => {
-            assert!(message.contains("circuit open"));
-        }
-        other => panic!("expected ToolExecution, got {other:?}"),
-    }
+    assert!(!qos.record_failure("server-a", "tool-a", &error).await);
+    assert!(matches!(
+        qos.check_circuit("server-a", "tool-a").await,
+        Err(McpError::ToolExecution(message)) if message.contains("circuit open")
+    ));
 }
 
 #[tokio::test]
@@ -385,14 +620,11 @@ async fn qos_circuit_recovers_after_open_window() {
         max_concurrent_calls: 1,
         circuit_failure_threshold: 1,
         circuit_open_ms: 5,
-        // High so the recycle path doesn't reset the counter mid-test.
         reconnect_failure_threshold: u32::MAX,
     });
-
-    let err = McpError::Connection("boom".to_string());
-    qos.record_failure("server-b", "tool-b", &err).await;
+    let error = McpError::Connection("boom".to_string());
+    qos.record_failure("server-b", "tool-b", &error).await;
     assert!(qos.check_circuit("server-b", "tool-b").await.is_err());
-
     sleep(Duration::from_millis(15)).await;
     assert!(qos.check_circuit("server-b", "tool-b").await.is_ok());
 }
@@ -401,845 +633,1744 @@ async fn qos_circuit_recovers_after_open_window() {
 async fn qos_signals_recycle_at_reconnect_threshold() {
     let qos = McpServerQos::new(McpQosConfig {
         max_concurrent_calls: 1,
-        // High so only the reconnect threshold is exercised here.
         circuit_failure_threshold: u32::MAX,
         circuit_open_ms: 5,
         reconnect_failure_threshold: 3,
     });
-    let err = McpError::Connection("boom".to_string());
-
-    // Below the threshold: no recycle.
-    assert!(!qos.record_failure("s", "t", &err).await);
-    assert!(!qos.record_failure("s", "t", &err).await);
-    // 3rd consecutive failure: recycle signalled.
-    assert!(qos.record_failure("s", "t", &err).await);
-    // Counter reset after signalling — needs a fresh run of failures.
-    assert!(!qos.record_failure("s", "t", &err).await);
-    // A success resets the run too.
+    let error = McpError::Connection("boom".to_string());
+    assert!(!qos.record_failure("s", "t", &error).await);
+    assert!(!qos.record_failure("s", "t", &error).await);
+    assert!(qos.record_failure("s", "t", &error).await);
+    assert!(!qos.record_failure("s", "t", &error).await);
     qos.record_success().await;
-    assert!(!qos.record_failure("s", "t", &err).await);
-    assert!(!qos.record_failure("s", "t", &err).await);
-    assert!(qos.record_failure("s", "t", &err).await);
-}
-
-// ---------------------------------------------------------------------------
-// #366: server-notification drain + tools/list_changed -> refresh dispatch.
-// ---------------------------------------------------------------------------
-
-/// Mock transport for the notification-drain test. Preloads server-initiated
-/// messages for the client's handler to forward, and answers `tools/list`
-/// requests with a configurable tool set so `refresh_tools` can complete.
-struct NotifyingMockTransport {
-    connected: bool,
-    /// Messages delivered TO the client (its handler consumes these).
-    to_client_rx: tokio::sync::Mutex<Option<mpsc::Receiver<String>>>,
-    /// Sender used to push `tools/list` responses back to the client.
-    to_client_tx: mpsc::Sender<String>,
-    /// `(name, description)` returned by `tools/list`.
-    tools: Vec<(String, String)>,
-}
-
-impl NotifyingMockTransport {
-    fn new(preload: &[&str], tools: &[(&str, &str)]) -> Self {
-        let (tx, rx) = mpsc::channel::<String>(64);
-        for msg in preload {
-            tx.try_send((*msg).to_string())
-                .expect("preload fits the channel");
-        }
-        Self {
-            connected: false,
-            to_client_rx: tokio::sync::Mutex::new(Some(rx)),
-            to_client_tx: tx,
-            tools: tools
-                .iter()
-                .map(|(n, d)| (n.to_string(), d.to_string()))
-                .collect(),
-        }
-    }
-}
-
-#[async_trait]
-impl McpTransport for NotifyingMockTransport {
-    async fn connect(&mut self) -> Result<()> {
-        self.connected = true;
-        Ok(())
-    }
-    async fn disconnect(&mut self) -> Result<()> {
-        self.connected = false;
-        Ok(())
-    }
-    async fn send(&self, message: String) -> Result<()> {
-        let req: serde_json::Value =
-            serde_json::from_str(&message).map_err(|e| McpError::Protocol(e.to_string()))?;
-        if req["method"].as_str() == Some("tools/list") {
-            let tools: Vec<serde_json::Value> = self
-                .tools
-                .iter()
-                .map(|(n, d)| {
-                    serde_json::json!({
-                        "name": n,
-                        "description": d,
-                        "inputSchema": { "type": "object" }
-                    })
-                })
-                .collect();
-            let resp = serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": req["id"].clone(),
-                "result": { "tools": tools }
-            });
-            let _ = self.to_client_tx.send(resp.to_string()).await;
-        } else if req["method"].as_str() == Some("tools/call") {
-            let called_name = req["params"]["name"].as_str().unwrap_or_default();
-            let resp = serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": req["id"].clone(),
-                "result": {
-                    "content": [{"type": "text", "text": called_name}],
-                    "isError": false
-                }
-            });
-            let _ = self.to_client_tx.send(resp.to_string()).await;
-        }
-        Ok(())
-    }
-    async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
-        self.to_client_rx.lock().await.take()
-    }
-    async fn receive(&self) -> Result<Option<String>> {
-        Err(McpError::Disconnected)
-    }
-    fn is_connected(&self) -> bool {
-        self.connected
-    }
-}
-
-fn mock_runtime(server_id: &str, client: McpProtocolClient) -> Arc<ServerRuntime> {
-    mock_runtime_with_config(create_test_server_config(server_id), client)
-}
-
-fn mock_runtime_with_config(
-    config: McpServerConfig,
-    client: McpProtocolClient,
-) -> Arc<ServerRuntime> {
-    Arc::new(ServerRuntime {
-        config,
-        client: RwLock::new(client),
-        info: RwLock::new(RuntimeInfo {
-            status: ServerStatus::Ready,
-            last_error: None,
-            connected_at: Some(Utc::now()),
-            disconnected_at: None,
-            tool_count: 0,
-            restart_count: 0,
-            last_ping_at: Some(Utc::now()),
-            instructions: None,
-        }),
-        tools: RwLock::new(Vec::new()),
-        shutdown: AtomicBool::new(false),
-        reconnecting: AtomicBool::new(false),
-        qos: McpServerQos::new(McpQosConfig::default()),
-        proxy_fingerprint: None,
-    })
-}
-
-/// Inserts a `ServerRuntime` backed by an already-connected `client`, starting
-/// with zero registered tools. Returns the runtime so the test can take the
-/// client's notification receiver.
-fn insert_mock_runtime(
-    manager: &McpServerManager,
-    server_id: &str,
-    client: McpProtocolClient,
-) -> Arc<ServerRuntime> {
-    let runtime = mock_runtime(server_id, client);
-    manager
-        .runtimes
-        .insert(server_id.to_string(), runtime.clone());
-    runtime
-}
-
-async fn connected_mock_client() -> McpProtocolClient {
-    let transport = NotifyingMockTransport::new(&[], &[]);
-    let mut client = McpProtocolClient::new(Box::new(transport));
-    client.connect().await.expect("connect mock runtime");
-    client
-}
-
-fn marker_tool(name: &str) -> McpTool {
-    McpTool {
-        name: name.to_string(),
-        description: format!("{name} marker"),
-        parameters: serde_json::json!({"type": "object"}),
-        output_schema: None,
-    }
+    assert!(!qos.record_failure("s", "t", &error).await);
+    assert!(!qos.record_failure("s", "t", &error).await);
+    assert!(qos.record_failure("s", "t", &error).await);
 }
 
 #[tokio::test]
-async fn install_registration_failure_preserves_existing_publication() {
+async fn public_start_rejects_an_existing_published_server() {
     let manager = McpServerManager::new();
-    let old_runtime = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    let old_tool = marker_tool("old_tool");
-    *old_runtime.tools.write().await = vec![old_tool.clone()];
-    old_runtime.info.write().await.tool_count = 1;
-    let old_aliases = manager
-        .index
-        .register_server_tools("stable", std::slice::from_ref(&old_tool), &[], &[])
-        .unwrap();
-
-    // A real 130-bit tag collision is not a practical fixture. Corrupt only the
-    // staged test catalog to exercise the runtime ownership guard and install
-    // rollback path deterministically.
-    let candidate_tool = marker_tool("candidate_tool");
-    let mut candidate_catalog = manager
-        .index
-        .plan_server_tools("candidate", std::slice::from_ref(&candidate_tool), &[], &[])
-        .unwrap();
-    candidate_catalog.replace_first_canonical_alias_for_test(old_aliases[0].alias.clone());
-    let candidate_runtime = mock_runtime("candidate", connected_mock_client().await);
-    *candidate_runtime.tools.write().await = vec![candidate_tool];
-    candidate_runtime.info.write().await.tool_count = 1;
-    let prepared = PreparedServerRuntime {
-        runtime: candidate_runtime.clone(),
-        catalog: candidate_catalog,
-        notification_rx: None,
-    };
-
-    let error = match manager.install_prepared_runtime(prepared).await {
-        Err(error) => error,
-        Ok(_) => panic!("colliding install catalog must fail"),
-    };
+    let (transport, _) = MockTransport::new(vec![tool("echo", "existing")], "existing");
+    publish_mock(
+        &manager,
+        prepare_mock(
+            &manager,
+            "existing",
+            vec![tool("echo", "existing")],
+            transport,
+        )
+        .await,
+    )
+    .await;
 
     assert!(matches!(
-        error,
-        McpError::ToolRegistration(crate::error::ToolRegistrationError::AliasCollision {
-            ref alias
-        }) if alias == &old_aliases[0].alias
+        manager.start_server(test_config("existing")).await,
+        Err(McpError::AlreadyRunning(id)) if id == "existing"
     ));
-    assert!(Arc::ptr_eq(
-        manager.runtimes.get("stable").unwrap().value(),
-        &old_runtime
-    ));
-    assert!(!manager.runtimes.contains_key("candidate"));
-    assert_eq!(manager.index.all_aliases(), old_aliases);
-    assert!(old_runtime.client.read().await.is_connected().await);
-    assert!(candidate_runtime.shutdown.load(Ordering::SeqCst));
-    assert!(!candidate_runtime.client.read().await.is_connected().await);
-    assert_eq!(
-        candidate_runtime.info.read().await.status,
-        ServerStatus::Stopped
-    );
+    manager.stop_server("existing").await.unwrap();
 }
 
 #[tokio::test]
-async fn transactional_reconcile_bootstrap_failure_keeps_old_runtime_and_tool_index() {
+async fn legacy_initialize_skips_disabled_servers() {
     let manager = McpServerManager::new();
-    let transport = NotifyingMockTransport::new(&[], &[]);
-    let mut client = McpProtocolClient::new(Box::new(transport));
-    client.connect().await.expect("connect old mock runtime");
-    let old = insert_mock_runtime(&manager, "stable", client);
-    let old_tool = McpTool {
-        name: "still_available".to_string(),
-        description: "old runtime marker".to_string(),
-        parameters: serde_json::json!({"type": "object"}),
-        output_schema: None,
-    };
+    let mut disabled = test_config("disabled");
+    disabled.enabled = false;
     manager
-        .index
-        .register_server_tools("stable", &[old_tool], &[], &[])
-        .unwrap();
-    let alias = manager.index.generate_alias("stable", "still_available");
-
-    let mut replacement = create_test_server_config("stable");
-    replacement.transport = TransportConfig::Stdio(StdioConfig {
-        command: "definitely-not-a-real-mcp-command-597".to_string(),
-        args: vec![],
-        cwd: None,
-        env: std::collections::HashMap::new(),
-        env_encrypted: std::collections::HashMap::new(),
-        env_credential_refs: std::collections::HashMap::new(),
-        startup_timeout_ms: 100,
-    });
-    let candidate = McpConfig {
-        version: 1,
-        servers: vec![replacement],
-    };
-
-    let error = manager
-        .reconcile_from_config_transactional(&candidate)
-        .await
-        .expect_err("replacement bootstrap must fail");
-    assert!(!error.to_string().is_empty());
-    let live = manager
-        .runtimes
-        .get("stable")
-        .expect("old runtime remains published")
-        .clone();
-    assert!(Arc::ptr_eq(&live, &old));
-    assert!(manager.index.contains(&alias));
-    assert_eq!(
-        manager.index.lookup(&alias).unwrap().original_name,
-        "still_available"
-    );
-    assert_eq!(
-        old.info.read().await.status,
-        ServerStatus::Ready,
-        "failed candidate must not stop or degrade the old runtime"
-    );
-}
-
-#[tokio::test]
-async fn forced_transactional_reconcile_replaces_identical_effective_config() {
-    let dir = tempfile::tempdir().unwrap();
-    let script = dir.path().join("forced-reconnect-fixture.py");
-    std::fs::write(
-        &script,
-        r#"import json
-import sys
-
-for line in sys.stdin:
-    request = json.loads(line)
-    request_id = request.get("id")
-    if request_id is None:
-        continue
-    if request.get("method") == "server/discover":
-        print(json.dumps({
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "error": {"code": -32601, "message": "Method not found"},
-        }), flush=True)
-        continue
-    if request.get("method") == "initialize":
-        result = {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {"tools": {"listChanged": False}},
-            "serverInfo": {"name": "forced-reconnect-fixture", "version": "1.0.0"},
-        }
-    elif request.get("method") == "tools/list":
-        result = {"tools": []}
-    else:
-        result = {}
-    print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)
-"#,
-    )
-    .unwrap();
-    let python = ["python3", "python"]
-        .into_iter()
-        .find(|command| {
-            std::process::Command::new(command)
-                .arg("--version")
-                .output()
-                .is_ok_and(|output| output.status.success())
+        .initialize_from_config(&McpConfig {
+            version: 1,
+            servers: vec![disabled],
         })
-        .expect("a Python interpreter is required for the forced reconnect fixture");
-    let mut server = create_test_server_config("forced");
-    server.transport = TransportConfig::Stdio(StdioConfig {
-        command: python.to_string(),
-        args: vec![script.to_string_lossy().into_owned()],
-        cwd: None,
-        env: std::collections::HashMap::new(),
-        env_encrypted: std::collections::HashMap::new(),
-        env_credential_refs: std::collections::HashMap::new(),
-        startup_timeout_ms: 2_000,
-    });
-    server.request_timeout_ms = 2_000;
-    let candidate = McpConfig {
-        version: 1,
-        servers: vec![server],
-    };
-    let manager = McpServerManager::new();
-    manager
-        .reconcile_from_config_transactional(&candidate)
-        .await
-        .unwrap();
-    let first = manager.runtimes.get("forced").unwrap().clone();
-
-    manager
-        .reconcile_from_config_transactional_after_forcing(
-            &candidate,
-            &std::collections::HashSet::from(["forced".to_string()]),
-            || async { Ok(()) },
-        )
-        .await
-        .unwrap();
-    let second = manager.runtimes.get("forced").unwrap().clone();
-    assert!(!Arc::ptr_eq(&first, &second));
-    assert!(
-        first.shutdown.load(Ordering::SeqCst),
-        "the replaced generation is synchronously fenced before cleanup"
-    );
-    assert_eq!(second.info.read().await.status, ServerStatus::Ready);
-    manager.shutdown_all().await;
+        .await;
+    assert!(!manager.is_server_running("disabled"));
 }
 
-#[tokio::test]
-async fn committed_reconcile_publishes_all_removals_before_blocked_cleanup() {
-    use std::sync::atomic::AtomicBool;
-
-    let (event_tx, _event_rx) = mpsc::channel(1);
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn capacity_one_ready_batch_finishes_writer_and_excludes_successor() {
+    let (event_tx, mut event_rx) = mpsc::channel(1);
     event_tx
         .send(McpEvent::ToolsChanged {
             server_id: "blocker".to_string(),
             tools: Vec::new(),
         })
         .await
-        .expect("fill event channel");
-    let manager = McpServerManager::new().with_event_channel(event_tx);
+        .unwrap();
+    let manager = Arc::new(McpServerManager::new().with_event_channel(event_tx));
+    let (old_transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    publish_mock(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("old", "old")], old_transport).await,
+    )
+    .await;
 
-    let first = insert_mock_runtime(&manager, "first", connected_mock_client().await);
-    let second = insert_mock_runtime(&manager, "second", connected_mock_client().await);
-    for id in ["first", "second"] {
-        manager
-            .index
-            .register_server_tools(id, &[marker_tool("old")], &[], &[])
-            .unwrap();
-    }
-
-    let durable = Arc::new(AtomicBool::new(false));
-    let healthy = Arc::new(AtomicBool::new(false));
-    let durable_at_commit = durable.clone();
-    let healthy_after_reconcile = healthy.clone();
-    tokio::time::timeout(Duration::from_millis(100), async {
-        manager
-            .reconcile_from_config_transactional_after(
-                &McpConfig {
-                    version: 1,
-                    servers: Vec::new(),
-                },
-                || async move {
-                    durable_at_commit.store(true, Ordering::SeqCst);
-                    Ok(())
-                },
-            )
+    let old = expected(&manager, "server");
+    let (first_transport, _) = MockTransport::new(vec![tool("first", "first")], "first");
+    let first_candidate = prepare_mock(
+        &manager,
+        "server",
+        vec![tool("first", "first")],
+        first_transport,
+    )
+    .await;
+    let first_tools = first_candidate
+        .publication()
+        .catalog
+        .aliases()
+        .into_iter()
+        .map(|alias| alias.alias)
+        .collect::<Vec<_>>();
+    let first_start = Arc::new(tokio::sync::Barrier::new(2));
+    let first_manager = manager.clone();
+    let first_task_start = first_start.clone();
+    let first_writer = tokio::spawn(async move {
+        first_task_start.wait().await;
+        first_manager
+            .publish_reconnected_runtime_if_current(old, first_candidate)
             .await
-            .expect("committed reconcile is infallible");
-        // Models the section endpoint's post-reconcile health publication.
-        healthy_after_reconcile.store(true, Ordering::SeqCst);
+    });
+    first_start.wait().await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), first_writer)
+            .await
+            .expect("writer must not wait for event output capacity")
+            .unwrap()
+            .unwrap()
+    );
+    assert_eq!(manager.snapshot().aliases()[0].original_name, "first");
+    assert!(manager.event_sequence_lock.try_lock().is_err());
+
+    let first_expected = expected(&manager, "server");
+    let (second_transport, _) = MockTransport::new(vec![tool("second", "second")], "second");
+    let second_candidate = prepare_mock(
+        &manager,
+        "server",
+        vec![tool("second", "second")],
+        second_transport,
+    )
+    .await;
+    let second_tools = second_candidate
+        .publication()
+        .catalog
+        .aliases()
+        .into_iter()
+        .map(|alias| alias.alias)
+        .collect::<Vec<_>>();
+    let second_start = Arc::new(tokio::sync::Barrier::new(2));
+    let second_manager = manager.clone();
+    let second_task_start = second_start.clone();
+    let mut second_writer = tokio::spawn(async move {
+        second_task_start.wait().await;
+        second_manager
+            .publish_reconnected_runtime_if_current(first_expected, second_candidate)
+            .await
+    });
+    second_start.wait().await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut second_writer)
+            .await
+            .is_err()
+    );
+    assert_eq!(manager.snapshot().aliases()[0].original_name, "first");
+
+    assert!(matches!(
+        event_rx.recv().await,
+        Some(McpEvent::ToolsChanged { server_id, tools })
+            if server_id == "blocker" && tools.is_empty()
+    ));
+    assert!(matches!(
+        event_rx.recv().await,
+        Some(McpEvent::ServerStatusChanged {
+            server_id,
+            status: ServerStatus::Ready,
+            error: None,
+        }) if server_id == "server"
+    ));
+    assert!(matches!(
+        event_rx.recv().await,
+        Some(McpEvent::ToolsChanged { server_id, tools })
+            if server_id == "server" && tools == first_tools
+    ));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), &mut second_writer)
+            .await
+            .expect("successor completes after the prior pair enters the channel")
+            .unwrap()
+            .unwrap()
+    );
+    assert_eq!(manager.snapshot().aliases()[0].original_name, "second");
+    assert!(matches!(
+        event_rx.recv().await,
+        Some(McpEvent::ServerStatusChanged {
+            server_id,
+            status: ServerStatus::Ready,
+            error: None,
+        }) if server_id == "server"
+    ));
+    assert!(matches!(
+        event_rx.recv().await,
+        Some(McpEvent::ToolsChanged { server_id, tools })
+            if server_id == "server" && tools == second_tools
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn snapshot_reader_cannot_enter_after_fences_close_before_generation_swap() {
+    let gate = Arc::new((StdMutex::new((false, false)), std::sync::Condvar::new()));
+    let mut manager = McpServerManager::new();
+    let (old_transport, _) = MockTransport::new(vec![tool("echo", "old")], "old");
+    publish_mock(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("echo", "old")], old_transport).await,
+    )
+    .await;
+    let old_snapshot = manager.snapshot();
+    let old_ticket = old_snapshot
+        .resolve_call(&old_snapshot.aliases()[0].alias)
+        .unwrap();
+    let old_publication_id = old_ticket.publication_id();
+    let probe_gate = gate.clone();
+    manager.publish_probe = Some(Arc::new(move |phase| {
+        if phase != PublishProbePhase::AfterFencesBeforeSwap {
+            return;
+        }
+        let (state, condition) = &*probe_gate;
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.0 = true;
+        condition.notify_all();
+        while !state.1 {
+            state = condition
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }));
+    let manager = Arc::new(manager);
+    let expected = expected(&manager, "server");
+    let (new_transport, _) = MockTransport::new(vec![tool("echo", "new")], "new");
+    let candidate =
+        prepare_mock(&manager, "server", vec![tool("echo", "new")], new_transport).await;
+    let writer_manager = manager.clone();
+    let writer = tokio::spawn(async move {
+        writer_manager
+            .publish_reconnected_runtime_if_current(expected, candidate)
+            .await
+    });
+
+    let entered_gate = gate.clone();
+    tokio::task::spawn_blocking(move || {
+        let (state, condition) = &*entered_gate;
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while !state.0 {
+            state = condition
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
     })
     .await
-    .expect("blocked cleanup must not suspend committed publication");
+    .unwrap();
 
-    assert!(durable.load(Ordering::SeqCst));
-    assert!(healthy.load(Ordering::SeqCst));
-    assert!(manager.list_servers().is_empty());
-    assert!(manager.index.all_aliases().is_empty());
-    assert!(first.shutdown.load(Ordering::SeqCst));
-    assert!(second.shutdown.load(Ordering::SeqCst));
+    let (reader_started, reader_started_rx) = std::sync::mpsc::channel();
+    let (reader_done, reader_done_rx) = std::sync::mpsc::channel();
+    let reader_manager = manager.clone();
+    let reader = std::thread::spawn(move || {
+        reader_started.send(()).unwrap();
+        reader_done
+            .send(snapshot_shape(&reader_manager.snapshot()))
+            .unwrap();
+    });
+    reader_started_rx.recv().unwrap();
+    assert!(matches!(
+        reader_done_rx.recv_timeout(std::time::Duration::from_millis(50)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+    ));
+
+    {
+        let (state, condition) = &*gate;
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.1 = true;
+        condition.notify_all();
+    }
+    assert!(writer.await.unwrap().unwrap());
+    let reader_shape = reader_done_rx.recv().unwrap();
+    reader.join().unwrap();
+    assert_eq!(reader_shape, snapshot_shape(&manager.snapshot()));
+    let current = manager.snapshot();
+    let current_ticket = current.resolve_call(&current.aliases()[0].alias).unwrap();
+    assert_ne!(current_ticket.publication_id(), old_publication_id);
+    assert!(matches!(
+        manager
+            .call_resolved_tool(&old_ticket, serde_json::json!({}))
+            .await,
+        Err(McpError::StalePublication { .. })
+    ));
 }
 
 #[tokio::test]
-async fn manager_stop_preserves_colliding_survivor_and_historical_legacy_ambiguity() {
+async fn install_collision_preserves_existing_generation_and_drops_candidate() {
     let manager = McpServerManager::new();
-    let removed_runtime = insert_mock_runtime(&manager, "a::b", connected_mock_client().await);
-    let survivor_runtime = insert_mock_runtime(&manager, "a__b", connected_mock_client().await);
-    let remote_tool = marker_tool("c");
-    let removed_alias = manager
+    let (old_transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    let old = publish_mock(
+        &manager,
+        prepare_mock(&manager, "stable", vec![tool("old", "old")], old_transport).await,
+    )
+    .await;
+    let old_alias = old.catalog.aliases()[0].alias.clone();
+
+    let candidate_tool = tool("candidate", "candidate");
+    let mut catalog = manager
         .index
-        .register_server_tools("a::b", std::slice::from_ref(&remote_tool), &[], &[])
-        .unwrap()
-        .pop()
+        .plan_server_tools("candidate", std::slice::from_ref(&candidate_tool), &[], &[])
         .unwrap();
-    let survivor_alias = manager
-        .index
-        .register_server_tools("a__b", std::slice::from_ref(&remote_tool), &[], &[])
-        .unwrap()
-        .pop()
+    catalog.replace_first_canonical_alias_for_test(old_alias.clone());
+    let (candidate_transport, controls) =
+        MockTransport::new(vec![candidate_tool.clone()], "candidate");
+    let mut client = McpProtocolClient::new(Box::new(candidate_transport));
+    client.connect().await.unwrap();
+    let runtime = TransportRuntime::new(
+        manager.allocate_runtime_id().unwrap(),
+        ServerRuntime {
+            config: test_config("candidate"),
+            info: tokio::sync::RwLock::new(RuntimeInfo {
+                status: ServerStatus::Ready,
+                tool_count: 1,
+                ..RuntimeInfo::default()
+            }),
+            reconnecting: AtomicBool::new(false),
+            qos: McpServerQos::new(McpQosConfig::default()),
+            proxy_fingerprint: None,
+        },
+        client,
+    );
+    let candidate = ServerPublication::new(
+        manager.allocate_publication_id().unwrap(),
+        runtime,
+        catalog,
+        &[candidate_tool],
+    )
+    .unwrap();
+    let activation = manager.prepare_runtime_tasks(candidate.clone(), None);
+    let staged = PreparedServerRuntime {
+        publication: Some(candidate),
+        activation: Some(activation),
+    };
+    let base = manager.authority.generation();
+    let error = McpRuntimeGeneration::plan(
+        &base,
+        std::slice::from_ref(staged.publication()),
+        &[],
+        manager.authority.ledger_relationship_limit,
+        true,
+    )
+    .expect_err("colliding candidate must fail preflight");
+    assert!(matches!(
+        error,
+        McpError::ToolRegistration(ToolRegistrationError::AliasCollision { alias })
+            if alias == old_alias
+    ));
+    drop(staged);
+
+    assert!(Arc::ptr_eq(&manager.authority.generation(), &base));
+    assert!(Arc::ptr_eq(
+        &manager.current_expected("stable").unwrap().publication,
+        &old
+    ));
+    assert_eq!(controls.drops.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn transactional_bootstrap_failure_keeps_old_runtime_and_catalog() {
+    let manager = McpServerManager::new();
+    let (transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    let old = publish_mock(
+        &manager,
+        prepare_mock(&manager, "stable", vec![tool("old", "old")], transport).await,
+    )
+    .await;
+    let old_snapshot = manager.snapshot();
+    let mut replacement = test_config("stable");
+    replacement.transport = TransportConfig::Stdio(StdioConfig {
+        command: "definitely-not-a-real-mcp-command-995".to_string(),
+        args: Vec::new(),
+        cwd: None,
+        env: HashMap::new(),
+        env_encrypted: HashMap::new(),
+        env_credential_refs: HashMap::new(),
+        startup_timeout_ms: 100,
+    });
+
+    manager
+        .reconcile_from_config_transactional(&McpConfig {
+            version: 1,
+            servers: vec![replacement],
+        })
+        .await
+        .expect_err("replacement bootstrap must fail");
+
+    let current = manager.current_expected("stable").unwrap();
+    assert!(Arc::ptr_eq(&current.publication, &old));
+    assert_eq!(manager.snapshot().aliases(), old_snapshot.aliases());
+    assert_eq!(old.fence_state(), FenceState::Open);
+    assert_eq!(old.runtime.fence_state(), FenceState::Open);
+}
+
+#[tokio::test]
+async fn forced_transactional_reconcile_replaces_identical_effective_config() {
+    let directory = tempfile::tempdir().unwrap();
+    let Some(config) = fixture_config(&directory, &["forced"]) else {
+        return;
+    };
+    let manager = McpServerManager::new();
+    manager
+        .reconcile_from_config_transactional(&config)
+        .await
         .unwrap();
-    let legacy = "mcp__a__b__c";
-    assert!(manager.index.lookup(legacy).is_none());
+    let first = manager
+        .snapshot()
+        .resolve_call(&manager.snapshot().aliases()[0].alias)
+        .unwrap();
+    let first_publication = manager.current_expected("forced").unwrap().publication;
+
+    manager
+        .reconcile_from_config_transactional_after_forcing(
+            &config,
+            &std::collections::HashSet::from(["forced".to_string()]),
+            || async { Ok(()) },
+        )
+        .await
+        .unwrap();
+    let current = manager.snapshot();
+    let second = current.resolve_call(&current.aliases()[0].alias).unwrap();
+    assert_ne!(first.publication_id(), second.publication_id());
+    assert_ne!(first.runtime_id(), second.runtime_id());
+    assert_eq!(first_publication.fence_state(), FenceState::Closed);
+    assert_eq!(first_publication.runtime.fence_state(), FenceState::Closed);
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn committed_reconcile_publishes_all_removals_before_blocked_cleanup() {
+    let (event_tx, event_rx) = mpsc::channel(1);
+    event_tx
+        .send(McpEvent::ToolsChanged {
+            server_id: "blocker".to_string(),
+            tools: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let manager = McpServerManager::new().with_event_channel(event_tx);
+    let mut old = Vec::new();
+    for server_id in ["first", "second"] {
+        let (transport, _) = MockTransport::new(vec![tool("old", server_id)], server_id);
+        old.push(
+            publish_mock(
+                &manager,
+                prepare_mock(&manager, server_id, vec![tool("old", server_id)], transport).await,
+            )
+            .await,
+        );
+    }
+    let durable = Arc::new(AtomicBool::new(false));
+    let durable_callback = durable.clone();
+
+    tokio::time::timeout(
+        Duration::from_millis(200),
+        manager.reconcile_from_config_transactional_after(
+            &McpConfig {
+                version: 1,
+                servers: Vec::new(),
+            },
+            || async move {
+                durable_callback.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+        ),
+    )
+    .await
+    .expect("blocked event cleanup cannot suspend committed publication")
+    .unwrap();
+
+    assert!(durable.load(Ordering::SeqCst));
+    assert!(manager.snapshot().server_ids().is_empty());
+    assert!(manager.snapshot().aliases().is_empty());
+    assert!(old
+        .iter()
+        .all(|publication| publication.fence_state() == FenceState::Closed));
+    assert!(old
+        .iter()
+        .all(|publication| publication.runtime.fence_state() == FenceState::Closed));
+    drop(event_rx);
+}
+
+#[tokio::test]
+async fn manager_stop_preserves_survivor_and_historical_legacy_ambiguity() {
+    let manager = McpServerManager::new();
+    let mut publications = Vec::new();
+    for server_id in ["a::b", "a__b"] {
+        let (transport, _) = MockTransport::new(vec![tool("c", server_id)], server_id);
+        publications.push(
+            publish_mock(
+                &manager,
+                prepare_mock(&manager, server_id, vec![tool("c", server_id)], transport).await,
+            )
+            .await,
+        );
+    }
+    let removed_alias = publications[0].catalog.aliases()[0].alias.clone();
+    let survivor_alias = publications[1].catalog.aliases()[0].alias.clone();
+    assert!(manager.snapshot().lookup("mcp__a__b__c").is_none());
 
     manager.stop_server("a::b").await.unwrap();
-
-    assert!(!manager.runtimes.contains_key("a::b"));
-    assert!(Arc::ptr_eq(
-        manager.runtimes.get("a__b").unwrap().value(),
-        &survivor_runtime
-    ));
-    assert!(removed_runtime.shutdown.load(Ordering::SeqCst));
-    assert!(manager.index.lookup(&removed_alias.alias).is_none());
-    assert_eq!(
-        manager
-            .index
-            .lookup(&survivor_alias.alias)
-            .expect("survivor canonical alias remains")
-            .server_id,
-        "a__b"
-    );
-    assert!(
-        manager.index.lookup(legacy).is_none(),
-        "a historically ambiguous legacy alias must not retarget to the survivor"
-    );
-
+    let current = manager.snapshot();
+    assert!(current.lookup(&removed_alias).is_none());
+    assert_eq!(current.lookup(&survivor_alias).unwrap().server_id, "a__b");
+    assert!(current.lookup("mcp__a__b__c").is_none());
+    assert_eq!(publications[0].fence_state(), FenceState::Closed);
+    assert_eq!(publications[1].fence_state(), FenceState::Open);
     manager.stop_server("a__b").await.unwrap();
 }
 
 #[tokio::test]
-async fn detached_refresh_cannot_overwrite_replacement_tool_index() {
+async fn stale_reconnect_candidate_cannot_overwrite_successor() {
     let manager = McpServerManager::new();
-    let old = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    let replacement = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    manager.index.remove_server_tools("stable");
-    manager
-        .index
-        .register_server_tools("stable", &[marker_tool("replacement")], &[], &[])
-        .unwrap();
-
-    assert!(!manager
-        .publish_refreshed_tools_if_current("stable", &old, vec![marker_tool("stale_refresh")])
-        .await
-        .unwrap());
-    assert!(manager
-        .index
-        .contains(&manager.index.generate_alias("stable", "replacement")));
-    assert!(!manager
-        .index
-        .contains(&manager.index.generate_alias("stable", "stale_refresh")));
-    assert!(Arc::ptr_eq(
-        manager.runtimes.get("stable").unwrap().value(),
-        &replacement
-    ));
-}
-
-#[tokio::test]
-async fn detached_reconnect_cannot_overwrite_replacement_tool_index() {
-    let manager = McpServerManager::new();
-    let old = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    let replacement = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    manager.index.remove_server_tools("stable");
-    manager
-        .index
-        .register_server_tools("stable", &[marker_tool("replacement")], &[], &[])
-        .unwrap();
-
-    assert!(!manager
-        .publish_reconnected_runtime_if_current(
+    let (old_transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    publish_mock(
+        &manager,
+        prepare_mock(&manager, "stable", vec![tool("old", "old")], old_transport).await,
+    )
+    .await;
+    let stale = expected(&manager, "stable");
+    let (successor_transport, _) =
+        MockTransport::new(vec![tool("successor", "successor")], "successor");
+    let successor = publish_mock(
+        &manager,
+        prepare_mock(
+            &manager,
             "stable",
-            &old,
-            connected_mock_client().await,
-            vec![marker_tool("stale_reconnect")],
-            Some("stale instructions".to_string()),
-            None,
+            vec![tool("successor", "successor")],
+            successor_transport,
         )
+        .await,
+    )
+    .await;
+    let (candidate_transport, controls) = MockTransport::new(vec![tool("stale", "stale")], "stale");
+    let candidate = prepare_mock(
+        &manager,
+        "stable",
+        vec![tool("stale", "stale")],
+        candidate_transport,
+    )
+    .await;
+
+    assert!(!manager
+        .publish_reconnected_runtime_if_current(stale, candidate)
         .await
         .unwrap());
-    assert!(manager
-        .index
-        .contains(&manager.index.generate_alias("stable", "replacement")));
-    assert!(!manager
-        .index
-        .contains(&manager.index.generate_alias("stable", "stale_reconnect")));
+    assert_eq!(controls.drops.load(Ordering::SeqCst), 1);
     assert!(Arc::ptr_eq(
-        manager.runtimes.get("stable").unwrap().value(),
-        &replacement
+        &manager.current_expected("stable").unwrap().publication,
+        &successor
     ));
+    assert_eq!(manager.snapshot().aliases()[0].original_name, "successor");
 }
 
 #[tokio::test]
-async fn refresh_registration_failure_preserves_old_catalog_and_runtime_tools() {
+async fn refresh_registration_failure_preserves_old_publication() {
     let manager = McpServerManager::new();
-    let runtime = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    let old_tool = marker_tool("old_tool");
-    *runtime.tools.write().await = vec![old_tool.clone()];
-    runtime.info.write().await.tool_count = 1;
-    let old_aliases = manager
-        .index
-        .register_server_tools("stable", std::slice::from_ref(&old_tool), &[], &[])
-        .unwrap();
-
+    let (transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    let old = publish_mock(
+        &manager,
+        prepare_mock(&manager, "stable", vec![tool("old", "old")], transport).await,
+    )
+    .await;
+    let before = manager.snapshot();
     let error = manager
         .publish_refreshed_tools_if_current(
-            "stable",
-            &runtime,
-            vec![marker_tool("duplicate"), marker_tool("duplicate")],
+            expected(&manager, "stable"),
+            vec![tool("duplicate", "first"), tool("duplicate", "second")],
         )
         .await
-        .expect_err("duplicate refresh catalog must fail registration");
-
+        .expect_err("duplicate refresh must fail registration");
     assert!(matches!(
         error,
-        McpError::ToolRegistration(crate::error::ToolRegistrationError::DuplicateToolIdentity {
+        McpError::ToolRegistration(ToolRegistrationError::DuplicateToolIdentity {
             first_position: 0,
             duplicate_position: 1,
         })
     ));
-    assert_eq!(
-        runtime
-            .tools
-            .read()
-            .await
-            .iter()
-            .map(|tool| tool.name.as_str())
-            .collect::<Vec<_>>(),
-        ["old_tool"]
-    );
-    assert_eq!(runtime.info.read().await.tool_count, 1);
-    assert_eq!(manager.index.all_aliases(), old_aliases);
-    assert!(manager.index.lookup(&old_aliases[0].alias).is_some());
-    assert!(!manager
-        .index
-        .contains_exact_alias(&manager.index.generate_alias("stable", "duplicate")));
-}
-
-#[tokio::test]
-async fn reconnect_registration_failure_preserves_old_generation_and_catalog() {
-    let manager = McpServerManager::new();
-    let runtime = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    let old_tool = marker_tool("old_tool");
-    *runtime.tools.write().await = vec![old_tool.clone()];
-    {
-        let mut info = runtime.info.write().await;
-        info.tool_count = 1;
-        info.instructions = Some("old instructions".to_string());
-    }
-    let old_aliases = manager
-        .index
-        .register_server_tools("stable", std::slice::from_ref(&old_tool), &[], &[])
-        .unwrap();
-
-    let error = manager
-        .publish_reconnected_runtime_if_current(
-            "stable",
-            &runtime,
-            connected_mock_client().await,
-            vec![marker_tool("duplicate"), marker_tool("duplicate")],
-            Some("replacement instructions".to_string()),
-            None,
-        )
-        .await
-        .expect_err("duplicate reconnect catalog must fail registration");
-
-    assert!(matches!(
-        error,
-        McpError::ToolRegistration(crate::error::ToolRegistrationError::DuplicateToolIdentity {
-            first_position: 0,
-            duplicate_position: 1,
-        })
+    assert!(Arc::ptr_eq(
+        &manager.current_expected("stable").unwrap().publication,
+        &old
     ));
-    assert!(runtime.client.read().await.is_connected().await);
-    assert_eq!(
-        runtime
-            .tools
-            .read()
-            .await
-            .iter()
-            .map(|tool| tool.name.as_str())
-            .collect::<Vec<_>>(),
-        ["old_tool"]
-    );
-    let info = runtime.info.read().await;
-    assert_eq!(info.tool_count, 1);
-    assert_eq!(info.instructions.as_deref(), Some("old instructions"));
-    drop(info);
-    assert_eq!(manager.index.all_aliases(), old_aliases);
-    assert!(manager.index.lookup(&old_aliases[0].alias).is_some());
-    assert!(!manager
-        .index
-        .contains_exact_alias(&manager.index.generate_alias("stable", "duplicate")));
+    assert_eq!(manager.snapshot().revision(), before.revision());
+    assert_eq!(manager.snapshot().aliases(), before.aliases());
+    assert_eq!(old.fence_state(), FenceState::Open);
 }
 
 #[tokio::test]
-async fn reconnect_bootstrap_failure_keeps_old_client_and_catalog_published() {
+async fn reconnect_bootstrap_failure_keeps_old_runtime_and_catalog() {
     let manager = McpServerManager::new();
-    let mut config = create_test_server_config("stable");
+    let mut config = test_config("stable");
     config.transport = TransportConfig::Stdio(StdioConfig {
-        command: "definitely-not-a-real-mcp-command-990".to_string(),
+        command: "definitely-not-a-real-mcp-command-995-reconnect".to_string(),
         args: Vec::new(),
         cwd: None,
-        env: std::collections::HashMap::new(),
-        env_encrypted: std::collections::HashMap::new(),
-        env_credential_refs: std::collections::HashMap::new(),
+        env: HashMap::new(),
+        env_encrypted: HashMap::new(),
+        env_credential_refs: HashMap::new(),
         startup_timeout_ms: 100,
     });
-    let runtime = mock_runtime_with_config(config, connected_mock_client().await);
-    manager
-        .runtimes
-        .insert("stable".to_string(), runtime.clone());
-    let old_tool = marker_tool("old_tool");
-    *runtime.tools.write().await = vec![old_tool.clone()];
-    runtime.info.write().await.tool_count = 1;
-    let old_aliases = manager
-        .index
-        .register_server_tools("stable", std::slice::from_ref(&old_tool), &[], &[])
-        .unwrap();
+    let (transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    let old = publish_mock(
+        &manager,
+        prepare_mock_with_config(&manager, config, vec![tool("old", "old")], transport).await,
+    )
+    .await;
+    let old_aliases = manager.snapshot().aliases();
 
     manager
-        .reconnect_server(runtime.clone())
+        .reconnect_server(expected(&manager, "stable"))
         .await
         .expect_err("candidate transport bootstrap must fail");
-
-    assert!(runtime.client.read().await.is_connected().await);
-    assert_eq!(
-        runtime
-            .tools
-            .read()
-            .await
-            .iter()
-            .map(|tool| tool.name.as_str())
-            .collect::<Vec<_>>(),
-        ["old_tool"]
-    );
-    assert_eq!(manager.index.all_aliases(), old_aliases);
-    assert!(manager.index.lookup(&old_aliases[0].alias).is_some());
     assert!(Arc::ptr_eq(
-        manager.runtimes.get("stable").unwrap().value(),
-        &runtime
+        &manager.current_expected("stable").unwrap().publication,
+        &old
     ));
+    assert_eq!(manager.snapshot().aliases(), old_aliases);
+    assert_eq!(old.fence_state(), FenceState::Open);
+    assert_eq!(old.runtime.fence_state(), FenceState::Open);
+}
+
+#[tokio::test]
+async fn reconnect_registration_failure_after_bootstrap_rolls_back_old_generation() {
+    let directory = tempfile::tempdir().unwrap();
+    let Some(config) = fixture_config(&directory, &["stable"]) else {
+        return;
+    };
+    let mut manager = McpServerManager::new();
+    let (old_transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    let old = publish_mock(
+        &manager,
+        prepare_mock_with_config(
+            &manager,
+            config.servers[0].clone(),
+            vec![tool("old", "old")],
+            old_transport,
+        )
+        .await,
+    )
+    .await;
+    let old_snapshot = manager.snapshot();
+    manager.catalog_plan_probe = Some(Arc::new(|server_id, catalog| {
+        if server_id == "stable" {
+            catalog.replace_first_original_name_for_test("missing-after-bootstrap".to_string());
+        }
+    }));
+
+    let error = manager
+        .reconnect_server(expected(&manager, "stable"))
+        .await
+        .expect_err("provider-schema registration must fail after successful bootstrap");
+    assert!(matches!(
+        error,
+        McpError::ToolRegistration(ToolRegistrationError::ProviderSchemaUnavailable)
+    ));
+    assert!(Arc::ptr_eq(
+        &manager.current_expected("stable").unwrap().publication,
+        &old
+    ));
+    assert_eq!(manager.snapshot().aliases(), old_snapshot.aliases());
+    assert_eq!(old.fence_state(), FenceState::Open);
+    assert_eq!(old.runtime.fence_state(), FenceState::Open);
+}
+
+#[tokio::test]
+async fn reconnect_planning_failure_after_bootstrap_rolls_back_old_generation() {
+    let directory = tempfile::tempdir().unwrap();
+    let Some(config) = fixture_config(&directory, &["stable"]) else {
+        return;
+    };
+    let mut manager = McpServerManager::new();
+    let (stable_transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    let stable = publish_mock(
+        &manager,
+        prepare_mock_with_config(
+            &manager,
+            config.servers[0].clone(),
+            vec![tool("old", "old")],
+            stable_transport,
+        )
+        .await,
+    )
+    .await;
+    let (blocker_transport, _) = MockTransport::new(vec![tool("block", "block")], "block");
+    let blocker = publish_mock(
+        &manager,
+        prepare_mock(
+            &manager,
+            "blocker",
+            vec![tool("block", "block")],
+            blocker_transport,
+        )
+        .await,
+    )
+    .await;
+    let blocker_alias = blocker.catalog.aliases()[0].alias.clone();
+    let old_snapshot = manager.snapshot();
+    manager.catalog_plan_probe = Some(Arc::new(move |server_id, catalog| {
+        if server_id == "stable" {
+            catalog.replace_first_canonical_alias_for_test(blocker_alias.clone());
+        }
+    }));
+
+    let error = manager
+        .reconnect_server(expected(&manager, "stable"))
+        .await
+        .expect_err("catalog collision must fail after successful bootstrap");
+    assert!(matches!(
+        error,
+        McpError::ToolRegistration(ToolRegistrationError::AliasCollision { .. })
+    ));
+    assert!(Arc::ptr_eq(
+        &manager.current_expected("stable").unwrap().publication,
+        &stable
+    ));
+    assert!(Arc::ptr_eq(
+        &manager.current_expected("blocker").unwrap().publication,
+        &blocker
+    ));
+    assert_eq!(manager.snapshot().aliases(), old_snapshot.aliases());
+    assert_eq!(stable.fence_state(), FenceState::Open);
+    assert_eq!(stable.runtime.fence_state(), FenceState::Open);
+    assert_eq!(blocker.fence_state(), FenceState::Open);
 }
 
 #[tokio::test]
 async fn canonical_identity_is_exact_from_listing_through_execution() {
     let manager = Arc::new(McpServerManager::new());
-    let transport = NotifyingMockTransport::new(&[], &[]);
-    let mut client = McpProtocolClient::new(Box::new(transport));
-    client.connect().await.expect("connect execution fixture");
-    let runtime = insert_mock_runtime(&manager, "a::b", client);
-    let remote_tool = marker_tool("c");
-    *runtime.tools.write().await = vec![remote_tool.clone()];
-    runtime.info.write().await.tool_count = 1;
-    let alias = manager
-        .index
-        .register_server_tools("a::b", std::slice::from_ref(&remote_tool), &[], &[])
-        .unwrap()
-        .pop()
-        .unwrap();
-    let executor = McpToolExecutor::new(manager.clone(), manager.tool_index());
-
+    let (transport, _) = MockTransport::new(vec![tool("c", "remote")], "old-runtime");
+    publish_mock(
+        &manager,
+        prepare_mock(&manager, "a::b", vec![tool("c", "remote")], transport).await,
+    )
+    .await;
+    let executor = McpToolExecutor::from_manager(manager.clone());
     let listed = executor.list_tools();
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].function.name, alias.alias);
-    let identity = ClassifiedToolIdentity::from_schema_name(&listed[0].function.name)
-        .expect("listed canonical MCP alias is a loadable identity");
-    assert_eq!(identity.execution_name(), alias.alias);
-    assert_eq!(manager.index.lookup(&alias.alias).unwrap(), alias);
-    assert!(manager.index.contains_exact_alias(&alias.alias));
+    let alias = listed[0].function.name.clone();
+    let identity = ClassifiedToolIdentity::from_schema_name(&alias).unwrap();
+    assert_eq!(identity.execution_name(), alias);
+    assert!(manager.snapshot().contains_exact_alias(&alias));
 
     let result = executor
         .execute(&ToolCall {
             id: "call-exact-mcp-alias".to_string(),
             tool_type: "function".to_string(),
             function: FunctionCall {
-                name: alias.alias.clone(),
+                name: alias,
                 arguments: "{}".to_string(),
             },
         })
         .await
-        .expect("canonical provider identity executes");
+        .unwrap();
     assert!(result.success);
-    assert_eq!(
-        result.result, remote_tool.name,
-        "transport must receive the original MCP tool name"
-    );
+    assert_eq!(result.result, "old-runtime");
 }
 
 #[tokio::test]
-async fn detached_generation_cannot_publish_health_or_reconnect_status() {
-    let (event_tx, mut event_rx) = mpsc::channel(4);
+async fn tools_list_changed_notification_triggers_generation_refresh() {
+    let (event_tx, mut event_rx) = mpsc::channel(16);
     let manager = McpServerManager::new().with_event_channel(event_tx);
-    let old = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    let _replacement = insert_mock_runtime(&manager, "stable", connected_mock_client().await);
-    let initial = old.info.read().await.clone();
+    let (transport, controls) = MockTransport::new(vec![tool("old", "old")], "runtime");
+    let old = publish_mock_with_tasks(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("old", "old")], transport).await,
+    )
+    .await;
+    *controls
+        .tools
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) =
+        vec![tool("alpha", "Alpha"), tool("beta", "Beta")];
+    controls
+        .message_tx
+        .send(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/tools/list_changed"
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(3), event_rx.recv())
+        .await
+        .expect("tools change event")
+        .expect("event channel open");
+    assert!(matches!(
+        event,
+        McpEvent::ToolsChanged { server_id, tools }
+            if server_id == "server" && tools.len() == 2
+    ));
+    let snapshot = manager.snapshot();
+    assert_eq!(snapshot.aliases().len(), 2);
+    assert_snapshot_coherent(&snapshot);
+    assert_eq!(old.fence_state(), FenceState::Closed);
+    assert_eq!(old.runtime.fence_state(), FenceState::Open);
+    manager.stop_server("server").await.unwrap();
+}
+
+#[tokio::test]
+async fn unhandled_notification_is_drained_without_refresh() {
+    let (event_tx, mut event_rx) = mpsc::channel(16);
+    let manager = McpServerManager::new().with_event_channel(event_tx);
+    let (transport, controls) = MockTransport::new(vec![tool("old", "old")], "runtime");
+    let publication = publish_mock_with_tasks(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("old", "old")], transport).await,
+    )
+    .await;
+    let revision = manager.snapshot().revision();
+    controls
+        .message_tx
+        .send(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": {"level": "info"}
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), event_rx.recv())
+            .await
+            .is_err()
+    );
+    assert_eq!(manager.snapshot().revision(), revision);
+    assert!(Arc::ptr_eq(
+        &manager.current_expected("server").unwrap().publication,
+        &publication
+    ));
+    manager.stop_server("server").await.unwrap();
+}
+
+#[tokio::test]
+async fn stale_unadmitted_ticket_fails_after_refresh() {
+    let manager = McpServerManager::new();
+    let (transport, _) = MockTransport::new(vec![tool("echo", "old")], "old-runtime");
+    let old = publish_mock(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("echo", "old")], transport).await,
+    )
+    .await;
+    let snapshot = manager.snapshot();
+    let alias = snapshot.aliases().pop().expect("old alias");
+    let ticket = snapshot.resolve_call(&alias.alias).expect("old ticket");
+    let old_runtime_id = ticket.runtime_id();
+
+    manager
+        .publish_refreshed_tools_if_current(
+            expected(&manager, "server"),
+            vec![tool("echo", "new schema")],
+        )
+        .await
+        .expect("refresh publication")
+        .then_some(())
+        .expect("expected publication remained current");
+
+    let error = manager
+        .call_resolved_tool(&ticket, serde_json::json!({}))
+        .await
+        .expect_err("old passive ticket must fail admission");
+    assert!(matches!(error, McpError::StalePublication { .. }));
+    let current = manager.snapshot().resolve_call(&alias.alias).unwrap();
+    assert_eq!(current.runtime_id(), old_runtime_id);
+    assert_ne!(current.publication_id(), ticket.publication_id());
+    assert_eq!(old.fence_state(), FenceState::Closed);
+}
+
+#[tokio::test]
+async fn in_flight_old_call_never_retargets_across_reconnect() {
+    let manager = Arc::new(McpServerManager::new());
+    let (old_transport, mut old_controls) =
+        MockTransport::new_with_call_gate(vec![tool("echo", "old")], "old-runtime", true, false);
+    let old_publication = publish_mock(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("echo", "old")], old_transport).await,
+    )
+    .await;
+    let old_expected = expected(&manager, "server");
+    let ticket = manager
+        .snapshot()
+        .resolve_call(&manager.snapshot().aliases()[0].alias)
+        .unwrap();
+    let in_flight_ticket = ticket.clone();
+    let call_manager = manager.clone();
+    let call = tokio::spawn(async move {
+        call_manager
+            .call_resolved_tool(&in_flight_ticket, serde_json::json!({}))
+            .await
+    });
+    old_controls
+        .call_started
+        .as_mut()
+        .unwrap()
+        .recv()
+        .await
+        .expect("old call admitted and sent");
+
+    let (new_transport, _) = MockTransport::new(vec![tool("echo", "new")], "new-runtime");
+    let prepared = prepare_mock(&manager, "server", vec![tool("echo", "new")], new_transport).await;
+    assert!(manager
+        .publish_reconnected_runtime_if_current(old_expected, prepared)
+        .await
+        .expect("reconnect publication"));
+    assert_eq!(old_publication.fence_state(), FenceState::Retiring);
+    assert_eq!(old_publication.runtime.fence_state(), FenceState::Retiring);
+    assert_eq!(old_publication.runtime.active_calls(), 1);
+    old_controls.call_release.unwrap().add_permits(1);
+    let old_result = call.await.unwrap().expect("admitted old call completes");
+    assert!(matches!(
+        &old_result.content[0],
+        crate::types::McpContentItem::Text { text, .. } if text == "old-runtime"
+    ));
+    assert_eq!(old_publication.fence_state(), FenceState::Closed);
+    assert_eq!(old_publication.runtime.fence_state(), FenceState::Closed);
+
+    let current = manager.snapshot();
+    let new_ticket = current.resolve_call(&current.aliases()[0].alias).unwrap();
+    assert_ne!(ticket.runtime_id(), new_ticket.runtime_id());
+    let new_result = manager
+        .call_resolved_tool(&new_ticket, serde_json::json!({}))
+        .await
+        .expect("successor call");
+    assert!(matches!(
+        &new_result.content[0],
+        crate::types::McpContentItem::Text { text, .. } if text == "new-runtime"
+    ));
+}
+
+#[tokio::test]
+async fn stale_notification_cannot_refresh_successor() {
+    let manager = McpServerManager::new();
+    let (old_transport, _) = MockTransport::new(vec![tool("old", "old")], "old");
+    publish_mock(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("old", "old")], old_transport).await,
+    )
+    .await;
+    let stale = expected(&manager, "server");
+    let (new_transport, controls) = MockTransport::new(vec![tool("new", "successor")], "new");
+    publish_mock(
+        &manager,
+        prepare_mock(
+            &manager,
+            "server",
+            vec![tool("new", "successor")],
+            new_transport,
+        )
+        .await,
+    )
+    .await;
+    *controls
+        .tools
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = vec![tool("wrong", "stale")];
+
+    manager
+        .dispatch_server_notification(
+            stale,
+            JsonRpcNotification {
+                jsonrpc: "2.0".to_string(),
+                method: "notifications/tools/list_changed".to_string(),
+                params: None,
+            },
+        )
+        .await;
+    let snapshot = manager.snapshot();
+    assert_eq!(snapshot.aliases()[0].original_name, "new");
+    assert_snapshot_coherent(&snapshot);
+}
+
+#[tokio::test]
+async fn stale_health_and_qos_results_cannot_mutate_successor() {
+    let manager = McpServerManager::new();
+    let (old_transport, _) = MockTransport::new(vec![tool("echo", "old")], "old");
+    let old = publish_mock(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("echo", "old")], old_transport).await,
+    )
+    .await;
+    let stale = expected(&manager, "server");
+    let (new_transport, _) = MockTransport::new(vec![tool("echo", "new")], "new");
+    let new = publish_mock(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("echo", "new")], new_transport).await,
+    )
+    .await;
 
     assert_eq!(
         manager
-            .publish_health_result_if_current(
-                "stable",
-                &old,
-                Err("stale ping failure".to_string()),
-            )
+            .publish_health_result_if_current(stale.clone(), Err("stale".to_string()))
             .await,
         None
     );
-    manager.attempt_reconnection(old.clone()).await.unwrap();
-
-    let after = old.info.read().await;
-    assert_eq!(after.status, initial.status);
-    assert_eq!(after.last_error, initial.last_error);
-    assert!(!old.reconnecting.load(Ordering::SeqCst));
-    assert!(event_rx.try_recv().is_err());
-}
-
-#[tokio::test]
-async fn tools_list_changed_notification_triggers_refresh() {
-    // #366 headline capability: a server-initiated `tools/list_changed` reaches the
-    // drain consumer and triggers a real tool-list refresh (re-registering the
-    // index + emitting `ToolsChanged`). Before the fix the notification channel had
-    // no consumer, so the notification was dropped and this never fired.
-    let (event_tx, mut event_rx) = mpsc::channel::<McpEvent>(16);
-    let manager = McpServerManager::new().with_event_channel(event_tx);
-
-    // Mock server preloads a `tools/list_changed` for the client to forward, and
-    // answers the follow-up `tools/list` with two tools.
-    let transport = NotifyingMockTransport::new(
-        &[r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#],
-        &[("alpha", "Alpha tool"), ("beta", "Beta tool")],
-    );
-    let mut client = McpProtocolClient::new(Box::new(transport));
-    client.connect().await.expect("connect mock client");
-
-    let runtime = insert_mock_runtime(&manager, "srv", client);
-
-    // Wire the real drain (exactly as bootstrap does in production).
-    let rx = runtime
-        .client
-        .read()
-        .await
-        .take_notification_receiver()
-        .await
-        .expect("notification receiver available exactly once");
-    manager.spawn_notification_drain("srv".to_string(), runtime.clone(), rx);
-
-    // The drain observes the notification -> refresh_tools -> ToolsChanged.
-    let evt = tokio::time::timeout(Duration::from_secs(3), event_rx.recv())
-        .await
-        .expect("a ToolsChanged event must be emitted after tools/list_changed")
-        .expect("event channel stays open");
-    match evt {
-        McpEvent::ToolsChanged { server_id, tools } => {
-            assert_eq!(server_id, "srv");
-            assert_eq!(tools.len(), 2, "refresh should register the two new tools");
-        }
-        other => panic!("expected ToolsChanged, got {other:?}"),
-    }
-
-    // The tool index now holds the two aliases from the refreshed list.
+    old.runtime
+        .runtime
+        .qos
+        .record_failure("server", "echo", &McpError::Disconnected)
+        .await;
+    manager.maybe_recycle_server(stale, true);
     assert_eq!(
-        manager.tool_index().all_aliases().len(),
-        2,
-        "refreshed tools should be registered in the index"
+        new.runtime.runtime.info.read().await.status,
+        ServerStatus::Ready
+    );
+    assert_eq!(
+        new.runtime
+            .runtime
+            .qos
+            .state
+            .lock()
+            .await
+            .consecutive_failures,
+        0
+    );
+    assert!(!new.runtime.runtime.reconnecting.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn stopped_snapshot_ticket_fails_closed_and_never_retargets() {
+    let manager = McpServerManager::new();
+    let (transport, _) = MockTransport::new(vec![tool("echo", "old")], "old");
+    publish_mock(
+        &manager,
+        prepare_mock(&manager, "server", vec![tool("echo", "old")], transport).await,
+    )
+    .await;
+    let snapshot = manager.snapshot();
+    let ticket = snapshot.resolve_call(&snapshot.aliases()[0].alias).unwrap();
+    manager.stop_server("server").await.unwrap();
+    assert!(matches!(
+        manager
+            .call_resolved_tool(&ticket, serde_json::json!({}))
+            .await,
+        Err(McpError::StalePublication { .. })
+    ));
+    assert!(manager.snapshot().aliases().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lifecycle_writers_publish_only_old_or_new_coherent_generations() {
+    let start_dir = tempfile::tempdir().unwrap();
+    let Some(mut start_config) = fixture_config(&start_dir, &["start"]) else {
+        return;
+    };
+    let (start_events, _start_event_rx) = mpsc::channel(8);
+    let start_manager = Arc::new(McpServerManager::new().with_event_channel(start_events));
+    let start_writer_manager = start_manager.clone();
+    assert_old_or_new_during_writer(start_manager.clone(), async move {
+        start_writer_manager
+            .start_server(start_config.servers.remove(0))
+            .await
+    })
+    .await
+    .unwrap();
+    let start_snapshot = start_manager.snapshot();
+    let start_ticket = start_snapshot
+        .resolve_call(&start_snapshot.aliases()[0].alias)
+        .unwrap();
+    start_manager
+        .call_resolved_tool(&start_ticket, serde_json::json!({}))
+        .await
+        .unwrap();
+
+    let (refresh_events, _refresh_event_rx) = mpsc::channel(8);
+    let refresh_manager = Arc::new(McpServerManager::new().with_event_channel(refresh_events));
+    let (refresh_transport, _) = MockTransport::new(vec![tool("echo", "old")], "refresh");
+    publish_mock(
+        &refresh_manager,
+        prepare_mock(
+            &refresh_manager,
+            "refresh",
+            vec![tool("echo", "old")],
+            refresh_transport,
+        )
+        .await,
+    )
+    .await;
+    let refresh_snapshot = refresh_manager.snapshot();
+    let old_refresh = refresh_snapshot
+        .resolve_call(&refresh_snapshot.aliases()[0].alias)
+        .unwrap();
+    let refresh_expected = expected(&refresh_manager, "refresh");
+    let refresh_writer_manager = refresh_manager.clone();
+    assert!(
+        assert_old_or_new_during_writer(refresh_manager.clone(), async move {
+            refresh_writer_manager
+                .publish_refreshed_tools_if_current(
+                    refresh_expected,
+                    vec![tool("echo", "new schema")],
+                )
+                .await
+        })
+        .await
+        .unwrap()
+    );
+    assert!(matches!(
+        refresh_manager
+            .call_resolved_tool(&old_refresh, serde_json::json!({}))
+            .await,
+        Err(McpError::StalePublication { .. })
+    ));
+
+    let (reconnect_events, _reconnect_event_rx) = mpsc::channel(8);
+    let reconnect_manager = Arc::new(McpServerManager::new().with_event_channel(reconnect_events));
+    let (old_transport, _) = MockTransport::new(vec![tool("echo", "old")], "old");
+    publish_mock(
+        &reconnect_manager,
+        prepare_mock(
+            &reconnect_manager,
+            "reconnect",
+            vec![tool("echo", "old")],
+            old_transport,
+        )
+        .await,
+    )
+    .await;
+    let reconnect_snapshot = reconnect_manager.snapshot();
+    let old_reconnect = reconnect_snapshot
+        .resolve_call(&reconnect_snapshot.aliases()[0].alias)
+        .unwrap();
+    let reconnect_expected = expected(&reconnect_manager, "reconnect");
+    let (new_transport, _) = MockTransport::new(vec![tool("echo", "new")], "new");
+    let reconnect_candidate = prepare_mock(
+        &reconnect_manager,
+        "reconnect",
+        vec![tool("echo", "new")],
+        new_transport,
+    )
+    .await;
+    let reconnect_writer_manager = reconnect_manager.clone();
+    assert!(
+        assert_old_or_new_during_writer(reconnect_manager.clone(), async move {
+            reconnect_writer_manager
+                .publish_reconnected_runtime_if_current(reconnect_expected, reconnect_candidate)
+                .await
+        })
+        .await
+        .unwrap()
+    );
+    assert!(matches!(
+        reconnect_manager
+            .call_resolved_tool(&old_reconnect, serde_json::json!({}))
+            .await,
+        Err(McpError::StalePublication { .. })
+    ));
+
+    let (stop_events, _stop_event_rx) = mpsc::channel(8);
+    let stop_manager = Arc::new(McpServerManager::new().with_event_channel(stop_events));
+    let (stop_transport, stop_controls) = MockTransport::new(vec![tool("echo", "stop")], "stop");
+    publish_mock(
+        &stop_manager,
+        prepare_mock(
+            &stop_manager,
+            "stop",
+            vec![tool("echo", "stop")],
+            stop_transport,
+        )
+        .await,
+    )
+    .await;
+    let stop_snapshot = stop_manager.snapshot();
+    let stopped_ticket = stop_snapshot
+        .resolve_call(&stop_snapshot.aliases()[0].alias)
+        .unwrap();
+    let stop_writer_manager = stop_manager.clone();
+    assert_old_or_new_during_writer(stop_manager.clone(), async move {
+        stop_writer_manager.stop_server("stop").await
+    })
+    .await
+    .unwrap();
+    assert!(matches!(
+        stop_manager
+            .call_resolved_tool(&stopped_ticket, serde_json::json!({}))
+            .await,
+        Err(McpError::StalePublication { .. })
+    ));
+    assert_eq!(stop_controls.calls.load(Ordering::SeqCst), 0);
+
+    let old_dir = tempfile::tempdir().unwrap();
+    let new_dir = tempfile::tempdir().unwrap();
+    let old_config = fixture_config(&old_dir, &["old-a", "old-b"]).unwrap();
+    let new_config = fixture_config(&new_dir, &["new-a", "new-b"]).unwrap();
+    let (config_events, _config_event_rx) = mpsc::channel(32);
+    let config_manager = Arc::new(McpServerManager::new().with_event_channel(config_events));
+    config_manager
+        .reconcile_from_config_transactional(&old_config)
+        .await
+        .unwrap();
+    let old_snapshot = config_manager.snapshot();
+    let old_tickets = old_snapshot
+        .aliases()
+        .iter()
+        .map(|alias| old_snapshot.resolve_call(&alias.alias).unwrap())
+        .collect::<Vec<_>>();
+    let config_writer_manager = config_manager.clone();
+    assert_old_or_new_during_writer(config_manager.clone(), async move {
+        config_writer_manager
+            .reconcile_from_config_transactional(&new_config)
+            .await
+    })
+    .await
+    .unwrap();
+    for old_ticket in &old_tickets {
+        assert!(matches!(
+            config_manager
+                .call_resolved_tool(old_ticket, serde_json::json!({}))
+                .await,
+            Err(McpError::StalePublication { .. })
+        ));
+    }
+    let current = config_manager.snapshot();
+    assert_eq!(
+        current.server_ids(),
+        vec!["new-a".to_string(), "new-b".to_string()]
+    );
+    let current_ticket = current.resolve_call(&current.aliases()[0].alias).unwrap();
+    config_manager
+        .call_resolved_tool(&current_ticket, serde_json::json!({}))
+        .await
+        .unwrap();
+
+    start_manager.shutdown_all().await;
+    refresh_manager.shutdown_all().await;
+    reconnect_manager.shutdown_all().await;
+    config_manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn snapshots_are_old_or_new_during_bulk_publication() {
+    let manager = Arc::new(McpServerManager::new());
+    for server_id in ["old-a", "old-b"] {
+        let (transport, _) = MockTransport::new(vec![tool("echo", server_id)], server_id);
+        publish_mock(
+            &manager,
+            prepare_mock(
+                &manager,
+                server_id,
+                vec![tool("echo", server_id)],
+                transport,
+            )
+            .await,
+        )
+        .await;
+    }
+    let mut replacements = Vec::new();
+    for server_id in ["new-a", "new-b"] {
+        let (transport, _) = MockTransport::new(vec![tool("echo", server_id)], server_id);
+        let staged = prepare_mock(
+            &manager,
+            server_id,
+            vec![tool("echo", server_id)],
+            transport,
+        )
+        .await;
+        let mut commit = staged.into_commit();
+        let publication = commit.publication().clone();
+        commit.mark_published();
+        commit.discard_activation();
+        replacements.push(publication);
+    }
+    let base = manager.authority.generation();
+    let next = McpRuntimeGeneration::plan(
+        &base,
+        &replacements,
+        &["old-a".to_string(), "old-b".to_string()],
+        manager.authority.ledger_relationship_limit,
+        true,
+    )
+    .unwrap();
+    let barrier = Arc::new(Barrier::new(2));
+    let reader_manager = manager.clone();
+    let reader_barrier = barrier.clone();
+    let reader = std::thread::spawn(move || {
+        reader_barrier.wait();
+        for _ in 0..2_000 {
+            let snapshot = reader_manager.snapshot();
+            assert_snapshot_coherent(&snapshot);
+            let ids = snapshot.server_ids().into_iter().collect::<BTreeSet<_>>();
+            assert!(
+                ids == BTreeSet::from(["old-a".to_string(), "old-b".to_string()])
+                    || ids == BTreeSet::from(["new-a".to_string(), "new-b".to_string()])
+            );
+        }
+    });
+    barrier.wait();
+    manager
+        .authority
+        .replace_prevalidated_with(&base, next, || {
+            for publication in base.servers.values() {
+                publication.retire_with_runtime();
+            }
+        });
+    reader.join().unwrap();
+    assert_eq!(
+        manager.snapshot().server_ids(),
+        vec!["new-a".to_string(), "new-b".to_string()]
     );
 }
 
-/// A notification with no dispatcher is still drained (so the queue can't
-/// saturate) and does NOT trigger a tool-list refresh.
+fn python_command() -> Option<&'static str> {
+    ["python3", "python"].into_iter().find(|command| {
+        std::process::Command::new(command)
+            .arg("--version")
+            .output()
+            .is_ok_and(|output| output.status.success())
+    })
+}
+
+fn fixture_config(temp: &tempfile::TempDir, ids: &[&str]) -> Option<McpConfig> {
+    let python = python_command()?;
+    let script = temp.path().join("mcp_fixture.py");
+    std::fs::write(
+        &script,
+        r#"import json
+import sys
+for line in sys.stdin:
+    request = json.loads(line)
+    request_id = request.get("id")
+    if request_id is None:
+        continue
+    method = request.get("method")
+    if method == "server/discover":
+        print(json.dumps({"jsonrpc":"2.0","id":request_id,"error":{"code":-32601,"message":"missing"}}), flush=True)
+        continue
+    if method == "initialize":
+        result = {"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":False}},"serverInfo":{"name":"fixture","version":"1"}}
+    elif method == "tools/list":
+        result = {"tools":[{"name":"echo","description":"fixture","inputSchema":{"type":"object"}}]}
+    elif method == "tools/call":
+        result = {"content":[{"type":"text","text":"fixture"}],"isError":False}
+    else:
+        result = {}
+    print(json.dumps({"jsonrpc":"2.0","id":request_id,"result":result}), flush=True)
+"#,
+    )
+    .expect("write fixture");
+    Some(McpConfig {
+        version: 1,
+        servers: ids
+            .iter()
+            .map(|id| {
+                let mut config = test_config(id);
+                config.transport = TransportConfig::Stdio(StdioConfig {
+                    command: python.to_string(),
+                    args: vec![script.to_string_lossy().into_owned()],
+                    cwd: None,
+                    env: HashMap::new(),
+                    env_encrypted: HashMap::new(),
+                    env_credential_refs: HashMap::new(),
+                    startup_timeout_ms: 2_000,
+                });
+                config
+            })
+            .collect(),
+    })
+}
+
 #[tokio::test]
-async fn unhandled_notification_is_drained_without_refresh() {
-    let (event_tx, mut event_rx) = mpsc::channel::<McpEvent>(16);
-    let manager = McpServerManager::new().with_event_channel(event_tx);
-
-    let transport = NotifyingMockTransport::new(
-        &[r#"{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}"#],
-        &[("alpha", "Alpha tool")],
-    );
-    let mut client = McpProtocolClient::new(Box::new(transport));
-    client.connect().await.expect("connect mock client");
-
-    let runtime = insert_mock_runtime(&manager, "srv", client);
-    let rx = runtime
-        .client
-        .read()
+async fn cancel_before_durable_and_after_durable_boundary() {
+    if python_command().is_none() {
+        return;
+    }
+    // Keep the script directory alive independently for each phase.
+    let before_dir = tempfile::tempdir().unwrap();
+    let before_config = fixture_config(&before_dir, &["candidate"]).unwrap();
+    let task_phases = Arc::new(StdMutex::new(Vec::new()));
+    let mut probed_manager = McpServerManager::new();
+    let recorded_task_phases = task_phases.clone();
+    probed_manager.task_probe = Some(Arc::new(move |phase, task_count| {
+        recorded_task_phases
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push((phase, task_count));
+    }));
+    let manager = Arc::new(probed_manager);
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let before_manager = manager.clone();
+    let before = tokio::spawn(async move {
+        before_manager
+            .reconcile_from_config_transactional_after(&before_config, || async move {
+                let _ = entered_tx.send(());
+                pending::<Result<()>>().await
+            })
+            .await
+    });
+    entered_rx
         .await
-        .take_notification_receiver()
-        .await
-        .expect("notification receiver available");
-    manager.spawn_notification_drain("srv".to_string(), runtime.clone(), rx);
+        .expect("candidate staged before durable CAS");
+    before.abort();
+    let _ = before.await;
+    assert!(manager.snapshot().server_ids().is_empty());
+    let before_phases = task_phases
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    assert_eq!(
+        before_phases,
+        vec![
+            (TaskProbePhase::PreparedAndGated, 2),
+            (TaskProbePhase::Dropped, 2),
+        ]
+    );
+    task_phases
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clear();
 
-    // No dispatcher for `notifications/message` -> no ToolsChanged emitted.
-    let got = tokio::time::timeout(Duration::from_millis(300), event_rx.recv()).await;
-    assert!(
-        got.is_err(),
-        "an unhandled notification must not trigger a refresh event"
+    let after_dir = tempfile::tempdir().unwrap();
+    let after_config = fixture_config(&after_dir, &["candidate"]).expect("python fixture config");
+    let (durable_tx, durable_rx) = tokio::sync::oneshot::channel();
+    let after_manager = manager.clone();
+    let after = tokio::spawn(async move {
+        after_manager
+            .reconcile_from_config_transactional_after(&after_config, || async move {
+                let _ = durable_tx.send(());
+                Ok(())
+            })
+            .await
+    });
+    durable_rx
+        .await
+        .expect("durable callback returned Ready(Ok)");
+    after.abort();
+    let _ = after.await;
+    assert_eq!(
+        manager.snapshot().server_ids(),
+        vec!["candidate".to_string()]
     );
-    assert!(
-        manager.tool_index().all_aliases().is_empty(),
-        "no tools should be registered without a tools/list_changed"
+    assert_snapshot_coherent(&manager.snapshot());
+    assert_eq!(
+        *task_phases
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+        vec![
+            (TaskProbePhase::PreparedAndGated, 2),
+            (TaskProbePhase::Transferred, 2),
+            (TaskProbePhase::Activated, 2),
+        ]
     );
+    manager.shutdown_all().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn durable_publication_prepares_tasks_and_activates_in_one_sync_phase() {
+    let directory = tempfile::tempdir().unwrap();
+    let Some(config) = fixture_config(&directory, &["candidate"]) else {
+        return;
+    };
+    let order = Arc::new(StdMutex::new(Vec::<&'static str>::new()));
+    let (event_tx, mut event_rx) = mpsc::channel(4);
+    let mut manager = McpServerManager::new().with_event_channel(event_tx);
+
+    let task_order = order.clone();
+    manager.task_probe = Some(Arc::new(move |phase, task_count| {
+        assert_eq!(task_count, 2);
+        let label = match phase {
+            TaskProbePhase::PreparedAndGated => "task_prepared",
+            TaskProbePhase::Transferred => "task_transferred",
+            TaskProbePhase::Activated => "task_activated",
+            TaskProbePhase::Dropped => "task_dropped",
+        };
+        task_order
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(label);
+    }));
+    let publish_order = order.clone();
+    manager.publish_probe = Some(Arc::new(move |phase| {
+        let label = match phase {
+            PublishProbePhase::BeforeFenceAndSwap => "publish_before_fence",
+            PublishProbePhase::AfterFencesBeforeSwap => "publish_after_fence",
+            PublishProbePhase::AfterTransferAndSwapBeforeUnlock => "publish_after_transfer",
+        };
+        publish_order
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(label);
+    }));
+    let event_order = order.clone();
+    manager.event_probe = Some(Arc::new(move |phase| {
+        let label = match phase {
+            EventProbePhase::BeforeBatchValidation => "event_before_validation",
+            EventProbePhase::AcceptedBatchBeforeFirstDelivery => "event_accepted",
+            EventProbePhase::BeforeOutputSend => "event_before_send",
+        };
+        event_order
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(label);
+    }));
+
+    let callback_order = order.clone();
+    manager
+        .reconcile_from_config_transactional_after(&config, || async move {
+            let mut order = callback_order
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            order.push("callback_enter");
+            order.push("callback_ok");
+            Ok(())
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        event_rx.recv().await,
+        Some(McpEvent::ServerStatusChanged {
+            status: ServerStatus::Ready,
+            ..
+        })
+    ));
+    assert!(matches!(
+        event_rx.recv().await,
+        Some(McpEvent::ToolsChanged { .. })
+    ));
+
+    let order = order
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let position = |label| {
+        order
+            .iter()
+            .position(|entry| *entry == label)
+            .unwrap_or_else(|| panic!("missing phase {label}: {order:?}"))
+    };
+    assert!(position("task_prepared") < position("callback_enter"));
+    assert!(position("event_before_validation") < position("callback_enter"));
+    assert!(position("callback_enter") < position("callback_ok"));
+    assert!(position("callback_ok") < position("publish_before_fence"));
+    assert!(position("publish_before_fence") < position("publish_after_fence"));
+    assert!(position("publish_after_fence") < position("task_transferred"));
+    assert!(position("task_transferred") < position("task_activated"));
+    assert!(position("task_activated") < position("publish_after_transfer"));
+    assert!(position("publish_after_transfer") < position("event_accepted"));
+    assert!(position("event_accepted") < position("event_before_send"));
+    assert!(!order.contains(&"task_dropped"));
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn rejected_durable_callback_drops_the_whole_event_batch() {
+    let directory = tempfile::tempdir().unwrap();
+    let Some(config) = fixture_config(&directory, &["candidate"]) else {
+        return;
+    };
+    let phases = Arc::new(StdMutex::new(Vec::new()));
+    let recorded = phases.clone();
+    let (event_tx, mut event_rx) = mpsc::channel(1);
+    let mut manager = McpServerManager::new().with_event_channel(event_tx);
+    manager.event_probe = Some(Arc::new(move |phase| {
+        recorded
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(phase);
+    }));
+
+    let error = manager
+        .reconcile_from_config_transactional_after(&config, || async {
+            Err(McpError::Connection(
+                "durable callback rejected".to_string(),
+            ))
+        })
+        .await
+        .expect_err("rejected durable callback must cancel publication");
+    assert!(matches!(error, McpError::Connection(_)));
+    assert!(manager.snapshot().server_ids().is_empty());
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), event_rx.recv())
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        *phases
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+        vec![EventProbePhase::BeforeBatchValidation]
+    );
+}
+
+#[tokio::test]
+async fn all_failures_precede_durable_callback() {
+    let manager = McpServerManager::new();
+    manager.index.set_revision_for_test(u64::MAX);
+    let revision_callbacks = Arc::new(AtomicUsize::new(0));
+    let revision_callback = revision_callbacks.clone();
+    let error = manager
+        .reconcile_from_config_transactional_after(
+            &McpConfig {
+                version: 1,
+                servers: Vec::new(),
+            },
+            || async move {
+                revision_callback.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .expect_err("revision exhaustion must preflight before durable CAS");
+    assert!(matches!(
+        error,
+        McpError::ToolRegistration(ToolRegistrationError::PublicationRevisionExhausted)
+    ));
+    assert_eq!(revision_callbacks.load(Ordering::SeqCst), 0);
+
+    let collision_dir = tempfile::tempdir().unwrap();
+    let Some(collision_config) = fixture_config(&collision_dir, &["first", "second"]) else {
+        return;
+    };
+    let first_alias = Arc::new(StdMutex::new(None::<String>));
+    let mut collision_manager = McpServerManager::new();
+    let collision_alias = first_alias.clone();
+    collision_manager.catalog_plan_probe = Some(Arc::new(move |_, catalog| {
+        let mut first = collision_alias
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(alias) = first.as_ref() {
+            catalog.replace_first_canonical_alias_for_test(alias.clone());
+        } else {
+            *first = Some(catalog.aliases()[0].alias.clone());
+        }
+    }));
+    let collision_callbacks = Arc::new(AtomicUsize::new(0));
+    let collision_callback = collision_callbacks.clone();
+    let collision = collision_manager
+        .reconcile_from_config_transactional_after(&collision_config, || async move {
+            collision_callback.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await
+        .expect_err("collision must fail inside transactional generation planning");
+    assert!(matches!(
+        collision,
+        McpError::ToolRegistration(ToolRegistrationError::AliasCollision { .. })
+    ));
+    assert_eq!(collision_callbacks.load(Ordering::SeqCst), 0);
+    assert!(collision_manager.snapshot().server_ids().is_empty());
+
+    let authority = GenerationAuthority::new(1);
+    let limited = McpServerManager {
+        index: Arc::new(ToolIndex::from_authority(authority.clone())),
+        authority,
+        event_tx: None,
+        config: None,
+        event_sequence_lock: Arc::new(tokio::sync::Mutex::new(())),
+        reconcile_lock: Arc::new(tokio::sync::Mutex::new(())),
+        next_publication_id: Arc::new(AtomicU64::new(1)),
+        next_runtime_id: Arc::new(AtomicU64::new(1)),
+        publish_probe: None,
+        event_probe: None,
+        task_probe: None,
+        catalog_plan_probe: None,
+    };
+    let capacity_dir = tempfile::tempdir().unwrap();
+    let capacity_config = fixture_config(&capacity_dir, &["capacity"]).unwrap();
+    let capacity_callbacks = Arc::new(AtomicUsize::new(0));
+    let capacity_callback = capacity_callbacks.clone();
+    let error = limited
+        .reconcile_from_config_transactional_after(&capacity_config, || async move {
+            capacity_callback.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await
+        .expect_err("ledger capacity must fail inside transactional generation planning");
+    assert!(matches!(
+        error,
+        McpError::ToolRegistration(ToolRegistrationError::OwnershipLedgerCapacityExceeded { .. })
+    ));
+    assert_eq!(capacity_callbacks.load(Ordering::SeqCst), 0);
+    assert!(limited.snapshot().server_ids().is_empty());
+
+    let schema_dir = tempfile::tempdir().unwrap();
+    let schema_config = fixture_config(&schema_dir, &["schema"]).unwrap();
+    let mut schema_manager = McpServerManager::new();
+    schema_manager.catalog_plan_probe = Some(Arc::new(|_, catalog| {
+        catalog.replace_first_original_name_for_test("provider-schema-missing".to_string());
+    }));
+    let schema_callbacks = Arc::new(AtomicUsize::new(0));
+    let schema_callback = schema_callbacks.clone();
+    let schema_error = schema_manager
+        .reconcile_from_config_transactional_after(&schema_config, || async move {
+            schema_callback.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await
+        .expect_err("schema mismatch must fail inside transactional candidate staging");
+    assert!(matches!(
+        schema_error,
+        McpError::ToolRegistration(ToolRegistrationError::ProviderSchemaUnavailable)
+    ));
+    assert_eq!(schema_callbacks.load(Ordering::SeqCst), 0);
+    assert!(schema_manager.snapshot().server_ids().is_empty());
+}
+
+#[tokio::test]
+async fn legacy_initialize_and_facade_are_generation_coherent() {
+    let directory = tempfile::tempdir().unwrap();
+    let Some(config) = fixture_config(&directory, &["a", "b"]) else {
+        return;
+    };
+    let manager = Arc::new(McpServerManager::new());
+    manager.initialize_from_config(&config).await;
+    let snapshot = manager.snapshot();
+    assert_eq!(
+        snapshot.server_ids(),
+        vec!["a".to_string(), "b".to_string()]
+    );
+    assert_eq!(snapshot.aliases(), manager.tool_index().all_aliases());
+    assert_snapshot_coherent(&snapshot);
+
+    let attached = McpToolExecutor::from_manager(manager.clone());
+    assert_eq!(attached.list_tools().len(), 2);
+    let detached = McpToolExecutor::new(manager.clone(), Arc::new(ToolIndex::new()));
+    assert!(detached.list_tools().is_empty());
+    let call = ToolCall {
+        id: "detached".to_string(),
+        tool_type: "function".to_string(),
+        function: FunctionCall {
+            name: snapshot.aliases()[0].alias.clone(),
+            arguments: "{}".to_string(),
+        },
+    };
+    assert!(matches!(
+        detached.execute(&call).await,
+        Err(bamboo_agent_core::ToolError::NotFound(_))
+    ));
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn rejected_staged_runtime_drops_transport_without_snapshot_retention() {
+    let manager = McpServerManager::new();
+    let (transport, controls) = MockTransport::new(vec![tool("echo", "candidate")], "candidate");
+    let staged = prepare_mock(
+        &manager,
+        "candidate",
+        vec![tool("echo", "candidate")],
+        transport,
+    )
+    .await;
+    let runtime = staged.publication().runtime.clone();
+    drop(staged);
+    assert_eq!(runtime.fence_state(), FenceState::Closed);
+    assert_eq!(runtime.active_calls(), 0);
+    assert_eq!(controls.drops.load(Ordering::SeqCst), 1);
 }

--- a/crates/infra/bamboo-mcp/src/protocol/client.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/client.rs
@@ -222,6 +222,21 @@ pub struct McpProtocolClient {
     modern_tool_list_changes: Arc<AtomicBool>,
 }
 
+impl Drop for McpProtocolClient {
+    /// Cancellation safety for staged and retired runtimes. Graceful async
+    /// disconnect remains best-effort, but correctness never depends on it:
+    /// dropping an uncommitted client immediately aborts its inbound handler,
+    /// then transport-specific Drop guards stop readers/forwarders/processes.
+    fn drop(&mut self) {
+        if let Some(handler) = self.message_handler.take() {
+            handler.abort();
+        }
+        if let Ok(mut receiver) = self.notification_rx.try_lock() {
+            *receiver = None;
+        }
+    }
+}
+
 impl McpProtocolClient {
     pub fn new(transport: Box<dyn McpTransport>) -> Self {
         let (notification_tx, notification_rx) = mpsc::channel(NOTIFICATION_CHANNEL_CAPACITY);

--- a/crates/infra/bamboo-mcp/src/tool_index.rs
+++ b/crates/infra/bamboo-mcp/src/tool_index.rs
@@ -1,8 +1,11 @@
 use crate::error::ToolRegistrationError;
+use crate::manager::generation::GenerationAuthority;
+#[cfg(test)]
+use crate::manager::generation::McpRuntimeGeneration;
 use crate::types::{McpTool, ToolAlias};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::Arc;
 
 /// OpenAI and Anthropic function names are bounded to 64 provider-safe bytes.
 pub const MAX_MCP_TOOL_ALIAS_BYTES: usize = 64;
@@ -71,6 +74,10 @@ pub(crate) struct ServerToolCatalog {
 }
 
 impl ServerToolCatalog {
+    pub(crate) fn server_id(&self) -> &str {
+        &self.server_id
+    }
+
     pub(crate) fn aliases(&self) -> Vec<ToolAlias> {
         self.entries
             .iter()
@@ -85,10 +92,19 @@ impl ServerToolCatalog {
             .expect("test catalog must contain one tool")
             .canonical_alias = alias;
     }
+
+    #[cfg(test)]
+    pub(crate) fn replace_first_original_name_for_test(&mut self, original_name: String) {
+        self.entries
+            .first_mut()
+            .expect("test catalog must contain one tool")
+            .owner
+            .original_name = original_name;
+    }
 }
 
 #[derive(Debug, Clone, Default)]
-struct IndexState {
+pub(crate) struct IndexState {
     /// Monotonic publication generation. Every committed replacement advances
     /// this value exactly once while holding the state write lock.
     revision: u64,
@@ -112,6 +128,25 @@ struct IndexState {
 }
 
 impl IndexState {
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub(crate) fn plan_catalog_update(
+        &self,
+        replacements: &[ServerToolCatalog],
+        removals: &[String],
+        ledger_relationship_limit: usize,
+    ) -> Result<Self, ToolRegistrationError> {
+        let mut next = self.clone();
+        next.apply_catalog_update(replacements, removals, ledger_relationship_limit)?;
+        next.revision = self
+            .revision
+            .checked_add(1)
+            .ok_or(ToolRegistrationError::PublicationRevisionExhausted)?;
+        Ok(next)
+    }
+
     fn apply_catalog_update(
         &mut self,
         replacements: &[ServerToolCatalog],
@@ -210,16 +245,83 @@ impl IndexState {
                 total.saturating_add(owners.len())
             })
     }
+
+    pub(crate) fn lookup(&self, alias: &str) -> Option<ToolAlias> {
+        let resolved = self.resolve(alias)?;
+        Some(ToolAlias {
+            alias: alias.to_string(),
+            server_id: resolved.server_id,
+            original_name: resolved.original_name,
+        })
+    }
+
+    pub(crate) fn resolve(&self, alias: &str) -> Option<ResolvedIndexAlias> {
+        if let Some(owner) = self.aliases.get(alias) {
+            return Some(ResolvedIndexAlias {
+                canonical_alias: alias.to_string(),
+                server_id: owner.server_id.clone(),
+                original_name: owner.original_name.clone(),
+            });
+        }
+        let active_owners = self.legacy_candidates.get(alias)?;
+        if active_owners.len() != 1 {
+            return None;
+        }
+        let active_owner = active_owners.iter().next()?;
+        let historical_owners = self.legacy_owners.get(&legacy_alias_fingerprint(alias))?;
+        if historical_owners.len() != 1 || !historical_owners.contains(&active_owner.fingerprint())
+        {
+            return None;
+        }
+        let canonical_alias = self.aliases.iter().find_map(|(canonical_alias, owner)| {
+            (owner == active_owner).then(|| canonical_alias.clone())
+        })?;
+        Some(ResolvedIndexAlias {
+            canonical_alias,
+            server_id: active_owner.server_id.clone(),
+            original_name: active_owner.original_name.clone(),
+        })
+    }
+
+    pub(crate) fn all_aliases(&self) -> Vec<ToolAlias> {
+        self.aliases
+            .iter()
+            .map(|(alias, owner)| owner.as_alias(alias.clone()))
+            .collect()
+    }
+
+    pub(crate) fn get_server_tools(&self, server_id: &str) -> Option<Vec<String>> {
+        self.server_catalogs.get(server_id).map(|catalog| {
+            catalog
+                .entries
+                .iter()
+                .map(|entry| entry.owner.original_name.clone())
+                .collect()
+        })
+    }
+
+    pub(crate) fn contains_exact(&self, alias: &str) -> bool {
+        self.aliases.contains_key(alias)
+    }
+}
+
+pub(crate) struct ResolvedIndexAlias {
+    pub(crate) canonical_alias: String,
+    pub(crate) server_id: String,
+    pub(crate) original_name: String,
 }
 
 /// A whole-index update that has already validated every replacement/removal.
 /// The manager holds its reconciliation lock between preflight and commit.
+#[cfg(test)]
 #[derive(Debug)]
 pub(crate) struct ToolIndexTransaction {
+    base_generation: Arc<McpRuntimeGeneration>,
     base_revision: u64,
     next: IndexState,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 enum ToolIndexCommitError {
     #[error(
@@ -229,9 +331,6 @@ enum ToolIndexCommitError {
         base_revision: u64,
         current_revision: u64,
     },
-
-    #[error("MCP tool-index publication revision exhausted at {current_revision}")]
-    RevisionExhausted { current_revision: u64 },
 }
 
 /// Atomic owner index for MCP tool identities.
@@ -240,36 +339,47 @@ enum ToolIndexCommitError {
 /// published behind one lock so readers never observe a partially installed
 /// catalog.
 pub struct ToolIndex {
-    state: RwLock<IndexState>,
-    ledger_relationship_limit: usize,
+    authority: Arc<GenerationAuthority>,
 }
 
 impl ToolIndex {
     pub fn new() -> Self {
         Self {
-            state: RwLock::new(IndexState::default()),
-            ledger_relationship_limit: MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS,
+            authority: GenerationAuthority::new(MAX_MCP_OWNERSHIP_LEDGER_RELATIONSHIPS),
         }
+    }
+
+    pub(crate) fn from_authority(authority: Arc<GenerationAuthority>) -> Self {
+        Self { authority }
+    }
+
+    pub(crate) fn authority(&self) -> &Arc<GenerationAuthority> {
+        &self.authority
+    }
+
+    pub fn same_authority(&self, other: &Self) -> bool {
+        GenerationAuthority::same_authority(&self.authority, &other.authority)
     }
 
     #[cfg(test)]
     fn with_ledger_relationship_limit_for_test(ledger_relationship_limit: usize) -> Self {
         Self {
-            state: RwLock::new(IndexState::default()),
-            ledger_relationship_limit,
+            authority: GenerationAuthority::new(ledger_relationship_limit),
         }
     }
 
-    fn read_state(&self) -> RwLockReadGuard<'_, IndexState> {
-        self.state
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    #[cfg(test)]
+    pub(crate) fn set_revision_for_test(&self, revision: u64) {
+        let base = self.authority.generation();
+        let mut index = (*base.index).clone();
+        index.revision = revision;
+        let next = McpRuntimeGeneration::with_index(&base, &[], &[], index, false)
+            .expect("test revision must preserve the generation shape");
+        self.authority.replace_prevalidated(&base, next);
     }
 
-    fn write_state(&self) -> RwLockWriteGuard<'_, IndexState> {
-        self.state
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    fn read_state(&self) -> Arc<IndexState> {
+        self.authority.generation().index.clone()
     }
 
     /// Generate the stable provider-visible identity for one exact owner tuple.
@@ -348,17 +458,21 @@ impl ToolIndex {
 
     /// Preflight a complete set of catalog changes against one cloned snapshot.
     /// No live map is touched if any plan is invalid or collides.
+    #[cfg(test)]
     pub(crate) fn preflight_catalog_update(
         &self,
         replacements: &[ServerToolCatalog],
         removals: &[String],
     ) -> Result<ToolIndexTransaction, ToolRegistrationError> {
-        let state = self.read_state();
-        let base_revision = state.revision;
-        let mut next = state.clone();
-        drop(state);
-        next.apply_catalog_update(replacements, removals, self.ledger_relationship_limit)?;
+        let base_generation = self.authority.generation();
+        let base_revision = base_generation.index.revision;
+        let next = base_generation.index.plan_catalog_update(
+            replacements,
+            removals,
+            self.authority.ledger_relationship_limit,
+        )?;
         Ok(ToolIndexTransaction {
+            base_generation,
             base_revision,
             next,
         })
@@ -369,29 +483,44 @@ impl ToolIndex {
     /// a recoverable post-durable CAS outcome: production has exactly one writer
     /// behind that lock. Fail-stop before swapping in every build so a stale
     /// snapshot can never erase a newer catalog or ownership history.
+    #[cfg(test)]
     pub(crate) fn commit_catalog_update(&self, transaction: ToolIndexTransaction) {
         self.try_commit_catalog_update(transaction)
             .unwrap_or_else(|error| panic!("MCP tool-index writer invariant violated: {error}"));
     }
 
+    #[cfg(test)]
     fn try_commit_catalog_update(
         &self,
-        mut transaction: ToolIndexTransaction,
+        transaction: ToolIndexTransaction,
     ) -> Result<(), ToolIndexCommitError> {
-        let mut state = self.write_state();
-        let current_revision = state.revision;
-        if transaction.base_revision != current_revision {
+        let current = self.authority.generation();
+        let current_revision = current.index.revision;
+        if !Arc::ptr_eq(&current, &transaction.base_generation) {
             return Err(ToolIndexCommitError::StaleTransaction {
                 base_revision: transaction.base_revision,
                 current_revision,
             });
         }
-        let next_revision = current_revision
-            .checked_add(1)
-            .ok_or(ToolIndexCommitError::RevisionExhausted { current_revision })?;
-        transaction.next.revision = next_revision;
-        *state = transaction.next;
-        Ok(())
+        let next = McpRuntimeGeneration::with_index(
+            &transaction.base_generation,
+            &[],
+            &[],
+            transaction.next,
+            false,
+        )
+        .expect("test-only catalog state must construct a detached generation");
+        if self
+            .authority
+            .try_replace(&transaction.base_generation, next)
+        {
+            Ok(())
+        } else {
+            Err(ToolIndexCommitError::StaleTransaction {
+                base_revision: transaction.base_revision,
+                current_revision: self.authority.generation().revision,
+            })
+        }
     }
 
     /// Test-only direct registration seam. Production writes are owned by
@@ -426,45 +555,18 @@ impl ToolIndex {
     /// Lookup either an exact canonical alias or an unambiguous legacy alias.
     /// Canonical identities always win. Ambiguous legacy identities fail closed.
     pub fn lookup(&self, alias: &str) -> Option<ToolAlias> {
-        let state = self.read_state();
-        if let Some(owner) = state.aliases.get(alias) {
-            return Some(owner.as_alias(alias.to_string()));
-        }
-        let active_owners = state.legacy_candidates.get(alias)?;
-        if active_owners.len() != 1 {
-            return None;
-        }
-        let active_owner = active_owners.iter().next()?;
-        let historical_owners = state.legacy_owners.get(&legacy_alias_fingerprint(alias))?;
-        if historical_owners.len() != 1 || !historical_owners.contains(&active_owner.fingerprint())
-        {
-            return None;
-        }
-        Some(active_owner.as_alias(alias.to_string()))
+        self.read_state().lookup(alias)
     }
 
     /// Get every canonical provider-visible alias in stable lexical order.
     /// Legacy compatibility names are deliberately not advertised.
     pub fn all_aliases(&self) -> Vec<ToolAlias> {
-        self.read_state()
-            .aliases
-            .iter()
-            .map(|(alias, owner)| owner.as_alias(alias.clone()))
-            .collect()
+        self.read_state().all_aliases()
     }
 
     /// Get exact original tool names for one server in canonical alias order.
     pub fn get_server_tools(&self, server_id: &str) -> Option<Vec<String>> {
-        self.read_state()
-            .server_catalogs
-            .get(server_id)
-            .map(|catalog| {
-                catalog
-                    .entries
-                    .iter()
-                    .map(|entry| entry.owner.original_name.clone())
-                    .collect()
-            })
+        self.read_state().get_server_tools(server_id)
     }
 
     /// Test-only clear seam. Process-lifetime owner ledgers remain so removed
@@ -489,7 +591,7 @@ impl ToolIndex {
     /// Execution surfaces that promise exact tool membership must use this
     /// method rather than the legacy-aware [`Self::contains`] seam.
     pub fn contains_exact_alias(&self, alias: &str) -> bool {
-        self.read_state().aliases.contains_key(alias)
+        self.read_state().contains_exact(alias)
     }
 
     /// Check whether a canonical or unambiguous compatibility alias resolves.

--- a/crates/infra/bamboo-mcp/src/transports/sse.rs
+++ b/crates/infra/bamboo-mcp/src/transports/sse.rs
@@ -423,6 +423,18 @@ impl McpTransport for SseTransport {
     }
 }
 
+impl Drop for SseTransport {
+    /// A staged SSE candidate may be cancelled after connect but before
+    /// publication. Abort the stream reader synchronously so dropping that
+    /// candidate cannot leak a background connection.
+    fn drop(&mut self) {
+        self.connected.store(false, Ordering::SeqCst);
+        if let Some(handle) = self.sse_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -446,6 +458,20 @@ mod tests {
         let transport = SseTransport::new(config);
         assert!(!transport.is_connected());
         assert!(transport.sse_handle.is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_staged_sse_aborts_reader() {
+        let mut transport = SseTransport::new(create_test_config());
+        let reader = tokio::spawn(std::future::pending::<()>());
+        let abort = reader.abort_handle();
+        transport.sse_handle = Some(reader);
+        transport.connected.store(true, Ordering::SeqCst);
+
+        drop(transport);
+        tokio::task::yield_now().await;
+
+        assert!(abort.is_finished());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- publish one immutable MCP runtime generation that binds server publications, exact aliases, provider schemas, runtime clients, and historical ownership state;
- resolve passive, generation-pinned `ResolvedMcpCall` tickets and reject foreign/stale authority before QoS, transport, reconnect, or event side effects;
- make install, refresh, reconnect, stop, health, tool-executed, and whole-config event publication linearizable under one sequencer without holding the generation writer on bounded channel capacity;
- stage runtime tasks and event batches before the durable callback, then complete fence swap, ownership transfer, activation, and rollback synchronously;
- keep atomic multi-ticket admission out of this PR; that focused consumer seam remains #1006.

Closes #995

## Test Plan

- `cargo fmt --all -- --check`
- `git diff origin/dev...HEAD --check`
- `cargo test --locked -p bamboo-mcp --lib -- --test-threads=1` — 237 passed
- `cargo clippy --locked -p bamboo-mcp --all-targets --all-features -- -D warnings`
- `cargo check --locked -p bamboo-server --lib --bins`
- `cargo test --locked -p bamboo-server --lib mcp -- --test-threads=1` — focused MCP/server tests passed
- `cargo test --quiet --locked -p bamboo-server --lib -- --test-threads=1` — 1,961 passed, 0 failed, 1 ignored (exact rebased head)

## Review Evidence

- independent frozen-diff review: APPROVE, no P0/P1/P2 findings;
- rebase delta review: APPROVE; stable patch ID, file set, and numstat are identical, with no overlap between the new base changes and this PR's 15 files;
- exact-head CI and live mergeability/thread gates remain required before merge.

## Screenshots

Not applicable; no UI changes.
