### PR TITLE
fix: account for provider-visible tool schemas

### DIFF
--- a/crates/app/bamboo-server/src/reloadable_provider.rs
+++ b/crates/app/bamboo-server/src/reloadable_provider.rs
@@ -5,7 +5,7 @@ use tokio::sync::RwLock;
 use bamboo_agent_core::{tools::ToolSchema, Message};
 use bamboo_domain::CapabilityLoadingMode;
 use bamboo_llm::provider::{LLMProvider, LLMRequestOptions, Result};
-use bamboo_llm::{LLMStream, PromptIR};
+use bamboo_llm::{LLMStream, PromptIR, ProviderVisibleToolFootprint};
 
 /// An `LLMProvider` wrapper that always delegates to the latest provider stored in a shared lock.
 ///
@@ -35,6 +35,19 @@ impl LLMProvider for ReloadableProvider {
         self.current()
             .await
             .capability_loading_mode(model, required_tool)
+            .await
+    }
+
+    async fn provider_visible_tool_footprint(
+        &self,
+        ir: &PromptIR,
+        tools: &[ToolSchema],
+        model: &str,
+        required_tool: Option<&str>,
+    ) -> Result<ProviderVisibleToolFootprint> {
+        self.current()
+            .await
+            .provider_visible_tool_footprint(ir, tools, model, required_tool)
             .await
     }
 
@@ -91,6 +104,41 @@ impl LLMProvider for ReloadableProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bamboo_llm::{ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind};
+
+    struct FootprintProvider;
+
+    #[async_trait]
+    impl LLMProvider for FootprintProvider {
+        async fn provider_visible_tool_footprint(
+            &self,
+            ir: &PromptIR,
+            tools: &[ToolSchema],
+            model: &str,
+            required_tool: Option<&str>,
+        ) -> Result<ProviderVisibleToolFootprint> {
+            assert_eq!(ir.system_text, "forward this IR");
+            assert!(tools.is_empty());
+            assert_eq!(model, "forward-model");
+            assert_eq!(required_tool, Some("load_skill"));
+            Ok(ProviderVisibleToolFootprint {
+                segments: vec![ProviderVisibleToolSegment {
+                    kind: ProviderVisibleToolSegmentKind::ProviderLateBound,
+                    serialized: r#"{"forwarded":true}"#.to_string(),
+                }],
+            })
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream> {
+            panic!("footprint forwarding test must not dispatch")
+        }
+    }
 
     fn wrapped(provider: Arc<dyn LLMProvider>) -> ReloadableProvider {
         ReloadableProvider::new(Arc::new(RwLock::new(provider)))
@@ -130,5 +178,26 @@ mod tests {
                 .await,
             CapabilityLoadingMode::LegacyFullCatalog
         );
+    }
+
+    #[tokio::test]
+    async fn provider_visible_tool_footprint_forwards_to_current_provider() {
+        let provider = wrapped(Arc::new(FootprintProvider));
+        let ir = PromptIR {
+            system_text: "forward this IR".to_string(),
+            ..Default::default()
+        };
+
+        let footprint = provider
+            .provider_visible_tool_footprint(&ir, &[], "forward-model", Some("load_skill"))
+            .await
+            .expect("forwarded footprint");
+
+        assert_eq!(footprint.segments.len(), 1);
+        assert_eq!(
+            footprint.segments[0].kind,
+            ProviderVisibleToolSegmentKind::ProviderLateBound
+        );
+        assert_eq!(footprint.segments[0].serialized, r#"{"forwarded":true}"#);
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
@@ -883,7 +883,9 @@ pub(super) async fn prepare_round_context(
             config,
             tool_schemas,
             model_name,
-        );
+            llm,
+        )
+        .await?;
         if projected.ledger_rendered_bytes > MAX_MODEL_CONTEXT_RENDERED_BYTES {
             return Err(AgentError::Budget(format!(
                 "projected model-context ledger exceeds byte limit: ledger_bytes={}, ledger_byte_limit={MAX_MODEL_CONTEXT_RENDERED_BYTES}",
@@ -902,8 +904,11 @@ pub(super) async fn prepare_round_context(
         }
         if refit_pass >= MAX_PROJECTED_REQUEST_REFIT_PASSES {
             return Err(AgentError::Budget(format!(
-                "projected model-context request remains over budget after {refit_pass} refit passes: input_tokens={}, input_limit={request_input_limit}",
+                "projected known provider-visible request remains over budget after {refit_pass} refit passes: message_input_tokens={}, tool_schema_input_tokens={}, input_tokens={}, input_limit={request_input_limit}, tool_schema_late_bound_segments={}",
+                projected.message_input_tokens,
+                projected.tool_schema_input_tokens,
                 projected.input_tokens,
+                projected.tool_schema_late_bound_segment_count,
             )));
         }
 
@@ -922,6 +927,9 @@ pub(super) async fn prepare_round_context(
             session_id = %session.id,
             refit_pass,
             projected_input_tokens = projected.input_tokens,
+            message_input_tokens = projected.message_input_tokens,
+            tool_schema_input_tokens = projected.tool_schema_input_tokens,
+            tool_schema_late_bound_segments = projected.tool_schema_late_bound_segment_count,
             request_input_limit,
             deficit_tokens,
             prepared_message_tokens,
@@ -934,7 +942,16 @@ pub(super) async fn prepare_round_context(
             &budget,
             &counter,
             refit_fixed_tokens,
-        )?;
+        )
+        .map_err(|error| {
+            AgentError::Budget(format!(
+                "known provider-visible request cannot be refitted: message_input_tokens={}, tool_schema_input_tokens={}, input_tokens={}, input_limit={request_input_limit}, tool_schema_late_bound_segments={}, cause={error}",
+                projected.message_input_tokens,
+                projected.tool_schema_input_tokens,
+                projected.input_tokens,
+                projected.tool_schema_late_bound_segment_count,
+            ))
+        })?;
     }
 
     logging::log_context_truncation(session_id, &prepared_context);

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
@@ -7,7 +7,7 @@ use super::{
     prepare_round_context, LAST_PRESSURE_LEVEL_KEY,
 };
 use crate::runtime::config::{AgentLoopConfig, ImageFallbackConfig, ImageFallbackMode};
-use bamboo_agent_core::tools::{FunctionCall, ToolCall};
+use bamboo_agent_core::tools::{FunctionCall, FunctionSchema, ToolCall, ToolSchema};
 use bamboo_agent_core::{
     AgentEvent, AgentHook, CompressionTriggerType, Message, Role, Session, TokenBudgetUsage,
 };
@@ -1072,7 +1072,10 @@ async fn projected_relocation_does_not_double_reserve_large_system_env_context()
         &config,
         &[],
         "test-model",
-    );
+        &llm,
+    )
+    .await
+    .expect("provider-visible projection");
 
     assert!(projected.input_tokens <= request_input_limit);
     assert!(
@@ -1148,7 +1151,10 @@ async fn projected_compression_reseed_does_not_double_reserve_large_summary() {
         &config,
         &[],
         "test-model",
-    );
+        &llm,
+    )
+    .await
+    .expect("provider-visible projection");
 
     assert!(projected.input_tokens <= request_input_limit);
     assert_eq!(
@@ -1250,13 +1256,17 @@ async fn projected_refit_handles_over_limit_vision_transform_exactly_once() {
         counter.count_messages(&expanded_candidate_messages) > request_input_limit,
         "fixture must make the transformed candidate itself exceed the input limit"
     );
+    let projection_llm = noop_llm();
     let naive_projection = super::super::stream_execution::project_request_usage(
         &session,
         &naive,
         &config,
         &[],
         "test-model",
-    );
+        &projection_llm,
+    )
+    .await
+    .expect("provider-visible naive projection");
     assert!(
         naive_projection.input_tokens
             > session
@@ -1297,12 +1307,109 @@ async fn projected_refit_handles_over_limit_vision_transform_exactly_once() {
         &config,
         &[],
         "test-model",
-    );
+        &llm,
+    )
+    .await
+    .expect("provider-visible projection");
     assert!(
         counter.count_messages(&prepared.prepared_context.messages) <= request_input_limit,
         "refit must bring the transformed message vector itself back under the limit"
     );
     assert!(projected.input_tokens <= prepared.budget.max_request_input_tokens());
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn prepare_round_context_refits_for_provider_visible_tool_schemas() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let mut base = Session::new("session-schema-refit", "test-model");
+    base.messages.push(Message::system("system"));
+    for index in 0..36 {
+        base.messages.push(Message::user(format!(
+            "history-{index} {}",
+            "bounded user transcript ".repeat(18)
+        )));
+        base.messages.push(Message::assistant(
+            format!(
+                "answer-{index} {}",
+                "bounded assistant transcript ".repeat(18)
+            ),
+            None,
+        ));
+    }
+    base.messages.push(Message::user("continue"));
+    base.token_budget = Some(TokenBudget::with_safety_margin(
+        5_000,
+        256,
+        BudgetStrategy::default(),
+        0,
+    ));
+    let config = AgentLoopConfig {
+        model_name: Some("test-model".to_string()),
+        system_prompt: Some("system".to_string()),
+        ..Default::default()
+    };
+    let tool = ToolSchema {
+        schema_type: "function".to_string(),
+        function: FunctionSchema {
+            name: "large_lookup".to_string(),
+            description: "Large lookup".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "provider-visible parameter ".repeat(320)
+                    }
+                }
+            }),
+        },
+    };
+    let llm = noop_llm();
+
+    let mut without_tools = base.clone();
+    let without_tools_prepared = prepare_round_context(
+        &mut without_tools,
+        &config,
+        "test-model",
+        "session-schema-refit-empty",
+        &[],
+        &llm,
+        None,
+    )
+    .await
+    .expect("message-only context preparation");
+
+    let mut with_tools = base;
+    let with_tools_prepared = prepare_round_context(
+        &mut with_tools,
+        &config,
+        "test-model",
+        "session-schema-refit-tools",
+        std::slice::from_ref(&tool),
+        &llm,
+        None,
+    )
+    .await
+    .expect("schema-aware context preparation");
+
+    assert!(
+        with_tools_prepared.prepared_context.messages.len()
+            < without_tools_prepared.prepared_context.messages.len(),
+        "the fixed schema footprint must reserve room before fitting history"
+    );
+    let projected = super::super::stream_execution::project_request_usage(
+        &with_tools,
+        &with_tools_prepared.prepared_context,
+        &config,
+        std::slice::from_ref(&tool),
+        "test-model",
+        &llm,
+    )
+    .await
+    .expect("schema-aware final projection");
+    assert!(projected.tool_schema_input_tokens > 0);
+    assert!(projected.input_tokens <= with_tools_prepared.budget.max_request_input_tokens());
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -32,8 +32,8 @@ use bamboo_domain::{
 };
 use bamboo_llm::provider::ResponsesRequestOptions;
 use bamboo_llm::{
-    CacheTtl, Continuation, LLMProvider, LLMRequestOptions, PromptCachePlan, PromptIR, Segment,
-    SegmentRole,
+    CacheTtl, Continuation, LLMProvider, LLMRequestOptions, PromptCachePlan, PromptIR,
+    ProviderVisibleToolFootprint, ProviderVisibleToolSegmentKind, Segment, SegmentRole,
 };
 use bamboo_tools::exposure::activated_discoverable_tools;
 use sha2::{Digest, Sha256};
@@ -364,19 +364,26 @@ struct PreparedRequestEnvelope {
     prefix_reset_reason: Option<bamboo_domain::ModelContextResetReason>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub(super) struct ProjectedRequestUsage {
+    pub message_input_tokens: u32,
+    pub tool_schema_input_tokens: u32,
     pub input_tokens: u32,
+    pub tool_schema_serialized_bytes: usize,
+    pub tool_schema_serialized_chars: usize,
+    pub tool_schema_segment_count: usize,
+    pub tool_schema_late_bound_segment_count: usize,
     pub ledger_rendered_bytes: usize,
 }
 
 fn measure_request_usage(
     session: &Session,
     envelope: &PreparedRequestEnvelope,
+    tool_footprint: &ProviderVisibleToolFootprint,
 ) -> ProjectedRequestUsage {
     let counter = TiktokenTokenCounter::default();
     let messages = envelope.ir.flatten();
-    let mut input_tokens = counter.count_messages(&messages);
+    let mut message_input_tokens = counter.count_messages(&messages);
     let mut replaced_anchors = HashSet::new();
     for group in &envelope.ir.provider_transcript_groups {
         if replaced_anchors.insert(group.anchor_message_id()) {
@@ -384,7 +391,8 @@ fn measure_request_usage(
                 .iter()
                 .find(|message| message.id == group.anchor_message_id())
             {
-                input_tokens = input_tokens.saturating_sub(counter.count_message(anchor));
+                message_input_tokens =
+                    message_input_tokens.saturating_sub(counter.count_message(anchor));
             }
         }
         let payloads = group
@@ -393,10 +401,28 @@ fn measure_request_usage(
             .map(|item| item.payload())
             .collect::<Vec<_>>();
         let wire = serde_json::to_string(&payloads).unwrap_or_default();
-        input_tokens = input_tokens
+        message_input_tokens = message_input_tokens
             .saturating_add(counter.count_text(&wire))
             .saturating_add((group.items().len() as u32).saturating_mul(4));
     }
+    let tool_estimate = counter.estimate_provider_visible_tool_segments(
+        tool_footprint
+            .segments
+            .iter()
+            .filter(|segment| segment.kind != ProviderVisibleToolSegmentKind::ProviderLateBound)
+            .map(|segment| segment.serialized.as_str()),
+    );
+    let tool_schema_segment_count = tool_footprint
+        .segments
+        .iter()
+        .filter(|segment| segment.kind != ProviderVisibleToolSegmentKind::ProviderLateBound)
+        .count();
+    let tool_schema_late_bound_segment_count = tool_footprint
+        .segments
+        .iter()
+        .filter(|segment| segment.kind == ProviderVisibleToolSegmentKind::ProviderLateBound)
+        .count();
+    let input_tokens = message_input_tokens.saturating_add(tool_estimate.input_tokens);
     let ledger_rendered_bytes = session
         .model_context_state
         .as_ref()
@@ -407,7 +433,13 @@ fn measure_request_usage(
         })
         .unwrap_or(0);
     ProjectedRequestUsage {
+        message_input_tokens,
+        tool_schema_input_tokens: tool_estimate.input_tokens,
         input_tokens,
+        tool_schema_serialized_bytes: tool_estimate.serialized_bytes,
+        tool_schema_serialized_chars: tool_estimate.serialized_chars,
+        tool_schema_segment_count,
+        tool_schema_late_bound_segment_count,
         ledger_rendered_bytes,
     }
 }
@@ -439,14 +471,16 @@ pub(in crate::runtime::runner) fn effective_tool_schemas<'a>(
 /// mutating the live session. Context preparation uses this shadow pass to
 /// reserve space for snapshots that are created only after ordinary message
 /// fitting (notably when a retention reset seeds a fresh prefix epoch).
-pub(super) fn project_request_usage(
+pub(super) async fn project_request_usage(
     session: &Session,
     prepared_context: &PreparedContext,
     config: &AgentLoopConfig,
     tool_schemas: &[ToolSchema],
     model: &str,
-) -> ProjectedRequestUsage {
+    llm: &Arc<dyn LLMProvider>,
+) -> Result<ProjectedRequestUsage, AgentError> {
     let mut shadow = session.clone();
+    let required_tool = required_tool_for_session(&shadow);
     let effective_tool_schemas = effective_tool_schemas(&shadow, tool_schemas);
     let envelope = build_request_envelope_reconciled(
         &mut shadow,
@@ -455,7 +489,20 @@ pub(super) fn project_request_usage(
         effective_tool_schemas.as_ref(),
         model,
     );
-    measure_request_usage(&shadow, &envelope)
+    let tool_footprint = llm
+        .provider_visible_tool_footprint(
+            &envelope.ir,
+            effective_tool_schemas.as_ref(),
+            model,
+            required_tool,
+        )
+        .await
+        .map_err(|error| {
+            AgentError::LLM(format!(
+                "provider-visible tool footprint projection failed: {error}"
+            ))
+        })?;
+    Ok(measure_request_usage(&shadow, &envelope, &tool_footprint))
 }
 
 fn build_request_envelope_reconciled(
@@ -809,6 +856,13 @@ pub(crate) struct RequestRenderObservability {
     /// Messages actually sent: the continuation delta size, or the full chat list.
     pub request_message_count: usize,
     pub tool_count: usize,
+    pub message_input_tokens: u32,
+    pub tool_schema_input_tokens: u32,
+    pub total_input_tokens: u32,
+    pub tool_schema_serialized_bytes: usize,
+    pub tool_schema_serialized_chars: usize,
+    pub tool_schema_segment_count: usize,
+    pub tool_schema_late_bound_segment_count: usize,
     pub cache_system: bool,
     pub cache_tools: bool,
     pub cache_breakpoints: usize,
@@ -820,7 +874,7 @@ pub(crate) struct RequestRenderObservability {
 impl RequestRenderObservability {
     fn log(&self, session_id: &str) {
         tracing::info!(
-            "[{}] LLM request render: wire={} system_blocks={} system_chars={} stable_prefix_msgs={} model_transcript_msgs={} dynamic_ctx_msgs={} conversation_msgs={} volatile_ctx_msgs={} request_msgs={} tools={} cache(system={}, tools={}, breakpoints={}, ttl={}) prefix_epoch={} prefix_reset_reason={}",
+            "[{}] LLM request render: wire={} system_blocks={} system_chars={} stable_prefix_msgs={} model_transcript_msgs={} dynamic_ctx_msgs={} conversation_msgs={} volatile_ctx_msgs={} request_msgs={} tools={} known_input_tokens(message={}, tool_schema={}, total={}) tool_schema_shape(known_segments={}, late_bound_segments={}, bytes={}, chars={}) cache(system={}, tools={}, breakpoints={}, ttl={}) prefix_epoch={} prefix_reset_reason={}",
             session_id,
             self.wire,
             self.system_block_count,
@@ -832,6 +886,13 @@ impl RequestRenderObservability {
             self.volatile_context_messages,
             self.request_message_count,
             self.tool_count,
+            self.message_input_tokens,
+            self.tool_schema_input_tokens,
+            self.total_input_tokens,
+            self.tool_schema_segment_count,
+            self.tool_schema_late_bound_segment_count,
+            self.tool_schema_serialized_bytes,
+            self.tool_schema_serialized_chars,
             self.cache_system,
             self.cache_tools,
             self.cache_breakpoints,
@@ -873,6 +934,7 @@ fn plan_llm_request(
     reasoning_effort: Option<ReasoningEffort>,
     tool_count: usize,
     required_tool: Option<&str>,
+    usage: ProjectedRequestUsage,
 ) -> LlmRequestPlan {
     let is_continuation = envelope.ir.continuation.is_some();
 
@@ -916,6 +978,13 @@ fn plan_llm_request(
             envelope.ir.flatten().len()
         },
         tool_count,
+        message_input_tokens: usage.message_input_tokens,
+        tool_schema_input_tokens: usage.tool_schema_input_tokens,
+        total_input_tokens: usage.input_tokens,
+        tool_schema_serialized_bytes: usage.tool_schema_serialized_bytes,
+        tool_schema_serialized_chars: usage.tool_schema_serialized_chars,
+        tool_schema_segment_count: usage.tool_schema_segment_count,
+        tool_schema_late_bound_segment_count: usage.tool_schema_late_bound_segment_count,
         cache_system: envelope.ir.cache.cache_system,
         cache_tools: envelope.ir.cache.cache_tools,
         cache_breakpoints: envelope.ir.cache.breakpoint_message_ids.len(),
@@ -985,7 +1054,20 @@ pub(super) async fn execute_llm_stream(
     // exact final IR again before checkpoint/provider dispatch. Failing closed
     // preserves the context-window contract without committing an unsendable
     // ledger candidate.
-    let final_usage = measure_request_usage(session, &prepared_envelope);
+    let tool_footprint = match llm
+        .provider_visible_tool_footprint(&prepared_envelope.ir, tool_schemas, model, required_tool)
+        .await
+    {
+        Ok(footprint) => footprint,
+        Err(error) => {
+            session.model_context_state = previous_model_context_state;
+            session.provider_transcript = previous_provider_transcript;
+            return Err(AgentError::LLM(format!(
+                "provider-visible tool footprint projection failed before dispatch: {error}"
+            )));
+        }
+    };
+    let final_usage = measure_request_usage(session, &prepared_envelope, &tool_footprint);
     let request_input_limit = max_context_tokens.saturating_sub(max_output_tokens);
     if final_usage.input_tokens > request_input_limit
         || final_usage.ledger_rendered_bytes > MAX_MODEL_CONTEXT_RENDERED_BYTES
@@ -993,8 +1075,15 @@ pub(super) async fn execute_llm_stream(
         session.model_context_state = previous_model_context_state;
         session.provider_transcript = previous_provider_transcript;
         return Err(AgentError::Budget(format!(
-            "final PromptIR message input exceeds ledger-safe limits: input_tokens={}, input_limit={request_input_limit}, ledger_bytes={}, ledger_byte_limit={MAX_MODEL_CONTEXT_RENDERED_BYTES}",
-            final_usage.input_tokens, final_usage.ledger_rendered_bytes,
+            "final known provider-visible request exceeds ledger-safe limits: message_input_tokens={}, tool_schema_input_tokens={}, input_tokens={}, input_limit={request_input_limit}, tool_schema_known_segments={}, tool_schema_late_bound_segments={}, tool_schema_bytes={}, tool_schema_chars={}, ledger_bytes={}, ledger_byte_limit={MAX_MODEL_CONTEXT_RENDERED_BYTES}",
+            final_usage.message_input_tokens,
+            final_usage.tool_schema_input_tokens,
+            final_usage.input_tokens,
+            final_usage.tool_schema_segment_count,
+            final_usage.tool_schema_late_bound_segment_count,
+            final_usage.tool_schema_serialized_bytes,
+            final_usage.tool_schema_serialized_chars,
+            final_usage.ledger_rendered_bytes,
         )));
     }
     // Reconciliation changes the next outbound model transcript. It must become
@@ -1051,6 +1140,7 @@ pub(super) async fn execute_llm_stream(
         reasoning_effort,
         tool_schemas.len(),
         required_tool,
+        final_usage,
     );
     if !continuation_enabled {
         tracing::debug!(

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -11,9 +11,13 @@ use tokio_util::sync::CancellationToken;
 use super::execute_llm_stream;
 use super::LlmStreamFrame;
 use bamboo_agent_core::agent::types::{ConversationSummary, TaskItem, TaskItemStatus, TaskList};
+use bamboo_agent_core::tools::{FunctionSchema, ToolSchema};
 use bamboo_agent_core::{AgentError, AgentEvent, Message, Role, Session};
 use bamboo_compression::{BudgetStrategy, PreparedContext, TokenBudget, TokenUsageBreakdown};
-use bamboo_llm::{Config, LLMChunk, LLMProvider, LLMRequestOptions, LLMStream};
+use bamboo_llm::{
+    Config, LLMChunk, LLMProvider, LLMRequestOptions, LLMStream, ProviderVisibleToolFootprint,
+    ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind,
+};
 use chrono::Utc;
 
 fn isolate_prompt_safe_env_cache() -> MutexGuard<'static, ()> {
@@ -168,6 +172,21 @@ fn mock_llm(chunks: Vec<LLMChunk>) -> Arc<MockLlmProvider> {
         ir_invoked: Mutex::new(false),
         ir_call_count: std::sync::atomic::AtomicUsize::new(0),
     })
+}
+
+fn provider_visible_schema(
+    name: &str,
+    description: impl Into<String>,
+    parameters: serde_json::Value,
+) -> ToolSchema {
+    ToolSchema {
+        schema_type: "function".to_string(),
+        function: FunctionSchema {
+            name: name.to_string(),
+            description: description.into(),
+            parameters,
+        },
+    }
 }
 
 fn test_config(system_prompt: &str) -> crate::runtime::config::AgentLoopConfig {
@@ -771,8 +790,8 @@ async fn explicit_activation_pending_suppresses_answer_tokens() {
         .all(|event| matches!(event, AgentEvent::TokenBudgetUpdated { .. })));
 }
 
-#[test]
-fn projected_explicit_activation_uses_the_live_restricted_tool_schema_slice() {
+#[tokio::test]
+async fn projected_explicit_activation_uses_the_live_restricted_tool_schema_slice() {
     let _env_lock = isolate_prompt_safe_env_cache();
     let mut session = Session::new("session-explicit-projection", "test-model");
     session.metadata.insert(
@@ -808,6 +827,7 @@ fn projected_explicit_activation_uses_the_live_restricted_tool_schema_slice() {
     let effective = super::effective_tool_schemas(&session, &tool_schemas);
     assert_eq!(effective.len(), 1);
     assert_eq!(effective[0].function.name, "load_skill");
+    let llm: Arc<dyn LLMProvider> = mock_llm(Vec::new());
 
     let projected_from_full = super::project_request_usage(
         &session,
@@ -815,14 +835,20 @@ fn projected_explicit_activation_uses_the_live_restricted_tool_schema_slice() {
         &config,
         &tool_schemas,
         "test-model",
-    );
+        &llm,
+    )
+    .await
+    .expect("full projection");
     let projected_from_live_slice = super::project_request_usage(
         &session,
         &prepared_context,
         &config,
         &tool_schemas[..1],
         "test-model",
-    );
+        &llm,
+    )
+    .await
+    .expect("live-slice projection");
     assert_eq!(
         projected_from_full.input_tokens,
         projected_from_live_slice.input_tokens
@@ -831,6 +857,241 @@ fn projected_explicit_activation_uses_the_live_restricted_tool_schema_slice() {
         projected_from_full.ledger_rendered_bytes,
         projected_from_live_slice.ledger_rendered_bytes
     );
+    assert!(projected_from_full.tool_schema_input_tokens > 0);
+    assert_eq!(
+        projected_from_full.tool_schema_input_tokens,
+        projected_from_live_slice.tool_schema_input_tokens
+    );
+    assert_eq!(projected_from_full.tool_schema_segment_count, 1);
+}
+
+#[tokio::test]
+async fn projected_usage_adds_the_provider_visible_schema_lane_once() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let session = Session::new("session-provider-visible-budget", "test-model");
+    let config = test_config("system");
+    let prepared_context = PreparedContext {
+        messages: vec![Message::system("system"), Message::user("continue")],
+        token_usage: usage(0, 24),
+        truncation_occurred: false,
+        segments_removed: 0,
+        compressed_message_ids: Vec::new(),
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+    };
+    let llm: Arc<dyn LLMProvider> = mock_llm(Vec::new());
+
+    let empty = super::project_request_usage(
+        &session,
+        &prepared_context,
+        &config,
+        &[],
+        "test-model",
+        &llm,
+    )
+    .await
+    .expect("empty provider-visible projection");
+    assert_eq!(empty.tool_schema_input_tokens, 0);
+    assert_eq!(empty.tool_schema_serialized_bytes, 0);
+    assert_eq!(empty.tool_schema_serialized_chars, 0);
+    assert_eq!(empty.tool_schema_segment_count, 0);
+    assert_eq!(empty.input_tokens, empty.message_input_tokens);
+
+    let tools = vec![provider_visible_schema(
+        "large_lookup",
+        "provider-visible lookup",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "large provider-visible parameter ".repeat(256)
+                }
+            }
+        }),
+    )];
+    let projected = super::project_request_usage(
+        &session,
+        &prepared_context,
+        &config,
+        &tools,
+        "test-model",
+        &llm,
+    )
+    .await
+    .expect("schema provider-visible projection");
+    let repeated = super::project_request_usage(
+        &session,
+        &prepared_context,
+        &config,
+        &tools,
+        "test-model",
+        &llm,
+    )
+    .await
+    .expect("deterministic provider-visible projection");
+
+    assert!(projected.tool_schema_input_tokens > 0);
+    assert!(projected.tool_schema_serialized_bytes > 0);
+    assert!(projected.tool_schema_serialized_chars > 0);
+    assert_eq!(projected.tool_schema_segment_count, 1);
+    assert_eq!(projected.input_tokens, repeated.input_tokens);
+    assert_eq!(
+        projected.input_tokens,
+        projected
+            .message_input_tokens
+            .saturating_add(projected.tool_schema_input_tokens)
+    );
+}
+
+#[test]
+fn openai_loaded_tool_items_increase_only_the_message_lane() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let mut session = Session::new("session-openai-loaded-budget", "test-model");
+    let assistant = Message::assistant("normalized search result", None);
+    let anchor = assistant.id.clone();
+    session.add_message(assistant);
+    let mut config = test_config("system");
+    config.provider_name = Some("openai-footprint".to_string());
+    config.provider_type = Some("openai".to_string());
+    let prepared_context = PreparedContext {
+        messages: session.messages.clone(),
+        token_usage: usage(0, 24),
+        truncation_occurred: false,
+        segments_removed: 0,
+        compressed_message_ids: Vec::new(),
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+    };
+    let footprint = ProviderVisibleToolFootprint {
+        segments: vec![ProviderVisibleToolSegment {
+            kind: ProviderVisibleToolSegmentKind::InitialFullDefinition,
+            serialized: r#"[{"type":"function","name":"Read"}]"#.to_string(),
+        }],
+    };
+    let baseline_envelope =
+        super::build_request_envelope(&session, &prepared_context, &config, &[]);
+    let baseline = super::measure_request_usage(&session, &baseline_envelope, &footprint);
+
+    let boundary = bamboo_domain::provider_transcript_boundary_sha256(
+        config.provider_name.as_deref(),
+        config.provider_type.as_deref(),
+    )
+    .unwrap();
+    session
+        .activate_provider_transcript_route(
+            bamboo_domain::ProviderFamily::OpenAi,
+            bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+            &boundary,
+        )
+        .unwrap();
+    let search_output = bamboo_domain::ProviderTranscriptItem::try_from_payload(
+        bamboo_domain::ProviderFamily::OpenAi,
+        bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+        bamboo_domain::ProviderTranscriptOrigin::HostToolSearch,
+        bamboo_domain::ProviderTranscriptAuthor::ToolResult,
+        serde_json::json!({
+            "type":"tool_search_output",
+            "execution":"client",
+            "call_id":"search_loaded_budget",
+            "status":"completed",
+            "tools":[{
+                "type":"function",
+                "name":"loaded_tool",
+                "description":"loaded message payload ".repeat(128),
+                "parameters":{"type":"object"},
+                "strict":false,
+                "defer_loading":true
+            }]
+        }),
+    )
+    .unwrap();
+    session
+        .append_provider_transcript_group(&anchor, None, vec![search_output])
+        .unwrap();
+    let additional_tools = bamboo_domain::ProviderTranscriptItem::try_from_payload(
+        bamboo_domain::ProviderFamily::OpenAi,
+        bamboo_domain::ProviderProtocol::OpenAiResponsesV1,
+        bamboo_domain::ProviderTranscriptOrigin::DeveloperContext,
+        bamboo_domain::ProviderTranscriptAuthor::Host,
+        serde_json::json!({
+            "type":"additional_tools",
+            "role":"developer",
+            "tools":[{
+                "type":"function",
+                "name":"additional_tool",
+                "description":"additional message payload ".repeat(128),
+                "parameters":{"type":"object"},
+                "strict":false
+            }]
+        }),
+    )
+    .unwrap();
+    session
+        .append_provider_transcript_group(&anchor, None, vec![additional_tools])
+        .unwrap();
+
+    let loaded_envelope = super::build_request_envelope(&session, &prepared_context, &config, &[]);
+    let loaded = super::measure_request_usage(&session, &loaded_envelope, &footprint);
+
+    assert!(loaded.message_input_tokens > baseline.message_input_tokens);
+    assert_eq!(
+        loaded.tool_schema_input_tokens,
+        baseline.tool_schema_input_tokens
+    );
+    assert_eq!(
+        loaded.tool_schema_serialized_bytes,
+        baseline.tool_schema_serialized_bytes
+    );
+    assert_eq!(
+        loaded.input_tokens - baseline.input_tokens,
+        loaded.message_input_tokens - baseline.message_input_tokens
+    );
+}
+
+#[test]
+fn late_bound_marker_is_explicit_but_not_claimed_as_known_input() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let session = Session::new("session-late-bound-budget", "test-model");
+    let config = test_config("system");
+    let prepared_context = PreparedContext {
+        messages: vec![Message::system("system"), Message::user("continue")],
+        token_usage: usage(0, 24),
+        truncation_occurred: false,
+        segments_removed: 0,
+        compressed_message_ids: Vec::new(),
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+    };
+    let envelope = super::build_request_envelope(&session, &prepared_context, &config, &[]);
+    let known = ProviderVisibleToolSegment {
+        kind: ProviderVisibleToolSegmentKind::InitialFullDefinition,
+        serialized: r#"[{"type":"tool_search"}]"#.to_string(),
+    };
+    let known_only = super::measure_request_usage(
+        &session,
+        &envelope,
+        &ProviderVisibleToolFootprint {
+            segments: vec![known.clone()],
+        },
+    );
+    let with_late_bound = super::measure_request_usage(
+        &session,
+        &envelope,
+        &ProviderVisibleToolFootprint {
+            segments: vec![
+                known,
+                ProviderVisibleToolSegment {
+                    kind: ProviderVisibleToolSegmentKind::ProviderLateBound,
+                    serialized: String::new(),
+                },
+            ],
+        },
+    );
+
+    assert_eq!(with_late_bound.input_tokens, known_only.input_tokens);
+    assert_eq!(with_late_bound.tool_schema_segment_count, 1);
+    assert_eq!(with_late_bound.tool_schema_late_bound_segment_count, 1);
 }
 
 #[tokio::test]
@@ -1094,6 +1355,79 @@ async fn final_ir_guard_rejects_unbudgeted_large_ledger_before_provider_dispatch
 }
 
 #[tokio::test]
+async fn final_guard_rejects_an_oversized_provider_visible_schema_before_dispatch() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let mut session = Session::new("session-schema-final-budget", "test-model");
+    let config = test_config("system");
+    let prepared_context = PreparedContext {
+        messages: vec![Message::system("system"), Message::user("continue")],
+        token_usage: usage(0, 24),
+        truncation_occurred: false,
+        segments_removed: 0,
+        compressed_message_ids: Vec::new(),
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+    };
+    let secret_sentinel = "SCHEMA_SENTINEL_MUST_NOT_APPEAR_IN_DIAGNOSTICS";
+    let tools = vec![provider_visible_schema(
+        "oversized_lookup",
+        "oversized provider-visible schema",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": format!("{} {}", secret_sentinel, "large parameter ".repeat(2_000))
+                }
+            }
+        }),
+    )];
+    let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(16);
+    let llm = mock_llm(vec![LLMChunk::Done]);
+    let llm_dyn: Arc<dyn LLMProvider> = llm.clone();
+
+    let result = execute_llm_stream(
+        &mut session,
+        &config,
+        &llm_dyn,
+        &prepared_context,
+        &tools,
+        &LlmStreamFrame {
+            event_tx: &event_tx,
+            cancel_token: &CancellationToken::new(),
+            session_id: "session-schema-final-budget",
+            model: "test-model",
+            provider_name: Some("test"),
+            provider_type: Some("test"),
+            reasoning_effort: None,
+            max_context_tokens: 1_000,
+            max_output_tokens: 200,
+        },
+    )
+    .await;
+
+    let message = match result {
+        Err(AgentError::Budget(message)) => message,
+        Err(error) => panic!("oversized schema must fail with a budget error, got {error}"),
+        Ok(_) => panic!("oversized schema must be rejected"),
+    };
+    assert!(message.contains("message_input_tokens="));
+    assert!(message.contains("tool_schema_input_tokens="));
+    assert!(message.contains("input_limit=800"));
+    assert!(!message.contains(secret_sentinel));
+    assert_eq!(
+        llm.ir_call_count.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "the final schema budget guard must run before chat_stream_ir"
+    );
+    assert!(llm
+        .requested_messages
+        .lock()
+        .expect("messages lock")
+        .is_empty());
+}
+
+#[tokio::test]
 async fn projected_epoch_reseed_refits_and_dispatches_an_idempotent_request() {
     struct CountingCheckpointPersistence(std::sync::atomic::AtomicUsize);
 
@@ -1161,16 +1495,18 @@ async fn projected_epoch_reseed_refits_and_dispatches_an_idempotent_request() {
         0,
     )
     .expect("the legacy zero-reservation fit should succeed");
+    let llm = mock_llm(vec![LLMChunk::Done]);
+    let llm_dyn: Arc<dyn LLMProvider> = llm.clone();
     let naive_projection =
-        super::project_request_usage(&session, &naive, &config, &[], "test-model");
+        super::project_request_usage(&session, &naive, &config, &[], "test-model", &llm_dyn)
+            .await
+            .expect("naive provider-visible projection");
     assert!(
         naive_projection.input_tokens > budget.max_request_input_tokens(),
         "without projected snapshots the prepared transcript must reproduce the old overflow"
     );
     let naive_message_count = naive.messages.len();
 
-    let llm = mock_llm(vec![LLMChunk::Done]);
-    let llm_dyn: Arc<dyn LLMProvider> = llm.clone();
     let prepared = super::super::context_preparation::prepare_round_context(
         &mut session,
         &config,
@@ -1190,7 +1526,10 @@ async fn projected_epoch_reseed_refits_and_dispatches_an_idempotent_request() {
         &config,
         &[],
         "test-model",
-    );
+        &llm_dyn,
+    )
+    .await
+    .expect("provider-visible projection");
     assert!(projected.input_tokens <= prepared.budget.max_request_input_tokens());
 
     let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(16);
@@ -1257,7 +1596,10 @@ async fn projected_epoch_reseed_refits_and_dispatches_an_idempotent_request() {
         &config,
         &[],
         "test-model",
-    );
+        &llm_dyn,
+    )
+    .await
+    .expect("retry provider-visible projection");
     assert!(retry_projection.input_tokens <= retry_prepared.budget.max_request_input_tokens());
 
     execute_llm_stream(
@@ -2334,7 +2676,17 @@ fn plan_llm_request_model_transcript_path_records_observability() {
     };
     let envelope = super::build_request_envelope(&session, &prepared_context, &config, &[]);
 
-    let planned = super::plan_llm_request(&envelope, "session-plan", None, 3, None);
+    let usage = super::ProjectedRequestUsage {
+        message_input_tokens: 120,
+        tool_schema_input_tokens: 30,
+        input_tokens: 150,
+        tool_schema_serialized_bytes: 512,
+        tool_schema_serialized_chars: 500,
+        tool_schema_segment_count: 2,
+        tool_schema_late_bound_segment_count: 1,
+        ledger_rendered_bytes: 64,
+    };
+    let planned = super::plan_llm_request(&envelope, "session-plan", None, 3, None, usage);
 
     // No continuation set on the IR → the canonical model-transcript wire.
     assert!(envelope.ir.continuation.is_none());
@@ -2343,6 +2695,13 @@ fn plan_llm_request_model_transcript_path_records_observability() {
     // System rendered as structured blocks (tool guide present → relocation on).
     assert!(planned.render.system_block_count >= 1);
     assert_eq!(planned.render.tool_count, 3);
+    assert_eq!(planned.render.message_input_tokens, 120);
+    assert_eq!(planned.render.tool_schema_input_tokens, 30);
+    assert_eq!(planned.render.total_input_tokens, 150);
+    assert_eq!(planned.render.tool_schema_segment_count, 2);
+    assert_eq!(planned.render.tool_schema_late_bound_segment_count, 1);
+    assert_eq!(planned.render.tool_schema_serialized_bytes, 512);
+    assert_eq!(planned.render.tool_schema_serialized_chars, 500);
     // Cache plan surfaced into the observability + carried in the request options.
     assert!(planned.render.cache_system);
     assert_eq!(planned.render.cache_ttl, "1h");
@@ -2386,7 +2745,14 @@ fn plan_llm_request_continuation_path_builds_delta() {
         "resp_prev",
     );
 
-    let planned = super::plan_llm_request(&envelope, "session-plan-cont", None, 0, None);
+    let planned = super::plan_llm_request(
+        &envelope,
+        "session-plan-cont",
+        None,
+        0,
+        None,
+        super::ProjectedRequestUsage::default(),
+    );
 
     assert_eq!(planned.render.wire, "responses_continuation");
     // Delta is the tool result after the last assistant turn — NOT the full convo.
@@ -2592,7 +2958,14 @@ fn responses_continuation_uses_full_input_not_the_delta() {
         super::build_request_envelope(&session, &prepared_context, &config, &[]),
         "resp_prev",
     );
-    let planned = super::plan_llm_request(&envelope, "session-resp-cont", None, 0, None);
+    let planned = super::plan_llm_request(
+        &envelope,
+        "session-resp-cont",
+        None,
+        0,
+        None,
+        super::ProjectedRequestUsage::default(),
+    );
 
     // The adapter derives the Responses wire view from the IR + the engine's request
     // POLICY (planned.request_options.responses).
@@ -2635,7 +3008,14 @@ fn ir_cache_matches_request_options_cache() {
     };
 
     let envelope = super::build_request_envelope(&session, &prepared_context, &config, &[]);
-    let planned = super::plan_llm_request(&envelope, "session-cache-dup", None, 0, None);
+    let planned = super::plan_llm_request(
+        &envelope,
+        "session-cache-dup",
+        None,
+        0,
+        None,
+        super::ProjectedRequestUsage::default(),
+    );
     let options_cache = planned
         .request_options
         .cache

--- a/crates/infra/bamboo-compression/src/counter.rs
+++ b/crates/infra/bamboo-compression/src/counter.rs
@@ -56,6 +56,20 @@ pub trait TokenCounter: Send + Sync {
     fn count_text(&self, text: &str) -> u32;
 }
 
+/// Deterministic aggregate for ordered provider-visible tool positions.
+///
+/// This is a local context-window estimate, not provider-authoritative billing
+/// usage. The provider-reported usage remains authoritative after dispatch.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProviderVisibleToolEstimate {
+    /// Saturating token sum across the ordered positions.
+    pub input_tokens: u32,
+    /// Saturating UTF-8 byte sum across the ordered positions.
+    pub serialized_bytes: usize,
+    /// Saturating Unicode scalar-value sum across the ordered positions.
+    pub serialized_chars: usize,
+}
+
 /// Heuristic token counter using character-based estimation.
 ///
 /// Uses the approximation: tokens ≈ characters / 4, with a 10% safety margin
@@ -164,6 +178,35 @@ impl TiktokenTokenCounter {
     /// Create with a custom metadata overhead.
     pub fn new(metadata_overhead: u32) -> Self {
         Self { metadata_overhead }
+    }
+
+    /// Estimate already-lowered provider-visible tool segments exactly once.
+    ///
+    /// `segments` must contain compact serialized JSON/text in the order the
+    /// selected provider exposes it to the model. Each segment is one contiguous
+    /// model position and is tokenized separately with the same counter used for
+    /// prompt text; provider lowering must serialize adjacent content such as an
+    /// initial tools array into one segment. This prevents BPE merges across
+    /// positions separated by transcript content.
+    ///
+    /// Repeated fragments at different model-visible positions remain repeated
+    /// by design; callers must omit definitions that are not model-visible at
+    /// that position. An empty slice returns an all-zero estimate.
+    pub fn estimate_provider_visible_tool_segments<'a>(
+        &self,
+        segments: impl IntoIterator<Item = &'a str>,
+    ) -> ProviderVisibleToolEstimate {
+        let mut estimate = ProviderVisibleToolEstimate::default();
+        for segment in segments {
+            estimate.input_tokens = estimate
+                .input_tokens
+                .saturating_add(self.count_text(segment));
+            estimate.serialized_bytes = estimate.serialized_bytes.saturating_add(segment.len());
+            estimate.serialized_chars = estimate
+                .serialized_chars
+                .saturating_add(segment.chars().count());
+        }
+        estimate
     }
 
     /// Truncate `text` to at most `max_tokens` tokens, keeping the START.
@@ -465,6 +508,73 @@ mod tests {
     fn tiktoken_counter_counts_empty_text() {
         let counter = TiktokenTokenCounter::default();
         assert_eq!(counter.count_text(""), 0);
+    }
+
+    #[test]
+    fn provider_visible_tool_estimate_is_zero_for_no_segments() {
+        let counter = TiktokenTokenCounter::default();
+        assert_eq!(
+            counter.estimate_provider_visible_tool_segments(std::iter::empty()),
+            ProviderVisibleToolEstimate::default()
+        );
+    }
+
+    #[test]
+    fn provider_visible_tool_estimate_counts_each_ordered_position_once() {
+        let counter = TiktokenTokenCounter::default();
+        let segments = [
+            r#"{"type":"function","function":{"#.to_string(),
+            r#""name":"lookup","description":"café 工具","#.to_string(),
+            r#""parameters":{"type":"object"}}}"#.to_string(),
+        ];
+        let estimate =
+            counter.estimate_provider_visible_tool_segments(segments.iter().map(String::as_str));
+        let expected_tokens = segments.iter().fold(0u32, |total, segment| {
+            total.saturating_add(counter.count_text(segment))
+        });
+        let expected_bytes = segments.iter().map(String::len).sum::<usize>();
+        let expected_chars = segments
+            .iter()
+            .map(|segment| segment.chars().count())
+            .sum::<usize>();
+
+        assert_eq!(estimate.input_tokens, expected_tokens);
+        assert_eq!(estimate.serialized_bytes, expected_bytes);
+        assert_eq!(estimate.serialized_chars, expected_chars);
+    }
+
+    #[test]
+    fn provider_visible_tool_estimate_keeps_bpe_boundaries_between_positions() {
+        let counter = TiktokenTokenCounter::default();
+        let segments = ["a".to_string(), "b".to_string()];
+
+        let estimate =
+            counter.estimate_provider_visible_tool_segments(segments.iter().map(String::as_str));
+        let separate = counter
+            .count_text(&segments[0])
+            .saturating_add(counter.count_text(&segments[1]));
+
+        assert_eq!(estimate.input_tokens, separate);
+        assert_ne!(estimate.input_tokens, counter.count_text("ab"));
+    }
+
+    #[test]
+    fn larger_provider_visible_tool_segment_increases_every_measure() {
+        let counter = TiktokenTokenCounter::default();
+        let small = [r#"{"parameters":{}}"#.to_string()];
+        let large = [format!(
+            r#"{{"parameters":{{"description":"{}"}}}}"#,
+            "provider visible parameter ".repeat(128)
+        )];
+
+        let small =
+            counter.estimate_provider_visible_tool_segments(small.iter().map(String::as_str));
+        let large =
+            counter.estimate_provider_visible_tool_segments(large.iter().map(String::as_str));
+
+        assert!(large.input_tokens > small.input_tokens);
+        assert!(large.serialized_bytes > small.serialized_bytes);
+        assert!(large.serialized_chars > small.serialized_chars);
     }
 
     #[test]

--- a/crates/infra/bamboo-compression/src/lib.rs
+++ b/crates/infra/bamboo-compression/src/lib.rs
@@ -32,7 +32,9 @@ pub use compression_tooling::{
     CompressionCandidatePlan, CompressionPlan, CompressionPlanError, ContextCompressionExposure,
     DEFAULT_SUMMARY_TARGET_RATIO,
 };
-pub use counter::{HeuristicTokenCounter, TiktokenTokenCounter, TokenCounter};
+pub use counter::{
+    HeuristicTokenCounter, ProviderVisibleToolEstimate, TiktokenTokenCounter, TokenCounter,
+};
 pub use limits::{create_budget_for_model, ModelLimitsRegistry};
 pub use preparation::{
     estimate_prompt_cache_savings, estimate_prompt_cache_savings_with_fixed_tokens,

--- a/crates/infra/bamboo-llm/src/lib.rs
+++ b/crates/infra/bamboo-llm/src/lib.rs
@@ -37,7 +37,10 @@ pub use protocol::{
     AnthropicProtocol, FromProvider, GeminiProtocol, OpenAIProtocol, ProtocolError, ProtocolResult,
     ToProvider,
 };
-pub use provider::{LLMError, LLMProvider, LLMRequestOptions, LLMStream};
+pub use provider::{
+    LLMError, LLMProvider, LLMRequestOptions, LLMStream, ProviderVisibleToolFootprint,
+    ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind,
+};
 pub use provider_factory::{
     create_provider, create_provider_by_name, create_provider_with_dir, validate_provider_config,
     AVAILABLE_PROVIDERS,

--- a/crates/infra/bamboo-llm/src/provider.rs
+++ b/crates/infra/bamboo-llm/src/provider.rs
@@ -10,6 +10,7 @@ use bamboo_domain::ToolSchema;
 use bamboo_domain::{CapabilityLoadingMode, ReasoningEffort};
 use bamboo_domain::{Message, ModelContextResetReason};
 use futures::Stream;
+use serde::Serialize;
 use std::pin::Pin;
 use thiserror::Error;
 
@@ -46,6 +47,64 @@ pub type Result<T> = std::result::Result<T, LLMError>;
 
 /// Type alias for boxed streaming LLM responses
 pub type LLMStream = Pin<Box<dyn Stream<Item = Result<LLMChunk>> + Send>>;
+
+/// Why one compact tool-schema segment is visible at its model position.
+///
+/// The footprint deliberately describes already-lowered JSON rather than
+/// estimating tokens in the provider crate. Adjacent top-level definitions are
+/// one segment; provider-inlined definitions later in history are separate
+/// segments because prompt text lies between those positions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderVisibleToolSegmentKind {
+    /// Complete definitions visible in the request's initial tools position.
+    InitialFullDefinition,
+    /// Name and description retained for one or more OpenAI hosted-search
+    /// functions while their parameter schemas remain deferred.
+    InitialDeferredDescriptor,
+    /// A complete Anthropic definition expanded at a validated tool reference.
+    AnthropicToolReferenceExpansion,
+    /// Empty marker following an initial search-enabled definition array. Later
+    /// definitions are bound by the provider or by transcript items rather than
+    /// duplicated at the initial position.
+    ProviderLateBound,
+}
+
+/// One compact serialized provider-visible schema position.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderVisibleToolSegment {
+    pub kind: ProviderVisibleToolSegmentKind,
+    pub serialized: String,
+}
+
+impl ProviderVisibleToolSegment {
+    pub(crate) fn from_serializable<T: Serialize + ?Sized>(
+        kind: ProviderVisibleToolSegmentKind,
+        value: &T,
+    ) -> Result<Self> {
+        Ok(Self {
+            kind,
+            serialized: serde_json::to_string(value)?,
+        })
+    }
+
+    pub(crate) fn empty_marker(kind: ProviderVisibleToolSegmentKind) -> Self {
+        Self {
+            kind,
+            serialized: String::new(),
+        }
+    }
+}
+
+/// Ordered tool-schema material visible to a provider model for one request.
+///
+/// [`ProviderVisibleToolSegmentKind::ProviderLateBound`] explicitly marks
+/// provider-selected schema material that cannot be known before dispatch. It
+/// is not included in the known local token estimate; provider-reported usage
+/// remains authoritative after the response.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProviderVisibleToolFootprint {
+    pub segments: Vec<ProviderVisibleToolSegment>,
+}
 
 /// Metadata for a provider model returned by `list_model_info`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -220,6 +279,30 @@ pub trait LLMProvider: Send + Sync {
         _required_tool: Option<&str>,
     ) -> CapabilityLoadingMode {
         CapabilityLoadingMode::LegacyFullCatalog
+    }
+
+    /// Lower the tool definitions visible to the model at this request.
+    ///
+    /// The default matches Bamboo's OpenAI-compatible Chat wire, which is also
+    /// the legacy surface used by generic providers. Native adapters override
+    /// this when their schema shape or deferred-loading protocol differs.
+    async fn provider_visible_tool_footprint(
+        &self,
+        _ir: &PromptIR,
+        tools: &[ToolSchema],
+        _model: &str,
+        _required_tool: Option<&str>,
+    ) -> Result<ProviderVisibleToolFootprint> {
+        if tools.is_empty() {
+            return Ok(ProviderVisibleToolFootprint::default());
+        }
+        let projected = crate::providers::common::openai_compat::tools_to_openai_compat_json(tools);
+        Ok(ProviderVisibleToolFootprint {
+            segments: vec![ProviderVisibleToolSegment::from_serializable(
+                ProviderVisibleToolSegmentKind::InitialFullDefinition,
+                &projected,
+            )?],
+        })
     }
 
     /// Stream chat completion from the LLM
@@ -432,6 +515,50 @@ mod tests {
     struct RecordingProvider {
         requested_models: Arc<Mutex<Vec<String>>>,
         requested_max_tokens: Arc<Mutex<Vec<Option<u32>>>>,
+    }
+
+    #[tokio::test]
+    async fn default_tool_footprint_is_one_compact_openai_compat_position() {
+        let provider = RecordingProvider::default();
+        let tools = vec![ToolSchema {
+            schema_type: "function".to_string(),
+            function: bamboo_domain::FunctionSchema {
+                name: "lookup".to_string(),
+                description: "Look up a value".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {"key": {"type": "string"}},
+                    "oneOf": [{"required": ["key"]}]
+                }),
+            },
+        }];
+
+        let footprint = provider
+            .provider_visible_tool_footprint(&PromptIR::default(), &tools, "model", None)
+            .await
+            .expect("footprint");
+
+        assert_eq!(footprint.segments.len(), 1);
+        assert_eq!(
+            footprint.segments[0].kind,
+            ProviderVisibleToolSegmentKind::InitialFullDefinition
+        );
+        let rendered: serde_json::Value =
+            serde_json::from_str(&footprint.segments[0].serialized).unwrap();
+        assert_eq!(
+            footprint.segments[0].serialized,
+            serde_json::to_string(&rendered).unwrap()
+        );
+        assert_eq!(rendered[0]["function"]["name"], "lookup");
+        assert!(rendered[0]["function"]["parameters"].get("oneOf").is_none());
+
+        assert_eq!(
+            provider
+                .provider_visible_tool_footprint(&PromptIR::default(), &[], "model", None)
+                .await
+                .unwrap(),
+            ProviderVisibleToolFootprint::default()
+        );
     }
 
     #[async_trait]

--- a/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
@@ -34,7 +34,10 @@ use serde_json::{json, Value};
 use crate::cache::{CacheTtl, PromptCachePlan, MAX_ANTHROPIC_CACHE_BREAKPOINTS};
 use crate::prompt_ir::PromptIR;
 use crate::provider::LLMRequestOptions;
-use crate::provider::{required_tool_from_options, LLMError, LLMProvider, LLMStream, Result};
+use crate::provider::{
+    required_tool_from_options, LLMError, LLMProvider, LLMStream, ProviderVisibleToolFootprint,
+    ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind, Result,
+};
 use crate::providers::common::model_fetcher;
 use crate::providers::common::request_overrides;
 use crate::types::LLMChunk;
@@ -284,6 +287,52 @@ impl LLMProvider for AnthropicProvider {
         } else {
             CapabilityLoadingMode::LegacyFullCatalog
         }
+    }
+
+    async fn provider_visible_tool_footprint(
+        &self,
+        ir: &PromptIR,
+        tools: &[ToolSchema],
+        model: &str,
+        required_tool: Option<&str>,
+    ) -> Result<ProviderVisibleToolFootprint> {
+        let mode = self.capability_loading_mode(model, required_tool).await;
+        if mode == CapabilityLoadingMode::LegacyFullCatalog {
+            let projected = tools_to_anthropic_json(tools, mode);
+            if projected.is_empty() {
+                return Ok(ProviderVisibleToolFootprint::default());
+            }
+            return Ok(ProviderVisibleToolFootprint {
+                segments: vec![ProviderVisibleToolSegment::from_serializable(
+                    ProviderVisibleToolSegmentKind::InitialFullDefinition,
+                    &projected,
+                )?],
+            });
+        }
+
+        let initial = tools_to_anthropic_json(tools, mode)
+            .into_iter()
+            .filter(|tool| tool.get("defer_loading").and_then(Value::as_bool) != Some(true))
+            .collect::<Vec<_>>();
+        let mut segments = vec![ProviderVisibleToolSegment::from_serializable(
+            ProviderVisibleToolSegmentKind::InitialFullDefinition,
+            &initial,
+        )?];
+        segments.push(ProviderVisibleToolSegment::empty_marker(
+            ProviderVisibleToolSegmentKind::ProviderLateBound,
+        ));
+
+        for definition in validated_anthropic_reference_definitions_in_order(
+            ir.provider_transcript_groups.iter(),
+            tools,
+        )? {
+            segments.push(ProviderVisibleToolSegment::from_serializable(
+                ProviderVisibleToolSegmentKind::AnthropicToolReferenceExpansion,
+                &definition,
+            )?);
+        }
+
+        Ok(ProviderVisibleToolFootprint { segments })
     }
 
     async fn chat_stream(
@@ -1783,21 +1832,20 @@ fn tool_call_to_tool_use_block(tool_call: &bamboo_domain::ToolCall) -> Value {
     })
 }
 
-fn tools_to_anthropic_json(
+fn tool_to_anthropic_json(tool: &ToolSchema) -> Value {
+    json!({
+        "name": tool.function.name,
+        "description": tool.function.description,
+        "input_schema": tool.function.parameters,
+    })
+}
+
+pub(crate) fn tools_to_anthropic_json(
     tools: &[ToolSchema],
     capability_loading_mode: CapabilityLoadingMode,
 ) -> Vec<Value> {
     if capability_loading_mode == CapabilityLoadingMode::LegacyFullCatalog {
-        return tools
-            .iter()
-            .map(|tool| {
-                json!({
-                    "name": tool.function.name,
-                    "description": tool.function.description,
-                    "input_schema": tool.function.parameters,
-                })
-            })
-            .collect();
+        return tools.iter().map(tool_to_anthropic_json).collect();
     }
 
     let mut rendered = tools
@@ -1807,11 +1855,7 @@ fn tools_to_anthropic_json(
             if identity.loading_class() == CapabilityLoadingClass::HostOnly {
                 return None;
             }
-            let mut value = json!({
-                "name": tool.function.name,
-                "description": tool.function.description,
-                "input_schema": tool.function.parameters,
-            });
+            let mut value = tool_to_anthropic_json(tool);
             if identity.loading_class() == CapabilityLoadingClass::Deferred {
                 value["defer_loading"] = Value::Bool(true);
             }
@@ -1890,6 +1934,42 @@ pub fn validated_anthropic_loaded_tool_names<'a>(
     }
 
     loaded.into_iter().collect()
+}
+
+/// Resolve every model-visible Anthropic reference occurrence, in transcript
+/// order, to the exact complete definition from this request's frozen catalog.
+/// Repeated references remain repeated because each one is expanded at a
+/// distinct history position by the provider.
+fn validated_anthropic_reference_definitions_in_order<'a>(
+    groups: impl IntoIterator<Item = &'a ProviderTranscriptGroup>,
+    eligible_tools: &[ToolSchema],
+) -> Result<Vec<Value>> {
+    let catalog = eligible_tools
+        .iter()
+        .filter_map(|tool| {
+            let identity = ClassifiedToolIdentity::from_schema_name(&tool.function.name)?;
+            (identity.loading_class() != CapabilityLoadingClass::HostOnly)
+                .then_some((identity.execution_name().to_string(), tool))
+        })
+        .collect::<HashMap<_, _>>();
+    let mut definitions = Vec::new();
+
+    for group in groups.into_iter().filter(|group| {
+        group.family() == ProviderFamily::Anthropic
+            && group.protocol() == ProviderProtocol::AnthropicMessages2023_06_01
+            && ProviderTranscriptGroup::validate_items(group.items()).is_ok()
+    }) {
+        for reference in group.items().iter().flat_map(anthropic_reference_names) {
+            let tool = catalog.get(reference).ok_or_else(|| {
+                LLMError::Api(format!(
+                    "Anthropic tool reference '{reference}' was not offered in the eligible catalog"
+                ))
+            })?;
+            definitions.push(tool_to_anthropic_json(tool));
+        }
+    }
+
+    Ok(definitions)
 }
 
 /// Stateful parser for Anthropic SSE streaming events.
@@ -2618,6 +2698,8 @@ pub fn parse_anthropic_sse_event(
 #[cfg(test)]
 mod anthropic_request_building {
     use crate::models::{ContentPart, ImageUrl};
+    use crate::prompt_ir::{PromptIR, Segment, SegmentRole};
+    use crate::provider::{LLMProvider, ProviderVisibleToolSegmentKind};
     use bamboo_domain::Message;
     use bamboo_domain::{FunctionCall, ToolCall};
     use bamboo_domain::{FunctionSchema, ToolSchema};
@@ -2676,6 +2758,199 @@ mod anthropic_request_building {
                 }),
             ),
         ]
+    }
+
+    fn host_reference_item(
+        tool_use_id: &str,
+        references: &[&str],
+    ) -> super::ProviderTranscriptItem {
+        super::ProviderTranscriptItem::try_from_payload(
+            super::ProviderFamily::Anthropic,
+            super::ProviderProtocol::AnthropicMessages2023_06_01,
+            super::ProviderTranscriptOrigin::HostToolSearch,
+            super::ProviderTranscriptAuthor::ToolResult,
+            json!({
+                "type":"tool_result",
+                "tool_use_id":tool_use_id,
+                "is_error":false,
+                "content":references.iter().map(|name| {
+                    json!({"type":"tool_reference","tool_name":name})
+                }).collect::<Vec<_>>()
+            }),
+        )
+        .unwrap()
+    }
+
+    fn anthropic_ir_with_reference_groups(groups: &[(&str, &[&str])]) -> PromptIR {
+        let mut session = bamboo_domain::Session::new("footprint-references", "claude");
+        activate_native_route(&mut session);
+        for (tool_use_id, references) in groups {
+            let result = Message::tool_result(*tool_use_id, "normalized reference result");
+            let anchor = result.id.clone();
+            session.add_message(result);
+            session
+                .append_provider_transcript_group(
+                    &anchor,
+                    None,
+                    vec![host_reference_item(tool_use_id, references)],
+                )
+                .unwrap();
+        }
+        PromptIR {
+            segments: vec![Segment::new(
+                SegmentRole::Conversation,
+                session.messages.clone(),
+            )],
+            provider_transcript_groups: session.provider_transcript.groups().to_vec(),
+            ..PromptIR::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn progressive_footprint_keeps_initial_array_and_each_reference_occurrence_ordered() {
+        let tools = vec![
+            tool_schema("Read"),
+            tool_schema("alpha_tool"),
+            tool_schema("beta_tool"),
+            tool_schema("Workspace"),
+        ];
+        let ir = anthropic_ir_with_reference_groups(&[
+            ("search_1", &["beta_tool", "Read", "alpha_tool"]),
+            ("search_2", &["beta_tool"]),
+        ]);
+        let footprint = super::AnthropicProvider::new("k")
+            .provider_visible_tool_footprint(&ir, &tools, "claude-sonnet-4-6", None)
+            .await
+            .unwrap();
+
+        assert_eq!(footprint.segments.len(), 6);
+        assert_eq!(
+            footprint.segments[0].kind,
+            ProviderVisibleToolSegmentKind::InitialFullDefinition
+        );
+        let initial: Value = serde_json::from_str(&footprint.segments[0].serialized).unwrap();
+        assert_eq!(initial.as_array().unwrap().len(), 2, "Read + search");
+        assert_eq!(initial[0]["name"], "Read");
+        assert_eq!(initial[1]["type"], super::ANTHROPIC_TOOL_SEARCH_TYPE);
+        assert!(initial.as_array().unwrap().iter().all(|tool| {
+            tool["name"] != "alpha_tool"
+                && tool["name"] != "beta_tool"
+                && tool["name"] != "Workspace"
+        }));
+        assert_eq!(
+            footprint.segments[1].kind,
+            ProviderVisibleToolSegmentKind::ProviderLateBound
+        );
+        assert!(footprint.segments[1].serialized.is_empty());
+
+        let expanded = footprint.segments[2..]
+            .iter()
+            .map(|segment| {
+                assert_eq!(
+                    segment.kind,
+                    ProviderVisibleToolSegmentKind::AnthropicToolReferenceExpansion
+                );
+                serde_json::from_str::<Value>(&segment.serialized).unwrap()["name"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            expanded,
+            vec!["beta_tool", "Read", "alpha_tool", "beta_tool"]
+        );
+    }
+
+    #[tokio::test]
+    async fn progressive_footprint_rejects_a_reference_missing_from_the_frozen_catalog() {
+        let ir = anthropic_ir_with_reference_groups(&[("search_missing", &["missing_tool"])]);
+        let error = super::AnthropicProvider::new("k")
+            .provider_visible_tool_footprint(&ir, &[tool_schema("Read")], "claude-sonnet-4-6", None)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("missing_tool"));
+        assert!(error.to_string().contains("eligible catalog"));
+    }
+
+    #[tokio::test]
+    async fn unreferenced_deferred_tools_do_not_change_the_initial_footprint() {
+        let provider = super::AnthropicProvider::new("k");
+        let baseline_tools = vec![tool_schema("Read")];
+        let baseline = provider
+            .provider_visible_tool_footprint(
+                &PromptIR::default(),
+                &baseline_tools,
+                "claude-sonnet-4-6",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let mut expanded_tools = baseline_tools.clone();
+        expanded_tools.extend((0..100).map(|index| {
+            let mut tool = tool_schema(&format!("deferred_tool_{index}"));
+            tool.function.parameters = json!({
+                "type": "object",
+                "description": "hidden".repeat(1_000),
+            });
+            tool
+        }));
+        let expanded = provider
+            .provider_visible_tool_footprint(
+                &PromptIR::default(),
+                &expanded_tools,
+                "claude-sonnet-4-6",
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(expanded.segments, baseline.segments);
+        let baseline_transport = super::tools_to_anthropic_json(
+            &baseline_tools,
+            super::CapabilityLoadingMode::Progressive,
+        );
+        let expanded_transport = super::tools_to_anthropic_json(
+            &expanded_tools,
+            super::CapabilityLoadingMode::Progressive,
+        );
+        assert_eq!(expanded_transport.len(), baseline_transport.len() + 100);
+        assert_eq!(
+            expanded_transport
+                .iter()
+                .filter(|tool| tool["defer_loading"] == true)
+                .count(),
+            100
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_footprint_matches_the_complete_anthropic_tools_lowering() {
+        let tools = vec![tool_schema("Read"), tool_schema("Glob")];
+        let footprint = super::AnthropicProvider::new("k")
+            .provider_visible_tool_footprint(
+                &PromptIR::default(),
+                &tools,
+                "claude-sonnet-4-6",
+                Some("Read"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(footprint.segments.len(), 1);
+        assert_eq!(
+            footprint.segments[0].kind,
+            ProviderVisibleToolSegmentKind::InitialFullDefinition
+        );
+        assert_eq!(
+            footprint.segments[0].serialized,
+            serde_json::to_string(&super::tools_to_anthropic_json(
+                &tools,
+                super::CapabilityLoadingMode::LegacyFullCatalog,
+            ))
+            .unwrap()
+        );
     }
 
     fn activate_native_route(session: &mut bamboo_domain::Session) {

--- a/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
@@ -9,13 +9,17 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION},
     Client,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 
-use crate::provider::{LLMError, LLMProvider, LLMRequestOptions, LLMStream, Result};
+use crate::protocol::ToProvider;
+use crate::provider::{
+    LLMError, LLMProvider, LLMRequestOptions, LLMStream, ProviderVisibleToolFootprint,
+    ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind, Result,
+};
 use crate::providers::common::model_fetcher;
 use crate::providers::common::openai_compat::{
     build_openai_compat_body, openai_compat_chat_stream_from_sse,
-    parse_openai_compat_sse_data_strict_multi,
+    parse_openai_compat_sse_data_strict_multi, tools_to_openai_compat_json,
 };
 use crate::providers::common::sse::llm_stream_from_sse;
 use bamboo_config::KeywordMaskingConfig;
@@ -93,6 +97,44 @@ impl BodhiProvider {
 
 #[async_trait]
 impl LLMProvider for BodhiProvider {
+    async fn provider_visible_tool_footprint(
+        &self,
+        _ir: &crate::prompt_ir::PromptIR,
+        tools: &[ToolSchema],
+        _model: &str,
+        _required_tool: Option<&str>,
+    ) -> Result<ProviderVisibleToolFootprint> {
+        let projected: Vec<Value> = match self.target_provider.as_str() {
+            "openai" => tools_to_openai_compat_json(tools),
+            "anthropic" => crate::providers::anthropic::tools_to_anthropic_json(
+                tools,
+                bamboo_domain::CapabilityLoadingMode::LegacyFullCatalog,
+            ),
+            "gemini" => {
+                let tools: Vec<crate::protocol::gemini::GeminiTool> =
+                    tools.to_vec().to_provider()?;
+                tools
+                    .into_iter()
+                    .map(serde_json::to_value)
+                    .collect::<std::result::Result<_, _>>()?
+            }
+            other => {
+                return Err(LLMError::Auth(format!(
+                    "Unknown bodhi target provider: {other}"
+                )))
+            }
+        };
+        if projected.is_empty() {
+            return Ok(ProviderVisibleToolFootprint::default());
+        }
+        Ok(ProviderVisibleToolFootprint {
+            segments: vec![ProviderVisibleToolSegment::from_serializable(
+                ProviderVisibleToolSegmentKind::InitialFullDefinition,
+                &projected,
+            )?],
+        })
+    }
+
     async fn chat_stream(
         &self,
         messages: &[Message],
@@ -495,6 +537,53 @@ mod tests {
                 parameters: serde_json::json!({"type": "object"}),
             },
         }
+    }
+
+    #[tokio::test]
+    async fn tool_footprint_matches_each_bodhi_target_lowering() {
+        let tools = vec![load_skill_tool()];
+        let ir = crate::prompt_ir::PromptIR::default();
+
+        let openai = BodhiProvider::new("k")
+            .provider_visible_tool_footprint(&ir, &tools, "model", None)
+            .await
+            .unwrap();
+        assert_eq!(
+            openai.segments[0].serialized,
+            serde_json::to_string(&tools_to_openai_compat_json(&tools)).unwrap()
+        );
+
+        let anthropic = BodhiProvider::new("k")
+            .with_target_provider("anthropic")
+            .provider_visible_tool_footprint(&ir, &tools, "model", None)
+            .await
+            .unwrap();
+        assert_eq!(
+            anthropic.segments[0].serialized,
+            serde_json::to_string(&crate::providers::anthropic::tools_to_anthropic_json(
+                &tools,
+                bamboo_domain::CapabilityLoadingMode::LegacyFullCatalog,
+            ))
+            .unwrap()
+        );
+
+        let gemini = BodhiProvider::new("k")
+            .with_target_provider("gemini")
+            .provider_visible_tool_footprint(&ir, &tools, "model", None)
+            .await
+            .unwrap();
+        let gemini: Value = serde_json::from_str(&gemini.segments[0].serialized).unwrap();
+        assert_eq!(gemini[0]["functionDeclarations"][0]["name"], "load_skill");
+        assert!(gemini[0]["functionDeclarations"][0]
+            .get("parametersJsonSchema")
+            .is_some());
+
+        let error = BodhiProvider::new("k")
+            .with_target_provider("unknown")
+            .provider_visible_tool_footprint(&ir, &tools, "model", None)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("Unknown bodhi target provider"));
     }
 
     fn unsigned_tool_loop_messages() -> Vec<Message> {

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -510,6 +510,45 @@ pub fn tools_to_progressive_responses_json(
     projected
 }
 
+/// Return the complete progressive Responses definitions inserted into the
+/// model's initial prefix. Hosted deferred functions retain a separate visible
+/// name/description descriptor, returned by
+/// [`tools_to_progressive_responses_deferred_descriptors_json`].
+pub fn tools_to_progressive_responses_footprint_json(
+    tools: &[ToolSchema],
+    execution: ResponsesToolSearchExecution,
+) -> Vec<Value> {
+    tools_to_progressive_responses_json(tools, execution)
+        .into_iter()
+        .filter(|tool| tool.get("defer_loading").and_then(Value::as_bool) != Some(true))
+        .collect()
+}
+
+/// Return the descriptor-only surface retained for server-hosted deferred
+/// functions. OpenAI keeps function names and descriptions visible while the
+/// potentially large parameter schemas stay deferred. Client search receives
+/// no deferred functions in the initial request and therefore has no matching
+/// descriptor segment.
+pub fn tools_to_progressive_responses_deferred_descriptors_json(
+    tools: &[ToolSchema],
+    execution: ResponsesToolSearchExecution,
+) -> Vec<Value> {
+    if execution == ResponsesToolSearchExecution::Client {
+        return Vec::new();
+    }
+    tools_to_progressive_responses_json(tools, execution)
+        .into_iter()
+        .filter_map(|mut tool| {
+            (tool.get("defer_loading").and_then(Value::as_bool) == Some(true)).then(|| {
+                if let Some(object) = tool.as_object_mut() {
+                    object.remove("parameters");
+                }
+                tool
+            })
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponsesInputSource {
     Explicit,
@@ -3182,6 +3221,9 @@ mod tests {
         assert_eq!(out[0]["name"], "Read");
         assert!(out[0].get("defer_loading").is_none());
         assert_eq!(out[1]["name"], "Glob");
+        assert_eq!(out[1]["description"], "Use Glob");
+        assert!(out[1]["parameters"].is_object());
+        assert_eq!(out[1]["strict"], false);
         assert_eq!(out[1]["defer_loading"], true);
         assert_eq!(out[2]["type"], "tool_search");
         assert_eq!(out[2]["execution"], "server");
@@ -3189,6 +3231,57 @@ mod tests {
         assert!(out[2].get("parameters").is_none());
         assert!(out[2].get("defer_loading").is_none());
         assert!(out.iter().all(|tool| tool["name"] != "Workspace"));
+
+        let footprint = tools_to_progressive_responses_footprint_json(
+            &tools,
+            ResponsesToolSearchExecution::Server,
+        );
+        assert_eq!(footprint.len(), 2, "Read + hosted search only");
+        assert_eq!(footprint[0]["name"], "Read");
+        assert_eq!(footprint[1]["type"], "tool_search");
+        assert!(footprint.iter().all(|tool| tool["name"] != "Glob"));
+    }
+
+    #[test]
+    fn hosted_deferred_descriptor_counts_names_but_not_hidden_parameter_size() {
+        let small = loading_schema("Glob");
+        let mut huge = small.clone();
+        huge.function.parameters = json!({
+            "type":"object",
+            "properties":{
+                "payload":{
+                    "type":"string",
+                    "description":"x".repeat(32_000)
+                }
+            }
+        });
+        let small_descriptor = tools_to_progressive_responses_deferred_descriptors_json(
+            std::slice::from_ref(&small),
+            ResponsesToolSearchExecution::Server,
+        );
+        let huge_descriptor = tools_to_progressive_responses_deferred_descriptors_json(
+            std::slice::from_ref(&huge),
+            ResponsesToolSearchExecution::Server,
+        );
+        assert_eq!(small_descriptor, huge_descriptor);
+        assert!(!serde_json::to_string(&huge_descriptor)
+            .unwrap()
+            .contains(&"x".repeat(128)));
+
+        let named = loading_schema("much_longer_deferred_function_name");
+        let named_descriptor = tools_to_progressive_responses_deferred_descriptors_json(
+            &[named],
+            ResponsesToolSearchExecution::Server,
+        );
+        assert!(
+            serde_json::to_string(&named_descriptor).unwrap().len()
+                > serde_json::to_string(&small_descriptor).unwrap().len()
+        );
+        assert!(tools_to_progressive_responses_deferred_descriptors_json(
+            &[small],
+            ResponsesToolSearchExecution::Client,
+        )
+        .is_empty());
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
@@ -9,6 +9,7 @@ use tokio::sync::RwLock;
 pub mod auth;
 use crate::provider::{
     LLMError, LLMProvider, LLMRequestOptions, LLMStream, ProviderModelInfo,
+    ProviderVisibleToolFootprint, ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind,
     ResponsesRequestOptions, Result,
 };
 use crate::types::LLMChunk;
@@ -25,7 +26,7 @@ use super::common::openai_compat::{
 };
 use super::common::openai_responses::{
     build_responses_body, retain_provider_transcript_family, select_responses_input_messages,
-    ResponsesInputSource, ResponsesSseParser,
+    tools_to_responses_json, ResponsesInputSource, ResponsesSseParser,
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
@@ -1107,6 +1108,29 @@ impl CopilotProvider {
 
 #[async_trait]
 impl LLMProvider for CopilotProvider {
+    async fn provider_visible_tool_footprint(
+        &self,
+        _ir: &crate::prompt_ir::PromptIR,
+        tools: &[ToolSchema],
+        model: &str,
+        _required_tool: Option<&str>,
+    ) -> Result<ProviderVisibleToolFootprint> {
+        if tools.is_empty() {
+            return Ok(ProviderVisibleToolFootprint::default());
+        }
+        let projected = if self.uses_responses_api(model) {
+            tools_to_responses_json(tools)
+        } else {
+            tools_to_openai_compat_json(tools)
+        };
+        Ok(ProviderVisibleToolFootprint {
+            segments: vec![ProviderVisibleToolSegment::from_serializable(
+                ProviderVisibleToolSegmentKind::InitialFullDefinition,
+                &projected,
+            )?],
+        })
+    }
+
     async fn chat_stream(
         &self,
         messages: &[Message],
@@ -1705,6 +1729,52 @@ mod tests {
         assert!(provider.uses_responses_api("gpt-5.3-codex"));
         assert!(provider.uses_responses_api("gpt-5.4-whatever"));
         assert!(!provider.uses_responses_api("gpt-4o"));
+    }
+
+    #[tokio::test]
+    async fn tool_footprint_matches_copilot_chat_and_responses_routes() {
+        let tools = vec![ToolSchema {
+            schema_type: "function".to_string(),
+            function: FunctionSchema {
+                name: "lookup".to_string(),
+                description: "Lookup".to_string(),
+                parameters: json!({"type":"object"}),
+            },
+        }];
+        let provider =
+            CopilotProvider::new().with_responses_only_models(vec!["gpt-5*".to_string()]);
+
+        let chat = provider
+            .provider_visible_tool_footprint(
+                &crate::prompt_ir::PromptIR::default(),
+                &tools,
+                "gpt-4o",
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            chat.segments[0].serialized,
+            serde_json::to_string(&tools_to_openai_compat_json(&tools)).unwrap()
+        );
+
+        let responses = provider
+            .provider_visible_tool_footprint(
+                &crate::prompt_ir::PromptIR::default(),
+                &tools,
+                "gpt-5.6",
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            responses.segments[0].serialized,
+            serde_json::to_string(&tools_to_responses_json(&tools)).unwrap()
+        );
+        assert_ne!(
+            responses.segments[0].serialized,
+            chat.segments[0].serialized
+        );
     }
 
     // ============================================

--- a/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
@@ -13,7 +13,10 @@ use serde_json::{json, Value};
 
 use crate::protocol::gemini::GeminiRequest;
 use crate::protocol::ToProvider;
-use crate::provider::{LLMError, LLMProvider, LLMRequestOptions, LLMStream, Result};
+use crate::provider::{
+    LLMError, LLMProvider, LLMRequestOptions, LLMStream, ProviderVisibleToolFootprint,
+    ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind, Result,
+};
 use crate::providers::common::model_fetcher;
 use crate::providers::common::request_overrides;
 use crate::types::LLMChunk;
@@ -174,6 +177,25 @@ impl GeminiProvider {
 
 #[async_trait]
 impl LLMProvider for GeminiProvider {
+    async fn provider_visible_tool_footprint(
+        &self,
+        _ir: &crate::prompt_ir::PromptIR,
+        tools: &[ToolSchema],
+        _model: &str,
+        _required_tool: Option<&str>,
+    ) -> Result<ProviderVisibleToolFootprint> {
+        if tools.is_empty() {
+            return Ok(ProviderVisibleToolFootprint::default());
+        }
+        let projected: Vec<crate::protocol::gemini::GeminiTool> = tools.to_vec().to_provider()?;
+        Ok(ProviderVisibleToolFootprint {
+            segments: vec![ProviderVisibleToolSegment::from_serializable(
+                ProviderVisibleToolSegmentKind::InitialFullDefinition,
+                &projected,
+            )?],
+        })
+    }
+
     async fn chat_stream(
         &self,
         messages: &[Message],
@@ -425,6 +447,50 @@ impl LLMProvider for GeminiProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn tool_footprint_reuses_grouped_gemini_function_declarations() {
+        let tools = vec!["lookup", "summarize"]
+            .into_iter()
+            .map(|name| ToolSchema {
+                schema_type: "function".to_string(),
+                function: bamboo_domain::FunctionSchema {
+                    name: name.to_string(),
+                    description: format!("Use {name}"),
+                    parameters: json!({"type":"object"}),
+                },
+            })
+            .collect::<Vec<_>>();
+        let expected: Vec<crate::protocol::gemini::GeminiTool> =
+            tools.clone().to_provider().unwrap();
+        let footprint = GeminiProvider::new("k")
+            .provider_visible_tool_footprint(
+                &crate::prompt_ir::PromptIR::default(),
+                &tools,
+                "gemini-test",
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(footprint.segments.len(), 1);
+        assert_eq!(
+            footprint.segments[0].kind,
+            ProviderVisibleToolSegmentKind::InitialFullDefinition
+        );
+        assert_eq!(
+            footprint.segments[0].serialized,
+            serde_json::to_string(&expected).unwrap()
+        );
+        let rendered: Value = serde_json::from_str(&footprint.segments[0].serialized).unwrap();
+        assert_eq!(
+            rendered[0]["functionDeclarations"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+    }
 
     #[test]
     fn max_reasoning_uses_a_distinct_larger_thinking_budget() {

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -13,6 +13,7 @@ use serde_json::{json, Value};
 use crate::prompt_ir::PromptIR;
 use crate::provider::{
     required_tool_from_options, LLMError, LLMProvider, LLMRequestOptions, LLMStream,
+    ProviderVisibleToolFootprint, ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind,
     ResponsesRequestOptions, Result,
 };
 use crate::types::LLMChunk;
@@ -22,12 +23,13 @@ use bamboo_domain::{CapabilityLoadingMode, Message, ReasoningEffort, ToolSchema}
 use super::common::model_fetcher;
 use super::common::openai_compat::{
     build_openai_compat_body, openai_compat_chat_stream_from_sse,
-    parse_openai_compat_sse_data_strict_multi,
+    parse_openai_compat_sse_data_strict_multi, tools_to_openai_compat_json,
 };
 use super::common::openai_responses::{
     build_responses_body_with_capability_loading, retain_provider_transcript_family,
-    select_responses_input_messages, ResponsesInputSource, ResponsesSseParser,
-    ResponsesToolSearchExecution, ResponsesWirePrefixTracker,
+    select_responses_input_messages, tools_to_progressive_responses_deferred_descriptors_json,
+    tools_to_progressive_responses_footprint_json, tools_to_responses_json, ResponsesInputSource,
+    ResponsesSseParser, ResponsesToolSearchExecution, ResponsesWirePrefixTracker,
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
@@ -542,6 +544,55 @@ impl LLMProvider for OpenAIProvider {
         }
     }
 
+    async fn provider_visible_tool_footprint(
+        &self,
+        _ir: &PromptIR,
+        tools: &[ToolSchema],
+        model: &str,
+        required_tool: Option<&str>,
+    ) -> Result<ProviderVisibleToolFootprint> {
+        let mode = self.capability_loading_mode(model, required_tool).await;
+        let (projected, deferred_descriptors, late_bound) = if self.uses_responses_api(model) {
+            match mode {
+                CapabilityLoadingMode::Progressive => {
+                    let execution = self
+                        .tool_search_execution
+                        .unwrap_or(ResponsesToolSearchExecution::Client);
+                    (
+                        tools_to_progressive_responses_footprint_json(tools, execution),
+                        tools_to_progressive_responses_deferred_descriptors_json(tools, execution),
+                        true,
+                    )
+                }
+                CapabilityLoadingMode::LegacyFullCatalog
+                | CapabilityLoadingMode::StickyFallback => {
+                    (tools_to_responses_json(tools), Vec::new(), false)
+                }
+            }
+        } else {
+            (tools_to_openai_compat_json(tools), Vec::new(), false)
+        };
+        if projected.is_empty() {
+            return Ok(ProviderVisibleToolFootprint::default());
+        }
+        let mut segments = vec![ProviderVisibleToolSegment::from_serializable(
+            ProviderVisibleToolSegmentKind::InitialFullDefinition,
+            &projected,
+        )?];
+        if !deferred_descriptors.is_empty() {
+            segments.push(ProviderVisibleToolSegment::from_serializable(
+                ProviderVisibleToolSegmentKind::InitialDeferredDescriptor,
+                &deferred_descriptors,
+            )?);
+        }
+        if late_bound {
+            segments.push(ProviderVisibleToolSegment::empty_marker(
+                ProviderVisibleToolSegmentKind::ProviderLateBound,
+            ));
+        }
+        Ok(ProviderVisibleToolFootprint { segments })
+    }
+
     async fn chat_stream(
         &self,
         messages: &[Message],
@@ -885,12 +936,16 @@ impl LLMProvider for OpenAIProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prompt_ir::{Segment, SegmentRole};
     use crate::providers::common::openai_compat::parse_openai_compat_sse_data_strict;
     use bamboo_config::{
         BodyPatch, BodyPatchOp, PatchValue, RequestOverridesConfig, RequestScopeOverride,
     };
     use bamboo_domain::Message;
-    use bamboo_domain::{FunctionSchema, ToolSchema};
+    use bamboo_domain::{
+        FunctionSchema, ProviderFamily, ProviderProtocol, ProviderTranscriptAuthor,
+        ProviderTranscriptItem, ProviderTranscriptOrigin, ToolSchema,
+    };
 
     // ===== Basic Tests (5 tests) =====
 
@@ -934,6 +989,262 @@ mod tests {
         assert!(provider.uses_responses_api("gpt-5.3-codex"));
         assert!(provider.uses_responses_api("gpt-5.0-any"));
         assert!(!provider.uses_responses_api("gpt-4o-mini"));
+    }
+
+    fn footprint_schema(name: &str) -> ToolSchema {
+        ToolSchema {
+            schema_type: "function".to_string(),
+            function: FunctionSchema {
+                name: name.to_string(),
+                description: format!("Use {name}"),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}}
+                }),
+            },
+        }
+    }
+
+    fn ir_with_openai_loaded_history() -> PromptIR {
+        let mut session = bamboo_domain::Session::new("footprint-history", "gpt-5.6");
+        let assistant = Message::assistant("", None);
+        let anchor = assistant.id.clone();
+        session.add_message(assistant.clone());
+        let boundary = bamboo_domain::provider_transcript_boundary_sha256(
+            Some("openai-footprint"),
+            Some("openai"),
+        )
+        .unwrap();
+        session
+            .activate_provider_transcript_route(
+                ProviderFamily::OpenAi,
+                ProviderProtocol::OpenAiResponsesV1,
+                &boundary,
+            )
+            .unwrap();
+        let output = ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::HostToolSearch,
+            ProviderTranscriptAuthor::ToolResult,
+            json!({
+                "type":"tool_search_output","execution":"client","call_id":"search_1",
+                "status":"completed","tools":[{
+                    "type":"function","name":"Glob","description":"Find files",
+                    "parameters":{"type":"object"},"strict":false,"defer_loading":true
+                }]
+            }),
+        )
+        .unwrap();
+        session
+            .append_provider_transcript_group(&anchor, None, vec![output])
+            .unwrap();
+        let additional = ProviderTranscriptItem::try_from_payload(
+            ProviderFamily::OpenAi,
+            ProviderProtocol::OpenAiResponsesV1,
+            ProviderTranscriptOrigin::DeveloperContext,
+            ProviderTranscriptAuthor::Host,
+            json!({
+                "type":"additional_tools","role":"developer","tools":[{
+                    "type":"function","name":"extra_tool","description":"Extra",
+                    "parameters":{"type":"object"},"strict":false
+                }]
+            }),
+        )
+        .unwrap();
+        session
+            .append_provider_transcript_group(&anchor, None, vec![additional])
+            .unwrap();
+
+        PromptIR {
+            segments: vec![Segment::new(SegmentRole::Conversation, vec![assistant])],
+            provider_transcript_groups: session.provider_transcript.groups().to_vec(),
+            ..PromptIR::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn responses_progressive_footprint_is_core_plus_search_for_client_and_server() {
+        let tools = vec![
+            footprint_schema("Read"),
+            footprint_schema("Glob"),
+            footprint_schema("Workspace"),
+        ];
+        let ir = ir_with_openai_loaded_history();
+        for execution in [
+            ResponsesToolSearchExecution::Client,
+            ResponsesToolSearchExecution::Server,
+        ] {
+            let expected_execution = match execution {
+                ResponsesToolSearchExecution::Client => "client",
+                ResponsesToolSearchExecution::Server => "server",
+            };
+            let provider = OpenAIProvider::new("k")
+                .with_responses_only_models(vec!["gpt-5*".to_string()])
+                .with_tool_search_execution(execution);
+            let footprint = provider
+                .provider_visible_tool_footprint(&ir, &tools, "gpt-5.6", None)
+                .await
+                .unwrap();
+
+            let marker_index = match execution {
+                ResponsesToolSearchExecution::Client => {
+                    assert_eq!(footprint.segments.len(), 2);
+                    1
+                }
+                ResponsesToolSearchExecution::Server => {
+                    assert_eq!(footprint.segments.len(), 3);
+                    assert_eq!(
+                        footprint.segments[1].kind,
+                        ProviderVisibleToolSegmentKind::InitialDeferredDescriptor
+                    );
+                    let descriptors: Value =
+                        serde_json::from_str(&footprint.segments[1].serialized).unwrap();
+                    assert_eq!(descriptors.as_array().unwrap().len(), 1);
+                    assert_eq!(descriptors[0]["type"], "function");
+                    assert_eq!(descriptors[0]["name"], "Glob");
+                    assert_eq!(descriptors[0]["description"], "Use Glob");
+                    assert_eq!(descriptors[0]["defer_loading"], true);
+                    assert_eq!(descriptors[0]["strict"], false);
+                    assert!(descriptors[0].get("parameters").is_none());
+                    assert!(!footprint.segments[1].serialized.contains("extra_tool"));
+                    2
+                }
+            };
+            assert_eq!(
+                footprint.segments[0].kind,
+                ProviderVisibleToolSegmentKind::InitialFullDefinition
+            );
+            assert_eq!(
+                footprint.segments[marker_index],
+                ProviderVisibleToolSegment::empty_marker(
+                    ProviderVisibleToolSegmentKind::ProviderLateBound
+                )
+            );
+            let projected: Value = serde_json::from_str(&footprint.segments[0].serialized).unwrap();
+            let projected = projected.as_array().unwrap();
+            assert_eq!(projected.len(), 2, "Core definition plus search");
+            assert_eq!(projected[0]["name"], "Read");
+            assert_eq!(projected[1]["type"], "tool_search");
+            assert_eq!(projected[1]["execution"], expected_execution);
+            assert!(projected.iter().all(|tool| tool["name"] != "Glob"));
+            assert!(projected.iter().all(|tool| tool["name"] != "Workspace"));
+            assert!(projected.iter().all(|tool| tool["name"] != "extra_tool"));
+        }
+    }
+
+    #[tokio::test]
+    async fn hosted_deferred_descriptor_ignores_hidden_parameters_but_tracks_description() {
+        let provider = OpenAIProvider::new("k")
+            .with_responses_only_models(vec!["gpt-5*".to_string()])
+            .with_tool_search_execution(ResponsesToolSearchExecution::Server);
+        let mut tools = vec![footprint_schema("Read"), footprint_schema("Glob")];
+
+        let baseline = provider
+            .provider_visible_tool_footprint(&PromptIR::default(), &tools, "gpt-5.6", None)
+            .await
+            .unwrap();
+        let baseline_descriptor = baseline
+            .segments
+            .iter()
+            .find(|segment| {
+                segment.kind == ProviderVisibleToolSegmentKind::InitialDeferredDescriptor
+            })
+            .unwrap()
+            .serialized
+            .clone();
+
+        tools[1].function.parameters = json!({
+            "type": "object",
+            "description": "hidden".repeat(50_000),
+        });
+        let huge_hidden_schema = provider
+            .provider_visible_tool_footprint(&PromptIR::default(), &tools, "gpt-5.6", None)
+            .await
+            .unwrap();
+        let huge_descriptor = huge_hidden_schema
+            .segments
+            .iter()
+            .find(|segment| {
+                segment.kind == ProviderVisibleToolSegmentKind::InitialDeferredDescriptor
+            })
+            .unwrap();
+        assert_eq!(huge_descriptor.serialized, baseline_descriptor);
+        assert!(!huge_descriptor.serialized.contains("hidden"));
+
+        tools[1].function.description = "A different visible description".to_string();
+        let changed_description = provider
+            .provider_visible_tool_footprint(&PromptIR::default(), &tools, "gpt-5.6", None)
+            .await
+            .unwrap();
+        let changed_descriptor = changed_description
+            .segments
+            .iter()
+            .find(|segment| {
+                segment.kind == ProviderVisibleToolSegmentKind::InitialDeferredDescriptor
+            })
+            .unwrap();
+        assert_ne!(changed_descriptor.serialized, baseline_descriptor);
+        assert!(changed_descriptor
+            .serialized
+            .contains("A different visible description"));
+    }
+
+    #[tokio::test]
+    async fn responses_legacy_and_chat_sticky_footprints_match_their_top_level_lowering() {
+        let full = vec![footprint_schema("Read"), footprint_schema("Glob")];
+        let responses =
+            OpenAIProvider::new("k").with_responses_only_models(vec!["gpt-5*".to_string()]);
+        let legacy = responses
+            .provider_visible_tool_footprint(&PromptIR::default(), &full, "gpt-5.6", None)
+            .await
+            .unwrap();
+        assert_eq!(legacy.segments.len(), 1);
+        assert_eq!(
+            legacy.segments[0].kind,
+            ProviderVisibleToolSegmentKind::InitialFullDefinition
+        );
+        assert_eq!(
+            legacy.segments[0].serialized,
+            serde_json::to_string(&tools_to_responses_json(&full)).unwrap()
+        );
+
+        let sticky_tools = vec![
+            footprint_schema("Read"),
+            bamboo_domain::discovery_control_fallback_schema(),
+        ];
+        let sticky = OpenAIProvider::new("k").with_sticky_tool_loading(true);
+        assert_eq!(
+            sticky.capability_loading_mode("gpt-4o-mini", None).await,
+            CapabilityLoadingMode::StickyFallback
+        );
+        let sticky_footprint = sticky
+            .provider_visible_tool_footprint(
+                &PromptIR::default(),
+                &sticky_tools,
+                "gpt-4o-mini",
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            sticky_footprint.segments[0].serialized,
+            serde_json::to_string(&tools_to_openai_compat_json(&sticky_tools)).unwrap()
+        );
+
+        let forced = responses
+            .with_tool_search_execution(ResponsesToolSearchExecution::Server)
+            .provider_visible_tool_footprint(&PromptIR::default(), &full, "gpt-5.6", Some("Glob"))
+            .await
+            .unwrap();
+        assert_eq!(
+            forced.segments[0].kind,
+            ProviderVisibleToolSegmentKind::InitialFullDefinition
+        );
+        assert_eq!(
+            forced.segments[0].serialized,
+            serde_json::to_string(&tools_to_responses_json(&full)).unwrap()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add provider-owned, ordered model-visible tool-footprint lowering for Anthropic, OpenAI Responses/Chat, Copilot, Gemini, Bodhi, and reloadable providers
- account for message tokens and known provider-visible schema tokens in separate lanes, then use their saturating total during shadow refit and the final pre-dispatch guard
- preserve progressive loading semantics: Anthropic deferred definitions count only when referenced, OpenAI hosted descriptors exclude hidden parameters, and loaded history items remain in the message lane
- persist only numeric request-render measurements (tokens, bytes, chars, known segments, and late-bound markers)

Hosted same-response tool selection remains explicitly `ProviderLateBound`. The public protocol exposes no hard bound from which to derive an honest pre-dispatch token reserve, so this PR does not add a guessed constant or a new configuration framework. The local guard is exact for known pre-dispatch input; provider-reported usage remains authoritative after the response.

Closes #964

## Test Plan

- `cargo test -p bamboo-compression -p bamboo-llm -p bamboo-engine --lib` — 2,235 passed, 0 failed
- `cargo test -p bamboo-server reloadable_provider` — 2 passed, 0 failed
- `cargo clippy -p bamboo-compression --all-targets --no-deps -- -D warnings -A clippy::needless_borrows_for_generic_args`
- `cargo clippy -p bamboo-llm --all-targets --no-deps -- -D warnings`
- `cargo clippy -p bamboo-engine --all-targets --no-deps -- -D warnings` with only existing unrelated repository lint classes allowed for verification
- `cargo clippy -p bamboo-server --lib --no-deps -- -D warnings -A clippy::too-many-arguments`
- `cargo fmt --all -- --check`
- `git diff --check`

The unmodified all-targets workspace baseline still contains unrelated lint debt (including `compression_tooling.rs:1845` and existing engine/server test lint classes); this PR does not expand scope to repair it.
