### PR TITLE
fix: preserve typed workspace handoff at external entrypoints (#998)

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -378,6 +378,17 @@ impl Agent {
                 session.set_project_id_meta(project_id.to_string());
             }
         }
+
+        // Complete the external Project/Workspace handoff before replaying an
+        // approved mutating tool. The replay executor reads the runtime
+        // workspace registry, so deferring this until the loop's first round
+        // would execute against stale process state. Assigned sessions fail
+        // closed here when this runtime has no Project resolver; the pending
+        // replay marker remains intact for a correctly configured retry.
+        self.inner
+            .prepare_external_session_for_execution(session)
+            .await?;
+
         // If `answer()` just approved a gated tool call, `session.metadata` carries
         // the re-execution marker `submit_pending_response` set — the gated tool
         // never actually ran (the permission gate intercepted it before
@@ -389,12 +400,12 @@ impl Agent {
         self.reexecute_approved_tool_if_pending(session, &event_tx)
             .await?;
 
-        // Apply the instruction as the session's leading System message and set
-        // the configured model via the single authoritative pre-execution
-        // mutation point. The builder's prompt is AUTHORITATIVE: it replaces a
-        // leading System message, otherwise inserts one at index 0, so a
-        // caller-supplied session can't silently shadow the configured
-        // instruction.
+        // Apply the instruction as the session's leading System message, set
+        // the configured model, and refresh the typed prompt snapshot via the
+        // single authoritative pre-execution mutation point. This intentionally
+        // follows replay: a failed replay remains observable without replacing
+        // caller System bytes, while a successful handoff always reaches the
+        // provider with one clean configured System message.
         bamboo_engine::session_app::execution_prep::prepare_session_for_execution(
             session,
             self.system_prompt.as_deref(),
@@ -1323,6 +1334,7 @@ mod reexecute_and_child_approval_tests {
     struct RealOutputTool {
         calls: AtomicUsize,
         flags: StdMutex<Vec<ToolExecutionSessionFlags>>,
+        workspaces: StdMutex<Vec<Option<std::path::PathBuf>>>,
     }
 
     impl RealOutputTool {
@@ -1330,6 +1342,7 @@ mod reexecute_and_child_approval_tests {
             Self {
                 calls: AtomicUsize::new(0),
                 flags: StdMutex::new(Vec::new()),
+                workspaces: StdMutex::new(Vec::new()),
             }
         }
     }
@@ -1370,6 +1383,10 @@ mod reexecute_and_child_approval_tests {
 
     struct ImmediateDoneProvider;
 
+    struct CountingDoneProvider {
+        calls: AtomicUsize,
+    }
+
     #[async_trait]
     impl bamboo_llm::LLMProvider for ImmediateDoneProvider {
         async fn chat_stream(
@@ -1379,6 +1396,23 @@ mod reexecute_and_child_approval_tests {
             _max_output_tokens: Option<u32>,
             _model: &str,
         ) -> Result<bamboo_llm::LLMStream, bamboo_llm::LLMError> {
+            Ok(Box::pin(futures::stream::iter([
+                Ok(bamboo_llm::LLMChunk::Token("done".to_string())),
+                Ok(bamboo_llm::LLMChunk::Done),
+            ])))
+        }
+    }
+
+    #[async_trait]
+    impl bamboo_llm::LLMProvider for CountingDoneProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<bamboo_llm::LLMStream, bamboo_llm::LLMError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(Box::pin(futures::stream::iter([
                 Ok(bamboo_llm::LLMChunk::Token("done".to_string())),
                 Ok(bamboo_llm::LLMChunk::Done),
@@ -1411,6 +1445,11 @@ mod reexecute_and_child_approval_tests {
                 auto_approve_permissions: ctx.auto_approve_permissions,
                 plan_read_only: ctx.plan_read_only,
             });
+            self.workspaces.lock().unwrap().push(
+                ctx.session_id
+                    .as_deref()
+                    .and_then(bamboo_agent_core::workspace_state::get_workspace),
+            );
             Ok(ToolOutcome::Completed(
                 bamboo_agent_core::tools::ToolResult::text(true, format!("REAL TOOL OUTPUT #{n}")),
             ))
@@ -1636,6 +1675,332 @@ mod reexecute_and_child_approval_tests {
             .find(|m| m.tool_call_id.as_deref() == Some("call-reexec-1"))
             .expect("tool result message present");
         assert_eq!(reloaded_result.content, "REAL TOOL OUTPUT #0");
+    }
+
+    #[tokio::test]
+    async fn normal_run_prepares_project_workspace_before_approved_tool_replay() {
+        let data_dir = tempfile::tempdir().expect("SDK data dir");
+        let project_path = tempfile::tempdir().expect("SDK Project path");
+        let project = bamboo_projects::ProjectStore::open(data_dir.path())
+            .expect("Project store")
+            .create_with_project_path(
+                "Replay Project",
+                None,
+                project_path.path().to_string_lossy(),
+                Vec::new(),
+            )
+            .expect("Replay Project");
+        std::fs::write(
+            data_dir.path().join("config.json"),
+            r#"{
+                "provider": "anthropic",
+                "providers": {
+                    "anthropic": { "api_key": "test-key", "model": "claude-test" }
+                }
+            }"#,
+        )
+        .expect("SDK config");
+        let tool = Arc::new(RealOutputTool::new());
+        let agent = AgentBuilder::new()
+            .provider(Arc::new(ImmediateDoneProvider))
+            .model("claude-test")
+            .instruction("configured System")
+            .project_id(project.id.to_string())
+            .tool_shared(tool.clone())
+            .with_defaults_for_data_dir(data_dir.path().to_path_buf())
+            .await
+            .expect("defaults should assemble")
+            .build()
+            .expect("Project-backed SDK agent");
+
+        let seed = seed_gated_tool_session("sdk-project-replay", "project-replay-call");
+        agent
+            .storage()
+            .save_session(&seed)
+            .await
+            .expect("seed replay session");
+        let outcome = agent
+            .answer("sdk-project-replay", "Approve")
+            .await
+            .expect("approve replay");
+        let mut session = outcome.session;
+        session.add_message(Message::user("continue after replay"));
+
+        agent
+            .run_session(&mut session)
+            .await
+            .expect("normal run should complete");
+
+        assert_eq!(tool.calls.load(Ordering::SeqCst), 1);
+        let canonical = project_path
+            .path()
+            .canonicalize()
+            .expect("canonical Project workspace");
+        assert_eq!(
+            tool.workspaces.lock().unwrap().as_slice(),
+            &[Some(canonical.clone())],
+            "approved replay must observe the published Project workspace on its first call"
+        );
+        assert_eq!(
+            session.project_id_meta().as_deref(),
+            Some(project.id.as_str())
+        );
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some(bamboo_config::paths::path_to_display_string(&canonical).as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceSource::ProjectDefault.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceBindingStatus::Registered.as_str())
+        );
+        let systems = session
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, Role::System))
+            .collect::<Vec<_>>();
+        assert_eq!(systems.len(), 1);
+        assert_eq!(systems[0].content, "configured System");
+        assert!(!systems[0]
+            .content
+            .contains(canonical.to_string_lossy().as_ref()));
+        assert!(!systems[0].content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        let snapshot = session
+            .prompt_snapshot
+            .as_ref()
+            .expect("SDK prompt snapshot");
+        assert_eq!(snapshot.effective_system_prompt, "configured System");
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed SDK Workspace context");
+        assert!(workspace_context.contains(canonical.to_string_lossy().as_ref()));
+        assert!(workspace_context.contains("Workspace source: project_default"));
+        assert!(workspace_context.contains("Binding status: registered"));
+    }
+
+    #[tokio::test]
+    async fn normal_run_recovers_serialized_legacy_workspace_before_replay_and_replaces_system() {
+        let data_dir = tempfile::tempdir().expect("SDK data dir");
+        let legacy_workspace = tempfile::tempdir().expect("legacy SDK Workspace");
+        let canonical = legacy_workspace
+            .path()
+            .canonicalize()
+            .expect("canonical legacy Workspace");
+        let display = bamboo_config::paths::path_to_display_string(&canonical);
+        std::fs::write(
+            data_dir.path().join("config.json"),
+            r#"{
+                "provider": "anthropic",
+                "providers": {
+                    "anthropic": { "api_key": "test-key", "model": "claude-test" }
+                }
+            }"#,
+        )
+        .expect("SDK config");
+        let tool = Arc::new(RealOutputTool::new());
+        let agent = AgentBuilder::new()
+            .provider(Arc::new(ImmediateDoneProvider))
+            .model("claude-test")
+            .instruction("configured System")
+            .tool_shared(tool.clone())
+            .with_defaults_for_data_dir(data_dir.path().to_path_buf())
+            .await
+            .expect("defaults should assemble")
+            .build()
+            .expect("SDK agent");
+
+        let mut legacy = seed_gated_tool_session("sdk-legacy-replay", "legacy-replay-call");
+        legacy.messages.insert(
+            0,
+            Message::system(
+                bamboo_engine::runtime::context::build_workspace_prompt_context(&display)
+                    .expect("legacy Workspace marker"),
+            ),
+        );
+        assert!(legacy.workspace_path_meta().is_none());
+        let serialized = serde_json::to_vec(&legacy).expect("serialize legacy SDK session");
+        let legacy: Session =
+            serde_json::from_slice(&serialized).expect("deserialize legacy SDK session");
+        agent
+            .storage()
+            .save_session(&legacy)
+            .await
+            .expect("seed serialized legacy session");
+        let outcome = agent
+            .answer("sdk-legacy-replay", "Approve")
+            .await
+            .expect("approve legacy replay");
+        let mut session = outcome.session;
+        session.add_message(Message::user("continue after legacy replay"));
+
+        agent
+            .run_session(&mut session)
+            .await
+            .expect("normal legacy run should complete");
+
+        assert_eq!(tool.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            tool.workspaces.lock().unwrap().as_slice(),
+            &[Some(canonical.clone())],
+            "legacy Workspace must be published before the approved tool is replayed"
+        );
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some(display.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceSource::Session.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceBindingStatus::Unregistered.as_str())
+        );
+        let systems = session
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, Role::System))
+            .collect::<Vec<_>>();
+        assert_eq!(systems.len(), 1);
+        assert_eq!(systems[0].content, "configured System");
+        assert!(!systems[0].content.contains(&display));
+        assert!(!systems[0].content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        let snapshot = session
+            .prompt_snapshot
+            .as_ref()
+            .expect("SDK prompt snapshot");
+        assert_eq!(snapshot.effective_system_prompt, "configured System");
+        assert!(snapshot
+            .workspace_context
+            .as_deref()
+            .is_some_and(|context| context.contains(&display)));
+    }
+
+    #[tokio::test]
+    async fn missing_project_resolver_stops_sdk_before_replay_system_replacement_or_provider() {
+        let data_dir = tempfile::tempdir().expect("manual SDK data dir");
+        let legacy_workspace = tempfile::tempdir().expect("retryable legacy Workspace");
+        let legacy_display = bamboo_config::paths::path_to_display_string(legacy_workspace.path());
+        let store = Arc::new(
+            bamboo_storage::SessionStoreV2::new(data_dir.path().join("sessions"))
+                .await
+                .expect("session store"),
+        );
+        let persistence: Arc<dyn bamboo_domain::RuntimeSessionPersistence> =
+            Arc::new(bamboo_storage::LockedSessionStore::new(store.clone()));
+        let metrics = bamboo_metrics::MetricsCollector::spawn(
+            Arc::new(bamboo_metrics::SqliteMetricsStorage::new(
+                data_dir.path().join("metrics.db"),
+            )),
+            7,
+        );
+        let tool = Arc::new(RealOutputTool::new());
+        let registry = bamboo_tools::ToolRegistry::new();
+        registry
+            .register_shared(tool.clone())
+            .expect("register replay tool");
+        let provider = Arc::new(CountingDoneProvider {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = bamboo_engine::Agent::builder()
+            .storage(store.clone())
+            .persistence(persistence)
+            .attachment_reader(store.clone())
+            .skill_manager(Arc::new(bamboo_skills::SkillManager::new()))
+            .metrics_collector(metrics)
+            .config(Arc::new(tokio::sync::RwLock::new(
+                bamboo_llm::Config::default(),
+            )))
+            .provider(provider.clone())
+            .default_tools(Arc::new(bamboo_tools::BuiltinToolExecutor::with_registry(
+                registry,
+            )))
+            .build()
+            .expect("manual runtime without Project resolver");
+        let agent = Agent::from_runtime_with_config(
+            runtime,
+            Some("configured System".to_string()),
+            Some("configured-model".to_string()),
+            None,
+            None,
+            None,
+            None,
+            PermissionMode::Default,
+        );
+
+        let mut session = seed_gated_tool_session("sdk-missing-resolver", "missing-resolver-call");
+        let legacy_block =
+            bamboo_engine::runtime::context::build_workspace_prompt_context(&legacy_display)
+                .expect("retryable legacy Workspace marker");
+        session.messages.insert(
+            0,
+            Message::system(format!("caller System\n\n{legacy_block}")),
+        );
+        session.set_project_id_meta("project-missing-resolver");
+        session.metadata.insert(
+            PERMISSION_REEXECUTE_METADATA_KEY.to_string(),
+            "missing-resolver-call".to_string(),
+        );
+        session.prompt_snapshot = Some(
+            serde_json::from_value(serde_json::json!({
+                "base_system_prompt": "stale SDK snapshot",
+                "effective_system_prompt": "stale SDK snapshot"
+            }))
+            .expect("synthetic stale SDK prompt snapshot"),
+        );
+        agent
+            .storage()
+            .save_session(&session)
+            .await
+            .expect("seed assigned replay session");
+        let before = serde_json::to_vec(&session).expect("serialize retryable SDK session");
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+
+        let error = agent
+            .execute_internal(&mut session, event_tx, CancellationToken::new())
+            .await
+            .expect_err("assigned SDK session must fail without Project resolver");
+
+        assert!(matches!(error, AgentError::ProjectContext(_)));
+        assert_eq!(tool.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+        assert!(
+            event_rx.try_recv().is_err(),
+            "prep failure must emit no events"
+        );
+        assert_eq!(
+            serde_json::to_vec(&session).expect("serialize failed SDK session"),
+            before,
+            "missing resolver must preserve the full serialized retry state"
+        );
+        assert!(session.messages[0].content.contains(&legacy_display));
+        assert!(session.messages[0]
+            .content
+            .contains("BAMBOO_WORKSPACE_CONTEXT"));
+        assert_eq!(
+            session
+                .metadata
+                .get(PERMISSION_REEXECUTE_METADATA_KEY)
+                .map(String::as_str),
+            Some("missing-resolver-call"),
+            "approval replay marker must remain retryable"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -200,7 +200,7 @@ fn create_connect_session(
     model: &str,
     system_prompt: &str,
     base_system_prompt: &str,
-    workspace_path: Option<&str>,
+    workspace: Option<bamboo_engine::session_app::execution_prep::ResolvedExecutionWorkspace<'_>>,
     project_id: Option<&bamboo_domain::ProjectId>,
     reasoning_effort: Option<ReasoningEffort>,
     workspace_resolver: &bamboo_agent_core::workspace_state::WorkspaceResolver,
@@ -219,21 +219,22 @@ fn create_connect_session(
     if let Some(project_id) = project_id {
         session.set_project_id_meta(project_id.to_string());
     }
-    if let Some(path) = workspace_path {
-        let final_workspace = workspace_resolver.publish_resolved_workspace(
-            &session_id,
-            PathBuf::from(path),
+    if let Some(workspace) = workspace {
+        bamboo_engine::session_app::execution_prep::publish_resolved_workspace_for_execution(
+            &mut session,
+            workspace,
+            workspace_resolver,
             "connect",
         );
-        session.set_workspace_path_meta(bamboo_config::paths::path_to_display_string(
-            &final_workspace,
-        ));
     }
     if let Some(effort) = reasoning_effort {
         session.set_reasoning_effort_meta(effort.as_str());
     }
-    session.add_message(Message::system(system_prompt.to_string()));
-    bamboo_engine::runner::refresh_prompt_snapshot(&mut session);
+    bamboo_engine::session_app::execution_prep::prepare_session_for_execution(
+        &mut session,
+        Some(system_prompt),
+        None,
+    );
     session
         .agent_runtime_state
         .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
@@ -764,9 +765,6 @@ impl ConnectBridge {
         .map_err(|error| {
             format!("Connect workspace is unavailable; no session was created: {error}")
         })?;
-        let final_workspace_display = final_workspace
-            .as_deref()
-            .map(bamboo_config::paths::path_to_display_string);
         let binding_status = match (project_id, final_workspace.as_deref()) {
             (Some(project_id), Some(workspace)) => {
                 let workspace = bamboo_config::paths::path_to_display_string(workspace);
@@ -784,31 +782,27 @@ impl ConnectBridge {
             }
             _ => bamboo_engine::project_context::WorkspaceBindingStatus::Unregistered,
         };
-        let system_prompt =
-            bamboo_engine::runtime::context::upsert_workspace_prompt_context_with_source(
-                &resolved.system_prompt,
-                final_workspace_display.as_deref(),
-                binding_status,
-                project_id.map(|_| bamboo_engine::project_context::WorkspaceSource::ProjectDefault),
-            );
-        let mut session = create_connect_session(
+        let workspace_source = if project_id.is_some() {
+            bamboo_engine::project_context::WorkspaceSource::ProjectDefault
+        } else {
+            bamboo_engine::project_context::WorkspaceSource::Session
+        };
+        let session = create_connect_session(
             key,
             &model,
-            &system_prompt,
+            &resolved.system_prompt,
             &resolved.base_system_prompt,
-            final_workspace_display.as_deref(),
+            final_workspace.as_deref().map(|path| {
+                bamboo_engine::session_app::execution_prep::ResolvedExecutionWorkspace {
+                    path,
+                    source: workspace_source,
+                    binding_status,
+                }
+            }),
             project_id,
             resolved.reasoning_effort,
             &self.ctx.workspace_resolver,
         );
-        if project_id.is_some() {
-            session.metadata.insert(
-                bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
-                bamboo_engine::project_context::WorkspaceSource::ProjectDefault
-                    .as_str()
-                    .to_string(),
-            );
-        }
         self.set_session_id_for_key(key, &session.id).await;
         Ok(session)
     }
@@ -1656,7 +1650,14 @@ mod tests {
             "model",
             "system",
             "base",
-            Some(relocated.to_string_lossy().as_ref()),
+            Some(
+                bamboo_engine::session_app::execution_prep::ResolvedExecutionWorkspace {
+                    path: &relocated,
+                    source: bamboo_engine::project_context::WorkspaceSource::Explicit,
+                    binding_status:
+                        bamboo_engine::project_context::WorkspaceBindingStatus::Unregistered,
+                },
+            ),
             None,
             None,
             &resolver,
@@ -1670,6 +1671,42 @@ mod tests {
             relocated.is_dir(),
             "the AppState resolver must materialize its own validated target"
         );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceSource::Explicit.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceBindingStatus::Unregistered.as_str())
+        );
+        let system = session
+            .messages
+            .iter()
+            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .expect("Connect System");
+        assert_eq!(system.content, "system");
+        assert!(!system
+            .content
+            .contains(relocated.to_string_lossy().as_ref()));
+        assert!(!system.content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        let snapshot = session
+            .prompt_snapshot
+            .as_ref()
+            .expect("first prompt snapshot");
+        assert_eq!(snapshot.effective_system_prompt, "system");
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed Workspace context");
+        assert!(workspace_context.contains(relocated.to_string_lossy().as_ref()));
+        assert!(workspace_context.contains("Workspace source: explicit"));
+        assert!(workspace_context.contains("Binding status: unregistered"));
     }
 
     #[tokio::test]
@@ -1715,12 +1752,26 @@ mod tests {
                 .map(String::as_str),
             Some(bamboo_engine::project_context::WorkspaceSource::ProjectDefault.as_str())
         );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceBindingStatus::Registered.as_str())
+        );
+        assert_eq!(
+            bamboo_agent_core::workspace_state::get_workspace(&session.id)
+                .as_deref()
+                .map(bamboo_config::paths::path_to_display_string),
+            project.project_path.clone()
+        );
         let project_path_display = project.project_path.as_deref().expect("Project path");
         let system_prompt = session
             .messages
             .iter()
             .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
             .expect("Connect system prompt");
+        assert_eq!(system_prompt.content, resolved.system_prompt);
         assert!(!system_prompt.content.contains(project_path_display));
         assert!(!system_prompt
             .content
@@ -1729,6 +1780,7 @@ mod tests {
             .content
             .contains("BAMBOO_PROJECT_CONTEXT_START"));
         let snapshot = session.prompt_snapshot.as_ref().expect("prompt snapshot");
+        assert_eq!(snapshot.effective_system_prompt, resolved.system_prompt);
         assert!(snapshot
             .workspace_context
             .as_deref()
@@ -1739,6 +1791,76 @@ mod tests {
         assert!(!snapshot
             .effective_system_prompt
             .contains("BAMBOO_WORKSPACE_CONTEXT_START"));
+    }
+
+    #[tokio::test]
+    async fn unassigned_connect_session_publishes_configured_workspace_before_first_snapshot() {
+        let (ctx, _dir) = test_context().await;
+        let configured_workspace = tempfile::tempdir().expect("configured Workspace");
+        {
+            let mut config = ctx.config.write().await;
+            config.default_work_area = Some(bamboo_config::DefaultWorkAreaConfig {
+                path: Some(configured_workspace.path().to_string_lossy().into_owned()),
+            });
+        }
+        let resolved = {
+            let config = ctx.config.read().await.clone();
+            resolve_connect_run_config(&config, &ctx.provider_registry)
+        };
+        let bridge = ConnectBridge::new(ctx, None);
+
+        let session = bridge
+            .create_and_register_session("fake:configured:user", &resolved)
+            .await
+            .expect("configured Workspace must create an unassigned Connect session");
+        let canonical = configured_workspace
+            .path()
+            .canonicalize()
+            .expect("canonical configured Workspace");
+        let display = bamboo_config::paths::path_to_display_string(&canonical);
+        assert!(session.project_id_meta().is_none());
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some(display.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceSource::Session.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceBindingStatus::Unregistered.as_str())
+        );
+        assert_eq!(
+            bamboo_agent_core::workspace_state::get_workspace(&session.id),
+            Some(canonical)
+        );
+        let system = session
+            .messages
+            .iter()
+            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .expect("Connect System");
+        assert_eq!(system.content, resolved.system_prompt);
+        assert!(!system.content.contains(&display));
+        assert!(!system.content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        let snapshot = session
+            .prompt_snapshot
+            .as_ref()
+            .expect("first prompt snapshot");
+        assert_eq!(snapshot.effective_system_prompt, resolved.system_prompt);
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed Workspace context");
+        assert!(workspace_context.contains(&display));
+        assert!(workspace_context.contains("Workspace source: session"));
+        assert!(workspace_context.contains("Binding status: unregistered"));
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -356,20 +356,7 @@ async fn run_schedule_job(
         }
         _ => bamboo_engine::project_context::WorkspaceBindingStatus::Unregistered,
     };
-    let workspace_source = job.run_config.project_id.as_ref().map(|_| {
-        if explicit_workspace.is_some() {
-            bamboo_engine::project_context::WorkspaceSource::Explicit
-        } else {
-            bamboo_engine::project_context::WorkspaceSource::ProjectDefault
-        }
-    });
-    resolved.system_prompt =
-        bamboo_engine::runtime::context::upsert_workspace_prompt_context_with_source(
-            &resolved.system_prompt,
-            resolved.workspace_path.as_deref(),
-            binding_status,
-            workspace_source,
-        );
+    let workspace_source = schedule_workspace_source(&job.run_config);
     // Primary model is required for a schedule run; the roster stores it as
     // `Option<String>`, so recover the owned String once for the checks/logging
     // below (an absent primary is treated as the old empty-string skip).
@@ -400,7 +387,13 @@ async fn run_schedule_job(
         &resolved_model,
         &resolved.system_prompt,
         &resolved.base_system_prompt,
-        resolved.workspace_path.as_deref(),
+        final_workspace.as_deref().map(|path| {
+            bamboo_engine::session_app::execution_prep::ResolvedExecutionWorkspace {
+                path,
+                source: workspace_source,
+                binding_status,
+            }
+        }),
         resolved.reasoning_effort,
         &ctx.workspace_resolver,
     );
@@ -707,6 +700,22 @@ async fn run_schedule_job(
     Ok(ScheduleRunLifecycleResult::BackgroundExecutionInProgress)
 }
 
+fn schedule_workspace_source(
+    run_config: &ScheduleRunConfig,
+) -> bamboo_engine::project_context::WorkspaceSource {
+    if run_config
+        .workspace_path
+        .as_deref()
+        .is_some_and(|workspace| !workspace.trim().is_empty())
+    {
+        bamboo_engine::project_context::WorkspaceSource::Explicit
+    } else if run_config.project_id.is_some() {
+        bamboo_engine::project_context::WorkspaceSource::ProjectDefault
+    } else {
+        bamboo_engine::project_context::WorkspaceSource::Session
+    }
+}
+
 fn validate_schedule_project_at_fire(
     store: &bamboo_projects::ProjectStore,
     run_config: &ScheduleRunConfig,
@@ -856,7 +865,10 @@ fn resolve_run_config_from_config(
 #[cfg(test)]
 mod build_context_tests {
     use super::ScheduleRunJob;
-    use super::{resolve_run_config_from_config, validate_schedule_project_at_fire};
+    use super::{
+        resolve_run_config_from_config, schedule_workspace_source,
+        validate_schedule_project_at_fire,
+    };
     use bamboo_config::DefaultsConfig;
     use bamboo_config::{OpenAIConfig, ProviderConfigs};
     use bamboo_domain::{ProviderModelRef, ScheduleRunConfig};
@@ -901,6 +913,32 @@ mod build_context_tests {
         store.archive(&project.id, project.revision).unwrap();
         let error = validate_schedule_project_at_fire(&store, &run_config).unwrap_err();
         assert!(error.contains("archived at execution time"));
+    }
+
+    #[test]
+    fn schedule_workspace_source_matrix_is_explicit_project_default_or_session() {
+        let explicit = ScheduleRunConfig {
+            workspace_path: Some(" /tmp/explicit ".to_string()),
+            ..ScheduleRunConfig::default()
+        };
+        assert_eq!(
+            schedule_workspace_source(&explicit),
+            bamboo_engine::project_context::WorkspaceSource::Explicit
+        );
+
+        let assigned = ScheduleRunConfig {
+            project_id: Some("project-schedule-source".parse().unwrap()),
+            ..ScheduleRunConfig::default()
+        };
+        assert_eq!(
+            schedule_workspace_source(&assigned),
+            bamboo_engine::project_context::WorkspaceSource::ProjectDefault
+        );
+
+        assert_eq!(
+            schedule_workspace_source(&ScheduleRunConfig::default()),
+            bamboo_engine::project_context::WorkspaceSource::Session
+        );
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/schedule_app/scheduler_tool.rs
+++ b/crates/app/bamboo-server/src/schedule_app/scheduler_tool.rs
@@ -1157,6 +1157,296 @@ mod tests {
                 .map(String::as_str),
             Some(bamboo_engine::project_context::WorkspaceSource::ProjectDefault.as_str())
         );
+        assert_eq!(
+            fired_session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceBindingStatus::Registered.as_str())
+        );
+        let project_path = updated_project
+            .project_path
+            .as_deref()
+            .expect("moved Project path");
+        let system = fired_session
+            .messages
+            .iter()
+            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .expect("Schedule System");
+        assert!(!system.content.contains(project_path));
+        assert!(!system.content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        assert!(!system.content.contains("BAMBOO_PROJECT_CONTEXT"));
+        let snapshot = fired_session
+            .prompt_snapshot
+            .as_ref()
+            .expect("Schedule first prompt snapshot");
+        assert_eq!(snapshot.effective_system_prompt, system.content);
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed Schedule Workspace context");
+        assert!(workspace_context.contains(project_path));
+        assert!(workspace_context.contains("Workspace source: project_default"));
+        assert!(workspace_context.contains("Binding status: registered"));
+    }
+
+    #[tokio::test]
+    async fn fired_unassigned_explicit_workspace_is_published_before_clean_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        bamboo_config::paths::init_bamboo_dir(dir.path().to_path_buf());
+        let state = crate::AppState::new(dir.path().to_path_buf())
+            .await
+            .expect("AppState");
+        let explicit_workspace = tempfile::tempdir().expect("explicit Schedule Workspace");
+        let canonical = explicit_workspace
+            .path()
+            .canonicalize()
+            .expect("canonical explicit Workspace");
+        let display = bamboo_config::paths::path_to_display_string(&canonical);
+        let caller = Session::new("unassigned-explicit-scheduler-caller", "model");
+        state.storage.save_session(&caller).await.unwrap();
+        let tool = ScheduleTasksTool::new(
+            state.schedule_store.clone(),
+            state.schedule_manager.clone(),
+            state.session_store.clone(),
+            state.storage.clone(),
+            state.config.clone(),
+            state.project_store.clone(),
+            state.workspace_resolver.clone(),
+        );
+
+        tool.invoke(
+            json!({
+                "action": "create",
+                "name": "unassigned explicit Workspace",
+                "trigger": {"type": "interval", "every_seconds": 3600},
+                "enabled": false,
+                "run_config": {
+                    "auto_execute": false,
+                    "model": "test-model",
+                    "workspace_path": display
+                }
+            }),
+            context(&caller.id),
+        )
+        .await
+        .expect("create explicit Schedule");
+        let schedules = state.schedule_store.list_schedules().await;
+        let schedule = schedules.first().expect("created Schedule");
+        assert!(schedule.run_config.project_id.is_none());
+        assert_eq!(
+            schedule.run_config.workspace_path.as_deref(),
+            Some(display.as_str())
+        );
+
+        tool.invoke(
+            json!({"action": "run_now", "schedule_id": schedule.id}),
+            context(&caller.id),
+        )
+        .await
+        .expect("run explicit Schedule");
+
+        let fired = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(entry) = state
+                    .session_store
+                    .list_index_entries()
+                    .await
+                    .into_iter()
+                    .find(|entry| {
+                        entry.created_by_schedule_id.as_deref() == Some(schedule.id.as_str())
+                    })
+                {
+                    break entry;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("explicit scheduled session should be persisted");
+        let fired_session = state
+            .storage
+            .load_session(&fired.id)
+            .await
+            .expect("load explicit fired session")
+            .expect("explicit fired session");
+
+        assert!(fired_session.project_id_meta().is_none());
+        assert_eq!(
+            fired_session.workspace_path_meta().as_deref(),
+            Some(display.as_str())
+        );
+        assert_eq!(
+            fired_session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceSource::Explicit.as_str())
+        );
+        assert_eq!(
+            fired_session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceBindingStatus::Unregistered.as_str())
+        );
+        assert_eq!(
+            bamboo_agent_core::workspace_state::get_workspace(&fired_session.id),
+            Some(canonical)
+        );
+        let system = fired_session
+            .messages
+            .iter()
+            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .expect("clean Schedule System");
+        assert!(!system.content.contains(&display));
+        assert!(!system.content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        let snapshot = fired_session
+            .prompt_snapshot
+            .as_ref()
+            .expect("first explicit Schedule snapshot");
+        assert_eq!(snapshot.effective_system_prompt, system.content);
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed explicit Schedule Workspace context");
+        assert!(workspace_context.contains(&display));
+        assert!(workspace_context.contains("Workspace source: explicit"));
+        assert!(workspace_context.contains("Binding status: unregistered"));
+    }
+
+    #[tokio::test]
+    async fn fired_assigned_explicit_project_workspace_is_registered_before_clean_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        bamboo_config::paths::init_bamboo_dir(dir.path().to_path_buf());
+        let state = crate::AppState::new(dir.path().to_path_buf())
+            .await
+            .expect("AppState");
+        let project_path = tempfile::tempdir().expect("explicit Project Workspace");
+        let canonical = project_path
+            .path()
+            .canonicalize()
+            .expect("canonical explicit Project Workspace");
+        let display = bamboo_config::paths::path_to_display_string(&canonical);
+        let project = state
+            .project_store
+            .create_with_project_path("Explicit Scheduled", None, &display, Vec::new())
+            .expect("Project with explicit Workspace");
+        let mut caller = Session::new("assigned-explicit-scheduler-caller", "model");
+        caller.set_project_id_meta(project.id.to_string());
+        state.storage.save_session(&caller).await.unwrap();
+        let tool = ScheduleTasksTool::new(
+            state.schedule_store.clone(),
+            state.schedule_manager.clone(),
+            state.session_store.clone(),
+            state.storage.clone(),
+            state.config.clone(),
+            state.project_store.clone(),
+            state.workspace_resolver.clone(),
+        );
+
+        tool.invoke(
+            json!({
+                "action": "create",
+                "name": "assigned explicit Project Workspace",
+                "trigger": {"type": "interval", "every_seconds": 3600},
+                "enabled": false,
+                "run_config": {
+                    "auto_execute": false,
+                    "model": "test-model",
+                    "workspace_path": display
+                }
+            }),
+            context(&caller.id),
+        )
+        .await
+        .expect("create assigned explicit Schedule");
+        let schedules = state.schedule_store.list_schedules().await;
+        let schedule = schedules.first().expect("created assigned Schedule");
+        assert_eq!(schedule.run_config.project_id.as_ref(), Some(&project.id));
+        assert_eq!(
+            schedule.run_config.workspace_path.as_deref(),
+            Some(display.as_str())
+        );
+
+        tool.invoke(
+            json!({"action": "run_now", "schedule_id": schedule.id}),
+            context(&caller.id),
+        )
+        .await
+        .expect("run assigned explicit Schedule");
+
+        let fired = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(entry) = state
+                    .session_store
+                    .list_index_entries()
+                    .await
+                    .into_iter()
+                    .find(|entry| {
+                        entry.created_by_schedule_id.as_deref() == Some(schedule.id.as_str())
+                    })
+                {
+                    break entry;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("assigned explicit scheduled session should be persisted");
+        let fired_session = state
+            .storage
+            .load_session(&fired.id)
+            .await
+            .expect("load assigned explicit fired session")
+            .expect("assigned explicit fired session");
+
+        assert_eq!(
+            fired_session.project_id_meta().as_deref(),
+            Some(project.id.as_str())
+        );
+        assert_eq!(
+            fired_session.workspace_path_meta().as_deref(),
+            Some(display.as_str())
+        );
+        assert_eq!(
+            fired_session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceSource::Explicit.as_str())
+        );
+        assert_eq!(
+            fired_session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(bamboo_engine::project_context::WorkspaceBindingStatus::Registered.as_str())
+        );
+        assert_eq!(
+            bamboo_agent_core::workspace_state::get_workspace(&fired_session.id),
+            Some(canonical)
+        );
+        let system = fired_session
+            .messages
+            .iter()
+            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .expect("clean assigned Schedule System");
+        assert!(!system.content.contains(&display));
+        assert!(!system.content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        assert!(!system.content.contains("BAMBOO_PROJECT_CONTEXT"));
+        let snapshot = fired_session
+            .prompt_snapshot
+            .as_ref()
+            .expect("first assigned explicit Schedule snapshot");
+        assert_eq!(snapshot.effective_system_prompt, system.content);
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed assigned explicit Schedule Workspace context");
+        assert!(workspace_context.contains(&display));
+        assert!(workspace_context.contains("Workspace source: explicit"));
+        assert!(workspace_context.contains("Binding status: registered"));
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/schedule_app/session_factory.rs
+++ b/crates/app/bamboo-server/src/schedule_app/session_factory.rs
@@ -2,7 +2,10 @@
 
 use bamboo_domain::reasoning::ReasoningEffort;
 use bamboo_domain::{Message, Session, SessionPermissionMode};
-use bamboo_engine::runner;
+use bamboo_engine::session_app::execution_prep::{
+    prepare_session_for_execution, publish_resolved_workspace_for_execution,
+    ResolvedExecutionWorkspace,
+};
 
 use super::manager::ScheduleRunJob;
 
@@ -26,7 +29,7 @@ pub fn create_schedule_session(
     model: &str,
     system_prompt: &str,
     base_system_prompt: &str,
-    workspace_path: Option<&str>,
+    workspace: Option<ResolvedExecutionWorkspace<'_>>,
     reasoning_effort: Option<ReasoningEffort>,
     workspace_resolver: &bamboo_agent_core::workspace_state::WorkspaceResolver,
 ) -> Session {
@@ -59,36 +62,18 @@ pub fn create_schedule_session(
     if let Some(project_id) = job.run_config.project_id.as_ref() {
         session.set_project_id_meta(project_id.to_string());
     }
-    if let Some(path) = workspace_path {
-        let final_workspace = workspace_resolver.publish_resolved_workspace(
-            &session_id,
-            std::path::PathBuf::from(path),
+    if let Some(workspace) = workspace {
+        publish_resolved_workspace_for_execution(
+            &mut session,
+            workspace,
+            workspace_resolver,
             "schedule",
         );
-        let final_workspace = bamboo_config::paths::path_to_display_string(&final_workspace);
-        session.set_workspace_path_meta(final_workspace);
-        if job.run_config.project_id.is_some() {
-            let source = if job
-                .run_config
-                .workspace_path
-                .as_deref()
-                .is_some_and(|workspace| !workspace.trim().is_empty())
-            {
-                bamboo_engine::project_context::WorkspaceSource::Explicit
-            } else {
-                bamboo_engine::project_context::WorkspaceSource::ProjectDefault
-            };
-            session.metadata.insert(
-                bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY.to_string(),
-                source.as_str().to_string(),
-            );
-        }
     }
     if let Some(effort) = reasoning_effort {
         session.set_reasoning_effort_meta(effort.as_str());
     }
-    session.add_message(Message::system(system_prompt.to_string()));
-    runner::refresh_prompt_snapshot(&mut session);
+    prepare_session_for_execution(&mut session, Some(system_prompt), None);
 
     if let Some(task) = job
         .run_config
@@ -109,6 +94,7 @@ mod tests {
     use bamboo_agent_core::tools::ToolExecutionSessionFlags;
     use bamboo_agent_core::workspace_state::{WorkspaceResolver, WorkspaceRootConfig};
     use bamboo_domain::{PermissionAuditSnapshot, PermissionMode, ScheduleRunConfig};
+    use bamboo_engine::project_context::{WorkspaceBindingStatus, WorkspaceSource};
     use bamboo_tools::permission::{
         EffectivePermissionPolicy, PermissionConfig, PermissionDecisionKind,
         PermissionDecisionSource, PermissionEvaluation, PermissionOutcome, PermissionReasonCode,
@@ -241,19 +227,24 @@ mod tests {
                 confine: true,
             }
         });
-        let job = ScheduleRunJob {
+        let mut job = ScheduleRunJob {
             run_id: "run-instance-root".to_string(),
             schedule_id: "schedule-instance-root".to_string(),
             schedule_name: "instance root".to_string(),
             ..test_job()
         };
+        job.run_config.workspace_path = Some(relocated.to_string_lossy().into_owned());
 
         let session = create_schedule_session(
             &job,
             "model",
             "system",
             "base",
-            Some(relocated.to_string_lossy().as_ref()),
+            Some(ResolvedExecutionWorkspace {
+                path: &relocated,
+                source: WorkspaceSource::Explicit,
+                binding_status: WorkspaceBindingStatus::Unregistered,
+            }),
             None,
             &resolver,
         );
@@ -266,5 +257,45 @@ mod tests {
             relocated.is_dir(),
             "the AppState resolver must materialize its own validated target"
         );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(WorkspaceSource::Explicit.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(bamboo_engine::project_context::WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(WorkspaceBindingStatus::Unregistered.as_str())
+        );
+        assert_eq!(
+            bamboo_agent_core::workspace_state::get_workspace(&session.id),
+            Some(relocated.clone())
+        );
+        let system = session
+            .messages
+            .iter()
+            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+            .expect("clean Schedule System");
+        assert_eq!(system.content, "system");
+        assert!(!system
+            .content
+            .contains(relocated.to_string_lossy().as_ref()));
+        assert!(!system.content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        let snapshot = session
+            .prompt_snapshot
+            .as_ref()
+            .expect("first prompt snapshot");
+        assert_eq!(snapshot.effective_system_prompt, "system");
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed Workspace context in first snapshot");
+        assert!(workspace_context.contains(relocated.to_string_lossy().as_ref()));
+        assert!(workspace_context.contains("Workspace source: explicit"));
+        assert!(workspace_context.contains("Binding status: unregistered"));
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/agent.rs
+++ b/crates/engine/bamboo-engine/src/runtime/agent.rs
@@ -73,7 +73,26 @@ impl Agent {
         req: ExecuteRequest,
     ) -> crate::runtime::runner::Result<()> {
         let lease = self.begin_direct_execution(&session.id).await?;
+        self.prepare_external_session_for_execution(session).await?;
         self.execute_direct_registered(session, req, lease).await
+    }
+
+    /// Validate and publish Project/Workspace context for a caller-owned
+    /// session before any external pre-execution side effect.
+    ///
+    /// SDK facades that acquire a direct lease themselves call this before
+    /// approved-tool replay. [`execute_direct`](Self::execute_direct) also calls
+    /// it, so the lower-level escape hatch cannot bypass legacy migration,
+    /// Project validation, or runtime workspace publication.
+    pub async fn prepare_external_session_for_execution(
+        &self,
+        session: &mut Session,
+    ) -> crate::runtime::runner::Result<()> {
+        crate::session_app::execution_prep::prepare_external_session_for_execution(
+            session,
+            self.runtime.project_context_resolver.as_deref(),
+        )
+        .await
     }
 
     /// Acquire direct logical-session ownership before an SDK facade performs

--- a/crates/engine/bamboo-engine/src/runtime/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/tests.rs
@@ -610,6 +610,46 @@ fn direct_request(
 }
 
 #[tokio::test]
+async fn public_execute_direct_fails_closed_for_assigned_session_without_project_resolver() {
+    let (_temp, agent, _storage) =
+        build_direct_execute_agent(Arc::new(NeverCalledTranscriptProvider), None, None).await;
+    let mut session = Session::new("direct-assigned-no-resolver", "test-model");
+    session.set_project_id_meta("project-direct-no-resolver");
+    session.add_message(Message::system("caller System"));
+    session.add_message(Message::user("must not reach provider"));
+    session.metadata.insert(
+        crate::session_app::respond::PERMISSION_REEXECUTE_METADATA_KEY.to_string(),
+        "retryable-tool-call".to_string(),
+    );
+    let (event_tx, mut event_rx) = mpsc::channel(8);
+
+    let error = agent
+        .execute_direct(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect_err("assigned direct execution must require Project resolver authority");
+
+    assert!(matches!(
+        error,
+        bamboo_agent_core::AgentError::ProjectContext(_)
+    ));
+    assert_eq!(session.messages[0].content, "caller System");
+    assert_eq!(
+        session
+            .metadata
+            .get(crate::session_app::respond::PERMISSION_REEXECUTE_METADATA_KEY)
+            .map(String::as_str),
+        Some("retryable-tool-call")
+    );
+    assert!(
+        event_rx.try_recv().is_err(),
+        "prep failure must emit no events"
+    );
+}
+
+#[tokio::test]
 async fn direct_execute_checkpoints_normal_completion_without_task_context() {
     let (_temp, agent, storage) =
         build_direct_execute_agent(Arc::new(CompletedTranscriptProvider), None, None).await;

--- a/crates/engine/bamboo-engine/src/session_app/execution_prep.rs
+++ b/crates/engine/bamboo-engine/src/session_app/execution_prep.rs
@@ -15,7 +15,139 @@
 //! - the child spawn path (`sdk::spawn::run_child_spawn`), likewise `None` for the
 //!   system prompt and only the child model.
 
-use bamboo_agent_core::{Message, Role, Session};
+use std::path::Path;
+
+use bamboo_agent_core::{AgentError, Message, Role, Session};
+
+use crate::project_context::{
+    ProjectContextResolver, SessionProjectIdentity, WorkspaceBindingStatus, WorkspaceSource,
+    WORKSPACE_BINDING_STATUS_METADATA_KEY, WORKSPACE_SOURCE_METADATA_KEY,
+};
+
+/// A workspace that an adapter has already validated for one execution.
+///
+/// Keeping path, provenance, and Project-binding status in one value prevents
+/// Schedule/Connect factories from publishing a path and taking their first
+/// prompt snapshot before the two authority fields are present.
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedExecutionWorkspace<'a> {
+    pub path: &'a Path,
+    pub source: WorkspaceSource,
+    pub binding_status: WorkspaceBindingStatus,
+}
+
+/// Publish an adapter-validated workspace and its typed provenance as one
+/// pre-snapshot operation.
+///
+/// The supplied [`bamboo_agent_core::workspace_state::WorkspaceResolver`] must
+/// be the same instance that performed validation. Publication can materialize
+/// a resolver-owned fallback, so the returned path is the only path persisted
+/// on the session.
+pub fn publish_resolved_workspace_for_execution(
+    session: &mut Session,
+    workspace: ResolvedExecutionWorkspace<'_>,
+    workspace_resolver: &bamboo_agent_core::workspace_state::WorkspaceResolver,
+    publication_source: &str,
+) {
+    let final_workspace = workspace_resolver.publish_resolved_workspace(
+        &session.id,
+        workspace.path.to_path_buf(),
+        publication_source,
+    );
+    session.set_workspace_path_meta(bamboo_config::paths::path_to_display_string(
+        &final_workspace,
+    ));
+    session.metadata.insert(
+        WORKSPACE_SOURCE_METADATA_KEY.to_string(),
+        workspace.source.as_str().to_string(),
+    );
+    session.metadata.insert(
+        WORKSPACE_BINDING_STATUS_METADATA_KEY.to_string(),
+        workspace.binding_status.as_str().to_string(),
+    );
+}
+
+/// Prepare a caller-owned session before any approved-tool replay or provider
+/// execution.
+///
+/// This is the engine-owned external handoff seam used by the SDK. It is
+/// deliberately idempotent and runs before a configured System prompt replaces
+/// the caller's leading message:
+///
+/// - validate Project identity and required resolver authority without mutation;
+/// - recover and remove legacy host-owned prompt blocks;
+/// - validate Project workspace ownership when a resolver exists;
+/// - fail closed for an assigned Project when no resolver authority exists;
+/// - publish the exact runtime workspace and typed path/source/binding metadata;
+/// - refresh the typed prompt snapshot without ever persisting host context in
+///   System text.
+pub async fn prepare_external_session_for_execution(
+    session: &mut Session,
+    project_context_resolver: Option<&ProjectContextResolver>,
+) -> Result<(), AgentError> {
+    // Establish that this process has the authority required for the session
+    // before migrating any retryable legacy state. In particular, an assigned
+    // session without a Project resolver must remain byte-for-byte retryable:
+    // even a marker-only System message cannot be consumed on this error path.
+    match ProjectContextResolver::session_project_identity(session) {
+        SessionProjectIdentity::Invalid { raw, message } => {
+            return Err(AgentError::ProjectContext(format!(
+                "session carries an invalid Project identity '{raw}': {message}"
+            )));
+        }
+        SessionProjectIdentity::Assigned(project_id) if project_context_resolver.is_none() => {
+            return Err(AgentError::ProjectContext(format!(
+                "assigned Project '{project_id}' requires a ProjectContextResolver before external execution"
+            )));
+        }
+        SessionProjectIdentity::Assigned(_) | SessionProjectIdentity::Unassigned => {}
+    }
+
+    // Once authority is known to be sufficient, recover a legacy workspace
+    // before resolution: its host-owned System block may be the sole source of
+    // the path that the resolver must validate and publish.
+    crate::runtime::runner::session_setup::migrate_legacy_workspace_prompt(session);
+
+    if let Some(resolver) = project_context_resolver {
+        resolver
+            .refresh_session_prompt(session)
+            .await
+            .map_err(|error| AgentError::ProjectContext(error.to_string()))?;
+        return Ok(());
+    }
+
+    // An unassigned embedding has no Project authority to consult, but it must
+    // still hand the resolved workspace to tools before replay/provider work.
+    // The process-global resolver is the compatibility authority for this SDK
+    // shape. Unassigned workspaces are necessarily unregistered.
+    let workspace = ProjectContextResolver::resolve_workspace_candidate(session, None)
+        .map_err(|error| AgentError::ProjectContext(error.to_string()))?;
+    if let Some(workspace) = workspace.as_deref() {
+        let source = WorkspaceSource::from_metadata(
+            session
+                .metadata
+                .get(WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+        );
+        publish_resolved_workspace_for_execution(
+            session,
+            ResolvedExecutionWorkspace {
+                path: workspace,
+                source,
+                binding_status: WorkspaceBindingStatus::Unregistered,
+            },
+            &bamboo_agent_core::workspace_state::WorkspaceResolver::from_process_globals(),
+            "external_execution_prep",
+        );
+    } else {
+        session.metadata.remove(WORKSPACE_SOURCE_METADATA_KEY);
+        session
+            .metadata
+            .remove(WORKSPACE_BINDING_STATUS_METADATA_KEY);
+    }
+    crate::runner::refresh_prompt_snapshot(session);
+    Ok(())
+}
 
 /// Apply the authoritative pre-execution mutations to `session`.
 ///
@@ -51,12 +183,35 @@ pub fn prepare_session_for_execution(
     if let Some(model) = model {
         session.model = model.to_string();
     }
+
+    // A configured prompt may itself have been copied from a legacy Bamboo
+    // snapshot. Strip only recognized host-owned blocks after replacement;
+    // recovered typed metadata remains authoritative. Every caller observes a
+    // snapshot whose System bytes and typed workspace context agree.
+    crate::runtime::runner::session_setup::migrate_legacy_workspace_prompt(session);
+    crate::runner::refresh_prompt_snapshot(session);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use bamboo_agent_core::Message;
+    use std::sync::Arc;
+
+    struct EmptyProjectSource;
+
+    #[async_trait::async_trait]
+    impl crate::project_context::ProjectContextSource for EmptyProjectSource {
+        async fn find_project(
+            &self,
+            _project_id: &bamboo_domain::ProjectId,
+        ) -> Result<
+            Option<crate::project_context::ProjectDescriptor>,
+            crate::project_context::ProjectContextError,
+        > {
+            Ok(None)
+        }
+    }
 
     fn session_with(messages: Vec<Message>) -> Session {
         let mut s = Session::new("test-session", "old-model");
@@ -126,5 +281,158 @@ mod tests {
 
         assert_eq!(session.model, "old-model");
         assert_eq!(session.messages.len(), 1);
+        assert!(session.prompt_snapshot.is_some());
+    }
+
+    #[tokio::test]
+    async fn external_prep_migrates_serialized_legacy_workspace_idempotently_before_configured_prompt(
+    ) {
+        let root = tempfile::tempdir().expect("workspace root");
+        let workspace = root.path().join("legacy-workspace");
+        std::fs::create_dir_all(&workspace).expect("legacy workspace");
+        let canonical = workspace.canonicalize().expect("canonical workspace");
+        let display = bamboo_config::paths::path_to_display_string(&canonical);
+        let legacy_block = crate::runtime::context::build_workspace_prompt_context(&display)
+            .expect("legacy Workspace block");
+
+        let mut legacy = Session::new("external-legacy", "old-model");
+        legacy.add_message(Message::system(legacy_block));
+        legacy.metadata.insert(
+            "runtime_prompt_snapshot".to_string(),
+            "stale-snapshot".to_string(),
+        );
+        let serialized = serde_json::to_vec(&legacy).expect("serialize legacy session");
+        let mut session: Session =
+            serde_json::from_slice(&serialized).expect("deserialize legacy session");
+
+        let resolver = ProjectContextResolver::new_with_workspace_resolver(
+            Arc::new(EmptyProjectSource),
+            bamboo_agent_core::workspace_state::WorkspaceResolver::new(|| None, {
+                let root = root.path().to_path_buf();
+                move || bamboo_agent_core::workspace_state::WorkspaceRootConfig {
+                    root: root.clone(),
+                    confine: false,
+                }
+            }),
+        );
+
+        prepare_external_session_for_execution(&mut session, Some(&resolver))
+            .await
+            .expect("first external prep");
+        assert!(
+            session
+                .messages
+                .iter()
+                .all(|message| !matches!(message.role, Role::System)),
+            "a marker-only legacy System message must be removed"
+        );
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some(display.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(WORKSPACE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(WorkspaceSource::Session.as_str())
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(WORKSPACE_BINDING_STATUS_METADATA_KEY)
+                .map(String::as_str),
+            Some(WorkspaceBindingStatus::Unregistered.as_str())
+        );
+        assert!(!session.metadata.contains_key("runtime_prompt_snapshot"));
+        assert_eq!(
+            bamboo_agent_core::workspace_state::get_workspace(&session.id),
+            Some(canonical.clone())
+        );
+
+        let once = serde_json::to_value(&session).expect("first prepared session");
+        prepare_external_session_for_execution(&mut session, Some(&resolver))
+            .await
+            .expect("second external prep");
+        assert_eq!(
+            serde_json::to_value(&session).expect("second prepared session"),
+            once,
+            "external prep must be an exact session-state no-op after the first handoff"
+        );
+
+        prepare_session_for_execution(&mut session, Some("configured System"), Some("new-model"));
+        let systems = session
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, Role::System))
+            .collect::<Vec<_>>();
+        assert_eq!(systems.len(), 1);
+        assert_eq!(systems[0].content, "configured System");
+        assert!(!systems[0].content.contains(&display));
+        assert!(!systems[0].content.contains("BAMBOO_WORKSPACE_CONTEXT"));
+        assert_eq!(session.model, "new-model");
+        assert_eq!(
+            bamboo_agent_core::workspace_state::get_workspace(&session.id),
+            Some(canonical)
+        );
+        let snapshot = session
+            .prompt_snapshot
+            .as_ref()
+            .expect("configured snapshot");
+        assert_eq!(snapshot.effective_system_prompt, "configured System");
+        let workspace_context = snapshot
+            .workspace_context
+            .as_deref()
+            .expect("typed Workspace context");
+        assert!(workspace_context.contains(&display));
+        assert!(workspace_context.contains("Workspace source: session"));
+        assert!(workspace_context.contains("Binding status: unregistered"));
+    }
+
+    #[tokio::test]
+    async fn assigned_external_prep_without_resolver_fails_closed_before_mutating_retry_state() {
+        let workspace = tempfile::tempdir().expect("legacy Workspace");
+        let display = bamboo_config::paths::path_to_display_string(workspace.path());
+        let legacy_block = crate::runtime::context::build_workspace_prompt_context(&display)
+            .expect("legacy Workspace block");
+        let mut session = session_with(vec![Message::system(format!(
+            "caller System\n\n{legacy_block}"
+        ))]);
+        session.set_project_id_meta("project-external-prep");
+        session.metadata.insert(
+            crate::session_app::respond::PERMISSION_REEXECUTE_METADATA_KEY.to_string(),
+            "retryable-tool-call".to_string(),
+        );
+        session.prompt_snapshot = Some(
+            serde_json::from_value(serde_json::json!({
+                "base_system_prompt": "stale caller snapshot",
+                "effective_system_prompt": "stale caller snapshot"
+            }))
+            .expect("synthetic stale prompt snapshot"),
+        );
+        let before = serde_json::to_vec(&session).expect("serialize retryable legacy state");
+
+        let error = prepare_external_session_for_execution(&mut session, None)
+            .await
+            .expect_err("assigned external execution requires resolver authority");
+
+        assert!(matches!(error, AgentError::ProjectContext(_)));
+        assert_eq!(
+            serde_json::to_vec(&session).expect("serialize failed legacy state"),
+            before,
+            "missing resolver must leave the complete serialized Session state unchanged"
+        );
+        assert!(session.messages[0].content.contains(&display));
+        assert!(session.messages[0]
+            .content
+            .contains("BAMBOO_WORKSPACE_CONTEXT"));
+        assert_eq!(
+            session
+                .metadata
+                .get(crate::session_app::respond::PERMISSION_REEXECUTE_METADATA_KEY)
+                .map(String::as_str),
+            Some("retryable-tool-call")
+        );
+        assert!(session.prompt_snapshot.is_some());
     }
 }


### PR DESCRIPTION
## Summary

- pass one typed `ResolvedExecutionWorkspace` through Schedule and Connect factories, publishing path/source/binding before their first prompt snapshot;
- keep workspace paths and Bamboo host markers out of System messages at every external creation boundary;
- add one engine-owned external execution-preparation seam and use it from SDK normal execution and public `execute_direct`;
- recover legacy marker-only sessions before approved-tool replay or configured System replacement, while missing Project resolver configuration remains retryable;
- cover Project-default, explicit registered/unregistered, and session fallback behavior with end-to-end Schedule/Connect/SDK tests.

Closes #998

## Test Plan

- `cargo test --locked -p bamboo-engine` — 1,433 passed plus doctest
- `cargo test --locked -p bamboo-sdk` — 56 unit, 1 integration, and 7 doctests passed
- `cargo test --locked -p bamboo-server` — 1,965 passed, 0 failed, 1 ignored; workspace and ws_v2 integrations and docs passed
- focused execution-prep, SDK replay/order, Schedule fired matrix, Connect bridge, and factory tests
- affected all-target and production Clippy with the repository's confirmed pre-existing lint allow-list
- `cargo fmt --all -- --check`
- `git diff --check`

## Review Evidence

- independent exact-diff review: APPROVE on patch SHA-256 `6dab7ef12019015afeb431299190e6759187f3cc3406f40db982b7ca24af4c1d`;
- no P0/P1/P2 findings within #998's direct functionality and regression scope;
- exact-head CI and live mergeability/thread gates remain required before merge.

## Screenshots

Not applicable; no UI changes.
