### PR TITLE
feat: export bounded immutable Session context files (#1049)

### DIFF
--- a/crates/app/bamboo-server-tools/src/session_inspector/args.rs
+++ b/crates/app/bamboo-server-tools/src/session_inspector/args.rs
@@ -5,6 +5,9 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub(super) enum SessionInspectorArgs {
+    /// Materialize a bounded, immutable observation of this root or its tree.
+    ExportContext { session_id: String },
+
     /// List sessions from the global index, with filtering/pagination.
     List {
         #[serde(default)]

--- a/crates/app/bamboo-server-tools/src/session_inspector/context_view.rs
+++ b/crates/app/bamboo-server-tools/src/session_inspector/context_view.rs
@@ -1,0 +1,336 @@
+//! Same-tree, on-demand observations. No transcript or arbitrary metadata is
+//! serialized, and the projection never writes back to a canonical Session.
+
+use bamboo_agent_core::tools::{ToolError, ToolResult};
+use bamboo_domain::{Session, SessionKind, TaskItemStatus};
+use bamboo_engine::project_context::{ProjectContextResolver, SessionProjectIdentity};
+use bamboo_storage::context_view::{publish_session_context_snapshot, ContextSnapshotFiles};
+use serde::Serialize;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use super::SessionInspectorTool;
+
+const SCHEMA: &str = "session-context-view.v1";
+const MAX_TASKS: usize = 32;
+const MAX_LINE_BYTES: usize = 512;
+
+fn digest(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn invalid(message: &str) -> ToolError {
+    ToolError::InvalidArguments(format!("export_context: {message}"))
+}
+
+fn validate_id(id: &str) -> Result<(), ToolError> {
+    if id.is_empty()
+        || id.len() > 256
+        || id.trim() != id
+        || id.contains(['/', '\\'])
+        || id.contains("..")
+        || id.chars().any(char::is_control)
+    {
+        return Err(invalid("invalid session identity"));
+    }
+    Ok(())
+}
+
+fn root_id(session: &Session) -> &str {
+    if session.root_session_id.is_empty() {
+        &session.id
+    } else {
+        &session.root_session_id
+    }
+}
+
+fn project_id(session: &Session) -> Result<Option<String>, ToolError> {
+    match ProjectContextResolver::session_project_identity(session) {
+        SessionProjectIdentity::Unassigned => Ok(None),
+        SessionProjectIdentity::Assigned(id) => Ok(Some(id.to_string())),
+        SessionProjectIdentity::Invalid { .. } => {
+            Err(invalid("invalid persisted Project identity"))
+        }
+    }
+}
+
+async fn control_plane(tool: &SessionInspectorTool, id: &str) -> Result<Session, ToolError> {
+    validate_id(id)?;
+    let session = tool
+        .storage
+        .load_runtime_control_plane(id)
+        .await
+        .map_err(|error| {
+            ToolError::Execution(format!(
+                "export_context: control-plane read failed: {error}"
+            ))
+        })?
+        .ok_or_else(|| invalid("session not found"))?;
+    if session.id != id {
+        return Err(invalid("persisted session identity mismatch"));
+    }
+    Ok(session)
+}
+
+#[derive(Serialize)]
+struct Preview {
+    text: String,
+    truncated: bool,
+    source_sha256: String,
+}
+
+/// A single escaped Markdown line bounded in UTF-8 bytes (including ellipsis).
+fn preview(value: &str, limit: usize) -> Preview {
+    let mut text = String::new();
+    let mut truncated = false;
+    for ch in value.chars() {
+        let escaped = match ch {
+            '<' => "&lt;".to_string(),
+            '>' => "&gt;".to_string(),
+            '&' => "&amp;".to_string(),
+            '\\' | '`' | '*' | '_' | '[' | ']' | '#' | '!' | '|' => format!("\\{ch}"),
+            ch if ch.is_control() || matches!(ch, '\u{2028}' | '\u{2029}') => " ".to_string(),
+            ch => ch.to_string(),
+        };
+        if text.len() + escaped.len() > limit.saturating_sub(3) {
+            truncated = true;
+            text.push_str("...");
+            break;
+        }
+        text.push_str(&escaped);
+    }
+    Preview {
+        text,
+        truncated,
+        source_sha256: digest(value.as_bytes()),
+    }
+}
+
+#[derive(Serialize)]
+struct Scope {
+    caller_session_id: String,
+    root_session_id: String,
+    target_session_id: String,
+    project_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TaskPreview {
+    id: Preview,
+    description: Preview,
+    status: &'static str,
+}
+
+#[derive(Serialize)]
+struct SafeSource {
+    scope: Scope,
+    kind: SessionKind,
+    parent_session_id: Option<String>,
+    title: Preview,
+    created_at: String,
+    updated_at: String,
+    title_version: u64,
+    metadata_version: u64,
+    last_persisted_status: &'static str,
+    has_pending_question: bool,
+    task_list_title: Option<Preview>,
+    task_list_updated_at: Option<String>,
+    task_count: usize,
+    tasks: Vec<TaskPreview>,
+}
+
+fn safe_source(caller: &Session, target: &Session, project: Option<String>) -> SafeSource {
+    // Unknown raw status values are not a free-text export channel.
+    let status = match target.last_run_status().as_deref() {
+        Some("pending") => "pending",
+        Some("running") => "running",
+        Some("completed") => "completed",
+        Some("error") => "error",
+        Some("cancelled") => "cancelled",
+        Some("suspended") => "suspended",
+        Some("skipped") => "skipped",
+        Some("timeout") => "timeout",
+        _ => "unknown",
+    };
+    let tasks = target.task_list.as_ref();
+    SafeSource {
+        scope: Scope {
+            caller_session_id: caller.id.clone(),
+            root_session_id: root_id(caller).to_string(),
+            target_session_id: target.id.clone(),
+            project_id: project,
+        },
+        kind: target.kind,
+        parent_session_id: target.parent_session_id.clone(),
+        title: preview(&target.title, 360),
+        created_at: target.created_at.to_rfc3339(),
+        updated_at: target.updated_at.to_rfc3339(),
+        title_version: target.title_version,
+        metadata_version: target.metadata_version,
+        last_persisted_status: status,
+        has_pending_question: target.has_pending_question(),
+        task_list_title: tasks.map(|t| preview(&t.title, 360)),
+        task_list_updated_at: tasks.map(|t| t.updated_at.to_rfc3339()),
+        task_count: tasks.map_or(0, |t| t.items.len()),
+        tasks: tasks
+            .map(|list| {
+                list.items
+                    .iter()
+                    .take(MAX_TASKS)
+                    .map(|task| TaskPreview {
+                        id: preview(&task.id, 80),
+                        description: preview(&task.description, 300),
+                        status: match task.status {
+                            TaskItemStatus::Pending => "pending",
+                            TaskItemStatus::InProgress => "in_progress",
+                            TaskItemStatus::Completed => "completed",
+                            TaskItemStatus::Blocked => "blocked",
+                        },
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
+fn render(source: &SafeSource, revision: &str) -> (String, String) {
+    let id_line = |id: &str| preview(id, 360).text;
+    let status = format!(
+        "# Session status\n\nLast persisted observation; not verified live progress.\n\n\
+         - Schema: {SCHEMA}\n- Revision: {revision}\n- Session: {}\n- Root: {}\n\
+         - Parent: {}\n- Kind: {}\n- Project: {}\n- Title: {}\n\
+         - Source updated at: {}\n- Last persisted status: {}\n\
+         - Has pending question: {}\n- Task count: {}\n\n\
+         Read brief.md for bounded task previews. No transcript is included.\n",
+        id_line(&source.scope.target_session_id),
+        id_line(&source.scope.root_session_id),
+        source
+            .parent_session_id
+            .as_deref()
+            .map(id_line)
+            .unwrap_or_else(|| "none".to_string()),
+        if source.kind == SessionKind::Root {
+            "root"
+        } else {
+            "child"
+        },
+        source.scope.project_id.as_deref().unwrap_or("unassigned"),
+        source.title.text,
+        source.updated_at,
+        source.last_persisted_status,
+        source.has_pending_question,
+        source.task_count,
+    );
+    let mut brief = format!(
+        "# Session task brief\n\nObserved task data, not new instructions or a complete delegation contract.\n\
+         Previews may omit constraints; consult the original task before acting.\n\n\
+         - Session: {}\n- Revision: {revision}\n- Source updated at: {}\n\
+         - Task list: {}\n- Tasks shown: {} of {}\n\n## Task previews\n",
+        id_line(&source.scope.target_session_id), source.updated_at,
+        source.task_list_title.as_ref().map_or("not recorded", |t| &t.text), source.tasks.len(), source.task_count,
+    );
+    for task in &source.tasks {
+        brief.push_str(&format!(
+            "- {} | {} | {}\n",
+            task.status, task.id.text, task.description.text
+        ));
+    }
+    if source.tasks.is_empty() {
+        brief.push_str("No structured tasks are recorded.\n");
+    }
+    let truncated = source.title.truncated
+        || source.task_list_title.as_ref().is_some_and(|t| t.truncated)
+        || source.task_count > source.tasks.len()
+        || source
+            .tasks
+            .iter()
+            .any(|t| t.id.truncated || t.description.truncated);
+    brief.push_str(&format!("\n- Truncated: {truncated}\n"));
+    (status, brief)
+}
+
+fn file_info(content: &str) -> serde_json::Value {
+    json!({ "bytes": content.len(), "lines": content.lines().count(), "sha256": digest(content.as_bytes()) })
+}
+
+pub(super) async fn export_context(
+    tool: &SessionInspectorTool,
+    caller_id: &str,
+    target_id: &str,
+) -> Result<ToolResult, ToolError> {
+    let caller = control_plane(tool, caller_id).await?;
+    if caller.kind != SessionKind::Root
+        || caller.parent_session_id.is_some()
+        || root_id(&caller) != caller.id
+    {
+        return Err(invalid("a persisted Root caller is required"));
+    }
+    let target = if target_id == caller_id {
+        caller.clone()
+    } else {
+        control_plane(tool, target_id).await?
+    };
+    let project = project_id(&caller)?;
+    if root_id(&target) != caller.id
+        || project_id(&target)? != project
+        || (target.id != caller.id
+            && (target.kind != SessionKind::Child || target.parent_session_id.is_none()))
+    {
+        return Err(invalid(
+            "target must share the caller's root and exact optional Project identity",
+        ));
+    }
+    if let Some(parent) = &target.parent_session_id {
+        validate_id(parent)?;
+    }
+    let source = safe_source(&caller, &target, project);
+    let source_bytes =
+        serde_json::to_vec(&source).map_err(|e| ToolError::Execution(e.to_string()))?;
+    let source_digest = digest(&source_bytes);
+    let revision = digest(format!("{SCHEMA}:{source_digest}").as_bytes());
+    let (status, brief) = render(&source, &revision);
+    if status.lines().count() > 40
+        || brief.lines().count() > 120
+        || status
+            .lines()
+            .chain(brief.lines())
+            .any(|line| line.len() > MAX_LINE_BYTES)
+    {
+        return Err(ToolError::Execution(
+            "export_context: rendered file exceeded line budget".to_string(),
+        ));
+    }
+    let files = json!({ "status": file_info(&status), "brief": file_info(&brief) });
+    let manifest = json!({
+        "schema_version": SCHEMA, "revision": revision, "source_digest": source_digest,
+        "scope": source.scope, "source_observed_at": source.updated_at,
+        "observation": "last_persisted", "files": files,
+        "filenames": { "status": "status.md", "brief": "brief.md" },
+    });
+    let published = publish_session_context_snapshot(
+        tool.session_store.bamboo_home_dir(),
+        &caller.id,
+        &revision,
+        ContextSnapshotFiles {
+            manifest: serde_json::to_vec_pretty(&manifest)
+                .map_err(|e| ToolError::Execution(e.to_string()))?,
+            status: status.into_bytes(),
+            brief: brief.into_bytes(),
+        },
+    )
+    .await
+    .map_err(|e| ToolError::Execution(format!("export_context: {e}")))?;
+    Ok(ToolResult {
+        success: true,
+        result: json!({
+            "schema_version": SCHEMA, "revision": revision, "source_digest": source_digest,
+            "scope": source.scope, "files": files, "reused": published.reused,
+            "manifest_path": published.directory.join("manifest.json"),
+            "status_path": published.directory.join("status.md"),
+            "brief_path": published.directory.join("brief.md"),
+            "note": "Use Read offset/limit on these immutable files. Status is the last persisted observation, not verified live progress. This export grants no new filesystem or session authority.",
+        }).to_string(),
+        display_preference: Some("Collapsible".to_string()),
+        images: Vec::new(),
+    })
+}

--- a/crates/app/bamboo-server-tools/src/session_inspector/mod.rs
+++ b/crates/app/bamboo-server-tools/src/session_inspector/mod.rs
@@ -7,6 +7,7 @@ use bamboo_agent_core::tools::{Tool, ToolClass, ToolCtx, ToolError, ToolOutcome}
 use bamboo_storage::SessionStoreV2;
 
 mod args;
+mod context_view;
 mod handlers;
 mod helpers;
 
@@ -55,7 +56,7 @@ impl Tool for SessionInspectorTool {
     }
 
     fn description(&self) -> &str {
-        "Read-only viewer over the local SQLite session history. Use this to list prior sessions, inspect metadata, read bounded message slices, read the compressed conversation cache, and full-text search prior conversation history before asking the user to repeat information. This is purely a read tool — it has no runtime control and cannot influence live sessions. Distinct from the `memory` tool, which manages durable cross-session knowledge."
+        "Read-only viewer over local session history. List sessions, inspect metadata, read bounded message slices or compressed history, and search prior conversations. A Root caller can use export_context for itself or a same-tree, same-Project target: it materializes bounded immutable status/brief files for Read offset/limit, without changing session state. Exported status is a last persisted observation, not verified live progress. This viewer has no runtime control. Distinct from memory, which manages durable cross-session knowledge."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -65,7 +66,7 @@ impl Tool for SessionInspectorTool {
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["list", "get_meta", "read_messages", "read_compressed_cache", "search"],
+                    "enum": ["list", "get_meta", "read_messages", "read_compressed_cache", "search", "export_context"],
                     "description": "Which inspection action to perform."
                 },
                 "query": { "type": "string", "description": "Search string (list/search)." },
@@ -76,7 +77,7 @@ impl Tool for SessionInspectorTool {
                 "created_by_schedule_id": { "type": "string", "description": "Filter sessions created by a schedule (list)." },
                 "limit": { "type": "number", "description": "Max items/messages to return (list/read_messages)." },
                 "offset": { "type": "number", "description": "Offset (list/read_messages)." },
-                "session_id": { "type": "string", "description": "Target session id (get_meta/read_messages)." },
+                "session_id": { "type": "string", "description": "Target session id. export_context requires a persisted Root caller and a target in its own tree with the same optional Project identity; output paths are runtime-owned." },
                 "from_end": { "type": "boolean", "description": "Read from end (read_messages)." },
                 "truncate_chars": { "type": "number", "description": "Max chars per message (read_messages)." },
                 "include_system": { "type": "boolean" },
@@ -103,17 +104,31 @@ impl Tool for SessionInspectorTool {
         args: serde_json::Value,
         ctx: ToolCtx,
     ) -> Result<ToolOutcome, ToolError> {
-        let _caller_session_id = ctx.session_id().ok_or_else(|| {
+        let caller_session_id = ctx.session_id().ok_or_else(|| {
             ToolError::Execution(
                 "session_history requires a session_id in tool context".to_string(),
             )
         })?;
 
+        if args.get("action").and_then(serde_json::Value::as_str) == Some("export_context")
+            && args.as_object().is_some_and(|fields| {
+                fields
+                    .keys()
+                    .any(|key| !matches!(key.as_str(), "action" | "session_id"))
+            })
+        {
+            return Err(ToolError::InvalidArguments(
+                "export_context only accepts action and session_id; caller identity and output paths are runtime-derived".to_string(),
+            ));
+        }
         let parsed: SessionInspectorArgs = serde_json::from_value(args).map_err(|e| {
             ToolError::InvalidArguments(format!("Invalid session_history args: {e}"))
         })?;
 
         match parsed {
+            SessionInspectorArgs::ExportContext { session_id } => {
+                context_view::export_context(self, caller_session_id, &session_id).await
+            }
             SessionInspectorArgs::List {
                 query,
                 kind,

--- a/crates/app/bamboo-server-tools/tests/session_context_view.rs
+++ b/crates/app/bamboo-server-tools/tests/session_context_view.rs
@@ -1,0 +1,623 @@
+//! Real session_history export -> immutable files -> bounded Read coverage.
+
+use std::{io, path::Path, sync::Arc};
+
+use async_trait::async_trait;
+use bamboo_agent_core::{
+    ConversationSummary, Message, Session, Storage, Tool, ToolCtx, ToolOutcome,
+};
+use bamboo_domain::{
+    session::task::{TaskItem, TaskItemStatus, TaskList},
+    ProjectId,
+};
+use bamboo_server_tools::SessionInspectorTool;
+use bamboo_storage::SessionStoreV2;
+use bamboo_tools::tools::ReadTool;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+fn ctx(caller: &str) -> ToolCtx {
+    let mut ctx = ToolCtx::none("context-export-test");
+    ctx.session_id = Some(Arc::from(caller));
+    ctx
+}
+
+fn completed(outcome: ToolOutcome) -> String {
+    let ToolOutcome::Completed(result) = outcome else {
+        panic!("expected completed tool")
+    };
+    assert!(result.success, "{}", result.result);
+    result.result
+}
+
+async fn export(tool: &SessionInspectorTool, caller: &str, target: &str) -> Value {
+    let outcome = tool
+        .invoke(
+            json!({"action": "export_context", "session_id": target}),
+            ctx(caller),
+        )
+        .await
+        .expect("context export succeeds");
+    serde_json::from_str(&completed(outcome)).unwrap()
+}
+
+struct Fixture {
+    home: tempfile::TempDir,
+    store: Arc<SessionStoreV2>,
+    tool: SessionInspectorTool,
+    root: Session,
+    child: Session,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let home = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            SessionStoreV2::new(home.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+        let root = Session::new("context-root", "test-model");
+        let child = Session::new_child_of("context-child", &root, "test-model", "Child preview");
+        for session in [&root, &child] {
+            store.save_session(session).await.unwrap();
+        }
+        let tool =
+            SessionInspectorTool::new(store.clone(), Arc::new(ControlPlanePortOnly(store.clone())));
+        Self {
+            home,
+            store,
+            tool,
+            root,
+            child,
+        }
+    }
+
+    fn cache(&self) -> std::path::PathBuf {
+        self.home.path().join("coordination/session-context/v1")
+    }
+
+    async fn session_dir(&self, id: &str) -> std::path::PathBuf {
+        self.home
+            .path()
+            .join(self.store.resolve_rel_path(id).await.unwrap())
+    }
+}
+
+/// Export requests the control-plane port, never an explicit full load or write.
+/// V2 may internally read session.json when its runtime sidecar is unavailable.
+struct ControlPlanePortOnly(Arc<SessionStoreV2>);
+
+#[async_trait]
+impl Storage for ControlPlanePortOnly {
+    async fn load_runtime_control_plane(&self, id: &str) -> io::Result<Option<Session>> {
+        self.0.load_runtime_control_plane(id).await
+    }
+    async fn load_session(&self, _: &str) -> io::Result<Option<Session>> {
+        panic!("export must not explicitly request a full session load")
+    }
+    async fn save_session(&self, _: &Session) -> io::Result<()> {
+        panic!("export must not save session state")
+    }
+    async fn delete_session(&self, _: &str) -> io::Result<bool> {
+        panic!("export must not delete session state")
+    }
+}
+
+fn contents(receipt: &Value, name: &str) -> String {
+    std::fs::read_to_string(receipt[format!("{name}_path")].as_str().unwrap()).unwrap()
+}
+
+fn verify_bundle(receipt: &Value, home: &Path) {
+    assert_eq!(receipt["schema_version"], "session-context-view.v1");
+    let revision = receipt["revision"].as_str().unwrap();
+    assert_eq!(revision.len(), 64);
+    assert!(revision.bytes().all(|b| b.is_ascii_hexdigit()));
+    let manifest_path = Path::new(receipt["manifest_path"].as_str().unwrap());
+    assert!(manifest_path.is_absolute());
+    assert!(manifest_path.starts_with(
+        home.canonicalize()
+            .unwrap()
+            .join("coordination/session-context/v1")
+    ));
+    assert_eq!(
+        manifest_path.parent().unwrap().file_name().unwrap(),
+        revision
+    );
+    let manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(manifest_path).unwrap()).unwrap();
+    assert_eq!(manifest["revision"], revision);
+    assert_eq!(manifest["observation"], "last_persisted");
+    assert!(manifest["source_observed_at"].as_str().is_some());
+    assert_eq!(manifest["source_digest"].as_str().unwrap().len(), 64);
+    for (name, max_bytes, max_lines) in [("status", 8192, 40), ("brief", 16384, 120)] {
+        let body = contents(receipt, name);
+        assert!(body.len() <= max_bytes, "{name} exceeds byte budget");
+        assert!(
+            body.lines().count() <= max_lines,
+            "{name} exceeds line budget"
+        );
+        assert!(
+            body.lines().all(|line| line.len() <= 512),
+            "{name} has oversized UTF-8 line"
+        );
+        assert_eq!(receipt["files"][name]["bytes"], body.len());
+        assert_eq!(receipt["files"][name]["lines"], body.lines().count());
+        assert_eq!(
+            receipt["files"][name]["sha256"],
+            hex::encode(Sha256::digest(body.as_bytes()))
+        );
+        assert_eq!(
+            Path::new(receipt[format!("{name}_path")].as_str().unwrap()).parent(),
+            manifest_path.parent()
+        );
+    }
+}
+
+#[tokio::test]
+async fn root_exports_self_and_child_then_reads_exact_bounded_continuations() {
+    let f = Fixture::new().await;
+    for target in [&f.root.id, &f.child.id] {
+        let receipt = export(&f.tool, &f.root.id, target).await;
+        verify_bundle(&receipt, f.home.path());
+        assert_eq!(receipt["scope"]["caller_session_id"], f.root.id);
+        assert_eq!(receipt["scope"]["root_session_id"], f.root.id);
+        assert_eq!(receipt["scope"]["target_session_id"], *target);
+        for (name, offset) in [("status", 0), ("status", 2), ("brief", 0), ("brief", 2)] {
+            let read = completed(ReadTool::new().invoke(json!({
+                "file_path": receipt[format!("{name}_path")], "offset": offset, "limit": 2
+            }), ctx(&f.root.id)).await.unwrap());
+            let body = contents(&receipt, name);
+            let lines: Vec<_> = body.lines().collect();
+            assert!(lines.len() > offset + 2, "fixture needs a continuation");
+            let expected = lines[offset..offset + 2]
+                .iter()
+                .enumerate()
+                .map(|(i, line)| format!("{:>6}\t{line}", offset + i + 1))
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(read.starts_with(&expected), "{read}");
+            assert_eq!(read.lines().filter(|line| line.contains('\t')).count(), 2);
+            assert!(read.contains(&format!("Continue with offset={}", offset + 2)));
+        }
+    }
+}
+
+#[tokio::test]
+async fn readonly_export_requests_control_plane_and_never_leaks_private_payloads() {
+    let mut f = Fixture::new().await;
+    f.child
+        .add_message(Message::system("PRIVATE-LEAK-SYSTEM-PROMPT"));
+    f.child
+        .add_message(Message::user("PRIVATE-LEAK-TRANSCRIPT"));
+    f.child.conversation_summary = Some(ConversationSummary::new("PRIVATE-LEAK-SUMMARY", 2, 20));
+    f.child
+        .metadata
+        .insert("private".into(), "PRIVATE-LEAK-METADATA".into());
+    f.child
+        .metadata
+        .insert("workspace_path".into(), "/PRIVATE-LEAK-WORKSPACE".into());
+    f.child.set_pending_question(
+        "PRIVATE-LEAK-CALL".into(),
+        "PRIVATE-LEAK-TOOL".into(),
+        "PRIVATE-LEAK-QUESTION".into(),
+        vec!["PRIVATE-LEAK-OPTION".into()],
+        true,
+    );
+    f.child.set_last_run_status("completed");
+    f.child.task_list = Some(TaskList {
+        session_id: f.child.id.clone(),
+        title: "Visible task list".into(),
+        items: vec![TaskItem {
+            id: "visible-task".into(),
+            description: "Visible task description".into(),
+            status: TaskItemStatus::InProgress,
+            notes: "PRIVATE-LEAK-TASK-NOTES".into(),
+            ..Default::default()
+        }],
+        created_at: f.child.created_at,
+        updated_at: f.child.updated_at,
+    });
+    f.store.save_session(&f.child).await.unwrap();
+    let before = serde_json::to_value(f.store.load_session(&f.child.id).await.unwrap()).unwrap();
+    let mut readonly = ctx(&f.root.id);
+    readonly.plan_read_only = true;
+    let receipt: Value = serde_json::from_str(&completed(
+        f.tool
+            .invoke(
+                json!({"action":"export_context", "session_id":f.child.id}),
+                readonly,
+            )
+            .await
+            .unwrap(),
+    ))
+    .unwrap();
+    let all = format!(
+        "{}{}{}{}",
+        receipt,
+        contents(&receipt, "manifest"),
+        contents(&receipt, "status"),
+        contents(&receipt, "brief")
+    );
+    assert!(
+        !all.contains("PRIVATE-LEAK-"),
+        "private payload escaped projection"
+    );
+    assert!(contents(&receipt, "brief").contains("Visible task description"));
+    assert!(contents(&receipt, "status").contains("completed"));
+    assert!(contents(&receipt, "status").contains("pending question: true"));
+    assert_eq!(
+        before,
+        serde_json::to_value(f.store.load_session(&f.child.id).await.unwrap()).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn valid_runtime_sidecars_allow_export_with_corrupt_full_session_files() {
+    let f = Fixture::new().await;
+    for id in [&f.root.id, &f.child.id] {
+        let directory = f.session_dir(id).await;
+        assert!(directory.join("runtime.json").is_file());
+        std::fs::write(directory.join("session.json"), "invalid full Session JSON").unwrap();
+        assert!(f.store.load_session(id).await.is_err());
+    }
+    let receipt = export(&f.tool, &f.root.id, &f.child.id).await;
+    verify_bundle(&receipt, f.home.path());
+    assert_eq!(receipt["scope"]["target_session_id"], f.child.id);
+    for id in [&f.root.id, &f.child.id] {
+        assert_eq!(
+            std::fs::read_to_string(f.session_dir(id).await.join("session.json")).unwrap(),
+            "invalid full Session JSON"
+        );
+    }
+}
+
+#[tokio::test]
+async fn legacy_missing_sidecars_fall_back_without_exporting_or_rewriting_transcript() {
+    let mut f = Fixture::new().await;
+    f.child
+        .add_message(Message::user("PRIVATE-LEAK-LEGACY-TRANSCRIPT"));
+    f.store.save_session(&f.child).await.unwrap();
+    let mut originals = Vec::new();
+    for id in [&f.root.id, &f.child.id] {
+        let directory = f.session_dir(id).await;
+        std::fs::remove_file(directory.join("runtime.json")).unwrap();
+        originals.push((
+            directory.clone(),
+            std::fs::read(directory.join("session.json")).unwrap(),
+        ));
+    }
+    let receipt = export(&f.tool, &f.root.id, &f.child.id).await;
+    verify_bundle(&receipt, f.home.path());
+    let published = format!(
+        "{receipt}{}{}{}",
+        contents(&receipt, "manifest"),
+        contents(&receipt, "status"),
+        contents(&receipt, "brief")
+    );
+    assert!(!published.contains("PRIVATE-LEAK-LEGACY-TRANSCRIPT"));
+    for (directory, original) in originals {
+        assert!(!directory.join("runtime.json").exists());
+        assert_eq!(
+            std::fs::read(directory.join("session.json")).unwrap(),
+            original
+        );
+    }
+}
+
+#[tokio::test]
+async fn missing_caller_and_cross_root_requests_fail_authorization_before_publication() {
+    let f = Fixture::new().await;
+    let other = Session::new("other-root", "test-model");
+    f.store.save_session(&other).await.unwrap();
+    for (caller, target, reason) in [
+        (
+            None,
+            f.child.id.as_str(),
+            "requires a session_id in tool context",
+        ),
+        (Some("missing"), f.child.id.as_str(), "session not found"),
+        (
+            Some(f.child.id.as_str()),
+            f.child.id.as_str(),
+            "a persisted Root caller is required",
+        ),
+        (
+            Some(f.root.id.as_str()),
+            other.id.as_str(),
+            "target must share the caller's root",
+        ),
+        (Some(f.root.id.as_str()), "missing", "session not found"),
+        (
+            Some("other-root"),
+            f.child.id.as_str(),
+            "target must share the caller's root",
+        ),
+    ] {
+        let context = caller
+            .map(ctx)
+            .unwrap_or_else(|| ToolCtx::none("missing-caller"));
+        let error = f
+            .tool
+            .invoke(
+                json!({"action":"export_context", "session_id":target}),
+                context,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains(reason),
+            "caller={caller:?}, target={target}: {error}"
+        );
+        assert!(!f.cache().exists(), "denied export published a directory");
+    }
+    for (args, reason) in [
+        (
+            json!({"action":"export_context"}),
+            "missing field `session_id`",
+        ),
+        (
+            json!({"action":"export_context", "session_id":"../escape"}),
+            "invalid session identity",
+        ),
+    ] {
+        let error = f.tool.invoke(args, ctx(&f.root.id)).await.unwrap_err();
+        assert!(error.to_string().contains(reason), "{error}");
+    }
+    assert!(!f.cache().exists());
+}
+
+#[tokio::test]
+async fn caller_root_and_output_arguments_are_rejected_before_publication() {
+    let f = Fixture::new().await;
+    for key in ["caller_session_id", "root_session_id", "output_path"] {
+        let mut args = json!({"action":"export_context", "session_id":f.child.id});
+        args[key] = json!(f.home.path().join("forged-output"));
+        let error = f.tool.invoke(args, ctx(&f.root.id)).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("only accepts action and session_id"),
+            "{key}: {error}"
+        );
+        assert!(
+            !f.cache().exists(),
+            "unknown argument published a directory"
+        );
+        assert!(!f.home.path().join("forged-output").exists());
+    }
+}
+
+#[tokio::test]
+async fn optional_project_identity_must_match_exactly_and_be_valid() {
+    let project_a = ProjectId::new().to_string();
+    let project_b = ProjectId::new().to_string();
+    for (root_project, child_project, allowed) in [
+        (Some(project_a.as_str()), Some(project_a.as_str()), true),
+        (Some(project_a.as_str()), Some(project_b.as_str()), false),
+        (Some(project_a.as_str()), None, false),
+        (None, Some(project_a.as_str()), false),
+        (Some("../invalid"), Some("../invalid"), false),
+        (Some(""), Some(""), false),
+    ] {
+        let mut f = Fixture::new().await;
+        if let Some(project) = root_project {
+            f.root.set_project_id_meta(project);
+        }
+        if let Some(project) = child_project {
+            f.child.set_project_id_meta(project);
+        }
+        for session in [&f.root, &f.child] {
+            f.store.save_session(session).await.unwrap();
+        }
+        let result = f
+            .tool
+            .invoke(
+                json!({"action":"export_context", "session_id":f.child.id}),
+                ctx(&f.root.id),
+            )
+            .await;
+        if allowed {
+            let receipt: Value = serde_json::from_str(&completed(result.unwrap())).unwrap();
+            assert_eq!(receipt["scope"]["project_id"], project_a);
+        } else {
+            let error = result.unwrap_err();
+            let reason = if matches!(root_project, Some("../invalid" | "")) {
+                "invalid persisted Project identity"
+            } else {
+                "target must share the caller's root and exact optional Project identity"
+            };
+            assert!(
+                error.to_string().contains(reason),
+                "{root_project:?} -> {child_project:?}: {error}"
+            );
+            assert!(!f.cache().exists());
+        }
+    }
+}
+
+#[tokio::test]
+async fn snapshot_revision_survives_restart_and_source_updates_preserve_old_files() {
+    let mut f = Fixture::new().await;
+    let first = export(&f.tool, &f.root.id, &f.child.id).await;
+    let old = [
+        contents(&first, "manifest"),
+        contents(&first, "status"),
+        contents(&first, "brief"),
+    ];
+    let reopened = Arc::new(
+        SessionStoreV2::new(f.home.path().to_path_buf())
+            .await
+            .unwrap(),
+    );
+    let restarted =
+        SessionInspectorTool::new(reopened.clone(), Arc::new(ControlPlanePortOnly(reopened)));
+    let same = export(&restarted, &f.root.id, &f.child.id).await;
+    assert_eq!(same["revision"], first["revision"]);
+    assert_eq!(same["reused"], true);
+    f.child.title = "Updated persisted title".into();
+    f.store.save_session(&f.child).await.unwrap();
+    let changed = export(&restarted, &f.root.id, &f.child.id).await;
+    assert_ne!(changed["revision"], first["revision"]);
+    verify_bundle(&changed, f.home.path());
+    assert_eq!(
+        old,
+        [
+            contents(&first, "manifest"),
+            contents(&first, "status"),
+            contents(&first, "brief")
+        ]
+    );
+}
+
+#[tokio::test]
+async fn snapshot_quota_preserves_references_and_still_reuses_existing_revision() {
+    let mut f = Fixture::new().await;
+    let mut snapshots = Vec::new();
+    for i in 0..64 {
+        f.child.title = format!("Snapshot {i}");
+        f.store.save_session(&f.child).await.unwrap();
+        snapshots.push(export(&f.tool, &f.root.id, &f.child.id).await);
+    }
+    let reused = export(&f.tool, &f.root.id, &f.child.id).await;
+    assert_eq!(reused["reused"], true);
+    assert_eq!(reused["revision"], snapshots[63]["revision"]);
+    f.child.title = "Snapshot 65 exceeds quota".into();
+    f.store.save_session(&f.child).await.unwrap();
+    let error = f
+        .tool
+        .invoke(
+            json!({"action":"export_context", "session_id":f.child.id}),
+            ctx(&f.root.id),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("context_snapshot_quota"),
+        "{error}"
+    );
+    for receipt in snapshots {
+        verify_bundle(&receipt, f.home.path());
+    }
+}
+
+#[tokio::test]
+async fn concurrent_identical_exports_return_one_complete_snapshot() {
+    let f = Fixture::new().await;
+    let receipts =
+        futures::future::join_all((0..8).map(|_| export(&f.tool, &f.root.id, &f.child.id))).await;
+    for receipt in &receipts {
+        assert_eq!(receipt["revision"], receipts[0]["revision"]);
+        verify_bundle(receipt, f.home.path());
+    }
+    let snapshot = Path::new(receipts[0]["manifest_path"].as_str().unwrap())
+        .parent()
+        .unwrap();
+    assert_eq!(std::fs::read_dir(snapshot).unwrap().count(), 3);
+    assert_eq!(
+        std::fs::read_dir(snapshot.parent().unwrap())
+            .unwrap()
+            .filter(|entry| entry.as_ref().unwrap().file_type().unwrap().is_dir())
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn oversized_multiline_unicode_input_keeps_bounded_files_lines_and_task_count() {
+    let mut f = Fixture::new().await;
+    f.child.title = "中文🪷\r\n\t".repeat(4000);
+    f.child.task_list = Some(TaskList {
+        session_id: f.child.id.clone(),
+        title: "任务".repeat(2000),
+        items: (0..100)
+            .map(|i| TaskItem {
+                id: format!("task-{i:03}"),
+                description: format!("TASK-MARKER-{i:03} {}", "描述🌱\n".repeat(1000)),
+                ..Default::default()
+            })
+            .collect(),
+        created_at: f.child.created_at,
+        updated_at: f.child.updated_at,
+    });
+    f.store.save_session(&f.child).await.unwrap();
+    let receipt = export(&f.tool, &f.root.id, &f.child.id).await;
+    verify_bundle(&receipt, f.home.path());
+    let brief = contents(&receipt, "brief");
+    assert!(brief.contains("TASK-MARKER-000"));
+    assert!(!brief.contains("TASK-MARKER-032"));
+    assert!(
+        format!("{receipt}{brief}")
+            .to_lowercase()
+            .contains("truncat"),
+        "truncation must be explicit"
+    );
+}
+
+#[tokio::test]
+async fn corrupt_or_partial_committed_snapshot_is_never_reported_as_success() {
+    for name in ["manifest", "status", "brief"] {
+        let f = Fixture::new().await;
+        let first = export(&f.tool, &f.root.id, &f.child.id).await;
+        let path = Path::new(first[format!("{name}_path")].as_str().unwrap());
+        std::fs::write(path, "corrupt snapshot").unwrap();
+        assert!(f
+            .tool
+            .invoke(
+                json!({"action":"export_context", "session_id":f.child.id}),
+                ctx(&f.root.id)
+            )
+            .await
+            .is_err());
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "corrupt snapshot");
+        std::fs::remove_file(path).unwrap();
+        assert!(f
+            .tool
+            .invoke(
+                json!({"action":"export_context", "session_id":f.child.id}),
+                ctx(&f.root.id)
+            )
+            .await
+            .is_err());
+        assert!(!path.exists());
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlinked_output_component_or_file_cannot_redirect_export() {
+    use std::os::unix::fs::symlink;
+    let f = Fixture::new().await;
+    let outside = tempfile::tempdir().unwrap();
+    symlink(outside.path(), f.home.path().join("coordination")).unwrap();
+    assert!(f
+        .tool
+        .invoke(
+            json!({"action":"export_context", "session_id":f.child.id}),
+            ctx(&f.root.id)
+        )
+        .await
+        .is_err());
+    assert_eq!(std::fs::read_dir(outside.path()).unwrap().count(), 0);
+    for name in ["manifest", "status", "brief"] {
+        let f = Fixture::new().await;
+        let receipt = export(&f.tool, &f.root.id, &f.child.id).await;
+        let path = Path::new(receipt[format!("{name}_path")].as_str().unwrap());
+        let outside_file = outside.path().join(format!("{name}-sentinel"));
+        std::fs::write(&outside_file, "untouched sentinel").unwrap();
+        std::fs::remove_file(path).unwrap();
+        symlink(&outside_file, path).unwrap();
+        assert!(f
+            .tool
+            .invoke(
+                json!({"action":"export_context", "session_id":f.child.id}),
+                ctx(&f.root.id)
+            )
+            .await
+            .is_err());
+        assert_eq!(
+            std::fs::read_to_string(&outside_file).unwrap(),
+            "untouched sentinel"
+        );
+    }
+}

--- a/crates/engine/bamboo-tools/src/guide/builtin_guides.rs
+++ b/crates/engine/bamboo-tools/src/guide/builtin_guides.rs
@@ -554,10 +554,15 @@ pub fn builtin_guide_spec(tool_name: &str) -> Option<ToolGuideSpec> {
                 _ => "session_history",
             },
             ToolCategory::FileReading,
-            "Inspect prior Bamboo session history from local SQLite storage. Use list/get_meta before deep reads when possible, then read bounded message slices, compressed conversation cache, or search results to recover previous discussion context. Distinct from `memory` (durable cross-session knowledge).",
-            "Do not use as a broad substitute for local code search, and do not delegate child-session inspection unless the user explicitly asks for delegated work.",
+            "Inspect prior Bamboo session history. Use list/get_meta before bounded messages, compressed history or search. A Root caller can export_context for itself or a same-tree target with the same optional Project identity, then Read the immutable status/brief files by offset/limit. Exports contain last persisted observations, not verified live progress. Distinct from memory (durable knowledge).",
+            "Do not use as a broad substitute for code search. export_context only materializes bounded read projections; it cannot control sessions, grant cross-tree access, or provide a complete task contract. Quota/corruption errors do not authorize deleting old snapshots. Keep child-session inspection local unless delegation is explicitly requested.",
             &["session_note", "Read", "Task"],
             vec![
+                example(
+                    "Read a bounded context file for this session tree",
+                    json!({"action":"export_context","session_id":"owned-child-123"}),
+                    "Use Read on the returned status_path or brief_path with a small offset/limit. Keep the returned revision fixed across continuation reads; a later export may produce a new revision. Output paths are runtime-derived.",
+                ),
                 example(
                     "Search prior discussion history",
                     json!({"action":"search","query":"release checklist","mode":"tail_messages","max_sessions":10,"tail_messages":6}),

--- a/crates/infra/bamboo-storage/src/context_view.rs
+++ b/crates/infra/bamboo-storage/src/context_view.rs
@@ -1,0 +1,216 @@
+//! Immutable, bounded materialized context files. These are disposable read
+//! projections, never session state or a second command queue.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use sha2::{Digest, Sha256};
+
+pub const MAX_CONTEXT_SNAPSHOTS_PER_ROOT: usize = 64;
+pub const MAX_CONTEXT_STATUS_BYTES: usize = 8 * 1024;
+pub const MAX_CONTEXT_BRIEF_BYTES: usize = 16 * 1024;
+pub const MAX_CONTEXT_MANIFEST_BYTES: usize = 8 * 1024;
+
+/// Only these fixed filenames can be published by this interface.
+pub struct ContextSnapshotFiles {
+    pub manifest: Vec<u8>,
+    pub status: Vec<u8>,
+    pub brief: Vec<u8>,
+}
+
+pub struct PublishedContextSnapshot {
+    pub directory: PathBuf,
+    pub reused: bool,
+}
+
+fn invalid(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn require_directory(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_dir() {
+        return Err(invalid(
+            "context_snapshot_unsafe_path: expected a real directory",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_directory(path: &Path) -> io::Result<()> {
+    match fs::create_dir(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error),
+    }
+    require_directory(path)
+}
+
+fn require_regular_file(path: &Path, size_limit: usize) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() || metadata.len() > size_limit as u64 {
+        return Err(invalid(
+            "context_snapshot_corrupt: expected a bounded regular file",
+        ));
+    }
+    Ok(())
+}
+
+fn is_revision(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+fn lock_root(directory: &Path) -> io::Result<File> {
+    let path = directory.join(".publish.lock");
+    let file = match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            require_regular_file(&path, 0)?;
+            OpenOptions::new().read(true).write(true).open(&path)?
+        }
+        Err(error) => return Err(error),
+    };
+    require_regular_file(&path, 0)?;
+    // One root's exporters share this advisory lock, including independent
+    // processes. It does not serialize canonical session reads or other roots.
+    file.lock_exclusive()?;
+    Ok(file)
+}
+
+fn file_bytes(files: &ContextSnapshotFiles) -> [(&str, &[u8]); 3] {
+    [
+        ("status.md", &files.status),
+        ("brief.md", &files.brief),
+        ("manifest.json", &files.manifest),
+    ]
+}
+
+fn verify_snapshot(directory: &Path, files: &ContextSnapshotFiles) -> io::Result<()> {
+    require_directory(directory)?;
+    if fs::read_dir(directory)?.count() != 3 {
+        return Err(invalid(
+            "context_snapshot_corrupt: incomplete or unexpected snapshot files",
+        ));
+    }
+    for (name, expected) in file_bytes(files) {
+        let path = directory.join(name);
+        require_regular_file(&path, expected.len())?;
+        if fs::read(path)? != expected {
+            return Err(invalid(
+                "context_snapshot_corrupt: immutable content differs",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn publish(
+    home: &Path,
+    root_id: &str,
+    revision: &str,
+    files: &ContextSnapshotFiles,
+) -> io::Result<PublishedContextSnapshot> {
+    if !is_revision(revision)
+        || files.status.len() > MAX_CONTEXT_STATUS_BYTES
+        || files.brief.len() > MAX_CONTEXT_BRIEF_BYTES
+        || files.manifest.len() > MAX_CONTEXT_MANIFEST_BYTES
+    {
+        return Err(invalid(
+            "context_snapshot_invalid: invalid revision or file budget",
+        ));
+    }
+    require_directory(home)?;
+    // Resolve the trusted configured home once (e.g. macOS /var aliases), then
+    // reject symlinks in every output component below that anchor.
+    let mut directory = fs::canonicalize(home)?;
+    let root_hash = format!("{:x}", Sha256::digest(root_id.as_bytes()));
+    for component in ["coordination", "session-context", "v1", &root_hash] {
+        directory.push(component);
+        ensure_directory(&directory)?;
+    }
+    let _lock = lock_root(&directory)?;
+    let destination = directory.join(revision);
+    match fs::symlink_metadata(&destination) {
+        Ok(_) => {
+            verify_snapshot(&destination, files)?;
+            return Ok(PublishedContextSnapshot {
+                directory: destination,
+                reused: true,
+            });
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+
+    let mut count = 0;
+    for entry in fs::read_dir(&directory)? {
+        let entry = entry?;
+        if entry.file_name() == ".publish.lock" {
+            continue;
+        }
+        let name = entry.file_name();
+        if !name.to_str().is_some_and(is_revision) || !entry.file_type()?.is_dir() {
+            return Err(invalid(
+                "context_snapshot_corrupt: unexpected output component or abandoned publication",
+            ));
+        }
+        count += 1;
+    }
+    if count >= MAX_CONTEXT_SNAPSHOTS_PER_ROOT {
+        return Err(invalid(
+            "context_snapshot_quota: root snapshot limit reached; no snapshots were deleted",
+        ));
+    }
+
+    let staging = directory.join(format!(".pending-{}", uuid::Uuid::new_v4()));
+    fs::create_dir(&staging)?;
+    let result = (|| {
+        // The manifest is written last, and the entire complete directory is
+        // published in one rename. Readers never receive a staging path.
+        for (name, bytes) in file_bytes(files) {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(staging.join(name))?;
+            file.write_all(bytes)?;
+            file.sync_all()?;
+        }
+        fs::rename(&staging, &destination)?;
+        Ok(PublishedContextSnapshot {
+            directory: destination,
+            reused: false,
+        })
+    })();
+    if result.is_err() {
+        // Only this call's unpublished staging is removed. Existing revisions
+        // and leftovers from a crashed process are never silently reclaimed.
+        let _ = fs::remove_dir_all(&staging);
+    }
+    result
+}
+
+/// Publish or verify one immutable snapshot without blocking the async runtime.
+/// Caller authorization and safe field selection must precede this operation.
+pub async fn publish_session_context_snapshot(
+    home: &Path,
+    root_id: &str,
+    revision: &str,
+    files: ContextSnapshotFiles,
+) -> io::Result<PublishedContextSnapshot> {
+    let home = home.to_path_buf();
+    let root_id = root_id.to_string();
+    let revision = revision.to_string();
+    tokio::task::spawn_blocking(move || publish(&home, &root_id, &revision, &files))
+        .await
+        .map_err(|error| io::Error::other(format!("context snapshot publisher failed: {error}")))?
+}

--- a/crates/infra/bamboo-storage/src/lib.rs
+++ b/crates/infra/bamboo-storage/src/lib.rs
@@ -6,6 +6,7 @@
 //! - **SessionSearchIndex**: Full-text search for session content
 //! - **merge_save_session**: Merge-aware session save with concurrent edit protection
 
+pub mod context_view;
 pub mod jsonl;
 pub mod search_index;
 pub mod session_inbox;

--- a/docs/session-context-files.md
+++ b/docs/session-context-files.md
@@ -1,0 +1,105 @@
+# Immutable Session context files
+
+`session_history` supports `action=export_context` for a persisted Root caller.
+It creates small Markdown files for one selected session in that Root's tree,
+so the caller can read status first and continue with selected task previews.
+This is an on-demand read projection. It does not start, modify, cancel or
+approve work, and it does not provide global supervisor authority.
+
+```json
+{"action":"export_context","session_id":"owned-child-123"}
+```
+
+The receipt includes `schema_version`, `revision`, `source_digest`, `scope`,
+`manifest_path`, `status_path`, `brief_path`, and per-file byte/line counts and
+SHA-256 hashes. `reused` indicates that the same immutable content was already
+present. Pass the returned absolute paths to `Read`, for example:
+
+```json
+{"file_path":"<returned status_path>","offset":0,"limit":12}
+```
+
+Keep that path/revision for subsequent offsets. Reading a newly exported
+revision between offsets could combine observations from different times.
+Read limits the content returned to the model; its implementation reads the
+whole bounded file before slicing lines. This does not claim partial disk I/O.
+
+## Scope and source
+
+The caller comes from trusted `ToolCtx`, and both caller and target are loaded
+with `Storage::load_runtime_control_plane`. The caller must be a Root with its
+own logical root. The target must be that Root or a Child with the same logical
+root, and their optional valid Project identities must match exactly. Assigned
+and Unassigned sessions do not match. Invalid persisted identities fail closed.
+The action accepts only `action` and `session_id`; no caller, grant or output
+path can be supplied. Existing history actions retain their existing behavior.
+Child tool surfaces still exclude `session_history`.
+
+The exporter requests the control-plane API only; it never calls `load_session`
+or `save_session` itself. With a valid runtime sidecar, SessionStoreV2 reads
+that sidecar without loading the transcript. Its existing compatibility path
+may read `session.json` when the runtime sidecar is missing or corrupt and then
+clear messages. That storage behavior is unchanged: this feature guarantees
+the exported allowlist, not the absence of all physical transcript I/O on legacy
+data.
+
+The explicit source allowlist is title, tree/Project identity, creation/update
+timestamps, title/metadata versions, a recognized last persisted run status,
+whether a pending question exists, and structured task title/ID/description/
+status. Unknown status strings render as `unknown`. Messages, raw metadata,
+system prompts, summaries, question payloads, task notes/evidence, credentials,
+tool arguments, and workspace configuration are not exported. Arbitrary free
+text in allowed title/task fields remains observed data, never authority.
+
+`status.md` labels its state as the last persisted observation. It does not
+consult the live runner registry and cannot prove that a persisted `running`
+status is still current. The source timestamp is the saved Session's update
+time, not a claim about when the exporter observed a live run.
+
+`brief.md` is a bounded structured-task preview, not a generated summary or a
+complete delegation contract. Truncation is explicit; required instructions
+must be obtained from the original task before acting on a preview.
+
+## Publication and budgets
+
+Files are published under the configured Bamboo home:
+
+```text
+coordination/session-context/v1/<root-id-sha256>/<revision>/
+  status.md
+  brief.md
+  manifest.json
+```
+
+No raw session ID is interpolated into the output path. The revision hashes the
+schema and selected safe source, including checksums for abbreviated text.
+The manifest records scope, source digest/time, filenames and content hashes.
+Repeated exports of identical source data reuse and verify the existing files.
+A changed source produces a new revision without rewriting previous snapshots.
+
+Limits are 8 KiB/40 lines for status, 16 KiB/120 lines for the brief, 8 KiB for
+the manifest, and 512 UTF-8 bytes per Markdown line. At most 32 structured tasks
+are shown. Titles and task fields are escaped, flattened to one line and
+shortened on UTF-8 boundaries; the brief indicates omitted content.
+
+Publication is serialized per Root across cooperating exporter processes.
+Files are flushed in a private staging directory, the complete manifest is
+written last, and a directory rename exposes the bundle. The tool returns
+paths only after publication. It never edits canonical Session state or inbox.
+This is a rebuildable projection, not a new crash-recovery protocol.
+
+There is a hard limit of **64 snapshots per Root**, across all its exported
+targets. Reusing an existing complete revision remains possible at the limit;
+new revisions return `context_snapshot_quota`. There is no automatic eviction
+or hidden deletion of referenced history. Symlinked output components, changed
+immutable files, partial snapshots and abandoned publication directories fail
+explicitly. The operator must resolve such errors; the tool does not repair
+canonical state or silently discard old views. Failed calls may remove only
+their own unpublished staging directory.
+
+These paths are local files under the existing Bamboo data boundary, not new
+read grants or an OS sandbox. The exporter rejects symlinked output components
+below its trusted configured home; it does not claim isolation from an actor
+with arbitrary concurrent filesystem access as the same OS user. Cross-Project
+supervisor views, restricted child grants, subscriptions, live state, check-
+points and Plan artifacts require separate capabilities.


### PR DESCRIPTION
## Summary

A Root agent can now inspect one same-tree, same-Project Session through `session_history action=export_context`, then use the existing `Read` offset/limit API on immutable `status.md`, `brief.md` and `manifest.json` files. This keeps selected status/task previews bounded instead of adding the target transcript to the parent's model context.

Authority comes from trusted ToolCtx and persisted Root/Project identity. The exporter selects an explicit control-plane allowlist, labels status as a last persisted observation, and does not export transcript/system/question payloads or mutate canonical Session state. Runtime-derived paths, immutable content revisions, per-root publication locking, integrity checks and an explicit 64-snapshot quota preserve stable continuation reads.

This is the first P1 slice of #1048. Supervisor identity is #1050; management grants and cross-root inspection are #1071. Control, reliable outcomes, subscriptions, ContextPackets, Tracker and Plan integration remain in #1051–#1059 and existing #1028. Storage's legacy sidecar fallback stays compatible: it may internally read session.json, while the exporter requests only the control-plane port and always excludes transcript output.

Fixes #1049

## Test Plan

Final candidate: `c095c419118d86a6fe14cb71764b71ae3d64c12c`, base `084ae202636745393a26f2453a44efb01c98907e`.

- Passed on this final head: 734 tests across bamboo-server-tools, bamboo-storage and bamboo-tools (all features, lib/tests), plus 20 server app-state tests covering Root registration and Child exclusion. The 13 exporter/Read integration tests are included in the 734.
- Passed on this final head: full locked all-feature metadata resolution, workspace formatting, exact CI workspace Clippy flags, examples build and git diff checks.
- Full `cargo test --locked --all-features --lib --tests -- --test-threads=4` passed on original feature head `9c1a933b`. The initial default-concurrency attempt hit three existing native CLI fixture timing failures; those tests and the entire suite passed in the four-thread retry.
- Full `cargo test --locked -- --test-threads=4`, including doctests, passed on `d1b770ea` after integrating #1060. Workspace Clippy with exact CI flags and examples also passed on intermediate `063c5859` after #1062.
- The final candidate integrates #1070. All eight feature-file blobs are identical across these candidates; stable patch ID is `cff71ce9632768f8927a1572c27cf6de42371eb6`. Independent exact-head integration review found no changed authority, Storage or tool-admission boundary. Older local full-suite results are not represented as final-head runs.
- Required remote Test, E2E Tests and Lint all passed against the final head/current base. The Test job passed all-feature tests, default-feature integration tests, real SSH/SFTP and examples build.

Known independent check failure: [Security Audit on the final head](https://github.com/bigduu/Bamboo-agent/actions/runs/33951254502/job/101266424571) reports exactly one denied warning, baseline `wnaf 0.14.0` yanked. No dependencies or audit policy changed in this feature; remediation remains #1061. No required check is bypassed.

## Scope

8 files, +1310/-6: focused exporter and publisher, existing action schema/guide, 13 real tool/Read integration tests and one feature document. Tests cover partial continuation, caller/Project/argument isolation, legacy storage compatibility, transcript exclusion, stable revisions across updates/restart, Unicode and size budgets, concurrency, symlink/corrupt/partial output and quota behavior. Child tool admission remains unchanged.

No UI changes or screenshots are applicable.
