### PR TITLE
fix: isolate live session events and reclaim idle children (#1046)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -525,7 +525,13 @@ impl AppState {
         // Idle-evict completed runners together with their paired session event
         // senders (issue #346). Spawned here (not next to `agent_runners`) so it
         // owns handles to both maps.
-        spawn_session_map_cleanup_task(agent_runners.clone(), session_event_senders.clone(), None);
+        spawn_session_map_cleanup_task(
+            agent_runners.clone(),
+            session_event_senders.clone(),
+            session_watchers.clone(),
+            sessions.clone(),
+            None,
+        );
 
         // Bridge both instruction and orchestration catalog transitions onto
         // the same durable account feed used by SSE and v2 WebSocket clients.

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -405,9 +405,10 @@ pub(crate) fn evict_idle_session_entries(
 /// Spawn a background task that idle-evicts completed agent runners **and their
 /// paired session event senders** after [`SESSION_MAP_IDLE_TTL_SECS`].
 ///
-/// Fire-and-forget (runs for the process lifetime), matching the other
-/// background maintenance tickers. See [`evict_idle_session_entries`] for the
-/// eviction predicate and its race-freedom argument.
+/// Detached maintenance holds only weak map/cache references between sweeps,
+/// so releasing the server or worker executor also releases its resources.
+/// The task exits on the next tick after an owner disappears. See
+/// [`evict_idle_session_entries`] for the eviction predicate and ordering.
 pub fn spawn_session_map_cleanup_task(
     runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
     senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
@@ -415,9 +416,17 @@ pub fn spawn_session_map_cleanup_task(
     sessions: bamboo_engine::SessionCache,
     log_prefix: Option<&'static str>,
 ) {
+    let runners = Arc::downgrade(&runners);
+    let senders = Arc::downgrade(&senders);
+    let sessions = Arc::downgrade(&sessions);
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(Duration::from_secs(60)).await;
+            let (Some(runners), Some(senders), Some(sessions)) =
+                (runners.upgrade(), senders.upgrade(), sessions.upgrade())
+            else {
+                break;
+            };
 
             // Lock order: runners ⊃ senders. This matches `reserve_runner_core`
             // (which nests senders inside the runners write lock to re-assert the
@@ -713,6 +722,29 @@ mod eviction_tests {
     use chrono::Duration as ChronoDuration;
 
     const TTL: i64 = SESSION_MAP_IDLE_TTL_SECS;
+
+    #[tokio::test]
+    async fn sleeping_cleanup_does_not_retain_released_worker_maps_or_transcripts() {
+        let runners = Arc::new(RwLock::new(HashMap::new()));
+        let senders = Arc::new(RwLock::new(HashMap::new()));
+        let sessions = bamboo_engine::SessionCache::default();
+        let weak_runners = Arc::downgrade(&runners);
+        let weak_senders = Arc::downgrade(&senders);
+        let weak_sessions = Arc::downgrade(&sessions);
+        spawn_session_map_cleanup_task(
+            runners.clone(),
+            senders.clone(),
+            super::super::watchers::SessionWatchers::new(),
+            sessions.clone(),
+            Some("released-worker"),
+        );
+        // Let maintenance park at its first tick, as in a warm worker runtime.
+        tokio::task::yield_now().await;
+        drop((runners, senders, sessions));
+        assert!(weak_runners.upgrade().is_none());
+        assert!(weak_senders.upgrade().is_none());
+        assert!(weak_sessions.upgrade().is_none());
+    }
 
     #[tokio::test]
     async fn failed_admission_channel_obeys_ttl_and_live_subscriber_retention() {

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -309,20 +309,12 @@ pub(crate) const SESSION_MAP_IDLE_TTL_SECS: i64 = 300;
 /// Single idle-eviction pass over the per-session runner + event-sender maps.
 ///
 /// Drops a `(agent_runners, session_event_senders)` pair together when the
-/// runner is terminal, older than `ttl_secs`, and its broadcast channel has **no
-/// live receivers**. Returns the number of runners evicted.
-///
-/// # Why `receiver_count() == 0` is required
-///
-/// A runner's `event_sender` is a clone of the session's long-lived sender (see
-/// `reserve_runner` / `try_reserve_runner`), so `receiver_count()` reflects
-/// every SSE/WS subscriber on the session stream. Evicting while a receiver is
-/// live would (a) yank the replay cache out from under a client that just
-/// subscribed after `Complete`, and (b) silently drop a terminal parent whose
-/// still-running children forward events into this stream (that parent keeps a
-/// live subscription). So we only reclaim genuinely-idle terminal sessions —
-/// exactly the ephemeral sub-agent / guardian / scheduled runs that never had a
-/// UI subscription and whose count therefore reaches zero.
+/// runner is terminal, older than `ttl_secs`, and has no external subscribers
+/// or active producer handles. The internal notification relay is classified
+/// by exact channel identity, so its own receiver cannot prevent reclamation.
+/// A live UI receiver retains replay; a sender held by a still-running child's
+/// heartbeat retains its parent stream even after the parent turn finishes.
+/// Returns the number of runners evicted.
 ///
 /// Removing the map's `Sender` (the last clone once the terminal runner's own
 /// clone is dropped by the `retain`) closes the channel, which also lets any
@@ -334,11 +326,13 @@ pub(crate) const SESSION_MAP_IDLE_TTL_SECS: i64 = 300;
 pub(crate) fn evict_idle_session_entries(
     runners: &mut HashMap<String, AgentRunner>,
     senders: &mut HashMap<String, broadcast::Sender<AgentEvent>>,
+    watchers: &super::watchers::SessionWatchers,
+    sessions: &bamboo_engine::SessionCache,
     ttl_secs: i64,
     now: chrono::DateTime<Utc>,
     log_prefix: Option<&'static str>,
 ) -> usize {
-    let mut evicted: Vec<String> = Vec::new();
+    let mut evicted = Vec::new();
 
     runners.retain(|session_id, runner| {
         let keep = match &runner.status {
@@ -347,13 +341,21 @@ pub(crate) fn evict_idle_session_entries(
                 let age =
                     now.signed_duration_since(runner.completed_at.unwrap_or(runner.started_at));
                 let expired = age.num_seconds() >= ttl_secs;
-                let has_receivers = runner.event_sender.receiver_count() > 0;
-                // Keep unless it is BOTH past the TTL AND has no live receiver.
-                !expired || has_receivers
+                let has_receivers =
+                    watchers.has_external_receivers(session_id, &runner.event_sender);
+                let paired_sender = senders
+                    .get(session_id)
+                    .is_some_and(|sender| sender.same_channel(&runner.event_sender));
+                let owned_senders = 1 + usize::from(paired_sender);
+                let has_producers = runner.event_sender.strong_count() > owned_senders;
+                !expired
+                    || has_receivers
+                    || has_producers
+                    || !runner.event_publication.retire_if_idle()
             }
         };
         if !keep {
-            evicted.push(session_id.clone());
+            evicted.push((session_id.clone(), runner.event_sender.downgrade()));
             if let Some(prefix) = log_prefix {
                 tracing::debug!("[{}:{}] Evicting idle terminal runner", prefix, session_id);
             } else {
@@ -363,19 +365,39 @@ pub(crate) fn evict_idle_session_entries(
         keep
     });
 
-    // Drop the paired long-lived sender for each evicted runner, but only if it
-    // too has no live receiver (re-checked here; it is the same channel as the
-    // runner's `event_sender`, so this is normally a formality — a session sender
-    // can, however, outlive its runner, and we must never close a channel a
-    // client is actively reading).
-    for session_id in &evicted {
-        if senders
-            .get(session_id)
-            .is_some_and(|sender| sender.receiver_count() == 0)
-        {
+    // Recheck the paired sender after removing its runner. No external handle
+    // can start a subscription unnoticed: a pre-existing sender clone itself
+    // prevents eviction until its owner releases it.
+    for (session_id, channel) in &evicted {
+        // The durable Session remains authoritative. Drop the bulky completed
+        // transcript under the same runner lock that excludes a live successor.
+        sessions.remove(session_id);
+        if senders.get(session_id).is_some_and(|sender| {
+            channel
+                .upgrade()
+                .is_some_and(|old| old.same_channel(sender))
+                && !watchers.has_external_receivers(session_id, sender)
+                && sender.strong_count() == 1
+        }) {
             senders.remove(session_id);
         }
     }
+
+    // Admission can fail after observer setup but before a runner is reserved.
+    // Such orphan channels have no runner timestamp; their exact relay's start
+    // time supplies the same replay grace period and prevents permanent leaks.
+    senders.retain(|session_id, sender| {
+        let keep = runners.contains_key(session_id)
+            || sender.strong_count() > 1
+            || watchers.has_external_receivers(session_id, sender)
+            || watchers
+                .relay_started_at(session_id, sender)
+                .is_none_or(|started| now.signed_duration_since(started).num_seconds() < ttl_secs);
+        if !keep {
+            sessions.remove(session_id);
+        }
+        keep
+    });
 
     evicted.len()
 }
@@ -389,6 +411,8 @@ pub(crate) fn evict_idle_session_entries(
 pub fn spawn_session_map_cleanup_task(
     runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
     senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
+    watchers: Arc<super::watchers::SessionWatchers>,
+    sessions: bamboo_engine::SessionCache,
     log_prefix: Option<&'static str>,
 ) {
     tokio::spawn(async move {
@@ -414,6 +438,8 @@ pub fn spawn_session_map_cleanup_task(
             let evicted = evict_idle_session_entries(
                 &mut runners_guard,
                 &mut senders_guard,
+                &watchers,
+                &sessions,
                 SESSION_MAP_IDLE_TTL_SECS,
                 now,
                 log_prefix,
@@ -688,6 +714,185 @@ mod eviction_tests {
 
     const TTL: i64 = SESSION_MAP_IDLE_TTL_SECS;
 
+    #[tokio::test]
+    async fn failed_admission_channel_obeys_ttl_and_live_subscriber_retention() {
+        use super::super::session_events::{ensure_notification_relay, NotificationRelayDeps};
+        let dir = tempfile::tempdir().unwrap();
+        let deps = NotificationRelayDeps {
+            notification_service: Arc::new(bamboo_notification::NotificationService::new(
+                dir.path().join("notifications.json"),
+            )),
+            session_event_senders: Arc::new(RwLock::new(HashMap::new())),
+            session_watchers: super::super::watchers::SessionWatchers::new(),
+            config: Arc::new(RwLock::new(Config::default())),
+        };
+        let (sender, _) = broadcast::channel(16);
+        let mut senders = deps.session_event_senders.write().await;
+        senders.insert("failed-child".into(), sender.clone());
+        let ui_receiver = sender.subscribe();
+        ensure_notification_relay(&deps, "failed-child", sender);
+        let cache = bamboo_engine::SessionCache::default();
+        cache.insert(
+            "failed-child".into(),
+            Arc::new(bamboo_engine::SessionSnapshot::new(
+                bamboo_agent_core::Session::new_child("failed-child", "parent", "model", "Child"),
+            )),
+        );
+        let mut runners = HashMap::new();
+        let now = Utc::now();
+        evict_idle_session_entries(
+            &mut runners,
+            &mut senders,
+            &deps.session_watchers,
+            &cache,
+            TTL,
+            now,
+            None,
+        );
+        assert!(
+            senders.contains_key("failed-child"),
+            "new channel retains replay window"
+        );
+        let expired = now + ChronoDuration::seconds(TTL + 1);
+        evict_idle_session_entries(
+            &mut runners,
+            &mut senders,
+            &deps.session_watchers,
+            &cache,
+            TTL,
+            expired,
+            None,
+        );
+        assert!(
+            senders.contains_key("failed-child"),
+            "actual UI receiver retains channel beyond TTL"
+        );
+        assert!(cache.contains_key("failed-child"));
+        drop(ui_receiver);
+        evict_idle_session_entries(
+            &mut runners,
+            &mut senders,
+            &deps.session_watchers,
+            &cache,
+            TTL,
+            expired,
+            None,
+        );
+        assert!(
+            senders.is_empty(),
+            "failed launch channel can be collected without a runner"
+        );
+        assert!(
+            cache.is_empty(),
+            "failed launch transcript leaves cache with its channel"
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_children_with_real_notification_relays_are_reclaimed() {
+        use super::super::session_events::{ensure_notification_relay, NotificationRelayDeps};
+        let dir = tempfile::tempdir().unwrap();
+        let deps = NotificationRelayDeps {
+            notification_service: Arc::new(bamboo_notification::NotificationService::new(
+                dir.path().join("notifications.json"),
+            )),
+            session_event_senders: Arc::new(RwLock::new(HashMap::new())),
+            session_watchers: super::super::watchers::SessionWatchers::new(),
+            config: Arc::new(RwLock::new(Config::default())),
+        };
+        let cache = bamboo_engine::SessionCache::default();
+        let mut runners = HashMap::new();
+        let now = Utc::now();
+        let mut senders = deps.session_event_senders.write().await;
+        for index in 0..512 {
+            let id = format!("completed-child-{index}");
+            let (sender, _) = broadcast::channel(16);
+            runners.insert(id.clone(), terminal_runner(&sender, TTL + 1, now));
+            cache.insert(
+                id.clone(),
+                Arc::new(bamboo_engine::SessionSnapshot::new(
+                    bamboo_agent_core::Session::new_child(&id, "parent", "model", "Child"),
+                )),
+            );
+            senders.insert(id.clone(), sender.clone());
+            ensure_notification_relay(&deps, &id, sender);
+        }
+        // Real relay receivers are present even without any frontend clients.
+        assert!(senders.values().all(|sender| sender.receiver_count() == 1));
+        assert_eq!(
+            evict_idle_session_entries(
+                &mut runners,
+                &mut senders,
+                &deps.session_watchers,
+                &cache,
+                TTL,
+                now,
+                None,
+            ),
+            512,
+        );
+        assert!(runners.is_empty());
+        assert!(
+            cache.is_empty(),
+            "completed child transcripts leave the memory cache"
+        );
+        assert!(senders.is_empty());
+        drop(senders);
+        tokio::time::timeout(Duration::from_secs(3), async {
+            for index in 0..512 {
+                let id = format!("completed-child-{index}");
+                while !deps.notification_service.try_begin_relay(&id) {
+                    tokio::task::yield_now().await;
+                }
+                deps.notification_service.end_relay(&id);
+            }
+        })
+        .await
+        .expect("all relay tasks release their registrations after eviction");
+    }
+
+    #[test]
+    fn terminal_parent_retains_channel_while_child_producer_is_alive() {
+        let now = Utc::now();
+        let (sender, _) = broadcast::channel(16);
+        let mut runners = HashMap::new();
+        let mut senders = HashMap::new();
+        insert_pair(
+            &mut runners,
+            &mut senders,
+            "parent",
+            terminal_runner(&sender, TTL + 1, now),
+            sender.clone(),
+        );
+        let watchers = super::super::watchers::SessionWatchers::default();
+        assert_eq!(
+            evict_idle_session_entries(
+                &mut runners,
+                &mut senders,
+                &watchers,
+                &bamboo_engine::SessionCache::default(),
+                TTL,
+                now,
+                None
+            ),
+            0,
+            "a child's heartbeat sender keeps its finished parent addressable",
+        );
+        drop(sender);
+        assert_eq!(
+            evict_idle_session_entries(
+                &mut runners,
+                &mut senders,
+                &watchers,
+                &bamboo_engine::SessionCache::default(),
+                TTL,
+                now,
+                None
+            ),
+            1,
+        );
+    }
+
     /// A terminal (Completed) runner whose `event_sender` shares `tx`'s channel,
     /// exactly as production sets it in `reserve_runner`.
     fn terminal_runner(
@@ -727,7 +932,16 @@ mod eviction_tests {
             tx.clone(),
         );
 
-        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+        drop(tx);
+        let evicted = evict_idle_session_entries(
+            &mut runners,
+            &mut senders,
+            &super::super::watchers::SessionWatchers::default(),
+            &bamboo_engine::SessionCache::default(),
+            TTL,
+            now,
+            None,
+        );
 
         assert_eq!(evicted, 1);
         assert!(runners.is_empty(), "terminal idle runner must be dropped");
@@ -755,7 +969,16 @@ mod eviction_tests {
             tx.clone(),
         );
 
-        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+        drop(tx);
+        let evicted = evict_idle_session_entries(
+            &mut runners,
+            &mut senders,
+            &super::super::watchers::SessionWatchers::default(),
+            &bamboo_engine::SessionCache::default(),
+            TTL,
+            now,
+            None,
+        );
 
         assert_eq!(evicted, 0, "must not evict while a receiver is live");
         assert!(runners.contains_key("s1"));
@@ -777,7 +1000,16 @@ mod eviction_tests {
             tx.clone(),
         );
 
-        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+        drop(tx);
+        let evicted = evict_idle_session_entries(
+            &mut runners,
+            &mut senders,
+            &super::super::watchers::SessionWatchers::default(),
+            &bamboo_engine::SessionCache::default(),
+            TTL,
+            now,
+            None,
+        );
 
         assert_eq!(
             evicted, 0,
@@ -801,7 +1033,16 @@ mod eviction_tests {
         let mut senders = HashMap::new();
         insert_pair(&mut runners, &mut senders, "s1", runner, tx.clone());
 
-        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+        drop(tx);
+        let evicted = evict_idle_session_entries(
+            &mut runners,
+            &mut senders,
+            &super::super::watchers::SessionWatchers::default(),
+            &bamboo_engine::SessionCache::default(),
+            TTL,
+            now,
+            None,
+        );
 
         assert_eq!(evicted, 0, "a Running runner is never evicted");
         assert!(runners.contains_key("s1"));
@@ -826,9 +1067,18 @@ mod eviction_tests {
             "s1".to_string(),
             terminal_runner(&runner_tx, TTL + 100, now),
         );
-        senders.insert("s1".to_string(), sender_tx.clone());
+        senders.insert("s1".to_string(), sender_tx);
+        drop(runner_tx);
 
-        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+        let evicted = evict_idle_session_entries(
+            &mut runners,
+            &mut senders,
+            &super::super::watchers::SessionWatchers::default(),
+            &bamboo_engine::SessionCache::default(),
+            TTL,
+            now,
+            None,
+        );
 
         assert_eq!(evicted, 1, "runner (no receivers) is evicted");
         assert!(runners.is_empty());

--- a/crates/app/bamboo-server/src/app_state/session_events.rs
+++ b/crates/app/bamboo-server/src/app_state/session_events.rs
@@ -66,29 +66,31 @@ impl bamboo_engine::execution::ChildRunLaunchHook for NotificationRelayLaunchHoo
 ///   on every notification so a hot-reloaded topic/token/toggle takes effect
 ///   immediately.
 ///
-/// Idempotent: at most one relay per session (tracked by the notification
-/// service via `try_begin_relay`). The relay does not hold a `Sender` clone,
-/// so the channel still closes naturally (`RecvError::Closed`) when the
-/// session is torn down, and this task exits cleanly with it — nothing leaks.
+/// Idempotent for the exact session channel. Its RAII subscription releases the
+/// registration on normal close, cancellation, or panic, and permits a recreated
+/// channel to replace a still-draining old relay without losing notifications.
 pub fn ensure_notification_relay(
     deps: &NotificationRelayDeps,
     session_id: &str,
     sender: broadcast::Sender<AgentEvent>,
 ) {
-    if !deps.notification_service.try_begin_relay(session_id) {
+    let Some(mut subscription) = deps.session_watchers.begin_notification_relay(
+        deps.notification_service.clone(),
+        session_id,
+        &sender,
+    ) else {
         return;
-    }
+    };
     let service = deps.notification_service.clone();
-    let senders = deps.session_event_senders.clone();
+    let channel = sender.downgrade();
     let watchers = deps.session_watchers.clone();
     let config = deps.config.clone();
     let sid = session_id.to_string();
-    let mut rx = sender.subscribe();
     drop(sender);
     tokio::spawn(async move {
         use tokio::sync::broadcast::error::RecvError;
         loop {
-            match rx.recv().await {
+            match subscription.recv().await {
                 Ok(event) => {
                     if let Some(notification) = service.notify(&sid, &event) {
                         // Build the sink payload before `notification` is moved
@@ -96,8 +98,10 @@ pub fn ensure_notification_relay(
                         let sink_notification =
                             crate::notify_sinks::SinkNotification::from_event(&notification);
 
-                        let tx = senders.read().await.get(&sid).cloned();
-                        if let Some(tx) = tx {
+                        // Publish back onto this generation only. Re-reading
+                        // the map could inject a delayed old notification into
+                        // a replacement channel after idle eviction/resume.
+                        if let Some(tx) = channel.upgrade() {
                             let _ = tx.send(notification);
                         }
 
@@ -116,7 +120,6 @@ pub fn ensure_notification_relay(
                 Err(RecvError::Closed) => break,
             }
         }
-        service.end_relay(&sid);
     });
 }
 

--- a/crates/app/bamboo-server/src/app_state/watchers.rs
+++ b/crates/app/bamboo-server/src/app_state/watchers.rs
@@ -15,12 +15,62 @@
 
 use std::sync::Arc;
 
+use bamboo_agent_core::AgentEvent;
 use dashmap::DashMap;
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
 
 /// Per-session count of live SSE/WS client subscribers.
 #[derive(Default)]
 pub struct SessionWatchers {
     counts: DashMap<String, usize>,
+    /// Internal observers are tracked by exact channel, independently of UI
+    /// watchers. A relay cannot keep its own terminal session alive forever.
+    relays: DashMap<String, RelayRegistration>,
+}
+
+struct RelayRegistration {
+    channel: broadcast::WeakSender<AgentEvent>,
+    generation: Arc<()>,
+    cancel: CancellationToken,
+    started_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Owns both the internal-observer registration and its actual receiver.
+/// Drop unregisters before Rust drops the receiver, including task abort and
+/// unwind, so eviction can never subtract an observer that has already left.
+pub(crate) struct NotificationRelaySubscription {
+    watchers: Arc<SessionWatchers>,
+    service: Arc<bamboo_notification::NotificationService>,
+    session_id: String,
+    generation: Arc<()>,
+    cancel: CancellationToken,
+    receiver: broadcast::Receiver<AgentEvent>,
+}
+
+impl NotificationRelaySubscription {
+    pub(crate) async fn recv(&mut self) -> Result<AgentEvent, broadcast::error::RecvError> {
+        tokio::select! {
+            biased;
+            _ = self.cancel.cancelled() => Err(broadcast::error::RecvError::Closed),
+            event = self.receiver.recv() => event,
+        }
+    }
+}
+
+impl Drop for NotificationRelaySubscription {
+    fn drop(&mut self) {
+        if let dashmap::mapref::entry::Entry::Occupied(entry) =
+            self.watchers.relays.entry(self.session_id.clone())
+        {
+            if Arc::ptr_eq(&entry.get().generation, &self.generation) {
+                // Clear the compatibility marker while still holding the entry
+                // lock; a new generation cannot race between clear and remove.
+                self.service.end_relay(&self.session_id);
+                entry.remove();
+            }
+        }
+    }
 }
 
 impl SessionWatchers {
@@ -51,6 +101,79 @@ impl SessionWatchers {
     /// Whether `session_id` currently has ≥1 live watcher.
     pub fn has_watcher(&self, session_id: &str) -> bool {
         self.counts.get(session_id).is_some_and(|count| *count > 0)
+    }
+
+    pub(crate) fn begin_notification_relay(
+        self: &Arc<Self>,
+        service: Arc<bamboo_notification::NotificationService>,
+        session_id: &str,
+        sender: &broadcast::Sender<AgentEvent>,
+    ) -> Option<NotificationRelaySubscription> {
+        let entry = self.relays.entry(session_id.to_string());
+        if let dashmap::mapref::entry::Entry::Occupied(occupied) = &entry {
+            if occupied
+                .get()
+                .channel
+                .upgrade()
+                .is_some_and(|channel| channel.same_channel(sender))
+            {
+                return None;
+            }
+            // A channel recreated after eviction needs a new relay immediately.
+            // The old task may still be draining; it cannot clear this successor.
+            occupied.get().cancel.cancel();
+            service.end_relay(session_id);
+        }
+        let receiver = sender.subscribe();
+        let generation = Arc::new(());
+        let cancel = CancellationToken::new();
+        let registration = RelayRegistration {
+            channel: sender.downgrade(),
+            generation: generation.clone(),
+            cancel: cancel.clone(),
+            started_at: chrono::Utc::now(),
+        };
+        service.try_begin_relay(session_id);
+        entry.insert(registration);
+        Some(NotificationRelaySubscription {
+            watchers: self.clone(),
+            service,
+            session_id: session_id.to_string(),
+            generation,
+            cancel,
+            receiver,
+        })
+    }
+
+    /// Count every real receiver, excluding only our live relay on this exact
+    /// channel. Holding the entry guard across receiver_count prevents its
+    /// RAII owner from unregistering/dropping between those two observations.
+    pub(crate) fn has_external_receivers(
+        &self,
+        session_id: &str,
+        sender: &broadcast::Sender<AgentEvent>,
+    ) -> bool {
+        let relay = self.relays.get(session_id);
+        let internal = usize::from(relay.as_ref().is_some_and(|relay| {
+            relay
+                .channel
+                .upgrade()
+                .is_some_and(|channel| channel.same_channel(sender))
+        }));
+        sender.receiver_count() > internal
+    }
+
+    pub(crate) fn relay_started_at(
+        &self,
+        session_id: &str,
+        sender: &broadcast::Sender<AgentEvent>,
+    ) -> Option<chrono::DateTime<chrono::Utc>> {
+        let relay = self.relays.get(session_id)?;
+        relay
+            .channel
+            .upgrade()
+            .filter(|channel| channel.same_channel(sender))
+            .map(|_| relay.started_at)
     }
 }
 
@@ -85,6 +208,71 @@ impl Drop for WatcherGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn notification_service() -> (
+        Arc<bamboo_notification::NotificationService>,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        (
+            Arc::new(bamboo_notification::NotificationService::new(
+                dir.path().join("prefs.json"),
+            )),
+            dir,
+        )
+    }
+
+    #[tokio::test]
+    async fn relay_generation_does_not_hide_replacement_channel_subscribers() {
+        let watchers = SessionWatchers::new();
+        let (service, _dir) = notification_service();
+        let (old, _) = broadcast::channel(8);
+        let old_relay = watchers
+            .begin_notification_relay(service.clone(), "s", &old)
+            .unwrap();
+        assert!(!watchers.has_external_receivers("s", &old));
+        let (replacement, _ui_receiver) = broadcast::channel(8);
+        assert!(watchers.has_external_receivers("s", &replacement));
+        let new_relay = watchers
+            .begin_notification_relay(service.clone(), "s", &replacement)
+            .unwrap();
+        drop(old_relay);
+        assert!(
+            !service.try_begin_relay("s"),
+            "old Drop cannot clear the new registration"
+        );
+        assert!(watchers.has_external_receivers("s", &replacement));
+        drop(new_relay);
+        assert!(service.try_begin_relay("s"));
+        service.end_relay("s");
+    }
+
+    #[tokio::test]
+    async fn aborted_and_dropped_relay_tasks_release_receiver_and_registration() {
+        let watchers = SessionWatchers::new();
+        let (service, _dir) = notification_service();
+        let (sender, _) = broadcast::channel(8);
+        let subscription = watchers
+            .begin_notification_relay(service.clone(), "aborted", &sender)
+            .unwrap();
+        let task = tokio::spawn(async move {
+            let _subscription = subscription;
+            std::future::pending::<()>().await;
+        });
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert_eq!(sender.receiver_count(), 0);
+        assert!(service.try_begin_relay("aborted"));
+        service.end_relay("aborted");
+
+        let subscription = watchers
+            .begin_notification_relay(service.clone(), "failed-setup", &sender)
+            .unwrap();
+        drop(subscription);
+        assert_eq!(sender.receiver_count(), 0);
+        assert!(service.try_begin_relay("failed-setup"));
+        service.end_relay("failed-setup");
+    }
 
     #[test]
     fn watch_and_unwatch_tracks_presence() {

--- a/crates/app/bamboo-server/src/handlers/agent/delete.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/delete.rs
@@ -83,7 +83,13 @@ pub async fn handler(state: web::Data<AppState>, path: web::Path<String>) -> Res
         let mut runners = state.agent_runners.write().await;
         let mut cancelled = false;
         for id in ids_to_cancel.iter() {
-            if let Some(runner) = runners.remove(id) {
+            if let Some(runner) =
+                bamboo_engine::runtime::execution::runner_lifecycle::remove_runner_entry(
+                    &mut runners,
+                    id,
+                )
+                .await
+            {
                 runner.cancel_token.cancel();
                 cancelled = true;
             }

--- a/crates/app/bamboo-server/src/handlers/agent/dev.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/dev.rs
@@ -18,9 +18,11 @@ pub async fn reset(state: web::Data<AppState>) -> Result<HttpResponse> {
     state.sessions.clear();
     {
         let mut runners = state.agent_runners.write().await;
-        for (_, runner) in runners.drain() {
+        for runner in runners.values() {
             runner.cancel_token.cancel();
+            runner.event_publication.retire().await;
         }
+        runners.clear();
     }
     {
         let mut tokens = state.cancel_tokens.write().await;

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -277,7 +277,11 @@ async fn rollback_startup(
         .get(session_id)
         .is_some_and(|runner| runner.run_id == run_id)
     {
-        runners.remove(session_id);
+        bamboo_engine::runtime::execution::runner_lifecycle::remove_runner_entry(
+            &mut runners,
+            session_id,
+        )
+        .await;
     }
     drop(runners);
 

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
@@ -50,17 +50,18 @@ pub(crate) fn spawn_event_forwarder(
                 session_id: session_id.clone(),
                 started_at: chrono::Utc::now().to_rfc3339(),
             };
-            {
+            let publication = {
                 let runners = state.agent_runners.read().await;
-                if runners
+                let Some(runner) = runners
                     .get(&session_id)
-                    .is_none_or(|runner| runner.run_id != run_id)
-                {
+                    .filter(|runner| runner.run_id == run_id)
+                else {
                     return;
-                }
+                };
                 state.account_sink.record(Some(&session_id), &started_event);
                 let _ = session_tx.send(started_event);
-            }
+                runner.event_publication.clone()
+            };
             let mut forwarded_lifecycle_ids = HashSet::new();
             while let Some(event) = mpsc_rx.recv().await {
                 let lifecycle_id = match &event {
@@ -110,19 +111,13 @@ pub(crate) fn spawn_event_forwarder(
                     state.account_sink.record(Some(route_session_id), &event);
                     let _ = session_tx.send(event);
                 } else {
-                    let runners = state.agent_runners.read().await;
-                    if runners
-                        .get(&session_id)
-                        .is_none_or(|runner| runner.run_id != run_id)
-                    {
+                    if !publication.publish(|| {
+                        let route_session_id = event.session_id().unwrap_or(&session_id);
+                        state.account_sink.record(Some(route_session_id), &event);
+                        let _ = session_tx.send(event);
+                    }) {
                         return;
                     }
-                    // The read guard remains held through both synchronous
-                    // sends, closing the check-then-publish replacement race
-                    // without taking a write lock for token-hot paths.
-                    let route_session_id = event.session_id().unwrap_or(&session_id);
-                    state.account_sink.record(Some(route_session_id), &event);
-                    let _ = session_tx.send(event);
                 }
             }
 
@@ -233,6 +228,50 @@ mod tests {
 
     async fn current_run_id(state: &actix_web::web::Data<AppState>, session_id: &str) -> String {
         state.agent_runners.read().await[session_id].run_id.clone()
+    }
+
+    #[tokio::test]
+    async fn server_tokens_progress_without_the_shared_runner_registry() {
+        let directory = tempfile::tempdir().unwrap();
+        let state =
+            actix_web::web::Data::new(AppState::new(directory.path().to_path_buf()).await.unwrap());
+        let id = "server-independent-tokens";
+        let sender = state.get_session_event_sender(id).await;
+        let mut receiver = sender.subscribe();
+        bamboo_engine::execution::reserve_runner_core(
+            &state.agent_runners,
+            &state.session_event_senders,
+            id,
+            &sender,
+        )
+        .await;
+        let run_id = current_run_id(&state, id).await;
+        let (input, events) = mpsc::channel(8);
+        spawn_event_forwarder(state.clone(), id.into(), run_id, events, sender, None);
+        assert!(matches!(
+            receiver.recv().await.unwrap(),
+            AgentEvent::ExecutionStarted { .. }
+        ));
+        let registry = state.agent_runners.write().await;
+        input
+            .send(AgentEvent::Token {
+                content: "independent".into(),
+            })
+            .await
+            .unwrap();
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if let AgentEvent::Token { content } = receiver.recv().await.unwrap() {
+                    assert_eq!(content, "independent");
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("the server token path must not wait for runner registry ownership");
+        assert!(registry[id].last_activity_at().is_some());
+        drop(registry);
+        drop(input);
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/running_snapshot.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/running_snapshot.rs
@@ -62,7 +62,7 @@ pub async fn running_sessions_snapshot(state: web::Data<AppState>) -> Result<Htt
                 round_count: runner.round_count,
                 last_tool_name: runner.last_tool_name.clone(),
                 last_tool_phase: runner.last_tool_phase.clone(),
-                last_event_at: runner.last_event_at.map(|t| t.to_rfc3339()),
+                last_event_at: runner.last_activity_at().map(|t| t.to_rfc3339()),
                 last_critical_events: runner.last_critical_events.clone(),
                 running_child_session_ids,
             })

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
@@ -200,7 +200,13 @@ pub async fn cleanup_sessions(
         {
             let mut runners = state.agent_runners.write().await;
             for session_id in &result.deleted_session_ids {
-                if let Some(runner) = runners.remove(session_id) {
+                if let Some(runner) =
+                    bamboo_engine::runtime::execution::runner_lifecycle::remove_runner_entry(
+                        &mut runners,
+                        session_id,
+                    )
+                    .await
+                {
                     runner.cancel_token.cancel();
                 }
             }

--- a/crates/app/bamboo-server/src/handlers/agent/subagent_snapshot.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/subagent_snapshot.rs
@@ -78,7 +78,7 @@ pub async fn handler(state: web::Data<AppState>) -> Result<HttpResponse> {
         .map(|(session_id, runner)| {
             (
                 session_id.clone(),
-                runner.last_event_at.unwrap_or(runner.started_at),
+                runner.last_activity_at().unwrap_or(runner.started_at),
             )
         })
         .collect::<HashMap<_, _>>();

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -883,7 +883,13 @@ impl ChildSessionPort for ChildSessionAdapter {
     ) -> Result<DeleteChildResult, ChildSessionError> {
         let cancelled_running_child = {
             let mut runners = self.agent_runners.write().await;
-            if let Some(runner) = runners.remove(child_id) {
+            if let Some(runner) =
+                bamboo_engine::runtime::execution::runner_lifecycle::remove_runner_entry(
+                    &mut runners,
+                    child_id,
+                )
+                .await
+            {
                 runner.cancel_token.cancel();
                 true
             } else {
@@ -931,7 +937,7 @@ impl ChildSessionPort for ChildSessionAdapter {
             completed_at: runner.completed_at,
             last_tool_name: runner.last_tool_name.clone(),
             last_tool_phase: runner.last_tool_phase.clone(),
-            last_event_at: runner.last_event_at,
+            last_event_at: runner.last_activity_at(),
             round_count: runner.round_count,
         })
     }

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -364,7 +364,7 @@ async fn remove_runner_exact(
         .get(session_id)
         .is_some_and(|runner| runner.run_id == run_id)
     {
-        runners.remove(session_id);
+        super::runner_lifecycle::remove_runner_entry(&mut runners, session_id).await;
         true
     } else {
         false

--- a/crates/engine/bamboo-engine/src/runtime/execution/event_forwarder.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/event_forwarder.rs
@@ -39,6 +39,62 @@ fn mirror_to_account_feed(inbox: &Option<AccountFeedInbox>, session_id: &str, ev
 mod tests {
     use super::*;
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn hundreds_of_child_streams_progress_while_global_registry_is_locked() {
+        let runners = Arc::new(RwLock::new(HashMap::new()));
+        let mut streams = Vec::new();
+        for index in 0..512 {
+            let id = format!("child-{index}");
+            let mut runner = AgentRunner::new();
+            runner.status = super::super::runner_state::AgentStatus::Running;
+            let mut receiver = runner.event_sender.subscribe();
+            let sender = runner.event_sender.clone();
+            let run_id = runner.run_id.clone();
+            runners.write().await.insert(id.clone(), runner);
+            let (input, task) = create_event_forwarder(id, run_id, sender, runners.clone(), None);
+            assert!(matches!(
+                receiver.recv().await.unwrap(),
+                AgentEvent::ExecutionStarted { .. }
+            ));
+            streams.push((input, receiver, task));
+        }
+        let held_registry = runners.write().await;
+        let started = std::time::Instant::now();
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            futures::future::join_all(streams.iter_mut().map(|(input, receiver, _)| async move {
+                for _ in 0..64 {
+                    input
+                        .send(AgentEvent::Token {
+                            content: "delta".into(),
+                        })
+                        .await
+                        .unwrap();
+                }
+                for _ in 0..64 {
+                    assert!(matches!(
+                        receiver.recv().await.unwrap(),
+                        AgentEvent::Token { .. }
+                    ));
+                }
+            }))
+            .await;
+        })
+        .await
+        .expect("independent token streams must not wait for registry ownership");
+        eprintln!(
+            "512 child streams / 32768 tokens with held registry: {:?}",
+            started.elapsed()
+        );
+        assert!(held_registry
+            .values()
+            .all(|runner| runner.last_activity_at().is_some()));
+        drop(held_registry);
+        for (input, _, task) in streams {
+            drop(input);
+            task.await.unwrap();
+        }
+    }
+
     #[tokio::test]
     async fn child_approval_change_routes_to_parent_account_envelope() {
         let (tx, mut rx) = mpsc::channel(4);
@@ -145,19 +201,37 @@ pub fn create_event_forwarder(
             session_id: session_id.clone(),
             started_at: Utc::now().to_rfc3339(),
         };
-        {
+        let publication = {
             let runners = runners.read().await;
-            if runners
+            let Some(runner) = runners
                 .get(&session_id)
-                .is_none_or(|runner| runner.run_id != run_id)
-            {
+                .filter(|runner| runner.run_id == run_id)
+            else {
                 return;
-            }
+            };
             mirror_to_account_feed(&account_feed_inbox, &session_id, &started_event);
             let _ = broadcast_tx.send(started_event);
-        }
+            runner.event_publication.clone()
+        };
 
         while let Some(event) = mpsc_rx.recv().await {
+            let needs_runner_update = event.is_replayable_session_state()
+                || matches!(
+                    &event,
+                    AgentEvent::TokenBudgetUpdated { .. }
+                        | AgentEvent::ToolStart { .. }
+                        | AgentEvent::ToolLifecycle { .. }
+                        | AgentEvent::RunnerProgress { .. }
+                );
+            if !needs_runner_update {
+                if !publication.publish(|| {
+                    mirror_to_account_feed(&account_feed_inbox, &session_id, &event);
+                    let _ = broadcast_tx.send(event);
+                }) {
+                    return;
+                }
+                continue;
+            }
             let mut runners = runners.write().await;
             let Some(runner) = runners
                 .get_mut(&session_id)
@@ -170,6 +244,7 @@ pub fn create_event_forwarder(
                 return;
             };
             runner.last_event_at = Some(Utc::now());
+            publication.touch();
 
             // Cache live state before publication so a subscriber installed
             // between a clarification pause and its response sees the exact

--- a/crates/engine/bamboo-engine/src/runtime/execution/event_publication.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/event_publication.rs
@@ -1,0 +1,115 @@
+//! Per-run atomic publication fence. Token traffic never acquires the shared
+//! runner registry. Replacement closes the old fence and drains synchronous
+//! publications before the successor can emit Started on the same channel.
+
+use chrono::{DateTime, Utc};
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+
+const CLOSED: usize = 1 << (usize::BITS - 1);
+
+#[derive(Debug, Default)]
+pub struct EventPublication {
+    state: AtomicUsize,
+    last_event_millis: AtomicI64,
+}
+
+struct PublicationGuard<'a>(&'a AtomicUsize);
+impl Drop for PublicationGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Release);
+    }
+}
+
+impl EventPublication {
+    /// Only synchronous sends belong in this closure. An async producer cannot
+    /// keep a publication permit across suspension and delay a successor.
+    pub fn publish(&self, send: impl FnOnce()) -> bool {
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            if state & CLOSED != 0 {
+                return false;
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(current) => state = current,
+            }
+        }
+        let _permit = PublicationGuard(&self.state);
+        self.touch();
+        send();
+        true
+    }
+
+    pub fn touch(&self) {
+        self.last_event_millis
+            .fetch_max(Utc::now().timestamp_millis(), Ordering::Relaxed);
+    }
+
+    pub fn last_event_at(&self) -> Option<DateTime<Utc>> {
+        let millis = self.last_event_millis.load(Ordering::Relaxed);
+        (millis != 0)
+            .then(|| DateTime::from_timestamp_millis(millis))
+            .flatten()
+    }
+
+    pub async fn retire(&self) {
+        self.state.fetch_or(CLOSED, Ordering::AcqRel);
+        while self.state.load(Ordering::Acquire) & !CLOSED != 0 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// Maintenance removes an entry only once admitted publications have exited.
+    pub fn retire_if_idle(&self) -> bool {
+        self.state.fetch_or(CLOSED, Ordering::AcqRel) & !CLOSED == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn replacement_drains_admitted_frame_and_rejects_late_frames() {
+        let gate = Arc::new(EventPublication::default());
+        let admitted = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let publisher = {
+            let gate = gate.clone();
+            let admitted = admitted.clone();
+            let release = release.clone();
+            std::thread::spawn(move || {
+                gate.publish(|| {
+                    admitted.wait();
+                    release.wait();
+                })
+            })
+        };
+        admitted.wait();
+        assert!(!gate.retire_if_idle());
+        assert!(!gate.publish(|| panic!("old generation published")));
+        let retiring = {
+            let gate = gate.clone();
+            tokio::spawn(async move { gate.retire().await })
+        };
+        tokio::task::yield_now().await;
+        assert!(!retiring.is_finished());
+        release.wait();
+        assert!(publisher.join().unwrap());
+        retiring.await.unwrap();
+        assert!(gate.retire_if_idle());
+    }
+
+    #[test]
+    fn panic_releases_publication_permit() {
+        let gate = EventPublication::default();
+        let _ = std::panic::catch_unwind(|| gate.publish(|| panic!("sink panic")));
+        assert!(gate.retire_if_idle());
+    }
+}

--- a/crates/engine/bamboo-engine/src/runtime/execution/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/mod.rs
@@ -16,6 +16,7 @@
 pub mod agent_spawn;
 pub mod child_completion;
 pub mod event_forwarder;
+pub mod event_publication;
 pub mod runner_lifecycle;
 pub mod runner_state;
 pub mod session_events;

--- a/crates/engine/bamboo-engine/src/runtime/execution/runner_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/runner_lifecycle.rs
@@ -132,6 +132,10 @@ pub async fn remove_runner_entry(
     session_id: &str,
 ) -> Option<AgentRunner> {
     if let Some(runner) = runners.get(session_id) {
+        // Arm execution cancellation before the drain can suspend. Dropping a
+        // delete/rollback future must not leave a live runner with a closed
+        // event fence that a subsequent execute mistakes for healthy work.
+        runner.cancel_token.cancel();
         runner.event_publication.retire().await;
     }
     runners.remove(session_id)
@@ -207,7 +211,9 @@ mod tests {
     #[tokio::test]
     async fn cancelling_removal_keeps_the_predecessor_fence_discoverable() {
         use std::sync::Barrier;
-        let runner = AgentRunner::new();
+        let mut runner = AgentRunner::new();
+        runner.status = AgentStatus::Running;
+        let cancel = runner.cancel_token.clone();
         let publication = runner.event_publication.clone();
         let entered = Arc::new(Barrier::new(2));
         let release = Arc::new(Barrier::new(2));
@@ -227,6 +233,10 @@ mod tests {
         let mut removing = Box::pin(remove_runner_entry(&mut runners, "child"));
         assert!(futures::poll!(removing.as_mut()).is_pending());
         drop(removing);
+        assert!(
+            cancel.is_cancelled(),
+            "retired execution must be told to stop even when removal is cancelled"
+        );
         assert!(
             runners.contains_key("child"),
             "a successor must still find the old fence after cancellation"

--- a/crates/engine/bamboo-engine/src/runtime/execution/runner_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/runner_lifecycle.rs
@@ -72,6 +72,9 @@ pub async fn reserve_runner_core(
     // registry. In particular, cancellation while waiting for the sender map
     // must not leave a `Running` slot with no task behind it.
     let mut senders_guard = senders.write().await;
+    if let Some(previous) = runners_guard.get(session_id) {
+        previous.event_publication.retire().await;
+    }
     runners_guard.remove(session_id);
 
     let mut runner = AgentRunner::new();
@@ -119,6 +122,19 @@ pub async fn try_reserve_runner(
             None
         }
     }
+}
+
+/// Drain publication before removing the old generation from the registry.
+/// If the caller is cancelled at the await, the closed old fence remains in
+/// the map, so a subsequent reservation still has to drain it before Started.
+pub async fn remove_runner_entry(
+    runners: &mut HashMap<String, AgentRunner>,
+    session_id: &str,
+) -> Option<AgentRunner> {
+    if let Some(runner) = runners.get(session_id) {
+        runner.event_publication.retire().await;
+    }
+    runners.remove(session_id)
 }
 
 /// Map an execution result to `AgentStatus`.
@@ -187,6 +203,40 @@ pub async fn finalize_rejected_runner_if_distinct(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn cancelling_removal_keeps_the_predecessor_fence_discoverable() {
+        use std::sync::Barrier;
+        let runner = AgentRunner::new();
+        let publication = runner.event_publication.clone();
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let publisher = {
+            let publication = publication.clone();
+            let entered = entered.clone();
+            let release = release.clone();
+            std::thread::spawn(move || {
+                publication.publish(|| {
+                    entered.wait();
+                    release.wait();
+                })
+            })
+        };
+        entered.wait();
+        let mut runners = HashMap::from([("child".to_string(), runner)]);
+        let mut removing = Box::pin(remove_runner_entry(&mut runners, "child"));
+        assert!(futures::poll!(removing.as_mut()).is_pending());
+        drop(removing);
+        assert!(
+            runners.contains_key("child"),
+            "a successor must still find the old fence after cancellation"
+        );
+        assert!(!publication.publish(|| panic!("retired run must reject late frames")));
+        release.wait();
+        publisher.join().unwrap();
+        assert!(remove_runner_entry(&mut runners, "child").await.is_some());
+        assert!(runners.is_empty());
+    }
 
     fn new_runners() -> Arc<RwLock<HashMap<String, AgentRunner>>> {
         Arc::new(RwLock::new(HashMap::new()))

--- a/crates/engine/bamboo-engine/src/runtime/execution/runner_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/runner_state.rs
@@ -61,6 +61,8 @@ pub enum AgentStatus {
 /// an in-progress agent execution.
 #[derive(Debug, Clone)]
 pub struct AgentRunner {
+    /// Generation fence and activity clock shared only by this run's producers.
+    pub event_publication: std::sync::Arc<super::event_publication::EventPublication>,
     /// Broadcast sender for agent events.
     ///
     /// Allows multiple clients to subscribe to agent events
@@ -124,6 +126,11 @@ impl Default for AgentRunner {
 }
 
 impl AgentRunner {
+    /// Includes lock-free event traffic as well as legacy diagnostic updates.
+    pub fn last_activity_at(&self) -> Option<DateTime<Utc>> {
+        self.last_event_at
+            .max(self.event_publication.last_event_at())
+    }
     /// Broadcast channel capacity for agent events.
     pub const EVENT_CHANNEL_CAPACITY: usize = 1000;
 
@@ -138,6 +145,7 @@ impl AgentRunner {
         let (event_sender, _) = broadcast::channel(Self::EVENT_CHANNEL_CAPACITY);
         Self {
             event_sender,
+            event_publication: std::sync::Arc::default(),
             cancel_token: CancellationToken::new(),
             status: AgentStatus::Pending,
             started_at: Utc::now(),

--- a/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
@@ -460,7 +460,7 @@ pub(crate) async fn watch_child_liveness(
                     return;
                 }
 
-                let last_activity_at = runner.last_event_at.unwrap_or(runner.started_at);
+                let last_activity_at = runner.last_activity_at().unwrap_or(runner.started_at);
                 let idle_secs = now.signed_duration_since(last_activity_at).num_seconds();
                 if idle_secs >= policy.max_idle_secs {
                     let reason = format!(

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -303,9 +303,8 @@ fn read_config_snapshot(config: &Arc<RwLock<Config>>, cached_config: &StdRwLock<
 ///
 /// The inner `std::sync::Mutex` guards only the brief HashMap lookup/insert
 /// (no await inside); the per-parent `tokio::sync::Mutex` is the one held
-/// across the async critical section. Entries accumulate but are small
-/// (`Arc<tokio::sync::Mutex<()>>` ≈ 24 bytes) and bounded by the number of
-/// distinct parent sessions.
+/// across the async critical section. Entries exist only while a holder or
+/// waiter owns a `SessionResumeLock`; historical parent IDs are reclaimed.
 fn parent_locks() -> &'static std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>> {
     static LOCKS: OnceLock<std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> =
         OnceLock::new();
@@ -318,11 +317,44 @@ fn parent_locks() -> &'static std::sync::Mutex<HashMap<String, Arc<tokio::sync::
 /// ([`BashCompletionSink::on_bash_completed`]), and the bash **backstop** poll
 /// ([`ChildCompletionCoordinator::bash_self_resume`]) — can never double-resume.
 /// The inner sync `Mutex` guards only the brief map lookup (no await inside).
-fn session_resume_lock(session_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+fn session_resume_lock(session_id: &str) -> SessionResumeLock {
     let mut map = parent_locks().lock().recover_poison();
-    map.entry(session_id.to_string())
+    let lock = map
+        .entry(session_id.to_string())
         .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-        .clone()
+        .clone();
+    SessionResumeLock {
+        session_id: session_id.to_string(),
+        lock: Some(lock),
+    }
+}
+
+/// The lease is constructed before awaiting the mutex, so cancelled waiters
+/// also reclaim their registration. Lookup and last-owner removal use the same
+/// brief registry lock; two live mutexes can never exist for the same ID.
+struct SessionResumeLock {
+    session_id: String,
+    lock: Option<Arc<tokio::sync::Mutex<()>>>,
+}
+
+impl std::ops::Deref for SessionResumeLock {
+    type Target = tokio::sync::Mutex<()>;
+    fn deref(&self) -> &Self::Target {
+        self.lock.as_ref().expect("live resume-lock lease")
+    }
+}
+
+impl Drop for SessionResumeLock {
+    fn drop(&mut self) {
+        self.lock.take();
+        let mut map = parent_locks().lock().recover_poison();
+        if map
+            .get(&self.session_id)
+            .is_some_and(|lock| Arc::strong_count(lock) == 1)
+        {
+            map.remove(&self.session_id);
+        }
+    }
 }
 
 fn wait_policy_satisfied(
@@ -2502,7 +2534,7 @@ impl ChildCompletionCoordinator {
                     // per-child watchdog machinery itself is dead (task
                     // panicked or lost), because it would have cancelled and
                     // published a timeout long before.
-                    let last_activity = runner.last_event_at.unwrap_or(runner.started_at);
+                    let last_activity = runner.last_activity_at().unwrap_or(runner.started_at);
                     let idle_secs = now.signed_duration_since(last_activity).num_seconds();
                     let total_secs = now.signed_duration_since(runner.started_at).num_seconds();
                     let policy = match &control_plane {
@@ -2802,6 +2834,49 @@ impl ChildCompletionCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn cancelled_resume_waiters_do_not_retain_historical_parent_ids() {
+        for index in 0..512 {
+            let id = format!("resume-lock-reclaim-{index}");
+            let owner = session_resume_lock(&id);
+            let held = owner.lock().await;
+            let waiter = session_resume_lock(&id);
+            let mut waiting = Box::pin(waiter.lock());
+            assert!(futures::poll!(waiting.as_mut()).is_pending());
+            drop(held);
+            drop(owner);
+            drop(waiting);
+            drop(waiter);
+            assert!(!parent_locks().lock().recover_poison().contains_key(&id));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn resume_lock_reclamation_preserves_exclusive_parent_wake_ownership() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let active = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+        for _ in 0..32 {
+            let active = active.clone();
+            tasks.push(tokio::spawn(async move {
+                for _ in 0..16 {
+                    let lease = session_resume_lock("resume-lock-exclusive");
+                    let _guard = lease.lock().await;
+                    assert_eq!(active.fetch_add(1, Ordering::SeqCst), 0);
+                    tokio::task::yield_now().await;
+                    assert_eq!(active.fetch_sub(1, Ordering::SeqCst), 1);
+                }
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        assert!(!parent_locks()
+            .lock()
+            .recover_poison()
+            .contains_key("resume-lock-exclusive"));
+    }
     use bamboo_agent_core::Message;
     use bamboo_domain::SessionInboxPort;
     use futures::stream;

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -299,12 +299,16 @@ impl LockedSessionStore {
             .entry(session_id.to_string())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone();
-        let guard = lock.lock_owned().await;
-        SessionLockGuard {
-            guard: Some(guard),
+        // Arm cleanup before the cancellable wait. The previous holder may
+        // drop while this waiter owns the last extra Arc; cancelling that waiter
+        // must still reclaim the map entry without needing another acquisition.
+        let mut guard = SessionLockGuard {
+            guard: None,
             locks: self.locks.clone(),
             session_id: session_id.to_string(),
-        }
+        };
+        guard.guard = Some(lock.lock_owned().await);
+        guard
     }
 
     /// Save a full snapshot while preserving Task generations advanced by an
@@ -4614,6 +4618,28 @@ mod tests {
             0,
             "acquiring locks for many distinct ids must not grow the map"
         );
+    }
+
+    #[tokio::test]
+    async fn cancelled_last_waiter_reclaims_hundreds_of_session_locks() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage);
+        for index in 0..512 {
+            let id = format!("cancelled-child-{index}");
+            let held = store.acquire_lock(&id).await;
+            let mut waiter = Box::pin(store.acquire_lock(&id));
+            assert!(
+                std::future::poll_fn(|cx| std::task::Poll::Ready(
+                    std::future::Future::poll(waiter.as_mut(), cx).is_pending()
+                ))
+                .await
+            );
+            drop(held);
+            // Cancel after the previous holder handed ownership to the waiter,
+            // but before the waiter is polled again to construct its guard.
+            drop(waiter);
+        }
+        assert!(store.locks.is_empty());
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -1780,12 +1780,9 @@ impl SessionStoreV2 {
             .entry(session_id.to_string())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone();
-        let guard = lock.lock_owned().await;
-        // Construct the self-cleaning guard before awaiting the cross-process
-        // file lock. If this future is cancelled while flock is contended, the
-        // process-local DashMap entry is still reclaimed.
+        // Arm cleanup before either the process-local or cross-process wait.
         let mut session_guard = SessionWriteGuard {
-            guard: Some(guard),
+            guard: None,
             file: None,
             locks: self.session_write_locks.clone(),
             session_id: session_id.to_string(),
@@ -1793,6 +1790,7 @@ impl SessionStoreV2 {
             acquired: Instant::now(),
             metrics: self.persistence_metrics.clone(),
         };
+        session_guard.guard = Some(lock.lock_owned().await);
         let file = self.open_session_write_lock_file(session_id).await?;
         session_guard.file = Some(file);
         drop(waiting);
@@ -6540,6 +6538,34 @@ mod tests {
             Some("run-after-full")
         );
         assert!(storage.session_write_locks.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancelled_last_waiter_reclaims_session_write_locks() -> io::Result<()> {
+        let temp = TempDir::new()?;
+        let store = SessionStoreV2::new(temp.path().to_path_buf()).await?;
+        for index in 0..512 {
+            let id = format!("cancelled-child-{index}");
+            let held = store.acquire_session_maintenance_lock(&id).await?;
+            let mut waiter = Box::pin(store.acquire_session_write_lock(&id, SaveKind::Runtime));
+            assert!(
+                std::future::poll_fn(|cx| std::task::Poll::Ready(
+                    std::future::Future::poll(waiter.as_mut(), cx).is_pending()
+                ))
+                .await
+            );
+            drop(held);
+            drop(waiter);
+        }
+        assert!(store.session_write_locks.is_empty());
+        assert_eq!(
+            store
+                .persistence_metrics
+                .waiting_saves
+                .load(Ordering::Relaxed),
+            0
+        );
         Ok(())
     }
 

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -599,6 +599,13 @@ impl BambooRuntimeExecutor {
         let worker_runners = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
         let worker_event_senders =
             Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+        bamboo_server::app_state::init::spawn_session_map_cleanup_task(
+            worker_runners.clone(),
+            worker_event_senders.clone(),
+            bamboo_server::app_state::watchers::SessionWatchers::new(),
+            worker_sessions.clone(),
+            Some("actor-worker"),
+        );
         let default_tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = {
             let session_repo = bamboo_engine::SessionRepository::new(
                 worker_sessions.clone(),


### PR DESCRIPTION
## Summary
High-volume child token streams acquired the process-wide runner registry, and every notification relay counted as a receiver that prevented terminal-session cleanup. Token publication now uses a per-run atomic admission fence and activity clock. Runner replacement drains admitted old frames before the next Started event, while replayable state retains its existing ordering.

Idle cleanup identifies the exact internal relay generation and reclaims paired runner, sender and cached transcript when no external subscriber or producer owns them. The maintenance loop holds weak resource references between sweeps so dropping its executor also releases the maps and cached transcripts. Storage-lock waiters and parent resume-lock leases reclaim their registry entries on cancellation. Removing a runner arms execution cancellation before the drain can suspend.

Closes #1046. This is the event/lifecycle slice of #1044, following cache PR #1060. Worker transport/process ownership remains separately tracked in #1047.

## Test Plan
- 512 independent child streams deliver 32,768 tokens while the global runner write guard is held.
- 512 real notification relays and cached transcripts are reclaimed after terminal TTL; live/subscribed/producer-owned sessions are retained.
- Deterministic predecessor retirement, replacement, and cancelled-removal tests; 9 runner-lifecycle tests pass after the final review correction.
- 512 cancelled persistence waiters, parent wake cancellation and concurrent exclusivity regressions.
- Full local all-features library/integration suite passed 8,429 tests before final review corrections; 9 runner-lifecycle tests and 142 AppState tests passed after the respective corrections. Full locked metadata, MSRV dependency audit, formatting and exact CI Clippy command passed; affected server Clippy passed again after the weak-ownership fix.
- Independent read-only review approved the cache-independent lifecycle diff and the final cancellation-order correction. Exact-head CI is required before merge.
