### PR TITLE
refactor: delete Project memory aliases (#1015)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,6 @@ dependencies = [
  "bamboo-infrastructure",
  "bamboo-llm",
  "bamboo-mcp",
- "bamboo-memory",
  "bamboo-metrics",
  "bamboo-plugin-protocol",
  "bamboo-projects",

--- a/crates/app/bamboo-sdk/Cargo.toml
+++ b/crates/app/bamboo-sdk/Cargo.toml
@@ -22,7 +22,6 @@ bamboo-skills = { path = "../../infra/bamboo-skills" }
 bamboo-storage = { path = "../../infra/bamboo-storage" }
 bamboo-tools = { path = "../../engine/bamboo-tools" }
 bamboo-mcp = { path = "../../infra/bamboo-mcp" }
-bamboo-memory = { path = "../../infra/bamboo-memory" }
 bamboo-projects = { path = "../../infra/bamboo-projects" }
 bamboo-plugin-protocol = { path = "../../infra/bamboo-plugin-protocol" }
 bamboo-server-tools = { path = "../bamboo-server-tools" }

--- a/crates/app/bamboo-sdk/src/agent/builder.rs
+++ b/crates/app/bamboo-sdk/src/agent/builder.rs
@@ -77,12 +77,6 @@ impl bamboo_engine::project_context::ProjectContextSource for SdkProjectContextS
         let resources = self.store.resource_summary(project_id).map_err(|error| {
             bamboo_engine::project_context::ProjectContextError::Source(error.to_string())
         })?;
-        let roots = self
-            .store
-            .project_memory_read_roots(project_id)
-            .map_err(|error| {
-                bamboo_engine::project_context::ProjectContextError::Source(error.to_string())
-            })?;
         Ok(Some(bamboo_engine::project_context::ProjectDescriptor {
             id: manifest.id.clone(),
             name: manifest.name,
@@ -90,19 +84,6 @@ impl bamboo_engine::project_context::ProjectContextSource for SdkProjectContextS
             home: self.store.paths().project_home(project_id),
             workspace_bindings: manifest.workspace_bindings,
             resources,
-            memory_read_roots: bamboo_engine::project_context::ProjectMemoryReadRoots {
-                primary: roots.primary,
-                legacy_aliases: roots
-                    .legacy_aliases
-                    .into_iter()
-                    .map(
-                        |root| bamboo_memory::memory_store::LegacyProjectMemoryReadRoot {
-                            project_key: root.legacy_project_key,
-                            root: root.root,
-                        },
-                    )
-                    .collect(),
-            },
         }))
     }
 

--- a/crates/app/bamboo-server-tools/src/memory/mod.rs
+++ b/crates/app/bamboo-server-tools/src/memory/mod.rs
@@ -4,8 +4,8 @@ use serde_json::json;
 use bamboo_agent_core::tools::{Tool, ToolClass, ToolCtx, ToolError, ToolOutcome, ToolResult};
 use bamboo_agent_core::Session;
 use bamboo_memory::memory_store::{
-    DurableMemoryStatus, LegacyProjectMemoryReadRoot, MemoryQueryOptions, MemoryScope, MemoryStore,
-    MAX_MAX_CHARS, MAX_QUERY_LIMIT,
+    DurableMemoryStatus, MemoryQueryOptions, MemoryScope, MemoryStore, MAX_MAX_CHARS,
+    MAX_QUERY_LIMIT,
 };
 use bamboo_tools::tools::session_memory::{
     execute_session_memory_action, SessionMemoryAction, MEMORY_SESSION_ACTION_NAMES,
@@ -23,13 +23,11 @@ use args::MemoryArgs;
 pub struct MemoryTool {
     session_repo: bamboo_engine::SessionRepository,
     memory_store: MemoryStore,
-    project_store: Option<std::sync::Arc<bamboo_projects::ProjectStore>>,
 }
 
-struct ResolvedProjectMemoryAccess {
+struct ResolvedMemoryAccess {
     store: MemoryStore,
     project_key: Option<String>,
-    writable: bool,
 }
 
 impl MemoryTool {
@@ -40,27 +38,19 @@ impl MemoryTool {
         Self {
             session_repo,
             memory_store: MemoryStore::new(data_dir),
-            project_store: None,
         }
-    }
-
-    pub fn with_project_store(
-        mut self,
-        project_store: std::sync::Arc<bamboo_projects::ProjectStore>,
-    ) -> Self {
-        self.project_store = Some(project_store);
-        self
     }
 
     async fn session_for_context(&self, session_id: Option<&str>) -> Option<Session> {
         self.session_repo.load(session_id?).await
     }
 
-    async fn resolve_project_memory_access(
+    async fn resolve_memory_access(
         &self,
         explicit: Option<&str>,
         session_id: Option<&str>,
-    ) -> Result<ResolvedProjectMemoryAccess, ToolError> {
+        requested_scope: Option<MemoryScope>,
+    ) -> Result<ResolvedMemoryAccess, ToolError> {
         let explicit = explicit
             .map(str::trim)
             .filter(|value| !value.is_empty())
@@ -89,78 +79,26 @@ impl MemoryTool {
                     "project_key cannot override the session's assigned Project".to_string(),
                 ));
             }
-            let project_store = self.project_store.as_ref().ok_or_else(|| {
-                ToolError::Execution(
-                    "Project memory resolver is unavailable for this assigned session".to_string(),
-                )
-            })?;
-            let roots = project_store
-                .project_memory_read_roots(&project_id)
-                .map_err(|error| {
-                    ToolError::Execution(format!("Failed to resolve Project memory roots: {error}"))
-                })?;
-            let aliases = roots
-                .legacy_aliases
-                .into_iter()
-                .map(|legacy| LegacyProjectMemoryReadRoot {
-                    project_key: legacy.legacy_project_key,
-                    root: legacy.root,
-                })
-                .collect();
-            return Ok(ResolvedProjectMemoryAccess {
-                store: self
-                    .memory_store
-                    .for_project_with_legacy_read_roots(&project_id, aliases),
+            return Ok(ResolvedMemoryAccess {
+                store: self.memory_store.for_project(&project_id),
                 project_key: Some(project_id.to_string()),
-                writable: true,
             });
         }
 
-        let derived_legacy_key = session.as_ref().and_then(|session| {
-            bamboo_engine::project_context::ProjectContextResolver::memory_read_scope_for_session(
-                session,
-            )
-        });
-        if explicit.as_deref() != derived_legacy_key.as_deref() && explicit.is_some() {
+        if explicit.is_some() {
             return Err(ToolError::InvalidArguments(
-                "project_key cannot override the session's legacy Project read scope".to_string(),
+                "project_key requires the session to be assigned to that Project".to_string(),
             ));
         }
-        Ok(ResolvedProjectMemoryAccess {
+        if requested_scope == Some(MemoryScope::Project) {
+            return Err(ToolError::InvalidArguments(
+                "Project memory requires an assigned Project".to_string(),
+            ));
+        }
+        Ok(ResolvedMemoryAccess {
             store: self.memory_store.clone(),
-            project_key: derived_legacy_key,
-            writable: false,
+            project_key: None,
         })
-    }
-
-    async fn ensure_memory_mutation_allowed(
-        &self,
-        access: &ResolvedProjectMemoryAccess,
-        id: &str,
-    ) -> Result<(), ToolError> {
-        let Some(doc) = access
-            .store
-            .get_memory(id, access.project_key.as_deref())
-            .await
-            .map_err(|error| {
-                ToolError::Execution(format!("Failed to resolve memory mutation scope: {error}"))
-            })?
-        else {
-            return Ok(());
-        };
-        if doc.frontmatter.scope == MemoryScope::Project && !access.writable {
-            return Err(ToolError::Execution(
-                "Unassigned sessions may read legacy Project memory but cannot mutate it"
-                    .to_string(),
-            ));
-        }
-        if access.store.is_read_only_project_memory_path(&doc.path) {
-            return Err(ToolError::Execution(
-                "Legacy Project memory aliases are read-only; migrate the memory before mutating it"
-                    .to_string(),
-            ));
-        }
-        Ok(())
     }
 }
 
@@ -358,7 +296,7 @@ impl Tool for MemoryTool {
                     ));
                 }
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), Some(scope))
                     .await?;
                 let options = MemoryQueryOptions {
                     limit: options
@@ -411,7 +349,7 @@ impl Tool for MemoryTool {
                 options,
             } => {
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), None)
                     .await?;
                 let max_chars = options
                     .and_then(|value| value.max_chars)
@@ -469,14 +407,8 @@ impl Tool for MemoryTool {
                 }
                 let granularity = Self::parse_granularity(granularity.as_deref())?;
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), Some(scope))
                     .await?;
-                if scope == MemoryScope::Project && !memory_access.writable {
-                    return Err(ToolError::Execution(
-                        "Unassigned sessions may read legacy Project memory but cannot write it"
-                            .to_string(),
-                    ));
-                }
                 let doc = memory_access
                     .store
                     .write_memory(
@@ -526,9 +458,7 @@ impl Tool for MemoryTool {
                 reason,
             } => {
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
-                    .await?;
-                self.ensure_memory_mutation_allowed(&memory_access, id.trim())
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), None)
                     .await?;
                 let mode = Self::parse_merge_mode(mode.as_deref())?;
                 if matches!(mode.as_deref(), Some("contradict")) {
@@ -618,7 +548,7 @@ impl Tool for MemoryTool {
                     None => None,
                 };
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), Some(scope))
                     .await?;
                 let limit = options
                     .and_then(|value| value.limit)
@@ -661,9 +591,7 @@ impl Tool for MemoryTool {
                     ));
                 }
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
-                    .await?;
-                self.ensure_memory_mutation_allowed(&memory_access, id.trim())
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), None)
                     .await?;
                 let mut split_pieces = Vec::with_capacity(pieces.len());
                 for piece in pieces {
@@ -721,7 +649,7 @@ impl Tool for MemoryTool {
                     ));
                 }
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), Some(scope))
                     .await?;
                 let min_sections = min_sections.unwrap_or(3);
                 let limit = options
@@ -764,7 +692,7 @@ impl Tool for MemoryTool {
                     ));
                 }
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), Some(scope))
                     .await?;
                 let min_score = min_score.unwrap_or(0.6);
                 let limit = options
@@ -813,7 +741,7 @@ impl Tool for MemoryTool {
                     None => None,
                 };
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), None)
                     .await?;
                 let merged = bamboo_memory::memory_store::MemorySplitPiece {
                     title,
@@ -822,10 +750,6 @@ impl Tool for MemoryTool {
                     tags,
                 };
                 let ids: Vec<String> = ids.iter().map(|id| id.trim().to_string()).collect();
-                for id in &ids {
-                    self.ensure_memory_mutation_allowed(&memory_access, id)
-                        .await?;
-                }
                 let Some(result) = memory_access
                     .store
                     .consolidate_memories(
@@ -871,17 +795,31 @@ impl Tool for MemoryTool {
                     Some(value) => Self::parse_status(value)?,
                     None => DurableMemoryStatus::Archived,
                 };
-                let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
-                    .await?;
-
-                if let Some(id) = id
+                let id = id
                     .as_deref()
                     .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                {
-                    self.ensure_memory_mutation_allowed(&memory_access, id)
-                        .await?;
+                    .filter(|value| !value.is_empty());
+                let requested_scope = match id {
+                    Some(_) => None,
+                    None => {
+                        let scope = Self::parse_scope(scope.as_deref())?;
+                        if scope == MemoryScope::Session {
+                            return Err(ToolError::InvalidArguments(
+                                "purge supports durable scopes only in v1".to_string(),
+                            ));
+                        }
+                        Some(scope)
+                    }
+                };
+                let memory_access = self
+                    .resolve_memory_access(
+                        project_key.as_deref(),
+                        Some(session_id),
+                        requested_scope,
+                    )
+                    .await?;
+
+                if let Some(id) = id {
                     let Some(doc) = memory_access
                         .store
                         .archive_memory(
@@ -909,41 +847,7 @@ impl Tool for MemoryTool {
                         images: Vec::new(),
                     })
                 } else {
-                    let scope = Self::parse_scope(scope.as_deref())?;
-                    if scope == MemoryScope::Session {
-                        return Err(ToolError::InvalidArguments(
-                            "purge supports durable scopes only in v1".to_string(),
-                        ));
-                    }
-                    if scope == MemoryScope::Project && !memory_access.writable {
-                        return Err(ToolError::Execution(
-                            "Unassigned sessions may read legacy Project memory but cannot purge it"
-                                .to_string(),
-                        ));
-                    }
-                    if scope == MemoryScope::Project {
-                        let contains_alias = memory_access
-                            .store
-                            .list_memory_documents(scope, memory_access.project_key.as_deref())
-                            .await
-                            .map_err(|error| {
-                                ToolError::Execution(format!(
-                                    "Failed to inspect Project memory aliases: {error}"
-                                ))
-                            })?
-                            .iter()
-                            .any(|doc| {
-                                memory_access
-                                    .store
-                                    .is_read_only_project_memory_path(&doc.path)
-                            });
-                        if contains_alias {
-                            return Err(ToolError::Execution(
-                                "Batch purge is unavailable while read-only legacy Project memory aliases are present; migrate them first"
-                                    .to_string(),
-                            ));
-                        }
-                    }
+                    let scope = requested_scope.expect("batch purge scope was parsed");
                     let (filter_types, filter_statuses, filter_granularity) =
                         Self::parse_query_filters(filters.as_ref())?;
                     let result = memory_access
@@ -981,7 +885,7 @@ impl Tool for MemoryTool {
                     ));
                 }
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), Some(scope))
                     .await?;
                 let result = memory_access
                     .store
@@ -1009,14 +913,8 @@ impl Tool for MemoryTool {
                     ));
                 }
                 let memory_access = self
-                    .resolve_project_memory_access(project_key.as_deref(), Some(session_id))
+                    .resolve_memory_access(project_key.as_deref(), Some(session_id), Some(scope))
                     .await?;
-                if scope == MemoryScope::Project && !memory_access.writable {
-                    return Err(ToolError::Execution(
-                        "Unassigned sessions may read legacy Project memory but cannot rebuild it"
-                            .to_string(),
-                    ));
-                }
                 memory_access
                     .store
                     .rebuild_scope(scope, memory_access.project_key.as_deref())

--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -322,17 +322,196 @@ async fn query_action_filters_by_granularity() {
 }
 
 #[tokio::test]
-async fn malformed_project_identity_cannot_read_path_derived_legacy_memory() {
+async fn assigned_project_memory_uses_only_the_canonical_project_store() {
     let dir = tempfile::tempdir().expect("memory dir");
-    let workspace = tempfile::tempdir().expect("legacy workspace");
-    let legacy_key = bamboo_memory::memory_store::project_key_from_path(workspace.path());
-    let store = MemoryStore::new(dir.path());
-    store
+    let workspace = tempfile::tempdir().expect("workspace");
+    let project_id =
+        bamboo_domain::ProjectId::parse("project-memory-tool").expect("valid Project identity");
+    let mut session = Session::new("assigned-project-memory-tool", "model");
+    session.set_project_id_meta(project_id.to_string());
+    session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    let tool = build_memory_tool_with_session(dir.path(), session).await;
+
+    let out = tool
+        .invoke(
+            json!({
+                "action": "write",
+                "scope": "project",
+                "project_key": project_id.as_str(),
+                "type": "project",
+                "title": "Canonical Project memory",
+                "content": "Project memory is keyed only by the assigned ProjectId."
+            }),
+            test_context("assigned-project-memory-tool"),
+        )
+        .await
+        .expect("assigned Project write should succeed");
+    let ToolOutcome::Completed(result) = out else {
+        panic!("expected Completed")
+    };
+    let value: serde_json::Value = serde_json::from_str(&result.result).expect("valid json");
+    let path = value["memory"]["path"]
+        .as_str()
+        .expect("memory path in response");
+    assert!(std::path::Path::new(path).starts_with(
+        dir.path()
+            .join("projects")
+            .join(project_id.as_str())
+            .join("memory")
+            .join("v1")
+    ));
+
+    let docs = MemoryStore::new(dir.path())
+        .for_project(&project_id)
+        .list_memory_documents(MemoryScope::Project, Some(project_id.as_str()))
+        .await
+        .expect("read canonical Project memory");
+    assert_eq!(docs.len(), 1);
+    assert_eq!(docs[0].frontmatter.title, "Canonical Project memory");
+
+    let error = tool
+        .invoke(
+            json!({
+                "action": "query",
+                "scope": "project",
+                "project_key": "project-other"
+            }),
+            test_context("assigned-project-memory-tool"),
+        )
+        .await
+        .expect_err("an explicit key must not override the assigned Project");
+    assert!(matches!(
+        error,
+        ToolError::InvalidArguments(ref message)
+            if message.contains("cannot override the session's assigned Project")
+    ));
+}
+
+#[tokio::test]
+async fn unassigned_workspace_cannot_select_or_discover_project_memory() {
+    let dir = tempfile::tempdir().expect("memory dir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let project_id =
+        bamboo_domain::ProjectId::parse("project-private").expect("valid Project identity");
+    let seeded = MemoryStore::new(dir.path())
+        .for_project(&project_id)
         .write_memory(
             MemoryScope::Project,
-            Some(&legacy_key),
+            Some(project_id.as_str()),
             bamboo_memory::memory_store::DurableMemoryType::Project,
-            "Legacy secret",
+            "Private Project memory",
+            "MUST NOT LEAK TO AN UNASSIGNED WORKSPACE SESSION",
+            &[],
+            Some("seed-session"),
+            "test",
+            false,
+            None,
+        )
+        .await
+        .expect("seed canonical Project memory");
+    let mut session = Session::new("unassigned-workspace-memory-tool", "model");
+    session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    let tool = build_memory_tool_with_session(dir.path(), session).await;
+
+    let query_error = tool
+        .invoke(
+            json!({
+                "action": "query",
+                "scope": "project",
+                "query": "Private Project memory"
+            }),
+            test_context("unassigned-workspace-memory-tool"),
+        )
+        .await
+        .expect_err("workspace metadata must not create Project memory scope");
+    assert!(matches!(
+        query_error,
+        ToolError::InvalidArguments(ref message)
+            if message.contains("requires an assigned Project")
+    ));
+
+    let explicit_error = tool
+        .invoke(
+            json!({
+                "action": "query",
+                "scope": "global",
+                "project_key": project_id.as_str(),
+                "query": "Private Project memory"
+            }),
+            test_context("unassigned-workspace-memory-tool"),
+        )
+        .await
+        .expect_err("explicit project_key must not create Project memory scope");
+    assert!(matches!(
+        explicit_error,
+        ToolError::InvalidArguments(ref message)
+            if message.contains("requires the session to be assigned")
+    ));
+
+    let get_error = tool
+        .invoke(
+            json!({"action": "get", "id": seeded.frontmatter.id}),
+            test_context("unassigned-workspace-memory-tool"),
+        )
+        .await
+        .expect_err("unscoped get must not enumerate Project directories");
+    assert!(get_error.to_string().contains("memory not found"));
+    assert!(!get_error
+        .to_string()
+        .contains("MUST NOT LEAK TO AN UNASSIGNED WORKSPACE SESSION"));
+}
+
+#[tokio::test]
+async fn assigned_project_cannot_get_memory_from_an_unrelated_project() {
+    let dir = tempfile::tempdir().expect("memory dir");
+    let assigned_id =
+        bamboo_domain::ProjectId::parse("project-assigned").expect("valid assigned Project");
+    let unrelated_id =
+        bamboo_domain::ProjectId::parse("project-unrelated").expect("valid unrelated Project");
+    let unrelated = MemoryStore::new(dir.path())
+        .for_project(&unrelated_id)
+        .write_memory(
+            MemoryScope::Project,
+            Some(unrelated_id.as_str()),
+            bamboo_memory::memory_store::DurableMemoryType::Project,
+            "Unrelated Project memory",
+            "MUST NOT LEAK ACROSS PROJECTS",
+            &[],
+            Some("seed-session"),
+            "test",
+            false,
+            None,
+        )
+        .await
+        .expect("seed unrelated Project memory");
+    let mut session = Session::new("assigned-isolation-memory-tool", "model");
+    session.set_project_id_meta(assigned_id.to_string());
+    let tool = build_memory_tool_with_session(dir.path(), session).await;
+
+    let error = tool
+        .invoke(
+            json!({"action": "get", "id": unrelated.frontmatter.id}),
+            test_context("assigned-isolation-memory-tool"),
+        )
+        .await
+        .expect_err("unscoped get must stay within the assigned Project and Global");
+    assert!(error.to_string().contains("memory not found"));
+    assert!(!error.to_string().contains("MUST NOT LEAK ACROSS PROJECTS"));
+}
+
+#[tokio::test]
+async fn malformed_project_identity_cannot_read_canonical_project_memory() {
+    let dir = tempfile::tempdir().expect("memory dir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let project_id =
+        bamboo_domain::ProjectId::parse("project-secret").expect("valid Project identity");
+    MemoryStore::new(dir.path())
+        .for_project(&project_id)
+        .write_memory(
+            MemoryScope::Project,
+            Some(project_id.as_str()),
+            bamboo_memory::memory_store::DurableMemoryType::Project,
+            "Project secret",
             "MUST NOT LEAK THROUGH MALFORMED PROJECT ID",
             &[],
             Some("seed-session"),
@@ -341,7 +520,7 @@ async fn malformed_project_identity_cannot_read_path_derived_legacy_memory() {
             None,
         )
         .await
-        .expect("seed legacy memory");
+        .expect("seed canonical Project memory");
     let mut session = Session::new("malformed-project-memory-tool", "model");
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
     session.set_project_id_meta("../malformed".to_string());
@@ -352,13 +531,13 @@ async fn malformed_project_identity_cannot_read_path_derived_legacy_memory() {
             json!({
                 "action": "query",
                 "scope": "project",
-                "project_key": legacy_key,
-                "query": "Legacy secret"
+                "project_key": project_id.as_str(),
+                "query": "Project secret"
             }),
             test_context("malformed-project-memory-tool"),
         )
         .await
-        .expect_err("malformed Project identity must fail before legacy lookup");
+        .expect_err("malformed Project identity must fail before Project lookup");
     assert!(
         matches!(error, ToolError::InvalidArguments(ref message) if message.contains("invalid Project identity"))
     );

--- a/crates/app/bamboo-server/src/app_state/tools.rs
+++ b/crates/app/bamboo-server/src/app_state/tools.rs
@@ -91,10 +91,10 @@ pub(super) fn build_base_tools(
         project_tool,
     ));
 
-    let memory_tool = Arc::new(
-        crate::tools::MemoryTool::new(session_repo.clone(), app_data_dir.clone())
-            .with_project_store(project_store.clone()),
-    );
+    let memory_tool = Arc::new(crate::tools::MemoryTool::new(
+        session_repo.clone(),
+        app_data_dir.clone(),
+    ));
     let with_memory: Arc<dyn ToolExecutor> = Arc::new(crate::tools::OverlayToolExecutor::new(
         with_project,
         memory_tool,

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
@@ -2,11 +2,8 @@ use actix_web::{web, HttpResponse, Result};
 
 use crate::app_state::AppState;
 use bamboo_agent_core::{Session, Storage};
-use bamboo_engine::auto_dream::{
-    run_project_auto_dream_once_for_project_with_read_roots, AutoDreamContext,
-};
+use bamboo_engine::auto_dream::{run_project_auto_dream_once_for_project, AutoDreamContext};
 use bamboo_engine::project_context::ProjectContextResolver;
-use bamboo_memory::memory_store::LegacyProjectMemoryReadRoot;
 use bamboo_storage::{CleanupMode, CleanupResult};
 
 use super::super::types::CleanupRequest;
@@ -135,34 +132,13 @@ pub async fn run_project_dream(
         config: state.config.clone(),
         provider_registry: state.provider_registry.clone(),
     };
-    let memory_roots = state
-        .project_store
-        .project_memory_read_roots(&project_id)
+    let result = run_project_auto_dream_once_for_project(&ctx, &project_id)
+        .await
         .map_err(|error| {
             crate::error::json_internal_server_error(format!(
-                "Failed to resolve Project memory roots: {error}"
+                "Failed to run project Dream generation: {error}"
             ))
         })?;
-    let legacy_read_roots = memory_roots
-        .legacy_aliases
-        .into_iter()
-        .map(|legacy| LegacyProjectMemoryReadRoot {
-            project_key: legacy.legacy_project_key,
-            root: legacy.root,
-        })
-        .collect();
-
-    let result = run_project_auto_dream_once_for_project_with_read_roots(
-        &ctx,
-        &project_id,
-        legacy_read_roots,
-    )
-    .await
-    .map_err(|error| {
-        crate::error::json_internal_server_error(format!(
-            "Failed to run project Dream generation: {error}"
-        ))
-    })?;
 
     let response = match result {
         Some(result) => serde_json::json!({

--- a/crates/app/bamboo-server/src/project_context.rs
+++ b/crates/app/bamboo-server/src/project_context.rs
@@ -6,9 +6,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bamboo_domain::ProjectId;
 use bamboo_engine::project_context::{
-    ProjectContextError, ProjectContextSource, ProjectDescriptor, ProjectMemoryReadRoots,
+    ProjectContextError, ProjectContextSource, ProjectDescriptor,
 };
-use bamboo_memory::memory_store::LegacyProjectMemoryReadRoot;
 use bamboo_projects::{ProjectStore, ProjectStoreError};
 
 #[derive(Debug, thiserror::Error)]
@@ -550,10 +549,6 @@ impl ProjectContextSource for ProjectStoreContextSource {
             .store
             .resource_summary(project_id)
             .map_err(|error| ProjectContextError::Source(error.to_string()))?;
-        let memory_read_roots = self
-            .store
-            .project_memory_read_roots(project_id)
-            .map_err(|error| ProjectContextError::Source(error.to_string()))?;
         Ok(Some(ProjectDescriptor {
             id: manifest.id.clone(),
             name: manifest.name,
@@ -561,17 +556,6 @@ impl ProjectContextSource for ProjectStoreContextSource {
             home: self.store.paths().project_home(project_id),
             workspace_bindings: manifest.workspace_bindings,
             resources,
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: memory_read_roots.primary,
-                legacy_aliases: memory_read_roots
-                    .legacy_aliases
-                    .into_iter()
-                    .map(|legacy| LegacyProjectMemoryReadRoot {
-                        project_key: legacy.legacy_project_key,
-                        root: legacy.root,
-                    })
-                    .collect(),
-            },
         }))
     }
 

--- a/crates/engine/bamboo-engine/src/auto_dream.rs
+++ b/crates/engine/bamboo-engine/src/auto_dream.rs
@@ -25,7 +25,7 @@ use bamboo_memory::ledger_store::{LedgerStore, RecordFilter, MAX_RECORD_TITLE_LE
 use bamboo_memory::memory_store::{MemoryScope, MemoryStore};
 use bamboo_storage::{SessionIndexEntry, SessionStoreV2};
 
-use crate::project_context::{ProjectContextResolver, ProjectMemoryScope};
+use crate::project_context::ProjectContextResolver;
 
 const DREAM_RUNTIME_SESSION_ID: &str = "__dream__";
 const DREAM_TRACING_TARGET: &str = "bamboo.auto_dream";
@@ -134,32 +134,29 @@ async fn collect_candidate_sessions(
     out
 }
 
-async fn resolve_session_project_key(
+async fn resolve_session_project_id(
     ctx: &AutoDreamContext,
-    _memory: &MemoryStore,
     session_id: &str,
-) -> Option<String> {
+) -> Option<bamboo_domain::ProjectId> {
     ctx.storage
         .load_session(session_id)
         .await
         .ok()
         .flatten()
-        .and_then(|session| ProjectContextResolver::memory_write_scope_for_session(&session))
+        .and_then(|session| ProjectContextResolver::memory_read_identity_for_session(&session))
 }
 
 async fn collect_candidate_sessions_for_project(
     ctx: &AutoDreamContext,
-    memory: &MemoryStore,
     project_key: &str,
     since: DateTime<Utc>,
 ) -> Vec<(SessionIndexEntry, Option<String>)> {
     let mut out = Vec::new();
     for (entry, summary) in collect_candidate_sessions(ctx, since).await {
-        if resolve_session_project_key(ctx, memory, &entry.id)
-            .await
-            .as_deref()
-            != Some(project_key)
-        {
+        let Some(project_id) = resolve_session_project_id(ctx, &entry.id).await else {
+            continue;
+        };
+        if project_id.as_str() != project_key {
             continue;
         }
         out.push((entry, summary));
@@ -177,7 +174,9 @@ async fn collect_candidate_session_contexts_from_sessions(
 ) -> Vec<CandidateSessionContext> {
     let mut out = Vec::new();
     for (entry, summary) in sessions {
-        let project_key = resolve_session_project_key(ctx, memory, &entry.id).await;
+        let project_key = resolve_session_project_id(ctx, &entry.id)
+            .await
+            .map(bamboo_domain::ProjectId::into_string);
         let topics = memory
             .read_session_topics_with_content(&entry.id)
             .await
@@ -228,7 +227,7 @@ async fn collect_candidate_session_contexts_for_project(
     collect_candidate_session_contexts_from_sessions(
         ctx,
         memory,
-        collect_candidate_sessions_for_project(ctx, memory, project_key, since).await,
+        collect_candidate_sessions_for_project(ctx, project_key, since).await,
     )
     .await
 }
@@ -379,11 +378,7 @@ async fn extract_and_persist_durable_candidates_with_project_resolver(
                         "failed to resolve Project memory scope for session '{session_id}': {error}"
                     )
                 })?;
-            let Some(ProjectMemoryScope::Assigned {
-                project_id,
-                legacy_aliases,
-            }) = resolved
-            else {
+            let Some(project_id) = resolved else {
                 tracing::warn!(
                     target: DREAM_TRACING_TARGET,
                     event = "project_candidate_skipped",
@@ -394,7 +389,7 @@ async fn extract_and_persist_durable_candidates_with_project_resolver(
                 continue;
             };
             write_project_key = Some(project_id.to_string());
-            write_memory = memory.for_project_with_legacy_read_roots(&project_id, legacy_aliases);
+            write_memory = memory.for_project(&project_id);
         }
         let tags = candidate.tags;
         let _ = &candidate.confidence;
@@ -761,7 +756,7 @@ async fn run_auto_dream_once_for_scope(
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .ok_or_else(|| "project Dream generation requires a project_key".to_string())?;
-            collect_candidate_sessions_for_project(ctx, memory, project_key, since).await
+            collect_candidate_sessions_for_project(ctx, project_key, since).await
         }
         MemoryScope::Session => {
             return Err("session-scoped Dream generation is not supported".to_string())
@@ -976,34 +971,12 @@ pub async fn run_auto_dream_once_with_project_resolver(
     .await
 }
 
-pub async fn run_project_auto_dream_once(
-    ctx: &AutoDreamContext,
-    project_key: &str,
-) -> Result<Option<AutoDreamRunResult>, String> {
-    let memory = memory_store_for_context(ctx);
-    run_project_auto_dream_once_with_store(ctx, &memory, project_key).await
-}
-
 /// Run Project Dream against the first-class Project-home memory layout.
-///
-/// The legacy string-key entrypoint above remains for migration-only callers;
-/// assigned sessions must call this typed entrypoint so new Dream writes cannot
-/// land in a path-hash scope.
 pub async fn run_project_auto_dream_once_for_project(
     ctx: &AutoDreamContext,
     project_id: &bamboo_domain::ProjectId,
 ) -> Result<Option<AutoDreamRunResult>, String> {
     let memory = memory_store_for_context(ctx).for_project(project_id);
-    run_project_auto_dream_once_with_store(ctx, &memory, project_id.as_str()).await
-}
-
-pub async fn run_project_auto_dream_once_for_project_with_read_roots(
-    ctx: &AutoDreamContext,
-    project_id: &bamboo_domain::ProjectId,
-    legacy_read_roots: Vec<bamboo_memory::memory_store::LegacyProjectMemoryReadRoot>,
-) -> Result<Option<AutoDreamRunResult>, String> {
-    let memory = memory_store_for_context(ctx)
-        .for_project_with_legacy_read_roots(project_id, legacy_read_roots);
     run_project_auto_dream_once_with_store(ctx, &memory, project_id.as_str()).await
 }
 
@@ -1315,14 +1288,6 @@ mod tests {
             .expect("query should succeed");
         assert_eq!(results.matched_count, 1);
         assert_eq!(results.items[0].title, "User prefers terse responses");
-        let legacy_project_key = bamboo_memory::memory_store::project_key_from_path(
-            &temp_dir.path().join("workspace-a"),
-        );
-        assert!(!temp_dir
-            .path()
-            .join("memory/v1/scopes/projects")
-            .join(legacy_project_key)
-            .exists());
 
         let state = memory
             .read_session_state("session-auto")
@@ -1350,10 +1315,6 @@ mod tests {
                     project_id: project_id.clone(),
                     resource_revision: 1,
                     resources: Vec::new(),
-                },
-                memory_read_roots: crate::project_context::ProjectMemoryReadRoots {
-                    primary: project_home.join("memory/v1"),
-                    legacy_aliases: Vec::new(),
                 },
             },
         )));
@@ -1424,12 +1385,20 @@ mod tests {
             .await
             .expect("query global");
         assert_eq!(global.matched_count, 0);
-        let legacy_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
-        assert!(!temp_dir
-            .path()
-            .join("memory/v1/scopes/projects")
-            .join(legacy_key)
-            .exists());
+        let project = memory
+            .for_project(&project_id)
+            .query_scope(
+                MemoryScope::Project,
+                Some(project_id.as_str()),
+                Some("Must not persist"),
+                None,
+                None,
+                None,
+                &bamboo_memory::memory_store::MemoryQueryOptions::default(),
+            )
+            .await
+            .expect("query Project memory");
+        assert_eq!(project.matched_count, 0);
     }
 
     #[tokio::test]
@@ -1465,10 +1434,6 @@ mod tests {
                     project_id: project_id.clone(),
                     resource_revision: 1,
                     resources: Vec::new(),
-                },
-                memory_read_roots: crate::project_context::ProjectMemoryReadRoots {
-                    primary: memory_root.clone(),
-                    legacy_aliases: Vec::new(),
                 },
             },
         )));
@@ -1554,19 +1519,6 @@ mod tests {
             .expect("query Project memory");
         assert_eq!(results.matched_count, 2);
         assert!(memory_root.join("topics").is_dir());
-        assert!(!temp_dir
-            .path()
-            .join("memory/v1/scopes/projects")
-            .join(project_id.as_str())
-            .exists());
-        for workspace in [&workspace_one, &workspace_two] {
-            let legacy_key = bamboo_memory::memory_store::project_key_from_path(workspace);
-            assert!(!temp_dir
-                .path()
-                .join("memory/v1/scopes/projects")
-                .join(legacy_key)
-                .exists());
-        }
     }
 
     #[tokio::test]
@@ -1949,7 +1901,8 @@ mod tests {
         let workspace_b = temp_dir.path().join("workspace-b");
         std::fs::create_dir_all(&workspace_a).expect("workspace a");
         std::fs::create_dir_all(&workspace_b).expect("workspace b");
-        let project_key_a = bamboo_memory::memory_store::project_key_from_path(&workspace_a);
+        let project_id_a = ProjectId::parse("project-auto-dream-a").expect("project id");
+        let project_key_a = project_id_a.to_string();
 
         let session_store = Arc::new(
             SessionStoreV2::new(temp_dir.path().to_path_buf())
@@ -1971,7 +1924,7 @@ mod tests {
 
         let mut session_a = bamboo_agent_core::Session::new("session-project-a", "model");
         session_a.title = "Project A session".to_string();
-        session_a.set_project_id_meta(project_key_a.clone());
+        session_a.set_project_id_meta(project_id_a.to_string());
         session_a.metadata.insert(
             "workspace_path".to_string(),
             workspace_a.to_string_lossy().to_string(),
@@ -2004,8 +1957,8 @@ mod tests {
             .await
             .expect("save session b");
 
-        let memory = MemoryStore::new(temp_dir.path());
-        memory
+        let base_memory = MemoryStore::new(temp_dir.path());
+        base_memory
             .write_session_topic(
                 "session-project-a",
                 "default",
@@ -2013,7 +1966,7 @@ mod tests {
             )
             .await
             .expect("write session topic a");
-        memory
+        base_memory
             .write_session_topic(
                 "session-project-b",
                 "default",
@@ -2021,6 +1974,7 @@ mod tests {
             )
             .await
             .expect("write session topic b");
+        let memory = base_memory.for_project(&project_id_a);
 
         let context = AutoDreamContext {
             session_store,
@@ -2029,7 +1983,7 @@ mod tests {
             config,
             provider_registry: test_registry(),
         };
-        let result = run_project_auto_dream_once_with_store(&context, &memory, &project_key_a)
+        let result = run_project_auto_dream_once_for_project(&context, &project_id_a)
             .await
             .expect("project auto dream should succeed")
             .expect("project auto dream should produce output");
@@ -2081,8 +2035,8 @@ mod tests {
         let workspace_target = temp_dir.path().join("workspace-target");
         std::fs::create_dir_all(&workspace_other).expect("workspace other");
         std::fs::create_dir_all(&workspace_target).expect("workspace target");
-        let target_project_key =
-            bamboo_memory::memory_store::project_key_from_path(&workspace_target);
+        let target_project_id = ProjectId::parse("project-auto-dream-target").expect("project id");
+        let target_project_key = target_project_id.to_string();
 
         let session_store = Arc::new(
             SessionStoreV2::new(temp_dir.path().to_path_buf())
@@ -2116,7 +2070,7 @@ mod tests {
             .await
             .expect("save other session");
 
-        let memory = MemoryStore::new(temp_dir.path());
+        let memory = MemoryStore::new(temp_dir.path()).for_project(&target_project_id);
         memory
             .write_project_dream_view(
                 &target_project_key,
@@ -2132,7 +2086,7 @@ mod tests {
             config,
             provider_registry: test_registry(),
         };
-        let result = run_project_auto_dream_once_with_store(&context, &memory, &target_project_key)
+        let result = run_project_auto_dream_once_for_project(&context, &target_project_id)
             .await
             .expect("project auto dream without sessions should not error");
         assert!(result.is_none());
@@ -2152,7 +2106,8 @@ mod tests {
 
         let workspace = temp_dir.path().join("workspace-manual-project-dream");
         std::fs::create_dir_all(&workspace).expect("workspace dir");
-        let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+        let project_id = ProjectId::parse("project-manual-dream").expect("project id");
+        let project_key = project_id.to_string();
 
         let session_store = Arc::new(
             SessionStoreV2::new(temp_dir.path().to_path_buf())
@@ -2173,7 +2128,7 @@ mod tests {
 
         let mut session = bamboo_agent_core::Session::new("session-manual-project-dream", "model");
         session.title = "Manual project dream session".to_string();
-        session.set_project_id_meta(project_key.clone());
+        session.set_project_id_meta(project_id.to_string());
         session.metadata.insert(
             "workspace_path".to_string(),
             workspace.to_string_lossy().to_string(),
@@ -2186,8 +2141,8 @@ mod tests {
         session.add_message(Message::user("Generate a project-scoped dream manually."));
         storage.save_session(&session).await.expect("save session");
 
-        let memory = MemoryStore::new(temp_dir.path());
-        memory
+        let base_memory = MemoryStore::new(temp_dir.path());
+        base_memory
             .write_session_topic(
                 "session-manual-project-dream",
                 "default",
@@ -2195,6 +2150,7 @@ mod tests {
             )
             .await
             .expect("write session topic");
+        let memory = base_memory.for_project(&project_id);
 
         let context = AutoDreamContext {
             session_store,
@@ -2203,7 +2159,7 @@ mod tests {
             config,
             provider_registry: test_registry(),
         };
-        let result = run_project_auto_dream_once_with_store(&context, &memory, &project_key)
+        let result = run_project_auto_dream_once_for_project(&context, &project_id)
             .await
             .expect(
                 "manual project dream should succeed even when auto background dream is disabled",
@@ -2249,11 +2205,12 @@ mod tests {
 
         let workspace = temp_dir.path().join("workspace-grounded-mode");
         std::fs::create_dir_all(&workspace).expect("workspace dir");
-        let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+        let project_id = ProjectId::parse("project-grounded-dream").expect("project id");
+        let project_key = project_id.to_string();
 
         let mut session = bamboo_agent_core::Session::new("session-grounded-mode", "model");
         session.title = "Grounded mode test".to_string();
-        session.set_project_id_meta(project_key.clone());
+        session.set_project_id_meta(project_id.to_string());
         session.metadata.insert(
             "workspace_path".to_string(),
             workspace.to_string_lossy().to_string(),
@@ -2266,7 +2223,7 @@ mod tests {
         session.add_message(Message::user("Update the dream from durable memory."));
         storage.save_session(&session).await.expect("save session");
 
-        let memory = MemoryStore::new(temp_dir.path());
+        let memory = MemoryStore::new(temp_dir.path()).for_project(&project_id);
         // Existing notebook with only a "Last consolidated at" line (NO "Last full
         // rebuild at") → force_full_rebuild is false, so this is a NON-forced pass.
         memory
@@ -2300,7 +2257,7 @@ mod tests {
             provider_registry: test_registry(),
         };
 
-        let result = run_project_auto_dream_once_with_store(&context, &memory, &project_key)
+        let result = run_project_auto_dream_once_for_project(&context, &project_id)
             .await
             .expect("grounded auto dream should succeed")
             .expect("dream output should be produced");
@@ -2359,11 +2316,12 @@ mod tests {
 
         let workspace = temp_dir.path().join("workspace-rebuild-mode");
         std::fs::create_dir_all(&workspace).expect("workspace dir");
-        let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+        let project_id = ProjectId::parse("project-rebuild-dream").expect("project id");
+        let project_key = project_id.to_string();
 
         let mut session = bamboo_agent_core::Session::new("session-rebuild-mode", "model");
         session.title = "Rebuild mode test".to_string();
-        session.set_project_id_meta(project_key.clone());
+        session.set_project_id_meta(project_id.to_string());
         session.metadata.insert(
             "workspace_path".to_string(),
             workspace.to_string_lossy().to_string(),
@@ -2378,7 +2336,7 @@ mod tests {
         ));
         storage.save_session(&session).await.expect("save session");
 
-        let memory = MemoryStore::new(temp_dir.path());
+        let memory = MemoryStore::new(temp_dir.path()).for_project(&project_id);
         memory
             .write_project_dream_view(
                 &project_key,
@@ -2410,7 +2368,7 @@ mod tests {
             provider_registry: test_registry(),
         };
 
-        let result = run_project_auto_dream_once_with_store(&context, &memory, &project_key)
+        let result = run_project_auto_dream_once_for_project(&context, &project_id)
             .await
             .expect("rebuild auto dream should succeed")
             .expect("rebuild dream output should be produced");

--- a/crates/engine/bamboo-engine/src/gardener.rs
+++ b/crates/engine/bamboo-engine/src/gardener.rs
@@ -169,13 +169,13 @@ async fn gardener_targets(
 ) -> Vec<(MemoryScope, Option<String>, MemoryStore)> {
     let mut targets = vec![(MemoryScope::Global, None, memory.clone())];
     if let Some(resolver) = project_context_resolver {
-        match resolver.list_memory_read_scopes().await {
-            Ok(scopes) => {
-                targets.extend(scopes.into_iter().map(|scope| {
+        match resolver.list_project_ids().await {
+            Ok(project_ids) => {
+                targets.extend(project_ids.into_iter().map(|project_id| {
                     (
                         MemoryScope::Project,
-                        Some(scope.key().to_string()),
-                        scope.scoped_store(memory),
+                        Some(project_id.to_string()),
+                        memory.for_project(&project_id),
                     )
                 }));
             }
@@ -184,15 +184,6 @@ async fn gardener_targets(
                 "failed to resolve first-class Project gardener scopes: {error}"
             ),
         }
-    } else {
-        targets.extend(
-            memory
-                .list_project_keys()
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .map(|key| (MemoryScope::Project, Some(key), memory.clone())),
-        );
     }
     targets
 }
@@ -283,10 +274,6 @@ async fn run_gardener_once_with_store_and_resolver(
         else {
             continue;
         };
-        if target_store.is_read_only_project_memory_path(&doc.path) {
-            continue;
-        }
-
         let prompt = build_blob_split_prompt(&doc.frontmatter.title, &doc.body);
         let raw = match collect_model_json(
             provider.clone(),
@@ -433,10 +420,6 @@ async fn run_dedup_gardener_once_with_store_and_resolver(
                 .await
                 .map_err(|error| format!("dedup get failed: {error}"))?
             {
-                if target_store.is_read_only_project_memory_path(&doc.path) {
-                    members.clear();
-                    break;
-                }
                 if doc.frontmatter.status == DurableMemoryStatus::Active {
                     members.push((
                         doc.frontmatter.id.clone(),

--- a/crates/engine/bamboo-engine/src/project_context.rs
+++ b/crates/engine/bamboo-engine/src/project_context.rs
@@ -52,13 +52,6 @@ pub struct ProjectDescriptor {
     pub home: PathBuf,
     pub workspace_bindings: Vec<WorkspaceBinding>,
     pub resources: ProjectResourceSummary,
-    pub memory_read_roots: ProjectMemoryReadRoots,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProjectMemoryReadRoots {
-    pub primary: PathBuf,
-    pub legacy_aliases: Vec<bamboo_memory::memory_store::LegacyProjectMemoryReadRoot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -208,37 +201,6 @@ pub enum SessionProjectIdentity {
     Invalid { raw: String, message: String },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ProjectMemoryScope {
-    Assigned {
-        project_id: ProjectId,
-        legacy_aliases: Vec<bamboo_memory::memory_store::LegacyProjectMemoryReadRoot>,
-    },
-    LegacyReadOnly(String),
-}
-
-impl ProjectMemoryScope {
-    pub fn key(&self) -> &str {
-        match self {
-            Self::Assigned { project_id, .. } => project_id.as_str(),
-            Self::LegacyReadOnly(project_key) => project_key,
-        }
-    }
-
-    pub fn scoped_store(
-        &self,
-        store: &bamboo_memory::memory_store::MemoryStore,
-    ) -> bamboo_memory::memory_store::MemoryStore {
-        match self {
-            Self::Assigned {
-                project_id,
-                legacy_aliases,
-            } => store.for_project_with_legacy_read_roots(project_id, legacy_aliases.clone()),
-            Self::LegacyReadOnly(_) => store.clone(),
-        }
-    }
-}
-
 impl ProjectContextResolver {
     pub fn new(source: Arc<dyn ProjectContextSource>) -> Self {
         Self {
@@ -300,33 +262,10 @@ impl ProjectContextResolver {
         }
     }
 
-    /// Resolve the Project id used for memory reads.
-    ///
-    /// Assigned sessions always use their stable Project id. The path-derived
-    /// fallback is read-compatibility for unassigned legacy sessions only; new
-    /// sessions and writes must use [`Self::project_id_from_session`].
-    pub fn memory_read_scope_for_session(session: &Session) -> Option<String> {
-        Self::memory_read_identity_for_session(session).map(|scope| scope.key().to_string())
-    }
-
-    pub fn memory_read_identity_for_session(session: &Session) -> Option<ProjectMemoryScope> {
+    pub fn memory_read_identity_for_session(session: &Session) -> Option<ProjectId> {
         match Self::session_project_identity(session) {
-            SessionProjectIdentity::Assigned(project_id) => Some(ProjectMemoryScope::Assigned {
-                project_id,
-                legacy_aliases: Vec::new(),
-            }),
-            SessionProjectIdentity::Unassigned => session
-                .workspace_path_meta()
-                .map(PathBuf::from)
-                .or_else(|| {
-                    bamboo_tools::tools::workspace_state::get_workspace(session.id.as_str())
-                })
-                .map(|path| {
-                    ProjectMemoryScope::LegacyReadOnly(
-                        bamboo_memory::memory_store::project_key_from_path(&path),
-                    )
-                }),
-            SessionProjectIdentity::Invalid { .. } => None,
+            SessionProjectIdentity::Assigned(project_id) => Some(project_id),
+            SessionProjectIdentity::Unassigned | SessionProjectIdentity::Invalid { .. } => None,
         }
     }
 
@@ -334,10 +273,10 @@ impl ProjectContextResolver {
         &self,
         session: &Session,
         workspace: Option<&Path>,
-    ) -> Result<Option<ProjectMemoryScope>, ProjectContextError> {
+    ) -> Result<Option<ProjectId>, ProjectContextError> {
         match Self::session_project_identity(session) {
             SessionProjectIdentity::Unassigned => {
-                return Ok(Self::memory_read_identity_for_session(session));
+                return Ok(None);
             }
             SessionProjectIdentity::Invalid { raw, message } => {
                 return Err(ProjectContextError::InvalidProjectIdentity { raw, message });
@@ -347,37 +286,17 @@ impl ProjectContextResolver {
         Ok(self
             .resolve(session, workspace)
             .await?
-            .map(|context| ProjectMemoryScope::Assigned {
-                project_id: context.project.id,
-                legacy_aliases: context.project.memory_read_roots.legacy_aliases,
-            }))
+            .map(|context| context.project.id))
     }
 
-    pub async fn list_memory_read_scopes(
-        &self,
-    ) -> Result<Vec<ProjectMemoryScope>, ProjectContextError> {
+    pub async fn list_project_ids(&self) -> Result<Vec<ProjectId>, ProjectContextError> {
         Ok(self
             .source
             .list_projects()
             .await?
             .into_iter()
-            .map(|project| ProjectMemoryScope::Assigned {
-                project_id: project.id,
-                legacy_aliases: project.memory_read_roots.legacy_aliases,
-            })
+            .map(|project| project.id)
             .collect())
-    }
-
-    /// Resolve the only valid Project write scope.
-    ///
-    /// Unassigned legacy sessions intentionally return `None`: their
-    /// path-derived scopes are read/migration aliases and must never receive
-    /// new Project memory or Dream writes.
-    pub fn memory_write_scope_for_session(session: &Session) -> Option<String> {
-        match Self::session_project_identity(session) {
-            SessionProjectIdentity::Assigned(project_id) => Some(project_id.into_string()),
-            SessionProjectIdentity::Unassigned | SessionProjectIdentity::Invalid { .. } => None,
-        }
     }
 
     pub async fn resolve(
@@ -1003,12 +922,6 @@ mod tests {
                 resource_revision: 7,
                 resources: Vec::new(),
             },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/01JPROJECT00000000000000000/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let resolver = ProjectContextResolver::new(Arc::new(StaticSource(descriptor)));
         let mut session = Session::new("session-1", "test");
@@ -1049,10 +962,6 @@ mod tests {
                 project_id: project_id.clone(),
                 resource_revision: 1,
                 resources: Vec::new(),
-            },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory.path().join("projects/project-default/memory/v1"),
-                legacy_aliases: Vec::new(),
             },
         };
         let resolver = ProjectContextResolver::new_with_workspace_resolver(
@@ -1126,10 +1035,6 @@ mod tests {
                 resource_revision: 2,
                 resources: Vec::new(),
             },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory.path().join("projects/project-default/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let moved_resolver = ProjectContextResolver::new(Arc::new(StaticSource(moved_descriptor)));
         let moved = moved_resolver
@@ -1168,12 +1073,6 @@ mod tests {
                 resource_revision: 1,
                 resources: Vec::new(),
             },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/legacy-persisted-workspace/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let resolver = ProjectContextResolver::new(Arc::new(StaticSource(descriptor)));
         let mut session = Session::new("legacy-persisted-workspace", "test");
@@ -1206,12 +1105,6 @@ mod tests {
                 project_id,
                 resource_revision: 2,
                 resources: Vec::new(),
-            },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/legacy-persisted-workspace/memory/v1"),
-                legacy_aliases: Vec::new(),
             },
         };
         let moved_resolver = ProjectContextResolver::new(Arc::new(StaticSource(moved_descriptor)));
@@ -1246,12 +1139,6 @@ mod tests {
                 project_id: project_id.clone(),
                 resource_revision: 1,
                 resources: Vec::new(),
-            },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/symlink-replaced-project/memory/v1"),
-                legacy_aliases: Vec::new(),
             },
         };
         let resolver = ProjectContextResolver::new(Arc::new(StaticSource(descriptor)));
@@ -1292,12 +1179,6 @@ mod tests {
                 resource_revision: 1,
                 resources: Vec::new(),
             },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/symlink-explicit-project/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let resolver = ProjectContextResolver::new(Arc::new(StaticSource(descriptor)));
         let mut session = Session::new("symlink-explicit-project", "test");
@@ -1337,12 +1218,6 @@ mod tests {
                 resource_revision: 1,
                 resources: Vec::new(),
             },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/unconfigured-project/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let resolver = ProjectContextResolver::new(Arc::new(StaticSource(descriptor)));
         let mut session = Session::new("unconfigured", "test");
@@ -1363,12 +1238,6 @@ mod tests {
                 project_id: project_id.clone(),
                 resource_revision: 1,
                 resources: Vec::new(),
-            },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/unconfigured-project/memory/v1"),
-                legacy_aliases: Vec::new(),
             },
         };
         let resolver = ProjectContextResolver::new(Arc::new(StaticSource(descriptor)));
@@ -1403,12 +1272,6 @@ mod tests {
                 project_id: project_id.clone(),
                 resource_revision: 1,
                 resources: Vec::new(),
-            },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/project-prompt-refresh/memory/v1"),
-                legacy_aliases: Vec::new(),
             },
         };
         let resolver = ProjectContextResolver::new(Arc::new(StaticSource(descriptor)));
@@ -1479,10 +1342,6 @@ mod tests {
                 resource_revision: 1,
                 resources: Vec::new(),
             },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory.path().join("projects/project-a/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let resolver = ProjectContextResolver::new(Arc::new(OwnedWorkspaceSource {
             descriptor,
@@ -1541,10 +1400,6 @@ mod tests {
                 resource_revision: 1,
                 resources: Vec::new(),
             },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory.path().join("projects/descriptor/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let resolver = ProjectContextResolver::new(Arc::new(StaticSource(descriptor)));
         let mut session = Session::new("malformed", "test");
@@ -1581,10 +1436,6 @@ mod tests {
                 project_id: descriptor_id,
                 resource_revision: 1,
                 resources: Vec::new(),
-            },
-            memory_read_roots: ProjectMemoryReadRoots {
-                primary: directory.path().join("projects/descriptor/memory/v1"),
-                legacy_aliases: Vec::new(),
             },
         };
         let resolver = ProjectContextResolver::new(Arc::new(OwnedWorkspaceSource {
@@ -1655,10 +1506,9 @@ mod tests {
     }
 
     #[test]
-    fn unassigned_legacy_scope_is_read_only() {
-        let mut session = Session::new("legacy-session", "legacy");
-        session.set_workspace_path_meta("/tmp/legacy-workspace");
-        assert!(ProjectContextResolver::memory_read_scope_for_session(&session).is_some());
-        assert!(ProjectContextResolver::memory_write_scope_for_session(&session).is_none());
+    fn unassigned_session_with_workspace_has_no_project_memory_scope() {
+        let mut session = Session::new("unassigned-session", "unassigned");
+        session.set_workspace_path_meta("/tmp/unassigned-workspace");
+        assert!(ProjectContextResolver::memory_read_identity_for_session(&session).is_none());
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/context/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/context/mod.rs
@@ -408,10 +408,6 @@ mod project_context_tests {
                         },
                     ],
                 },
-                memory_read_roots: crate::project_context::ProjectMemoryReadRoots {
-                    primary: PathBuf::from("/data/projects/01JPROJECT00000000000000000/memory/v1"),
-                    legacy_aliases: Vec::new(),
-                },
             },
             workspace: Some(PathBuf::from(workspace)),
             workspace_source: WorkspaceSource::Session,

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -3625,7 +3625,6 @@ mod tests {
     };
     use crate::project_context::{
         ProjectContextError, ProjectContextResolver, ProjectContextSource, ProjectDescriptor,
-        ProjectMemoryReadRoots,
     };
     use crate::runtime::config::{AgentLoopConfig, GuardianConfig, GuardianSpawner};
     use crate::runtime::goal_state::{
@@ -7675,12 +7674,6 @@ mod tests {
                     project_id: project_id.clone(),
                     resource_revision: 1,
                     resources: Vec::new(),
-                },
-                memory_read_roots: ProjectMemoryReadRoots {
-                    primary: directory
-                        .path()
-                        .join("projects/pipeline-context-cancel-project/memory/v1"),
-                    legacy_aliases: Vec::new(),
                 },
             },
             cancel_token: cancel.clone(),

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/external_memory.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/external_memory.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::project_context::{ProjectContextResolver, ProjectMemoryScope};
+use crate::project_context::ProjectContextResolver;
 use crate::runtime::config::PromptMemoryFlags;
 use bamboo_agent_core::{PromptMemoryObservability, Session};
 use bamboo_domain::ledger::LedgerScope;
@@ -232,22 +232,20 @@ pub(super) async fn refresh_external_memory_context_with_store_and_resolver(
             Err(error) => {
                 tracing::warn!(
                     session_id = %session.id,
-                    "failed to resolve Project memory read roots: {error}"
+                    "failed to resolve Project memory identity: {error}"
                 );
                 None
             }
         }
     } else {
-        resolve_prompt_project_scope(session)
+        ProjectContextResolver::memory_read_identity_for_session(session)
     };
     let scoped_memory = resolved_project_scope
         .as_ref()
-        .map(|scope| scope.scoped_store(memory))
+        .map(|project_id| memory.for_project(project_id))
         .unwrap_or_else(|| memory.clone());
     let memory = &scoped_memory;
-    let resolved_project_key = resolved_project_scope
-        .as_ref()
-        .map(|scope| scope.key().to_string());
+    let resolved_project_key = resolved_project_scope.as_ref().map(ToString::to_string);
     let session_note_snippets = load_session_note_snippets(memory, session_id.as_str()).await;
     let ledger_agenda = if prompt_memory_flags.ledger_agenda {
         load_ledger_agenda_snippet(memory, resolved_project_key.as_deref()).await
@@ -446,10 +444,6 @@ fn render_ledger_agenda_section(snippet: &LedgerAgendaSnippet) -> String {
     }
     section.push('\n');
     section
-}
-
-fn resolve_prompt_project_scope(session: &Session) -> Option<ProjectMemoryScope> {
-    ProjectContextResolver::memory_read_identity_for_session(session)
 }
 
 pub(super) fn latest_user_query_text(session: &Session) -> Option<String> {

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
@@ -253,11 +253,13 @@ async fn external_memory_omits_ledger_agenda_when_ledger_is_empty() {
 async fn external_memory_includes_project_memory_index_and_omits_global_dream_fallback() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id = bamboo_domain::ProjectId::parse("project-prompt-index").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-alpha");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    store
+    project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -278,6 +280,7 @@ async fn external_memory_includes_project_memory_index_and_omits_global_dream_fa
         .expect("save dream notebook");
 
     let mut session = bamboo_agent_core::Session::new("session-project-memory", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -306,14 +309,18 @@ async fn external_memory_includes_project_memory_index_and_omits_global_dream_fa
 async fn external_memory_excludes_other_project_memory_index_content() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id_a = bamboo_domain::ProjectId::parse("project-prompt-a").expect("project id");
+    let project_id_b = bamboo_domain::ProjectId::parse("project-prompt-b").expect("project id");
+    let project_memory_a = store.for_project(&project_id_a);
+    let project_memory_b = store.for_project(&project_id_b);
     let workspace_a = temp_dir.path().join("workspace-project-a");
     let workspace_b = temp_dir.path().join("workspace-project-b");
     std::fs::create_dir_all(&workspace_a).expect("workspace a dir");
     std::fs::create_dir_all(&workspace_b).expect("workspace b dir");
-    let project_key_a = bamboo_memory::memory_store::project_key_from_path(&workspace_a);
-    let project_key_b = bamboo_memory::memory_store::project_key_from_path(&workspace_b);
+    let project_key_a = project_id_a.to_string();
+    let project_key_b = project_id_b.to_string();
 
-    store
+    project_memory_a
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key_a.as_str()),
@@ -328,7 +335,7 @@ async fn external_memory_excludes_other_project_memory_index_content() {
         )
         .await
         .expect("save project A memory");
-    store
+    project_memory_b
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key_b.as_str()),
@@ -345,6 +352,7 @@ async fn external_memory_excludes_other_project_memory_index_content() {
         .expect("save project B memory");
 
     let mut session = bamboo_agent_core::Session::new("session-project-a", "test-model");
+    session.set_project_id_meta(project_id_a.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -370,7 +378,7 @@ async fn external_memory_excludes_other_project_memory_index_content() {
 }
 
 #[tokio::test]
-async fn external_memory_malformed_project_id_does_not_read_path_derived_legacy_scope() {
+async fn external_memory_malformed_project_id_does_not_read_canonical_project_memory() {
     struct EmptyProjectSource;
 
     #[async_trait]
@@ -388,13 +396,14 @@ async fn external_memory_malformed_project_id_does_not_read_path_derived_legacy_
 
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
-    let workspace = temp_dir.path().join("legacy-workspace");
+    let project_id = bamboo_domain::ProjectId::parse("project-prompt-secret").expect("project id");
+    let project_memory = store.for_project(&project_id);
+    let workspace = temp_dir.path().join("workspace");
     std::fs::create_dir_all(&workspace).expect("workspace");
-    let legacy_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
-    store
+    project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
-            Some(&legacy_key),
+            Some(project_id.as_str()),
             bamboo_memory::memory_store::DurableMemoryType::Project,
             "Legacy secret",
             "MUST NOT ENTER PROMPT THROUGH MALFORMED PROJECT ID",
@@ -405,7 +414,7 @@ async fn external_memory_malformed_project_id_does_not_read_path_derived_legacy_
             None,
         )
         .await
-        .expect("seed legacy memory");
+        .expect("seed canonical Project memory");
     let mut session = bamboo_agent_core::Session::new("malformed-prompt-memory", "test-model");
     session.set_workspace_path_meta(workspace.to_string_lossy().into_owned());
     session.set_project_id_meta("../malformed".to_string());
@@ -431,10 +440,13 @@ async fn external_memory_malformed_project_id_does_not_read_path_derived_legacy_
 async fn external_memory_truncates_project_memory_index_and_adds_freshness_note() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id =
+        bamboo_domain::ProjectId::parse("project-prompt-truncated").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-beta");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
-    let views_dir = store.resolver().views_dir(
+    let project_key = project_id.to_string();
+    let views_dir = project_memory.resolver().views_dir(
         bamboo_memory::memory_store::MemoryScope::Project,
         Some(project_key.as_str()),
     );
@@ -452,6 +464,7 @@ async fn external_memory_truncates_project_memory_index_and_adds_freshness_note(
 
     let mut session =
         bamboo_agent_core::Session::new("session-project-memory-truncated", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -527,11 +540,13 @@ async fn external_memory_truncates_multi_topic_content_and_is_idempotent() {
 async fn external_memory_renders_relevant_memory_section_for_project_hits() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id = bamboo_domain::ProjectId::parse("project-prompt-recall").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-recall-project");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    store
+    project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -548,6 +563,7 @@ async fn external_memory_renders_relevant_memory_section_for_project_hits() {
         .expect("save relevant project memory");
 
     let mut session = bamboo_agent_core::Session::new("session-recall-project", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -578,11 +594,13 @@ async fn external_memory_renders_relevant_memory_section_for_project_hits() {
 async fn external_memory_adds_stale_guidance_for_old_relevant_memory_hits() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id = bamboo_domain::ProjectId::parse("project-prompt-stale").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-recall-stale");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    let doc = store
+    let doc = project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -604,7 +622,7 @@ async fn external_memory_adds_stale_guidance_for_old_relevant_memory_hits() {
         .replace(&doc.frontmatter.updated_at, old_timestamp)
         .replace(&doc.frontmatter.created_at, old_timestamp);
     std::fs::write(&doc.path, rewritten).expect("rewrite timestamps");
-    store
+    project_memory
         .rebuild_scope(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -613,6 +631,7 @@ async fn external_memory_adds_stale_guidance_for_old_relevant_memory_hits() {
         .expect("rebuild scope after timestamp rewrite");
 
     let mut session = bamboo_agent_core::Session::new("session-recall-stale", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -675,12 +694,14 @@ async fn external_memory_omits_relevant_memory_section_when_no_match_exists() {
 async fn external_memory_limits_relevant_memories_to_top_k() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id = bamboo_domain::ProjectId::parse("project-prompt-topk").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-recall-topk");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
     for idx in 0..4 {
-        store
+        project_memory
             .write_memory(
                 bamboo_memory::memory_store::MemoryScope::Project,
                 Some(project_key.as_str()),
@@ -699,6 +720,7 @@ async fn external_memory_limits_relevant_memories_to_top_k() {
     }
 
     let mut session = bamboo_agent_core::Session::new("session-recall-topk", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -725,11 +747,14 @@ async fn external_memory_limits_relevant_memories_to_top_k() {
 async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_has_no_hits() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id =
+        bamboo_domain::ProjectId::parse("project-prompt-fallback").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-recall-fallback");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    store
+    project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -761,6 +786,7 @@ async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_
         .expect("save global fallback memory");
 
     let mut session = bamboo_agent_core::Session::new("session-recall-fallback", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -789,11 +815,13 @@ async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_
 async fn external_memory_prefers_project_dream_over_global_fallback() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id = bamboo_domain::ProjectId::parse("project-prompt-dream").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-project-dream");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    store
+    project_memory
         .write_project_dream_view(
             project_key.as_str(),
             "# Bamboo Dream Notebook\n\nProject dream context",
@@ -806,6 +834,7 @@ async fn external_memory_prefers_project_dream_over_global_fallback() {
         .expect("write global dream");
 
     let mut session = bamboo_agent_core::Session::new("session-project-dream", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -869,11 +898,14 @@ async fn external_memory_uses_global_dream_fallback_when_project_dream_and_index
 async fn external_memory_omits_project_index_when_project_prompt_injection_disabled() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id =
+        bamboo_domain::ProjectId::parse("project-prompt-disabled").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-no-project-index");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    store
+    project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -890,6 +922,7 @@ async fn external_memory_omits_project_index_when_project_prompt_injection_disab
         .expect("save project memory");
 
     let mut session = bamboo_agent_core::Session::new("session-no-project-index", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -935,11 +968,14 @@ async fn external_memory_omits_project_index_when_project_prompt_injection_disab
 async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_project_first_disabled() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id =
+        bamboo_domain::ProjectId::parse("project-prompt-global-mode").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-global-dream-mode");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    store
+    project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -954,7 +990,7 @@ async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_projec
         )
         .await
         .expect("save relevant project memory");
-    store
+    project_memory
         .write_project_dream_view(
             project_key.as_str(),
             "# Bamboo Dream Notebook\n\nProject dream context",
@@ -967,6 +1003,7 @@ async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_projec
         .expect("write global dream");
 
     let mut session = bamboo_agent_core::Session::new("session-global-dream-mode", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -1014,11 +1051,13 @@ async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_projec
 async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id = bamboo_domain::ProjectId::parse("project-prompt-rerank").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-rerank-recall");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    let lexical_first = store
+    let lexical_first = project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -1033,7 +1072,7 @@ async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() 
         )
         .await
         .expect("save lexical-first memory");
-    let reranked_first = store
+    let reranked_first = project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -1060,6 +1099,7 @@ async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() 
     };
 
     let mut session = bamboo_agent_core::Session::new("session-rerank-recall", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),
@@ -1111,11 +1151,14 @@ async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() 
 async fn external_memory_uses_latest_background_model_on_repeated_refresh() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
+    let project_id =
+        bamboo_domain::ProjectId::parse("project-prompt-rerank-reload").expect("project id");
+    let project_memory = store.for_project(&project_id);
     let workspace = temp_dir.path().join("workspace-rerank-reload");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
-    let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
+    let project_key = project_id.to_string();
 
-    let lexical_first = store
+    let lexical_first = project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -1130,7 +1173,7 @@ async fn external_memory_uses_latest_background_model_on_repeated_refresh() {
         )
         .await
         .expect("save lexical-first memory");
-    let reranked_first = store
+    let reranked_first = project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -1153,6 +1196,7 @@ async fn external_memory_uses_latest_background_model_on_repeated_refresh() {
     let requested_models = provider.requested_models.clone();
 
     let mut session = bamboo_agent_core::Session::new("session-rerank-reload", "test-model");
+    session.set_project_id_meta(project_id.to_string());
     session.add_message(bamboo_agent_core::Message::system("Base prompt"));
     session.metadata.insert(
         "workspace_path".to_string(),

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
@@ -484,10 +484,6 @@ mod project_prompt_tests {
                 resource_revision: 1,
                 resources: Vec::new(),
             },
-            memory_read_roots: crate::project_context::ProjectMemoryReadRoots {
-                primary: directory.path().join("projects/project-1/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let resolver = ProjectContextResolver::new(std::sync::Arc::new(StaticSource(descriptor)));
         let mut session = Session::new("session-1", "model");
@@ -604,10 +600,6 @@ mod project_prompt_tests {
                 resource_revision: 1,
                 resources: Vec::new(),
             },
-            memory_read_roots: crate::project_context::ProjectMemoryReadRoots {
-                primary: directory.path().join("projects/round-project/memory/v1"),
-                legacy_aliases: Vec::new(),
-            },
         };
         let resolver =
             ProjectContextResolver::new(std::sync::Arc::new(StaticSource(descriptor.clone())));
@@ -669,12 +661,6 @@ mod project_prompt_tests {
                 project_id,
                 resource_revision: 1,
                 resources: Vec::new(),
-            },
-            memory_read_roots: crate::project_context::ProjectMemoryReadRoots {
-                primary: directory
-                    .path()
-                    .join("projects/unrelated-project/memory/v1"),
-                legacy_aliases: Vec::new(),
             },
         };
         let resolver = ProjectContextResolver::new(std::sync::Arc::new(StaticSource(descriptor)));

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -2171,10 +2171,6 @@ async fn runtime_skill_context_rejects_another_projects_workspace_overlay() {
             resource_revision: 1,
             resources: Vec::new(),
         },
-        memory_read_roots: crate::project_context::ProjectMemoryReadRoots {
-            primary: project_home.join("memory/v1"),
-            legacy_aliases: Vec::new(),
-        },
     };
     let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
         skills_dir: directory.path().join("global-skills"),

--- a/crates/infra/bamboo-memory/src/memory_store/mod.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/mod.rs
@@ -18,10 +18,7 @@ pub use freshness::{
     memory_age_days, memory_age_label, memory_freshness_text, render_memory_freshness_note,
     FreshnessKind,
 };
-pub use paths::{
-    LegacyProjectMemoryReadRoot, MemoryPathResolver, ProjectMemoryPathResolver, SESSIONS_DIR,
-    TOPICS_DIR,
-};
+pub use paths::{MemoryPathResolver, ProjectMemoryPathResolver, SESSIONS_DIR, TOPICS_DIR};
 pub use recall::{shortlist_relevant_memories, MemoryRecallCandidate, MemoryRecallOptions};
 pub use store::MemoryStore;
 pub use types::{

--- a/crates/infra/bamboo-memory/src/memory_store/paths.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/paths.rs
@@ -23,13 +23,6 @@ pub struct MemoryPathResolver {
     data_dir: PathBuf,
     root: PathBuf,
     project_id: Option<ProjectId>,
-    legacy_project_read_roots: Vec<LegacyProjectMemoryReadRoot>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LegacyProjectMemoryReadRoot {
-    pub project_key: String,
-    pub root: PathBuf,
 }
 
 /// Explicit first-class Project memory layout.
@@ -37,8 +30,8 @@ pub struct LegacyProjectMemoryReadRoot {
 /// This resolver is intentionally separate from the legacy path-hash
 /// `MemoryPathResolver::project_root(&str)`: a safe legacy key and a ProjectId
 /// can have the same character shape, so guessing by string format would move
-/// old scopes silently. Assigned-session writes must use this typed resolver;
-/// legacy roots remain read-only migration aliases.
+/// scopes silently. Assigned-session reads and writes must use this typed
+/// resolver.
 #[derive(Debug, Clone)]
 pub struct ProjectMemoryPathResolver {
     data_dir: PathBuf,
@@ -60,28 +53,6 @@ impl ProjectMemoryPathResolver {
             .join(MEMORY_ROOT_DIR)
             .join(MEMORY_VERSION_DIR)
     }
-
-    pub fn legacy_read_root(&self, legacy_project_key: &str) -> std::io::Result<PathBuf> {
-        let legacy_project_key = legacy_project_key.trim();
-        if legacy_project_key.is_empty()
-            || legacy_project_key.contains('/')
-            || legacy_project_key.contains('\\')
-            || legacy_project_key == "."
-            || legacy_project_key == ".."
-        {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "legacy project key is not a safe path component",
-            ));
-        }
-        Ok(self
-            .data_dir
-            .join(MEMORY_ROOT_DIR)
-            .join(MEMORY_VERSION_DIR)
-            .join(SCOPES_DIR)
-            .join(PROJECTS_DIR)
-            .join(legacy_project_key))
-    }
 }
 
 impl Default for MemoryPathResolver {
@@ -98,7 +69,6 @@ impl MemoryPathResolver {
             data_dir,
             root,
             project_id: None,
-            legacy_project_read_roots: Vec::new(),
         }
     }
 
@@ -109,7 +79,6 @@ impl MemoryPathResolver {
             data_dir,
             root,
             project_id: None,
-            legacy_project_read_roots: Vec::new(),
         }
     }
 
@@ -122,59 +91,11 @@ impl MemoryPathResolver {
             data_dir: self.data_dir.clone(),
             root: self.root.clone(),
             project_id: Some(project_id.clone()),
-            legacy_project_read_roots: Vec::new(),
-        }
-    }
-
-    pub fn for_project_with_legacy_read_roots(
-        &self,
-        project_id: &ProjectId,
-        legacy_project_read_roots: Vec<LegacyProjectMemoryReadRoot>,
-    ) -> Self {
-        Self {
-            data_dir: self.data_dir.clone(),
-            root: self.root.clone(),
-            project_id: Some(project_id.clone()),
-            legacy_project_read_roots,
         }
     }
 
     pub fn project_id(&self) -> Option<&ProjectId> {
         self.project_id.as_ref()
-    }
-
-    pub fn has_legacy_project_read_roots(&self) -> bool {
-        !self.legacy_project_read_roots.is_empty()
-    }
-
-    pub fn project_read_roots(&self, project_key: &str) -> Vec<PathBuf> {
-        if self
-            .project_id
-            .as_ref()
-            .is_some_and(|project_id| project_id.as_str() == project_key)
-        {
-            let mut roots = vec![self.project_root(project_key)];
-            roots.extend(
-                self.legacy_project_read_roots
-                    .iter()
-                    .map(|legacy| legacy.root.clone()),
-            );
-            return roots;
-        }
-        vec![self.project_root(project_key)]
-    }
-
-    pub fn is_legacy_project_read_path(&self, path: &Path) -> bool {
-        self.legacy_project_read_roots
-            .iter()
-            .any(|legacy| path.starts_with(&legacy.root))
-    }
-
-    pub fn scope_read_roots(&self, scope: MemoryScope, project_key: Option<&str>) -> Vec<PathBuf> {
-        match scope {
-            MemoryScope::Project => self.project_read_roots(project_key.unwrap_or("unknown")),
-            _ => vec![self.scope_root(scope, project_key)],
-        }
     }
 
     pub fn data_dir(&self) -> PathBuf {
@@ -362,12 +283,5 @@ mod tests {
             scoped.topic_dir(MemoryScope::Project, Some(project_id.as_str())),
             PathBuf::from("/tmp/bamboo/projects/01JABCDEF0123456789ABCDEFG/memory/v1/topics")
         );
-        assert_eq!(
-            resolver
-                .legacy_read_root("zenith-deadbeef")
-                .expect("legacy"),
-            PathBuf::from("/tmp/bamboo/memory/v1/scopes/projects/zenith-deadbeef")
-        );
-        assert!(resolver.legacy_read_root("../escape").is_err());
     }
 }

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -7,8 +7,6 @@ use dashmap::DashMap;
 use tokio::fs;
 use tokio::sync::Mutex;
 
-use bamboo_agent_core::workspace_state;
-
 use super::access_log::{
     self, AccessLogEntry, AccessStats, ACCESS_LOG_COMPACT_TRIGGER_BYTES, ACCESS_LOG_FILE,
 };
@@ -18,18 +16,17 @@ use super::{
     build_dream_view, build_memory_markdown_view, build_recent_markdown_view,
     build_stale_markdown_view, derive_summary, detect_entities, extract_keywords,
     make_query_cursor, match_memory_query, normalize_tags, now_rfc3339, parse_markdown_document,
-    parse_query_cursor, parse_rfc3339, project_key_from_path, render_markdown_document,
-    short_stable_hash, sort_memories_desc, validate_memory_title, validate_session_id,
-    validate_session_topic, AuditLogEntry, GraphIndex, GraphIndexItem, LegacyProjectMemoryReadRoot,
-    LexicalIndex, LexicalIndexItem, MemoryContradictionResult, MemoryDuplicateCandidate,
-    MemoryInspectResult, MemoryMergeResult, MemoryPathResolver, MemoryPurgeResult, MemoryQueryItem,
-    MemoryQueryOptions, MemoryQueryResult, MemorySplitPiece, MemorySplitResult, RecentIndex,
-    RecentIndexItem, StaleCandidateItem, StaleCandidatesIndex, TaxonomyIndex,
-    CONTRADICTION_AUDIT_LOG, DEFAULT_MAX_CHARS, DEFAULT_QUERY_LIMIT, DEFAULT_SESSION_TOPIC,
-    DREAM_VIEW_FILE, GRAPH_INDEX_FILE, LEXICAL_INDEX_FILE, MAX_MAX_CHARS, MAX_QUERY_LIMIT,
-    MEMORY_SCHEMA_VERSION, MEMORY_VIEW_FILE, MERGE_AUDIT_LOG, PURGE_AUDIT_LOG, RECENT_INDEX_FILE,
-    RECENT_VIEW_FILE, STALE_CANDIDATES_INDEX_FILE, STALE_VIEW_FILE, TAXONOMY_INDEX_FILE,
-    WRITE_AUDIT_LOG,
+    parse_query_cursor, parse_rfc3339, render_markdown_document, short_stable_hash,
+    sort_memories_desc, validate_memory_title, validate_session_id, validate_session_topic,
+    AuditLogEntry, GraphIndex, GraphIndexItem, LexicalIndex, LexicalIndexItem,
+    MemoryContradictionResult, MemoryDuplicateCandidate, MemoryInspectResult, MemoryMergeResult,
+    MemoryPathResolver, MemoryPurgeResult, MemoryQueryItem, MemoryQueryOptions, MemoryQueryResult,
+    MemorySplitPiece, MemorySplitResult, RecentIndex, RecentIndexItem, StaleCandidateItem,
+    StaleCandidatesIndex, TaxonomyIndex, CONTRADICTION_AUDIT_LOG, DEFAULT_MAX_CHARS,
+    DEFAULT_QUERY_LIMIT, DEFAULT_SESSION_TOPIC, DREAM_VIEW_FILE, GRAPH_INDEX_FILE,
+    LEXICAL_INDEX_FILE, MAX_MAX_CHARS, MAX_QUERY_LIMIT, MEMORY_SCHEMA_VERSION, MEMORY_VIEW_FILE,
+    MERGE_AUDIT_LOG, PURGE_AUDIT_LOG, RECENT_INDEX_FILE, RECENT_VIEW_FILE,
+    STALE_CANDIDATES_INDEX_FILE, STALE_VIEW_FILE, TAXONOMY_INDEX_FILE, WRITE_AUDIT_LOG,
 };
 use super::{
     BlobScanItem, BlobScanReport, DuplicateCluster, DuplicateClusterMember, DuplicateScanReport,
@@ -202,22 +199,6 @@ impl MemoryStore {
         }
     }
 
-    pub fn for_project_with_legacy_read_roots(
-        &self,
-        project_id: &bamboo_domain::ProjectId,
-        legacy_project_read_roots: Vec<LegacyProjectMemoryReadRoot>,
-    ) -> Self {
-        Self {
-            resolver: self
-                .resolver
-                .for_project_with_legacy_read_roots(project_id, legacy_project_read_roots),
-        }
-    }
-
-    pub fn is_read_only_project_memory_path(&self, path: &Path) -> bool {
-        self.resolver.is_legacy_project_read_path(path)
-    }
-
     /// Return the process-global write lock guarding the given scope's on-disk
     /// state. Callers acquire it for the full duration of a read-modify-write +
     /// `refresh_scope_artifacts` critical section so concurrent writers to the same
@@ -267,17 +248,6 @@ impl MemoryStore {
             .entry(key)
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
-    }
-
-    pub fn derive_project_key_from_workspace(workspace: Option<&Path>) -> Option<String> {
-        workspace.map(project_key_from_path)
-    }
-
-    pub fn project_key_for_session(&self, session_id: Option<&str>) -> Option<String> {
-        let workspace = session_id
-            .and_then(workspace_state::get_workspace)
-            .or_else(workspace_state::get_configured_default_workspace);
-        workspace.map(|path| project_key_from_path(&path))
     }
 
     pub async fn read_session_topic(
@@ -446,12 +416,6 @@ impl MemoryStore {
         project_key: Option<&str>,
     ) -> io::Result<Option<String>> {
         let project_key = self.require_project_key(scope, project_key)?;
-        if scope == MemoryScope::Project && self.resolver.has_legacy_project_read_roots() {
-            let docs = self.list_memory_documents(scope, project_key).await?;
-            return Ok(
-                (!docs.is_empty()).then(|| build_memory_markdown_view(scope, project_key, &docs))
-            );
-        }
         let path = self
             .resolver
             .views_dir(scope, project_key)
@@ -491,40 +455,6 @@ impl MemoryStore {
         project_key: Option<&str>,
     ) -> io::Result<Option<LexicalIndex>> {
         let project_key = self.require_project_key(scope, project_key)?;
-        if scope == MemoryScope::Project && self.resolver.has_legacy_project_read_roots() {
-            let docs = self.list_memory_documents(scope, project_key).await?;
-            if docs.is_empty() {
-                return Ok(None);
-            }
-            return Ok(Some(LexicalIndex {
-                generated_at: now_rfc3339(),
-                items: docs
-                    .iter()
-                    .filter(|doc| {
-                        matches!(
-                            doc.frontmatter.status,
-                            DurableMemoryStatus::Active | DurableMemoryStatus::Stale
-                        )
-                    })
-                    .map(|doc| LexicalIndexItem {
-                        id: doc.frontmatter.id.clone(),
-                        title: doc.frontmatter.title.clone(),
-                        scope: doc.frontmatter.scope,
-                        project_key: doc.frontmatter.project_key.clone(),
-                        r#type: doc.frontmatter.r#type,
-                        status: doc.frontmatter.status,
-                        tags: doc.frontmatter.tags.clone(),
-                        keywords: doc.frontmatter.retrieval.keywords.clone(),
-                        entities: doc.frontmatter.retrieval.entities.clone(),
-                        updated_at: doc.frontmatter.updated_at.clone(),
-                        created_at: doc.frontmatter.created_at.clone(),
-                        summary: derive_summary(&doc.body, 240),
-                        granularity: doc.frontmatter.granularity,
-                        embedding: None,
-                    })
-                    .collect(),
-            }));
-        }
         let path = self
             .resolver
             .indexes_dir(scope, project_key)
@@ -791,18 +721,6 @@ impl MemoryStore {
             return Ok(Some(doc));
         }
 
-        for project_key in self.list_project_keys().await? {
-            if Some(project_key.as_str()) == preferred_project_key {
-                continue;
-            }
-            if let Some(doc) = self
-                .get_memory_in_scope(MemoryScope::Project, Some(project_key.as_str()), id)
-                .await?
-            {
-                return Ok(Some(doc));
-            }
-        }
-
         Ok(None)
     }
 
@@ -849,77 +767,69 @@ impl MemoryStore {
             {
                 WriteSimilarity::Merge(existing) => {
                     let mut existing = *existing;
-                    if self.resolver.is_legacy_project_read_path(&existing.path) {
-                        // Legacy aliases participate in recall and duplicate
-                        // detection, but never become mutation targets. Treat a
-                        // strong match as a related source and create a new
-                        // primary Project-home record below.
-                        related_ids = vec![existing.frontmatter.id.clone()];
-                    } else {
-                        // Structural guard: never grow a memory into a blob. If appending
-                        // would exceed the body cap, don't merge — fall through to a new
-                        // atomic memory and instead LINK it to the dup, rather than
-                        // silently orphaning it.
-                        let already_present = existing.body.contains(content);
-                        if already_present
-                            || projected_merged_body_chars(&existing.body, content)
-                                <= MAX_DURABLE_MEMORY_BODY_CHARS
-                        {
-                            if !already_present {
-                                existing.body = format!(
-                                    "{}{}{}",
-                                    existing.body.trim_end(),
-                                    MEMORY_SECTION_SEPARATOR,
-                                    content
-                                );
-                            }
-                            existing.frontmatter.updated_at = now_rfc3339();
-                            existing.frontmatter.updated_by = CreatedBy {
-                                kind: "memory_write".to_string(),
-                                id: None,
-                                actor: Some(actor.to_string()),
-                            };
-                            let mut merged_tags = existing.frontmatter.tags.clone();
-                            merged_tags.extend(tags.clone());
-                            existing.frontmatter.tags =
-                                normalize_tags(merged_tags.iter().map(String::as_str));
-                            existing.frontmatter.retrieval.keywords = extract_keywords(
-                                &existing.frontmatter.title,
-                                &existing.body,
-                                &existing.frontmatter.tags,
+                    // Structural guard: never grow a memory into a blob. If appending
+                    // would exceed the body cap, don't merge — fall through to a new
+                    // atomic memory and instead LINK it to the dup, rather than
+                    // silently orphaning it.
+                    let already_present = existing.body.contains(content);
+                    if already_present
+                        || projected_merged_body_chars(&existing.body, content)
+                            <= MAX_DURABLE_MEMORY_BODY_CHARS
+                    {
+                        if !already_present {
+                            existing.body = format!(
+                                "{}{}{}",
+                                existing.body.trim_end(),
+                                MEMORY_SECTION_SEPARATOR,
+                                content
                             );
-                            existing.frontmatter.retrieval.entities =
-                                detect_entities(&existing.frontmatter.title, &existing.body);
-                            self.write_document(&existing).await?;
-                            self.append_audit(
-                                scope,
-                                project_key,
-                                MERGE_AUDIT_LOG,
-                                AuditLogEntry {
-                                    timestamp: now_rfc3339(),
-                                    action: "merge".to_string(),
-                                    scope,
-                                    memory_id: Some(existing.frontmatter.id.clone()),
-                                    session_id: session_id.map(|value| value.to_string()),
-                                    topic: None,
-                                    summary: format!(
-                                        "Merged new content into existing memory '{}'.",
-                                        existing.frontmatter.title
-                                    ),
-                                    metadata: Some(serde_json::json!({
-                                        "type": existing.frontmatter.r#type.as_str(),
-                                        "project_key": project_key,
-                                        "allow_merge_if_similar": true,
-                                    })),
-                                },
-                            )
-                            .await?;
-                            self.refresh_scope_artifacts(scope, project_key).await?;
-                            return Ok(existing);
                         }
-                        // Too big to merge without blobbing → link instead.
-                        related_ids = vec![existing.frontmatter.id.clone()];
+                        existing.frontmatter.updated_at = now_rfc3339();
+                        existing.frontmatter.updated_by = CreatedBy {
+                            kind: "memory_write".to_string(),
+                            id: None,
+                            actor: Some(actor.to_string()),
+                        };
+                        let mut merged_tags = existing.frontmatter.tags.clone();
+                        merged_tags.extend(tags.clone());
+                        existing.frontmatter.tags =
+                            normalize_tags(merged_tags.iter().map(String::as_str));
+                        existing.frontmatter.retrieval.keywords = extract_keywords(
+                            &existing.frontmatter.title,
+                            &existing.body,
+                            &existing.frontmatter.tags,
+                        );
+                        existing.frontmatter.retrieval.entities =
+                            detect_entities(&existing.frontmatter.title, &existing.body);
+                        self.write_document(&existing).await?;
+                        self.append_audit(
+                            scope,
+                            project_key,
+                            MERGE_AUDIT_LOG,
+                            AuditLogEntry {
+                                timestamp: now_rfc3339(),
+                                action: "merge".to_string(),
+                                scope,
+                                memory_id: Some(existing.frontmatter.id.clone()),
+                                session_id: session_id.map(|value| value.to_string()),
+                                topic: None,
+                                summary: format!(
+                                    "Merged new content into existing memory '{}'.",
+                                    existing.frontmatter.title
+                                ),
+                                metadata: Some(serde_json::json!({
+                                    "type": existing.frontmatter.r#type.as_str(),
+                                    "project_key": project_key,
+                                    "allow_merge_if_similar": true,
+                                })),
+                            },
+                        )
+                        .await?;
+                        self.refresh_scope_artifacts(scope, project_key).await?;
+                        return Ok(existing);
                     }
+                    // Too big to merge without blobbing → link instead.
+                    related_ids = vec![existing.frontmatter.id.clone()];
                 }
                 WriteSimilarity::Relate(ids) => related_ids = ids,
                 WriteSimilarity::None => {}
@@ -2038,45 +1948,28 @@ impl MemoryStore {
     ) -> io::Result<Vec<DurableMemoryDocument>> {
         let project_key = self.require_project_key(scope, project_key)?;
         let mut docs = Vec::new();
-        let mut seen = HashSet::new();
-        for root in self.resolver.scope_read_roots(scope, project_key) {
-            let topic_dir = root.join(super::TOPICS_DIR);
-            if !topic_dir.exists() {
+        let topic_dir = self.resolver.topic_dir(scope, project_key);
+        if !topic_dir.exists() {
+            return Ok(docs);
+        }
+        let mut entries = fs::read_dir(topic_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if !path.extension().is_some_and(|ext| ext == "md") {
                 continue;
             }
-            let is_legacy_alias = self.resolver.is_legacy_project_read_path(&topic_dir);
-            let mut entries = fs::read_dir(topic_dir).await?;
-            while let Some(entry) = entries.next_entry().await? {
-                let path = entry.path();
-                if !path.extension().is_some_and(|ext| ext == "md") {
-                    continue;
+            let raw = fs::read_to_string(&path).await?;
+            let (mut frontmatter, body) = parse_markdown_document(&raw)?;
+            if scope == MemoryScope::Project {
+                if let Some(project_id) = self.resolver.project_id() {
+                    frontmatter.project_key = Some(project_id.to_string());
                 }
-                let raw = fs::read_to_string(&path).await?;
-                let (mut frontmatter, body) = match parse_markdown_document(&raw) {
-                    Ok(parsed) => parsed,
-                    Err(error) if is_legacy_alias => {
-                        tracing::warn!(
-                            path = %path.display(),
-                            "skipping invalid legacy Project memory during read union: {error}"
-                        );
-                        continue;
-                    }
-                    Err(error) => return Err(error),
-                };
-                if !seen.insert(frontmatter.id.clone()) {
-                    continue;
-                }
-                if scope == MemoryScope::Project {
-                    if let Some(project_id) = self.resolver.project_id() {
-                        frontmatter.project_key = Some(project_id.to_string());
-                    }
-                }
-                docs.push(DurableMemoryDocument {
-                    frontmatter,
-                    body,
-                    path,
-                });
             }
+            docs.push(DurableMemoryDocument {
+                frontmatter,
+                body,
+                path,
+            });
         }
         sort_memories_desc(&mut docs);
         Ok(docs)
@@ -2091,9 +1984,6 @@ impl MemoryStore {
         project_key: Option<&str>,
     ) -> io::Result<usize> {
         let project_key = self.require_project_key(scope, project_key)?;
-        if scope == MemoryScope::Project && self.resolver.has_legacy_project_read_roots() {
-            return Ok(self.list_memory_documents(scope, project_key).await?.len());
-        }
         let topic_dir = self.resolver.topic_dir(scope, project_key);
         if !topic_dir.exists() {
             return Ok(0);
@@ -2174,7 +2064,6 @@ impl MemoryStore {
             .filter(|doc| {
                 is_scorable(doc.frontmatter.status)
                     && doc.frontmatter.r#type == DurableMemoryType::Project
-                    && !self.resolver.is_legacy_project_read_path(&doc.path)
             })
             .collect();
 
@@ -2293,7 +2182,6 @@ impl MemoryStore {
         for doc in docs
             .iter_mut()
             .filter(|doc| doc.frontmatter.status == DurableMemoryStatus::Active)
-            .filter(|doc| !self.resolver.is_legacy_project_read_path(&doc.path))
             .filter(|doc| {
                 freshness::granularity_expired(
                     doc.frontmatter.granularity,
@@ -2478,34 +2366,25 @@ impl MemoryStore {
         id: &str,
     ) -> io::Result<Option<DurableMemoryDocument>> {
         let project_key = self.require_project_key(scope, project_key)?;
-        for root in self.resolver.scope_read_roots(scope, project_key) {
-            let path = root.join(super::TOPICS_DIR).join(format!("{id}.md"));
-            if !path.exists() {
-                continue;
-            }
-            let raw = fs::read_to_string(&path).await?;
-            let (mut frontmatter, body) = parse_markdown_document(&raw)?;
-            if scope == MemoryScope::Project {
-                if let Some(project_id) = self.resolver.project_id() {
-                    frontmatter.project_key = Some(project_id.to_string());
-                }
-            }
-            return Ok(Some(DurableMemoryDocument {
-                frontmatter,
-                body,
-                path,
-            }));
+        let path = self.resolver.topic_path(scope, project_key, id);
+        if !path.exists() {
+            return Ok(None);
         }
-        Ok(None)
+        let raw = fs::read_to_string(&path).await?;
+        let (mut frontmatter, body) = parse_markdown_document(&raw)?;
+        if scope == MemoryScope::Project {
+            if let Some(project_id) = self.resolver.project_id() {
+                frontmatter.project_key = Some(project_id.to_string());
+            }
+        }
+        Ok(Some(DurableMemoryDocument {
+            frontmatter,
+            body,
+            path,
+        }))
     }
 
     async fn write_document(&self, doc: &DurableMemoryDocument) -> io::Result<()> {
-        if self.resolver.is_legacy_project_read_path(&doc.path) {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "legacy Project memory aliases are read-only; migrate or write a new primary memory",
-            ));
-        }
         if let Some(parent) = doc.path.parent() {
             fs::create_dir_all(parent).await?;
         }
@@ -3113,13 +2992,11 @@ impl MemoryStore {
         if scope == MemoryScope::Global {
             self.maybe_migrate_legacy_dream().await?;
         }
-        for root in self.resolver.scope_read_roots(scope, project_key) {
-            let path = root.join(super::paths::VIEWS_DIR).join(DREAM_VIEW_FILE);
-            if let Some(content) = self.read_optional_trimmed_text_file(path).await? {
-                return Ok(Some(content));
-            }
-        }
-        Ok(None)
+        let path = self
+            .resolver
+            .views_dir(scope, project_key)
+            .join(DREAM_VIEW_FILE);
+        self.read_optional_trimmed_text_file(path).await
     }
 
     async fn write_scope_dream_view(
@@ -3760,6 +3637,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_memory_isolated_to_preferred_project_or_global_scope() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        let project_a = store
+            .write_memory(
+                MemoryScope::Project,
+                Some("project-a"),
+                DurableMemoryType::Project,
+                "Project A only",
+                "This durable memory belongs only to Project A.",
+                &[],
+                Some("session-a"),
+                "test",
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        let global = store
+            .write_memory(
+                MemoryScope::Global,
+                None,
+                DurableMemoryType::Reference,
+                "Global reference",
+                "This durable memory is available globally.",
+                &[],
+                None,
+                "test",
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(store
+            .get_memory(&project_a.frontmatter.id, None)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .get_memory(&project_a.frontmatter.id, Some("project-b"))
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            store
+                .get_memory(&project_a.frontmatter.id, Some("project-a"))
+                .await
+                .unwrap()
+                .expect("preferred Project can read its own memory")
+                .frontmatter
+                .id,
+            project_a.frontmatter.id
+        );
+        assert_eq!(
+            store
+                .get_memory(&global.frontmatter.id, None)
+                .await
+                .unwrap()
+                .expect("Global memory remains readable without a Project")
+                .frontmatter
+                .id,
+            global.frontmatter.id
+        );
+    }
+
+    #[tokio::test]
     async fn assigned_project_writes_use_project_home_memory_root() {
         let dir = tempdir().unwrap();
         let project_id = bamboo_domain::ProjectId::parse("01JPROJECT00000000000000000").unwrap();
@@ -3820,160 +3764,6 @@ mod tests {
             )
             .await
             .is_err());
-    }
-
-    #[tokio::test]
-    async fn assigned_project_reads_legacy_alias_with_primary_precedence_and_isolation() {
-        let dir = tempdir().unwrap();
-        let legacy_store = MemoryStore::new(dir.path());
-        let legacy = legacy_store
-            .write_memory(
-                MemoryScope::Project,
-                Some("legacy-workspace-key"),
-                DurableMemoryType::Project,
-                "Shared legacy fact",
-                "legacy-only content",
-                &[],
-                Some("legacy-session"),
-                "test",
-                false,
-                None,
-            )
-            .await
-            .unwrap();
-        let project_id = bamboo_domain::ProjectId::parse("project-a").unwrap();
-        let alias_root = dir
-            .path()
-            .join("memory/v1/scopes/projects/legacy-workspace-key");
-        let store = MemoryStore::new(dir.path()).for_project_with_legacy_read_roots(
-            &project_id,
-            vec![LegacyProjectMemoryReadRoot {
-                project_key: "legacy-workspace-key".to_string(),
-                root: alias_root.clone(),
-            }],
-        );
-
-        let before_migration = store
-            .query_scope(
-                MemoryScope::Project,
-                Some(project_id.as_str()),
-                Some("legacy-only"),
-                None,
-                None,
-                None,
-                &MemoryQueryOptions::default(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(before_migration.matched_count, 1);
-        assert_eq!(
-            before_migration.items[0].project_key.as_deref(),
-            Some(project_id.as_str())
-        );
-
-        let mut primary = legacy.clone();
-        primary.frontmatter.project_key = Some(project_id.to_string());
-        primary.body = "primary content wins".to_string();
-        primary.path = store.resolver.topic_path(
-            MemoryScope::Project,
-            Some(project_id.as_str()),
-            &primary.frontmatter.id,
-        );
-        store.write_document(&primary).await.unwrap();
-
-        let union = store
-            .list_memory_documents(MemoryScope::Project, Some(project_id.as_str()))
-            .await
-            .unwrap();
-        assert_eq!(union.len(), 1, "same id must be deduplicated");
-        assert_eq!(union[0].body, "primary content wins");
-        assert!(store
-            .write_document(&DurableMemoryDocument {
-                path: legacy.path.clone(),
-                ..legacy
-            })
-            .await
-            .is_err());
-
-        let other_project = bamboo_domain::ProjectId::parse("project-b").unwrap();
-        let other = MemoryStore::new(dir.path()).for_project(&other_project);
-        assert_eq!(
-            other
-                .query_scope(
-                    MemoryScope::Project,
-                    Some(other_project.as_str()),
-                    Some("legacy-only"),
-                    None,
-                    None,
-                    None,
-                    &MemoryQueryOptions::default(),
-                )
-                .await
-                .unwrap()
-                .matched_count,
-            0
-        );
-    }
-
-    #[tokio::test]
-    async fn assigned_project_write_never_merges_into_a_legacy_read_alias() {
-        let dir = tempdir().unwrap();
-        let legacy_store = MemoryStore::new(dir.path());
-        let legacy = legacy_store
-            .write_memory(
-                MemoryScope::Project,
-                Some("legacy-workspace-key"),
-                DurableMemoryType::Project,
-                "Shared durable fact",
-                "identical durable content",
-                &[],
-                Some("legacy-session"),
-                "test",
-                false,
-                None,
-            )
-            .await
-            .unwrap();
-        let legacy_bytes = std::fs::read(&legacy.path).unwrap();
-        let project_id = bamboo_domain::ProjectId::parse("project-primary-write").unwrap();
-        let store = MemoryStore::new(dir.path()).for_project_with_legacy_read_roots(
-            &project_id,
-            vec![LegacyProjectMemoryReadRoot {
-                project_key: "legacy-workspace-key".to_string(),
-                root: dir
-                    .path()
-                    .join("memory/v1/scopes/projects/legacy-workspace-key"),
-            }],
-        );
-
-        let written = store
-            .write_memory(
-                MemoryScope::Project,
-                Some(project_id.as_str()),
-                DurableMemoryType::Project,
-                "Shared durable fact",
-                "identical durable content",
-                &[],
-                Some("assigned-session"),
-                "test",
-                true,
-                None,
-            )
-            .await
-            .expect("strong legacy match must copy on write into Project primary");
-
-        assert!(written.path.starts_with(
-            dir.path()
-                .join("projects")
-                .join(project_id.as_str())
-                .join("memory/v1/topics")
-        ));
-        assert!(written
-            .frontmatter
-            .relations
-            .related
-            .contains(&legacy.frontmatter.id));
-        assert_eq!(std::fs::read(&legacy.path).unwrap(), legacy_bytes);
     }
 
     /// L2: a near-identical RESTATEMENT (different title wording, ~same body)


### PR DESCRIPTION
## Summary

- delete runtime Project-memory path-hash aliases and alias read unions
- require an assigned, validated `ProjectId` for Project memory
- route Project memory, Dream, Gardener, prompt recall, and the memory tool only through `${BAMBOO_DATA_DIR}/projects/<id>/memory/v1`
- keep unassigned sessions Global-only and stop unscoped reads from enumerating unrelated Project directories
- remove the SDK memory-root translation dependency

This is the deletion-only prerequisite for #1003. It adds no Jiandu dependency, migration, fallback, daemon, or compatibility layer. Bamboo Projects' administrative legacy-migration surface remains for the focused #1016 cleanup.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- CI-equivalent strict `cargo clippy --all-features -- -D warnings ...`
- `cargo test --locked -p bamboo-memory --no-fail-fast` — 166 passed
- `cargo test --locked -p bamboo-engine --no-fail-fast` — 1,455 passed
- `cargo test --locked -p bamboo-server-tools -p bamboo-server -p bamboo-sdk --no-fail-fast` — SDK 56, Server 1,967 plus integration/doc tests, Server Tools 148; zero failures
- `git diff --check`
- compatibility-symbol zero-hit scan over runtime memory surfaces

## Screenshots

N/A — backend/runtime refactor.

Closes #1015