### PR TITLE
fix: gate model tool calls by effective set (#1005)

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/tool.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/tool.rs
@@ -64,6 +64,8 @@ impl ToolManager for DefaultToolManager {
             .agent_runtime_state
             .clone()
             .unwrap_or_else(|| bamboo_domain::AgentRuntimeState::new(session_id));
+        let effective_callable_set =
+            crate::runtime::runner::tool_execution::legacy_effective_callable_set(tool_schemas);
 
         // Mirror the live pipeline's #30 biased-cancel wrap so a cancel issued
         // DURING tool execution (e.g. a long foreground Bash run) is honored on
@@ -91,6 +93,7 @@ impl ToolManager for DefaultToolManager {
                         .as_ref()
                         .or(config.background_model_provider.as_ref()),
                     tool_schemas,
+                    effective_callable_set: &effective_callable_set,
                 },
             ) => result?,
         };

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -1633,6 +1633,8 @@ async fn handle_tool_calls_path(
     }
     let tool_schemas =
         resolve_available_tool_schemas_for_session(frame.config, frame.tools.as_ref(), session);
+    let effective_callable_set =
+        crate::runtime::runner::tool_execution::legacy_effective_callable_set(&tool_schemas);
 
     // Tool execution can block for a long time (up to parallel_batch_timeout_secs,
     // default 300s, and per_tool_timeout_secs for single tools). The loop only
@@ -1666,6 +1668,7 @@ async fn handle_tool_calls_path(
                     .as_ref()
                     .or(auxiliary_models.background_model_provider.as_ref()),
                 tool_schemas: &tool_schemas,
+                effective_callable_set: &effective_callable_set,
             },
         ) => result?,
     };
@@ -6980,6 +6983,8 @@ mod tests {
             tools: &tools,
         };
         let tool_schemas = tools.list_tools();
+        let effective_callable_set =
+            crate::runtime::runner::tool_execution::legacy_effective_callable_set(&tool_schemas);
         let mut runtime_state = AgentRuntimeState::new("s-normal");
         let mut task_context: Option<TaskLoopContext> = None;
 
@@ -6996,6 +7001,7 @@ mod tests {
                 compression_model_name: None,
                 compression_model_provider: None,
                 tool_schemas: &tool_schemas,
+                effective_callable_set: &effective_callable_set,
             }),
         )
         .await

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -9,7 +9,10 @@ use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::{ToolCall, ToolExecutor, ToolSchema};
 use bamboo_agent_core::{AgentError, AgentEvent, Session};
-use bamboo_domain::{AgentHookPoint, AgentRuntimeState};
+use bamboo_domain::{
+    AgentHookPoint, AgentRuntimeState, CapabilityLoadingMode, ClassifiedToolSchema,
+    EffectiveCallableSet,
+};
 use bamboo_llm::LLMProvider;
 use bamboo_metrics::{MetricsCollector, RoundStatus as MetricsRoundStatus};
 
@@ -85,6 +88,25 @@ fn scheduling_mode_for_tool_call(
     }
 }
 
+/// Preserve the current full-catalog behavior at execution boundaries that do
+/// not yet have a progressive provider adapter. The input is already filtered
+/// for this session/round, so the rebuilt classified view contains only those
+/// eligible schemas; HostOnly entries remain non-callable by domain policy.
+pub(crate) fn legacy_effective_callable_set(
+    eligible_tool_schemas: &[ToolSchema],
+) -> EffectiveCallableSet {
+    let catalog = eligible_tool_schemas
+        .iter()
+        .cloned()
+        .filter_map(ClassifiedToolSchema::new)
+        .collect::<Vec<_>>();
+    EffectiveCallableSet::from_catalog(
+        &catalog,
+        CapabilityLoadingMode::LegacyFullCatalog,
+        std::iter::empty::<&str>(),
+    )
+}
+
 pub(crate) struct RoundToolExecutionResult {
     pub awaiting_clarification: bool,
     pub waiting_for_children: bool,
@@ -108,6 +130,7 @@ async fn execute_and_apply_single_tool_call(
     session: &mut Session,
     tools: &Arc<dyn ToolExecutor>,
     config: &AgentLoopConfig,
+    effective_callable_set: &EffectiveCallableSet,
     // Pre-built per-round snapshot of the executor's full tool-schema list —
     // avoids re-cloning every schema on each tool call.
     available_tool_schemas: &[ToolSchema],
@@ -212,21 +235,24 @@ async fn execute_and_apply_single_tool_call(
                 let before_tool_hooks = config
                     .hook_runner
                     .has_hooks_for(AgentHookPoint::BeforeToolExecution);
-                per_call::execute_tool_call_only(per_call::ToolExecutionOnlyContext {
-                    tool_call,
-                    event_tx,
-                    metrics_collector,
-                    session_id,
-                    root_session_id: &root_session_id,
-                    round_id,
-                    round,
-                    tools,
-                    config,
-                    hook_session: before_tool_hooks.then_some(&mut *session),
-                    hook_runtime_state: before_tool_hooks.then_some(&mut *runtime_state),
-                    session_flags,
-                    available_tool_schemas,
-                })
+                per_call::execute_model_requested_tool_call_only(
+                    effective_callable_set,
+                    per_call::ToolExecutionOnlyContext {
+                        tool_call,
+                        event_tx,
+                        metrics_collector,
+                        session_id,
+                        root_session_id: &root_session_id,
+                        round_id,
+                        round,
+                        tools,
+                        config,
+                        hook_session: before_tool_hooks.then_some(&mut *session),
+                        hook_runtime_state: before_tool_hooks.then_some(&mut *runtime_state),
+                        session_flags,
+                        available_tool_schemas,
+                    },
+                )
                 .await?
             }
         }
@@ -421,6 +447,8 @@ pub(crate) struct RoundToolExecution<'a, 'frame> {
     pub(crate) compression_model_name: Option<&'a str>,
     pub(crate) compression_model_provider: Option<&'a Arc<dyn LLMProvider>>,
     pub(crate) tool_schemas: &'a [ToolSchema],
+    /// Provider/session-resolved function membership at this conversation position.
+    pub(crate) effective_callable_set: &'a EffectiveCallableSet,
 }
 
 pub(crate) async fn execute_round_tool_calls(
@@ -435,6 +463,7 @@ pub(crate) async fn execute_round_tool_calls(
         compression_model_name,
         compression_model_provider,
         tool_schemas,
+        effective_callable_set,
     } = execution;
 
     // Bind frame fields as locals so the rest of the function body stays unchanged.
@@ -511,6 +540,7 @@ pub(crate) async fn execute_round_tool_calls(
                         session,
                         tools,
                         config,
+                        effective_callable_set,
                         available_tool_schemas,
                         runtime_state,
                         task_context,
@@ -551,6 +581,7 @@ pub(crate) async fn execute_round_tool_calls(
                     session,
                     tools,
                     config,
+                    effective_callable_set,
                     available_tool_schemas,
                     runtime_state,
                     task_context,
@@ -618,21 +649,24 @@ pub(crate) async fn execute_round_tool_calls(
                     async move {
                         tokio::time::timeout(
                             timeout,
-                            per_call::execute_tool_call_only(per_call::ToolExecutionOnlyContext {
-                                tool_call,
-                                event_tx,
-                                metrics_collector,
-                                session_id,
-                                root_session_id,
-                                round_id,
-                                round,
-                                tools,
-                                config,
-                                hook_session: None,
-                                hook_runtime_state: None,
-                                session_flags,
-                                available_tool_schemas,
-                            }),
+                            per_call::execute_model_requested_tool_call_only(
+                                effective_callable_set,
+                                per_call::ToolExecutionOnlyContext {
+                                    tool_call,
+                                    event_tx,
+                                    metrics_collector,
+                                    session_id,
+                                    root_session_id,
+                                    round_id,
+                                    round,
+                                    tools,
+                                    config,
+                                    hook_session: None,
+                                    hook_runtime_state: None,
+                                    session_flags,
+                                    available_tool_schemas,
+                                },
+                            ),
                         )
                         .await
                         .unwrap_or_else(|_| {
@@ -786,6 +820,7 @@ pub(crate) async fn execute_round_tool_calls(
             session,
             tools,
             config,
+            effective_callable_set,
             available_tool_schemas,
             runtime_state,
             task_context,
@@ -820,8 +855,8 @@ pub(crate) async fn execute_round_tool_calls(
 #[cfg(test)]
 mod tests {
     use super::{
-        execute_round_tool_calls, scheduling_mode_for_tool_call, RoundToolExecution,
-        RoundToolExecutionResult, ToolSchedulingMode,
+        execute_round_tool_calls, legacy_effective_callable_set, scheduling_mode_for_tool_call,
+        RoundToolExecution, RoundToolExecutionResult, ToolSchedulingMode,
     };
     use bamboo_agent_core::storage::Storage;
     use bamboo_agent_core::tools::{
@@ -829,7 +864,10 @@ mod tests {
         ToolResult, ToolSchema,
     };
     use bamboo_agent_core::{AgentError, AgentEvent, Message, Session};
-    use bamboo_domain::{AgentRuntimeState, PermissionAuditSnapshot, SessionPermissionMode};
+    use bamboo_domain::{
+        AgentRuntimeState, CapabilityLoadingMode, ClassifiedToolSchema, EffectiveCallableSet,
+        PermissionAuditSnapshot, SessionPermissionMode,
+    };
     use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
     use bamboo_tools::BuiltinToolExecutor;
     use futures::stream;
@@ -1118,8 +1156,34 @@ mod tests {
     async fn run_permission_boundary_calls(
         storage: Arc<BoundaryStorage>,
         executor: Arc<PermissionBoundaryExecutor>,
+        session: Session,
+        calls: &[ToolCall],
+    ) -> (
+        Result<RoundToolExecutionResult, AgentError>,
+        Session,
+        AgentRuntimeState,
+        Vec<AgentEvent>,
+    ) {
+        let tool_schemas = executor.list_tools();
+        let effective_callable_set = legacy_effective_callable_set(&tool_schemas);
+        run_permission_boundary_calls_with_set(
+            storage,
+            executor,
+            session,
+            calls,
+            tool_schemas,
+            effective_callable_set,
+        )
+        .await
+    }
+
+    async fn run_permission_boundary_calls_with_set(
+        storage: Arc<BoundaryStorage>,
+        executor: Arc<PermissionBoundaryExecutor>,
         mut session: Session,
         calls: &[ToolCall],
+        tool_schemas: Vec<ToolSchema>,
+        effective_callable_set: EffectiveCallableSet,
     ) -> (
         Result<RoundToolExecutionResult, AgentError>,
         Session,
@@ -1146,7 +1210,6 @@ mod tests {
             llm: &llm,
             tools: &tools,
         };
-        let tool_schemas = tools.list_tools();
         let mut runtime_state = session
             .agent_runtime_state
             .clone()
@@ -1161,6 +1224,7 @@ mod tests {
             compression_model_name: None,
             compression_model_provider: None,
             tool_schemas: &tool_schemas,
+            effective_callable_set: &effective_callable_set,
         })
         .await;
         let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
@@ -1324,6 +1388,63 @@ mod tests {
             2,
             "one load for the two-call parallel batch plus one for the following sequential call"
         );
+    }
+
+    #[tokio::test]
+    async fn progressive_gate_rejects_one_parallel_call_without_aborting_allowed_sibling() {
+        let session =
+            permission_session("progressive-mixed-parallel", SessionPermissionMode::Auto, 1);
+        let storage = Arc::new(BoundaryStorage::new(session.clone()));
+        let executor = Arc::new(PermissionBoundaryExecutor::new(
+            storage.clone(),
+            "never",
+            BoundaryTransition::Mode(SessionPermissionMode::Auto, 1),
+        ));
+        let calls = [
+            named_call("parallel-a", "parallel_a"),
+            named_call("parallel-b", "parallel_b"),
+        ];
+        let tool_schemas = executor.list_tools();
+        let catalog = tool_schemas
+            .iter()
+            .cloned()
+            .filter_map(ClassifiedToolSchema::new)
+            .collect::<Vec<_>>();
+        let effective_callable_set = EffectiveCallableSet::from_catalog(
+            &catalog,
+            CapabilityLoadingMode::Progressive,
+            ["parallel_a"],
+        );
+
+        let (result, session, _, events) = run_permission_boundary_calls_with_set(
+            storage,
+            executor.clone(),
+            session,
+            &calls,
+            tool_schemas,
+            effective_callable_set,
+        )
+        .await;
+
+        assert!(!result.unwrap().awaiting_clarification);
+        assert!(executor.entered("parallel_a"));
+        assert!(!executor.entered("parallel_b"));
+        assert!(events.iter().any(
+            |event| matches!(event, AgentEvent::ToolStart { tool_call_id, .. } if tool_call_id == "parallel-a")
+        ));
+        assert!(events.iter().all(
+            |event| !matches!(event, AgentEvent::ToolStart { tool_call_id, .. } if tool_call_id == "parallel-b")
+        ));
+        assert!(session.messages.iter().any(|message| {
+            message.tool_call_id.as_deref() == Some("parallel-a")
+                && message.content.contains("parallel_a complete")
+        }));
+        assert!(session.messages.iter().any(|message| {
+            message.tool_call_id.as_deref() == Some("parallel-b")
+                && message
+                    .content
+                    .contains("not callable at the current conversation position")
+        }));
     }
 
     #[test]
@@ -1554,6 +1675,8 @@ mod tests {
             permission_mode: Some(PermissionMode::Plan),
             ..Default::default()
         };
+        let available_tool_schemas = tools.list_tools();
+        let effective_callable_set = legacy_effective_callable_set(&available_tool_schemas);
 
         let mut state = RoundExecutionState::default();
         let mut runtime_state = AgentRuntimeState::new("test-session");
@@ -1575,7 +1698,8 @@ mod tests {
             &mut session,
             &tools,
             &config,
-            tools.list_tools().as_slice(),
+            &effective_callable_set,
+            &available_tool_schemas,
             &mut runtime_state,
             &mut None,
             &mut state,
@@ -1612,6 +1736,8 @@ mod tests {
             permission_mode: Some(PermissionMode::Plan),
             ..Default::default()
         };
+        let available_tool_schemas = tools.list_tools();
+        let effective_callable_set = legacy_effective_callable_set(&available_tool_schemas);
 
         let mut state = RoundExecutionState::default();
         let mut runtime_state = AgentRuntimeState::new("test-session");
@@ -1635,7 +1761,8 @@ mod tests {
             &mut session,
             &tools,
             &config,
-            tools.list_tools().as_slice(),
+            &effective_callable_set,
+            &available_tool_schemas,
             &mut runtime_state,
             &mut None,
             &mut state,
@@ -1659,7 +1786,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auto_request_permissions_returns_error_without_pending_clarification() {
+    async fn host_only_request_permissions_is_rejected_before_tool_start_under_auto() {
         use super::{execute_and_apply_single_tool_call, loop_state::RoundExecutionState, policy};
         use bamboo_agent_core::Session;
         use bamboo_config::PermissionMode;
@@ -1672,6 +1799,8 @@ mod tests {
             permission_mode: Some(PermissionMode::Auto),
             ..Default::default()
         };
+        let available_tool_schemas = tools.list_tools();
+        let effective_callable_set = legacy_effective_callable_set(&available_tool_schemas);
         let mut state = RoundExecutionState::default();
         let mut runtime_state = AgentRuntimeState::new("auto-no-prompt");
         runtime_state.set_permission_mode(bamboo_domain::SessionPermissionMode::Auto);
@@ -1688,7 +1817,8 @@ mod tests {
             &mut session,
             &tools,
             &config,
-            tools.list_tools().as_slice(),
+            &effective_callable_set,
+            &available_tool_schemas,
             &mut runtime_state,
             &mut None,
             &mut state,
@@ -1703,15 +1833,16 @@ mod tests {
         assert!(!session.has_pending_question());
         assert!(session.messages.last().is_some_and(|message| message
             .content
-            .contains("cannot request expanded permissions")));
+            .contains("not callable at the current conversation position")));
         let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
-        assert!(events
-            .iter()
-            .all(|event| !matches!(event, AgentEvent::NeedClarification { .. })));
+        assert!(events.iter().all(|event| !matches!(
+            event,
+            AgentEvent::NeedClarification { .. } | AgentEvent::ToolStart { .. }
+        )));
     }
 
     #[tokio::test]
-    async fn proactive_request_permissions_without_a_checker_completes_without_legacy_pause() {
+    async fn host_only_request_permissions_is_rejected_before_tool_start_by_default() {
         use super::{execute_and_apply_single_tool_call, loop_state::RoundExecutionState, policy};
         use bamboo_agent_core::Session;
         use tokio::sync::mpsc;
@@ -1720,6 +1851,8 @@ mod tests {
         let mut session = Session::new("typed-no-legacy-pause", "test-model");
         let tools = builtin_tools();
         let config = crate::runtime::config::AgentLoopConfig::default();
+        let available_tool_schemas = tools.list_tools();
+        let effective_callable_set = legacy_effective_callable_set(&available_tool_schemas);
         let mut state = RoundExecutionState::default();
         let mut runtime_state = AgentRuntimeState::new("typed-no-legacy-pause");
         let mut policy_guard = policy::ToolPolicyGuard::new(80, 3);
@@ -1744,7 +1877,8 @@ mod tests {
             &mut session,
             &tools,
             &config,
-            tools.list_tools().as_slice(),
+            &effective_callable_set,
+            &available_tool_schemas,
             &mut runtime_state,
             &mut None,
             &mut state,
@@ -1757,14 +1891,14 @@ mod tests {
         assert!(!control.should_break);
         assert!(!control.stop_round);
         assert!(!session.has_pending_question());
-        assert!(session
-            .messages
-            .last()
-            .is_some_and(|message| message.content.contains("permissions_authorized")));
+        assert!(session.messages.last().is_some_and(|message| message
+            .content
+            .contains("not callable at the current conversation position")));
         let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
-        assert!(events
-            .iter()
-            .all(|event| !matches!(event, AgentEvent::NeedClarification { .. })));
+        assert!(events.iter().all(|event| !matches!(
+            event,
+            AgentEvent::NeedClarification { .. } | AgentEvent::ToolStart { .. }
+        )));
     }
 
     #[tokio::test]
@@ -1781,6 +1915,8 @@ mod tests {
             permission_mode: Some(PermissionMode::Plan),
             ..Default::default()
         };
+        let available_tool_schemas = tools.list_tools();
+        let effective_callable_set = legacy_effective_callable_set(&available_tool_schemas);
 
         let mut state = RoundExecutionState::default();
         let mut runtime_state = AgentRuntimeState::new("test-session");
@@ -1798,7 +1934,8 @@ mod tests {
             &mut session,
             &tools,
             &config,
-            tools.list_tools().as_slice(),
+            &effective_callable_set,
+            &available_tool_schemas,
             &mut runtime_state,
             &mut None,
             &mut state,
@@ -1829,6 +1966,8 @@ mod tests {
         let mut session = Session::new("test-session", "test-model");
         let tools = builtin_tools();
         let config = crate::runtime::config::AgentLoopConfig::default();
+        let available_tool_schemas = tools.list_tools();
+        let effective_callable_set = legacy_effective_callable_set(&available_tool_schemas);
 
         let mut state = RoundExecutionState::default();
         let mut runtime_state = AgentRuntimeState::new("test-session");
@@ -1853,7 +1992,8 @@ mod tests {
             &mut session,
             &tools,
             &config,
-            tools.list_tools().as_slice(),
+            &effective_callable_set,
+            &available_tool_schemas,
             &mut runtime_state,
             &mut None,
             &mut state,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -9,7 +9,10 @@ use bamboo_agent_core::tools::{
     ToolExecutor, ToolOutcome, ToolResult, ToolSchema,
 };
 use bamboo_agent_core::{AgentError, AgentEvent, Session};
-use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookPayload, HookResult, HookToolOutcome};
+use bamboo_domain::{
+    AgentHookPoint, AgentRuntimeState, EffectiveCallableSet, HookPayload, HookResult,
+    HookToolOutcome,
+};
 use bamboo_metrics::MetricsCollector;
 
 use super::execution_paths;
@@ -97,7 +100,54 @@ pub(super) struct ToolExecutionOutcome {
     pub tool_duration: std::time::Duration,
 }
 
+/// Admit one model-requested function call before it enters Bamboo's existing
+/// tool execution pipeline.
+///
+/// Capability loading changes availability only: an admitted call retains its
+/// original spelling and continues through the exact same argument, event,
+/// hook, permission, and executor path below. A rejected call is represented as
+/// an ordinary per-call outcome so sibling calls in a parallel batch keep
+/// running and the normal result-application path can append the corresponding
+/// tool error without emitting `ToolStart` or entering downstream hooks.
+pub(super) async fn execute_model_requested_tool_call_only(
+    effective_callable_set: &EffectiveCallableSet,
+    ctx: ToolExecutionOnlyContext<'_>,
+) -> Result<ToolExecutionOutcome, AgentError> {
+    let Some(execution_name) =
+        effective_callable_set.resolve_callable_reference(&ctx.tool_call.function.name)
+    else {
+        let message = format!(
+            "Tool '{}' is not callable at the current conversation position",
+            ctx.tool_call.function.name
+        );
+        tracing::warn!(
+            "[{}][round:{}] Tool call rejected by capability loading before ToolStart: tool_call_id={}, tool_name={}",
+            ctx.session_id,
+            ctx.round,
+            ctx.tool_call.id,
+            ctx.tool_call.function.name,
+        );
+        return Ok(ToolExecutionOutcome {
+            result: Err(message),
+            needs_human: None,
+            post_tool_hook_eligible: false,
+            tool_duration: std::time::Duration::ZERO,
+        });
+    };
+
+    execute_tool_call_only_with_execution_name(&execution_name, ctx).await
+}
+
+#[cfg(test)]
 pub(super) async fn execute_tool_call_only(
+    ctx: ToolExecutionOnlyContext<'_>,
+) -> Result<ToolExecutionOutcome, AgentError> {
+    let execution_name = ctx.tool_call.function.name.clone();
+    execute_tool_call_only_with_execution_name(&execution_name, ctx).await
+}
+
+async fn execute_tool_call_only_with_execution_name(
+    execution_name: &str,
     mut ctx: ToolExecutionOnlyContext<'_>,
 ) -> Result<ToolExecutionOutcome, AgentError> {
     if let Err(policy_error) = policy::validate_tool_call_arguments(ctx.tool_call) {
@@ -300,14 +350,13 @@ pub(super) async fn execute_tool_call_only(
     // apply before the success path) and collapse the rest to a ToolResult so the
     // compressor / policy / transcript path is unchanged. Completed -> its result,
     // Running -> its synthetic ack, NeedsHuman -> its rich display result.
-    let dispatch = bamboo_agent_core::tools::executor::execute_tool_call_with_context_outcome(
-        ctx.tool_call,
-        ctx.tools.as_ref(),
-        // Agent execution does not route through the legacy composition
-        // runtime; catalog-pinned workflow_run is the sole orchestrator.
-        None,
-        tool_ctx,
-    );
+    // Dispatch through the exact identity already selected by the effective
+    // callable-set resolver. Events, hooks, and permission handling above keep
+    // the model's original call spelling, while the executor cannot re-resolve
+    // that spelling to a different (possibly excluded) exact owner.
+    let dispatch =
+        ctx.tools
+            .execute_exact_with_context_outcome(ctx.tool_call, execution_name, tool_ctx);
     let (needs_human, result, post_tool_hook_eligible) =
         match bamboo_tools::with_hook_permission_override(
             permission_override,
@@ -663,11 +712,13 @@ mod hook_tests {
     use super::*;
     use async_trait::async_trait;
     use bamboo_agent_core::tools::{
-        AsyncWaitKind, FunctionCall, RunningCompletion, RunningHandle, ToolError,
+        AsyncWaitKind, FunctionCall, FunctionSchema, RunningCompletion, RunningHandle, ToolError,
     };
     use bamboo_agent_core::AgentHook;
     use bamboo_config::{LifecycleHookGroup, LifecycleHookHandler, LifecycleHooksConfig};
+    use bamboo_domain::{CapabilityLoadingMode, ClassifiedToolSchema};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     #[derive(Default)]
     struct BlockingPendingPersistence {
@@ -884,6 +935,82 @@ mod hook_tests {
         }
     }
 
+    struct NameRecordingExecutor {
+        entered: Mutex<Vec<String>>,
+        schemas: Vec<ToolSchema>,
+    }
+
+    impl NameRecordingExecutor {
+        fn new(schema_names: &[&str]) -> Self {
+            Self {
+                entered: Mutex::new(Vec::new()),
+                schemas: schema_names.iter().copied().map(tool_schema).collect(),
+            }
+        }
+
+        fn entered(&self) -> Vec<String> {
+            self.entered
+                .lock()
+                .expect("capability gate probe lock")
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl ToolExecutor for NameRecordingExecutor {
+        async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+            self.entered
+                .lock()
+                .expect("capability gate probe lock")
+                .push(call.function.name.clone());
+            Ok(ToolResult::text(true, "executed"))
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            self.schemas.clone()
+        }
+    }
+
+    #[derive(Default)]
+    struct ExactOwnerRecordingExecutor {
+        ordinary_dispatches: Mutex<Vec<String>>,
+        exact_dispatches: Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for ExactOwnerRecordingExecutor {
+        async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+            self.ordinary_dispatches
+                .lock()
+                .expect("ordinary dispatch probe lock")
+                .push(call.function.name.clone());
+            Ok(ToolResult::text(true, "ordinary dispatch"))
+        }
+
+        async fn execute_exact_with_context_outcome(
+            &self,
+            call: &ToolCall,
+            execution_name: &str,
+            _ctx: ToolExecutionContext<'_>,
+        ) -> Result<ToolOutcome, ToolError> {
+            self.exact_dispatches
+                .lock()
+                .expect("exact dispatch probe lock")
+                .push((call.function.name.clone(), execution_name.to_string()));
+            Ok(ToolOutcome::Completed(ToolResult::text(
+                true,
+                "exact dispatch",
+            )))
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            ["Edit", "apply_patch"]
+                .into_iter()
+                .map(tool_schema)
+                .collect()
+        }
+    }
+
     enum NonTerminalOutcome {
         Running,
         NeedsHuman,
@@ -950,6 +1077,249 @@ mod hook_tests {
                 arguments: serde_json::json!({"value": 7}).to_string(),
             },
         }
+    }
+
+    fn tool_schema(name: &str) -> ToolSchema {
+        ToolSchema {
+            schema_type: "function".to_string(),
+            function: FunctionSchema {
+                name: name.to_string(),
+                description: format!("{name} capability gate probe"),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+        }
+    }
+
+    fn effective_callable_set(
+        catalog_names: &[&str],
+        mode: CapabilityLoadingMode,
+        loaded_names: &[&str],
+    ) -> EffectiveCallableSet {
+        let catalog = catalog_names
+            .iter()
+            .copied()
+            .map(tool_schema)
+            .filter_map(ClassifiedToolSchema::new)
+            .collect::<Vec<_>>();
+        EffectiveCallableSet::from_catalog(&catalog, mode, loaded_names.iter().copied())
+    }
+
+    async fn execute_without_hooks(
+        effective_callable_set: &EffectiveCallableSet,
+        tools: &Arc<dyn ToolExecutor>,
+        tool_call: &ToolCall,
+        event_tx: &mpsc::Sender<AgentEvent>,
+    ) -> ToolExecutionOutcome {
+        let session = Session::new("capability-gate-session", "model");
+        execute_model_requested_tool_call_only(
+            effective_callable_set,
+            ToolExecutionOnlyContext {
+                tool_call,
+                event_tx,
+                metrics_collector: None,
+                session_id: "capability-gate-session",
+                root_session_id: "capability-gate-session",
+                round_id: "round-1",
+                round: 0,
+                tools,
+                config: &AgentLoopConfig::default(),
+                hook_session: None,
+                hook_runtime_state: None,
+                session_flags: ToolExecutionSessionFlags::from_session(&session),
+                available_tool_schemas: &[],
+            },
+        )
+        .await
+        .expect("capability admission is a per-call outcome")
+    }
+
+    #[tokio::test]
+    async fn capability_gate_allows_legacy_deferred_and_progressive_core_or_loaded_calls() {
+        let concrete_tools = Arc::new(NameRecordingExecutor::new(&["Read", "probe"]));
+        let tools: Arc<dyn ToolExecutor> = concrete_tools.clone();
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        let legacy = effective_callable_set(
+            &["Read", "probe"],
+            CapabilityLoadingMode::LegacyFullCatalog,
+            &[],
+        );
+        let progressive = effective_callable_set(
+            &["Read", "probe"],
+            CapabilityLoadingMode::Progressive,
+            &["probe"],
+        );
+
+        let legacy_deferred =
+            execute_without_hooks(&legacy, &tools, &probe_call("probe"), &event_tx).await;
+        let progressive_core =
+            execute_without_hooks(&progressive, &tools, &probe_call("Read"), &event_tx).await;
+        let progressive_loaded =
+            execute_without_hooks(&progressive, &tools, &probe_call("probe"), &event_tx).await;
+
+        assert!(legacy_deferred.result.is_ok());
+        assert!(progressive_core.result.is_ok());
+        assert!(progressive_loaded.result.is_ok());
+        assert_eq!(concrete_tools.entered(), ["probe", "Read", "probe"]);
+        let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, AgentEvent::ToolStart { .. }))
+                .count(),
+            3
+        );
+    }
+
+    #[tokio::test]
+    async fn capability_gate_rejects_unloaded_host_only_unknown_and_excluded_before_hooks() {
+        let concrete_tools = Arc::new(NameRecordingExecutor::new(&[
+            "Read",
+            "probe",
+            "Workspace",
+            "excluded",
+        ]));
+        let tools: Arc<dyn ToolExecutor> = concrete_tools.clone();
+        let effective_callable_set = effective_callable_set(
+            &["Read", "probe", "Workspace"],
+            CapabilityLoadingMode::Progressive,
+            &[],
+        );
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+
+        let mut runner = crate::runtime::hooks::HookRunner::new();
+        runner.register(Arc::new(DenyToolHook));
+        let config = AgentLoopConfig {
+            hook_runner: Arc::new(runner),
+            ..Default::default()
+        };
+        let unloaded_call = probe_call("probe");
+        let mut session = Session::new("capability-gate-hook-session", "model");
+        let session_flags = ToolExecutionSessionFlags::from_session(&session);
+        let mut runtime_state = AgentRuntimeState::new(&session.id);
+        let unloaded = execute_model_requested_tool_call_only(
+            &effective_callable_set,
+            ToolExecutionOnlyContext {
+                tool_call: &unloaded_call,
+                event_tx: &event_tx,
+                metrics_collector: None,
+                session_id: "capability-gate-hook-session",
+                root_session_id: "capability-gate-hook-session",
+                round_id: "round-1",
+                round: 0,
+                tools: &tools,
+                config: &config,
+                hook_session: Some(&mut session),
+                hook_runtime_state: Some(&mut runtime_state),
+                session_flags,
+                available_tool_schemas: &[],
+            },
+        )
+        .await
+        .expect("unloaded rejection is a per-call outcome");
+
+        let mut outcomes = vec![("probe", unloaded)];
+        for name in ["Workspace", "unknown_tool", "excluded"] {
+            outcomes.push((
+                name,
+                execute_without_hooks(
+                    &effective_callable_set,
+                    &tools,
+                    &probe_call(name),
+                    &event_tx,
+                )
+                .await,
+            ));
+        }
+
+        for (name, outcome) in outcomes {
+            assert!(matches!(
+                outcome.result,
+                Err(ref error)
+                    if error.contains(name)
+                        && error.contains("not callable at the current conversation position")
+            ));
+        }
+        assert!(concrete_tools.entered().is_empty());
+        let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert!(events.iter().all(|event| !matches!(
+            event,
+            AgentEvent::ToolStart { .. } | AgentEvent::HookLifecycle { .. }
+        )));
+    }
+
+    #[tokio::test]
+    async fn capability_gate_preserves_exact_shadow_without_alias_fallback() {
+        let concrete_tools = Arc::new(NameRecordingExecutor::new(&["Edit", "apply_patch"]));
+        let tools: Arc<dyn ToolExecutor> = concrete_tools.clone();
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        let core_only = effective_callable_set(
+            &["Edit", "apply_patch"],
+            CapabilityLoadingMode::Progressive,
+            &[],
+        );
+        let exact_loaded = effective_callable_set(
+            &["Edit", "apply_patch"],
+            CapabilityLoadingMode::Progressive,
+            &["apply_patch"],
+        );
+        let exact_call = probe_call("apply_patch");
+
+        let rejected = execute_without_hooks(&core_only, &tools, &exact_call, &event_tx).await;
+        let admitted = execute_without_hooks(&exact_loaded, &tools, &exact_call, &event_tx).await;
+
+        assert!(matches!(
+            rejected.result,
+            Err(ref error) if error.contains("not callable at the current conversation position")
+        ));
+        assert!(admitted.result.is_ok());
+        assert_eq!(concrete_tools.entered(), ["apply_patch"]);
+        let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, AgentEvent::ToolStart { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn capability_gate_dispatches_the_resolved_owner_without_reresolving_original_shadow() {
+        let concrete_tools = Arc::new(ExactOwnerRecordingExecutor::default());
+        let tools: Arc<dyn ToolExecutor> = concrete_tools.clone();
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        let effective_callable_set =
+            effective_callable_set(&["Edit"], CapabilityLoadingMode::LegacyFullCatalog, &[]);
+        let call = probe_call("apply_patch");
+        assert_eq!(
+            effective_callable_set
+                .resolve_callable_reference(&call.function.name)
+                .as_deref(),
+            Some("Edit"),
+            "with no exact registration in the eligible catalog, the shared resolver selects the allowed builtin owner"
+        );
+
+        let outcome =
+            execute_without_hooks(&effective_callable_set, &tools, &call, &event_tx).await;
+
+        assert!(outcome.result.is_ok());
+        assert!(concrete_tools
+            .ordinary_dispatches
+            .lock()
+            .expect("ordinary dispatch probe lock")
+            .is_empty());
+        assert_eq!(
+            *concrete_tools
+                .exact_dispatches
+                .lock()
+                .expect("exact dispatch probe lock"),
+            vec![("apply_patch".to_string(), "Edit".to_string())]
+        );
+        let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::ToolStart { tool_name, .. } if tool_name == "apply_patch"
+        )));
     }
 
     async fn apply_test_outcome(


### PR DESCRIPTION
## Summary

- resolve every model-requested function call against the effective callable set before the existing tool pipeline
- return rejected calls as ordinary per-call outcomes before ToolStart, hooks, permissions, or executor dispatch
- pin admitted calls to the exact execution owner selected by the effective-set resolver while preserving the original call for events and hooks
- use one ready callable set across sequential and parallel round execution without changing existing routing, permission, or result semantics

Closes #1005

## Test Plan

- cargo test --locked -p bamboo-engine (1439 passed; 0 failed; doc test passed)
- cargo test --locked -p bamboo-tools executor_prefers_exact_tool_name_before_builtin_alias
- cargo test --locked -p bamboo-tools exact_permission_seam_preserves_default_apply_patch_builtin_provenance
- cargo test --locked -p bamboo-mcp secondary_exact_apply_patch_beats_builtin_alias_across_all_routes
- cargo test --locked -p bamboo-server-tools stacked_overlays_keep_base_exact_owner_for_permission_and_classification
- cargo fmt --all -- --check
- cargo clippy --locked -p bamboo-engine --lib --no-deps -- -D warnings
- git diff --check

## Screenshots

Not applicable; engine-only behavior.