### PR TITLE
docs: correct runtime and Zenith README boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ### The local-first AI agent runtime, in Rust.
 
-**Persistent memory, 22 built-in tools, skills, MCP, workflows & schedules — behind one HTTP + SSE API.**
+**Persistent memory, 22 built-in tools, skills, MCP, workflows & schedules — behind HTTP + WebSocket + SSE APIs.**
 Run it as a server, or embed the same agent loop as a Rust crate. Your data stays on your machine.
 
 [![Crates.io](https://img.shields.io/crates/v/bamboo-agent.svg?logo=rust)](https://crates.io/crates/bamboo-agent)
 [![docs.rs](https://img.shields.io/docsrs/bamboo-agent?logo=docsdotrs&label=docs.rs)](https://docs.rs/bamboo-agent)
-[![CI](https://img.shields.io/github/actions/workflow/status/bigduu/Bamboo-agent/ci.yml?branch=main&logo=github&label=CI)](https://github.com/bigduu/Bamboo-agent/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/bigduu/Bamboo-agent/ci.yml?branch=dev&logo=github&label=CI)](https://github.com/bigduu/Bamboo-agent/actions/workflows/ci.yml)
 [![License MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![中文 README](https://img.shields.io/badge/lang-中文-red)](./README.zh-CN.md)
 
@@ -37,7 +37,7 @@ If Bodhi is the AI product you see, **Bamboo is the engine running underneath it
 | 🎯 **Skills** | Optional/discoverable skills with lightweight selection based on request hints, including built-in docx / pdf / pptx / xlsx / skill-creator |
 | 🔌 **MCP** | Model Context Protocol client that hooks into external tool servers |
 | ⏰ **Workflows & schedules** | Declarative workflow loading + a cron-style schedule trigger engine |
-| 🌐 **HTTP / SSE** | Actix server, REST API, Server-Sent Events streaming, compatible with OpenAI / Anthropic / Gemini endpoints |
+| 🌐 **HTTP / WebSocket / SSE** | Actix server, REST API, shared `/v2/stream` WebSocket, legacy SSE feeds, and OpenAI / Anthropic / Gemini-compatible endpoints |
 | 🏗️ **Multi-provider** | anthropic (default), openai, gemini, copilot, bodhi routing |
 
 ---
@@ -48,7 +48,7 @@ Bamboo is a Cargo **workspace**: a thin root binary (`bamboo-agent`, which expos
 
 ```mermaid
 graph TD
-  CLI["bamboo (root bin)<br/>serve / config / -p headless / actor / broker"] --> SRV[bamboo-server<br/>Actix HTTP + SSE, routes, schedules, workflows]
+  CLI["bamboo (root bin)<br/>serve / config / -p headless / actor / broker"] --> SRV[bamboo-server<br/>Actix HTTP + WebSocket + SSE, routes, schedules, workflows]
   SRV --> ENG[bamboo-engine<br/>agent runtime, auto-dream, gardener, metrics]
   ENG --> CORE[bamboo-agent-core<br/>core abstractions]
   CORE --> DOM[bamboo-domain<br/>pure domain types]
@@ -75,7 +75,7 @@ graph TD
 
 …plus the root `bamboo-agent` binary.
 
-**Place in the Zenith stack:** lotus (the React UI) and bamboo communicate over **HTTP**; bodhi (the Tauri shell) is just the container that hosts the interface. Bamboo is the execution engine, and bodhi-server (Go) handles accounts/persistence/billing and the LLM proxy.
+**Place in the Zenith stack:** Bodhi is the Tauri desktop shell that starts or reuses a local `bamboo serve`, waits for `GET /api/v1/health`, and manages the sidecar lifecycle. In packaged builds, Bamboo serves the embedded Lotus frontend. Lotus sends requests over HTTP and receives live events through one shared `/v2/stream` WebSocket by default; the legacy account and session SSE feeds are fallbacks when the v2 transport is explicitly disabled or its initial WebSocket connection cannot be established. Bamboo remains the execution engine. `bodhi-server` is a separate, optional hosted account and provider path; the local Bodhi → Bamboo → Lotus path does not require it.
 
 ---
 
@@ -165,7 +165,7 @@ Arguments supported by `bamboo serve` (all override the config file):
 
 | Command | What it does |
 |---|---|
-| `bamboo serve` | Start the HTTP/SSE server (above). |
+| `bamboo serve` | Start the HTTP/WebSocket/SSE server (above). |
 | `bamboo tui` | Full-screen terminal client (chat, sessions, MCP, schedules, skills, config) over a running server; offers to auto-start a local one when unreachable (`--auto-serve`/`--no-auto-serve`). |
 | `bamboo init` | First-run setup: write `config.json` with a provider + API key (interactive, or `--non-interactive` for CI). |
 | `bamboo doctor` | Diagnose the install (config present, provider keyed, server reachable); exits non-zero on a blocking problem. |
@@ -307,7 +307,7 @@ dirs = "5"
 anyhow = "1"
 ```
 
-> Prefer not to manage these dependencies yourself? Run `bamboo serve` and use the HTTP API above — it drives the exact same loop. The full SDK type reference is the rustdoc at [docs.rs/bamboo-agent](https://docs.rs/bamboo-agent) (the published crate re-exports the facade as `bamboo_agent::agent`); [`docs/guides/API.md`](./docs/guides/API.md) covers the HTTP/SSE surface.
+> Prefer not to manage these dependencies yourself? Run `bamboo serve` and use the server APIs above — they drive the exact same loop. The full SDK type reference is the rustdoc at [docs.rs/bamboo-agent](https://docs.rs/bamboo-agent) (the published crate re-exports the facade as `bamboo_agent::agent`); [`docs/guides/API.md`](./docs/guides/API.md) covers the HTTP/WebSocket/SSE surface.
 
 ### Example configuration
 
@@ -345,6 +345,7 @@ curl http://localhost:9562/api/v1/health
 ### Selected API routes
 
 REST prefix `/api/v1`: `chat`, `execute/{session_id}`, `stream`, `sessions`, `skills`, `tools`, `tools/execute`, `models`, `commands`, `workflows`, `metrics/*`, `mcp`, `servers`, `stop/{session_id}`, `health`.
+The shared live transport is WebSocket `/v2/stream`; `/api/v1/stream` and `/api/v1/events/{session_id}` remain the legacy SSE feeds.
 There are also provider-compatible endpoints: `/openai/v1`, `/anthropic/v1`, `/gemini/v1beta`, `/v1/{chat/completions,responses,messages}`.
 
 ### Tests & quality
@@ -359,16 +360,19 @@ cargo build --release
 
 ## The Rest of the Stack
 
-Zenith is a monorepo, and bamboo is the execution-engine submodule within it.
+[`Zenith`](https://github.com/bigduu/Zenith) is a thin monorepo, and Bamboo is its execution-engine submodule.
 
 | Module | Role |
 |---|---|
-| [**bodhi**](../bodhi) | Desktop AI product surface (Tauri shell) |
-| [**lotus**](../lotus) | React+Vite UI layer (talks to bamboo over HTTP) |
-| **bamboo** | Local-first Rust agent runtime (this repo) |
-| [**bodhi-server**](../bodhi-server) | Go backend: auth, persistence, billing+quota, LLM proxy |
-| [**pavilion**](../pavilion) | Official website & docs |
-| [**Zenith (root)**](../) | Monorepo entry, submodule pointers, release train |
+| [**Bodhi**](https://github.com/bigduu/Bodhi-AI) | Tauri desktop shell: starts or reuses Bamboo, waits for health, manages the sidecar lifecycle, and displays Lotus served by Bamboo |
+| [**Lotus**](https://github.com/bigduu/Lotus) | Current React + Vite UI: HTTP requests, shared `/v2/stream` WebSocket by default, legacy SSE fallback |
+| [**Bamboo**](https://github.com/bigduu/Bamboo-agent) | Local-first Rust agent runtime and packaged Lotus host (this repo) |
+| [**bodhi-server**](https://github.com/bigduu/bodhi-server) | Optional hosted service for accounts, API keys, encrypted provider credentials, model routing, billing/quota, and provider proxy |
+| [**Pavilion**](https://github.com/bigduu/Pavilion) | Official website and documentation surface |
+| [**Jiandu**](https://github.com/bigduu/Jiandu) | Small filesystem-backed shared-memory boundary: Rust library plus stdio MCP server |
+| [**Nova**](https://github.com/bigduu/Nova) | Native computer-use capabilities exposed through MCP |
+| [**Lotus Next**](https://github.com/bigduu/lotus-next) | Experimental next-generation frontend developed alongside Lotus; not the current Bodhi default |
+| [**Magpie**](https://github.com/bigduu/Magpie) | IM connector for Bamboo, available standalone and as a Bamboo service plugin |
 
 **In-module docs:** start at [`docs/README.md`](./docs/README.md) for the full index. Highlights:
 - Getting started: [`docs/guides/GETTING_STARTED.md`](./docs/guides/GETTING_STARTED.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,12 +6,12 @@
 
 ### 本地优先的 AI agent 运行时，Rust 编写。
 
-**持久记忆、22 个内置工具、skills、MCP、workflows、schedules —— 统一在一个 HTTP + SSE API 之后。**
+**持久记忆、22 个内置工具、skills、MCP、workflows、schedules —— 统一在 HTTP + WebSocket + SSE API 之后。**
 既能作为服务器运行，也能把同一套 agent loop 作为 Rust crate 嵌入。数据始终留在你自己机器上。
 
 [![Crates.io](https://img.shields.io/crates/v/bamboo-agent.svg?logo=rust)](https://crates.io/crates/bamboo-agent)
 [![docs.rs](https://img.shields.io/docsrs/bamboo-agent?logo=docsdotrs&label=docs.rs)](https://docs.rs/bamboo-agent)
-[![CI](https://img.shields.io/github/actions/workflow/status/bigduu/Bamboo-agent/ci.yml?branch=main&logo=github&label=CI)](https://github.com/bigduu/Bamboo-agent/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/bigduu/Bamboo-agent/ci.yml?branch=dev&logo=github&label=CI)](https://github.com/bigduu/Bamboo-agent/actions/workflows/ci.yml)
 [![License MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![English README](https://img.shields.io/badge/lang-English-blue)](./README.md)
 
@@ -37,7 +37,7 @@ Bamboo 是一个能在你自己电脑上运行的 AI 助理"大脑"。它不只�
 | 🎯 **技能系统** | 可选/可发现的技能，按请求提示做轻量选择，含内置 docx / pdf / pptx / xlsx / skill-creator |
 | 🔌 **MCP 扩展** | Model Context Protocol 客户端，挂接外部工具服务器 |
 | ⏰ **工作流与调度** | 声明式工作流装载 + cron 风格的调度触发引擎 |
-| 🌐 **HTTP / SSE** | Actix 服务、REST API、Server-Sent Events 流式，兼容 OpenAI / Anthropic / Gemini 端点 |
+| 🌐 **HTTP / WebSocket / SSE** | Actix 服务、REST API、共享 `/v2/stream` WebSocket、legacy SSE 事件流，以及兼容 OpenAI / Anthropic / Gemini 的端点 |
 | 🏗️ **多 Provider** | anthropic（默认）、openai、gemini、copilot、bodhi 路由 |
 
 ---
@@ -48,7 +48,7 @@ Bamboo 是一个 Cargo **workspace**：根目录是一个很薄的二进制（`b
 
 ```mermaid
 graph TD
-  CLI["bamboo (root bin)<br/>serve / config / -p headless / actor / broker"] --> SRV[bamboo-server<br/>Actix HTTP + SSE, routes, schedules, workflows]
+  CLI["bamboo (root bin)<br/>serve / config / -p headless / actor / broker"] --> SRV[bamboo-server<br/>Actix HTTP + WebSocket + SSE, routes, schedules, workflows]
   SRV --> ENG[bamboo-engine<br/>agent runtime, auto-dream, gardener, metrics]
   ENG --> CORE[bamboo-agent-core<br/>core abstractions]
   CORE --> DOM[bamboo-domain<br/>pure domain types]
@@ -73,7 +73,7 @@ graph TD
 
 …以及根二进制 `bamboo-agent`。
 
-**在 Zenith 中的位置：** lotus（React UI）与 bamboo 通过 **HTTP** 通信；bodhi（Tauri 外壳）只是承载界面的容器。bamboo 是执行引擎，bodhi-server（Go）负责账号/持久化/计费与 LLM 代理。
+**在 Zenith 中的位置：** Bodhi 是 Tauri 桌面外壳，负责启动或复用本机 `bamboo serve`、等待 `GET /api/v1/health`，并管理 sidecar 生命周期。打包版本由 Bamboo 提供内嵌的 Lotus 前端。Lotus 通过 HTTP 发送请求，实时事件默认复用一条共享的 `/v2/stream` WebSocket；只有显式禁用 v2 transport 或首次 WebSocket 连接无法建立时，才回退到 legacy 账号级与会话级 SSE 事件流。Bamboo 仍是执行引擎。`bodhi-server` 是独立、可选的托管账号与 provider 路径；本地 Bodhi → Bamboo → Lotus 链路不依赖它。
 
 ---
 
@@ -142,7 +142,7 @@ bamboo serve
 
 | 命令 | 作用 |
 |---|---|
-| `bamboo serve` | 启动 HTTP/SSE 服务（见上）。 |
+| `bamboo serve` | 启动 HTTP/WebSocket/SSE 服务（见上）。 |
 | `bamboo tui` | 全屏终端客户端（聊天、会话、MCP、定时任务、技能、配置），连接运行中的服务；本地服务不可达时会提示自动拉起（`--auto-serve`/`--no-auto-serve`）。 |
 | `bamboo init` | 首次安装引导：写入含 provider + API key 的 `config.json`（交互式，CI 用 `--non-interactive`）。 |
 | `bamboo doctor` | 诊断安装状态（配置存在、provider 已配 key、服务可达）；有阻塞问题时以非零退出。 |
@@ -246,7 +246,7 @@ dirs = "5"
 anyhow = "1"
 ```
 
-> 不想自己管理这些依赖？直接 `bamboo serve` 用上面的 HTTP API —— 它驱动的是完全相同的 loop。完整 SDK 类型参考是 [docs.rs/bamboo-agent](https://docs.rs/bamboo-agent) 上的 rustdoc（已发布 crate 把门面重导出为 `bamboo_agent::agent`）；[`docs/guides/API.md`](./docs/guides/API.md) 覆盖 HTTP/SSE 接口。
+> 不想自己管理这些依赖？直接 `bamboo serve` 使用上面的服务 API —— 它们驱动的是完全相同的 loop。完整 SDK 类型参考是 [docs.rs/bamboo-agent](https://docs.rs/bamboo-agent) 上的 rustdoc（已发布 crate 把门面重导出为 `bamboo_agent::agent`）；[`docs/guides/API.md`](./docs/guides/API.md) 覆盖 HTTP/WebSocket/SSE 接口。
 
 ### 示例配置
 
@@ -282,6 +282,7 @@ curl http://localhost:9562/api/v1/health
 ### 常用 API 路由
 
 REST 前缀 `/api/v1`：`chat`、`execute/{session_id}`、`stream`、`sessions`、`skills`、`tools`、`tools/execute`、`models`、`commands`、`workflows`、`metrics/*`、`mcp`、`servers`、`stop/{session_id}`、`health`。
+共享实时传输使用 WebSocket `/v2/stream`；`/api/v1/stream` 与 `/api/v1/events/{session_id}` 保留为 legacy SSE 事件流。
 另有 provider 兼容端点：`/openai/v1`、`/anthropic/v1`、`/gemini/v1beta`、`/v1/{chat/completions,responses,messages}`。
 
 ### 测试与质量
@@ -296,16 +297,19 @@ cargo build --release
 
 ## 其余技术栈
 
-Zenith 是一个 monorepo，bamboo 是其中的执行引擎子模块。
+[`Zenith`](https://github.com/bigduu/Zenith) 是一个薄层 monorepo，Bamboo 是其中的执行引擎子模块。
 
 | 模块 | 角色 |
 |---|---|
-| [**bodhi**](../bodhi) | 桌面 AI 产品界面（Tauri 外壳） |
-| [**lotus**](../lotus) | React + Vite 前端 UI 层（通过 HTTP 调用 bamboo） |
-| **bamboo** | 本地优先 Rust 智能体运行时（本仓库） |
-| [**bodhi-server**](../bodhi-server) | Go 后端：认证 / 持久化 / 计费配额 / LLM 代理 |
-| [**pavilion**](../pavilion) | 官网与文档 |
-| [**Zenith (root)**](../) | monorepo 入口 + 子模块指针 + 发布列车 |
+| [**Bodhi**](https://github.com/bigduu/Bodhi-AI) | Tauri 桌面外壳：启动或复用 Bamboo、等待健康检查通过、管理 sidecar 生命周期，并展示由 Bamboo 提供的 Lotus |
+| [**Lotus**](https://github.com/bigduu/Lotus) | 当前 React + Vite UI：HTTP 请求、默认共享 `/v2/stream` WebSocket、legacy SSE fallback |
+| [**Bamboo**](https://github.com/bigduu/Bamboo-agent) | 本地优先 Rust 智能体运行时与打包版 Lotus 宿主（本仓库） |
+| [**bodhi-server**](https://github.com/bigduu/bodhi-server) | 可选托管服务：账号、API key、加密 provider 凭据、模型路由、计费配额与 provider proxy |
+| [**Pavilion**](https://github.com/bigduu/Pavilion) | 官方网站与文档入口 |
+| [**Jiandu**](https://github.com/bigduu/Jiandu) | 小型文件系统共享记忆边界：Rust library + stdio MCP server |
+| [**Nova**](https://github.com/bigduu/Nova) | 通过 MCP 暴露的原生 computer-use 能力 |
+| [**Lotus Next**](https://github.com/bigduu/lotus-next) | 与 Lotus 并行开发的实验性下一代前端；不是当前 Bodhi 默认 UI |
+| [**Magpie**](https://github.com/bigduu/Magpie) | Bamboo 的 IM connector，可独立运行，也可作为 Bamboo service plugin 使用 |
 
 **模块内文档：**
 - API 参考: [`docs/guides/API.md`](./docs/guides/API.md)


### PR DESCRIPTION
## Summary

- describe the Bamboo server surface as HTTP, WebSocket, and SSE while preserving the detailed SSE examples
- document the current Bodhi sidecar lifecycle, packaged Lotus hosting path, WS-first Lotus transport, and optional bodhi-server boundary in both languages
- replace the stale partial Zenith tables with the same nine modules and valid absolute GitHub links
- align the CI badges with the `dev` integration branch

Closes #1020

## Test Plan

- [x] Rendered `README.md` and `README.zh-CN.md` through the GitHub GFM Markdown API
- [x] Verified all local Markdown link targets exist
- [x] Verified all ten referenced GitHub repositories, including the nine module links, through the GitHub API
- [x] Verified each Zenith module table contains exactly nine absolute GitHub repository links and the English/Chinese URL sets match
- [x] Verified retired HTTP/SSE-only, UI-container, mandatory-server, `branch=main`, and stale relative-link wording is absent
- [x] Compared the existing memory sections and detailed SSE examples byte-for-byte with `origin/dev`
- [x] Ran `git diff --check`

## Screenshots

Not applicable — documentation-only change.