### PR TITLE
refactor: publish lock-free session cache snapshots (#1045)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1045,7 @@ name = "bamboo-engine"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bamboo-a2a",
  "bamboo-agent-core",
@@ -1057,6 +1067,7 @@ dependencies = [
  "bytes",
  "chrono",
  "colored",
+ "crossbeam-skiplist",
  "dashmap",
  "dirs",
  "fs2",
@@ -2228,6 +2239,25 @@ version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 

--- a/crates/app/bamboo-server-tools/src/ledger/tests.rs
+++ b/crates/app/bamboo-server-tools/src/ledger/tests.rs
@@ -70,11 +70,11 @@ fn build_tool_with_optional_session(
     session: Option<Session>,
     project_store: Option<Arc<bamboo_projects::ProjectStore>>,
 ) -> (LedgerTool, Arc<dyn Storage>) {
-    let sessions: bamboo_engine::SessionCache = Arc::new(dashmap::DashMap::new());
+    let sessions: bamboo_engine::SessionCache = Arc::default();
     if let Some(session) = session {
         sessions.insert(
             session.id.clone(),
-            Arc::new(parking_lot::RwLock::new(session)),
+            Arc::new(bamboo_engine::SessionSnapshot::new(session)),
         );
     }
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());

--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -50,7 +50,7 @@ fn test_context(session_id: &str) -> ToolCtx {
 }
 
 fn build_memory_tool(data_dir: &std::path::Path) -> MemoryTool {
-    let sessions: bamboo_engine::SessionCache = Arc::new(dashmap::DashMap::new());
+    let sessions: bamboo_engine::SessionCache = Arc::default();
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
     let persistence = Arc::new(LockedSessionStore::new(storage.clone()));
     let session_repo = bamboo_engine::SessionRepository::new(sessions, storage, persistence);
@@ -61,7 +61,7 @@ async fn build_memory_tool_with_session(
     data_dir: &std::path::Path,
     session: Session,
 ) -> MemoryTool {
-    let sessions: bamboo_engine::SessionCache = Arc::new(dashmap::DashMap::new());
+    let sessions: bamboo_engine::SessionCache = Arc::default();
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
     storage.save_session(&session).await.expect("save session");
     let persistence = Arc::new(LockedSessionStore::new(storage.clone()));

--- a/crates/app/bamboo-server-tools/src/project_tools.rs
+++ b/crates/app/bamboo-server-tools/src/project_tools.rs
@@ -854,7 +854,7 @@ mod tests {
         storage.save_session(&session).await.unwrap();
         let storage: Arc<dyn Storage> = storage;
         SessionRepository::new(
-            Arc::new(dashmap::DashMap::new()),
+            bamboo_engine::SessionCache::default(),
             storage.clone(),
             Arc::new(LockedSessionStore::new(storage)),
         )

--- a/crates/app/bamboo-server-tools/src/project_tools.rs
+++ b/crates/app/bamboo-server-tools/src/project_tools.rs
@@ -423,7 +423,7 @@ impl Tool for ProjectWorkspaceTool {
                 })?;
             self.sessions.cache().insert(
                 session_id.to_string(),
-                Arc::new(parking_lot::RwLock::new(authoritative.clone())),
+                Arc::new(bamboo_engine::SessionSnapshot::new(authoritative.clone())),
             );
             drop(persistence_guard);
             project = authoritative_project;

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -999,7 +999,7 @@ fn test_session_cache(session_id: &str, session: &Session) -> bamboo_engine::Ses
     let cache = Arc::new(dashmap::DashMap::new());
     cache.insert(
         session_id.to_string(),
-        Arc::new(parking_lot::RwLock::new(session.clone())),
+        Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
     );
     cache
 }
@@ -1768,7 +1768,7 @@ async fn session_workspace_skill_catalog_selection_and_runtime_roots_are_isolate
     for session in [&session_one, &session_two] {
         sessions.insert(
             session.id.clone(),
-            Arc::new(parking_lot::RwLock::new(session.clone())),
+            Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
         );
     }
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -128,7 +128,7 @@ RUNNER_RUNTIME_INSTRUCTIONS"#,
     manager.initialize().await.expect("manager");
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
     let locked = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
-    let cache = Arc::new(dashmap::DashMap::new());
+    let cache = bamboo_engine::SessionCache::default();
     let repo = bamboo_engine::SessionRepository::new(cache, storage.clone(), locked.clone());
     let config = Arc::new(RwLock::new(Config::default()));
     let load_skill = LoadSkillTool::new(manager.clone(), config.clone(), repo.clone());
@@ -375,7 +375,7 @@ async fn explicit_fail_closed_dynamic_context_stop_matrix_keeps_main_runner_aliv
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
     let locked = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
     let repo = bamboo_engine::SessionRepository::new(
-        Arc::new(dashmap::DashMap::new()),
+        bamboo_engine::SessionCache::default(),
         storage.clone(),
         locked,
     );
@@ -996,7 +996,7 @@ fn dynamic_context_plan_helper_fail_closes_mutating_and_unknown_tools() {
 
 /// Build a per-session-locked session cache pre-populated with one session.
 fn test_session_cache(session_id: &str, session: &Session) -> bamboo_engine::SessionCache {
-    let cache = Arc::new(dashmap::DashMap::new());
+    let cache = bamboo_engine::SessionCache::default();
     cache.insert(
         session_id.to_string(),
         Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
@@ -1764,7 +1764,7 @@ async fn session_workspace_skill_catalog_selection_and_runtime_roots_are_isolate
         SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
         r#"["shared-workflow"]"#.to_string(),
     );
-    let sessions = Arc::new(dashmap::DashMap::new());
+    let sessions = bamboo_engine::SessionCache::default();
     for session in [&session_one, &session_two] {
         sessions.insert(
             session.id.clone(),
@@ -1911,7 +1911,7 @@ async fn runtime_skill_store_keeps_project_home_across_workspace_switches() {
     manager.initialize().await.expect("initialize manager");
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
     let persistence = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
-    let sessions = Arc::new(dashmap::DashMap::new());
+    let sessions = bamboo_engine::SessionCache::default();
     let repo = bamboo_engine::SessionRepository::new(sessions, storage, persistence);
     let mut session = Session::new("project-runtime-skill", "model");
     session.set_project_id_meta(project.id.to_string());

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -279,7 +279,7 @@ impl AppState {
         ));
 
         // In-memory session cache (shared across handlers and background jobs).
-        let sessions: bamboo_engine::SessionCache = Arc::new(dashmap::DashMap::new());
+        let sessions: bamboo_engine::SessionCache = Arc::default();
 
         // Embed the mailbox bus (broker) in-process unless an external one is
         // configured. Mutates `config.subagents.broker` to point at the loopback

--- a/crates/app/bamboo-server/src/app_state/session_loader.rs
+++ b/crates/app/bamboo-server/src/app_state/session_loader.rs
@@ -109,7 +109,7 @@ mod tests {
         // Seed memory cache.
         state.sessions.insert(
             session_id.to_string(),
-            Arc::new(parking_lot::RwLock::new(session.clone())),
+            Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
         );
 
         let loaded = state.load_session(session_id).await;
@@ -182,7 +182,7 @@ mod tests {
 
         state.sessions.insert(
             session_id.to_string(),
-            Arc::new(parking_lot::RwLock::new(memory_session)),
+            Arc::new(bamboo_engine::SessionSnapshot::new(memory_session)),
         );
         state
             .storage

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -51,7 +51,7 @@ async fn persist_and_cache_session_locked(
     state.persistence.storage().save_session(session).await?;
     state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
     );
     Ok(())
 }

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -1223,7 +1223,7 @@ mod optional_model_e2e {
         state.storage.save_session(&session).await.unwrap();
         state.sessions.insert(
             session_id.to_string(),
-            std::sync::Arc::new(parking_lot::RwLock::new(session)),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
         );
         bamboo_agent_core::workspace_state::set_workspace(
             session_id,
@@ -1275,7 +1275,7 @@ mod optional_model_e2e {
             .unwrap();
         state.sessions.insert(
             session_id.to_string(),
-            std::sync::Arc::new(parking_lot::RwLock::new(latest)),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(latest)),
         );
         bamboo_agent_core::workspace_state::set_workspace(
             session_id,
@@ -1334,7 +1334,7 @@ mod optional_model_e2e {
         stale_cache.updated_at = chrono::Utc::now() + chrono::Duration::hours(1);
         state.sessions.insert(
             session_id.to_string(),
-            std::sync::Arc::new(parking_lot::RwLock::new(stale_cache)),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(stale_cache)),
         );
         let app = test::init_service(
             App::new()

--- a/crates/app/bamboo-server/src/handlers/agent/delete.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/delete.rs
@@ -185,11 +185,11 @@ mod tests {
             .expect("save child index");
         state.sessions.insert(
             root.id.clone(),
-            std::sync::Arc::new(parking_lot::RwLock::new(root.clone())),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(root.clone())),
         );
         state.sessions.insert(
             child.id.clone(),
-            std::sync::Arc::new(parking_lot::RwLock::new(child.clone())),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(child.clone())),
         );
         let ids = vec!["review".to_string()];
         for session_id in [&root.id, &child.id] {

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -264,7 +264,7 @@ pub(crate) async fn transition_startup_failure_if_owned(
     }
     state.sessions.insert(
         session_id.to_string(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let sender = state.get_session_event_sender(session_id).await;
     let _ = sender.send(AgentEvent::Error { message });

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -177,7 +177,7 @@ pub(super) async fn handle_execute_ready(context: ExecuteReadyContext<'_>) -> Ht
     }
     state.sessions.insert(
         session_id.to_string(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
     );
 
     let disabled_tools: BTreeSet<String> = disabled_tools.into_iter().collect();

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
@@ -847,7 +847,7 @@ async fn startup_failure_waiting_on_lock_cannot_overwrite_newer_turn() {
         .expect("persist newer turn while owning session lock");
     state.sessions.insert(
         session_id.to_string(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     drop(chat_guard);
     failure.await.expect("failure task completes");

--- a/crates/app/bamboo-server/src/handlers/agent/messages/shared.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/messages/shared.rs
@@ -50,7 +50,7 @@ pub(super) async fn save_and_cache_session(
 
     state.sessions.insert(
         session_id.to_string(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     Ok(())
 }

--- a/crates/app/bamboo-server/src/handlers/agent/respond/session.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/respond/session.rs
@@ -30,7 +30,7 @@ mod tests {
 
         state.sessions.insert(
             session_id.to_string(),
-            std::sync::Arc::new(parking_lot::RwLock::new(memory_session)),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(memory_session)),
         );
         state
             .storage

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/copy.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/copy.rs
@@ -63,7 +63,7 @@ pub async fn copy_session(
     // cache only after the durable transaction succeeds.
     state.sessions.insert(
         new_id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(copied.clone())),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(copied.clone())),
     );
 
     // Copy preserves the source's workspace assignment. Publish the copied

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -1166,7 +1166,7 @@ async fn create_session_once(
 
     state.sessions.insert(
         id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
     );
 
     // Publish only the exact candidate that passed Project ownership checks,
@@ -2241,13 +2241,12 @@ mod tests {
             .await
             .unwrap();
         let original_arc = state.sessions.get(&session_id).unwrap().value().clone();
-        {
-            let mut live = original_arc.write();
+        original_arc.update(|live| {
             live.title = "LIVE-SENTINEL".to_string();
             live.metadata
                 .insert("live_sentinel".to_string(), "must-survive".to_string());
             live.updated_at = Utc::now() + Duration::minutes(5);
-        }
+        });
         // Publish the newer live summary into the global index, then restore
         // the older authoritative files to model a delayed transcript snapshot.
         // Succeeded replay must repair identity/path without regressing either

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/discoverable_tools.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/discoverable_tools.rs
@@ -86,7 +86,7 @@ pub async fn activate_discoverable_tools(
 
     state.sessions.insert(
         session_id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
     );
 
     let activated = bamboo_tools::exposure::activated_discoverable_tools(&session);
@@ -133,7 +133,7 @@ pub async fn deactivate_discoverable_tools(
 
     state.sessions.insert(
         session_id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
     );
 
     let activated = bamboo_tools::exposure::activated_discoverable_tools(&session);

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -498,7 +498,7 @@ pub async fn patch_session(
                 })?;
             state.sessions.insert(
                 session_id.clone(),
-                std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+                std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
             );
             if let Some(workspace) = session
                 .workspace_path_meta()
@@ -755,7 +755,7 @@ pub async fn patch_session(
             })?;
         state.sessions.insert(
             session_id.clone(),
-            std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
         );
         drop(guard);
 
@@ -1402,7 +1402,7 @@ mod tests {
             .expect("seed session");
         state.sessions.insert(
             session_id.to_string(),
-            std::sync::Arc::new(parking_lot::RwLock::new(session)),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
         );
     }
 
@@ -1577,7 +1577,7 @@ mod tests {
             .expect("persist session");
         state.sessions.insert(
             session.id.clone(),
-            std::sync::Arc::new(parking_lot::RwLock::new(session)),
+            std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
         );
         let app = test::init_service(
             App::new()

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
@@ -57,7 +57,7 @@ pub async fn clear_session(
         })?;
     state.sessions.insert(
         session_id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(cleared_session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(cleared_session)),
     );
 
     // Publish onto the account change feed so other clients drop their cached

--- a/crates/app/bamboo-server/src/handlers/command/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/command/tests.rs
@@ -366,7 +366,7 @@ async fn project_command_is_listed_and_namespace_route_expands_arguments() {
     session.set_workspace_path_meta(project.path().to_string_lossy().to_string());
     app_state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let app = actix_web::test::init_service(
         actix_web::App::new()
@@ -421,7 +421,7 @@ async fn assigned_project_commands_use_workspace_overlay_then_project_source() {
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
     app_state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let app = actix_web::test::init_service(
         actix_web::App::new()
@@ -545,7 +545,7 @@ async fn production_command_routes_apply_workspace_over_project_over_global_prec
         .expect("persist session");
     app_state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let app = actix_web::test::init_service(
         actix_web::App::new()
@@ -630,7 +630,7 @@ async fn assigned_project_cannot_read_another_projects_workspace_commands() {
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
     app_state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
 
     let app = actix_web::test::init_service(

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -205,7 +205,7 @@ async fn workflow_catalog_session_without_workspace_uses_global_snapshot() {
     let session = bamboo_agent_core::Session::new("global-session", "test-model");
     state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let app = actix_web::test::init_service(actix_web::App::new().app_data(state).route(
         "/catalog",
@@ -379,7 +379,7 @@ async fn project_builtin_clone_uses_durable_session_project_authority() {
         .expect("persist Project Session");
     state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let project_home = state.project_store.paths().project_home(&project.id);
     let store = state
@@ -521,7 +521,7 @@ async fn assigned_project_workflow_catalog_reports_workspace_then_project_source
     session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
     state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let app = actix_web::test::init_service(actix_web::App::new().app_data(state).route(
         "/catalog",
@@ -591,7 +591,7 @@ async fn assigned_project_cannot_read_another_projects_workspace_workflows() {
         .expect("persist cross-Project Session");
     state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
 
     let app = actix_web::test::init_service(
@@ -686,7 +686,7 @@ async fn project_legacy_workflow_migration_is_exact_non_destructive_and_idempote
         .expect("persist migration Session");
     state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let app = actix_web::test::init_service(
         actix_web::App::new()
@@ -932,7 +932,7 @@ async fn global_legacy_workflow_migrates_into_canonical_user_skills() {
         .expect("persist migration Session");
     state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
     );
     let app = actix_web::test::init_service(
         actix_web::App::new()
@@ -1221,7 +1221,7 @@ async fn global_workflow_create_update_delete_is_immediate_in_cached_session_vie
     workspace_session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
     state.sessions.insert(
         workspace_session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(workspace_session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(workspace_session)),
     );
     let mut project_session =
         bamboo_agent_core::Session::new("project-cache-session", "test-model");
@@ -1229,7 +1229,7 @@ async fn global_workflow_create_update_delete_is_immediate_in_cached_session_vie
     project_session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
     state.sessions.insert(
         project_session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(project_session)),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(project_session)),
     );
     let app = actix_web::test::init_service(
         actix_web::App::new()

--- a/crates/app/bamboo-server/src/handlers/skill/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/skill/tests.rs
@@ -329,7 +329,7 @@ async fn filtered_tools_rejects_runner_marker_when_pinned_snapshot_is_missing() 
     );
     app_state.sessions.insert(
         session.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
     );
     app_state.save_session(&mut session).await;
 
@@ -364,7 +364,7 @@ async fn filtered_tools_rejects_runner_marker_when_pinned_snapshot_is_missing() 
     );
     app_state.sessions.insert(
         mismatched.id.clone(),
-        std::sync::Arc::new(parking_lot::RwLock::new(mismatched.clone())),
+        std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(mismatched.clone())),
     );
     app_state.save_session(&mut mismatched).await;
     let mismatch_error = super::get_filtered_tools(

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -449,7 +449,7 @@ async fn run_schedule_job(
     }
     ctx.sessions_cache.insert(
         session_id.clone(),
-        Arc::new(parking_lot::RwLock::new(session.clone())),
+        Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
     );
 
     if let Some(reason) = prompt_hook_block {

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -116,7 +116,7 @@ impl ChildSessionAdapter {
         })?;
         self.sessions_cache.insert(
             child.id.clone(),
-            Arc::new(parking_lot::RwLock::new(child.clone())),
+            Arc::new(bamboo_engine::SessionSnapshot::new(child.clone())),
         );
         Ok(())
     }
@@ -383,7 +383,7 @@ impl ChildSessionAdapter {
             })?;
         self.sessions_cache.insert(
             parent.id.clone(),
-            Arc::new(parking_lot::RwLock::new(parent)),
+            Arc::new(bamboo_engine::SessionSnapshot::new(parent)),
         );
 
         Ok(())
@@ -659,7 +659,7 @@ impl ChildSessionPort for ChildSessionAdapter {
                 |latest| {
                     self.sessions_cache.insert(
                         latest.id.clone(),
-                        Arc::new(parking_lot::RwLock::new(latest.clone())),
+                        Arc::new(bamboo_engine::SessionSnapshot::new(latest.clone())),
                     );
                 },
             )

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -215,7 +215,7 @@ async fn build_test_harness_with_options(
     let metrics_storage = Arc::new(SqliteMetricsStorage::new(bamboo_home.join("metrics.db")));
     let metrics_collector = MetricsCollector::spawn(metrics_storage, 7);
 
-    let sessions_cache: bamboo_engine::SessionCache = Arc::new(dashmap::DashMap::new());
+    let sessions_cache: bamboo_engine::SessionCache = Arc::default();
     let agent_runners = Arc::new(RwLock::new(HashMap::new()));
     let session_event_senders = Arc::new(RwLock::new(HashMap::<
         String,

--- a/crates/app/bamboo-server/src/workflow/run.rs
+++ b/crates/app/bamboo-server/src/workflow/run.rs
@@ -1377,7 +1377,7 @@ mod tests {
         let persistence = Arc::new(bamboo_storage::LockedSessionStore::new(
             storage_port.clone(),
         ));
-        let cache = Arc::new(dashmap::DashMap::new());
+        let cache = Arc::default();
         let repo = bamboo_engine::SessionRepository::new(cache, storage_port, persistence);
         let access = WorkflowRunAccess::new(directory.path(), tools, skills, repo.clone())
             .await
@@ -1913,7 +1913,7 @@ mod tests {
 
         let storage_port: Arc<dyn Storage> = storage;
         let reopened_repo = bamboo_engine::SessionRepository::new(
-            Arc::new(dashmap::DashMap::new()),
+            Arc::default(),
             storage_port.clone(),
             Arc::new(bamboo_storage::LockedSessionStore::new(storage_port)),
         );

--- a/crates/engine/bamboo-engine/Cargo.toml
+++ b/crates/engine/bamboo-engine/Cargo.toml
@@ -39,6 +39,8 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 regex = "1"
 dashmap = "6"
+arc-swap = "1.9"
+crossbeam-skiplist = "0.1.3"
 parking_lot = "0.12"
 fs2 = "0.4"
 base64 = "0.23"

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -19,6 +19,8 @@ pub mod runtime;
 pub mod sdk;
 pub mod session_activation;
 pub mod session_app;
+pub mod session_cache;
+pub use session_cache::SessionSnapshot;
 pub mod session_messaging;
 pub mod session_repository;
 pub use session_repository::SessionRepository;

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -34,16 +34,7 @@ use crate::session_activation::{
     SessionActivationRouter, SessionRunRegistration, SessionRunRegistrationError,
 };
 
-/// Shared, per-session-locked session cache.
-///
-/// A `DashMap` gives each session id its own shard-level lock (so unrelated
-/// sessions never contend), and the inner `parking_lot::RwLock` is a *sync*
-/// lock held only to briefly clone-out or mutate-and-write-back a single
-/// `Session` — never across an `.await`. Using a sync lock makes "no guard
-/// across await" a compile-time guarantee in Send futures.
-pub type SessionCache = std::sync::Arc<
-    dashmap::DashMap<String, std::sync::Arc<parking_lot::RwLock<bamboo_agent_core::Session>>>,
->;
+pub use crate::session_cache::SessionCache;
 
 enum SessionExecutionActivationOwnership {
     /// This runtime was built without a SessionInbox activation router.
@@ -434,8 +425,8 @@ pub async fn reserve_session_execution(
     SessionExecutionReserveOutcome::Reserved(execution_reservation)
 }
 
-/// Read a session out of the in-memory cache, cloning it out from under the
-/// brief sync read-lock. Returns `None` on a cache miss.
+/// Read a consistent session snapshot without acquiring a session or index
+/// lock. Returns `None` on a cache miss.
 ///
 /// This is the single canonical cache-read used everywhere a caller holds a
 /// `SessionCache` (HTTP handlers, server tools, the app-state loader). It
@@ -1024,7 +1015,7 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
             // Update memory cache.
             sessions_cache.insert(
                 session_id.clone(),
-                Arc::new(parking_lot::RwLock::new(session)),
+                Arc::new(crate::SessionSnapshot::new(session)),
             );
 
             if let (Some(handler), Some(parent_session_id), Some(status)) =

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
@@ -836,10 +836,11 @@ async fn child_task_control_planes_reload_without_rewriting_history_or_unrelated
         .expect("backfill child cache");
     {
         let cached_root = repository.cache().get("reload-root").expect("cached root");
-        cached_root
-            .write()
-            .metadata
-            .insert("cache.concurrent".to_string(), "preserve".to_string());
+        cached_root.update(|session| {
+            session
+                .metadata
+                .insert("cache.concurrent".to_string(), "preserve".to_string());
+        });
     }
 
     let mut live_child = durable_child.clone();

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -297,7 +297,7 @@ async fn run_child_spawn_inner(
             .await;
         ctx.sessions_cache.insert(
             job.child_session_id.clone(),
-            Arc::new(parking_lot::RwLock::new(session)),
+            Arc::new(crate::SessionSnapshot::new(session)),
         );
         publish_child_completion_parts(
             &parent_event_publisher,
@@ -702,7 +702,7 @@ async fn run_child_spawn_inner(
         }
         sessions_cache.insert(
             session_id_clone.clone(),
-            Arc::new(parking_lot::RwLock::new(session)),
+            Arc::new(crate::SessionSnapshot::new(session)),
         );
 
         // Stop forwarding/heartbeats and emit terminal child status through the

--- a/crates/engine/bamboo-engine/src/sdk/tests.rs
+++ b/crates/engine/bamboo-engine/src/sdk/tests.rs
@@ -414,7 +414,7 @@ async fn build_harness(
     ));
     let metrics_collector = MetricsCollector::spawn(metrics_storage, 7);
 
-    let sessions_cache: crate::SessionCache = Arc::new(dashmap::DashMap::new());
+    let sessions_cache: crate::SessionCache = Arc::default();
     let agent_runners = Arc::new(RwLock::new(HashMap::new()));
     let session_event_senders = Arc::new(RwLock::new(HashMap::<
         String,
@@ -564,7 +564,7 @@ async fn build_terminal_delivery_harness(
             .expect("delivery test agent"),
     );
 
-    let sessions_cache: crate::SessionCache = Arc::new(dashmap::DashMap::new());
+    let sessions_cache: crate::SessionCache = Arc::default();
     let agent_runners = Arc::new(RwLock::new(HashMap::new()));
     let session_event_senders = Arc::new(RwLock::new(HashMap::<
         String,
@@ -1069,7 +1069,7 @@ async fn activation_already_running_never_replaces_live_session_cache_arc() {
     let mut live = Session::new(&harness.parent_session_id, "live-cache-model");
     live.metadata
         .insert("cache_owner".to_string(), "manual-run".to_string());
-    let live_arc = Arc::new(parking_lot::RwLock::new(live));
+    let live_arc = Arc::new(crate::SessionSnapshot::new(live));
     harness
         .ctx
         .sessions_cache
@@ -1169,7 +1169,8 @@ async fn direct_registration_waits_for_activation_without_creating_a_phantom_own
     let mut live = Session::new(&harness.parent_session_id, "manual-owner-model");
     live.metadata
         .insert("cache_owner".to_string(), "manual-router-owner".to_string());
-    let live_arc = Arc::new(parking_lot::RwLock::new(live));
+    let live_arc = Arc::new(crate::SessionSnapshot::new(live));
+    let before_commit = live_arc.read();
     harness
         .ctx
         .sessions_cache
@@ -1205,8 +1206,9 @@ async fn direct_registration_waits_for_activation_without_creating_a_phantom_own
         .unwrap()
         .value()
         .clone();
-    assert!(
-        Arc::ptr_eq(&cached_before_launch, &live_arc),
+    assert_eq!(
+        cached_before_launch.read().metadata.get("cache_owner"),
+        before_commit.metadata.get("cache_owner"),
         "prepared activation cache must remain unpublished before router ownership commits"
     );
 
@@ -1264,9 +1266,9 @@ async fn direct_registration_waits_for_activation_without_creating_a_phantom_own
         .unwrap()
         .value()
         .clone();
-    assert!(
-        !Arc::ptr_eq(&cached, &live_arc),
-        "the winning activation publishes its prepared snapshot only after owner commit"
+    assert_eq!(
+        before_commit.metadata["cache_owner"], "manual-router-owner",
+        "a reader retained across owner commit must keep its original snapshot"
     );
     assert!(
         !cached.read().metadata.contains_key("cache_owner"),

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -593,7 +593,7 @@ impl ChildCompletionCoordinator {
         }
         self.sessions.insert(
             session.id.clone(),
-            Arc::new(parking_lot::RwLock::new(session.clone())),
+            Arc::new(crate::SessionSnapshot::new(session.clone())),
         );
     }
 }
@@ -881,7 +881,7 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
         }
         self.sessions.insert(
             parent.id.clone(),
-            Arc::new(parking_lot::RwLock::new(parent.clone())),
+            Arc::new(crate::SessionSnapshot::new(parent.clone())),
         );
 
         // Capture before releasing the per-parent lock so the borrow checker
@@ -1370,7 +1370,7 @@ impl SessionActivationSpawner for ChildCompletionCoordinator {
                         // replace the shared cache entry.
                         launch_sessions.insert(
                             launch_session_id,
-                            Arc::new(parking_lot::RwLock::new(launch_session)),
+                            Arc::new(crate::SessionSnapshot::new(launch_session)),
                         );
                         let request = ResumeSpawnRequest {
                             session_id: request_session_id,
@@ -1436,7 +1436,7 @@ impl SessionActivationSpawner for ChildCompletionCoordinator {
                         // snapshot only after router ownership commits.
                         launch_sessions.insert(
                             launch_session_id,
-                            Arc::new(parking_lot::RwLock::new(launch_session)),
+                            Arc::new(crate::SessionSnapshot::new(launch_session)),
                         );
                         // Dropping a JoinHandle detaches the task. The captured
                         // combined reservation remains RAII-protected if the
@@ -2065,7 +2065,7 @@ impl ChildCompletionCoordinator {
             }
             self.sessions.insert(
                 resumable.id.clone(),
-                Arc::new(parking_lot::RwLock::new(resumable)),
+                Arc::new(crate::SessionSnapshot::new(resumable)),
             );
         }
 
@@ -2663,8 +2663,10 @@ impl ChildCompletionCoordinator {
                         "child-wait watchdog: failed to persist synthesized terminal status"
                     );
                 }
-                self.sessions
-                    .insert(child.id.clone(), Arc::new(parking_lot::RwLock::new(child)));
+                self.sessions.insert(
+                    child.id.clone(),
+                    Arc::new(crate::SessionSnapshot::new(child)),
+                );
             }
             Ok(None) => {}
             Err(load_error) => {
@@ -2935,7 +2937,7 @@ mod tests {
         let coordinator = Arc::new(ChildCompletionCoordinator::new(
             storage,
             locked,
-            Arc::new(dashmap::DashMap::new()),
+            Arc::default(),
             Arc::new(RwLock::new(HashMap::new())),
             Arc::new(RwLock::new(HashMap::new())),
             agent,

--- a/crates/engine/bamboo-engine/src/session_app/metadata/mod.rs
+++ b/crates/engine/bamboo-engine/src/session_app/metadata/mod.rs
@@ -304,6 +304,6 @@ async fn refresh_in_memory_cache(
 ) {
     state.sessions().insert(
         session_id.to_string(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+        std::sync::Arc::new(crate::SessionSnapshot::new(session)),
     );
 }

--- a/crates/engine/bamboo-engine/src/session_app/repository.rs
+++ b/crates/engine/bamboo-engine/src/session_app/repository.rs
@@ -137,7 +137,7 @@ impl SessionAccess for SessionRepository {
                 move |saved| {
                     publish_cache.insert(
                         saved.id.clone(),
-                        std::sync::Arc::new(parking_lot::RwLock::new(saved.clone())),
+                        std::sync::Arc::new(crate::SessionSnapshot::new(saved.clone())),
                     );
                 },
             )

--- a/crates/engine/bamboo-engine/src/session_cache.rs
+++ b/crates/engine/bamboo-engine/src/session_cache.rs
@@ -1,0 +1,229 @@
+//! Lock-free session snapshots. Durable read/modify/write transactions remain
+//! the responsibility of SessionRepository; readers never join their queue.
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use bamboo_agent_core::Session;
+use crossbeam_skiplist::SkipMap;
+
+pub type SessionCache = Arc<SessionCacheMap>;
+
+/// An immutable version can remain in use while a writer publishes its successor.
+pub struct SessionSnapshot(ArcSwap<Session>);
+
+impl SessionSnapshot {
+    pub fn new(session: Session) -> Self {
+        Self(ArcSwap::from_pointee(session))
+    }
+
+    pub fn read(&self) -> SessionRead {
+        SessionRead(self.0.load_full())
+    }
+
+    /// Apply a narrow patch to the latest version. The closure may be retried
+    /// after a concurrent publication, so it must have no external side effects.
+    pub fn update(&self, mutate: impl Fn(&mut Session)) {
+        self.0.rcu(|current| {
+            let mut next = (**current).clone();
+            mutate(&mut next);
+            next
+        });
+    }
+}
+
+/// Deliberately does not implement Clone: `read().clone()` clones the Session,
+/// preserving the existing detached-snapshot read contract.
+pub struct SessionRead(Arc<Session>);
+
+impl Deref for SessionRead {
+    type Target = Session;
+    fn deref(&self) -> &Session {
+        &self.0
+    }
+}
+
+/// Both the index and the values use atomic publication. Unlike a DashMap
+/// guard, a returned entry does not hold a shard lock while cloning a transcript.
+#[derive(Default)]
+pub struct SessionCacheMap {
+    entries: SkipMap<String, Arc<SessionSnapshot>>,
+}
+
+pub struct SessionCacheEntry {
+    key: String,
+    value: Arc<SessionSnapshot>,
+}
+
+impl SessionCacheEntry {
+    pub fn key(&self) -> &String {
+        &self.key
+    }
+    pub fn value(&self) -> &Arc<SessionSnapshot> {
+        &self.value
+    }
+}
+
+impl Deref for SessionCacheEntry {
+    type Target = Arc<SessionSnapshot>;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl SessionCacheMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, id: String, snapshot: Arc<SessionSnapshot>) {
+        // Keep the slot stable until eviction. A concurrent narrow update must
+        // retry against this publication, not succeed on an orphaned old Arc.
+        let entry = self.entries.get_or_insert(id, snapshot.clone());
+        if !Arc::ptr_eq(entry.value(), &snapshot) {
+            entry.value().0.store(snapshot.0.load_full());
+        }
+    }
+
+    pub fn get(&self, id: &str) -> Option<SessionCacheEntry> {
+        self.entries.get(id).map(|entry| SessionCacheEntry {
+            key: entry.key().clone(),
+            value: entry.value().clone(),
+        })
+    }
+
+    pub fn remove(&self, id: &str) -> Option<(String, Arc<SessionSnapshot>)> {
+        self.entries
+            .remove(id)
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = SessionCacheEntry> + '_ {
+        self.entries.iter().map(|entry| SessionCacheEntry {
+            key: entry.key().clone(),
+            value: entry.value().clone(),
+        })
+    }
+
+    pub fn contains_key(&self, id: &str) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn clear(&self) {
+        self.entries.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retained_reader_does_not_block_publication_or_change_its_version() {
+        let snapshot = SessionSnapshot::new(Session::new("s", "model"));
+        let previous = snapshot.read();
+        snapshot.update(|session| {
+            session.metadata.insert("committed".into(), "yes".into());
+        });
+        assert!(!previous.metadata.contains_key("committed"));
+        assert_eq!(snapshot.read().metadata["committed"], "yes");
+    }
+
+    #[test]
+    fn concurrent_narrow_updates_preserve_every_writer() {
+        let snapshot = SessionSnapshot::new(Session::new("shared-root", "model"));
+        std::thread::scope(|scope| {
+            for worker in 0..16 {
+                let snapshot = &snapshot;
+                scope.spawn(move || {
+                    for item in 0..32 {
+                        snapshot.update(|session| {
+                            session
+                                .metadata
+                                .insert(format!("{worker}/{item}"), "yes".into());
+                        });
+                    }
+                });
+            }
+        });
+        assert_eq!(snapshot.read().metadata.len(), 512);
+    }
+
+    #[test]
+    fn narrow_update_retries_when_full_snapshot_is_published_to_same_slot() {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Barrier,
+        };
+        let cache = SessionCacheMap::new();
+        cache.insert(
+            "root".into(),
+            Arc::new(SessionSnapshot::new(Session::new("root", "old"))),
+        );
+        let entered = Barrier::new(2);
+        let release = Barrier::new(2);
+        std::thread::scope(|scope| {
+            let updater = scope.spawn(|| {
+                let first = AtomicBool::new(true);
+                cache.get("root").unwrap().update(|session| {
+                    // Deterministic test seam: stop only the first CAS attempt.
+                    if first.swap(false, Ordering::SeqCst) {
+                        entered.wait();
+                        release.wait();
+                    }
+                    session
+                        .metadata
+                        .insert("narrow-patch".into(), "kept".into());
+                });
+            });
+            entered.wait();
+            cache.insert(
+                "root".into(),
+                Arc::new(SessionSnapshot::new(Session::new("root", "new"))),
+            );
+            release.wait();
+            updater.join().unwrap();
+        });
+        let actual = cache.get("root").unwrap().read();
+        assert_eq!(actual.model, "new");
+        assert_eq!(actual.metadata["narrow-patch"], "kept");
+    }
+
+    #[test]
+    fn hundreds_of_independent_sessions_publish_and_remove_with_retained_reads() {
+        let cache = SessionCacheMap::new();
+        std::thread::scope(|scope| {
+            for worker in 0..16 {
+                let cache = &cache;
+                scope.spawn(move || {
+                    for item in 0..32 {
+                        let id = format!("child-{worker}-{item}");
+                        cache.insert(
+                            id.clone(),
+                            Arc::new(SessionSnapshot::new(Session::new(&id, "m"))),
+                        );
+                        let held = cache.get(&id).unwrap();
+                        let old = held.read();
+                        held.update(|session| {
+                            session.metadata.insert("done".into(), "yes".into());
+                        });
+                        assert_eq!(cache.get(&id).unwrap().read().metadata["done"], "yes");
+                        cache.remove(&id).unwrap();
+                        assert!(cache.get(&id).is_none());
+                        assert!(!old.metadata.contains_key("done"));
+                    }
+                });
+            }
+        });
+        assert!(cache.is_empty());
+    }
+}

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -93,7 +93,7 @@ impl SessionRepository {
             Ok(Some(session)) => {
                 self.cache.insert(
                     session_id.to_string(),
-                    Arc::new(parking_lot::RwLock::new(session.clone())),
+                    Arc::new(crate::SessionSnapshot::new(session.clone())),
                 );
                 Some(session)
             }
@@ -120,7 +120,7 @@ impl SessionRepository {
         if let Some(ref session) = loaded {
             self.cache.insert(
                 session_id.to_string(),
-                Arc::new(parking_lot::RwLock::new(session.clone())),
+                Arc::new(crate::SessionSnapshot::new(session.clone())),
             );
         }
         Ok(loaded)
@@ -137,7 +137,7 @@ impl SessionRepository {
                     self.run_post_durable_hook("save_full", &saved.id);
                     self.cache.insert(
                         saved.id.clone(),
-                        Arc::new(parking_lot::RwLock::new(saved.clone())),
+                        Arc::new(crate::SessionSnapshot::new(saved.clone())),
                     );
                 }
             })
@@ -159,14 +159,15 @@ impl SessionRepository {
         self.persistence
             .update_runtime_config_and_publish(session_id, mutate, |saved| {
                 if let Some(cached) = self.cache.get(session_id) {
-                    let mut cached = cached.write();
-                    for key in metadata_keys {
-                        if let Some(value) = saved.metadata.get(*key) {
-                            cached.metadata.insert((*key).to_string(), value.clone());
-                        } else {
-                            cached.metadata.remove(*key);
+                    cached.update(|cached| {
+                        for key in metadata_keys {
+                            if let Some(value) = saved.metadata.get(*key) {
+                                cached.metadata.insert((*key).to_string(), value.clone());
+                            } else {
+                                cached.metadata.remove(*key);
+                            }
                         }
-                    }
+                    });
                 }
             })
             .await
@@ -235,7 +236,7 @@ impl SessionRepository {
                 if prefer_storage && chosen.updated_at >= memory_updated_at {
                     self.cache.insert(
                         session_id.to_string(),
-                        Arc::new(parking_lot::RwLock::new(chosen.clone())),
+                        Arc::new(crate::SessionSnapshot::new(chosen.clone())),
                     );
                 }
                 Some(chosen)
@@ -244,7 +245,7 @@ impl SessionRepository {
             (None, Some(storage)) => {
                 self.cache.insert(
                     session_id.to_string(),
-                    Arc::new(parking_lot::RwLock::new(storage.clone())),
+                    Arc::new(crate::SessionSnapshot::new(storage.clone())),
                 );
                 Some(storage)
             }
@@ -279,7 +280,7 @@ impl SessionRepository {
                 self.run_post_durable_hook("save_and_cache", &saved.id);
                 self.cache.insert(
                     saved.id.clone(),
-                    Arc::new(parking_lot::RwLock::new(saved.clone())),
+                    Arc::new(crate::SessionSnapshot::new(saved.clone())),
                 );
             })
             .await;
@@ -292,7 +293,7 @@ impl SessionRepository {
         match self.storage.load_runtime_control_plane(session_id).await {
             Ok(Some(durable)) => {
                 if let Some(cached) = self.cache.get(session_id) {
-                    adopt_task_control_plane(&mut cached.write(), &durable);
+                    cached.update(|cached| adopt_task_control_plane(cached, &durable));
                 }
             }
             Ok(None) => {}
@@ -356,7 +357,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 self.run_post_durable_hook("save_runtime_session", &saved.id);
                 self.cache.insert(
                     saved.id.clone(),
-                    Arc::new(parking_lot::RwLock::new(saved.clone())),
+                    Arc::new(crate::SessionSnapshot::new(saved.clone())),
                 );
             })
             .await
@@ -370,7 +371,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 if committed {
                     self.cache.insert(
                         saved.id.clone(),
-                        Arc::new(parking_lot::RwLock::new(saved.clone())),
+                        Arc::new(crate::SessionSnapshot::new(saved.clone())),
                     );
                 }
             })
@@ -393,7 +394,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                     self.run_post_durable_hook("permission_posture_activation", &saved.id);
                     self.cache.insert(
                         saved.id.clone(),
-                        Arc::new(parking_lot::RwLock::new(saved.clone())),
+                        Arc::new(crate::SessionSnapshot::new(saved.clone())),
                     );
                 },
             )
@@ -414,25 +415,26 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 // persistence and is therefore preserved alongside the cached
                 // messages, matching the V2 sidecar overlay contract.
                 if let Some(cached) = self.cache.get(&saved.id) {
-                    let mut cached = cached.write();
-                    let messages = cached.messages.clone();
-                    let provider_transcript = cached.provider_transcript.clone();
-                    let admission = cached
-                        .runtime_metadata
-                        .as_ref()
-                        .and_then(|metadata| metadata.session_inbox_admission.clone());
-                    let mut refreshed = saved.clone();
-                    refreshed.messages = messages;
-                    refreshed.provider_transcript = provider_transcript;
-                    if let Some(admission) = admission {
-                        refreshed
+                    cached.update(|cached| {
+                        let messages = cached.messages.clone();
+                        let provider_transcript = cached.provider_transcript.clone();
+                        let admission = cached
                             .runtime_metadata
-                            .get_or_insert_with(Default::default)
-                            .session_inbox_admission = Some(admission);
-                    } else if let Some(metadata) = refreshed.runtime_metadata.as_mut() {
-                        metadata.session_inbox_admission = None;
-                    }
-                    *cached = refreshed;
+                            .as_ref()
+                            .and_then(|metadata| metadata.session_inbox_admission.clone());
+                        let mut refreshed = saved.clone();
+                        refreshed.messages = messages;
+                        refreshed.provider_transcript = provider_transcript;
+                        if let Some(admission) = admission {
+                            refreshed
+                                .runtime_metadata
+                                .get_or_insert_with(Default::default)
+                                .session_inbox_admission = Some(admission);
+                        } else if let Some(metadata) = refreshed.runtime_metadata.as_mut() {
+                            metadata.session_inbox_admission = None;
+                        }
+                        *cached = refreshed;
+                    });
                 }
             })
             .await
@@ -467,9 +469,10 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 // in memory cannot be replaced by a stale whole-control-
                 // plane snapshot.
                 if let Some(cached) = self.cache.get(session_id) {
-                    let mut cached = cached.write();
-                    cached.set_task_list(task_list.clone());
-                    cached.set_task_list_version_meta(version.to_string());
+                    cached.update(|cached| {
+                        cached.set_task_list(task_list.clone());
+                        cached.set_task_list_version_meta(version.to_string());
+                    });
                 }
             })
             .await;
@@ -503,9 +506,10 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 version,
                 |_| {
                     if let Some(cached) = self.cache.get(session_id) {
-                        let mut cached = cached.write();
-                        cached.set_task_list(task_list.clone());
-                        cached.set_task_list_version_meta(version.to_string());
+                        cached.update(|cached| {
+                            cached.set_task_list(task_list.clone());
+                            cached.set_task_list_version_meta(version.to_string());
+                        });
                     }
                 },
             )
@@ -532,9 +536,10 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 |_, _| {
                     for id in [session_id, shared_session_id] {
                         if let Some(cached) = self.cache.get(id) {
-                            let mut cached = cached.write();
-                            cached.set_task_list(task_list.clone());
-                            cached.set_task_list_version_meta(version.to_string());
+                            cached.update(|cached| {
+                                cached.set_task_list(task_list.clone());
+                                cached.set_task_list_version_meta(version.to_string());
+                            });
                         }
                     }
                 },
@@ -556,7 +561,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 if committed {
                     self.cache.insert(
                         saved.id.clone(),
-                        Arc::new(parking_lot::RwLock::new(saved.clone())),
+                        Arc::new(crate::SessionSnapshot::new(saved.clone())),
                     );
                 }
             })
@@ -582,7 +587,7 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                 self.run_post_durable_hook("clear_legacy", session_id);
                 self.cache.insert(
                     session_id.to_string(),
-                    Arc::new(parking_lot::RwLock::new(latest.clone())),
+                    Arc::new(crate::SessionSnapshot::new(latest.clone())),
                 );
             })
             .await
@@ -708,7 +713,7 @@ mod tests {
     }
 
     fn test_repo(storage: Arc<dyn Storage>) -> SessionRepository {
-        let cache: SessionCache = Arc::new(dashmap::DashMap::new());
+        let cache: SessionCache = Arc::default();
         let persistence = Arc::new(LockedSessionStore::new(storage.clone()));
         SessionRepository::new(cache, storage, persistence)
     }
@@ -716,7 +721,7 @@ mod tests {
     fn cache_put(repo: &SessionRepository, session: &Session) {
         repo.cache().insert(
             session.id.clone(),
-            Arc::new(parking_lot::RwLock::new(session.clone())),
+            Arc::new(crate::SessionSnapshot::new(session.clone())),
         );
     }
 

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -595,7 +595,7 @@ impl BambooRuntimeExecutor {
         // read_skill_resource) over its synced skills_dir, so it can pull a
         // skill's full SKILL.md — not just see the description. The orchestrator's
         // root surface has these; the worker previously only had the builtin set.
-        let worker_sessions: bamboo_engine::SessionCache = Arc::new(dashmap::DashMap::new());
+        let worker_sessions: bamboo_engine::SessionCache = Arc::default();
         let worker_runners = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
         let worker_event_senders =
             Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));

--- a/tests/schedule_tasks_tool.rs
+++ b/tests/schedule_tasks_tool.rs
@@ -199,7 +199,7 @@ fn build_manager(
         persistence: Arc::new(bamboo_storage::LockedSessionStore::new(store.clone())),
         tools: Arc::new(NoopTools),
         permission_config: None,
-        sessions_cache: Arc::new(dashmap::DashMap::new()),
+        sessions_cache: Arc::default(),
         agent_runners: Arc::new(RwLock::new(HashMap::<String, AgentRunner>::new())),
         session_event_senders: Arc::new(RwLock::new(HashMap::<
             String,


### PR DESCRIPTION
## Summary
Session reads currently hold a DashMap shard guard and a per-session RwLock while cloning transcripts, so a busy or long session can delay unrelated readers and writers. Replace the cache index with a concurrent skip-list and publish immutable Session versions through atomic snapshots. A retained read stays coherent while a writer publishes its successor; narrow metadata patches retry against concurrent full publications.

This is the cache slice of #1044. Durable storage transactions and task-generation fences retain their existing coordination. The follow-up event/lifecycle and worker-transport slices are tracked separately in #1046 and #1047.

Closes #1045.

## Test Plan
- Deterministic retained-reader and full-publication/CAS retry tests.
- 512 concurrent metadata patches and 512 independent session publication/removal fixtures.
- Existing SDK activation and repository tests migrated to the immutable snapshot contract.
- Full locked Cargo metadata resolution passed; local affected suites and independent review are in progress. Merge remains gated on exact-head CI and review completion.
