### PR TITLE
feat: expose frontend bootstrap contract

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/bootstrap.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/bootstrap.rs
@@ -1,0 +1,236 @@
+//! Canonical, public frontend compatibility bootstrap.
+//!
+//! `GET /api/v1/bootstrap` is the single compatibility authority for Lotus
+//! Next. It describes the currently implemented REST/realtime contract and the
+//! current request's access posture without exposing configuration internals or
+//! credential material. Older servers intentionally return 404; clients must
+//! surface that as an incompatible server rather than probe legacy endpoints.
+
+use actix_web::{http::header, web, HttpRequest, HttpResponse};
+use serde::Serialize;
+
+use crate::app_state::AppState;
+use crate::handlers::{
+    agent::ws_v2::{SUBPROTOCOL_JSON, SUBPROTOCOL_MSGPACK},
+    settings::{bootstrap_access_snapshot, BootstrapAccessSnapshot},
+};
+
+const SCHEMA_VERSION: u32 = 1;
+const SERVER_PRODUCT: &str = "bamboo";
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const API_NAME: &str = "bamboo.agent";
+const API_BASE_PATH: &str = "/api/v1";
+const API_MIN_VERSION: u32 = 1;
+const API_MAX_VERSION: u32 = 1;
+const REALTIME_NAME: &str = "bamboo.v2";
+const REALTIME_PATH: &str = "/v2/stream";
+const REALTIME_MIN_VERSION: u32 = 2;
+const REALTIME_MAX_VERSION: u32 = 2;
+const VERIFY_PATH: &str = "/api/v1/bamboo/access/verify";
+const PAIR_PATH: &str = "/v2/pair";
+
+const CAPABILITIES: &[&str] = &[
+    "auth.device_bearer.v1",
+    "auth.password_cookie.v1",
+    "auth.ws_device_hello.v1",
+    "realtime.account_feed.v1",
+    "realtime.agent_events.v1",
+    "realtime.application_heartbeat.v1",
+    "realtime.feed_cursor.v1",
+    "realtime.feed_reset.v1",
+    "realtime.stop_control.v1",
+];
+
+const SUBPROTOCOLS: &[BootstrapSubprotocol] = &[
+    BootstrapSubprotocol {
+        name: SUBPROTOCOL_JSON,
+        encoding: "json",
+    },
+    BootstrapSubprotocol {
+        name: SUBPROTOCOL_MSGPACK,
+        encoding: "messagepack",
+    },
+];
+
+#[derive(Debug, Serialize)]
+struct BootstrapResponse {
+    schema_version: u32,
+    server: BootstrapServer,
+    api: BootstrapApi,
+    realtime: BootstrapRealtime,
+    capabilities: &'static [&'static str],
+    auth: BootstrapAuth,
+}
+
+#[derive(Debug, Serialize)]
+struct BootstrapServer {
+    product: &'static str,
+    version: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct BootstrapApi {
+    name: &'static str,
+    canonical_base_path: &'static str,
+    min_version: u32,
+    max_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct BootstrapRealtime {
+    name: &'static str,
+    path: &'static str,
+    min_version: u32,
+    max_version: u32,
+    subprotocols: &'static [BootstrapSubprotocol],
+}
+
+#[derive(Debug, Serialize)]
+struct BootstrapSubprotocol {
+    name: &'static str,
+    encoding: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct BootstrapAuth {
+    #[serde(flatten)]
+    access: BootstrapAccessSnapshot,
+    verify_path: &'static str,
+    pair_path: &'static str,
+}
+
+fn response(access: BootstrapAccessSnapshot) -> BootstrapResponse {
+    BootstrapResponse {
+        schema_version: SCHEMA_VERSION,
+        server: BootstrapServer {
+            product: SERVER_PRODUCT,
+            version: SERVER_VERSION,
+        },
+        api: BootstrapApi {
+            name: API_NAME,
+            canonical_base_path: API_BASE_PATH,
+            min_version: API_MIN_VERSION,
+            max_version: API_MAX_VERSION,
+        },
+        realtime: BootstrapRealtime {
+            name: REALTIME_NAME,
+            path: REALTIME_PATH,
+            min_version: REALTIME_MIN_VERSION,
+            max_version: REALTIME_MAX_VERSION,
+            subprotocols: SUBPROTOCOLS,
+        },
+        capabilities: CAPABILITIES,
+        auth: BootstrapAuth {
+            access,
+            verify_path: VERIFY_PATH,
+            pair_path: PAIR_PATH,
+        },
+    }
+}
+
+/// Return the immutable frontend contract plus auth facts derived from one
+/// authoritative configuration snapshot and this exact request.
+pub async fn handler(state: web::Data<AppState>, req: HttpRequest) -> HttpResponse {
+    let access = {
+        let config = state.config.read().await;
+        bootstrap_access_snapshot(&config, &req)
+    };
+
+    HttpResponse::Ok()
+        .insert_header((header::CACHE_CONTROL, "no-store"))
+        .insert_header((header::VARY, "Cookie, Authorization, X-Device-Id"))
+        .json(response(access))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn response_shape_is_exact_stable_and_secret_free() {
+        let request = actix_web::test::TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .to_http_request();
+        let config = bamboo_config::Config::default();
+        let value =
+            serde_json::to_value(response(bootstrap_access_snapshot(&config, &request))).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "schema_version": 1,
+                "server": {
+                    "product": "bamboo",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "api": {
+                    "name": "bamboo.agent",
+                    "canonical_base_path": "/api/v1",
+                    "min_version": 1,
+                    "max_version": 1,
+                },
+                "realtime": {
+                    "name": "bamboo.v2",
+                    "path": "/v2/stream",
+                    "min_version": 2,
+                    "max_version": 2,
+                    "subprotocols": [
+                        {"name": "bamboo.v2", "encoding": "json"},
+                        {"name": "bamboo.v2.msgpack", "encoding": "messagepack"},
+                    ],
+                },
+                "capabilities": [
+                    "auth.device_bearer.v1",
+                    "auth.password_cookie.v1",
+                    "auth.ws_device_hello.v1",
+                    "realtime.account_feed.v1",
+                    "realtime.agent_events.v1",
+                    "realtime.application_heartbeat.v1",
+                    "realtime.feed_cursor.v1",
+                    "realtime.feed_reset.v1",
+                    "realtime.stop_control.v1",
+                ],
+                "auth": {
+                    "policy": "open",
+                    "request_state": "unauthenticated",
+                    "password_enabled": false,
+                    "device_auth_enabled": false,
+                    "verify_path": "/api/v1/bamboo/access/verify",
+                    "pair_path": "/v2/pair",
+                },
+            })
+        );
+
+        let capabilities = value["capabilities"].as_array().unwrap();
+        assert_eq!(
+            capabilities
+                .iter()
+                .map(|capability| capability.as_str().unwrap())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            capabilities.len(),
+            "capability identifiers must be unique"
+        );
+
+        // The exact response snapshot above is the strongest allowlist. Keep a
+        // focused denylist too so a future nested config envelope cannot slip
+        // verifier or filesystem details into this public endpoint unnoticed.
+        let serialized = serde_json::to_string(&value).unwrap();
+        for forbidden in [
+            "password_hash",
+            "password_salt",
+            "token_hash",
+            "token_salt",
+            "device_id",
+            "credential_ref",
+            "app_data_dir",
+            "config_path",
+        ] {
+            assert!(!serialized.contains(forbidden), "leaked key: {forbidden}");
+        }
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mod.rs
@@ -3,6 +3,7 @@
 //! These handlers provide the core agent functionality including
 //! chat, execution, event streaming, session management, and MCP.
 
+pub mod bootstrap;
 pub mod chat;
 pub mod child_approval;
 pub mod delete;

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -56,6 +56,8 @@
 mod envelope;
 mod forwarders;
 
+pub(crate) use self::envelope::{SUBPROTOCOL_JSON, SUBPROTOCOL_MSGPACK};
+
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -70,7 +72,7 @@ use serde::Deserialize;
 
 use self::envelope::{
     decode_client_frame, pong_frame, sys_keepalive_envelope, Channel, ClientFrame, Encoding,
-    OutFrame, SUBPROTOCOL_JSON, SUBPROTOCOL_MSGPACK,
+    OutFrame,
 };
 use self::forwarders::{
     spawn_agent_forwarder, spawn_agent_terminal_forwarder, spawn_feed_forwarder, OutboundTx,

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -41,6 +41,59 @@ pub(crate) struct AccessStatusResponse {
     pub requires_password: bool,
 }
 
+/// The configured access-control posture advertised by the frontend bootstrap
+/// contract.
+///
+/// This describes configuration policy only. Whether the current request used
+/// a local bypass or presented a valid credential is reported separately by
+/// [`BootstrapRequestState`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BootstrapAuthPolicy {
+    /// No root password, active device credential, or repair quarantine gates
+    /// remote requests.
+    Open,
+    /// A root password or at least one non-revoked device credential gates
+    /// remote requests.
+    CredentialRequired,
+    /// The access-control document is quarantined and remote credentials fail
+    /// closed until an explicit repair/reset clears the flag.
+    RepairRequired,
+}
+
+/// How the current bootstrap request relates to the configured auth policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BootstrapRequestState {
+    /// The real request locality qualifies for the existing desktop bypass.
+    LocalBypass,
+    /// A non-local request presented a currently valid cookie or device bearer.
+    Authenticated,
+    /// A non-local request did not present a currently valid credential.
+    /// Under [`BootstrapAuthPolicy::Open`] this is still an allowed request; the
+    /// state deliberately reports credential presence rather than duplicating
+    /// the policy decision.
+    Unauthenticated,
+}
+
+/// Access-control facts embedded in the public frontend bootstrap response.
+///
+/// All fields are derived from one caller-owned [`Config`] snapshot plus the
+/// current request. No device metadata, verifier material, or credential value
+/// is exposed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) struct BootstrapAccessSnapshot {
+    pub(crate) policy: BootstrapAuthPolicy,
+    pub(crate) request_state: BootstrapRequestState,
+    /// Durable root-password intent. A missing/degraded verifier does not
+    /// silently turn this off.
+    pub(crate) password_enabled: bool,
+    /// At least one non-revoked device is configured. In repair quarantine this
+    /// remains a configuration fact; [`BootstrapAuthPolicy::RepairRequired`]
+    /// communicates that remote credentials are not currently accepted.
+    pub(crate) device_auth_enabled: bool,
+}
+
 #[derive(Serialize)]
 pub(crate) struct AccessStatusEnvelope {
     #[serde(flatten)]
@@ -259,12 +312,11 @@ fn is_local_request(req: &HttpRequest) -> bool {
         return host_local && peer_local != Some(false);
     }
 
-    // No Host header: decide purely from the real socket peer.
-    if let Some(local) = peer_local {
-        return local;
-    }
-    let conn = req.connection_info();
-    conn.peer_addr().map(is_local_host).unwrap_or(false)
+    // No Host header: decide purely from the real socket peer. Actix derives
+    // `ConnectionInfo::peer_addr()` from this same request-head field, so a
+    // second fallback through `connection_info()` cannot recover an address.
+    // Avoid constructing that header-derived object for an untrusted request.
+    peer_local.unwrap_or(false)
 }
 
 /// Best-effort client-IP key for per-IP throttling (#190).
@@ -544,6 +596,13 @@ const PUBLIC_VERSIONED_SUFFIXES: &[&str] =
     &["/health", "/bamboo/access/status", "/bamboo/access/verify"];
 
 fn is_public_access_route(path: &str) -> bool {
+    // Frontend bootstrap is canonical-only. Do not add `/bootstrap` to
+    // `PUBLIC_VERSIONED_SUFFIXES`: that would also make an unregistered legacy
+    // `/v1/bootstrap` path public and silently invent a compatibility alias.
+    if path == "/api/v1/bootstrap" {
+        return true;
+    }
+
     for prefix in ["/api/v1", "/v1"] {
         if let Some(suffix) = path.strip_prefix(prefix) {
             if PUBLIC_VERSIONED_SUFFIXES.contains(&suffix) {
@@ -596,6 +655,56 @@ pub(crate) fn request_is_authorized(req: &HttpRequest, config: &Config) -> bool 
     !build_access_status(config, req).requires_password
         || request_has_verified_access_cookie(req, config)
         || request_has_valid_device_token(req, config)
+}
+
+/// Derive the access-control portion of the frontend bootstrap contract from a
+/// single configuration snapshot and the current request.
+///
+/// Policy and request state intentionally remain orthogonal: an open instance
+/// can receive an unauthenticated remote request, while a locally bypassed
+/// request retains `CredentialRequired` or `RepairRequired` as its configured
+/// policy. Repair quarantine is evaluated before remote credentials so a cookie
+/// or device bearer minted from stale verifier material always fails closed.
+pub(crate) fn bootstrap_access_snapshot(
+    config: &Config,
+    req: &HttpRequest,
+) -> BootstrapAccessSnapshot {
+    let password_enabled = config
+        .access_control
+        .as_ref()
+        .is_some_and(|access| access.password_enabled);
+    let device_auth_enabled = has_active_devices(config);
+    let repair_required = access_repair_required(config);
+
+    let policy = if repair_required {
+        BootstrapAuthPolicy::RepairRequired
+    } else if password_enabled || device_auth_enabled {
+        BootstrapAuthPolicy::CredentialRequired
+    } else {
+        BootstrapAuthPolicy::Open
+    };
+
+    let request_state = if is_local_request(req) {
+        BootstrapRequestState::LocalBypass
+    } else if repair_required {
+        // Keep the quarantine fail-closed boundary explicit here rather than
+        // allowing a future credential-helper change to make stale material
+        // appear authenticated in the public bootstrap snapshot.
+        BootstrapRequestState::Unauthenticated
+    } else if request_has_verified_access_cookie(req, config)
+        || request_has_valid_device_token(req, config)
+    {
+        BootstrapRequestState::Authenticated
+    } else {
+        BootstrapRequestState::Unauthenticated
+    };
+
+    BootstrapAccessSnapshot {
+        policy,
+        request_state,
+        password_enabled,
+        device_auth_enabled,
+    }
 }
 
 pub async fn enforce_access_password_middleware<B: MessageBody + 'static>(
@@ -2208,6 +2317,12 @@ mod tests {
     }
 
     #[test]
+    fn request_without_host_or_peer_is_not_local() {
+        let req = TestRequest::default().to_http_request();
+        assert!(!is_local_request(&req));
+    }
+
+    #[test]
     fn password_hash_roundtrip_verifies() {
         let salt_hex = hex::encode([1_u8; 16]);
         let hash = compute_password_hash("secret", &salt_hex).unwrap();
@@ -2513,6 +2628,221 @@ mod tests {
     }
 
     #[test]
+    fn bootstrap_access_snapshot_reports_policy_and_request_state_matrix() {
+        fn assert_snapshot(
+            config: &Config,
+            request: &HttpRequest,
+            policy: BootstrapAuthPolicy,
+            request_state: BootstrapRequestState,
+            password_enabled: bool,
+            device_auth_enabled: bool,
+        ) {
+            assert_eq!(
+                bootstrap_access_snapshot(config, request),
+                BootstrapAccessSnapshot {
+                    policy,
+                    request_state,
+                    password_enabled,
+                    device_auth_enabled,
+                }
+            );
+        }
+
+        // Open policy is independent from the request's credential state. A
+        // remote request is allowed by policy but still truthfully reports that
+        // it did not authenticate; locality remains visible when the same open
+        // instance is reached over the desktop bypass.
+        let open = Config::default();
+        assert_snapshot(
+            &open,
+            &remote_req(),
+            BootstrapAuthPolicy::Open,
+            BootstrapRequestState::Unauthenticated,
+            false,
+            false,
+        );
+        assert_snapshot(
+            &open,
+            &local_req(),
+            BootstrapAuthPolicy::Open,
+            BootstrapRequestState::LocalBypass,
+            false,
+            false,
+        );
+
+        // Password-only policy, both without and with a valid verification
+        // cookie derived from this exact Config snapshot.
+        let password_only = config_with_password();
+        assert_snapshot(
+            &password_only,
+            &remote_req(),
+            BootstrapAuthPolicy::CredentialRequired,
+            BootstrapRequestState::Unauthenticated,
+            true,
+            false,
+        );
+        let cookie_value = access_verification_cookie_value(&password_only)
+            .expect("healthy password config yields a cookie");
+        let valid_cookie = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .cookie(Cookie::new(ACCESS_VERIFIED_COOKIE_NAME, cookie_value))
+            .to_http_request();
+        assert_snapshot(
+            &password_only,
+            &valid_cookie,
+            BootstrapAuthPolicy::CredentialRequired,
+            BootstrapRequestState::Authenticated,
+            true,
+            false,
+        );
+        assert_snapshot(
+            &password_only,
+            &local_req(),
+            BootstrapAuthPolicy::CredentialRequired,
+            BootstrapRequestState::LocalBypass,
+            true,
+            false,
+        );
+
+        // Device-only policy and a valid bearer + companion device id.
+        let (device, device_token) = issue_device_token("bootstrap-device");
+        let device_id = device.device_id.clone();
+        let device_only = test_config! {
+            access_control: Some(AccessControlConfig {
+                devices: vec![device.clone()],
+                ..Default::default()
+            }),
+        };
+        assert_snapshot(
+            &device_only,
+            &remote_req(),
+            BootstrapAuthPolicy::CredentialRequired,
+            BootstrapRequestState::Unauthenticated,
+            false,
+            true,
+        );
+        let valid_device = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {device_token}")))
+            .insert_header((DEVICE_ID_HEADER, device_id.clone()))
+            .to_http_request();
+        assert_snapshot(
+            &device_only,
+            &valid_device,
+            BootstrapAuthPolicy::CredentialRequired,
+            BootstrapRequestState::Authenticated,
+            false,
+            true,
+        );
+
+        // Both mechanisms configured still form one credential-required policy.
+        let mut both = config_with_password();
+        both.access_control
+            .as_mut()
+            .unwrap()
+            .devices
+            .push(device.clone());
+        assert_snapshot(
+            &both,
+            &remote_req(),
+            BootstrapAuthPolicy::CredentialRequired,
+            BootstrapRequestState::Unauthenticated,
+            true,
+            true,
+        );
+
+        // An active device keeps the policy gated, but an invalid bearer cannot
+        // claim authentication.
+        let invalid_device = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .insert_header((header::AUTHORIZATION, "Bearer bd1_invalid"))
+            .insert_header((DEVICE_ID_HEADER, device_id.clone()))
+            .to_http_request();
+        assert_snapshot(
+            &device_only,
+            &invalid_device,
+            BootstrapAuthPolicy::CredentialRequired,
+            BootstrapRequestState::Unauthenticated,
+            false,
+            true,
+        );
+
+        // A revoked-only device is not an enabled auth mechanism and cannot
+        // authenticate even with the token that preceded its revocation.
+        let (mut revoked_device, revoked_token) = issue_device_token("revoked-device");
+        let revoked_device_id = revoked_device.device_id.clone();
+        revoked_device.revoked = true;
+        let revoked_only = test_config! {
+            access_control: Some(AccessControlConfig {
+                devices: vec![revoked_device],
+                ..Default::default()
+            }),
+        };
+        let revoked_request = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {revoked_token}")))
+            .insert_header((DEVICE_ID_HEADER, revoked_device_id))
+            .to_http_request();
+        assert_snapshot(
+            &revoked_only,
+            &revoked_request,
+            BootstrapAuthPolicy::Open,
+            BootstrapRequestState::Unauthenticated,
+            false,
+            false,
+        );
+
+        // Repair quarantine dominates previously valid cookie and device
+        // material for remote requests. The same configured mechanisms remain
+        // visible as configuration facts, while a local request reports its
+        // existing bypass without weakening the repair-required policy.
+        let stale_cookie = access_verification_cookie_value(&both)
+            .expect("healthy pre-repair config yields a cookie");
+        both.access_control.as_mut().unwrap().repair_required = true;
+        let repair_remote = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .cookie(Cookie::new(
+                ACCESS_VERIFIED_COOKIE_NAME,
+                stale_cookie.clone(),
+            ))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {device_token}")))
+            .insert_header((DEVICE_ID_HEADER, device_id.clone()))
+            .to_http_request();
+        assert_snapshot(
+            &both,
+            &repair_remote,
+            BootstrapAuthPolicy::RepairRequired,
+            BootstrapRequestState::Unauthenticated,
+            true,
+            true,
+        );
+        let repair_local = TestRequest::default()
+            .insert_header((header::HOST, "localhost:9562"))
+            .cookie(Cookie::new(ACCESS_VERIFIED_COOKIE_NAME, stale_cookie))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {device_token}")))
+            .insert_header((DEVICE_ID_HEADER, device_id))
+            .to_http_request();
+        assert_snapshot(
+            &both,
+            &repair_local,
+            BootstrapAuthPolicy::RepairRequired,
+            BootstrapRequestState::LocalBypass,
+            true,
+            true,
+        );
+
+        // The serialized values are part of the public bootstrap vocabulary.
+        assert_eq!(
+            serde_json::to_value(BootstrapAuthPolicy::CredentialRequired).unwrap(),
+            serde_json::json!("credential_required")
+        );
+        assert_eq!(
+            serde_json::to_value(BootstrapRequestState::LocalBypass).unwrap(),
+            serde_json::json!("local_bypass")
+        );
+    }
+
+    #[test]
     fn stream_is_public_but_sibling_routes_are_not() {
         // #189: the upgrade is whitelisted; the gated siblings are NOT.
         assert!(is_public_access_route("/v2/stream"));
@@ -2529,6 +2859,13 @@ mod tests {
         assert!(is_public_access_route("/healthz"));
         assert!(is_public_access_route("/readyz"));
         assert!(is_public_access_route("/api/v1/health"));
+    }
+
+    #[test]
+    fn bootstrap_is_public_only_at_the_exact_canonical_path() {
+        assert!(is_public_access_route("/api/v1/bootstrap"));
+        assert!(!is_public_access_route("/v1/bootstrap"));
+        assert!(!is_public_access_route("/api/v1/bootstrap/extra"));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -19,12 +19,14 @@ mod workflows;
 
 #[cfg(test)]
 pub(crate) use access_control::issue_device_token;
+pub(crate) use access_control::{
+    bootstrap_access_snapshot, request_is_authorized, verify_device_token, BootstrapAccessSnapshot,
+};
 pub use access_control::{
     create_pairing_code, enforce_access_password_middleware, get_access_status, list_devices,
     pair_device, revoke_device, rotate_device, update_access_password, verify_access_password,
     PairingCodeEntry, PairingCodeGuard, RootPasswordGuard,
 };
-pub(crate) use access_control::{request_is_authorized, verify_device_token};
 pub use bamboo_config::{
     clear_credential, confirm_config_recovery, detect_codex_cli, get_bamboo_config,
     get_bamboo_tools, get_config_recovery_status, get_connect_config, get_credential_status,

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -84,6 +84,7 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
         .wrap(actix_web::middleware::from_fn(
             settings::enforce_access_password_middleware,
         ))
+        .route("/bootstrap", web::get().to(agent::bootstrap::handler))
         .route("/chat", web::post().to(agent::chat::handler))
         .route(
             "/prompt-presets",

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -11,6 +11,7 @@ async fn configure_routes_registers_expected_api_prefixes() {
     let app = test::init_service(App::new().configure(configure_routes)).await;
 
     let requests = vec![
+        ("GET", "/api/v1/bootstrap"),
         ("GET", "/api/v1/health"),
         ("GET", "/api/v1/metrics/persistence"),
         // Unversioned liveness/readiness probes (#251 finding 6).
@@ -51,6 +52,7 @@ async fn configure_routes_with_rate_limiting_registers_expected_api_prefixes() {
     let app = test::init_service(App::new().configure(configure_routes_with_rate_limiting)).await;
 
     let requests = vec![
+        ("GET", "/api/v1/bootstrap"),
         ("GET", "/api/v1/health"),
         ("GET", "/api/v1/metrics/persistence"),
         // Unversioned liveness/readiness probes (#251 finding 6).
@@ -369,6 +371,166 @@ async fn access_bootstrap_endpoints_remain_public() {
         let resp = test::call_service(&app, req).await;
         assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
     }
+}
+
+#[actix_web::test]
+async fn frontend_bootstrap_is_public_canonical_request_aware_and_secret_free() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    let (device, device_token) =
+        crate::handlers::settings::issue_device_token("SECRET_BOOTSTRAP_DEVICE_LABEL");
+    let device_id = device.device_id.clone();
+    let device_hash = device.token_hash.clone();
+    let device_salt = device.token_salt.clone();
+    {
+        let mut config = app_state.config.write().await;
+        let mut access = password_access_control();
+        access.password_credential_ref =
+            Some(bamboo_config::CredentialRef::parse("access.bootstrap.secret").unwrap());
+        access.devices.push(device);
+        config.access_control = Some(access);
+    }
+    let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
+
+    // The canonical bootstrap stays public even though ordinary agent routes
+    // are credential-gated. Its response reports policy separately from the
+    // current request's lack of credentials.
+    let remote = test::TestRequest::get()
+        .uri("/api/v1/bootstrap")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+    let remote_response = test::call_service(&app, remote).await;
+    assert_eq!(remote_response.status(), StatusCode::OK);
+    assert_eq!(
+        remote_response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap(),
+        "no-store"
+    );
+    let vary = remote_response
+        .headers()
+        .get(header::VARY)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    for field in ["Cookie", "Authorization", "X-Device-Id"] {
+        assert!(vary.split(',').any(|value| value.trim() == field));
+    }
+    assert!(remote_response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("application/json"));
+    let remote_body = test::read_body(remote_response).await;
+    let remote_json: serde_json::Value = serde_json::from_slice(&remote_body).unwrap();
+    assert_eq!(remote_json["auth"]["policy"], "credential_required");
+    assert_eq!(remote_json["auth"]["request_state"], "unauthenticated");
+    assert_eq!(remote_json["auth"]["password_enabled"], true);
+    assert_eq!(remote_json["auth"]["device_auth_enabled"], true);
+
+    let serialized = String::from_utf8(remote_body.to_vec()).unwrap();
+    for secret in [
+        SECRET_HASH,
+        SECRET_SALT,
+        "SECRET_BOOTSTRAP_DEVICE_LABEL",
+        "access.bootstrap.secret",
+        device_id.as_str(),
+        device_token.as_str(),
+        device_hash.as_str(),
+        device_salt.as_str(),
+    ] {
+        assert!(
+            !serialized.contains(secret),
+            "bootstrap leaked secret material"
+        );
+    }
+
+    // Locality is evaluated from the real request rather than inferred from the
+    // configured policy.
+    let local = test::TestRequest::get()
+        .uri("/api/v1/bootstrap")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    let local_json: serde_json::Value = test::call_and_read_body_json(&app, local).await;
+    assert_eq!(local_json["auth"]["policy"], "credential_required");
+    assert_eq!(local_json["auth"]["request_state"], "local_bypass");
+
+    // A password-cookie authenticated request is reflected only after the
+    // server has verified the credential and issued its HttpOnly cookie.
+    let verify = test::TestRequest::post()
+        .uri("/api/v1/bamboo/access/verify")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .set_json(serde_json::json!({ "password": "secret" }))
+        .to_request();
+    let verify_response = test::call_service(&app, verify).await;
+    assert_eq!(verify_response.status(), StatusCode::OK);
+    let cookie = verify_response
+        .headers()
+        .get(header::SET_COOKIE)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string();
+    let cookie_bootstrap = test::TestRequest::get()
+        .uri("/api/v1/bootstrap")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .insert_header((header::COOKIE, cookie))
+        .to_request();
+    let cookie_json: serde_json::Value =
+        test::call_and_read_body_json(&app, cookie_bootstrap).await;
+    assert_eq!(cookie_json["auth"]["request_state"], "authenticated");
+
+    let device_bootstrap = test::TestRequest::get()
+        .uri("/api/v1/bootstrap")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .insert_header((header::AUTHORIZATION, format!("Bearer {device_token}")))
+        .insert_header(("X-Device-Id", device_id))
+        .to_request();
+    let device_json: serde_json::Value =
+        test::call_and_read_body_json(&app, device_bootstrap).await;
+    assert_eq!(device_json["auth"]["request_state"], "authenticated");
+
+    // Public matching is exact and canonical-only. A remote sibling remains
+    // gated; the legacy prefix is observably absent when local bypass allows
+    // the request through routing; non-GET methods cannot invoke the handler.
+    let sibling = test::TestRequest::get()
+        .uri("/api/v1/bootstrap/extra")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, sibling).await.status(),
+        StatusCode::UNAUTHORIZED
+    );
+
+    let legacy = test::TestRequest::get()
+        .uri("/v1/bootstrap")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, legacy).await.status(),
+        StatusCode::NOT_FOUND
+    );
+
+    let post = test::TestRequest::post()
+        .uri("/api/v1/bootstrap")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+    assert!(!test::call_service(&app, post).await.status().is_success());
+
+    let protected = test::TestRequest::get()
+        .uri("/api/v1/sessions")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, protected).await.status(),
+        StatusCode::UNAUTHORIZED
+    );
 }
 
 #[actix_web::test]

--- a/docs/design/api-v2-transport.md
+++ b/docs/design/api-v2-transport.md
@@ -277,8 +277,7 @@ bd1_<32 hex>          // 例如 bd1_4f8a...e2c9
 
 2. 正常连接(WSS 握手首帧):
    Client → { "type": "hello", "device_id": "...", "token": "bd1_..." }
-   Server → { "type": "welcome", "server_version": "...", "capabilities": [...] }
-   校验 token hash → 绑定连接身份 = device_id
+   Server 校验 token hash → 在服务端绑定连接身份 = device_id
 
 3. 后续设备配对(已有已认证设备在场):
    已认证设备生成一次性 6 位配对码:
@@ -290,6 +289,12 @@ bd1_<32 hex>          // 例如 bd1_4f8a...e2c9
 ```
 
 **loopback 桌面端**:`local_bypass` 语义保留——本地连接免 token(桌面开发零摩擦),仅公网连接强制 device token。
+
+> **当前实现边界:** 成功的 `hello` 只更新服务端连接的授权状态，尚不返回
+> `welcome` / `hello_ack`。客户端也不能以 socket open、首个业务事件或 pong
+> 推断认证成功。显式 acknowledgement 与订阅前等待 ACK 属于独立后续切片；在它
+> 落地前，`GET /api/v1/bootstrap` 只广告已经实现的
+> `auth.ws_device_hello.v1`，不会虚假广告 welcome/ACK 能力。
 
 ### 4.4 管理
 
@@ -471,17 +476,42 @@ WS 标准 RFC 7692 扩展,握手自动协商。对 JSON 文本通常 −60~80%�
 ### 8.1 双轨并存
 
 ```
-/v1  (SSE ×2 + REST)   ── 保留,桌面 loopback 默认,标记 deprecated
-/v2  (单 WSS)           ── 新增,公网/移动端默认
+/v1      (SSE ×2 + REST) ── 仅供遗留 Lotus 过渡,标记 deprecated
+/api/v1  (REST)          ── Lotus Next 全 surface 的 canonical HTTP API
+/v2      (单 WSS)        ── Lotus Next 全 surface 的 realtime transport
 ```
 
-- **桌面 lotus**:`server.tls` 缺省(loopback)→ 继续走 `/v1`,**零行为回退**;`server.tls` 存在 → 可选切 `/v2`。
-- **移动端**:只实现 `/v2` WS 客户端,不碰 SSE。
+- **Lotus Next**:浏览器、嵌入式 WebView、桌面与移动端共享同一套
+  `/api/v1` + `/v2/stream` contract；surface 不再决定协议或 feature tree。
+- **遗留 Lotus**:迁移期间可继续使用 `/v1`/SSE，但 Lotus Next 不对它做运行时
+  fallback；旧路径的最终退休另行跟踪。
 - **broker/worker**:本地继续 loopback;远程启用 `bind_tls`(remote-actor P1)。
 
 ### 8.2 客户端发现
 
-`lotus/src/shared/utils/backendBaseUrl.ts` 的健康探测改为探测 `/v2` 握手能力;发现到 `server.tls` 存在的实例自动选 `wss://`。
+Lotus Next 的所有 surface（浏览器、嵌入式 WebView、桌面和移动端）使用同一个
+canonical public `GET /api/v1/bootstrap` 作为 Bamboo 身份、REST/realtime
+版本范围、编码能力与当前认证状态的唯一兼容性 authority。客户端不得通过
+`/healthz`、`/api/v1/health`、`/v1` 路由存在性或试连 WebSocket 来猜测能力；
+旧服务器的 404、非法响应、产品不匹配、版本范围无交集或必要 capability 缺失
+都应显示为可诊断的不兼容状态，不得回退旧 Lotus 或另一套 endpoint。
+
+响应 schema v1 固定为：
+
+- `server.product = "bamboo"`，`server.version` 仅用于诊断，不用于推导能力；
+- `api.name = "bamboo.agent"`，canonical base 仅为 `/api/v1`，范围 `1..=1`；
+- realtime 为 `/v2/stream`、范围 `2..=2`，显式列出 JSON/MessagePack
+  subprotocol；
+- `capabilities` 是已实现能力的稳定、可扩展 ID 列表；
+- `auth.policy` 与 `auth.request_state` 分离，后者由当前请求 cookie/header、
+  locality 和同一个配置快照计算；
+- 响应不含 verifier、token、device metadata、credential reference 或配置路径，
+  并带 `Cache-Control: no-store` 与
+  `Vary: Cookie, Authorization, X-Device-Id`。
+
+Bootstrap 只证明 HTTP 发现契约；它不等价于 WebSocket hello acknowledgement。
+Lotus Next 在后续独立切片中增加显式 WSS ACK 后，才可在 ACK 前禁止 subscribe
+并将 negotiated connection state 作为 realtime authority。
 
 ### 8.3 认证迁移
 
@@ -491,7 +521,9 @@ WS 标准 RFC 7692 扩展,握手自动协商。对 JSON 文本通常 −60~80%�
 
 ### 8.4 灰度开关
 
-`features` 段新增 `api_v2_ws: bool`(默认桌面 false / 公网 true),允许按实例开关 `/v2` 入口,降低风险。
+当前 `/v2/stream` 是 Bamboo 的固定能力，没有按 desktop/mobile 分叉的
+`api_v2_ws` 配置。迁移灰度由制品发布与 Lotus Next capability admission 控制；
+不得在同一个 Lotus Next 构建里根据 host kind 静默切回 `/v1`/SSE。
 
 ---
 
@@ -551,8 +583,8 @@ WS 标准 RFC 7692 扩展,握手自动协商。对 JSON 文本通常 −60~80%�
 | feed channel | `handlers/agent/stream/response.rs`(`plan_replay`/journal 逐帧复用) |
 | agent channel | `handlers/agent/events/stream.rs`(`AgentEvent` 序列化复用) |
 | token 合帧 | `handlers/agent/events/stream.rs` 帧出口 |
-| 桌面客户端切换 | `lotus/src/services/chat/accountFeed.ts` + `agentSubscriptionRunner.ts` |
-| 客户端发现 | `lotus/src/shared/utils/backendBaseUrl.ts`(探测 `/v2`) |
+| Lotus Next 全 surface realtime consumer | `bigduu/lotus-next` 的 `src/services/chat/v2Stream.ts` + `accountFeed.ts` |
+| canonical 客户端发现 contract | `handlers/agent/bootstrap.rs` + `routes/agent.rs` 的 `GET /api/v1/bootstrap`；Lotus Next typed consumer 由独立 Issue 接入 |
 
 ---
 


### PR DESCRIPTION
## Summary

- add canonical public `GET /api/v1/bootstrap` as the single Lotus Next server-compatibility authority
- freeze schema v1 for Bamboo identity, canonical REST and realtime ranges, supported WebSocket subprotocols, and explicit implemented capabilities
- derive `auth.policy` and per-request `auth.request_state` from one authoritative `Config` snapshot while reusing the existing cookie, device-bearer, locality, and repair-quarantine rules
- return request-sensitive bootstrap responses with `Cache-Control: no-store` and `Vary: Cookie, Authorization, X-Device-Id`, without exposing credential or configuration internals
- document that Lotus Next uses one contract across browser, embedded, desktop, and mobile surfaces, and that WebSocket `welcome` / `hello_ack` remains a separate follow-up

Closes #1039
Parent migration tracker: bigduu/lotus-next#11

## Acceptance boundary

- only `/api/v1/bootstrap` is registered and publicly allowlisted; there is no `/v1/bootstrap` alias or prefix/sibling match
- only GET invokes the bootstrap handler
- existing REST, access-control, pairing, WebSocket, and legacy Lotus behavior is unchanged
- capabilities are an explicit positive allowlist and do not advertise an unimplemented WebSocket acknowledgement

## Test Plan

- `cargo fmt --check`
- `cargo test -p bamboo-server bootstrap --no-fail-fast` — 11 passed
- `cargo test -p bamboo-server handlers::settings::access_control::tests --lib --no-fail-fast` — 47 passed
- `cargo test -p bamboo-server routes::tests --lib --no-fail-fast` — 34 passed
- `cargo test -p bamboo-server --no-fail-fast` — 1974 unit passed / 1 external-CLI test ignored; all integration, frontend-contract, WSS v2, and doc tests passed
- `cargo clippy -p bamboo-server --all-targets` — exits 0; reports only pre-existing warnings outside this diff
- independent adversarial review of the exact pre-commit diff: approved after correcting one stale `/v2` probing documentation anchor

## Screenshots

Not applicable: server contract, tests, and architecture documentation only.

## Non-goals

- Lotus Next typed bootstrap consumer and UI admission states
- device credential vault or pairing UI
- WebSocket `hello_ack` / welcome negotiation
- endpoint, health, SSE, or legacy Lotus fallback
- embedded frontend artifact changes or a release train
