### PR TITLE
feat: expose Jiandu recall contract to models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Bamboo Agent Guidance
+
+Read [README.md](./README.md) for the product boundary. Use this canonical Jiandu memory contract:
+
+- Session memory is continuity for the current session. Project memory holds durable project facts and decisions; Global memory holds cross-project user context.
+- Recall with a short lexical query. Use Jiandu's compact default top three `id`/summary results, then `get` only the selected item that needs full context.
+- Query before writing. Store one confirmed atomic fact with a specific title and a few useful keywords, entities, and tags.
+- Treat canonical Project memory as trusted durable project authority, but verify live repository or runtime state before acting. Treat Dream as a low-trust derived orientation snapshot, never as canonical evidence.
+- Never store secrets or tokens. Do not add embeddings, vectors, or a duplicate Bamboo persistence/index layer.
+
+Jiandu owns canonical persistence, derived indexes, lexical recall, and Dream snapshot bytes. Bamboo owns prompt selection and budget, optional reranking, and the model and cadence used to refresh Dream.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Guidance
+
+Read [README.md](./README.md) and [AGENTS.md](./AGENTS.md), then follow their canonical Jiandu memory contract. Do not revive Bamboo-owned memory storage, indexes, Dream bytes, embeddings, compatibility layers, or a duplicated action catalog.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If Bodhi is the AI product you see, **Bamboo is the engine running underneath it
 
 | Capability | What it does |
 |---|---|
-| 🧠 **Memory system** | Session notes, Dream notebook, cross-session durable memory, with auto-dream and background gardener |
+| 🧠 **Memory system** | Session notes, Jiandu-owned derived Dream snapshots, and cross-session durable memory, with auto-dream and background gardener |
 | 🗜️ **Context compression** | Hybrid compression with rolling summary + recent-window retention, automatic trimming of oversized tool output, executed against the model's context-window budget |
 | 🛠️ **Built-in tools** | 22 built-in tools: files, search, Shell, Web, plan mode, tasks, permission requests, and more |
 | 🎯 **Skills** | Optional/discoverable skills with lightweight selection based on request hints, including built-in docx / pdf / pptx / xlsx / skill-creator |
@@ -85,9 +85,11 @@ graph TD
 
 Bamboo does not maintain a second memory implementation. Its narrow `bamboo-memory` facade delegates canonical storage, deterministic lexical retrieval, session notes, and Dream snapshots to the exact `jiandu-memory` release.
 
+Jiandu owns canonical persistence, derived indexes, lexical recall, and the persisted Dream snapshot bytes. Bamboo owns prompt selection and budget, may optionally rerank a recalled shortlist, and chooses the model and cadence used to refresh Dream; it does not duplicate Jiandu's memory engine.
+
 - **Session notes** — the `session_note` tool (`read` / `append` / `replace` / `clear` / `list_topics`) keeps compression-resistant context for one session.
 - **Durable memory** — atomic Global or first-class Project facts with type, status, source, relations, and lexical retrieval metadata. Jiandu is the source of truth; there is no embedding pipeline.
-- **Dream** — a derived Global or Project orientation snapshot, never a canonical memory record. Bamboo extracts facts and Ledger candidates first, captures the Jiandu generation, reads canonical `MEMORY.md`, synthesizes once, then publishes with compare-and-swap so a stale run cannot overwrite newer facts.
+- **Dream** — a Jiandu-owned derived Global or Project orientation snapshot, never a canonical memory record. Bamboo extracts facts and Ledger candidates first, captures the Jiandu generation, reads canonical `MEMORY.md`, synthesizes once, then asks Jiandu to publish with compare-and-swap so a stale run cannot overwrite newer facts.
 
 Jiandu defaults to the independent `~/.jiandu` data root. Bamboo configuration, sessions, and the prospective-record Ledger remain under `~/.bamboo`; the two stores are not mixed.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@ Bamboo 是一个能在你自己电脑上运行的 AI 助理"大脑"。它不只�
 
 | 能力 | 说明 |
 |---|---|
-| 🧠 **记忆系统** | 会话便签、Dream 笔记本、跨会话的持久记忆，可自动梦境化（auto-dream）与后台整理（gardener） |
+| 🧠 **记忆系统** | 会话便签、由 Jiandu 持有的派生 Dream 快照和跨会话持久记忆，支持自动生成 Dream 与后台整理（gardener） |
 | 🗜️ **上下文压缩** | 滚动摘要 + 近窗保留的混合压缩，超大工具输出自动裁剪，按模型上下文窗口预算执行 |
 | 🛠️ **内置工具** | 22 个内置工具：文件、搜索、Shell、Web、计划模式、任务、权限请求等 |
 | 🎯 **技能系统** | 可选/可发现的技能，按请求提示做轻量选择，含内置 docx / pdf / pptx / xlsx / skill-creator |
@@ -83,9 +83,11 @@ graph TD
 
 Bamboo 不再维护第二套记忆实现。窄 `bamboo-memory` facade 通过精确版本依赖，把规范存储、确定性词法检索、会话便签和 Dream 快照交给 Jiandu。
 
+Jiandu 持有规范持久化、派生索引、词法召回和落盘的 Dream 快照字节。Bamboo 负责 prompt 选择与预算，可对召回短名单做可选 rerank，并选择刷新 Dream 所用的模型与节奏；它不会复制 Jiandu 的记忆引擎。
+
 - **会话便签** — `session_note` 工具（`read` / `append` / `replace` / `clear` / `list_topics`）保存单个会话内抗压缩的上下文。
 - **持久记忆** — 原子化的 Global 或一等 Project 事实，包含类型、状态、来源、关系和词法检索元数据。Jiandu 是唯一事实源，不存在 embedding 流水线。
-- **Dream** — Global 或 Project 的派生方向快照，不是规范记忆记录。Bamboo 先抽取事实和 Ledger 候选，再捕获 Jiandu generation、读取规范 `MEMORY.md`、只合成一次，最后通过 compare-and-swap 发布，避免过时任务覆盖新事实。
+- **Dream** — 由 Jiandu 持有的 Global 或 Project 派生方向快照，不是规范记忆记录。Bamboo 先抽取事实和 Ledger 候选，再捕获 Jiandu generation、读取规范 `MEMORY.md`、只合成一次，最后请求 Jiandu 通过 compare-and-swap 发布，避免过时任务覆盖新事实。
 
 Jiandu 默认使用独立的 `~/.jiandu` 数据根目录。Bamboo 配置、会话和面向未来事项的 Ledger 仍留在 `~/.bamboo`，两套存储不会混在一起。
 

--- a/crates/app/bamboo-server-tools/src/memory/args.rs
+++ b/crates/app/bamboo-server-tools/src/memory/args.rs
@@ -63,6 +63,10 @@ pub(super) enum MemoryArgs {
         #[serde(default)]
         tags: Vec<String>,
         #[serde(default)]
+        keywords: Vec<String>,
+        #[serde(default)]
+        entities: Vec<String>,
+        #[serde(default)]
         project_key: Option<String>,
         /// Optional temporal granularity (day/week/month/quarter/year). Orthogonal
         /// to `scope`; omitted means the memory carries no temporal dimension.
@@ -76,6 +80,10 @@ pub(super) enum MemoryArgs {
         content: String,
         #[serde(default)]
         tags: Vec<String>,
+        #[serde(default)]
+        keywords: Vec<String>,
+        #[serde(default)]
+        entities: Vec<String>,
         #[serde(default)]
         project_key: Option<String>,
         #[serde(default)]
@@ -100,6 +108,10 @@ pub(super) enum MemoryArgs {
         r#type: Option<String>,
         #[serde(default)]
         tags: Vec<String>,
+        #[serde(default)]
+        keywords: Vec<String>,
+        #[serde(default)]
+        entities: Vec<String>,
         #[serde(default)]
         project_key: Option<String>,
         #[serde(default)]
@@ -131,6 +143,10 @@ pub(super) enum MemoryArgs {
         r#type: Option<String>,
         #[serde(default)]
         tags: Vec<String>,
+        #[serde(default)]
+        keywords: Vec<String>,
+        #[serde(default)]
+        entities: Vec<String>,
         #[serde(default)]
         project_key: Option<String>,
     },
@@ -200,4 +216,8 @@ pub(super) struct SplitPiece {
     pub(super) content: String,
     #[serde(default)]
     pub(super) tags: Vec<String>,
+    #[serde(default)]
+    pub(super) keywords: Vec<String>,
+    #[serde(default)]
+    pub(super) entities: Vec<String>,
 }

--- a/crates/app/bamboo-server-tools/src/memory/mod.rs
+++ b/crates/app/bamboo-server-tools/src/memory/mod.rs
@@ -4,8 +4,11 @@ use serde_json::json;
 use bamboo_agent_core::tools::{Tool, ToolClass, ToolCtx, ToolError, ToolOutcome, ToolResult};
 use bamboo_agent_core::Session;
 use bamboo_memory::memory_store::{
-    DurableMemoryStatus, MemoryQueryOptions, MemoryScope, MemoryStore, MAX_MAX_CHARS,
-    MAX_QUERY_LIMIT,
+    normalize_retrieval_terms, normalize_tags, DurableMemoryDocument, DurableMemoryStatus,
+    MemoryQueryOptions, MemoryRetrievalInput, MemoryScope, MemoryStore, DEFAULT_QUERY_LIMIT,
+    MAX_EXPLICIT_MEMORY_ENTITIES, MAX_EXPLICIT_MEMORY_KEYWORDS, MAX_MAX_CHARS, MAX_MEMORY_ENTITIES,
+    MAX_MEMORY_ID_LEN, MAX_MEMORY_KEYWORDS, MAX_MEMORY_QUERY_CHARS, MAX_MEMORY_TAGS,
+    MAX_MEMORY_TAG_CHARS, MAX_MEMORY_TITLE_LEN, MAX_QUERY_LIMIT, MAX_RETRIEVAL_TERM_CHARS,
 };
 use bamboo_tools::tools::session_memory::{
     execute_session_memory_action, SessionMemoryAction, MEMORY_SESSION_ACTION_NAMES,
@@ -28,6 +31,26 @@ pub struct MemoryTool {
 struct ResolvedMemoryAccess {
     store: MemoryStore,
     project_key: Option<String>,
+}
+
+fn bound_retrieval_metadata(doc: &mut DurableMemoryDocument) -> bool {
+    let original_tags = doc.frontmatter.tags.clone();
+    let original_keywords = doc.frontmatter.retrieval.keywords.clone();
+    let original_entities = doc.frontmatter.retrieval.entities.clone();
+
+    doc.frontmatter.tags = normalize_tags(original_tags.iter().map(String::as_str));
+    doc.frontmatter.retrieval.keywords = normalize_retrieval_terms(
+        original_keywords.iter().map(String::as_str),
+        MAX_MEMORY_KEYWORDS,
+    );
+    doc.frontmatter.retrieval.entities = normalize_retrieval_terms(
+        original_entities.iter().map(String::as_str),
+        MAX_MEMORY_ENTITIES,
+    );
+
+    original_tags != doc.frontmatter.tags
+        || original_keywords != doc.frontmatter.retrieval.keywords
+        || original_entities != doc.frontmatter.retrieval.entities
 }
 
 impl MemoryTool {
@@ -123,7 +146,7 @@ impl Tool for MemoryTool {
     }
 
     fn description(&self) -> &str {
-        "Unified memory management tool for Bamboo. Use session_* actions for session continuity notes, and query/get/write/merge/split/consolidate/purge/inspect/rebuild for durable project/global memory backed by canonical topic files and derived indexes."
+        "Bamboo's unified memory tool. Use session_* for continuity notes. For durable memory, start with a short lexical query: omitting limit returns a compact top-3 shortlist with actionable ids and no bodies; then get only selected ids. Query before write/merge, and persist one atomic confirmed fact with bounded tags, keywords, and entities. The Session's assigned Project is trusted scope authority: project_key cannot grant or switch access. Verify live state when a fact may have changed. Retrieval is embedding-free; no embeddings are used. A blank query remains a management listing."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -132,6 +155,7 @@ impl Tool for MemoryTool {
             "properties": {
                 "action": {
                     "type": "string",
+                    "description": "Recall with query, inspect a selected result with get, then use a mutation only when needed. Query before write or merge to avoid duplicates.",
                     "enum": [
                         "session_read",
                         "session_append",
@@ -152,22 +176,94 @@ impl Tool for MemoryTool {
                         "scan_duplicates"
                     ]
                 },
-                "scope": {"type": "string", "enum": ["session", "project", "global"]},
+                "scope": {
+                    "type": "string",
+                    "enum": ["session", "project", "global"],
+                    "description": "Durable actions use project or global. Use session_* actions, not durable actions, for session continuity notes."
+                },
                 "granularity": {
                     "type": "string",
                     "enum": ["day", "week", "month", "quarter", "year"],
                     "description": "Optional temporal granularity for `write`, orthogonal to scope: day (today's working context), week (sprint), month, quarter (direction), year (long-term goals). Omit if the memory has no time horizon. Coarser granularities are prefix-cache friendly and recalled ahead of finer ones at equal relevance."
                 },
-                "project_key": {"type": "string"},
+                "project_key": {
+                    "type": "string",
+                    "description": "Optional assertion only. The trusted Session Project selects and authorizes Project memory; this value cannot grant access or switch projects."
+                },
                 "topic": {"type": "string"},
-                "id": {"type": "string"},
-                "query": {"type": "string"},
+                "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": MAX_MEMORY_ID_LEN,
+                    "description": "Actionable memory id returned by query; use get only for selected ids."
+                },
+                "query": {
+                    "type": "string",
+                    "maxLength": MAX_MEMORY_QUERY_CHARS,
+                    "description": "Short, discriminative lexical keywords or entities. Omit/blank only for a bounded management listing; no embedding search is used."
+                },
                 "type": {"type": "string", "enum": ["user", "feedback", "project", "reference"]},
-                "title": {"type": "string"},
-                "content": {"type": "string"},
-                "tags": {"type": "array", "items": {"type": "string"}},
-                "pieces": {"type": "array", "items": {"type": "object"}},
-                "ids": {"type": "array", "items": {"type": "string"}},
+                "title": {
+                    "type": "string",
+                    "maxLength": MAX_MEMORY_TITLE_LEN,
+                    "description": "Concise title for one atomic confirmed fact."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "One atomic confirmed fact, not a transcript or speculative note. Verify live state instead of trusting stale memory."
+                },
+                "tags": {
+                    "type": "array",
+                    "maxItems": MAX_MEMORY_TAGS,
+                    "items": {"type": "string", "maxLength": MAX_MEMORY_TAG_CHARS},
+                    "description": "Bounded categorical labels."
+                },
+                "keywords": {
+                    "type": "array",
+                    "maxItems": MAX_EXPLICIT_MEMORY_KEYWORDS,
+                    "items": {"type": "string", "maxLength": MAX_RETRIEVAL_TERM_CHARS},
+                    "description": "Bounded multilingual lexical aliases supplied by the model; embeddings are neither accepted nor computed."
+                },
+                "entities": {
+                    "type": "array",
+                    "maxItems": MAX_EXPLICIT_MEMORY_ENTITIES,
+                    "items": {"type": "string", "maxLength": MAX_RETRIEVAL_TERM_CHARS},
+                    "description": "Bounded canonical names, products, projects, people, or other entities useful for lexical recall."
+                },
+                "pieces": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string", "maxLength": MAX_MEMORY_TITLE_LEN},
+                            "type": {"type": "string", "enum": ["user", "feedback", "project", "reference"]},
+                            "content": {"type": "string"},
+                            "tags": {
+                                "type": "array",
+                                "maxItems": MAX_MEMORY_TAGS,
+                                "items": {"type": "string", "maxLength": MAX_MEMORY_TAG_CHARS}
+                            },
+                            "keywords": {
+                                "type": "array",
+                                "maxItems": MAX_EXPLICIT_MEMORY_KEYWORDS,
+                                "items": {"type": "string", "maxLength": MAX_RETRIEVAL_TERM_CHARS}
+                            },
+                            "entities": {
+                                "type": "array",
+                                "maxItems": MAX_EXPLICIT_MEMORY_ENTITIES,
+                                "items": {"type": "string", "maxLength": MAX_RETRIEVAL_TERM_CHARS}
+                            }
+                        },
+                        "required": ["title", "content"]
+                    },
+                    "description": "Atomic replacement facts for split; each piece carries its own retrieval metadata."
+                },
+                "ids": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {"type": "string", "maxLength": MAX_MEMORY_ID_LEN}
+                },
                 "min_score": {"type": "number"},
                 "filters": {
                     "type": "object",
@@ -193,7 +289,25 @@ impl Tool for MemoryTool {
                         }
                     }
                 },
-                "options": {"type": "object"},
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": MAX_QUERY_LIMIT,
+                            "default": DEFAULT_QUERY_LIMIT,
+                            "description": "Omit for the compact default top-3 query result."
+                        },
+                        "max_chars": {"type": "integer", "minimum": 1, "maximum": MAX_MAX_CHARS},
+                        "cursor": {"type": "string"},
+                        "include_related": {"type": "boolean"},
+                        "allow_merge_if_similar": {
+                            "type": "boolean",
+                            "description": "Write-only opt-in after query confirms an existing memory should absorb the fact."
+                        }
+                    }
+                },
                 "reason": {"type": "string"}
             },
             "required": ["action"]
@@ -385,6 +499,7 @@ impl Tool for MemoryTool {
                 let (body, truncated) =
                     bamboo_memory::memory_store::truncate_chars(&doc.body, max_chars);
                 doc.body = body;
+                let retrieval_metadata_truncated = bound_retrieval_metadata(&mut doc);
                 Ok(ToolResult {
                     success: true,
                     result: json!({
@@ -395,6 +510,7 @@ impl Tool for MemoryTool {
                             "body": doc.body,
                             "path": doc.path,
                             "body_truncated": truncated,
+                            "retrieval_metadata_truncated": retrieval_metadata_truncated,
                         }
                     })
                     .to_string(),
@@ -408,6 +524,8 @@ impl Tool for MemoryTool {
                 title,
                 content,
                 tags,
+                keywords,
+                entities,
                 project_key,
                 granularity,
                 options,
@@ -425,13 +543,14 @@ impl Tool for MemoryTool {
                     .await?;
                 let doc = memory_access
                     .store
-                    .write_memory(
+                    .write_memory_with_retrieval(
                         scope,
                         memory_access.project_key.as_deref(),
                         Self::parse_type(&r#type)?,
                         &title,
                         &content,
                         &tags,
+                        &MemoryRetrievalInput { keywords, entities },
                         Some(session_id),
                         "main-model",
                         options
@@ -466,6 +585,8 @@ impl Tool for MemoryTool {
                 id,
                 content,
                 tags,
+                keywords,
+                entities,
                 project_key,
                 source_memory_ids,
                 mode,
@@ -510,11 +631,12 @@ impl Tool for MemoryTool {
                 } else {
                     let Some(result) = memory_access
                         .store
-                        .merge_memory(
+                        .merge_memory_with_retrieval(
                             id.trim(),
                             memory_access.project_key.as_deref(),
                             &content,
                             &tags,
+                            &MemoryRetrievalInput { keywords, entities },
                             Some(session_id),
                             "main-model",
                             &source_memory_ids,
@@ -548,6 +670,8 @@ impl Tool for MemoryTool {
                 content,
                 r#type,
                 tags,
+                keywords,
+                entities,
                 project_key,
                 options,
             } => {
@@ -570,13 +694,14 @@ impl Tool for MemoryTool {
                     .clamp(1, MAX_QUERY_LIMIT);
                 let candidates = memory_access
                     .store
-                    .find_duplicate_candidates(
+                    .find_duplicate_candidates_with_retrieval(
                         scope,
                         memory_access.project_key.as_deref(),
                         r#type,
                         &title,
                         content.as_deref().unwrap_or(""),
                         &tags,
+                        &MemoryRetrievalInput { keywords, entities },
                         limit,
                     )
                     .await
@@ -608,6 +733,7 @@ impl Tool for MemoryTool {
                     .resolve_memory_access(project_key.as_deref(), Some(session_id), None)
                     .await?;
                 let mut split_pieces = Vec::with_capacity(pieces.len());
+                let mut retrieval = Vec::with_capacity(pieces.len());
                 for piece in pieces {
                     let r#type = match piece.r#type.as_deref() {
                         Some(value) => Some(Self::parse_type(value)?),
@@ -619,13 +745,18 @@ impl Tool for MemoryTool {
                         content: piece.content,
                         tags: piece.tags,
                     });
+                    retrieval.push(MemoryRetrievalInput {
+                        keywords: piece.keywords,
+                        entities: piece.entities,
+                    });
                 }
                 let Some(result) = memory_access
                     .store
-                    .split_memory(
+                    .split_memory_with_retrieval(
                         id.trim(),
                         memory_access.project_key.as_deref(),
                         &split_pieces,
+                        &retrieval,
                         Some(session_id),
                         "main-model",
                     )
@@ -743,6 +874,8 @@ impl Tool for MemoryTool {
                 content,
                 r#type,
                 tags,
+                keywords,
+                entities,
                 project_key,
             } => {
                 if ids.len() < 2 {
@@ -766,10 +899,11 @@ impl Tool for MemoryTool {
                 let ids: Vec<String> = ids.iter().map(|id| id.trim().to_string()).collect();
                 let Some(result) = memory_access
                     .store
-                    .consolidate_memories(
+                    .consolidate_memories_with_retrieval(
                         &ids,
                         memory_access.project_key.as_deref(),
                         &merged,
+                        &MemoryRetrievalInput { keywords, entities },
                         Some(session_id),
                         "main-model",
                     )

--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -69,6 +69,25 @@ async fn build_memory_tool_with_session(
     MemoryTool::new(session_repo, data_dir)
 }
 
+fn completed_json(outcome: ToolOutcome) -> serde_json::Value {
+    let ToolOutcome::Completed(result) = outcome else {
+        panic!("expected Completed")
+    };
+    serde_json::from_str(&result.result).expect("valid tool JSON")
+}
+
+async fn invoke_json(
+    tool: &MemoryTool,
+    args: serde_json::Value,
+    session_id: &str,
+) -> serde_json::Value {
+    completed_json(
+        tool.invoke(args, test_context(session_id))
+            .await
+            .expect("memory action should succeed"),
+    )
+}
+
 #[tokio::test]
 async fn memory_session_actions_share_read_shape_and_limits() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -544,4 +563,485 @@ async fn malformed_project_identity_cannot_read_canonical_project_memory() {
     assert!(!error
         .to_string()
         .contains("MUST NOT LEAK THROUGH MALFORMED PROJECT ID"));
+}
+
+#[test]
+fn memory_schema_teaches_the_llm_native_recall_and_authority_contract() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tool = build_memory_tool(dir.path());
+    let description = tool.description().to_ascii_lowercase();
+
+    assert!(description.contains("short lexical query"));
+    assert!(description.contains("compact top-3"));
+    assert!(description.contains("no bodies"));
+    assert!(description.contains("get only selected ids"));
+    assert!(description.contains("query before write/merge"));
+    assert!(description.contains("one atomic confirmed fact"));
+    assert!(description.contains("trusted scope authority"));
+    assert!(description.contains("verify live state"));
+    assert!(description.contains("embedding-free"));
+
+    let schema = tool.parameters_schema();
+    let properties = &schema["properties"];
+    assert_eq!(
+        properties["query"]["maxLength"],
+        json!(MAX_MEMORY_QUERY_CHARS)
+    );
+    assert_eq!(properties["id"]["minLength"], 1);
+    assert_eq!(
+        properties["options"]["properties"]["limit"]["default"],
+        json!(DEFAULT_QUERY_LIMIT)
+    );
+    assert_eq!(
+        properties["options"]["properties"]["limit"]["maximum"],
+        json!(MAX_QUERY_LIMIT)
+    );
+    assert_eq!(properties["tags"]["maxItems"], json!(MAX_MEMORY_TAGS));
+    assert_eq!(
+        properties["keywords"]["maxItems"],
+        json!(MAX_EXPLICIT_MEMORY_KEYWORDS)
+    );
+    assert_eq!(
+        properties["entities"]["maxItems"],
+        json!(MAX_EXPLICIT_MEMORY_ENTITIES)
+    );
+    assert_eq!(
+        properties["pieces"]["items"]["properties"]["keywords"]["maxItems"],
+        json!(MAX_EXPLICIT_MEMORY_KEYWORDS)
+    );
+    assert!(properties["project_key"]["description"]
+        .as_str()
+        .expect("project authority description")
+        .contains("cannot grant access or switch projects"));
+}
+
+#[tokio::test]
+async fn lexical_query_defaults_to_compact_top_three_without_bodies() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tool = build_memory_tool(dir.path());
+    let session_id = "compact-query-session";
+
+    for index in 0..4 {
+        invoke_json(
+            &tool,
+            json!({
+                "action": "write",
+                "scope": "global",
+                "type": "project",
+                "title": format!("Release freeze fact {index}"),
+                "content": format!("Confirmed release freeze detail number {index}."),
+                "keywords": ["release-freeze-alias"]
+            }),
+            session_id,
+        )
+        .await;
+    }
+
+    let value = invoke_json(
+        &tool,
+        json!({
+            "action": "query",
+            "scope": "global",
+            "query": "release-freeze-alias"
+        }),
+        session_id,
+    )
+    .await;
+    let items = value["data"]["items"].as_array().expect("query items");
+    assert_eq!(value["data"]["matched_count"], 4);
+    assert_eq!(value["data"]["returned_count"], DEFAULT_QUERY_LIMIT);
+    assert_eq!(items.len(), DEFAULT_QUERY_LIMIT);
+    for item in items {
+        let item = item.as_object().expect("compact query item");
+        assert!(item.get("id").and_then(|value| value.as_str()).is_some());
+        assert!(item
+            .get("summary")
+            .and_then(|value| value.as_str())
+            .is_some());
+        assert!(!item.contains_key("body"));
+        assert!(!item.contains_key("path"));
+        assert!(!item.contains_key("frontmatter"));
+        assert!(!item.contains_key("keywords"));
+        assert!(!item.contains_key("entities"));
+    }
+
+    let listing = invoke_json(
+        &tool,
+        json!({
+            "action": "query",
+            "scope": "global",
+            "query": "  ",
+            "options": {"limit": 4}
+        }),
+        session_id,
+    )
+    .await;
+    assert_eq!(listing["data"]["matched_count"], 4);
+    assert_eq!(
+        listing["data"]["items"]
+            .as_array()
+            .expect("management listing")
+            .len(),
+        4
+    );
+}
+
+#[tokio::test]
+async fn multilingual_retrieval_metadata_round_trips_through_query_and_get() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tool = build_memory_tool(dir.path());
+    let session_id = "multilingual-memory-session";
+
+    let written = invoke_json(
+        &tool,
+        json!({
+            "action": "write",
+            "scope": "global",
+            "type": "reference",
+            "title": "Suzaku transport alias",
+            "content": "The confirmed transport alias for 朱雀 is Suzaku.",
+            "tags": ["MCP 认证", "Transport"],
+            "keywords": ["transport-alias", "朱雀别名", "MCP-朱雀"],
+            "entities": ["ＡＰＩ 网关", "Project Suzaku"]
+        }),
+        session_id,
+    )
+    .await;
+    let id = written["memory"]["id"]
+        .as_str()
+        .expect("written memory id")
+        .to_string();
+
+    let queried = invoke_json(
+        &tool,
+        json!({
+            "action": "query",
+            "scope": "global",
+            "query": "朱雀别名"
+        }),
+        session_id,
+    )
+    .await;
+    assert_eq!(queried["data"]["items"][0]["id"], id);
+    assert!(queried["data"]["items"][0].get("body").is_none());
+
+    let fetched = invoke_json(&tool, json!({"action": "get", "id": id}), session_id).await;
+    let frontmatter = &fetched["memory"]["frontmatter"];
+    let tags = frontmatter["tags"].as_array().expect("tags");
+    let keywords = frontmatter["retrieval"]["keywords"]
+        .as_array()
+        .expect("keywords");
+    let entities = frontmatter["retrieval"]["entities"]
+        .as_array()
+        .expect("entities");
+    assert!(tags.contains(&json!("mcp-认证")));
+    assert!(tags.contains(&json!("transport")));
+    assert!(keywords.contains(&json!("transport-alias")));
+    assert!(keywords.contains(&json!("朱雀别名")));
+    assert!(keywords.contains(&json!("MCP-朱雀")));
+    assert!(entities.contains(&json!("API 网关")));
+    assert!(entities.contains(&json!("Project Suzaku")));
+    assert_eq!(fetched["memory"]["body_truncated"], false);
+    assert_eq!(fetched["memory"]["retrieval_metadata_truncated"], false);
+}
+
+#[tokio::test]
+async fn get_bounds_body_and_retrieval_metadata_independently_without_rewriting_canonical() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = MemoryStore::new(dir.path());
+    let tool = build_memory_tool(dir.path());
+    let session_id = "bounded-get-session";
+
+    let body_doc = store
+        .write_memory_with_retrieval(
+            MemoryScope::Global,
+            None,
+            bamboo_memory::memory_store::DurableMemoryType::Reference,
+            "Long body",
+            &"body".repeat(32),
+            &["bounded".to_string()],
+            &MemoryRetrievalInput {
+                keywords: vec!["body-bound".to_string()],
+                entities: vec!["Body Entity".to_string()],
+            },
+            Some(session_id),
+            "test",
+            false,
+            None,
+        )
+        .await
+        .expect("write long body");
+    let body_result = invoke_json(
+        &tool,
+        json!({
+            "action": "get",
+            "id": body_doc.frontmatter.id,
+            "options": {"max_chars": 8}
+        }),
+        session_id,
+    )
+    .await;
+    assert_eq!(body_result["memory"]["body_truncated"], true);
+    assert_eq!(body_result["memory"]["retrieval_metadata_truncated"], false);
+    assert_eq!(
+        body_result["memory"]["body"]
+            .as_str()
+            .expect("bounded body")
+            .chars()
+            .count(),
+        8
+    );
+
+    let mut metadata_doc = store
+        .write_memory(
+            MemoryScope::Global,
+            None,
+            bamboo_memory::memory_store::DurableMemoryType::Reference,
+            "Oversized legacy metadata",
+            "short body",
+            &[],
+            Some(session_id),
+            "test",
+            false,
+            None,
+        )
+        .await
+        .expect("write metadata fixture");
+    metadata_doc.frontmatter.tags = (0..MAX_MEMORY_TAGS + 4)
+        .map(|index| format!("legacy tag {index}"))
+        .collect();
+    metadata_doc.frontmatter.retrieval.keywords = (0..MAX_MEMORY_KEYWORDS + 4)
+        .map(|index| format!("legacy keyword {index} {}", "x".repeat(120)))
+        .collect();
+    metadata_doc.frontmatter.retrieval.entities = (0..MAX_MEMORY_ENTITIES + 4)
+        .map(|index| format!("legacy entity {index} {}", "y".repeat(120)))
+        .collect();
+    let canonical = format!(
+        "---\n{}\n---\n{}\n",
+        serde_json::to_string_pretty(&metadata_doc.frontmatter).expect("serialize fixture"),
+        metadata_doc.body
+    );
+    std::fs::write(&metadata_doc.path, &canonical).expect("write oversized canonical fixture");
+
+    let metadata_result = invoke_json(
+        &tool,
+        json!({"action": "get", "id": metadata_doc.frontmatter.id}),
+        session_id,
+    )
+    .await;
+    assert_eq!(metadata_result["memory"]["body_truncated"], false);
+    assert_eq!(
+        metadata_result["memory"]["retrieval_metadata_truncated"],
+        true
+    );
+    let bounded = &metadata_result["memory"]["frontmatter"];
+    assert_eq!(
+        bounded["tags"].as_array().expect("bounded tags").len(),
+        MAX_MEMORY_TAGS
+    );
+    assert_eq!(
+        bounded["retrieval"]["keywords"]
+            .as_array()
+            .expect("bounded keywords")
+            .len(),
+        MAX_MEMORY_KEYWORDS
+    );
+    assert_eq!(
+        bounded["retrieval"]["entities"]
+            .as_array()
+            .expect("bounded entities")
+            .len(),
+        MAX_MEMORY_ENTITIES
+    );
+    assert!(bounded["retrieval"]["keywords"]
+        .as_array()
+        .expect("bounded keywords")
+        .iter()
+        .all(|value| value.as_str().expect("keyword").chars().count() <= MAX_RETRIEVAL_TERM_CHARS));
+    assert_eq!(
+        std::fs::read_to_string(&metadata_doc.path).expect("read canonical after get"),
+        canonical,
+        "response bounding must not rewrite canonical memory"
+    );
+}
+
+#[tokio::test]
+async fn retrieval_metadata_is_forwarded_through_all_model_driven_mutations() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tool = build_memory_tool(dir.path());
+    let session_id = "retrieval-mutation-session";
+
+    let written = invoke_json(
+        &tool,
+        json!({
+            "action": "write",
+            "scope": "global",
+            "type": "reference",
+            "title": "Canonical release channel",
+            "content": "The confirmed release channel is stable.",
+            "keywords": ["write-forward-alias"],
+            "entities": ["Release Channel"]
+        }),
+        session_id,
+    )
+    .await;
+    let target_id = written["memory"]["id"]
+        .as_str()
+        .expect("write id")
+        .to_string();
+
+    let duplicates = invoke_json(
+        &tool,
+        json!({
+            "action": "find_duplicates",
+            "scope": "global",
+            "title": "Candidate with different prose",
+            "content": "A separate wording supplied for duplicate review.",
+            "keywords": ["write-forward-alias"],
+            "entities": ["Release Channel"]
+        }),
+        session_id,
+    )
+    .await;
+    assert!(duplicates["candidates"]
+        .as_array()
+        .expect("duplicate candidates")
+        .iter()
+        .any(|candidate| candidate["id"] == target_id));
+
+    invoke_json(
+        &tool,
+        json!({
+            "action": "merge",
+            "id": target_id,
+            "content": "The stable channel also carries signed artifacts.",
+            "keywords": ["merge-forward-alias"],
+            "entities": ["Signed Artifact"]
+        }),
+        session_id,
+    )
+    .await;
+    let merged = invoke_json(&tool, json!({"action": "get", "id": target_id}), session_id).await;
+    assert!(merged["memory"]["frontmatter"]["retrieval"]["keywords"]
+        .as_array()
+        .expect("merged keywords")
+        .contains(&json!("merge-forward-alias")));
+    assert!(merged["memory"]["frontmatter"]["retrieval"]["entities"]
+        .as_array()
+        .expect("merged entities")
+        .contains(&json!("Signed Artifact")));
+
+    let source = invoke_json(
+        &tool,
+        json!({
+            "action": "write",
+            "scope": "global",
+            "type": "reference",
+            "title": "Two independent transport facts",
+            "content": "Transport alpha is local. Transport beta is remote."
+        }),
+        session_id,
+    )
+    .await;
+    let source_id = source["memory"]["id"]
+        .as_str()
+        .expect("split source id")
+        .to_string();
+    let split = invoke_json(
+        &tool,
+        json!({
+            "action": "split",
+            "id": source_id,
+            "pieces": [
+                {
+                    "title": "Local transport",
+                    "content": "Transport alpha is local.",
+                    "keywords": ["split-alpha-alias"],
+                    "entities": ["Transport Alpha"]
+                },
+                {
+                    "title": "Remote transport",
+                    "content": "Transport beta is remote.",
+                    "keywords": ["split-beta-alias"],
+                    "entities": ["Transport Beta"]
+                }
+            ]
+        }),
+        session_id,
+    )
+    .await;
+    let split_ids = split["data"]["new_ids"].as_array().expect("split ids");
+    assert_eq!(split_ids.len(), 2);
+    for (index, expected_keyword) in ["split-alpha-alias", "split-beta-alias"]
+        .into_iter()
+        .enumerate()
+    {
+        let split_doc = invoke_json(
+            &tool,
+            json!({"action": "get", "id": split_ids[index]}),
+            session_id,
+        )
+        .await;
+        assert!(split_doc["memory"]["frontmatter"]["retrieval"]["keywords"]
+            .as_array()
+            .expect("split keywords")
+            .contains(&json!(expected_keyword)));
+    }
+
+    let first = invoke_json(
+        &tool,
+        json!({
+            "action": "write",
+            "scope": "global",
+            "type": "reference",
+            "title": "Legacy endpoint name",
+            "content": "The endpoint was called relay-v1."
+        }),
+        session_id,
+    )
+    .await;
+    let second = invoke_json(
+        &tool,
+        json!({
+            "action": "write",
+            "scope": "global",
+            "type": "reference",
+            "title": "Current endpoint name",
+            "content": "The endpoint is called relay-v2."
+        }),
+        session_id,
+    )
+    .await;
+    let consolidated = invoke_json(
+        &tool,
+        json!({
+            "action": "consolidate",
+            "ids": [first["memory"]["id"], second["memory"]["id"]],
+            "title": "Canonical endpoint name",
+            "content": "The confirmed endpoint name is relay-v2.",
+            "type": "reference",
+            "keywords": ["consolidate-forward-alias"],
+            "entities": ["Relay Endpoint"]
+        }),
+        session_id,
+    )
+    .await;
+    let consolidated_doc = invoke_json(
+        &tool,
+        json!({"action": "get", "id": consolidated["data"]["new_id"]}),
+        session_id,
+    )
+    .await;
+    assert!(
+        consolidated_doc["memory"]["frontmatter"]["retrieval"]["keywords"]
+            .as_array()
+            .expect("consolidated keywords")
+            .contains(&json!("consolidate-forward-alias"))
+    );
+    assert!(
+        consolidated_doc["memory"]["frontmatter"]["retrieval"]["entities"]
+            .as_array()
+            .expect("consolidated entities")
+            .contains(&json!("Relay Endpoint"))
+    );
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/external_memory.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/external_memory.rs
@@ -36,7 +36,7 @@ const PROJECT_MEMORY_INDEX_PROMPT_MAX_CHARS: usize = 1_800;
 const RELEVANT_MEMORY_RESULT_LIMIT: usize = 3;
 /// Max chars used by the full relevant-memory section.
 const RELEVANT_MEMORY_TOTAL_MAX_CHARS: usize = 1_600;
-/// Max chars used by each relevant-memory summary snippet.
+/// Max chars used by each fully rendered relevant-memory item.
 const RELEVANT_MEMORY_PER_ITEM_MAX_CHARS: usize = 220;
 /// Max chars injected from the global Dream notebook fallback.
 const GLOBAL_DREAM_NOTEBOOK_PROMPT_MAX_CHARS: usize = 1_500;
@@ -91,7 +91,6 @@ struct RelevantMemorySnippet {
     title: String,
     scope: MemoryScope,
     status: String,
-    score: f64,
     summary: String,
     freshness_note: Option<String>,
     /// Temporal granularity of the source memory, carried through so the render
@@ -667,14 +666,7 @@ async fn load_relevant_memory_snippets(
             continue;
         };
 
-        let estimated_len = count_chars(&snippet.summary)
-            + snippet
-                .freshness_note
-                .as_deref()
-                .map(count_chars)
-                .unwrap_or(0)
-            + count_chars(&snippet.title)
-            + 48;
+        let estimated_len = count_chars(&render_relevant_memory_item(&snippet));
         if total_chars + estimated_len > RELEVANT_MEMORY_TOTAL_MAX_CHARS && !rendered.is_empty() {
             break;
         }
@@ -707,7 +699,6 @@ fn build_relevant_memory_snippet(
         title: candidate.title,
         scope: candidate.scope,
         status: candidate.status.as_str().to_string(),
-        score: candidate.score,
         summary,
         freshness_note: render_memory_freshness_note(
             &candidate.updated_at,
@@ -865,12 +856,12 @@ fn build_external_memory_render_parts(
     );
     section.push_str("- If you learn durable information that will help later in other sessions (preferences, confirmed project decisions, stable references, non-derivable context), store it with the `memory` tool instead of only leaving it in session_note.\n");
     section.push_str("- When the user states a commitment, deadline, appointment, or recurring routine, record it with the `ledger` tool (action=upsert; set due_at/remind_at so reminders actually fire) instead of keeping it only in the session task list. Mark records done/cancelled with action=transition, and answer \"what's on my plate\" questions from action=agenda/query.\n");
-    section.push_str("- Proactively recall: when the user refers to their own preferences, past decisions, or subjective/personal context you don't already know — including first-person questions about themselves ('what do I...', 'did I...', '我...?') — call `memory` action=query BEFORE answering. Do not reply that you don't know about the user's own preferences, history, or prior decisions without first querying memory; the auto-injected memories above are only a keyword-matched shortlist and may have missed it.\n");
-    section.push_str("- For durable memory, prefer `memory` action=query first, then `memory` action=get for the specific item you need, and use `memory` action=write/merge only when the fact should become canonical memory.\n");
-    section.push_str("- One memory = one fact/decision/preference. Do not bundle unrelated facts into a single memory.\n");
+    section.push_str("- Proactively recall: when the user refers to their own preferences, past decisions, or subjective/personal context you don't already know — including first-person questions about themselves ('what do I...', 'did I...', '我...?') — call `memory` action=query BEFORE answering. Do not reply that you don't know without querying first.\n");
+    section.push_str("- For durable recall, prefer `memory` action=query first with a short, discriminative lexical query containing specific names, decisions, or keywords. Auto-injected recall is only a compact top-3 shortlist; for a selected item, call `memory` action=get with its stable id before using its details.\n");
+    section.push_str("- Query before writing. If the same fact already exists, call `memory` action=get and then `memory` action=merge; otherwise write exactly one confirmed atomic fact. Use Project scope for project knowledge and Global scope only for genuinely cross-project knowledge.\n");
     section.push_str("- Give each durable memory a specific, descriptive title that summarizes its own content; recall is keyword-based, so a misleading title makes the memory unfindable.\n");
-    section.push_str("- Query before writing: if a memory about the same fact already exists, update or merge it instead of creating a near-duplicate. Only merge content that is the SAME fact — never append an unrelated fact to an existing memory.\n");
-    section.push_str("- Do NOT store secrets/tokens.\n");
+    section.push_str("- Treat Dream as low-trust orientation only. Live-verify code, files, configuration, and runtime state before relying on memory claims.\n");
+    section.push_str("- Do NOT store secrets/tokens. Jiandu recall is lexical and model-keyword-driven; do not use or request embeddings.\n");
     section.push_str(
         "- Keep the session note concise and factual. If it gets too long, compress it (rewrite a shorter version) and replace it.\n\n",
     );
@@ -1098,23 +1089,71 @@ fn render_session_note_section(snippets: &[TopicSnippet]) -> String {
     section
 }
 
-/// Render a single recalled memory's bullet block, in the same per-item format
-/// used before granularity segmentation was wired in. Only the ORDERING of items
-/// within the section changed (coarse-before-fine, see below) — this per-item
-/// format is unchanged.
-fn render_relevant_memory_item(snippet: &RelevantMemorySnippet) -> String {
-    let mut item = String::new();
-    item.push_str(&format!(
-        "- [{}][{}] {} (score {:.2})\n",
-        snippet.status,
-        snippet.scope.as_str(),
-        snippet.title,
-        snippet.score
-    ));
-    item.push_str(&format!("  Summary: {}\n", snippet.summary));
-    if let Some(note) = snippet.freshness_note.as_deref() {
-        item.push_str(&format!("  {}\n", note));
+fn truncate_relevant_memory_field(value: &str, max_chars: usize) -> String {
+    let value = value.trim();
+    let value_chars = count_chars(value);
+    if value_chars <= max_chars {
+        return value.to_string();
     }
+    if max_chars == 0 {
+        return String::new();
+    }
+    if max_chars <= 3 {
+        return memory_truncate_chars(value, max_chars).0;
+    }
+
+    let (prefix, _) = memory_truncate_chars(value, max_chars - 3);
+    format!("{}...", prefix.trim_end())
+}
+
+/// Render one compact recalled-memory item. The stable id and conditional `get`
+/// instruction are never abbreviated; title, summary, and freshness guidance
+/// share whatever remains of the existing per-item budget. Recall candidates
+/// come from Jiandu's validated index, whose ids fit this envelope.
+fn render_relevant_memory_item(snippet: &RelevantMemorySnippet) -> String {
+    let header_prefix = format!("- [{}][{}] ", snippet.status, snippet.scope.as_str());
+    let summary_prefix = "  Summary: ";
+    let conditional_get = format!("  If selected: `memory` action=get id={}\n", snippet.id);
+    let freshness_note = snippet
+        .freshness_note
+        .as_deref()
+        .map(str::trim)
+        .filter(|note| !note.is_empty());
+
+    let fixed_chars = count_chars(&header_prefix)
+        + 1
+        + count_chars(summary_prefix)
+        + 1
+        + count_chars(&conditional_get)
+        + freshness_note.map_or(0, |_| 3);
+    let content_budget = RELEVANT_MEMORY_PER_ITEM_MAX_CHARS.saturating_sub(fixed_chars);
+    let freshness_budget = freshness_note
+        .map(|note| count_chars(note).min(64).min(content_budget / 3))
+        .unwrap_or(0);
+    let title_and_summary_budget = content_budget.saturating_sub(freshness_budget);
+    let summary_reserve = (title_and_summary_budget / 2).min(48);
+    let title_budget = count_chars(snippet.title.trim())
+        .min(64)
+        .min(title_and_summary_budget.saturating_sub(summary_reserve));
+    let title = truncate_relevant_memory_field(&snippet.title, title_budget);
+    let summary_budget = title_and_summary_budget.saturating_sub(count_chars(&title));
+    let summary = truncate_relevant_memory_field(&snippet.summary, summary_budget);
+
+    let mut item = String::new();
+    item.push_str(&header_prefix);
+    item.push_str(&title);
+    item.push('\n');
+    item.push_str(summary_prefix);
+    item.push_str(&summary);
+    item.push('\n');
+    if let Some(note) = freshness_note {
+        item.push_str("  ");
+        item.push_str(&truncate_relevant_memory_field(note, freshness_budget));
+        item.push('\n');
+    }
+    item.push_str(&conditional_get);
+
+    debug_assert!(count_chars(&item) <= RELEVANT_MEMORY_PER_ITEM_MAX_CHARS);
     item
 }
 
@@ -1274,17 +1313,15 @@ mod granularity_prompt_wiring_tests {
             title: title.to_string(),
             scope: MemoryScope::Project,
             status: "active".to_string(),
-            score: 0.5,
             summary: summary.to_string(),
             freshness_note: None,
             granularity,
         }
     }
 
-    /// Faithful copy of `render_relevant_memory_section`'s pre-#497 body (flat,
-    /// unsegmented render loop) — kept only in this test to pin the exact
-    /// byte-for-byte output the all-coarse case must still produce.
-    fn old_style_relevant_memory_section(snippets: &[RelevantMemorySnippet]) -> String {
+    /// Flat, unsegmented copy of the compact #1029 item format. This pins the
+    /// byte contract that granularity routing must preserve for all-coarse input.
+    fn flat_relevant_memory_section(snippets: &[RelevantMemorySnippet]) -> String {
         let mut section = String::new();
         section.push_str("### Relevant Durable Memories\n");
         section.push_str(
@@ -1292,23 +1329,26 @@ mod granularity_prompt_wiring_tests {
         );
         for snippet in snippets {
             section.push_str(&format!(
-                "- [{}][{}] {} (score {:.2})\n",
+                "- [{}][{}] {}\n",
                 snippet.status,
                 snippet.scope.as_str(),
-                snippet.title,
-                snippet.score
+                snippet.title
             ));
             section.push_str(&format!("  Summary: {}\n", snippet.summary));
             if let Some(note) = snippet.freshness_note.as_deref() {
                 section.push_str(&format!("  {}\n", note));
             }
+            section.push_str(&format!(
+                "  If selected: `memory` action=get id={}\n",
+                snippet.id
+            ));
         }
         section.push('\n');
         section
     }
 
     #[test]
-    fn all_untagged_memories_render_identically_to_pre_segmentation_format() {
+    fn all_untagged_memories_preserve_compact_flat_bytes() {
         let snippets = vec![
             snippet("a", None, "Alpha decision", "alpha summary"),
             snippet("b", None, "Beta preference", "beta summary"),
@@ -1317,9 +1357,51 @@ mod granularity_prompt_wiring_tests {
 
         assert_eq!(
             render_relevant_memory_section(&snippets),
-            old_style_relevant_memory_section(&snippets),
-            "an all-coarse (untagged) config must render byte-identical to the pre-#497 flat format"
+            flat_relevant_memory_section(&snippets),
+            "an all-coarse (untagged) config must preserve compact flat-render bytes"
         );
+    }
+
+    #[test]
+    fn compact_item_keeps_full_conditional_get_id_within_per_item_budget() {
+        let id = "m".repeat(128);
+        let mut memory = snippet(&id, None, &"title".repeat(40), &"summary".repeat(80));
+        memory.freshness_note = Some("Historical memory; verify against current state.".repeat(4));
+
+        let rendered = render_relevant_memory_item(&memory);
+
+        assert!(rendered.contains(&format!("If selected: `memory` action=get id={id}")));
+        assert!(rendered.contains("Summary:"));
+        assert!(count_chars(&rendered) <= RELEVANT_MEMORY_PER_ITEM_MAX_CHARS);
+    }
+
+    #[test]
+    fn compact_items_remain_within_existing_total_budget() {
+        let snippets = (0..20)
+            .map(|index| {
+                snippet(
+                    &format!("mem_{index:038}"),
+                    None,
+                    &"title".repeat(40),
+                    &"summary".repeat(80),
+                )
+            })
+            .collect::<Vec<_>>();
+        let items = snippets
+            .iter()
+            .map(|snippet| {
+                GranularityBudgetItem::new(
+                    snippet.id.clone(),
+                    snippet.granularity,
+                    render_relevant_memory_item(snippet),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let rendered =
+            segment_by_granularity_budget(&items, RELEVANT_MEMORY_TOTAL_MAX_CHARS).combined();
+
+        assert!(count_chars(&rendered) <= RELEVANT_MEMORY_TOTAL_MAX_CHARS);
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
@@ -206,7 +206,17 @@ async fn external_memory_includes_global_dream_fallback_and_session_note_when_pr
     assert!(system_prompt.contains("Session durable note"));
     assert!(!system_prompt.contains("### Project Durable Memory Index"));
     assert!(system_prompt.contains("the `memory` tool only for durable project/global knowledge"));
-    assert!(system_prompt.contains("prefer `memory` action=query first"));
+    assert!(system_prompt.contains("short, discriminative lexical query"));
+    assert!(system_prompt.contains("compact top-3 shortlist"));
+    assert!(system_prompt.contains("Query before writing"));
+    assert!(system_prompt.contains("`memory` action=merge"));
+    assert!(system_prompt.contains("one confirmed atomic fact"));
+    assert!(system_prompt.contains("Project scope"));
+    assert!(system_prompt.contains("Global scope"));
+    assert!(system_prompt.contains("Dream as low-trust orientation only"));
+    assert!(system_prompt.contains("Live-verify code"));
+    assert!(system_prompt.contains("Do NOT store secrets/tokens"));
+    assert!(system_prompt.contains("do not use or request embeddings"));
 }
 
 #[tokio::test]
@@ -612,13 +622,17 @@ async fn external_memory_renders_relevant_memory_section_for_project_hits() {
     std::fs::create_dir_all(&workspace).expect("workspace dir");
     let project_key = project_id.to_string();
 
-    project_memory
+    let body = format!(
+        "Keep responses concise and avoid unnecessary recap. {}FULL_BODY_SENTINEL_DO_NOT_INJECT",
+        "x".repeat(240)
+    );
+    let written = project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
             bamboo_memory::memory_store::DurableMemoryType::Feedback,
             "User prefers concise answers",
-            "Keep responses concise and avoid unnecessary recap.",
+            &body,
             &["concise".to_string(), "style".to_string()],
             Some("session-recall-project"),
             "main-model",
@@ -654,6 +668,12 @@ async fn external_memory_renders_relevant_memory_section_for_project_hits() {
     assert!(system_prompt.contains("User prefers concise answers"));
     assert!(system_prompt.contains("Summary: Keep responses concise"));
     assert!(system_prompt.contains("[active][project]"));
+    assert!(system_prompt.contains(&written.frontmatter.id));
+    assert!(system_prompt.contains(&format!(
+        "If selected: `memory` action=get id={}",
+        written.frontmatter.id
+    )));
+    assert!(!system_prompt.contains("FULL_BODY_SENTINEL_DO_NOT_INJECT"));
 }
 
 #[tokio::test]
@@ -807,6 +827,12 @@ async fn external_memory_limits_relevant_memories_to_top_k() {
 
     assert!(system_prompt.contains("### Relevant Durable Memories"));
     assert_eq!(system_prompt.matches("Summary:").count(), 3);
+    assert_eq!(
+        system_prompt
+            .matches("If selected: `memory` action=get id=")
+            .count(),
+        3
+    );
 }
 
 #[tokio::test]
@@ -820,7 +846,7 @@ async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_
     std::fs::create_dir_all(&workspace).expect("workspace dir");
     let project_key = project_id.to_string();
 
-    project_memory
+    let unrelated = project_memory
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Project,
             Some(project_key.as_str()),
@@ -835,7 +861,7 @@ async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_
         )
         .await
         .expect("save unrelated project memory");
-    store
+    let global = store
         .write_memory(
             bamboo_memory::memory_store::MemoryScope::Global,
             None,
@@ -874,7 +900,14 @@ async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_
     assert!(system_prompt.contains("### Relevant Durable Memories"));
     assert!(system_prompt.contains("Global release guidance"));
     assert!(system_prompt.contains("[active][global]"));
-    assert!(!system_prompt.contains("Unrelated project note (score"));
+    assert!(system_prompt.contains(&format!(
+        "If selected: `memory` action=get id={}",
+        global.frontmatter.id
+    )));
+    assert!(!system_prompt.contains(&format!(
+        "If selected: `memory` action=get id={}",
+        unrelated.frontmatter.id
+    )));
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-tools/src/guide/builtin_guides.rs
+++ b/crates/engine/bamboo-tools/src/guide/builtin_guides.rs
@@ -385,8 +385,8 @@ pub fn builtin_guide_spec(tool_name: &str) -> Option<ToolGuideSpec> {
         "memory" => Some(guide(
             "memory",
             ToolCategory::TaskManagement,
-            "Manage Bamboo's unified memory system. Use session_* actions only for current-session continuity notes, and use query/get/write/merge/split/consolidate/purge/inspect/rebuild for durable project or global memories backed by canonical topic files. Proactively query before answering when the user refers to their own preferences, past decisions, or subjective/personal context you don't already know — including first-person questions about themselves ('what do I...', 'did I...', '我...?') — recall first instead of replying that you don't know.",
-            "Do not use session actions for long-term project knowledge, and do not dump large bodies through query when query -> get(id) or inspect is more appropriate. Prefer query first, then get the specific durable item you need before writing or merging. One memory = one atomic fact: do not bundle unrelated facts into a single memory. Only merge/append content that is the SAME fact as the target — if it's a different topic, write a new memory instead of appending.",
+            "Use Session memory for current-session continuity, Project memory for durable project facts and decisions, and Global memory for cross-project user context. Recall with a short lexical query, use Jiandu's compact default top three IDs and summaries, then get only the selected item that needs full context. Query before writing; store one confirmed atomic fact with a few useful keywords, entities, and tags.",
+            "Do not store secrets, unverified claims, live state that you can inspect directly, embeddings, or unrelated facts in one memory. Treat canonical Project memory as trusted durable project authority but verify live state before acting; treat Dream as a low-trust derived orientation snapshot. Do not increase the query limit or get every hit by default, and merge or consolidate only the same confirmed fact.",
             &["session_note", "session_history", "Task"],
             vec![
                 example(
@@ -396,47 +396,47 @@ pub fn builtin_guide_spec(tool_name: &str) -> Option<ToolGuideSpec> {
                 ),
                 example(
                     "Shortlist durable memories before reading full content",
-                    json!({"action":"query","scope":"project","query":"release freeze mobile","options":{"limit":5,"max_chars":3000}}),
-                    "Prefer query first so the model gets a shortlist summary under budget; call get(id) only for the durable item that needs full context.",
+                    json!({"action":"query","scope":"project","query":"mobile release freeze"}),
+                    "Use Jiandu's compact default top three ID/summary results, then select only the item that needs full context.",
                 ),
                 example(
-                    "Read one durable memory in full after query",
+                    "Get the selected durable memory",
                     json!({"action":"get","id":"mem_20260403_001","options":{"max_chars":5000}}),
-                    "Use after query when you need the full body/frontmatter of a single durable memory item.",
+                    "Use after query for the one selected ID whose full body or frontmatter is needed.",
                 ),
                 example(
                     "Recall before answering about the user's own context",
-                    json!({"action":"query","scope":"global","query":"preferred testing framework","options":{"limit":5}}),
+                    json!({"action":"query","scope":"global","query":"preferred testing framework"}),
                     "When the user refers to their own preferences, opinions, or past decisions you don't already know — especially first-person questions ('what do I...', 'did I...', '我...?') — query memory BEFORE answering; do not say you don't know without checking.",
                 ),
                 example(
                     "Recall a past project decision before acting",
-                    json!({"action":"query","scope":"project","query":"why we chose HTTP over Tauri IPC","options":{"limit":5}}),
-                    "When continuing prior work, query project memory for past decisions and constraints before re-deciding or claiming none exist.",
+                    json!({"action":"query","scope":"project","query":"HTTP Tauri IPC decision"}),
+                    "Treat a matching canonical Project memory as trusted durable project authority, then verify any live implementation state before acting.",
                 ),
                 example(
-                    "Check for an existing duplicate before writing",
-                    json!({"action":"find_duplicates","scope":"project","type":"project","title":"Release freeze begins next week","content":"Mobile release freeze begins Tuesday."}),
-                    "Before write, check whether the same fact already exists; if a high-scoring candidate is the same fact, merge into it instead of creating a near-duplicate.",
+                    "Query before writing a durable fact",
+                    json!({"action":"query","scope":"project","query":"mobile release freeze Tuesday"}),
+                    "Check whether the same fact already exists before write; merge only when the selected existing item is the same confirmed fact.",
                 ),
                 example(
                     "Write a durable project memory",
-                    json!({"action":"write","scope":"project","type":"project","title":"Release freeze begins next week","content":"Merge freeze begins on Tuesday for the mobile release cut.","tags":["release","freeze"]}),
-                    "Use when the fact should persist across sessions as canonical project memory. Give it a specific title that summarizes this fact — recall is keyword-based, so a vague or mismatched title makes it unfindable.",
+                    json!({"action":"write","scope":"project","type":"project","title":"Mobile release freeze is Tuesday","content":"Mobile release freeze begins Tuesday.","keywords":["mobile","release freeze","Tuesday"],"entities":["Mobile"],"tags":["release"]}),
+                    "Write one confirmed atomic fact with a specific title and only a few lexical retrieval hints.",
                 ),
                 example(
                     "Merge follow-up details into an existing durable memory",
-                    json!({"action":"merge","id":"mem_20260403_001","content":"Additional confirmation from a later session.","tags":["confirmed"],"source_memory_ids":["mem_20260403_002"]}),
+                    json!({"action":"merge","id":"mem_20260403_001","content":"The release manager confirmed the Tuesday freeze.","keywords":["release freeze","Tuesday"],"entities":["release manager"],"tags":["confirmed"],"source_memory_ids":["mem_20260403_002"]}),
                     "Use ONLY when the new evidence is the same fact as the target memory and older overlapping items should be superseded. Do not merge unrelated facts together — create a separate memory instead.",
                 ),
                 example(
                     "Split a multi-topic memory into atomic memories",
-                    json!({"action":"split","id":"mem_20260403_001","pieces":[{"title":"User prefers pnpm","type":"user","content":"User prefers pnpm and strict TypeScript.","tags":["preference"]},{"title":"Mobile release freeze is Tuesday","type":"project","content":"Mobile release freeze begins Tuesday.","tags":["release"]}]}),
+                    json!({"action":"split","id":"mem_20260403_001","pieces":[{"title":"User prefers pnpm","type":"user","content":"User prefers pnpm.","keywords":["pnpm","package manager"],"entities":["pnpm"],"tags":["preference"]},{"title":"Mobile release freeze is Tuesday","type":"project","content":"Mobile release freeze begins Tuesday.","keywords":["release freeze","Tuesday"],"entities":["Mobile"],"tags":["release"]}]}),
                     "Use when one memory has accreted several unrelated facts (a 'blob'): split archives the original and creates one atomic memory per fact, preserving lineage via supersedes.",
                 ),
                 example(
                     "Consolidate near-duplicate memories into one",
-                    json!({"action":"consolidate","ids":["mem_20260403_001","mem_20260403_007"],"type":"project","title":"Mobile release freeze is Tuesday","content":"Mobile release freeze begins Tuesday for the release cut.","tags":["release","freeze"]}),
+                    json!({"action":"consolidate","ids":["mem_20260403_001","mem_20260403_007"],"type":"project","title":"Mobile release freeze is Tuesday","content":"Mobile release freeze begins Tuesday.","keywords":["release freeze","Tuesday"],"entities":["Mobile"],"tags":["release"]}),
                     "Use ONLY when two or more memories are the SAME fact: consolidate archives them all and creates one canonical atomic memory, preserving lineage via supersedes. Confirm sameness (e.g. via scan_duplicates / find_duplicates) before consolidating — never merge distinct facts.",
                 ),
             ],
@@ -742,6 +742,55 @@ mod tests {
                 .and_then(|value| value.as_str())
                 == Some("merge")
         }));
+    }
+
+    #[test]
+    fn memory_guide_teaches_compact_recall_and_small_lexical_hints() {
+        let guide = builtin_guide_spec("memory").expect("memory guide should exist");
+        let examples_for = |action: &str| {
+            guide
+                .examples
+                .iter()
+                .filter(|example| {
+                    example
+                        .parameters
+                        .get("action")
+                        .and_then(|value| value.as_str())
+                        == Some(action)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let queries = examples_for("query");
+        assert!(!queries.is_empty());
+        assert!(queries
+            .iter()
+            .all(|example| example.parameters.pointer("/options/limit").is_none()));
+        assert_eq!(examples_for("get").len(), 1);
+
+        for action in ["write", "merge", "consolidate"] {
+            let examples = examples_for(action);
+            assert_eq!(examples.len(), 1, "missing {action} example");
+            for field in ["keywords", "entities", "tags"] {
+                let hints = examples[0].parameters[field]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("{action} example is missing {field}"));
+                assert!(!hints.is_empty() && hints.len() <= 3);
+            }
+        }
+
+        let split = examples_for("split");
+        let pieces = split[0].parameters["pieces"]
+            .as_array()
+            .expect("split example should contain pieces");
+        for piece in pieces {
+            for field in ["keywords", "entities", "tags"] {
+                let hints = piece[field]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("split piece is missing {field}"));
+                assert!(!hints.is_empty() && hints.len() <= 3);
+            }
+        }
     }
 
     #[test]

--- a/crates/infra/bamboo-memory/src/memory_store/mod.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/mod.rs
@@ -7,14 +7,17 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 pub use jiandu_memory::memory_store::{
-    count_chars, normalize_tags, render_memory_freshness_note, summary_json, truncate_chars,
-    BlobScanItem, BlobScanReport, DreamReadResult, DreamSnapshot, DuplicateCluster,
-    DuplicateScanReport, DurableMemoryDocument, DurableMemoryStatus, DurableMemoryType,
-    FreshnessKind, MemoryConsolidateResult, MemoryContradictionResult, MemoryDuplicateCandidate,
-    MemoryMergeResult, MemoryPurgeResult, MemoryQueryOptions, MemoryQueryResult,
-    MemoryRecallCandidate, MemoryRecallOptions, MemoryScope, MemorySplitPiece, MemorySplitResult,
-    SessionState, TemporalGranularity, DEFAULT_SESSION_TOPIC, MAX_MAX_CHARS, MAX_MEMORY_TITLE_LEN,
-    MAX_QUERY_LIMIT,
+    count_chars, normalize_retrieval_terms, normalize_tags, render_memory_freshness_note,
+    summary_json, truncate_chars, BlobScanItem, BlobScanReport, DreamReadResult, DreamSnapshot,
+    DuplicateCluster, DuplicateScanReport, DurableMemoryDocument, DurableMemoryStatus,
+    DurableMemoryType, FreshnessKind, MemoryConsolidateResult, MemoryContradictionResult,
+    MemoryDuplicateCandidate, MemoryMergeResult, MemoryPurgeResult, MemoryQueryOptions,
+    MemoryQueryResult, MemoryRecallCandidate, MemoryRecallOptions, MemoryRetrievalInput,
+    MemoryScope, MemorySplitPiece, MemorySplitResult, SessionState, TemporalGranularity,
+    DEFAULT_QUERY_LIMIT, DEFAULT_SESSION_TOPIC, MAX_EXPLICIT_MEMORY_ENTITIES,
+    MAX_EXPLICIT_MEMORY_KEYWORDS, MAX_MAX_CHARS, MAX_MEMORY_ENTITIES, MAX_MEMORY_ID_LEN,
+    MAX_MEMORY_KEYWORDS, MAX_MEMORY_QUERY_CHARS, MAX_MEMORY_TAGS, MAX_MEMORY_TAG_CHARS,
+    MAX_MEMORY_TITLE_LEN, MAX_QUERY_LIMIT, MAX_RETRIEVAL_TERM_CHARS,
 };
 
 /// Jiandu's inspection result plus Bamboo's flattened Dream timestamp.
@@ -234,6 +237,38 @@ impl MemoryStore {
             .await
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub async fn write_memory_with_retrieval(
+        &self,
+        scope: MemoryScope,
+        project_key: Option<&str>,
+        r#type: DurableMemoryType,
+        title: &str,
+        content: &str,
+        tags: &[String],
+        retrieval: &MemoryRetrievalInput,
+        session_id: Option<&str>,
+        actor: &str,
+        allow_merge_if_similar: bool,
+        granularity: Option<TemporalGranularity>,
+    ) -> io::Result<DurableMemoryDocument> {
+        self.store
+            .write_memory_with_retrieval(
+                scope,
+                project_key,
+                r#type,
+                title,
+                content,
+                tags,
+                retrieval,
+                session_id,
+                actor,
+                allow_merge_if_similar,
+                granularity,
+            )
+            .await
+    }
+
     pub async fn archive_memory(
         &self,
         id: &str,
@@ -259,6 +294,27 @@ impl MemoryStore {
             .await
     }
 
+    pub async fn split_memory_with_retrieval(
+        &self,
+        id: &str,
+        preferred_project_key: Option<&str>,
+        pieces: &[MemorySplitPiece],
+        retrieval: &[MemoryRetrievalInput],
+        session_id: Option<&str>,
+        actor: &str,
+    ) -> io::Result<Option<MemorySplitResult>> {
+        self.store
+            .split_memory_with_retrieval(
+                id,
+                preferred_project_key,
+                pieces,
+                retrieval,
+                session_id,
+                actor,
+            )
+            .await
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn find_duplicate_candidates(
         &self,
@@ -272,6 +328,32 @@ impl MemoryStore {
     ) -> io::Result<Vec<MemoryDuplicateCandidate>> {
         self.store
             .find_duplicate_candidates(scope, project_key, r#type, title, content, tags, limit)
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn find_duplicate_candidates_with_retrieval(
+        &self,
+        scope: MemoryScope,
+        project_key: Option<&str>,
+        r#type: Option<DurableMemoryType>,
+        title: &str,
+        content: &str,
+        tags: &[String],
+        retrieval: &MemoryRetrievalInput,
+        limit: usize,
+    ) -> io::Result<Vec<MemoryDuplicateCandidate>> {
+        self.store
+            .find_duplicate_candidates_with_retrieval(
+                scope,
+                project_key,
+                r#type,
+                title,
+                content,
+                tags,
+                retrieval,
+                limit,
+            )
             .await
     }
 
@@ -316,6 +398,27 @@ impl MemoryStore {
     ) -> io::Result<Option<MemoryConsolidateResult>> {
         self.store
             .consolidate_memories(ids, preferred_project_key, merged, session_id, actor)
+            .await
+    }
+
+    pub async fn consolidate_memories_with_retrieval(
+        &self,
+        ids: &[String],
+        preferred_project_key: Option<&str>,
+        merged: &MemorySplitPiece,
+        retrieval: &MemoryRetrievalInput,
+        session_id: Option<&str>,
+        actor: &str,
+    ) -> io::Result<Option<MemoryConsolidateResult>> {
+        self.store
+            .consolidate_memories_with_retrieval(
+                ids,
+                preferred_project_key,
+                merged,
+                retrieval,
+                session_id,
+                actor,
+            )
             .await
     }
 
@@ -382,6 +485,32 @@ impl MemoryStore {
                 preferred_project_key,
                 content,
                 tags,
+                session_id,
+                actor,
+                source_memory_ids,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn merge_memory_with_retrieval(
+        &self,
+        id: &str,
+        preferred_project_key: Option<&str>,
+        content: &str,
+        tags: &[String],
+        retrieval: &MemoryRetrievalInput,
+        session_id: Option<&str>,
+        actor: &str,
+        source_memory_ids: &[String],
+    ) -> io::Result<Option<MemoryMergeResult>> {
+        self.store
+            .merge_memory_with_retrieval(
+                id,
+                preferred_project_key,
+                content,
+                tags,
+                retrieval,
                 session_id,
                 actor,
                 source_memory_ids,


### PR DESCRIPTION
## Summary

- Keep one Bamboo `memory` tool and one `bamboo-memory` facade over Jiandu 0.2.0; add no MCP client, backend, store, index, embedding, or compatibility layer.
- Teach the model short lexical query -> compact top 3 IDs/summaries -> conditional selected `get`, plus query-before-write and one confirmed atomic fact.
- Forward bounded keywords/entities/tags through write, merge, duplicate lookup, split, and consolidate; keep Project authority in trusted Session context.
- Bound `get` body and retrieval metadata independently without rewriting canonical Jiandu bytes.
- Align prompt budget tests, built-in guide, `AGENTS.md`, `CLAUDE.md`, and bilingual README with the Jiandu/Bamboo ownership boundary.

Closes #1029

## Test Plan

Passed on exact head `a56867517d55d8405f89edd800215f5ac478619e`:

- `cargo fmt --all -- --check`
- strict workspace `cargo clippy --all-features -- -D warnings` with the repository CI allowlist
- `cargo test --all-features --lib --tests`
- `cargo build --examples`
- `python3 scripts/check-msrv.py`
- `cargo +1.95.0 check --locked --workspace --all-targets --all-features`
- focused memory tool/facade/prompt/guide tests: 20 + 65 + 69 + 6 passing
- `python3 -m unittest discover -s scripts/tests -p test_*.py`: 3 passing
- full isolated Bamboo HTTP runtime: real Project/Session, four writes through `/api/v1/tools/execute`, default compact top 3 lexical query, selected bounded `get`, and a complete provider loop proving summaries/full IDs enter the prompt while the body sentinel does not

Default-feature `cargo test --tests` exposed two unrelated timing flakes while this exact head passed each failing test on immediate isolated rerun: existing #983 and newly routed #1035. The all-features full suite passed both. Required Test, E2E Tests, and Lint checks, plus CodeQL/MSRV/docs/security/cargo-deny/cross-platform jobs, are green on this exact head.

Runtime evidence: https://github.com/bigduu/Bamboo-agent/pull/1036#issuecomment-5490426381

Independent exact-head review: https://github.com/bigduu/Bamboo-agent/pull/1036#issuecomment-5490536400

## Screenshots

Not applicable; no UI change.
