### PR TITLE
feat: add OpenAI Responses progressive tool search

### DIFF
--- a/crates/core/bamboo-domain/src/session/provider_transcript.rs
+++ b/crates/core/bamboo-domain/src/session/provider_transcript.rs
@@ -2459,6 +2459,32 @@ fn openai_loaded_tool_names(payload: &Value) -> Vec<String> {
     names
 }
 
+/// Extract function identities only from validated OpenAI Responses
+/// `tool_search_output.tools` items. Ordinary function calls do not contribute
+/// loading state.
+pub fn validated_openai_loaded_tool_names<'a>(
+    groups: impl IntoIterator<Item = &'a ProviderTranscriptGroup>,
+    family: ProviderFamily,
+) -> Vec<String> {
+    if !matches!(family, ProviderFamily::OpenAi | ProviderFamily::Copilot) {
+        return Vec::new();
+    }
+    let mut names = groups
+        .into_iter()
+        .filter(|group| {
+            group.family() == family
+                && group.protocol() == ProviderProtocol::OpenAiResponsesV1
+                && ProviderTranscriptGroup::validate_items(group.items()).is_ok()
+        })
+        .flat_map(ProviderTranscriptGroup::items)
+        .filter(|item| item.kind() == ProviderTranscriptItemKind::OpenAiToolSearchOutput)
+        .flat_map(|item| openai_loaded_tool_names(item.payload()))
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    names
+}
+
 fn stable_item_id(
     family: ProviderFamily,
     protocol: ProviderProtocol,
@@ -2876,6 +2902,71 @@ mod tests {
         );
         ProviderTranscriptGroup::validate_items(std::slice::from_ref(&client))
             .expect("a client output is a standalone host-owned continuation group");
+    }
+
+    #[test]
+    fn openai_loaded_names_survive_resume_and_come_only_from_search_output() {
+        let mut session = Session::new("client-loaded-resume", "gpt-5.6");
+        activate_openai(&mut session);
+        let assistant = Message::assistant("", None);
+        let anchor = assistant.id.clone();
+        session.add_message(assistant);
+        let call = ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::Provider,
+            ProviderTranscriptAuthor::Model,
+            json!({
+                "type":"tool_search_call","id":"tsc_resume","execution":"client",
+                "call_id":"search_resume","status":"completed",
+                "arguments":{"query":"files"}
+            }),
+        )
+        .unwrap();
+        session
+            .append_provider_transcript_group(&anchor, None, vec![call])
+            .unwrap();
+        let output = ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::HostToolSearch,
+            ProviderTranscriptAuthor::ToolResult,
+            json!({
+                "type":"tool_search_output","execution":"client",
+                "call_id":"search_resume","status":"completed","tools":[{
+                    "type":"function","name":"Glob","description":"Find files",
+                    "parameters":{"type":"object"},"strict":false,"defer_loading":true
+                }]
+            }),
+        )
+        .unwrap();
+        session
+            .append_provider_transcript_group(&anchor, None, vec![output])
+            .unwrap();
+
+        let names =
+            validated_openai_loaded_tool_names(replayable_openai(&session), ProviderFamily::OpenAi);
+        assert_eq!(names, vec!["Glob"]);
+
+        let resumed: Session =
+            serde_json::from_value(serde_json::to_value(&session).unwrap()).unwrap();
+        let resumed_names =
+            validated_openai_loaded_tool_names(replayable_openai(&resumed), ProviderFamily::OpenAi);
+        assert_eq!(resumed_names, vec!["Glob"]);
+
+        let mut hosted = Session::new("hosted-loaded", "gpt-5.6");
+        activate_openai(&mut hosted);
+        let assistant = Message::assistant("normalized", None);
+        let anchor = assistant.id.clone();
+        hosted.add_message(assistant);
+        hosted
+            .append_provider_transcript_group(&anchor, None, openai_output_items())
+            .unwrap();
+        assert_eq!(
+            validated_openai_loaded_tool_names(replayable_openai(&hosted), ProviderFamily::OpenAi,),
+            vec!["list_open_orders"],
+            "the following ordinary function_call must not add loading state"
+        );
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -5,6 +5,7 @@
 //!
 //! "Round" is kept only as a counter for metrics compatibility.
 
+use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -32,8 +33,11 @@ use bamboo_domain::session::runtime_state::{
     WaitingForChildrenState,
 };
 use bamboo_domain::{
-    AgentHookPoint, CapabilityLoadingMode, ClassifiedToolSchema, EffectiveCallableSet, HookPayload,
-    HookResult, ProviderFamily, ProviderProtocol, ProviderTranscriptItem,
+    AgentHookPoint, CapabilityInvocationTarget, CapabilityLoadingClass, CapabilityLoadingMode,
+    CapabilityMatch, CapabilitySource, ClassifiedToolSchema, DiscoverCapabilitiesRequest,
+    EffectiveCallableSet, HookPayload, HookResult, ProviderFamily, ProviderProtocol,
+    ProviderTranscriptAuthor, ProviderTranscriptItem, ProviderTranscriptItemKind,
+    ProviderTranscriptOrigin,
 };
 use bamboo_llm::LLMProvider;
 use bamboo_metrics::{
@@ -87,23 +91,30 @@ fn effective_callable_set_for_round(
     }
 
     let transcript = &session.provider_transcript;
-    let progressive_route = transcript.active_family() == Some(ProviderFamily::Anthropic)
-        && transcript.active_protocol() == Some(ProviderProtocol::AnthropicMessages2023_06_01);
-    let groups = transcript
-        .active_provider_boundary_sha256()
-        .filter(|_| progressive_route)
-        .map(|boundary| {
-            transcript.replayable_groups(
-                ProviderFamily::Anthropic,
-                ProviderProtocol::AnthropicMessages2023_06_01,
-                boundary,
+    let family = transcript.active_family();
+    let protocol = transcript.active_protocol();
+    let groups = match (
+        family,
+        protocol,
+        transcript.active_provider_boundary_sha256(),
+    ) {
+        (Some(family), Some(protocol), Some(boundary)) => {
+            transcript.replayable_groups(family, protocol, boundary)
+        }
+        _ => Vec::new(),
+    };
+    let loaded_names = match (family, protocol) {
+        (Some(ProviderFamily::Anthropic), Some(ProviderProtocol::AnthropicMessages2023_06_01)) => {
+            bamboo_llm::providers::anthropic::validated_anthropic_loaded_tool_names(
+                groups.iter().copied(),
+                tool_schemas,
             )
-        })
-        .unwrap_or_default();
-    let loaded_names = bamboo_llm::providers::anthropic::validated_anthropic_loaded_tool_names(
-        groups.iter().copied(),
-        tool_schemas,
-    );
+        }
+        (Some(family @ ProviderFamily::OpenAi), Some(ProviderProtocol::OpenAiResponsesV1)) => {
+            bamboo_domain::validated_openai_loaded_tool_names(groups.iter().copied(), family)
+        }
+        _ => Vec::new(),
+    };
     let catalog = tool_schemas
         .iter()
         .cloned()
@@ -114,6 +125,312 @@ fn effective_callable_set_for_round(
         CapabilityLoadingMode::Progressive,
         loaded_names.iter().map(String::as_str),
     )
+}
+
+fn openai_client_tool_search_requests(
+    items: &[ProviderTranscriptItem],
+) -> Result<Vec<(String, DiscoverCapabilitiesRequest)>, AgentError> {
+    items
+        .iter()
+        .filter(|item| {
+            item.family() == ProviderFamily::OpenAi
+                && item.protocol() == ProviderProtocol::OpenAiResponsesV1
+                && item.kind() == ProviderTranscriptItemKind::OpenAiToolSearchCall
+                && item.payload()["execution"].as_str() == Some("client")
+        })
+        .map(|item| {
+            let call_id = item.payload()["call_id"]
+                .as_str()
+                .expect("validated client tool_search_call has call_id")
+                .to_string();
+            let request = serde_json::from_value::<DiscoverCapabilitiesRequest>(
+                item.payload()["arguments"].clone(),
+            )
+            .map_err(|error| {
+                AgentError::LLM(format!(
+                    "OpenAI client tool-search arguments are invalid: {error}"
+                ))
+            })?;
+            Ok((call_id, request))
+        })
+        .collect()
+}
+
+fn capability_source_name(source: CapabilitySource) -> &'static str {
+    match source {
+        CapabilitySource::Builtin => "builtin",
+        CapabilitySource::Server => "server",
+        CapabilitySource::Mcp => "mcp",
+        CapabilitySource::Custom => "custom",
+        CapabilitySource::Project => "project",
+        CapabilitySource::Workspace => "workspace",
+        CapabilitySource::User => "user",
+        CapabilitySource::Plugin => "plugin",
+    }
+}
+
+/// Keep the real gateway definition while narrowing its catalog identity
+/// argument to this bounded discovery result. Revision/source stay descriptive
+/// metadata because `load_skill` has no revision argument and multiple workflow
+/// IDs can legitimately carry different revisions.
+fn scope_discovered_gateway_definition(
+    entry: &ClassifiedToolSchema,
+    matches: &[&CapabilityMatch],
+) -> serde_json::Value {
+    let mut definition =
+        bamboo_llm::providers::common::openai_responses::loaded_tool_to_responses_json(
+            entry.schema(),
+        );
+    let (catalog_kind, id_property) = match entry.execution_name() {
+        "load_skill" => ("skill", "skill_id"),
+        "workflow_run" => ("workflow", "workflow_id"),
+        _ => return definition,
+    };
+    let mut ids = Vec::new();
+    let mut workflow_revisions = Vec::new();
+    let mut metadata = Vec::new();
+    for matched in matches {
+        let scoped = match &matched.invocation_target {
+            CapabilityInvocationTarget::Skill {
+                skill_id,
+                source,
+                revision,
+                ..
+            } if catalog_kind == "skill" => Some((skill_id, *source, *revision)),
+            CapabilityInvocationTarget::Workflow {
+                workflow_id,
+                source,
+                revision,
+                ..
+            } if catalog_kind == "workflow" => {
+                if !workflow_revisions.contains(revision) {
+                    workflow_revisions.push(*revision);
+                }
+                Some((workflow_id, *source, *revision))
+            }
+            _ => None,
+        };
+        let Some((id, source, revision)) = scoped else {
+            continue;
+        };
+        if !ids.contains(id) {
+            ids.push(id.clone());
+        }
+        let detail = format!(
+            "{id} — {} — {} [revision={revision}, source={}]",
+            matched.display_name,
+            matched.summary,
+            capability_source_name(source)
+        );
+        if !metadata.contains(&detail) {
+            metadata.push(detail);
+        }
+    }
+    if ids.is_empty() {
+        return definition;
+    }
+
+    let parameters = definition
+        .get_mut("parameters")
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("loaded function definitions always have object parameters");
+    let properties = parameters
+        .entry("properties")
+        .or_insert_with(|| serde_json::json!({}));
+    if !properties.is_object() {
+        *properties = serde_json::json!({});
+    }
+    let properties = properties
+        .as_object_mut()
+        .expect("scoped gateway properties are an object");
+    let id_schema = properties
+        .entry(id_property)
+        .or_insert_with(|| serde_json::json!({"type": "string"}));
+    if !id_schema.is_object() {
+        *id_schema = serde_json::json!({"type": "string"});
+    }
+    id_schema["enum"] = serde_json::json!(ids);
+    id_schema["description"] = serde_json::json!(format!(
+        "Use only the {id_property} values advertised by this discovery output."
+    ));
+
+    if catalog_kind == "workflow" && !workflow_revisions.is_empty() {
+        let revision_schema = properties
+            .entry("revision")
+            .or_insert_with(|| serde_json::json!({"type": "integer", "minimum": 1}));
+        if !revision_schema.is_object() {
+            *revision_schema = serde_json::json!({"type": "integer", "minimum": 1});
+        }
+        revision_schema["enum"] = serde_json::json!(workflow_revisions);
+    }
+
+    definition["description"] = serde_json::json!(format!(
+        "{}. Scoped {catalog_kind} matches in discovery relevance order: {}.",
+        entry.schema().function.description.trim_end_matches('.'),
+        metadata.join("; ")
+    ));
+    definition
+}
+
+async fn build_openai_client_tool_search_outputs(
+    session: &Session,
+    config: &AgentLoopConfig,
+    tool_schemas: &[bamboo_agent_core::tools::ToolSchema],
+    provider_items: &[ProviderTranscriptItem],
+) -> Result<Vec<ProviderTranscriptItem>, AgentError> {
+    let requests = openai_client_tool_search_requests(provider_items)?;
+    let catalog = tool_schemas
+        .iter()
+        .cloned()
+        .filter_map(ClassifiedToolSchema::new)
+        .collect::<Vec<_>>();
+    let searchable_tool_catalog = catalog
+        .iter()
+        .filter(|entry| entry.loading_class() == CapabilityLoadingClass::Deferred)
+        .cloned()
+        .collect::<Vec<_>>();
+    let (_, disabled_skill_ids) = config.resolve_disabled_filters();
+    let catalog_names = catalog
+        .iter()
+        .map(|entry| entry.execution_name())
+        .collect::<BTreeSet<_>>();
+    let eligibility = crate::capability_discovery::CapabilityDiscoveryEligibility {
+        disabled_skill_ids: disabled_skill_ids.into_owned(),
+        allowed_skill_ids: config
+            .selected_skill_ids
+            .as_ref()
+            .map(|ids| ids.iter().cloned().collect()),
+        skill_gateway_available: catalog_names.contains("load_skill"),
+        workflow_gateway_available: catalog_names.contains("workflow_run"),
+        ..Default::default()
+    };
+    let index = match crate::runtime::runner::session_setup::skill_context::resolve_skill_store_for_session(
+        config, session,
+    )
+    .await
+    .map_err(AgentError::Tool)?
+    {
+        Some(store) => {
+            crate::capability_discovery::CapabilityDiscoveryIndex::from_resolved_classified_store(
+                &searchable_tool_catalog,
+                store.as_ref(),
+                &eligibility,
+            )
+            .await
+        }
+        None => {
+            let empty_skills = bamboo_skills::WorkflowCatalogSnapshot::default();
+            let empty_workflows = bamboo_skills::WorkflowCatalogSnapshot::default();
+            crate::capability_discovery::CapabilityDiscoveryIndex::from_snapshots(
+                crate::capability_discovery::project_classified_tool_capability_metadata(
+                    &searchable_tool_catalog,
+                ),
+                &empty_skills,
+                &empty_workflows,
+                &eligibility,
+            )
+        }
+    };
+
+    let mut outputs = Vec::with_capacity(requests.len());
+    for (call_id, request) in requests {
+        let result = index
+            .discover(&request)
+            .map_err(|error| AgentError::LLM(format!("capability discovery failed: {error}")))?;
+        let mut matches_by_function = Vec::<(String, Vec<_>)>::new();
+        for matched in &result.matches {
+            let name = match &matched.invocation_target {
+                CapabilityInvocationTarget::Tool { name }
+                | CapabilityInvocationTarget::Skill { name, .. }
+                | CapabilityInvocationTarget::Workflow { name, .. } => name,
+            };
+            if let Some((_, matches)) = matches_by_function
+                .iter_mut()
+                .find(|(function, _)| function == name)
+            {
+                matches.push(matched);
+            } else {
+                matches_by_function.push((name.clone(), vec![matched]));
+            }
+        }
+        let tools = matches_by_function
+            .into_iter()
+            .filter_map(|(name, matches)| {
+                let entry = catalog
+                    .iter()
+                    .find(|entry| entry.execution_name() == name)?;
+                if entry.loading_class() != CapabilityLoadingClass::Deferred {
+                    return None;
+                }
+                Some(scope_discovered_gateway_definition(entry, &matches))
+            })
+            .collect::<Vec<_>>();
+        let item = ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::HostToolSearch,
+            ProviderTranscriptAuthor::ToolResult,
+            serde_json::json!({
+                "type": "tool_search_output",
+                "execution": "client",
+                "call_id": call_id,
+                "status": "completed",
+                "tools": tools,
+            }),
+        )
+        .map_err(|error| {
+            AgentError::LLM(format!(
+                "OpenAI client tool-search output could not be constructed: {error}"
+            ))
+        })?;
+        outputs.push(item);
+    }
+    Ok(outputs)
+}
+
+async fn commit_openai_client_tool_search_round(
+    stream_output: StreamHandlingOutput,
+    session: &mut Session,
+    config: &AgentLoopConfig,
+    tool_schemas: &[bamboo_agent_core::tools::ToolSchema],
+) -> Result<(), AgentError> {
+    let host_outputs = build_openai_client_tool_search_outputs(
+        session,
+        config,
+        tool_schemas,
+        &stream_output.provider_transcript_items,
+    )
+    .await?;
+    let reasoning = (!stream_output.reasoning_content.trim().is_empty())
+        .then_some(stream_output.reasoning_content);
+    let reasoning_signature = reasoning
+        .as_ref()
+        .and_then(|_| stream_output.reasoning_signature.clone());
+    let message = Message::assistant_with_reasoning(stream_output.content, None, reasoning)
+        .with_reasoning_signature(reasoning_signature);
+    let anchor = message.id.clone();
+    let mut provider_items = Some(stream_output.provider_transcript_items);
+    commit_assistant_message(session, message, &mut provider_items)?;
+    for output in host_outputs {
+        session
+            .append_provider_transcript_group(&anchor, None, vec![output])
+            .map_err(|error| {
+                AgentError::LLM(format!(
+                    "OpenAI client tool-search result could not be committed: {error}"
+                ))
+            })?;
+    }
+    if let Some(persistence) = config.persistence.as_ref() {
+        persistence
+            .save_runtime_session(session)
+            .await
+            .map_err(|error| {
+                AgentError::Tool(format!(
+                    "OpenAI client tool-search checkpoint could not be persisted: {error}"
+                ))
+            })?;
+    }
+    Ok(())
 }
 
 // ---- Error classification (from rounds.rs) ----
@@ -2308,6 +2625,34 @@ async fn run_pipeline_inner(
                 };
 
             if stream_output.tool_calls.is_empty() {
+                if crate::runtime::runner::round_lifecycle::is_openai_client_tool_search_boundary(
+                    &stream_output.provider_transcript_items,
+                ) {
+                    match commit_openai_client_tool_search_round(
+                        stream_output,
+                        session,
+                        config,
+                        &tool_schemas,
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            record_no_tool_calls_round_completed(
+                                state.metrics_collector.as_ref(),
+                                &round_id,
+                                &state.session_id,
+                                session,
+                                round_activity.token_usage(),
+                            );
+                            turn_outcome = Some(TurnOutcome {
+                                should_break: false,
+                                sent_complete: false,
+                            });
+                        }
+                        Err(error) => terminal_error = Some(error),
+                    }
+                    break;
+                }
                 // Safety net: if the model is about to finish but left background
                 // children running without waiting on them, suspend instead of
                 // completing so their results are collected.
@@ -2961,10 +3306,12 @@ mod tests {
     use super::super::startup::{InFlightTaskEvaluation, OverflowRecoveryState};
     use super::{
         apply_successful_explicit_activation, build_guardian_review_prompt,
-        check_run_budget_exceeded, commit_assistant_message, effective_callable_set_for_round,
-        is_overflow_recoverable, is_subagent_create_call, is_terminal_child_status,
-        map_turn_error_status, maybe_spawn_guardian_review, maybe_suspend_for_orphaned_children,
-        maybe_suspend_for_outstanding_bash, should_retry_turn_error, suspend_to_wait_for_bash,
+        build_openai_client_tool_search_outputs, check_run_budget_exceeded,
+        commit_assistant_message, commit_openai_client_tool_search_round,
+        effective_callable_set_for_round, is_overflow_recoverable, is_subagent_create_call,
+        is_terminal_child_status, map_turn_error_status, maybe_spawn_guardian_review,
+        maybe_suspend_for_orphaned_children, maybe_suspend_for_outstanding_bash,
+        scope_discovered_gateway_definition, should_retry_turn_error, suspend_to_wait_for_bash,
         validate_explicit_activation_first_step,
     };
     use crate::project_context::{
@@ -3025,29 +3372,270 @@ mod tests {
         }
     }
 
-    fn native_client_search_item() -> bamboo_domain::ProviderTranscriptItem {
+    fn native_client_search_item_with_arguments(
+        call_id: &str,
+        arguments: serde_json::Value,
+    ) -> bamboo_domain::ProviderTranscriptItem {
         bamboo_domain::ProviderTranscriptItem::try_from_payload(
             bamboo_domain::ProviderFamily::OpenAi,
             bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
             bamboo_domain::ProviderTranscriptOrigin::Provider,
             bamboo_domain::ProviderTranscriptAuthor::Model,
             serde_json::json!({
-                "type":"tool_search_call","id":"tsc_pipeline_search_1","execution":"client","call_id":"search_1",
-                "status":"completed","arguments":{"query":"orders"}
+                "type":"tool_search_call","id":format!("tsc_pipeline_{call_id}"),
+                "execution":"client","call_id":call_id,
+                "status":"completed","arguments":arguments
             }),
         )
         .unwrap()
     }
 
+    fn native_client_search_item_for(
+        call_id: &str,
+        query: &str,
+    ) -> bamboo_domain::ProviderTranscriptItem {
+        native_client_search_item_with_arguments(call_id, serde_json::json!({"query":query}))
+    }
+
+    fn native_client_search_item() -> bamboo_domain::ProviderTranscriptItem {
+        native_client_search_item_for("search_1", "orders")
+    }
+
     fn loading_test_schema(name: &str) -> bamboo_agent_core::tools::ToolSchema {
+        loading_test_schema_with_description(name, "")
+    }
+
+    fn loading_test_schema_with_description(
+        name: &str,
+        description: &str,
+    ) -> bamboo_agent_core::tools::ToolSchema {
         bamboo_agent_core::tools::ToolSchema {
             schema_type: "function".to_string(),
             function: bamboo_agent_core::tools::FunctionSchema {
                 name: name.to_string(),
-                description: String::new(),
+                description: description.to_string(),
                 parameters: serde_json::json!({"type":"object"}),
             },
         }
+    }
+
+    #[test]
+    fn discovered_catalog_gateways_are_scoped_to_matching_ids_and_metadata() {
+        let skill_gateway =
+            bamboo_domain::ClassifiedToolSchema::new(bamboo_agent_core::tools::ToolSchema {
+                schema_type: "function".to_string(),
+                function: bamboo_agent_core::tools::FunctionSchema {
+                    name: "load_skill".to_string(),
+                    description: "Load one instruction Skill".to_string(),
+                    parameters: serde_json::json!({
+                        "type":"object",
+                        "properties":{
+                            "skill_id":{"type":"string"},
+                            "detail":{"type":"string"}
+                        },
+                        "required":["skill_id"]
+                    }),
+                },
+            })
+            .unwrap();
+        let skill_match = bamboo_domain::CapabilityMatch {
+            capability_ref: "skill:review-helper".to_string(),
+            kind: bamboo_domain::CapabilityKind::Skill,
+            display_name: "Review Helper".to_string(),
+            summary: "Review a change".to_string(),
+            source: bamboo_domain::CapabilitySource::User,
+            revision: Some(7),
+            status: bamboo_domain::CapabilityStatus::Valid,
+            invocation_policy: None,
+            invocation_target: bamboo_domain::CapabilityInvocationTarget::Skill {
+                name: "load_skill".to_string(),
+                skill_id: "review-helper".to_string(),
+                source: bamboo_domain::CapabilitySource::User,
+                revision: 7,
+            },
+        };
+        let second_skill_match = bamboo_domain::CapabilityMatch {
+            capability_ref: "skill:lint-helper".to_string(),
+            kind: bamboo_domain::CapabilityKind::Skill,
+            display_name: "Lint Helper".to_string(),
+            summary: "Run focused lint checks".to_string(),
+            source: bamboo_domain::CapabilitySource::Project,
+            revision: Some(3),
+            status: bamboo_domain::CapabilityStatus::Valid,
+            invocation_policy: None,
+            invocation_target: bamboo_domain::CapabilityInvocationTarget::Skill {
+                name: "load_skill".to_string(),
+                skill_id: "lint-helper".to_string(),
+                source: bamboo_domain::CapabilitySource::Project,
+                revision: 3,
+            },
+        };
+        let skill = scope_discovered_gateway_definition(
+            &skill_gateway,
+            &[&skill_match, &second_skill_match],
+        );
+        assert_eq!(
+            skill["parameters"]["properties"]["skill_id"]["enum"],
+            serde_json::json!(["review-helper", "lint-helper"])
+        );
+        assert!(!skill["parameters"]["properties"]["skill_id"]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("unmatched-skill")));
+        assert_eq!(
+            skill["parameters"]["properties"]["detail"]["type"], "string",
+            "the rest of the real gateway schema remains complete"
+        );
+        assert!(skill["description"]
+            .as_str()
+            .unwrap()
+            .contains("revision=7"));
+        assert!(skill["description"]
+            .as_str()
+            .unwrap()
+            .contains("source=user"));
+        let skill_description = skill["description"].as_str().unwrap();
+        let first_skill = skill_description
+            .find("review-helper — Review Helper — Review a change [revision=7, source=user]")
+            .unwrap();
+        let second_skill = skill_description
+            .find(
+                "lint-helper — Lint Helper — Run focused lint checks [revision=3, source=project]",
+            )
+            .unwrap();
+        assert!(
+            first_skill < second_skill,
+            "discovery relevance order is kept"
+        );
+
+        let workflow_gateway =
+            bamboo_domain::ClassifiedToolSchema::new(bamboo_agent_core::tools::ToolSchema {
+                schema_type: "function".to_string(),
+                function: bamboo_agent_core::tools::FunctionSchema {
+                    name: "workflow_run".to_string(),
+                    description: "Run a catalog Workflow".to_string(),
+                    parameters: serde_json::json!({
+                        "type":"object",
+                        "properties":{
+                            "action":{"type":"string","enum":["start","list"]},
+                            "workflow_id":{"type":"string"},
+                            "revision":{"type":"integer","minimum":1}
+                        },
+                        "required":["action"],
+                        "additionalProperties":false
+                    }),
+                },
+            })
+            .unwrap();
+        let workflow_match = bamboo_domain::CapabilityMatch {
+            capability_ref: "workflow:review-pipeline".to_string(),
+            kind: bamboo_domain::CapabilityKind::Workflow,
+            display_name: "Review Pipeline".to_string(),
+            summary: "Review a repository".to_string(),
+            source: bamboo_domain::CapabilitySource::Workspace,
+            revision: Some(9),
+            status: bamboo_domain::CapabilityStatus::Valid,
+            invocation_policy: None,
+            invocation_target: bamboo_domain::CapabilityInvocationTarget::Workflow {
+                name: "workflow_run".to_string(),
+                workflow_id: "review-pipeline".to_string(),
+                source: bamboo_domain::CapabilitySource::Workspace,
+                revision: 9,
+            },
+        };
+        let second_workflow_match = bamboo_domain::CapabilityMatch {
+            capability_ref: "workflow:lint-pipeline".to_string(),
+            kind: bamboo_domain::CapabilityKind::Workflow,
+            display_name: "Lint Pipeline".to_string(),
+            summary: "Lint the selected package".to_string(),
+            source: bamboo_domain::CapabilitySource::Project,
+            revision: Some(4),
+            status: bamboo_domain::CapabilityStatus::Valid,
+            invocation_policy: None,
+            invocation_target: bamboo_domain::CapabilityInvocationTarget::Workflow {
+                name: "workflow_run".to_string(),
+                workflow_id: "lint-pipeline".to_string(),
+                source: bamboo_domain::CapabilitySource::Project,
+                revision: 4,
+            },
+        };
+        let workflow = scope_discovered_gateway_definition(
+            &workflow_gateway,
+            &[&workflow_match, &second_workflow_match],
+        );
+        assert_eq!(
+            workflow["parameters"]["properties"]["workflow_id"]["enum"],
+            serde_json::json!(["review-pipeline", "lint-pipeline"])
+        );
+        assert_eq!(
+            workflow["parameters"]["properties"]["revision"]["enum"],
+            serde_json::json!([9, 4])
+        );
+        assert!(!workflow["parameters"]["properties"]["workflow_id"]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("unmatched-workflow")));
+        assert_eq!(
+            workflow["parameters"]["properties"]["action"]["enum"],
+            serde_json::json!(["start", "list"])
+        );
+        assert!(workflow["description"]
+            .as_str()
+            .unwrap()
+            .contains("revision=9"));
+        assert!(workflow["description"]
+            .as_str()
+            .unwrap()
+            .contains("source=workspace"));
+        let workflow_description = workflow["description"].as_str().unwrap();
+        let first_workflow = workflow_description
+            .find(
+                "review-pipeline — Review Pipeline — Review a repository [revision=9, source=workspace]",
+            )
+            .unwrap();
+        let second_workflow = workflow_description
+            .find(
+                "lint-pipeline — Lint Pipeline — Lint the selected package [revision=4, source=project]",
+            )
+            .unwrap();
+        assert!(
+            first_workflow < second_workflow,
+            "workflow relevance order is kept"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_search_filters_core_before_applying_the_result_limit() {
+        let tools = vec![
+            loading_test_schema_with_description("Read", "Read repository files"),
+            loading_test_schema_with_description("ReadArchive", "Read archived repository files"),
+        ];
+        let call = native_client_search_item_with_arguments(
+            "search_deferred_limit",
+            serde_json::json!({"query":"read","kinds":["tool"],"limit":1}),
+        );
+        let outputs = build_openai_client_tool_search_outputs(
+            &Session::new("deferred-before-limit", "gpt-5.6"),
+            &AgentLoopConfig::default(),
+            &tools,
+            &[call],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            outputs[0].payload()["tools"],
+            serde_json::json!([{
+                "type":"function",
+                "name":"ReadArchive",
+                "description":"Read archived repository files",
+                "parameters":{"type":"object","properties":{}},
+                "strict":false,
+                "defer_loading":true
+            }]),
+            "the initially visible Core candidate must not consume limit=1"
+        );
     }
 
     #[test]
@@ -3143,6 +3731,249 @@ mod tests {
         assert!(legacy_effective.contains_execution_name("Bash"));
         assert!(legacy_effective.contains_execution_name("get_weather"));
         assert!(legacy_effective.contains_execution_name("Glob"));
+    }
+
+    #[test]
+    fn openai_search_output_drives_progressive_membership_across_resume() {
+        const BOUNDARY: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let tools = vec![
+            loading_test_schema("Bash"),
+            loading_test_schema("search_orders"),
+            loading_test_schema("Glob"),
+        ];
+        let mut session = Session::new("openai-loaded-round", "gpt-5.6");
+        session
+            .activate_provider_transcript_route(
+                bamboo_domain::ProviderFamily::OpenAi,
+                bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+                BOUNDARY,
+            )
+            .unwrap();
+        let first = effective_callable_set_for_round(
+            &session,
+            &tools,
+            bamboo_domain::CapabilityLoadingMode::Progressive,
+        );
+        assert!(first.contains_execution_name("Bash"));
+        assert!(!first.contains_execution_name("search_orders"));
+
+        let assistant = Message::assistant("", None);
+        let anchor = assistant.id.clone();
+        session.add_message(assistant);
+        session
+            .append_provider_transcript_group(&anchor, None, vec![native_client_search_item()])
+            .unwrap();
+        let output = bamboo_domain::ProviderTranscriptItem::try_from_payload(
+            bamboo_domain::ProviderFamily::OpenAi,
+            bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+            bamboo_domain::ProviderTranscriptOrigin::HostToolSearch,
+            bamboo_domain::ProviderTranscriptAuthor::ToolResult,
+            serde_json::json!({
+                "type":"tool_search_output","execution":"client","call_id":"search_1",
+                "status":"completed","tools":[{
+                    "type":"function","name":"search_orders","description":"Search orders",
+                    "parameters":{"type":"object"},"strict":false,"defer_loading":true
+                }]
+            }),
+        )
+        .unwrap();
+        session
+            .append_provider_transcript_group(&anchor, None, vec![output])
+            .unwrap();
+
+        let loaded = effective_callable_set_for_round(
+            &session,
+            &tools,
+            bamboo_domain::CapabilityLoadingMode::Progressive,
+        );
+        assert!(loaded.contains_execution_name("Bash"));
+        assert!(loaded.contains_execution_name("search_orders"));
+        assert!(!loaded.contains_execution_name("Glob"));
+
+        let resumed: Session =
+            serde_json::from_value(serde_json::to_value(&session).unwrap()).unwrap();
+        let resumed_loaded = effective_callable_set_for_round(
+            &resumed,
+            &tools,
+            bamboo_domain::CapabilityLoadingMode::Progressive,
+        );
+        assert!(resumed_loaded.contains_execution_name("search_orders"));
+        assert!(!resumed_loaded.contains_execution_name("Glob"));
+    }
+
+    #[test]
+    fn hosted_search_output_enables_its_same_response_function_but_not_an_ordinary_call() {
+        const BOUNDARY: &str = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        let tools = vec![
+            loading_test_schema("Bash"),
+            loading_test_schema("search_orders"),
+            loading_test_schema("Glob"),
+        ];
+        let mut session = Session::new("openai-hosted-search", "gpt-5.6");
+        session
+            .activate_provider_transcript_route(
+                bamboo_domain::ProviderFamily::OpenAi,
+                bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+                BOUNDARY,
+            )
+            .unwrap();
+        let assistant = Message::assistant("", None);
+        let anchor = assistant.id.clone();
+        session.add_message(assistant);
+        let item = |author, payload| {
+            bamboo_domain::ProviderTranscriptItem::try_from_payload(
+                bamboo_domain::ProviderFamily::OpenAi,
+                bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+                bamboo_domain::ProviderTranscriptOrigin::Provider,
+                author,
+                payload,
+            )
+            .unwrap()
+        };
+        session
+            .append_provider_transcript_group(
+                &anchor,
+                None,
+                vec![
+                    item(
+                        bamboo_domain::ProviderTranscriptAuthor::Model,
+                        serde_json::json!({
+                            "type":"tool_search_call","id":"tsc_hosted","execution":"server",
+                            "call_id":"search_hosted","status":"completed",
+                            "arguments":{"query":"orders"}
+                        }),
+                    ),
+                    item(
+                        bamboo_domain::ProviderTranscriptAuthor::ToolResult,
+                        serde_json::json!({
+                            "type":"tool_search_output","id":"tso_hosted","execution":"server",
+                            "call_id":"search_hosted","status":"completed",
+                            "tools":[{"type":"function","name":"search_orders"}]
+                        }),
+                    ),
+                    item(
+                        bamboo_domain::ProviderTranscriptAuthor::Model,
+                        serde_json::json!({
+                            "type":"function_call","id":"fc_loaded","call_id":"call_loaded",
+                            "name":"search_orders","arguments":"{}","status":"completed"
+                        }),
+                    ),
+                    item(
+                        bamboo_domain::ProviderTranscriptAuthor::Model,
+                        serde_json::json!({
+                            "type":"function_call","id":"fc_ordinary","call_id":"call_ordinary",
+                            "name":"Glob","arguments":"{}","status":"completed"
+                        }),
+                    ),
+                ],
+            )
+            .unwrap();
+
+        let effective = effective_callable_set_for_round(
+            &session,
+            &tools,
+            bamboo_domain::CapabilityLoadingMode::Progressive,
+        );
+        assert!(effective.contains_execution_name("Bash"));
+        assert!(effective.contains_execution_name("search_orders"));
+        assert!(
+            !effective.contains_execution_name("Glob"),
+            "an ordinary function_call cannot manufacture loaded state"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_search_builds_host_output_and_commits_an_internal_next_round_boundary() {
+        const BOUNDARY: &str = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let tools = vec![
+            loading_test_schema("Read"),
+            loading_test_schema("search_orders"),
+            loading_test_schema("Glob"),
+        ];
+        let config = AgentLoopConfig::default();
+        let mut session = Session::new("client-search-next-round", "gpt-5.6");
+        session
+            .activate_provider_transcript_route(
+                bamboo_domain::ProviderFamily::OpenAi,
+                bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+                BOUNDARY,
+            )
+            .unwrap();
+        let call = native_client_search_item();
+        let outputs = build_openai_client_tool_search_outputs(
+            &session,
+            &config,
+            &tools,
+            std::slice::from_ref(&call),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].payload()["type"], "tool_search_output");
+        assert_eq!(outputs[0].payload()["execution"], "client");
+        assert_eq!(outputs[0].payload()["call_id"], "search_1");
+        assert_eq!(outputs[0].payload()["status"], "completed");
+        let discovered = outputs[0].payload()["tools"].as_array().unwrap();
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0]["name"], "search_orders");
+        assert_eq!(discovered[0]["strict"], false);
+        assert_eq!(discovered[0]["defer_loading"], true);
+
+        let empty_call = native_client_search_item_for("search_empty", "zzqxvplmn");
+        let empty_outputs = build_openai_client_tool_search_outputs(
+            &session,
+            &config,
+            &tools,
+            std::slice::from_ref(&empty_call),
+        )
+        .await
+        .unwrap();
+        assert_eq!(empty_outputs.len(), 1);
+        assert_eq!(empty_outputs[0].payload()["call_id"], "search_empty");
+        assert_eq!(
+            empty_outputs[0].payload()["tools"],
+            serde_json::json!([]),
+            "an empty discovery result remains an explicit completed tools array"
+        );
+
+        let stream_output = crate::runtime::stream::handler::StreamHandlingOutput {
+            response_id: Some("resp_client_search".to_string()),
+            content: String::new(),
+            reasoning_content: String::new(),
+            reasoning_signature: None,
+            token_count: 0,
+            tool_calls: Vec::new(),
+            output_tokens: 0,
+            thinking_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            provider_usage: None,
+            input_tokens: 0,
+            provider_transcript_items: vec![call],
+        };
+        commit_openai_client_tool_search_round(stream_output, &mut session, &config, &tools)
+            .await
+            .unwrap();
+
+        assert_eq!(session.messages.len(), 1);
+        let groups = session.provider_transcript.replayable_groups(
+            bamboo_domain::ProviderFamily::OpenAi,
+            bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+            BOUNDARY,
+        );
+        assert_eq!(groups.len(), 2, "provider call then host output");
+        assert_eq!(groups[0].anchor_message_id(), groups[1].anchor_message_id());
+        assert_eq!(groups[0].items()[0].payload()["type"], "tool_search_call");
+        assert_eq!(groups[1].items()[0].payload()["type"], "tool_search_output");
+
+        let effective = effective_callable_set_for_round(
+            &session,
+            &tools,
+            bamboo_domain::CapabilityLoadingMode::Progressive,
+        );
+        assert!(effective.contains_execution_name("Read"));
+        assert!(effective.contains_execution_name("search_orders"));
+        assert!(!effective.contains_execution_name("Glob"));
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
@@ -27,6 +27,17 @@ pub(in crate::runtime::runner) use stream_execution::{
     effective_tool_schemas, required_tool_for_session,
 };
 
+pub(in crate::runtime::runner) fn is_openai_client_tool_search_boundary(
+    items: &[bamboo_domain::ProviderTranscriptItem],
+) -> bool {
+    items.iter().any(|item| {
+        item.family() == bamboo_domain::ProviderFamily::OpenAi
+            && item.protocol() == bamboo_domain::ProviderProtocol::OpenAiResponsesV1
+            && item.kind() == bamboo_domain::ProviderTranscriptItemKind::OpenAiToolSearchCall
+            && item.payload()["execution"].as_str() == Some("client")
+    })
+}
+
 pub(crate) struct RoundLlmExecutionOutput {
     pub stream_output: StreamHandlingOutput,
     pub prompt_tokens: u64,
@@ -126,11 +137,14 @@ pub(crate) async fn execute_llm_round(
     // This is a terminal validation error, but the completed stream was still
     // billed. Return it alongside the canonical attempt usage so the runner can
     // account for the attempt before ending the round.
+    let openai_client_search_boundary =
+        is_openai_client_tool_search_boundary(&stream_output.provider_transcript_items);
     let terminal_validation_error = (stream_output.tool_calls.is_empty()
-        && stream_output.content.trim().is_empty())
-    .then(|| AgentError::EmptyAssistantResponse {
-        response_id: stream_output.response_id.clone(),
-    });
+        && stream_output.content.trim().is_empty()
+        && !openai_client_search_boundary)
+        .then(|| AgentError::EmptyAssistantResponse {
+            response_id: stream_output.response_id.clone(),
+        });
 
     let prompt_tokens = estimate_prompt_tokens(&prepared.prepared_context.messages);
     let completion_tokens =
@@ -176,4 +190,39 @@ pub(crate) async fn maybe_apply_mid_turn_context_compression(
         "mid-turn",
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_openai_client_tool_search_boundary;
+    use bamboo_domain::{
+        ProviderFamily, ProviderProtocol, ProviderTranscriptAuthor, ProviderTranscriptItem,
+        ProviderTranscriptOrigin,
+    };
+    use serde_json::json;
+
+    fn client_search_item(family: ProviderFamily) -> ProviderTranscriptItem {
+        ProviderTranscriptItem::try_from_payload(
+            family,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::Provider,
+            ProviderTranscriptAuthor::Model,
+            json!({
+                "type":"tool_search_call","id":"tsc_boundary","execution":"client",
+                "call_id":"search_boundary","status":"completed",
+                "arguments":{"query":"files"}
+            }),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn client_search_boundary_is_exactly_openai_responses() {
+        assert!(is_openai_client_tool_search_boundary(&[
+            client_search_item(ProviderFamily::OpenAi)
+        ]));
+        assert!(!is_openai_client_tool_search_boundary(&[
+            client_search_item(ProviderFamily::Copilot)
+        ]));
+    }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
@@ -157,6 +157,23 @@ impl SkillResourceScope {
     }
 }
 
+/// Resolve the same Project/workspace-aware catalog store used by Skill
+/// activation so native client tool search cannot drift onto the global store.
+pub(crate) async fn resolve_skill_store_for_session(
+    config: &AgentLoopConfig,
+    session: &Session,
+) -> Result<Option<std::sync::Arc<bamboo_skills::SkillStore>>, String> {
+    let Some(skill_manager) = config.skill_manager.as_deref() else {
+        return Ok(None);
+    };
+    let scope = SkillResourceScope::resolve(config, session).await?;
+    scope
+        .store(skill_manager)
+        .await
+        .map(Some)
+        .map_err(|error| format!("Failed to resolve capability discovery store: {error}"))
+}
+
 #[derive(Debug, Clone, Default)]
 pub(super) struct SkillContextLoadResult {
     pub(super) context: String,

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -166,6 +166,17 @@ pub async fn create_provider_from_instance(
                     provider.with_responses_only_models(instance.responses_only_models.clone());
             }
 
+            let tool_search_execution = instance
+                .extra
+                .get("tool_search_execution")
+                .and_then(serde_json::Value::as_str)
+                .and_then(
+                    crate::providers::common::openai_responses::ResponsesToolSearchExecution::from_config,
+                );
+            if let Some(tool_search_execution) = tool_search_execution {
+                provider = provider.with_tool_search_execution(tool_search_execution);
+            }
+
             provider = provider.with_reasoning_effort(instance.reasoning_effort);
             provider = provider.with_explicit_prompt_cache(
                 instance
@@ -548,6 +559,49 @@ mod tests {
 
         let result = create_provider(&config).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn openai_tool_search_execution_requires_a_valid_explicit_instance_value() {
+        for (execution, expected) in [
+            (
+                None,
+                bamboo_domain::CapabilityLoadingMode::LegacyFullCatalog,
+            ),
+            (
+                Some("invalid"),
+                bamboo_domain::CapabilityLoadingMode::LegacyFullCatalog,
+            ),
+            (
+                Some("client"),
+                bamboo_domain::CapabilityLoadingMode::Progressive,
+            ),
+            (
+                Some("server"),
+                bamboo_domain::CapabilityLoadingMode::Progressive,
+            ),
+        ] {
+            let mut value = serde_json::json!({
+                "provider_type":"openai",
+                "api_key":"sk-test",
+                "base_url":"https://api.openai.com/v1",
+                "responses_only_models":["gpt-5*"],
+                "enabled":true
+            });
+            if let Some(execution) = execution {
+                value["tool_search_execution"] = serde_json::json!(execution);
+            }
+            let instance: ProviderInstanceConfig = serde_json::from_value(value).unwrap();
+            let provider =
+                create_provider_from_instance(&Config::default(), &instance, std::env::temp_dir())
+                    .await
+                    .unwrap();
+            assert_eq!(
+                provider.capability_loading_mode("gpt-5.6", None).await,
+                expected,
+                "execution={execution:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -12,8 +12,9 @@ use bamboo_domain::MessagePart;
 use bamboo_domain::ReasoningEffort;
 use bamboo_domain::ToolSchema;
 use bamboo_domain::{
-    Message, MessagePhase, ProviderFamily, ProviderProtocol, ProviderTranscriptAuthor,
-    ProviderTranscriptGroup, ProviderTranscriptItem, ProviderTranscriptOrigin, Role,
+    CapabilityLoadingClass, CapabilityLoadingMode, ClassifiedToolSchema, Message, MessagePhase,
+    ProviderFamily, ProviderProtocol, ProviderTranscriptAuthor, ProviderTranscriptGroup,
+    ProviderTranscriptItem, ProviderTranscriptOrigin, Role,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -24,6 +25,25 @@ const WIRE_TRACKER_KEY_DOMAIN: &[u8] = b"bamboo/responses-wire-tracker-key/v1\0"
 const WIRE_TOP_LEVEL_DOMAIN: &[u8] = b"bamboo/responses-wire-top-level/v1\0";
 const WIRE_INPUT_PREFIX_DOMAIN: &[u8] = b"bamboo/responses-wire-input-prefix/v1\0";
 const MAX_WIRE_TRACKER_FAMILIES: usize = 1024;
+
+/// Who executes OpenAI's native Responses tool-search gateway.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponsesToolSearchExecution {
+    Client,
+    Server,
+}
+
+impl ResponsesToolSearchExecution {
+    pub fn from_config(value: &str) -> Option<Self> {
+        if value.eq_ignore_ascii_case("client") {
+            Some(Self::Client)
+        } else if value.eq_ignore_ascii_case("server") {
+            Some(Self::Server)
+        } else {
+            None
+        }
+    }
+}
 
 /// Convert internal [`Message`] values to a Responses API `input` array.
 ///
@@ -404,6 +424,92 @@ pub fn tools_to_responses_json(tools: &[ToolSchema]) -> Vec<Value> {
         .collect()
 }
 
+fn tool_to_progressive_responses_json(
+    tool: &ToolSchema,
+    loading_class: CapabilityLoadingClass,
+) -> Value {
+    let mut value = json!({
+        "type": tool.schema_type,
+        "name": tool.function.name,
+        "description": tool.function.description,
+        "parameters": sanitize_openai_function_parameters_schema(&tool.function.parameters),
+        "strict": false,
+    });
+    if loading_class == CapabilityLoadingClass::Deferred {
+        value["defer_loading"] = Value::Bool(true);
+    }
+    value
+}
+
+/// Lower one discovered Bamboo function into the complete definition required
+/// by a client-executed `tool_search_output` item.
+pub fn loaded_tool_to_responses_json(tool: &ToolSchema) -> Value {
+    tool_to_progressive_responses_json(tool, CapabilityLoadingClass::Deferred)
+}
+
+fn responses_tool_search_json(execution: ResponsesToolSearchExecution) -> Value {
+    match execution {
+        ResponsesToolSearchExecution::Server => json!({
+            "type": "tool_search",
+            "execution": "server",
+        }),
+        ResponsesToolSearchExecution::Client => json!({
+            "type": "tool_search",
+            "execution": "client",
+            "description": "Search the current Bamboo tool, Skill, and Workflow catalog by capability.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "maxLength": bamboo_domain::MAX_DISCOVERY_QUERY_CHARS,
+                        "description": "Short capability query, such as git status, browser testing, or release workflow."
+                    },
+                    "kinds": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["tool", "skill", "workflow"]}
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": bamboo_domain::MAX_DISCOVERY_RESULTS
+                    }
+                },
+                "required": ["query"],
+                "additionalProperties": false
+            }
+        }),
+    }
+}
+
+/// Project Bamboo's classified catalog into OpenAI Responses progressive
+/// loading. Hosted search receives the full eligible catalog with Deferred
+/// functions marked; client search receives only Core functions. The search
+/// gateway itself is always present and never deferred.
+pub fn tools_to_progressive_responses_json(
+    tools: &[ToolSchema],
+    execution: ResponsesToolSearchExecution,
+) -> Vec<Value> {
+    let mut projected = tools
+        .iter()
+        .filter_map(|tool| {
+            let classified = ClassifiedToolSchema::new(tool.clone())?;
+            let loading_class = classified.loading_class();
+            let visible = match execution {
+                ResponsesToolSearchExecution::Client => {
+                    loading_class == CapabilityLoadingClass::Core
+                }
+                ResponsesToolSearchExecution::Server => {
+                    loading_class != CapabilityLoadingClass::HostOnly
+                }
+            };
+            visible.then(|| tool_to_progressive_responses_json(tool, loading_class))
+        })
+        .collect::<Vec<_>>();
+    projected.push(responses_tool_search_json(execution));
+    projected
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponsesInputSource {
     Explicit,
@@ -487,6 +593,36 @@ pub fn build_responses_body(
     parallel_tool_calls: Option<bool>,
     cache_plan: Option<&PromptCachePlan>,
 ) -> Value {
+    build_responses_body_with_capability_loading(
+        model,
+        messages,
+        tools,
+        max_output_tokens,
+        reasoning_effort,
+        responses_options,
+        parallel_tool_calls,
+        cache_plan,
+        CapabilityLoadingMode::LegacyFullCatalog,
+        ResponsesToolSearchExecution::Client,
+    )
+}
+
+/// Build a Responses request with an explicit provider-native capability
+/// loading projection. The legacy wrapper above remains byte-compatible for
+/// direct callers and compatibility fallbacks.
+#[allow(clippy::too_many_arguments)]
+pub fn build_responses_body_with_capability_loading(
+    model: &str,
+    messages: &[Message],
+    tools: &[ToolSchema],
+    max_output_tokens: Option<u32>,
+    reasoning_effort: Option<ReasoningEffort>,
+    responses_options: Option<&ResponsesRequestOptions>,
+    parallel_tool_calls: Option<bool>,
+    cache_plan: Option<&PromptCachePlan>,
+    capability_loading_mode: CapabilityLoadingMode,
+    tool_search_execution: ResponsesToolSearchExecution,
+) -> Value {
     let instructions = responses_options
         .and_then(|opts| opts.instructions.as_deref())
         .map(str::trim)
@@ -537,8 +673,14 @@ pub fn build_responses_body(
         body["previous_response_id"] = json!(previous_response_id);
     }
 
-    if !tools.is_empty() {
-        body["tools"] = json!(tools_to_responses_json(tools));
+    let projected_tools = match capability_loading_mode {
+        CapabilityLoadingMode::LegacyFullCatalog => tools_to_responses_json(tools),
+        CapabilityLoadingMode::Progressive => {
+            tools_to_progressive_responses_json(tools, tool_search_execution)
+        }
+    };
+    if !projected_tools.is_empty() {
+        body["tools"] = json!(projected_tools);
         // Best-effort default; upstreams may ignore/override.
         body["tool_choice"] = json!("auto");
     }
@@ -3009,6 +3151,91 @@ mod tests {
         assert_eq!(out[0]["description"], "Search things");
         assert!(out[0].get("function").is_none());
         assert!(out[0].get("parameters").is_some());
+    }
+
+    fn loading_schema(name: &str) -> ToolSchema {
+        ToolSchema {
+            schema_type: "function".to_string(),
+            function: FunctionSchema {
+                name: name.to_string(),
+                description: format!("Use {name}"),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}}
+                }),
+            },
+        }
+    }
+
+    #[test]
+    fn progressive_server_tools_keep_full_eligible_catalog_and_defer_non_core() {
+        let tools = vec![
+            loading_schema("Read"),
+            loading_schema("Glob"),
+            loading_schema("Workspace"),
+        ];
+        let out = tools_to_progressive_responses_json(&tools, ResponsesToolSearchExecution::Server);
+
+        assert_eq!(out.len(), 3, "Read + Glob + non-deferred search");
+        assert_eq!(out[0]["name"], "Read");
+        assert!(out[0].get("defer_loading").is_none());
+        assert_eq!(out[1]["name"], "Glob");
+        assert_eq!(out[1]["defer_loading"], true);
+        assert_eq!(out[2]["type"], "tool_search");
+        assert_eq!(out[2]["execution"], "server");
+        assert!(out[2].get("description").is_none());
+        assert!(out[2].get("parameters").is_none());
+        assert!(out[2].get("defer_loading").is_none());
+        assert!(out.iter().all(|tool| tool["name"] != "Workspace"));
+    }
+
+    #[test]
+    fn progressive_client_tools_are_sticky_core_plus_search_only() {
+        let tools = vec![
+            loading_schema("Read"),
+            loading_schema("Glob"),
+            loading_schema("Workspace"),
+        ];
+        let body = build_responses_body_with_capability_loading(
+            "gpt-5.6",
+            &[Message::user("find files")],
+            &tools,
+            None,
+            None,
+            None,
+            None,
+            None,
+            CapabilityLoadingMode::Progressive,
+            ResponsesToolSearchExecution::Client,
+        );
+        let projected = body["tools"].as_array().unwrap();
+
+        assert_eq!(projected.len(), 2);
+        assert_eq!(projected[0]["name"], "Read");
+        assert_eq!(projected[1]["type"], "tool_search");
+        assert_eq!(projected[1]["execution"], "client");
+        assert!(projected[1]["description"].is_string());
+        assert_eq!(projected[1]["parameters"]["required"], json!(["query"]));
+        assert_eq!(
+            projected[1]["parameters"]["properties"]["query"]["maxLength"],
+            bamboo_domain::MAX_DISCOVERY_QUERY_CHARS
+        );
+        assert_eq!(
+            projected[1]["parameters"]["properties"]["limit"]["maximum"],
+            bamboo_domain::MAX_DISCOVERY_RESULTS
+        );
+        assert!(projected.iter().all(|tool| tool["name"] != "Glob"));
+        assert!(projected.iter().all(|tool| tool["name"] != "Workspace"));
+    }
+
+    #[test]
+    fn discovered_client_function_definition_is_complete_and_remains_deferred() {
+        let loaded = loaded_tool_to_responses_json(&loading_schema("Glob"));
+        assert_eq!(loaded["type"], "function");
+        assert_eq!(loaded["name"], "Glob");
+        assert_eq!(loaded["strict"], false);
+        assert_eq!(loaded["defer_loading"], true);
+        assert!(loaded["parameters"].is_object());
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -10,15 +10,14 @@ use reqwest::{
 };
 use serde_json::{json, Value};
 
+use crate::prompt_ir::PromptIR;
 use crate::provider::{
     required_tool_from_options, LLMError, LLMProvider, LLMRequestOptions, LLMStream,
     ResponsesRequestOptions, Result,
 };
 use crate::types::LLMChunk;
 use bamboo_config::{KeywordMaskingConfig, RequestOverridesConfig};
-use bamboo_domain::Message;
-use bamboo_domain::ReasoningEffort;
-use bamboo_domain::ToolSchema;
+use bamboo_domain::{CapabilityLoadingMode, Message, ReasoningEffort, ToolSchema};
 
 use super::common::model_fetcher;
 use super::common::openai_compat::{
@@ -26,8 +25,9 @@ use super::common::openai_compat::{
     parse_openai_compat_sse_data_strict_multi,
 };
 use super::common::openai_responses::{
-    build_responses_body, retain_provider_transcript_family, select_responses_input_messages,
-    ResponsesInputSource, ResponsesSseParser, ResponsesWirePrefixTracker,
+    build_responses_body_with_capability_loading, retain_provider_transcript_family,
+    select_responses_input_messages, ResponsesInputSource, ResponsesSseParser,
+    ResponsesToolSearchExecution, ResponsesWirePrefixTracker,
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
@@ -39,6 +39,7 @@ pub struct OpenAIProvider {
     api_key: String,
     base_url: String,
     responses_only_models: Vec<String>,
+    tool_search_execution: Option<ResponsesToolSearchExecution>,
     default_reasoning_effort: Option<ReasoningEffort>,
     explicit_prompt_cache: bool,
     request_overrides: Option<RequestOverridesConfig>,
@@ -54,6 +55,7 @@ impl OpenAIProvider {
             api_key: api_key.into(),
             base_url: "https://api.openai.com/v1".to_string(),
             responses_only_models: vec![],
+            tool_search_execution: None,
             default_reasoning_effort: None,
             explicit_prompt_cache: true,
             request_overrides: None,
@@ -84,6 +86,13 @@ impl OpenAIProvider {
     /// Configure models that must use Responses API upstream.
     pub fn with_responses_only_models(mut self, models: Vec<String>) -> Self {
         self.responses_only_models = models;
+        self
+    }
+
+    /// Select whether native Responses tool search runs at OpenAI or in Bamboo.
+    /// Leaving this unset keeps the provider on the legacy full-catalog path.
+    pub fn with_tool_search_execution(mut self, execution: ResponsesToolSearchExecution) -> Self {
+        self.tool_search_execution = Some(execution);
         self
     }
 
@@ -189,6 +198,12 @@ impl OpenAIProvider {
             .any(|p| Self::matches_model_pattern(p, model))
     }
 
+    fn is_official_base_url(&self) -> bool {
+        let normalized = self.base_url.trim_end_matches('/');
+        normalized.eq_ignore_ascii_case("https://api.openai.com")
+            || normalized.eq_ignore_ascii_case("https://api.openai.com/v1")
+    }
+
     fn looks_like_responses_only_error(status: reqwest::StatusCode, body: &str) -> bool {
         if !(status == 400
             || status == 404
@@ -224,6 +239,7 @@ impl OpenAIProvider {
         reasoning_source: &str,
         request_purpose: &str,
         session_log_id: &str,
+        capability_loading_mode: CapabilityLoadingMode,
     ) -> Result<LLMStream> {
         let mut effective_responses_options = responses_options.cloned();
         if let Some(options) = effective_responses_options.as_mut() {
@@ -238,7 +254,10 @@ impl OpenAIProvider {
             ResponsesInputSource::Generic => "generic",
         };
         let generated_cache_plan = self.explicit_prompt_cache.then_some(cache_plan).flatten();
-        let mut body = build_responses_body(
+        let tool_search_execution = self
+            .tool_search_execution
+            .unwrap_or(ResponsesToolSearchExecution::Client);
+        let mut body = build_responses_body_with_capability_loading(
             model,
             messages,
             tools,
@@ -247,6 +266,8 @@ impl OpenAIProvider {
             responses_options,
             parallel_tool_calls,
             generated_cache_plan,
+            capability_loading_mode,
+            tool_search_execution,
         );
         request_overrides::apply_overrides_to_body(
             &mut body,
@@ -323,7 +344,7 @@ impl OpenAIProvider {
 
                 let mut fallback_options = responses_options.cloned().unwrap_or_default();
                 fallback_options.previous_response_id = None;
-                let mut fallback_body = build_responses_body(
+                let mut fallback_body = build_responses_body_with_capability_loading(
                     model,
                     messages,
                     tools,
@@ -332,6 +353,8 @@ impl OpenAIProvider {
                     Some(&fallback_options),
                     parallel_tool_calls,
                     generated_cache_plan,
+                    capability_loading_mode,
+                    tool_search_execution,
                 );
                 request_overrides::apply_overrides_to_body(
                     &mut fallback_body,
@@ -400,7 +423,7 @@ impl OpenAIProvider {
 
                 let mut fallback_options = responses_options.cloned().unwrap_or_default();
                 fallback_options.reasoning_summary = None;
-                let mut fallback_body = build_responses_body(
+                let mut fallback_body = build_responses_body_with_capability_loading(
                     model,
                     messages,
                     tools,
@@ -409,6 +432,8 @@ impl OpenAIProvider {
                     Some(&fallback_options),
                     parallel_tool_calls,
                     generated_cache_plan,
+                    capability_loading_mode,
+                    tool_search_execution,
                 );
                 request_overrides::apply_overrides_to_body(
                     &mut fallback_body,
@@ -487,6 +512,22 @@ impl OpenAIProvider {
 
 #[async_trait]
 impl LLMProvider for OpenAIProvider {
+    async fn capability_loading_mode(
+        &self,
+        model: &str,
+        required_tool: Option<&str>,
+    ) -> CapabilityLoadingMode {
+        if required_tool.is_none()
+            && self.tool_search_execution.is_some()
+            && self.is_official_base_url()
+            && self.uses_responses_api(model)
+        {
+            CapabilityLoadingMode::Progressive
+        } else {
+            CapabilityLoadingMode::LegacyFullCatalog
+        }
+    }
+
     async fn chat_stream(
         &self,
         messages: &[Message],
@@ -498,11 +539,74 @@ impl LLMProvider for OpenAIProvider {
             .await
     }
 
-    // No `chat_stream_ir` override: the trait default derives the Responses-API
-    // view (input array / instructions / previous_response_id) from the canonical
-    // IR via `PromptIR::responses_request_options` and routes it through
-    // `chat_stream_with_options` below — which dispatches to /responses for
-    // Responses-only models and chat/completions otherwise.
+    async fn chat_stream_ir(
+        &self,
+        ir: &PromptIR,
+        tools: &[ToolSchema],
+        max_output_tokens: Option<u32>,
+        model: &str,
+        options: Option<&LLMRequestOptions>,
+    ) -> Result<LLMStream> {
+        let messages = if ir.continuation.is_some() {
+            ir.continuation_delta()
+        } else {
+            ir.flatten()
+        };
+        let mut effective_options = options.cloned().unwrap_or_default();
+        effective_options.responses =
+            Some(ir.responses_request_options(effective_options.responses.as_ref()));
+
+        // Chat-Completions models keep the existing route. If that route later
+        // falls back to /responses after an upstream error, it also deliberately
+        // stays Legacy because the model was not explicitly configured for the
+        // native search contract.
+        if !self.uses_responses_api(model) {
+            return self
+                .chat_stream_with_options(
+                    &messages,
+                    tools,
+                    max_output_tokens,
+                    model,
+                    Some(&effective_options),
+                )
+                .await;
+        }
+
+        let reasoning_effort = effective_options
+            .reasoning_effort
+            .or(self.default_reasoning_effort);
+        let required_tool = required_tool_from_options(Some(&effective_options), tools)?;
+        let capability_loading_mode = self.capability_loading_mode(model, required_tool).await;
+        let reasoning_source = if effective_options.reasoning_effort.is_some() {
+            "request"
+        } else if self.default_reasoning_effort.is_some() {
+            "provider_default"
+        } else {
+            "none"
+        };
+        self.chat_stream_via_responses(
+            &messages,
+            tools,
+            max_output_tokens,
+            model,
+            reasoning_effort,
+            effective_options.responses.as_ref(),
+            effective_options.parallel_tool_calls,
+            effective_options.cache.as_ref(),
+            required_tool,
+            reasoning_source,
+            effective_options
+                .request_purpose
+                .as_deref()
+                .unwrap_or("unknown"),
+            effective_options
+                .session_id
+                .as_deref()
+                .unwrap_or("unknown-session"),
+            capability_loading_mode,
+        )
+        .await
+    }
 
     async fn chat_stream_with_options(
         &self,
@@ -550,6 +654,7 @@ impl LLMProvider for OpenAIProvider {
                     reasoning_source,
                     request_purpose,
                     session_log_id,
+                    CapabilityLoadingMode::LegacyFullCatalog,
                 )
                 .await;
         }
@@ -685,6 +790,7 @@ impl LLMProvider for OpenAIProvider {
                         reasoning_source,
                         request_purpose,
                         session_log_id,
+                        CapabilityLoadingMode::LegacyFullCatalog,
                     )
                     .await;
             }
@@ -814,6 +920,62 @@ mod tests {
         assert!(provider.uses_responses_api("gpt-5.3-codex"));
         assert!(provider.uses_responses_api("gpt-5.0-any"));
         assert!(!provider.uses_responses_api("gpt-4o-mini"));
+    }
+
+    #[tokio::test]
+    async fn progressive_loading_requires_official_explicit_responses_route_without_forcing() {
+        let official =
+            || OpenAIProvider::new("k").with_responses_only_models(vec!["gpt-5*".to_string()]);
+        assert_eq!(
+            official().capability_loading_mode("gpt-5.6", None).await,
+            CapabilityLoadingMode::LegacyFullCatalog,
+            "progressive loading requires explicit execution opt-in"
+        );
+        let client = official().with_tool_search_execution(ResponsesToolSearchExecution::Client);
+        assert_eq!(
+            client.capability_loading_mode("gpt-5.6", None).await,
+            CapabilityLoadingMode::Progressive
+        );
+        assert_eq!(
+            client
+                .capability_loading_mode("gpt-5.6", Some("load_skill"))
+                .await,
+            CapabilityLoadingMode::LegacyFullCatalog
+        );
+        assert_eq!(
+            client.capability_loading_mode("gpt-4o-mini", None).await,
+            CapabilityLoadingMode::LegacyFullCatalog
+        );
+        let server = official().with_tool_search_execution(ResponsesToolSearchExecution::Server);
+        assert_eq!(
+            server.capability_loading_mode("gpt-5.6", None).await,
+            CapabilityLoadingMode::Progressive
+        );
+
+        let custom = OpenAIProvider::new("k")
+            .with_base_url("https://proxy.example/v1")
+            .with_responses_only_models(vec!["gpt-5*".to_string()])
+            .with_tool_search_execution(ResponsesToolSearchExecution::Client);
+        assert_eq!(
+            custom.capability_loading_mode("gpt-5.6", None).await,
+            CapabilityLoadingMode::LegacyFullCatalog
+        );
+    }
+
+    #[test]
+    fn client_or_server_tool_search_must_be_explicitly_configured() {
+        let unset = OpenAIProvider::new("k");
+        assert_eq!(unset.tool_search_execution, None);
+        let client = unset.with_tool_search_execution(ResponsesToolSearchExecution::Client);
+        assert_eq!(
+            client.tool_search_execution,
+            Some(ResponsesToolSearchExecution::Client)
+        );
+        let server = client.with_tool_search_execution(ResponsesToolSearchExecution::Server);
+        assert_eq!(
+            server.tool_search_execution,
+            Some(ResponsesToolSearchExecution::Server)
+        );
     }
 
     // ===== Request Building Tests (4 tests) =====


### PR DESCRIPTION
## Summary

- add provider-native OpenAI Responses `tool_search` lowering for hosted and client execution
- keep client top-level tools sticky at Core + search while returning complete discovered definitions through typed `tool_search_output` items
- derive loaded capability state only from validated search outputs across later rounds and resume
- require explicit `extra.tool_search_execution = client|server`; missing or invalid values remain on the legacy full-catalog path
- preserve bounded Skill/Workflow match identity, summary, revision, source, and relevance order

Closes #969

## Test Plan

- `cargo test -p bamboo-domain -p bamboo-llm -p bamboo-engine --lib` (2,333 passed)
- `cargo clippy -p bamboo-domain -p bamboo-llm --all-targets --no-deps -- -D warnings`
- `cargo clippy -p bamboo-engine --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/dev`
- focused fixtures cover hosted/client lowering, explicit capability opt-in, Core-before-top-k filtering, typed continuation/replay, resume, loaded/unloaded invocation, and Skill/Workflow match ordering

## Screenshots

Not applicable; backend protocol change only.