### PR TITLE
fix: bound child event queues and own worker lifetimes (#1047)

### DIFF
--- a/crates/app/bamboo-broker/src/child_link.rs
+++ b/crates/app/bamboo-broker/src/child_link.rs
@@ -370,7 +370,7 @@ mod tests {
             mut steer: bamboo_subagent::SteerInbox,
             _cancel: tokio_util::sync::CancellationToken,
         ) -> bamboo_subagent::ChildOutcome {
-            events.emit(serde_json::json!({ "type": "ready" }));
+            events.emit(serde_json::json!({ "type": "ready" })).await;
             let s = steer.recv().await.unwrap_or_default();
             bamboo_subagent::ChildOutcome::completed(format!("steered: {s}"))
         }
@@ -394,18 +394,20 @@ mod tests {
                     root_session_id: "logical-root".to_string(),
                 })
             );
-            events.emit(serde_json::json!({ "type": "ready" }));
+            events.emit(serde_json::json!({ "type": "ready" })).await;
             let bamboo_subagent::SteerMessage::SessionMessage(delivery) =
                 steer.recv_message().await.expect("typed delivery")
             else {
                 panic!("expected typed delivery");
             };
-            events.confirm_session_message(bamboo_subagent::SessionMessageAdmissionConfirmation {
-                target_session_id: delivery.target_session_id,
-                envelope_id: delivery.envelope.id.as_str().to_string(),
-                canonical_claim_generation: delivery.canonical_claim_generation,
-                activation_run_id: delivery.activation_run_id,
-            });
+            events
+                .confirm_session_message(bamboo_subagent::SessionMessageAdmissionConfirmation {
+                    target_session_id: delivery.target_session_id,
+                    envelope_id: delivery.envelope.id.as_str().to_string(),
+                    canonical_claim_generation: delivery.canonical_claim_generation,
+                    activation_run_id: delivery.activation_run_id,
+                })
+                .await;
             bamboo_subagent::ChildOutcome::completed("confirmed")
         }
     }

--- a/crates/app/bamboo-broker/src/mux.rs
+++ b/crates/app/bamboo-broker/src/mux.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use bamboo_subagent::{AgentRef, InboxKind, InboxMessage, MsgId};
@@ -29,7 +29,21 @@ use crate::proto::ClientFrame;
 /// Bound on the delivery-receipt wait (mirrors `client::DELIVER_RECEIPT_TIMEOUT`).
 const DELIVER_RECEIPT_TIMEOUT: Duration = Duration::from_secs(30);
 
-type Pending = Arc<Mutex<HashMap<MsgId, oneshot::Sender<InboxMessage>>>>;
+type Pending = Arc<StdMutex<HashMap<MsgId, oneshot::Sender<InboxMessage>>>>;
+
+struct PendingRequest {
+    pending: Pending,
+    id: MsgId,
+}
+
+impl Drop for PendingRequest {
+    fn drop(&mut self) {
+        self.pending
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(&self.id);
+    }
+}
 
 /// A multiplexed request/reply driver over one broker connection. Built from a
 /// connected + subscribed [`crate::client::BrokerClient`] via
@@ -66,12 +80,16 @@ impl MultiplexedClient {
         reader_alive: Arc<AtomicBool>,
         me: AgentRef,
     ) -> Self {
-        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let pending: Pending = Arc::new(StdMutex::new(HashMap::new()));
         let routed = pending.clone();
         let router = tokio::spawn(async move {
             while let Some(msg) = messages.recv().await {
                 if let Some(cid) = msg.correlation_id.clone() {
-                    if let Some(tx) = routed.lock().await.remove(&cid) {
+                    if let Some(tx) = routed
+                        .lock()
+                        .unwrap_or_else(|error| error.into_inner())
+                        .remove(&cid)
+                    {
                         let _ = tx.send(msg);
                         continue;
                     }
@@ -83,7 +101,10 @@ impl MultiplexedClient {
             // `messages` closed == the reader exited == the connection is dead.
             // Drop every pending sender so all in-flight waiters resolve to an
             // error instead of hanging forever.
-            routed.lock().await.clear();
+            routed
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .clear();
         });
 
         Self {
@@ -143,10 +164,22 @@ impl MultiplexedClient {
 
         // Register the waiter BEFORE sending, so a fast reply can't arrive before
         // the waiter exists (the router would otherwise drop it).
-        self.pending.lock().await.insert(qid.clone(), tx);
+        self.pending
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .insert(qid.clone(), tx);
+        // Register cleanup before the first await: caller cancellation can
+        // happen while waiting for a receipt or a reply, not only at timeout.
+        let _pending_request = PendingRequest {
+            pending: self.pending.clone(),
+            id: qid.clone(),
+        };
 
         if let Err(e) = self.deliver(target, msg).await {
-            self.pending.lock().await.remove(&qid);
+            self.pending
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .remove(&qid);
             return Err(e);
         }
 
@@ -154,7 +187,10 @@ impl MultiplexedClient {
             Ok(Ok(reply)) => Ok(reply.body),
             Ok(Err(_)) => {
                 // Sender dropped == the router cleared pending == connection dead.
-                self.pending.lock().await.remove(&qid);
+                self.pending
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .remove(&qid);
                 Err(BrokerError::Transport(
                     "connection closed before reply".into(),
                 ))
@@ -162,7 +198,10 @@ impl MultiplexedClient {
             Err(_) => {
                 // Timed out: drop our waiter so a late reply isn't mis-routed, and
                 // tell the worker to stop the abandoned run (out-of-band, #50 parity).
-                self.pending.lock().await.remove(&qid);
+                self.pending
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .remove(&qid);
                 let _ = self.cancel(target, &qid).await;
                 Err(BrokerError::Transport(format!(
                     "request to '{target}' timed out after {timeout:?}"
@@ -333,8 +372,53 @@ mod tests {
             .await;
         assert!(err.is_err(), "request to a non-responder times out");
         assert!(
-            client.pending.lock().await.is_empty(),
+            client
+                .pending
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .is_empty(),
             "the timed-out waiter was unregistered"
         );
+    }
+
+    #[tokio::test]
+    async fn cancelled_request_releases_its_correlation_waiter() {
+        let (endpoint, _dir) = start().await;
+        let client = Arc::new(mux(&endpoint, "cancel-request").await);
+        let request = tokio::spawn({
+            let client = client.clone();
+            async move {
+                client
+                    .request(
+                        "absent-worker",
+                        InboxKind::McpRequest,
+                        serde_json::json!({}),
+                        Duration::from_secs(60),
+                    )
+                    .await
+            }
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if !client
+                    .pending
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        request.abort();
+        assert!(request.await.unwrap_err().is_cancelled());
+        assert!(client
+            .pending
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .is_empty());
     }
 }

--- a/crates/app/bamboo-broker/src/serve.rs
+++ b/crates/app/bamboo-broker/src/serve.rs
@@ -170,7 +170,7 @@ struct Completion {
 
 struct InflightHandler {
     cancel: CancellationToken,
-    task: tokio::task::JoinHandle<()>,
+    task: AbortOnDropTask<()>,
     /// Number of mailbox deliveries with this id observed while the one active
     /// admission runs. None is acked until that admission completes successfully.
     deliveries: usize,
@@ -184,6 +184,12 @@ struct AbortOnDropTask<T>(Option<tokio::task::JoinHandle<T>>);
 impl<T> AbortOnDropTask<T> {
     fn new(task: tokio::task::JoinHandle<T>) -> Self {
         Self(Some(task))
+    }
+
+    fn abort(&self) {
+        if let Some(task) = &self.0 {
+            task.abort();
+        }
     }
 
     async fn join(&mut self) -> Result<T, tokio::task::JoinError> {
@@ -546,7 +552,7 @@ where
             //    their acks don't starve behind a steady inbound stream.
             Some(done) = done_rx.recv() => {
                 let Completion { id, reply_to, handled } = done;
-                let Some(completed) = inflight.remove(&id) else {
+                let Some(mut completed) = inflight.remove(&id) else {
                     // A completion must belong to the one active admission for
                     // this id. Never let a stale/duplicate completion ack a
                     // later generation that happens to reuse the same MsgId.
@@ -604,7 +610,7 @@ where
                 } else {
                     Ok(())
                 };
-                let _ = completed.task.await;
+                let _ = completed.task.join().await;
                 if let Err(error) = wire_result {
                     tracing::warn!(%error, "broker worker completion delivery failed; cancelling remaining handlers");
                     messages_open = false;
@@ -705,7 +711,14 @@ where
                         let handler = Arc::clone(&handler);
                         let done_tx = done_tx.clone();
                         let task = tokio::spawn(async move {
-                            let handled = handler(msg, token).await;
+                            use futures_util::FutureExt;
+                            let handled = std::panic::AssertUnwindSafe(async { handler(msg, token).await })
+                                .catch_unwind()
+                                .await
+                                .unwrap_or_else(|_| {
+                                    tracing::error!(message_id = %id.as_str(), "broker handler panicked; preserving unacknowledged delivery");
+                                    Handled::Leave
+                                });
                             // Receiver gone == owner loop exited (conn dropped) -> drop.
                             let _ = done_tx.send(Completion { id, reply_to, handled });
                         });
@@ -713,7 +726,7 @@ where
                             inflight_id,
                             InflightHandler {
                                 cancel: inflight_cancel,
-                                task,
+                                task: AbortOnDropTask::new(task),
                                 deliveries: 1,
                             },
                         );
@@ -767,8 +780,8 @@ where
                     handler.task.abort();
                 }
                 let join_aborted = async move {
-                    for (_, handler) in stuck {
-                        let _ = handler.task.await;
+                    for (_, mut handler) in stuck {
+                        let _ = handler.task.join().await;
                     }
                 };
                 let abort_join_timed_out =
@@ -942,7 +955,7 @@ where
     // Per-run coordination so a SEPARATE Steer / ApprovalReply mailbox message can
     // reach the channels of the Run it belongs to (the Run + its control messages
     // arrive as independent messages handled by independent tasks).
-    let coords: RunCoords = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let coords: RunCoords = Arc::new(std::sync::Mutex::new(HashMap::new()));
     let waiters: ApprovalWaiters = Arc::new(std::sync::Mutex::new(HashMap::new()));
     let me_owned = me.clone();
     let approval_timeout = DEFAULT_APPROVAL_TIMEOUT;
@@ -991,7 +1004,8 @@ where
                         if let Some(run_id) = &msg.correlation_id {
                             let steer = decode_steer_body(&msg.body, Some(msg.id.as_str()));
                             if let Some(steer) = steer {
-                                let coords = coords.lock().await;
+                                let coords =
+                                    coords.lock().unwrap_or_else(|error| error.into_inner());
                                 if let Some(coord) = coords.get(run_id) {
                                     let _ = coord.steer_tx.send(steer);
                                 }
@@ -1035,7 +1049,21 @@ where
 struct RunCoord {
     steer_tx: tokio::sync::mpsc::UnboundedSender<bamboo_subagent::SteerMessage>,
 }
-type RunCoords = Arc<tokio::sync::Mutex<HashMap<MsgId, RunCoord>>>;
+type RunCoords = Arc<std::sync::Mutex<HashMap<MsgId, RunCoord>>>;
+
+struct RunCoordRegistration {
+    coords: RunCoords,
+    run_id: MsgId,
+}
+
+impl Drop for RunCoordRegistration {
+    fn drop(&mut self) {
+        self.coords
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(&self.run_id);
+    }
+}
 /// Pending gated-tool approvals a Run proxied up, keyed by approval-request id;
 /// an [`InboxKind::ApprovalReply`] fulfils the matching one.
 type ApprovalWaiters = Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<bool>>>>;
@@ -1168,8 +1196,12 @@ where
     let (steer_tx, steer_inbox) = SteerInbox::channel();
     coords
         .lock()
-        .await
+        .unwrap_or_else(|error| error.into_inner())
         .insert(run_id.clone(), RunCoord { steer_tx });
+    let registration = RunCoordRegistration {
+        coords: coords.clone(),
+        run_id: run_id.clone(),
+    };
     // Approval: a host bridge on the sink; its requests are pumped to the parent.
     let (host_bridge, mut host_rx) = HostBridge::channel();
     let sink = sink.with_host_bridge(host_bridge);
@@ -1339,8 +1371,12 @@ where
 
     // Run to completion (events stream into `sink`); dropping `sink` closes the
     // forward loop's `events` (→ outcome) and the approval drain's `host_rx`.
-    let outcome = executor.run(spec, sink, steer_inbox, cancel).await;
-    coords.lock().await.remove(&run_id);
+    use futures_util::FutureExt;
+    let outcome = std::panic::AssertUnwindSafe(executor.run(spec, sink, steer_inbox, cancel))
+        .catch_unwind()
+        .await
+        .unwrap_or_else(|_| bamboo_subagent::ChildOutcome::error("actor executor panicked"));
+    drop(registration);
     let _ = outcome_tx.send(outcome);
     let _ = forward.join().await;
     let _ = approval.join().await;
@@ -1388,7 +1424,10 @@ where
     };
 
     let prior = context.lock().await.clone();
-    let (sink, _discard) = EventSink::channel();
+    let (sink, discard) = EventSink::channel();
+    // Ask/Task return only the final reply. Close the intentionally unused
+    // stream so bounded sends cannot wait forever for a nonexistent consumer.
+    drop(discard);
     let outcome = executor
         .run(
             RunSpec {
@@ -1492,6 +1531,152 @@ mod tests {
     use tokio_tungstenite::tungstenite::Message as WsMessage;
 
     const TOKEN: &str = "t";
+
+    #[tokio::test]
+    async fn reply_only_ask_and_task_do_not_block_on_discarded_event_capacity() {
+        let question = std::iter::repeat_n("word", bamboo_subagent::EventSink::EVENT_CAPACITY + 1)
+            .collect::<Vec<_>>()
+            .join(" ");
+        for kind in [InboxKind::Ask, InboxKind::Task] {
+            let mut message = ask("parent", &question);
+            if kind == InboxKind::Task {
+                message.kind = InboxKind::Task;
+                message.body = serde_json::json!({ "assignment": question });
+            }
+            let context = tokio::sync::Mutex::new(Vec::new());
+            let handled = tokio::time::timeout(
+                Duration::from_secs(2),
+                handle_with_executor(
+                    &bamboo_subagent::EchoExecutor,
+                    &context,
+                    message,
+                    CancellationToken::new(),
+                ),
+            )
+            .await
+            .expect("reply-only execution must not await an unused stream consumer");
+            assert!(matches!(handled, Handled::Reply(answer) if answer == question));
+            assert_eq!(
+                context.lock().await.len(),
+                if kind == InboxKind::Task { 2 } else { 0 }
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn panicked_handler_releases_inflight_slot_and_preserves_unacked_delivery() {
+        let (endpoint, dir, core, connection) = start_single_connection().await;
+        core.deliver("panic-worker", &ask("parent", "panic"))
+            .await
+            .unwrap();
+        let me = AgentRef {
+            session_id: "panic-worker".into(),
+            role: None,
+        };
+        let mut client = BrokerClient::connect(&endpoint, me.clone(), TOKEN)
+            .await
+            .unwrap();
+        client.subscribe().await.unwrap();
+        let started = Arc::new(tokio::sync::Notify::new());
+        let shutdown = CancellationToken::new();
+        let task = tokio::spawn({
+            let started = started.clone();
+            let shutdown = shutdown.clone();
+            async move {
+                serve_loop(
+                    &mut client,
+                    &me,
+                    move |_, _| {
+                        let started = started.clone();
+                        async move {
+                            started.notify_one();
+                            panic!("intentional mailbox handler panic");
+                            #[allow(unreachable_code)]
+                            Handled::Leave
+                        }
+                    },
+                    shutdown,
+                )
+                .await
+            }
+        });
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .unwrap();
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("panicked admission must not block graceful drain")
+            .unwrap()
+            .unwrap();
+        assert_eq!(mailbox_pending_files(&dir, "panic-worker").await, 1);
+        connection.abort();
+    }
+
+    #[tokio::test]
+    async fn aborting_mailbox_owner_aborts_its_inflight_execution_and_coord_registration() {
+        let (endpoint, _dir, core, connection) = start_single_connection().await;
+        core.deliver("aborted-worker", &ask("parent", "hang"))
+            .await
+            .unwrap();
+        let me = AgentRef {
+            session_id: "aborted-worker".into(),
+            role: None,
+        };
+        let mut client = BrokerClient::connect(&endpoint, me.clone(), TOKEN)
+            .await
+            .unwrap();
+        client.subscribe().await.unwrap();
+        let started = Arc::new(tokio::sync::Notify::new());
+        let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let coords: RunCoords = Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let task = tokio::spawn({
+            let started = started.clone();
+            let dropped = dropped.clone();
+            let coords = coords.clone();
+            async move {
+                serve_loop(
+                    &mut client,
+                    &me,
+                    move |message, _| {
+                        let started = started.clone();
+                        let dropped = dropped.clone();
+                        let coords = coords.clone();
+                        async move {
+                            let _dropped = DropFlag(dropped);
+                            let (steer_tx, _inbox) = bamboo_subagent::SteerInbox::channel();
+                            coords
+                                .lock()
+                                .unwrap()
+                                .insert(message.id.clone(), RunCoord { steer_tx });
+                            let _registration = RunCoordRegistration {
+                                coords,
+                                run_id: message.id,
+                            };
+                            started.notify_one();
+                            std::future::pending::<Handled>().await
+                        }
+                    },
+                    CancellationToken::new(),
+                )
+                .await
+            }
+        });
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .unwrap();
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !dropped.load(std::sync::atomic::Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("owner drop must abort rather than detach handler");
+        assert!(coords.lock().unwrap().is_empty());
+        connection.abort();
+    }
 
     #[tokio::test]
     async fn shared_actor_uplink_accepts_200_parallel_live_runs() {

--- a/crates/app/bamboo-broker/src/serve.rs
+++ b/crates/app/bamboo-broker/src/serve.rs
@@ -1555,7 +1555,9 @@ mod tests {
             )
             .await
             .expect("reply-only execution must not await an unused stream consumer");
-            assert!(matches!(handled, Handled::Reply(answer) if answer == question));
+            assert!(
+                matches!(handled, Handled::Reply(answer) if answer == format!("echo: {question}"))
+            );
             assert_eq!(
                 context.lock().await.len(),
                 if kind == InboxKind::Task { 2 } else { 0 }

--- a/crates/infra/bamboo-subagent/src/executor.rs
+++ b/crates/infra/bamboo-subagent/src/executor.rs
@@ -75,15 +75,18 @@ impl HostBridge {
 /// Sink an executor emits events into; the transport forwards each as a `ChildFrame::Event`.
 #[derive(Clone)]
 pub struct EventSink {
-    tx: mpsc::UnboundedSender<serde_json::Value>,
-    control_tx: Option<mpsc::UnboundedSender<ExecutorControl>>,
+    tx: mpsc::Sender<serde_json::Value>,
+    control_tx: Option<mpsc::Sender<ExecutorControl>>,
     host: Option<HostBridge>,
 }
 
 impl EventSink {
+    pub const EVENT_CAPACITY: usize = 256;
+    pub const CONTROL_CAPACITY: usize = 32;
+
     /// Create a sink + the receiver the transport pumps to the wire.
-    pub fn channel() -> (Self, mpsc::UnboundedReceiver<serde_json::Value>) {
-        let (tx, rx) = mpsc::unbounded_channel();
+    pub fn channel() -> (Self, mpsc::Receiver<serde_json::Value>) {
+        let (tx, rx) = mpsc::channel(Self::EVENT_CAPACITY);
         (
             EventSink {
                 tx,
@@ -96,11 +99,11 @@ impl EventSink {
     /// Create a sink with a control channel for protocol-level confirmations.
     pub fn channel_with_control() -> (
         Self,
-        mpsc::UnboundedReceiver<serde_json::Value>,
-        mpsc::UnboundedReceiver<ExecutorControl>,
+        mpsc::Receiver<serde_json::Value>,
+        mpsc::Receiver<ExecutorControl>,
     ) {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let (control_tx, control_rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(Self::EVENT_CAPACITY);
+        let (control_tx, control_rx) = mpsc::channel(Self::CONTROL_CAPACITY);
         (
             EventSink {
                 tx,
@@ -120,15 +123,19 @@ impl EventSink {
     pub fn host(&self) -> Option<&HostBridge> {
         self.host.as_ref()
     }
-    /// Emit one event (serialized agent event). Dropped silently if the peer is gone.
-    pub fn emit(&self, event: serde_json::Value) {
-        let _ = self.tx.send(event);
+    /// Emit one event with bounded producer backpressure. Transport QoS still
+    /// decides whether a sequenced live batch can be dropped; durable events
+    /// cannot accumulate without bound ahead of that transport or be lost here.
+    pub async fn emit(&self, event: serde_json::Value) {
+        let _ = self.tx.send(event).await;
     }
     /// Confirm a forwarded SessionInbox message only after the executor has
     /// observed its durable local admitted receipt.
-    pub fn confirm_session_message(&self, confirmation: SessionMessageAdmissionConfirmation) {
+    pub async fn confirm_session_message(&self, confirmation: SessionMessageAdmissionConfirmation) {
         if let Some(tx) = &self.control_tx {
-            let _ = tx.send(ExecutorControl::SessionMessageAdmitted(confirmation));
+            let _ = tx
+                .send(ExecutorControl::SessionMessageAdmitted(confirmation))
+                .await;
         }
     }
 }
@@ -316,11 +323,13 @@ impl ChildExecutor for EchoExecutor {
             if cancel.is_cancelled() {
                 return ChildOutcome::cancelled();
             }
-            events.emit(serde_json::json!({ "type": "token", "content": format!("{word} ") }));
+            events
+                .emit(serde_json::json!({ "type": "token", "content": format!("{word} ") }))
+                .await;
             // tiny yield so cancellation can interleave; not a real delay
             tokio::task::yield_now().await;
         }
-        events.emit(serde_json::json!({ "type": "complete" }));
+        events.emit(serde_json::json!({ "type": "complete" })).await;
         ChildOutcome::completed(format!("echo: {}", words.join(" ")))
     }
 }
@@ -328,6 +337,39 @@ impl ChildExecutor for EchoExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn full_event_queue_backpressures_without_losing_durable_order_or_blocking_control() {
+        let (sink, mut events, mut controls) = EventSink::channel_with_control();
+        for index in 0..EventSink::EVENT_CAPACITY {
+            sink.emit(serde_json::json!({"type":"tool_start","index":index}))
+                .await;
+        }
+        assert_eq!(events.len(), EventSink::EVENT_CAPACITY);
+        let terminal = sink.emit(serde_json::json!({"type":"complete"}));
+        tokio::pin!(terminal);
+        assert!(futures_util::poll!(&mut terminal).is_pending());
+
+        // Admission control has its own bounded lane even while event
+        // production is parked at capacity.
+        let confirmation = SessionMessageAdmissionConfirmation {
+            target_session_id: "bounded-child".into(),
+            envelope_id: "message".into(),
+            canonical_claim_generation: 1,
+            activation_run_id: "activation".into(),
+        };
+        sink.confirm_session_message(confirmation.clone()).await;
+        assert_eq!(
+            controls.recv().await.unwrap(),
+            ExecutorControl::SessionMessageAdmitted(confirmation)
+        );
+        assert_eq!(events.recv().await.unwrap()["index"], 0);
+        terminal.await;
+        for index in 1..EventSink::EVENT_CAPACITY {
+            assert_eq!(events.recv().await.unwrap()["index"], index);
+        }
+        assert_eq!(events.recv().await.unwrap()["type"], "complete");
+    }
 
     #[test]
     fn echo_explicitly_opts_into_high_parallelism() {

--- a/crates/infra/bamboo-subagent/src/transport.rs
+++ b/crates/infra/bamboo-subagent/src/transport.rs
@@ -40,11 +40,90 @@ use crate::proto::{
 const DIRECT_EVENT_QUEUE_CAPACITY: usize = 64;
 const DIRECT_CONTROL_QUEUE_CAPACITY: usize = 32;
 const ACTOR_EVENT_BATCH_LATENCY: std::time::Duration = std::time::Duration::from_millis(20);
+const DIRECT_RUN_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Every connection/run owns its spawned helpers. A cancelled owner must not
+/// detach children merely because Tokio's plain JoinHandle was dropped.
+struct OwnedTask<T>(Option<tokio::task::JoinHandle<T>>);
+
+impl<T> OwnedTask<T> {
+    fn new(task: tokio::task::JoinHandle<T>) -> Self {
+        Self(Some(task))
+    }
+
+    async fn join(&mut self) -> Result<T, tokio::task::JoinError> {
+        let result = self.0.as_mut().expect("owned task present").await;
+        self.0.take();
+        result
+    }
+
+    fn abort(&self) {
+        if let Some(task) = &self.0 {
+            task.abort();
+        }
+    }
+}
+
+impl<T> Drop for OwnedTask<T> {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+struct ActiveRun {
+    cancel: CancellationToken,
+    task: OwnedTask<()>,
+}
+
+impl ActiveRun {
+    async fn stop(mut self, terminal_tx: Option<&mpsc::Sender<ChildFrame>>) {
+        self.cancel.cancel();
+        if tokio::time::timeout(DIRECT_RUN_DRAIN_TIMEOUT, self.task.join())
+            .await
+            .is_err()
+        {
+            self.task.abort();
+            let _ = tokio::time::timeout(DIRECT_RUN_DRAIN_TIMEOUT, self.task.join()).await;
+            if let Some(terminal_tx) = terminal_tx {
+                let _ = tokio::time::timeout(
+                    DIRECT_RUN_DRAIN_TIMEOUT,
+                    terminal_tx.send(ChildFrame::Terminal {
+                        status: crate::proto::TerminalStatus::Cancelled,
+                        result: None,
+                        error: None,
+                        transcript: Vec::new(),
+                    }),
+                )
+                .await;
+            }
+        }
+    }
+}
+
+impl Drop for ActiveRun {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
 
 /// Pending host-callback replies, keyed by request id, shared between the
 /// per-run pump (which inserts) and the connection read loop (which resolves
 /// them on [`ParentFrame::ApprovalReply`]).
 type PendingReplies = Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>;
+
+struct PendingReplyOwner {
+    pending: PendingReplies,
+    ids: Vec<String>,
+}
+
+impl Drop for PendingReplyOwner {
+    fn drop(&mut self) {
+        let mut pending = self.pending.lock().recover_poison();
+        for id in &self.ids {
+            pending.remove(id);
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum TransportError {
@@ -248,8 +327,15 @@ impl WsServer {
 
     /// Serve connections forever (long-running service agent).
     pub async fn serve<E: ChildExecutor + ?Sized>(self, executor: Arc<E>) -> TransportResult<()> {
+        let mut connections = tokio::task::JoinSet::new();
         loop {
-            let (stream, _) = self.listener.accept().await?;
+            let (stream, _) = tokio::select! {
+                connection = connections.join_next(), if !connections.is_empty() => {
+                    let _ = connection;
+                    continue;
+                }
+                accepted = self.listener.accept() => accepted?,
+            };
             let exec = executor.clone();
             // The TLS handshake + auth callback run inside the spawned task (not
             // on the accept loop) so a slow/hostile client cannot stall the
@@ -257,7 +343,7 @@ impl WsServer {
             // `TlsAcceptor` is `Arc`-backed, the token is a short `String`.
             let tls = self.tls.clone();
             let token = self.expected_token.clone();
-            tokio::spawn(async move {
+            connections.spawn(async move {
                 let _ = accept_and_handle(stream, &tls, &token, exec).await;
             });
         }
@@ -471,16 +557,24 @@ where
     // per-connection token queue or starve an approval/cancellation response.
     let (control_tx, control_rx) = mpsc::channel::<ChildFrame>(DIRECT_CONTROL_QUEUE_CAPACITY);
     let (event_tx, event_rx) = mpsc::channel::<ChildFrame>(DIRECT_EVENT_QUEUE_CAPACITY);
-    let writer = tokio::spawn(writer_task(ws_tx, control_rx, event_rx));
+    let mut writer = OwnedTask::new(tokio::spawn(writer_task(ws_tx, control_rx, event_rx)));
 
     // Host-callback replies for gated-tool approvals the active run proxies back
     // to the host over this WS. Shared with each run's pump.
     let pending: PendingReplies = Arc::new(Mutex::new(HashMap::new()));
 
-    let mut active_cancel: Option<CancellationToken> = None;
+    let mut active_run: Option<ActiveRun> = None;
     let mut active_steer: Option<mpsc::UnboundedSender<SteerMessage>> = None;
-    while let Some(msg) = ws_rx.next().await {
-        match msg? {
+    let result = loop {
+        let msg = tokio::select! {
+            _ = writer.join() => break Ok(()),
+            message = ws_rx.next() => match message {
+                Some(Ok(message)) => message,
+                Some(Err(error)) => break Err(TransportError::from(error)),
+                None => break Ok(()),
+            },
+        };
+        match msg {
             Message::Text(t) => match ParentFrame::from_text(t.as_str()) {
                 // Phase 2: the host's decision on a proxied gated-tool approval.
                 // Routed through the `pending` correlation map (body =
@@ -498,14 +592,13 @@ where
                     // old task is orphaned and its output interleaves with the
                     // new run's. (The old steer sender is dropped implicitly by
                     // the reassignment of `active_steer` below.)
-                    if let Some(prev) = active_cancel.take() {
-                        prev.cancel();
+                    if let Some(prev) = active_run.take() {
+                        prev.stop(Some(&event_tx)).await;
                     }
                     let cancel = CancellationToken::new();
                     let (steer_tx, steer_rx) = SteerInbox::channel();
-                    active_cancel = Some(cancel.clone());
                     active_steer = Some(steer_tx);
-                    start_run(
+                    active_run = Some(start_run(
                         executor.clone(),
                         spec,
                         steer_rx,
@@ -513,12 +606,13 @@ where
                         control_tx.clone(),
                         event_tx.clone(),
                         pending.clone(),
-                    );
+                    ));
                 }
                 Ok(ParentFrame::Cancel) => {
-                    if let Some(c) = &active_cancel {
-                        c.cancel();
+                    if let Some(run) = active_run.take() {
+                        run.stop(Some(&event_tx)).await;
                     }
+                    active_steer = None;
                 }
                 Ok(ParentFrame::Message { text }) => {
                     // In-band steering: hand to the active run's inbox; the
@@ -534,21 +628,25 @@ where
                 }
                 Err(_) => { /* ignore malformed frame */ }
             },
-            Message::Close(_) => break,
+            Message::Close(_) => break Ok(()),
             _ => {}
         }
-    }
+    };
 
     // Parent disconnected / closed: cancel any still-active run so its spawned
     // task ends and stops feeding the writer. Without this `writer.await` blocks
     // until the orphaned run finishes on its own.
-    if let Some(c) = active_cancel {
-        c.cancel();
+    if let Some(run) = active_run {
+        run.stop(None).await;
     }
+    drop(active_steer);
+    pending.lock().recover_poison().clear();
     drop(control_tx);
     drop(event_tx);
-    let _ = writer.await;
-    Ok(())
+    if writer.0.is_some() {
+        let _ = tokio::time::timeout(DIRECT_RUN_DRAIN_TIMEOUT, writer.join()).await;
+    }
+    result
 }
 
 async fn writer_task<S>(
@@ -596,7 +694,7 @@ fn start_run<E: ChildExecutor + ?Sized>(
     control_tx: mpsc::Sender<ChildFrame>,
     event_tx: mpsc::Sender<ChildFrame>,
     pending: PendingReplies,
-) {
+) -> ActiveRun {
     let (sink, mut ev_rx, mut control_rx) = EventSink::channel_with_control();
     let legacy_event_wire = spec.execution_epoch == 0;
     let mut batcher = ActorEventBatcher::for_run(&spec, None, None);
@@ -604,7 +702,7 @@ fn start_run<E: ChildExecutor + ?Sized>(
     // All event batches share one ordered data lane. Durable batches wait for
     // capacity; lossy data uses `try_send`, making overload observable as a
     // sequence gap. Approval/admission controls remain independent.
-    let fwd = tokio::spawn(async move {
+    let mut fwd = OwnedTask::new(tokio::spawn(async move {
         let mut flush = tokio::time::interval(ACTOR_EVENT_BATCH_LATENCY);
         flush.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         flush.tick().await;
@@ -641,9 +739,9 @@ fn start_run<E: ChildExecutor + ?Sized>(
                 let _ = send_direct_event_batch(&event_fwd, batch).await;
             }
         }
-    });
+    }));
     let out_control = control_tx.clone();
-    let control = tokio::spawn(async move {
+    let mut control = OwnedTask::new(tokio::spawn(async move {
         while let Some(control) = control_rx.recv().await {
             let frame = match control {
                 ExecutorControl::SessionMessageAdmitted(confirmation) => {
@@ -654,7 +752,7 @@ fn start_run<E: ChildExecutor + ?Sized>(
                 break;
             }
         }
-    });
+    }));
 
     // Host-callback pump: each gated-tool approval the executor proxies back
     // becomes an `ApprovalRequest` on the wire; its reply (an `ApprovalReply`
@@ -664,7 +762,11 @@ fn start_run<E: ChildExecutor + ?Sized>(
     let sink = sink.with_host_bridge(bridge);
     let out_req = control_tx.clone();
     let pending_for_pump = pending.clone();
-    let pump = tokio::spawn(async move {
+    let pump = OwnedTask::new(tokio::spawn(async move {
+        let mut registrations = PendingReplyOwner {
+            pending: pending_for_pump.clone(),
+            ids: Vec::new(),
+        };
         while let Some(req) = req_rx.recv().await {
             // Random + unguessable: the worker's pending map and the host-side
             // pending-approval registry both key on this exact string, so a
@@ -675,6 +777,7 @@ fn start_run<E: ChildExecutor + ?Sized>(
                 .lock()
                 .recover_poison()
                 .insert(id.clone(), req.reply);
+            registrations.ids.push(id.clone());
             let frame = match req.kind {
                 HostRequestKind::Approval => ChildFrame::ApprovalRequest { id, body: req.body },
             };
@@ -682,12 +785,17 @@ fn start_run<E: ChildExecutor + ?Sized>(
                 break;
             }
         }
-    });
+    }));
 
-    tokio::spawn(async move {
-        let outcome = executor.run(spec, sink, steer, cancel).await;
-        let _ = fwd.await; // flush all events before the terminal frame
-        let _ = control.await; // flush durable-admission confirmations first
+    let run_cancel = cancel.clone();
+    let task = OwnedTask::new(tokio::spawn(async move {
+        use futures_util::FutureExt;
+        let outcome = std::panic::AssertUnwindSafe(executor.run(spec, sink, steer, run_cancel))
+            .catch_unwind()
+            .await
+            .unwrap_or_else(|_| crate::executor::ChildOutcome::error("actor executor panicked"));
+        let _ = fwd.join().await; // flush all events before the terminal frame
+        let _ = control.join().await; // flush durable-admission confirmations first
         pump.abort(); // no more host callbacks after the run ends
                       // Terminal follows every accepted event batch on the bounded event
                       // lane. Approval/admission control remains independently prioritized.
@@ -699,7 +807,8 @@ fn start_run<E: ChildExecutor + ?Sized>(
                 transcript: outcome.transcript,
             })
             .await;
-    });
+    }));
+    ActiveRun { cancel, task }
 }
 
 async fn send_direct_event_batch(
@@ -842,6 +951,153 @@ mod tests {
     use super::*;
     use crate::executor::EchoExecutor;
     use crate::proto::{ChildFrame, TerminalStatus};
+
+    struct RunDropFlag(Arc<std::sync::atomic::AtomicBool>);
+
+    impl Drop for RunDropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    struct UncooperativeExecutor(Arc<std::sync::atomic::AtomicBool>);
+
+    #[async_trait::async_trait]
+    impl ChildExecutor for UncooperativeExecutor {
+        async fn run(
+            &self,
+            _spec: RunSpec,
+            events: EventSink,
+            _steer: SteerInbox,
+            _cancel: CancellationToken,
+        ) -> crate::ChildOutcome {
+            let _dropped = RunDropFlag(self.0.clone());
+            events.emit(serde_json::json!({"type":"ready"})).await;
+            std::future::pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn disconnect_and_server_abort_reclaim_uncooperative_execution() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Duration;
+        for abort_server in [false, true] {
+            let server = WsServer::bind_loopback().await.unwrap();
+            let endpoint = server.ws_endpoint();
+            let dropped = Arc::new(AtomicBool::new(false));
+            let executor = Arc::new(UncooperativeExecutor(dropped.clone()));
+            let task = tokio::spawn(async move { server.serve(executor).await });
+            let mut client = ChildClient::connect(&endpoint).await.unwrap();
+            let spec = serde_json::from_value(serde_json::json!({"assignment":"hang"})).unwrap();
+            client.send(ParentFrame::Run(spec)).await.unwrap();
+            tokio::time::timeout(Duration::from_secs(2), client.next_frame())
+                .await
+                .unwrap()
+                .unwrap();
+            if abort_server {
+                task.abort();
+                let _ = task.await;
+            } else {
+                client.close().await.unwrap();
+                tokio::time::timeout(Duration::from_secs(8), async {
+                    while !dropped.load(Ordering::SeqCst) {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .expect("disconnect must abort an executor that ignores cancellation");
+                task.abort();
+                let _ = task.await;
+            }
+            tokio::time::timeout(Duration::from_secs(2), async {
+                while !dropped.load(Ordering::SeqCst) {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("server cancellation must own and release connection/run tasks");
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_cancel_bounds_uncooperative_execution_and_emits_terminal() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Duration;
+        let server = WsServer::bind_loopback().await.unwrap();
+        let endpoint = server.ws_endpoint();
+        let dropped = Arc::new(AtomicBool::new(false));
+        let executor = Arc::new(UncooperativeExecutor(dropped.clone()));
+        let task = tokio::spawn(async move { server.serve_one(executor).await });
+        let mut client = ChildClient::connect(&endpoint).await.unwrap();
+        client
+            .send(ParentFrame::Run(
+                serde_json::from_value(serde_json::json!({"assignment":"hang"})).unwrap(),
+            ))
+            .await
+            .unwrap();
+        client.next_frame().await.unwrap();
+        client.send(ParentFrame::Cancel).await.unwrap();
+        let frame = tokio::time::timeout(Duration::from_secs(8), client.next_frame())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            frame,
+            ChildFrame::Terminal {
+                status: TerminalStatus::Cancelled,
+                ..
+            }
+        ));
+        assert!(dropped.load(Ordering::SeqCst));
+        client.close().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn executor_panic_becomes_terminal_error() {
+        struct Panics;
+        #[async_trait::async_trait]
+        impl ChildExecutor for Panics {
+            async fn run(
+                &self,
+                _spec: RunSpec,
+                _events: EventSink,
+                _steer: SteerInbox,
+                _cancel: CancellationToken,
+            ) -> crate::ChildOutcome {
+                panic!("intentional executor failure");
+            }
+        }
+        let server = WsServer::bind_loopback().await.unwrap();
+        let endpoint = server.ws_endpoint();
+        let task = tokio::spawn(async move { server.serve_one(Arc::new(Panics)).await });
+        let mut client = ChildClient::connect(&endpoint).await.unwrap();
+        client
+            .send(ParentFrame::Run(
+                serde_json::from_value(serde_json::json!({"assignment":"panic"})).unwrap(),
+            ))
+            .await
+            .unwrap();
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(2), client.next_frame())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            frame,
+            ChildFrame::Terminal {
+                status: TerminalStatus::Error,
+                ..
+            }
+        ));
+        client.close().await.unwrap();
+        task.await.unwrap().unwrap();
+    }
 
     #[test]
     fn transport_error_conversions_preserve_diagnostics_and_sources() {
@@ -1161,7 +1417,9 @@ mod tests {
                 _cancel: CancellationToken,
             ) -> ChildOutcome {
                 let steered = steer.recv().await.unwrap_or_default();
-                events.emit(serde_json::json!({"type": "token", "content": steered.clone()}));
+                events
+                    .emit(serde_json::json!({"type": "token", "content": steered.clone()}))
+                    .await;
                 ChildOutcome::completed(format!("steered: {steered}"))
             }
         }
@@ -1238,12 +1496,14 @@ mod tests {
                 else {
                     panic!("expected typed SessionInbox delivery");
                 };
-                events.confirm_session_message(SessionMessageAdmissionConfirmation {
-                    target_session_id: delivery.target_session_id,
-                    envelope_id: delivery.envelope.id.as_str().to_string(),
-                    canonical_claim_generation: delivery.canonical_claim_generation,
-                    activation_run_id: delivery.activation_run_id,
-                });
+                events
+                    .confirm_session_message(SessionMessageAdmissionConfirmation {
+                        target_session_id: delivery.target_session_id,
+                        envelope_id: delivery.envelope.id.as_str().to_string(),
+                        canonical_claim_generation: delivery.canonical_claim_generation,
+                        activation_run_id: delivery.activation_run_id,
+                    })
+                    .await;
                 ChildOutcome::completed("confirmed")
             }
         }
@@ -1537,7 +1797,9 @@ mod tests {
                 _steer: SteerInbox,
                 cancel: CancellationToken,
             ) -> ChildOutcome {
-                events.emit(serde_json::json!({"type": "token", "content": "go"}));
+                events
+                    .emit(serde_json::json!({"type": "token", "content": "go"}))
+                    .await;
                 cancel.cancelled().await;
                 ChildOutcome::cancelled()
             }

--- a/docs/design/session-subagent-scalability.md
+++ b/docs/design/session-subagent-scalability.md
@@ -1,0 +1,115 @@
+# Session and subagent concurrency
+
+The runtime gives each child its own event stream and bounded producer queue.
+The parent receives semantic child lifecycle events; it does not relay a child's
+token stream. This document covers the in-process coordination and resource
+lifetimes that remain important even after recursive token forwarding was removed.
+
+## Boundaries
+
+| Path | Coordination | Reason |
+| --- | --- | --- |
+| Session cache lookup/publication | Lock-free skip-list index and atomic immutable snapshots | A reader or a long transcript clone must not block another session or its writer. |
+| Narrow cached metadata patch | Retry a pure patch with compare-and-swap | Preserve another writer's publication instead of overwriting a detached old snapshot. |
+| Live token publication | Per-run atomic admission fence and activity clock | Token traffic does not acquire the process-wide runner registry. |
+| Runner replacement and replayable state | Existing lifecycle registry coordination | Drain admitted old frames before a successor publishes Started; preserve snapshot/live replay ordering. |
+| Durable session commits | Existing per-session and cross-process transaction locks | Preserve filesystem atomicity, task generations and recovery journals. These are not advertised as lock-free storage. |
+| Worker event production | Bounded async queue | Slow downstream transport applies backpressure instead of retaining unlimited JSON events. |
+| Idle session eviction | Exact channel identity, external subscribers and producer ownership | Internal notification relays must not prevent their own reclamation; active clients and child producers remain protected. |
+
+## Session snapshots
+
+`SessionCache::default()` creates the shared cache. `SessionSnapshot::new(session)`
+creates an immutable published version. `read()` returns a stable view, and
+`read().clone()` retains the existing detached `Session` contract.
+
+A live cache entry keeps a stable slot until eviction. Publishing a full snapshot
+updates that slot atomically. A narrow `update` retries against the latest slot
+value, so it cannot successfully patch an orphaned version while another writer
+publishes the replacement. Update closures must have no external side effects.
+Durable I/O remains in `SessionRepository`, outside those retry closures.
+
+Snapshot writes copy the session value. This deliberately trades copying on
+writes for independent readers. Token events do not mutate session snapshots;
+large transcript copying must not be moved into the token path.
+
+## Independent event delivery
+
+```mermaid
+flowchart LR
+  A[Child A executor] --> QA[Bounded A event queue]
+  B[Child B executor] --> QB[Bounded B event queue]
+  QA --> T[Worker transport and broker]
+  QB --> T
+  T --> EA[agent.A stream]
+  T --> EB[agent.B stream]
+  EA --> UA[Client subscribed to A]
+  EB --> UB[Client subscribed to B]
+  A -. Started / heartbeat / completed .-> P[Parent coordination]
+  B -. Started / heartbeat / completed .-> P
+```
+
+Each run owns an `EventPublication` fence. Synchronous token publication first
+obtains an atomic permit. Replacing or removing a runner closes admission and
+waits for admitted sends to finish before exposing a successor. This prevents a
+late old token from appearing after the successor's Started event without taking
+any global runner lock for that token. Critical replay state still uses the
+existing cache-and-broadcast transaction. The child's activity clock includes
+these atomic token publications, so a busy stream is not mistaken for a stalled
+worker by its watchdog.
+
+This is an application coordination guarantee. Tokio channels, networking,
+allocators, disk persistence and operating-system processes have their own
+synchronization and are not claimed to be universally lock-free.
+
+## Resource ownership
+
+Notification observers register their exact channel with a weak sender. Their
+RAII subscription unregisters before dropping its receiver, including task
+cancellation. An old channel generation cannot clear the registration of a new
+relay. Idle eviction discounts only the matching internal receiver and retains
+external receivers and outstanding producer handles. The paired runner, event
+sender and cached transcript are reclaimed together; durable session history
+remains available for later loads.
+
+The per-session persistence-lock registry also arms cleanup before waiting for
+the mutex. Cancelling the final waiter after its predecessor releases the lock
+must not leave one entry per historical child session. Parent wake serialization
+also leases its registry entry: completion or cancellation of the final holder
+removes the entry while keeping concurrent wakes serialized.
+
+Worker connection tasks own their execution and helper tasks. Disconnect and
+replacement cancel the execution, allow bounded cooperative shutdown, then abort
+and join remaining tasks. Correlation waiters and run registrations have RAII
+cleanup, and executor panics become terminal errors rather than leaving an
+inflight record with no task behind it. CLI process ownership also survives
+cancellation of the graceful-exit future: on Unix, Drop kills the owned process
+group and tracked descendants. An active app-server connection belongs to that
+run, and returns to the warm slot only after a completed turn and helper cleanup;
+an aborted run cannot leave the previous turn in a reusable connection.
+
+## Verification contract
+
+- Hold the global runner write guard while 512 independent child streams deliver
+  32,768 token events; every stream must make progress and record activity.
+- Retain an old session read across publication; it remains coherent while the
+  new version becomes readable. Concurrent narrow patches preserve all 512 keys.
+- Force a full publication between a narrow patch's first read and CAS; the
+  patch retries and keeps both the new snapshot and the patch.
+- Retire a run with an admitted publication; replacement waits for that frame,
+  and rejects new old-generation frames.
+- Cancel the final waiter for 512 session IDs and verify both persistence-lock
+  maps and waiting counters return to baseline.
+- Run real notification relays for 512 terminal children and verify idle cleanup
+  reclaims their runtime resources while preserving subscribed/running sessions.
+- Fill a worker's bounded event queue; the producer waits for receiver capacity,
+  and cancellation/disconnect leaves no detached execution or correlation waiter.
+- Run real Unix CLI stubs through WebSocket Cancel and server-owner abort; both
+  leader and grandchild disappear. After abort, app-server establishes a fresh
+  connection and can reuse it after a healthy completed turn.
+- Reply-only Ask/Task executions can emit more than one queue capacity and still
+  return their answer; intentionally unused event receivers are closed.
+
+These deterministic fixtures exercise hundreds of sessions without launching
+hundreds of paid model requests or OS worker processes. Physical worker capacity
+and provider/network quotas remain separate deployment limits.

--- a/src/claude_code_executor.rs
+++ b/src/claude_code_executor.rs
@@ -31,8 +31,8 @@ use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, Mutex};
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
 
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
 use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, HostBridge, SteerInbox};
@@ -40,6 +40,8 @@ use bamboo_subagent::executor_util::{
     render_history_preamble, spawn_with_etxtbsy_retry, write_json_atomic,
 };
 use bamboo_subagent::proto::RunSpec;
+
+use crate::codex_cli_executor::ProcessTreeChild;
 
 /// Upper bound on a single stdout NDJSON line. Tool results can be huge (the
 /// protocol doc specifies a 10 MB scanner buffer at `docs/claude-code-executor.md`
@@ -431,7 +433,7 @@ impl ClaudeCodeExecutor {
         value: Value,
         events: &EventSink,
         write_tx: &mpsc::UnboundedSender<Value>,
-        pending: &mut HashMap<String, JoinHandle<()>>,
+        pending: &mut HashMap<String, AbortOnDropHandle<()>>,
         last_text: &mut String,
         permission: bamboo_domain::PermissionModeResolution,
     ) -> Option<ChildOutcome> {
@@ -452,7 +454,7 @@ impl ClaudeCodeExecutor {
             "assistant" => {
                 if let Some(blocks) = value.pointer("/message/content").and_then(Value::as_array) {
                     for block in blocks {
-                        emit_assistant_block(block, events, last_text);
+                        emit_assistant_block(block, events, last_text).await;
                     }
                 }
                 None
@@ -460,7 +462,7 @@ impl ClaudeCodeExecutor {
             "user" => {
                 if let Some(blocks) = value.pointer("/message/content").and_then(Value::as_array) {
                     for block in blocks {
-                        emit_tool_result_block(block, events);
+                        emit_tool_result_block(block, events).await;
                     }
                 }
                 None
@@ -499,7 +501,9 @@ impl ClaudeCodeExecutor {
                         }
                     })
                     .unwrap_or_default();
-                events.emit(event_json(AgentEvent::Complete { usage }));
+                events
+                    .emit(event_json(AgentEvent::Complete { usage }))
+                    .await;
                 Some(ChildOutcome::completed(final_text))
             }
             "control_request" => {
@@ -533,7 +537,7 @@ impl ClaudeCodeExecutor {
         value: Value,
         events: &EventSink,
         write_tx: &mpsc::UnboundedSender<Value>,
-        pending: &mut HashMap<String, JoinHandle<()>>,
+        pending: &mut HashMap<String, AbortOnDropHandle<()>>,
         permission: bamboo_domain::PermissionModeResolution,
     ) {
         let request_id = value
@@ -584,7 +588,7 @@ impl ClaudeCodeExecutor {
         let relay_timeout = self.relay_timeout;
         let write_tx = write_tx.clone();
         let task_request_id = request_id.clone();
-        let handle = tokio::spawn(async move {
+        let handle = AbortOnDropHandle::new(tokio::spawn(async move {
             decide_and_respond(
                 host,
                 permission_mode,
@@ -595,7 +599,7 @@ impl ClaudeCodeExecutor {
                 &write_tx,
             )
             .await;
-        });
+        }));
         pending.insert(request_id, handle);
     }
 
@@ -650,7 +654,7 @@ impl ClaudeCodeExecutor {
         })
         .await
         {
-            Ok(c) => c,
+            Ok(c) => ProcessTreeChild::new(c),
             Err(e) => {
                 return (
                     ChildOutcome::error(format!("spawn '{}': {e}", self.binary)),
@@ -675,7 +679,9 @@ impl ClaudeCodeExecutor {
         let stderr_tail = Arc::new(Mutex::new(String::new()));
         let stderr_task = stderr.map(|stderr| {
             let tail = stderr_tail.clone();
-            tokio::spawn(async move { drain_stderr_tail(stderr, tail).await })
+            AbortOnDropHandle::new(tokio::spawn(async move {
+                drain_stderr_tail(stderr, tail).await
+            }))
         });
 
         let (write_tx, writer_handle) = spawn_stdin_writer(stdin);
@@ -694,7 +700,7 @@ impl ClaudeCodeExecutor {
         }
 
         let mut reader = tokio::io::BufReader::with_capacity(64 * 1024, stdout);
-        let mut pending: HashMap<String, JoinHandle<()>> = HashMap::new();
+        let mut pending: HashMap<String, AbortOnDropHandle<()>> = HashMap::new();
         let mut last_text = String::new();
 
         let (outcome, exited_without_result) = loop {
@@ -815,9 +821,11 @@ impl ChildExecutor for ClaudeCodeExecutor {
         let (permission, policy_revision) = match self.activation_permission(&spec) {
             Ok(permission) => permission,
             Err(ClaudePermissionActivationError::Invalid(message)) => {
-                events.emit(event_json(AgentEvent::Error {
-                    message: message.clone(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::Error {
+                        message: message.clone(),
+                    }))
+                    .await;
                 return ChildOutcome::error(message);
             }
             Err(ClaudePermissionActivationError::ExplicitDeny {
@@ -825,34 +833,42 @@ impl ChildExecutor for ClaudeCodeExecutor {
                 resolution,
                 policy_revision,
             }) => {
-                events.emit(event_json(AgentEvent::PermissionPostureActivated {
-                    session_id: logical_session_id,
-                    policy_revision,
-                    requested_mode: resolution.requested.as_str().to_string(),
-                    effective_mode: resolution.effective.as_str().to_string(),
-                    executor_mapping: "claude_code:blocked_explicit_deny".to_string(),
-                }));
-                events.emit(event_json(AgentEvent::Error {
-                    message: message.clone(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::PermissionPostureActivated {
+                        session_id: logical_session_id,
+                        policy_revision,
+                        requested_mode: resolution.requested.as_str().to_string(),
+                        effective_mode: resolution.effective.as_str().to_string(),
+                        executor_mapping: "claude_code:blocked_explicit_deny".to_string(),
+                    }))
+                    .await;
+                events
+                    .emit(event_json(AgentEvent::Error {
+                        message: message.clone(),
+                    }))
+                    .await;
                 return ChildOutcome::error(message);
             }
         };
         let mapped_permission_mode = self.mapped_permission_mode(permission);
         let executor_mapping = format!("claude_code:permission_mode={mapped_permission_mode}");
-        events.emit(event_json(AgentEvent::PermissionPostureActivated {
-            session_id: logical_session_id.clone(),
-            policy_revision,
-            requested_mode: permission.requested.as_str().to_string(),
-            effective_mode: permission.effective.as_str().to_string(),
-            executor_mapping: executor_mapping.clone(),
-        }));
+        events
+            .emit(event_json(AgentEvent::PermissionPostureActivated {
+                session_id: logical_session_id.clone(),
+                policy_revision,
+                requested_mode: permission.requested.as_str().to_string(),
+                effective_mode: permission.effective.as_str().to_string(),
+                executor_mapping: executor_mapping.clone(),
+            }))
+            .await;
 
         // Ignore steer messages (see doc comment on `steer` above) but keep
         // draining so the sender never sees an unbounded backlog. Spans BOTH
         // possible spawn attempts below — the inbox belongs to the whole
         // activation, not to one child process.
-        let steer_drain = tokio::spawn(async move { while steer.recv().await.is_some() {} });
+        let steer_drain = AbortOnDropHandle::new(tokio::spawn(async move {
+            while steer.recv().await.is_some() {}
+        }));
 
         // Step 1: a fresh activation must never resume stale context.
         if spec.messages.is_empty() {
@@ -868,16 +884,18 @@ impl ChildExecutor for ClaudeCodeExecutor {
 
         // Step 3: fallback body when there's history but no usable id.
         let body = build_turn_body(&spec, resume_id.as_deref());
-        events.emit(json!({
-            "type": "runner_progress",
-            "session_id": logical_session_id,
-            "round_count": 0,
-            "executor": "claude_code",
-            "phase": "bootstrap",
-            "requested_mode": permission.requested.as_str(),
-            "effective_mode": permission.effective.as_str(),
-            "executor_mapping": executor_mapping,
-        }));
+        events
+            .emit(json!({
+                "type": "runner_progress",
+                "session_id": logical_session_id,
+                "round_count": 0,
+                "executor": "claude_code",
+                "phase": "bootstrap",
+                "requested_mode": permission.requested.as_str(),
+                "effective_mode": permission.effective.as_str(),
+                "executor_mapping": executor_mapping,
+            }))
+            .await;
 
         let used_resume = resume_id.is_some();
         let (outcome, exited_without_result) = self
@@ -941,9 +959,9 @@ fn signal_process_group(_child: &Child, _signal: ProcessSignal) {}
 /// "dropped silently if the peer is gone" convention).
 fn spawn_stdin_writer(
     mut stdin: tokio::process::ChildStdin,
-) -> (mpsc::UnboundedSender<Value>, JoinHandle<()>) {
+) -> (mpsc::UnboundedSender<Value>, AbortOnDropHandle<()>) {
     let (tx, mut rx) = mpsc::unbounded_channel::<Value>();
-    let handle = tokio::spawn(async move {
+    let handle = AbortOnDropHandle::new(tokio::spawn(async move {
         while let Some(value) = rx.recv().await {
             let Ok(mut line) = serde_json::to_vec(&value) else {
                 continue;
@@ -958,7 +976,7 @@ fn spawn_stdin_writer(
         }
         // `stdin` drops here (once every sender clone is gone and the channel
         // drains), closing the write half — the EOF the CLI's Stop hooks see.
-    });
+    }));
     (tx, handle)
 }
 
@@ -1028,23 +1046,27 @@ async fn drain_stderr_tail(stderr: tokio::process::ChildStderr, tail: Arc<Mutex<
 
 /// Emit the `AgentEvent` for one `assistant` message content block (`text` /
 /// `thinking` / `tool_use`); unrecognized block types are ignored.
-fn emit_assistant_block(block: &Value, events: &EventSink, last_text: &mut String) {
+async fn emit_assistant_block(block: &Value, events: &EventSink, last_text: &mut String) {
     match block.get("type").and_then(Value::as_str) {
         Some("text") => {
             let text = block.get("text").and_then(Value::as_str).unwrap_or("");
             if !text.is_empty() {
                 last_text.push_str(text);
-                events.emit(event_json(AgentEvent::Token {
-                    content: text.to_string(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::Token {
+                        content: text.to_string(),
+                    }))
+                    .await;
             }
         }
         Some("thinking") => {
             let text = block.get("thinking").and_then(Value::as_str).unwrap_or("");
             if !text.is_empty() {
-                events.emit(event_json(AgentEvent::ReasoningToken {
-                    content: text.to_string(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::ReasoningToken {
+                        content: text.to_string(),
+                    }))
+                    .await;
             }
         }
         Some("tool_use") => {
@@ -1059,11 +1081,13 @@ fn emit_assistant_block(block: &Value, events: &EventSink, last_text: &mut Strin
                 .unwrap_or("")
                 .to_string();
             let arguments = block.get("input").cloned().unwrap_or_else(|| json!({}));
-            events.emit(event_json(AgentEvent::ToolStart {
-                tool_call_id,
-                tool_name,
-                arguments,
-            }));
+            events
+                .emit(event_json(AgentEvent::ToolStart {
+                    tool_call_id,
+                    tool_name,
+                    arguments,
+                }))
+                .await;
         }
         _ => {}
     }
@@ -1071,7 +1095,7 @@ fn emit_assistant_block(block: &Value, events: &EventSink, last_text: &mut Strin
 
 /// Emit the `AgentEvent` for one `user` message content block, when it is a
 /// `tool_result` (other block types in an echoed user message are ignored).
-fn emit_tool_result_block(block: &Value, events: &EventSink) {
+async fn emit_tool_result_block(block: &Value, events: &EventSink) {
     if block.get("type").and_then(Value::as_str) != Some("tool_result") {
         return;
     }
@@ -1099,7 +1123,7 @@ fn emit_tool_result_block(block: &Value, events: &EventSink) {
             result: ToolResult::text(true, text),
         }
     };
-    events.emit(event_json(event));
+    events.emit(event_json(event)).await;
 }
 
 /// A `tool_result` block's `content` is either a plain string or an array of
@@ -1719,6 +1743,35 @@ echo '{"type":"result","subtype":"success","result":"wrote file"}'
     }
 
     #[tokio::test]
+    async fn dropping_approval_owner_releases_pending_host_reply() {
+        let (host, mut host_rx) = HostBridge::channel();
+        let (events, receiver) = EventSink::channel();
+        drop(receiver);
+        let events = events.with_host_bridge(host);
+        let (write_tx, _write_rx) = mpsc::unbounded_channel();
+        let mut pending = HashMap::new();
+        executor(PathBuf::from("unused")).handle_control_request(
+            json!({"type": "control_request", "request_id": "pending", "request": {
+                "subtype": "can_use_tool", "tool_name": "Write", "input": {"file_path": "/tmp/x"}
+            }}),
+            &events,
+            &write_tx,
+            &mut pending,
+            bamboo_domain::resolve_permission_mode(
+                bamboo_domain::SessionPermissionMode::Default,
+                bamboo_domain::PermissionMode::Default,
+            ),
+        );
+        let mut request = host_rx.recv().await.unwrap();
+        drop(pending);
+        drop(events);
+        tokio::time::timeout(Duration::from_secs(1), request.reply.closed())
+            .await
+            .unwrap();
+        assert!(host_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
     async fn control_request_approval_relay_times_out_and_denies() {
         let dir = tempfile::tempdir().unwrap();
         let bin = write_stub(
@@ -1821,6 +1874,32 @@ echo '{"type":"result","subtype":"success","result":"ok"}'
         // the stub couldn't have run `env`/`cat`-family commands at all, and
         // this test would be vacuously passing.
         assert!(dump.contains("PATH="), "PATH missing from the child env");
+    }
+
+    #[tokio::test]
+    async fn websocket_cancel_and_owner_abort_reap_claude_process_tree() {
+        for abort_owner in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = write_stub(
+                dir.path(),
+                r#"
+DIR=$(cd "$(dirname "$0")" && pwd)
+read -r assignment
+trap '' TERM
+(trap '' TERM; sleep 60) &
+printf '%s %s\n' "$$" "$!" > "$DIR/pids"
+echo '{"type":"control_request","request_id":"pending","request":{"subtype":"can_use_tool","tool_name":"Bash","input":{"command":"sleep 60"}}}'
+wait
+"#,
+            );
+            crate::codex_cli_executor::process_lifecycle_tests::interrupt_over_websocket(
+                Arc::new(executor(bin)),
+                run_spec("wait"),
+                &dir.path().join("pids"),
+                abort_owner,
+            )
+            .await;
+        }
     }
 
     #[tokio::test]

--- a/src/codex_app_server_executor.rs
+++ b/src/codex_app_server_executor.rs
@@ -17,9 +17,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::io::{AsyncWriteExt, BufReader};
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
 
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
 use bamboo_subagent::codex_discovery::discover_codex_app_server;
@@ -31,6 +32,7 @@ use bamboo_subagent::proto::RunSpec;
 
 use crate::codex_cli_executor::{
     read_bounded_line, terminate_child, CodexAuthConfig, CodexAuthMode, CodexPermissionConfig,
+    ProcessTreeChild,
 };
 
 const MAX_STDOUT_LINE_BYTES: usize = 10 * 1024 * 1024;
@@ -63,14 +65,15 @@ struct AppServerSessionStore {
 }
 
 struct AppServerConnection {
-    child: Child,
+    child: ProcessTreeChild,
     write_tx: mpsc::UnboundedSender<Value>,
     incoming_rx: mpsc::Receiver<Value>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     next_id: AtomicU64,
     stderr_tail: Arc<Mutex<String>>,
-    writer_task: tokio::task::JoinHandle<()>,
-    reader_task: tokio::task::JoinHandle<()>,
+    writer_task: AbortOnDropHandle<()>,
+    reader_task: AbortOnDropHandle<()>,
+    _stderr_task: Option<AbortOnDropHandle<()>>,
 }
 
 impl AppServerConnection {
@@ -130,23 +133,6 @@ impl AppServerConnection {
 
     async fn stderr_summary(&self) -> String {
         self.stderr_tail.lock().await.trim().to_string()
-    }
-}
-
-impl Drop for AppServerConnection {
-    fn drop(&mut self) {
-        self.writer_task.abort();
-        self.reader_task.abort();
-        #[cfg(unix)]
-        if let Some(pgid) = self.child.id().map(|pid| pid as libc::pid_t) {
-            // The executor normally uses the graceful interrupt plus
-            // TERM/KILL ladder. Drop is the last-resort worker-shutdown path,
-            // so synchronously kill the whole process group rather than
-            // allowing an in-flight Codex tool descendant to outlive Bamboo.
-            // SAFETY: a negative live child pid targets only its process group.
-            let _ = unsafe { libc::kill(-pgid, libc::SIGKILL) };
-        }
-        let _ = self.child.start_kill();
     }
 }
 
@@ -383,7 +369,7 @@ impl CodexAppServerExecutor {
 
     async fn start_connection(&self) -> Result<AppServerConnection, String> {
         self.prepare_auth_home().await?;
-        let mut child =
+        let child =
             spawn_with_etxtbsy_retry(|| self.build_command().map_err(std::io::Error::other))
                 .await
                 .map_err(|error| {
@@ -392,6 +378,7 @@ impl CodexAppServerExecutor {
                         self.binary.display()
                     )
                 })?;
+        let mut child = ProcessTreeChild::new(child);
         let stdin = child
             .stdin
             .take()
@@ -403,7 +390,7 @@ impl CodexAppServerExecutor {
         let stderr = child.stderr.take();
 
         let (write_tx, mut write_rx) = mpsc::unbounded_channel::<Value>();
-        let writer_task = tokio::spawn(async move {
+        let writer_task = AbortOnDropHandle::new(tokio::spawn(async move {
             let mut stdin = stdin;
             while let Some(value) = write_rx.recv().await {
                 let Ok(mut bytes) = serde_json::to_vec(&value) else {
@@ -414,7 +401,7 @@ impl CodexAppServerExecutor {
                     break;
                 }
             }
-        });
+        }));
 
         let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -423,7 +410,7 @@ impl CodexAppServerExecutor {
         // without limit. Client responses bypass this queue via `pending`.
         let (incoming_tx, incoming_rx) = mpsc::channel(128);
         let reader_pending = pending.clone();
-        let reader_task = tokio::spawn(async move {
+        let reader_task = AbortOnDropHandle::new(tokio::spawn(async move {
             let mut reader = BufReader::new(stdout);
             loop {
                 let line = match read_bounded_line(&mut reader, MAX_STDOUT_LINE_BYTES).await {
@@ -464,13 +451,15 @@ impl CodexAppServerExecutor {
                 }
             }
             reader_pending.lock().await.clear();
-        });
+        }));
 
         let stderr_tail = Arc::new(Mutex::new(String::new()));
-        if let Some(stderr) = stderr {
+        let stderr_task = stderr.map(|stderr| {
             let tail = stderr_tail.clone();
-            tokio::spawn(async move { drain_stderr_tail(stderr, tail).await });
-        }
+            AbortOnDropHandle::new(tokio::spawn(async move {
+                drain_stderr_tail(stderr, tail).await
+            }))
+        });
         let connection = AppServerConnection {
             child,
             write_tx,
@@ -480,6 +469,7 @@ impl CodexAppServerExecutor {
             stderr_tail,
             writer_task,
             reader_task,
+            _stderr_task: stderr_task,
         };
         connection
             .request(
@@ -498,18 +488,13 @@ impl CodexAppServerExecutor {
         Ok(connection)
     }
 
-    async fn ensure_connection<'a>(
-        &'a self,
-        slot: &'a mut Option<AppServerConnection>,
-    ) -> Result<&'a mut AppServerConnection, String> {
-        let alive = slot.as_mut().is_some_and(AppServerConnection::is_alive);
-        if !alive {
-            if let Some(mut stale) = slot.take() {
-                terminate_child(&mut stale.child).await;
-            }
-            *slot = Some(self.start_connection().await?);
+    async fn take_connection(&self) -> Result<AppServerConnection, String> {
+        let mut previous = self.connection.lock().await.take();
+        if previous.as_mut().is_some_and(AppServerConnection::is_alive) {
+            return Ok(previous.expect("live connection"));
         }
-        Ok(slot.as_mut().expect("connection installed"))
+        drop(previous);
+        self.start_connection().await
     }
 
     fn thread_params(&self, policy: AppServerRunPolicy<'_>) -> Value {
@@ -594,7 +579,7 @@ impl CodexAppServerExecutor {
         turn_id: &str,
         events: &EventSink,
         steer: &mut SteerInbox,
-        approval_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+        approval_tasks: &mut Vec<AbortOnDropHandle<()>>,
         force_cancelled: bool,
         approval_disposition: UnexpectedApprovalDisposition,
     ) -> ChildOutcome {
@@ -616,7 +601,7 @@ impl CodexAppServerExecutor {
                                 "executor": "codex_app_server",
                                 "phase": "steer_rejected",
                                 "message": error,
-                            }));
+                            })).await;
                         }
                     } else {
                         steer_open = false;
@@ -677,7 +662,7 @@ impl CodexAppServerExecutor {
                         events,
                         &mut state,
                         force_cancelled,
-                    ) {
+                    ).await {
                         return outcome;
                     }
                 }
@@ -723,9 +708,11 @@ impl CodexAppServerExecutor {
         {
             Ok(activation) => activation,
             Err(error) => {
-                events.emit(event_json(AgentEvent::Error {
-                    message: error.clone(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::Error {
+                        message: error.clone(),
+                    }))
+                    .await;
                 return ChildOutcome::error(error);
             }
         };
@@ -733,16 +720,20 @@ impl CodexAppServerExecutor {
             let message = format!(
                 "Codex app-server cannot safely enforce Bamboo explicit-deny policy: {reason}"
             );
-            events.emit(event_json(AgentEvent::PermissionPostureActivated {
-                session_id: logical_session.clone(),
-                policy_revision: activation.policy_revision,
-                requested_mode: activation.resolution.requested.as_str().to_string(),
-                effective_mode: activation.resolution.effective.as_str().to_string(),
-                executor_mapping: "codex_app_server:blocked_explicit_deny".to_string(),
-            }));
-            events.emit(event_json(AgentEvent::Error {
-                message: message.clone(),
-            }));
+            events
+                .emit(event_json(AgentEvent::PermissionPostureActivated {
+                    session_id: logical_session.clone(),
+                    policy_revision: activation.policy_revision,
+                    requested_mode: activation.resolution.requested.as_str().to_string(),
+                    effective_mode: activation.resolution.effective.as_str().to_string(),
+                    executor_mapping: "codex_app_server:blocked_explicit_deny".to_string(),
+                }))
+                .await;
+            events
+                .emit(event_json(AgentEvent::Error {
+                    message: message.clone(),
+                }))
+                .await;
             return ChildOutcome::error(message);
         }
         let approval_policy = if activation.resolution.suppress_approval_prompts()
@@ -771,52 +762,61 @@ impl CodexAppServerExecutor {
             approval_policy,
             network_access,
         };
-        events.emit(event_json(AgentEvent::PermissionPostureActivated {
-            session_id: logical_session.clone(),
-            policy_revision: activation.policy_revision,
-            requested_mode: activation.resolution.requested.as_str().to_string(),
-            effective_mode: activation.resolution.effective.as_str().to_string(),
-            executor_mapping: executor_mapping.clone(),
-        }));
+        events
+            .emit(event_json(AgentEvent::PermissionPostureActivated {
+                session_id: logical_session.clone(),
+                policy_revision: activation.policy_revision,
+                requested_mode: activation.resolution.requested.as_str().to_string(),
+                effective_mode: activation.resolution.effective.as_str().to_string(),
+                executor_mapping: executor_mapping.clone(),
+            }))
+            .await;
         for warning in warnings {
-            events.emit(json!({
+            events
+                .emit(json!({
+                    "type": "runner_progress",
+                    "session_id": logical_session,
+                    "round_count": 0,
+                    "level": "warning",
+                    "message": warning,
+                }))
+                .await;
+        }
+        events
+            .emit(json!({
                 "type": "runner_progress",
                 "session_id": logical_session,
                 "round_count": 0,
-                "level": "warning",
-                "message": warning,
-            }));
-        }
-        events.emit(json!({
-            "type": "runner_progress",
-            "session_id": logical_session,
-            "round_count": 0,
-            "executor": "codex_app_server",
-            "binary": self.binary,
-            "version": self.version,
-            "model": self.model,
-            "auth_mode": self.auth.mode().as_str(),
-            "codex_home_mode": self.codex_home_mode(),
-            "sandbox": sandbox,
-            "approval_policy": approval_policy,
-            "approvals_reviewer": (!activation.resolution.suppress_approval_prompts()
-                && activation.resolution.effective != bamboo_domain::PermissionMode::Plan)
-                .then_some("user"),
-            "network_access": network_access,
-            "permission_profile": self.permissions.permission_profile(),
-            "requested_mode": activation.resolution.requested.as_str(),
-            "effective_mode": activation.resolution.effective.as_str(),
-            "executor_mapping": executor_mapping,
-        }));
+                "executor": "codex_app_server",
+                "binary": self.binary,
+                "version": self.version,
+                "model": self.model,
+                "auth_mode": self.auth.mode().as_str(),
+                "codex_home_mode": self.codex_home_mode(),
+                "sandbox": sandbox,
+                "approval_policy": approval_policy,
+                "approvals_reviewer": (!activation.resolution.suppress_approval_prompts()
+                    && activation.resolution.effective != bamboo_domain::PermissionMode::Plan)
+                    .then_some("user"),
+                "network_access": network_access,
+                "permission_profile": self.permissions.permission_profile(),
+                "requested_mode": activation.resolution.requested.as_str(),
+                "effective_mode": activation.resolution.effective.as_str(),
+                "executor_mapping": executor_mapping,
+            }))
+            .await;
 
         if spec.messages.is_empty() {
             self.forget_thread(&logical_session).await;
         }
-        let mut slot = self.connection.lock().await;
-        let connection = match self.ensure_connection(&mut slot).await {
+        // The active future owns the connection. A transport abort can drop
+        // this future while interrupt/approval/output awaits are pending; it
+        // must destroy that turn instead of leaving it in the warm slot.
+        let mut active_connection = match self.take_connection().await {
             Ok(connection) => connection,
             Err(error) => return ChildOutcome::error(error),
         };
+        let connection = &mut active_connection;
 
         while connection.incoming_rx.try_recv().is_ok() {}
         let stored = if spec.messages.is_empty() {
@@ -836,7 +836,7 @@ impl CodexAppServerExecutor {
                         "executor": "codex_app_server",
                         "phase": "resume_fallback",
                         "message": "resume failed; starting a new thread with bounded history rehydration",
-                    }));
+                    })).await;
                     self.forget_thread(&logical_session).await;
                     let new_id = match self.start_thread(connection, run_policy).await {
                         Ok(id) => id,
@@ -875,10 +875,12 @@ impl CodexAppServerExecutor {
             Ok(id) => id,
             Err(error) => return ChildOutcome::error(error),
         };
-        events.emit(event_json(AgentEvent::RunnerProgress {
-            session_id: thread_id.clone(),
-            round_count: 1,
-        }));
+        events
+            .emit(event_json(AgentEvent::RunnerProgress {
+                session_id: thread_id.clone(),
+                round_count: 1,
+            }))
+            .await;
         let mut approval_tasks = Vec::new();
         let outcome = tokio::select! {
             outcome = self.drive_turn(
@@ -915,9 +917,7 @@ impl CodexAppServerExecutor {
                 ).await {
                     Ok(_) => ChildOutcome::cancelled(),
                     Err(_) => {
-                        if let Some(mut connection) = slot.take() {
-                            terminate_child(&mut connection.child).await;
-                        }
+                        terminate_child(&mut connection.child).await;
                         ChildOutcome::cancelled()
                     }
                 }
@@ -925,6 +925,12 @@ impl CodexAppServerExecutor {
         };
         for task in approval_tasks {
             task.abort();
+            let _ = task.await;
+        }
+        // Only a fully completed turn is eligible for warm reuse. Errors and
+        // cancelled turns are discarded even if interrupt appeared successful.
+        if outcome.status == bamboo_subagent::proto::TerminalStatus::Completed {
+            *self.connection.lock().await = Some(active_connection);
         }
         outcome
     }
@@ -960,7 +966,7 @@ struct AppRunState {
     started_items: HashSet<String>,
 }
 
-fn handle_notification(
+async fn handle_notification(
     method: &str,
     params: &Value,
     thread_id: &str,
@@ -992,16 +998,20 @@ fn handle_notification(
                     state.last_agent_message.clear();
                 }
                 state.last_agent_message.push_str(delta);
-                events.emit(event_json(AgentEvent::Token {
-                    content: delta.to_string(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::Token {
+                        content: delta.to_string(),
+                    }))
+                    .await;
             }
         }
         "item/reasoning/textDelta" | "item/reasoning/summaryTextDelta" => {
             if let Some(delta) = params.get("delta").and_then(Value::as_str) {
-                events.emit(event_json(AgentEvent::ReasoningToken {
-                    content: delta.to_string(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::ReasoningToken {
+                        content: delta.to_string(),
+                    }))
+                    .await;
             }
         }
         "item/commandExecution/outputDelta" | "item/fileChange/outputDelta" => {
@@ -1009,10 +1019,12 @@ fn handle_notification(
                 params.get("itemId").and_then(Value::as_str),
                 params.get("delta").and_then(Value::as_str),
             ) {
-                events.emit(event_json(AgentEvent::ToolToken {
-                    tool_call_id: item_id.to_string(),
-                    content: delta.to_string(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::ToolToken {
+                        tool_call_id: item_id.to_string(),
+                        content: delta.to_string(),
+                    }))
+                    .await;
             }
         }
         "item/mcpToolCall/progress" => {
@@ -1020,20 +1032,22 @@ fn handle_notification(
                 params.get("itemId").and_then(Value::as_str),
                 params.get("message").and_then(Value::as_str),
             ) {
-                events.emit(event_json(AgentEvent::ToolToken {
-                    tool_call_id: item_id.to_string(),
-                    content: message.to_string(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::ToolToken {
+                        tool_call_id: item_id.to_string(),
+                        content: message.to_string(),
+                    }))
+                    .await;
             }
         }
         "item/started" => {
             if let Some(item) = params.get("item") {
-                emit_item_started(item, events, state);
+                emit_item_started(item, events, state).await;
             }
         }
         "item/completed" => {
             if let Some(item) = params.get("item") {
-                emit_item_completed(item, events, state);
+                emit_item_completed(item, events, state).await;
             }
         }
         "thread/tokenUsage/updated" => {
@@ -1041,37 +1055,47 @@ fn handle_notification(
         }
         "turn/completed" => {
             if force_cancelled {
-                events.emit(event_json(AgentEvent::Cancelled {
-                    message: Some("Codex app-server turn interrupted".to_string()),
-                }));
+                events
+                    .emit(event_json(AgentEvent::Cancelled {
+                        message: Some("Codex app-server turn interrupted".to_string()),
+                    }))
+                    .await;
                 return Some(ChildOutcome::cancelled());
             }
             let turn = params.get("turn").unwrap_or(&Value::Null);
             match turn.get("status").and_then(Value::as_str) {
                 Some("completed") => {
-                    events.emit(event_json(AgentEvent::Complete { usage: state.usage }));
+                    events
+                        .emit(event_json(AgentEvent::Complete { usage: state.usage }))
+                        .await;
                     return Some(ChildOutcome::completed(state.last_agent_message.clone()));
                 }
                 Some("interrupted") => {
-                    events.emit(event_json(AgentEvent::Cancelled {
-                        message: Some("Codex app-server turn interrupted".to_string()),
-                    }));
+                    events
+                        .emit(event_json(AgentEvent::Cancelled {
+                            message: Some("Codex app-server turn interrupted".to_string()),
+                        }))
+                        .await;
                     return Some(ChildOutcome::cancelled());
                 }
                 _ => {
                     let message = error_message(turn, "Codex app-server turn failed");
-                    events.emit(event_json(AgentEvent::Error {
-                        message: message.clone(),
-                    }));
+                    events
+                        .emit(event_json(AgentEvent::Error {
+                            message: message.clone(),
+                        }))
+                        .await;
                     return Some(ChildOutcome::error(message));
                 }
             }
         }
         "error" => {
             let message = error_message(params, "Codex app-server error");
-            events.emit(event_json(AgentEvent::Error {
-                message: message.clone(),
-            }));
+            events
+                .emit(event_json(AgentEvent::Error {
+                    message: message.clone(),
+                }))
+                .await;
             return Some(ChildOutcome::error(message));
         }
         other => tracing::debug!(
@@ -1082,7 +1106,7 @@ fn handle_notification(
     None
 }
 
-fn emit_item_started(item: &Value, events: &EventSink, state: &mut AppRunState) {
+async fn emit_item_started(item: &Value, events: &EventSink, state: &mut AppRunState) {
     let item_id = item
         .get("id")
         .and_then(Value::as_str)
@@ -1118,14 +1142,16 @@ fn emit_item_started(item: &Value, events: &EventSink, state: &mut AppRunState) 
         Some("webSearch") => ("WebSearch".to_string(), json!({"query": item.get("query")})),
         _ => return,
     };
-    events.emit(event_json(AgentEvent::ToolStart {
-        tool_call_id: item_id.to_string(),
-        tool_name,
-        arguments,
-    }));
+    events
+        .emit(event_json(AgentEvent::ToolStart {
+            tool_call_id: item_id.to_string(),
+            tool_name,
+            arguments,
+        }))
+        .await;
 }
 
-fn emit_item_completed(item: &Value, events: &EventSink, state: &mut AppRunState) {
+async fn emit_item_completed(item: &Value, events: &EventSink, state: &mut AppRunState) {
     if item.get("type").and_then(Value::as_str) == Some("agentMessage") {
         if let Some(text) = item.get("text").and_then(Value::as_str) {
             state.last_agent_item_id = item.get("id").and_then(Value::as_str).map(str::to_string);
@@ -1133,7 +1159,7 @@ fn emit_item_completed(item: &Value, events: &EventSink, state: &mut AppRunState
         }
         return;
     }
-    emit_item_started(item, events, state);
+    emit_item_started(item, events, state).await;
     let item_id = item
         .get("id")
         .and_then(Value::as_str)
@@ -1154,10 +1180,12 @@ fn emit_item_completed(item: &Value, events: &EventSink, state: &mut AppRunState
             })
         });
     if let Some(error) = error {
-        events.emit(event_json(AgentEvent::ToolError {
-            tool_call_id: item_id.to_string(),
-            error: truncate_chars(&error, TOOL_RESULT_TRUNCATE_CHARS),
-        }));
+        events
+            .emit(event_json(AgentEvent::ToolError {
+                tool_call_id: item_id.to_string(),
+                error: truncate_chars(&error, TOOL_RESULT_TRUNCATE_CHARS),
+            }))
+            .await;
     } else {
         let result = item
             .get("aggregatedOutput")
@@ -1165,10 +1193,12 @@ fn emit_item_completed(item: &Value, events: &EventSink, state: &mut AppRunState
             .or_else(|| item.get("changes"))
             .map(value_text)
             .unwrap_or_else(|| status.to_string());
-        events.emit(event_json(AgentEvent::ToolComplete {
-            tool_call_id: item_id.to_string(),
-            result: ToolResult::text(true, truncate_chars(&result, TOOL_RESULT_TRUNCATE_CHARS)),
-        }));
+        events
+            .emit(event_json(AgentEvent::ToolComplete {
+                tool_call_id: item_id.to_string(),
+                result: ToolResult::text(true, truncate_chars(&result, TOOL_RESULT_TRUNCATE_CHARS)),
+            }))
+            .await;
     }
 }
 
@@ -1188,8 +1218,8 @@ fn spawn_approval_relay(
     request: Value,
     host: Option<HostBridge>,
     timeout: Duration,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
+) -> AbortOnDropHandle<()> {
+    AbortOnDropHandle::new(tokio::spawn(async move {
         let id = request.get("id").cloned().unwrap_or(Value::Null);
         let method = request
             .get("method")
@@ -1238,7 +1268,7 @@ fn spawn_approval_relay(
             false
         };
         let _ = write_tx.send(approval_response_parts(id, &method, approved));
-    })
+    }))
 }
 
 fn approval_matches_active_turn(request: &Value, thread_id: &str, turn_id: &str) -> bool {
@@ -1500,6 +1530,123 @@ while IFS= read -r ignored; do :; done
     }
 
     #[cfg(unix)]
+    #[tokio::test]
+    async fn websocket_cancel_and_owner_abort_discard_turn_then_reuse_clean_connection() {
+        use crate::codex_cli_executor::process_lifecycle_tests::{
+            assert_processes_gone, interrupt_over_websocket,
+        };
+        use std::os::unix::fs::PermissionsExt as _;
+
+        for abort_owner in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let binary = root.path().join("codex-cancel-stub.sh");
+            std::fs::write(&binary, r###"#!/bin/sh
+if [ "$1" = "--version" ]; then echo 'codex-cli 0.144.5'; exit 0; fi
+if [ "$1" = "exec" ]; then echo '--json --output-last-message --config --sandbox --dangerously-bypass-approvals-and-sandbox stdin'; exit 0; fi
+if [ "$1" = "app-server" ] && [ "$2" = "--help" ]; then echo '--listen stdio:// --stdio'; exit 0; fi
+DIR=$(cd "$(dirname "$0")" && pwd)
+trap '' TERM
+while IFS= read -r request; do
+  id=$(printf '%s\n' "$request" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  case "$request" in
+    *'"method":"initialize"'*) printf '{"id":%s,"result":{}}\n' "$id" ;;
+    *'"method":"thread/start"'*) printf '{"id":%s,"result":{"thread":{"id":"thread-stub"}}}\n' "$id" ;;
+    *'"method":"turn/start"'*)
+      printf '{"id":%s,"result":{"turn":{"id":"turn-stub","status":"inProgress","items":[]}}}\n' "$id"
+      case "$request" in
+        *'finish'*) echo '{"method":"turn/completed","params":{"threadId":"thread-stub","turn":{"id":"turn-stub","status":"completed","items":[]}}}' ;;
+        *)
+          (trap '' TERM; sleep 60) &
+          printf '%s %s\n' "$$" "$!" > "$DIR/pids"
+          echo '{"id":41,"method":"item/commandExecution/requestApproval","params":{"threadId":"thread-stub","turnId":"turn-stub","itemId":"item-1","command":"sleep 60","cwd":"/tmp","reason":"pending approval"}}'
+          ;;
+      esac ;;
+    *'"method":"turn/interrupt"'*) : ;; # Deliberately never acknowledge interrupt.
+  esac
+done
+"###).unwrap();
+            std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+            let permissions = resolve_codex_app_server_permission_config(
+                Some("workspace-write"),
+                Some("on-request"),
+                false,
+                false,
+                None,
+                false,
+                false,
+            )
+            .unwrap();
+            let executor = Arc::new(
+                CodexAppServerExecutor::new(
+                    Some(binary.to_string_lossy().into_owned()),
+                    None,
+                    Some(root.path().to_string_lossy().into_owned()),
+                    Some(root.path().join("state")),
+                    Vec::new(),
+                    CodexAuthConfig::inherit(),
+                    permissions,
+                )
+                .await
+                .unwrap(),
+            );
+            let spec = |assignment: &str| -> RunSpec {
+                serde_json::from_value(json!({
+                    "assignment": assignment,
+                    "logical_session": {"session_id": "process-test", "root_session_id": "process-test"}
+                })).unwrap()
+            };
+            let old_pid = interrupt_over_websocket(
+                executor.clone(),
+                spec("hang"),
+                &root.path().join("pids"),
+                abort_owner,
+            )
+            .await;
+            assert!(
+                executor.connection.lock().await.is_none(),
+                "aborted turn cannot remain warm"
+            );
+
+            let mut warm_pid = None;
+            for _ in 0..2 {
+                let (events, receiver) = EventSink::channel();
+                drop(receiver);
+                let outcome = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    executor.run(
+                        spec("finish"),
+                        events,
+                        SteerInbox::disconnected(),
+                        CancellationToken::new(),
+                    ),
+                )
+                .await
+                .expect("subsequent warm run must be clean");
+                assert_eq!(
+                    outcome.status,
+                    bamboo_subagent::proto::TerminalStatus::Completed
+                );
+                let pid = executor
+                    .connection
+                    .lock()
+                    .await
+                    .as_ref()
+                    .unwrap()
+                    .child
+                    .id()
+                    .unwrap() as libc::pid_t;
+                assert_ne!(pid, old_pid, "interrupted connection must be replaced");
+                if let Some(warm_pid) = warm_pid {
+                    assert_eq!(pid, warm_pid, "completed connection should be reusable");
+                }
+                warm_pid = Some(pid);
+            }
+            drop(executor);
+            assert_processes_gone(&[warm_pid.unwrap()]).await;
+        }
+    }
+
+    #[cfg(unix)]
     async fn run_stub(
         approved: Option<bool>,
         run_auto_approve_permissions: Option<bool>,
@@ -1655,6 +1802,25 @@ while IFS= read -r ignored; do :; done
         task.await.unwrap();
         let response = write_rx.recv().await.expect("app-server response");
         assert_eq!(response, json!({"id": 9, "result": {"decision": "accept"}}));
+    }
+
+    #[tokio::test]
+    async fn dropping_approval_owner_releases_pending_host_reply() {
+        let (host, mut host_rx) = HostBridge::channel();
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel();
+        let task = spawn_approval_relay(
+            write_tx,
+            json!({"id": 10, "method": "item/fileChange/requestApproval", "params": {}}),
+            Some(host),
+            Duration::from_secs(300),
+        );
+        let mut request = host_rx.recv().await.unwrap();
+        drop(task);
+        tokio::time::timeout(Duration::from_secs(1), request.reply.closed())
+            .await
+            .unwrap();
+        assert!(host_rx.recv().await.is_none());
+        assert!(write_rx.recv().await.is_none());
     }
 
     #[tokio::test]

--- a/src/codex_cli_executor.rs
+++ b/src/codex_cli_executor.rs
@@ -23,6 +23,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
 
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
 use bamboo_subagent::codex_discovery::discover_codex_cli;
@@ -1042,7 +1043,7 @@ impl CodexExecutor {
         }
     }
 
-    fn handle_event(
+    async fn handle_event(
         &self,
         value: Value,
         policy: &EffectiveCodexPolicy,
@@ -1061,35 +1062,39 @@ impl CodexExecutor {
                 if !state.thread_id.is_empty() {
                     captured_thread_id = Some(state.thread_id.clone());
                 }
-                events.emit(json!({
-                    "type": "runner_progress",
-                    "session_id": state.thread_id,
-                    "round_count": 0,
-                    "executor": "codex",
-                    "binary": self.binary,
-                    "version": self.version,
-                    "model": self.model,
-                    "auth_mode": self.auth.mode().as_str(),
-                    "codex_home_mode": self.codex_home_mode(),
-                    "forward_env": self.forward_env,
-                    "sandbox": policy.sandbox.as_str(),
-                    "approval_policy": policy.approval_policy.as_str(),
-                    "network_access": policy.network_access,
-                    "policy_invocation": policy.invocation.as_str(),
-                    "permission_profile": self.permissions.permission_profile.as_deref(),
-                }));
+                events
+                    .emit(json!({
+                        "type": "runner_progress",
+                        "session_id": state.thread_id,
+                        "round_count": 0,
+                        "executor": "codex",
+                        "binary": self.binary,
+                        "version": self.version,
+                        "model": self.model,
+                        "auth_mode": self.auth.mode().as_str(),
+                        "codex_home_mode": self.codex_home_mode(),
+                        "forward_env": self.forward_env,
+                        "sandbox": policy.sandbox.as_str(),
+                        "approval_policy": policy.approval_policy.as_str(),
+                        "network_access": policy.network_access,
+                        "policy_invocation": policy.invocation.as_str(),
+                        "permission_profile": self.permissions.permission_profile.as_deref(),
+                    }))
+                    .await;
             }
             "turn.started" => {
                 state.turn_started = true;
-                events.emit(event_json(AgentEvent::RunnerProgress {
-                    session_id: state.session_id(),
-                    round_count: 1,
-                }));
+                events
+                    .emit(event_json(AgentEvent::RunnerProgress {
+                        session_id: state.session_id(),
+                        round_count: 1,
+                    }))
+                    .await;
             }
             "item.started" | "item.updated" | "item.completed" => {
                 let phase = event_type.trim_start_matches("item.");
                 if let Some(item) = value.get("item") {
-                    handle_item(phase, item, events, state);
+                    handle_item(phase, item, events, state).await;
                     // Codex CLI 0.144 can omit the command_execution item when
                     // the OS sandbox itself rejects the command, even though
                     // it reports the exit status and errno to the model. Keep
@@ -1111,10 +1116,12 @@ impl CodexExecutor {
                         let error = item.get("text").and_then(Value::as_str).unwrap_or(
                             "Codex reported that the OS sandbox denied a tool operation",
                         );
-                        events.emit(event_json(AgentEvent::ToolError {
-                            tool_call_id: format!("{item_id}-sandbox-denial"),
-                            error: truncate_chars(error, TOOL_RESULT_TRUNCATE_CHARS),
-                        }));
+                        events
+                            .emit(event_json(AgentEvent::ToolError {
+                                tool_call_id: format!("{item_id}-sandbox-denial"),
+                                error: truncate_chars(error, TOOL_RESULT_TRUNCATE_CHARS),
+                            }))
+                            .await;
                         state.tool_error_emitted = true;
                     }
                 }
@@ -1125,17 +1132,19 @@ impl CodexExecutor {
                 if let Some(text) = final_text_from_terminal(&value) {
                     state.last_agent_message = text;
                 }
-                events.emit(event_json(AgentEvent::Complete { usage: state.usage }));
+                events
+                    .emit(event_json(AgentEvent::Complete { usage: state.usage }))
+                    .await;
             }
             "turn.failed" => {
                 let message = error_message(&value, "Codex turn failed");
                 state.failure = Some(message.clone());
-                events.emit(event_json(AgentEvent::Error { message }));
+                events.emit(event_json(AgentEvent::Error { message })).await;
             }
             "error" => {
                 let message = error_message(&value, "Codex CLI error");
                 state.failure = Some(message.clone());
-                events.emit(event_json(AgentEvent::Error { message }));
+                events.emit(event_json(AgentEvent::Error { message })).await;
             }
             other => {
                 tracing::debug!(event_type = other, "codex: unrecognized JSONL event");
@@ -1163,7 +1172,8 @@ impl CodexExecutor {
         let policy = self
             .permissions
             .effective_for_session(permission, running_as_root());
-        self.emit_policy_bootstrap(&policy, permission, events);
+        self.emit_policy_bootstrap(&policy, permission, events)
+            .await;
         // Warm workers reuse this executor across activations. Reassert the
         // isolated-home invariant at every run boundary so a prior Codex
         // process cannot leave an auth artifact or mutate provider routing for
@@ -1181,7 +1191,7 @@ impl CodexExecutor {
         })
         .await
         {
-            Ok(child) => child,
+            Ok(child) => ProcessTreeChild::new(child),
             Err(error) => {
                 return (
                     ChildOutcome::error(format!(
@@ -1212,7 +1222,7 @@ impl CodexExecutor {
                 terminate_child(&mut child).await;
                 events.emit(event_json(AgentEvent::Cancelled {
                     message: Some("Codex child cancelled".to_string()),
-                }));
+                })).await;
                 return (ChildOutcome::cancelled(), false);
             }
         };
@@ -1228,7 +1238,9 @@ impl CodexExecutor {
         let stderr_tail = Arc::new(Mutex::new(String::new()));
         let stderr_task = stderr.map(|stderr| {
             let tail = stderr_tail.clone();
-            tokio::spawn(async move { drain_stderr_tail(stderr, tail).await })
+            AbortOnDropHandle::new(tokio::spawn(async move {
+                drain_stderr_tail(stderr, tail).await
+            }))
         });
 
         let mut reader = BufReader::with_capacity(64 * 1024, stdout);
@@ -1255,7 +1267,7 @@ impl CodexExecutor {
                                         &policy,
                                         events,
                                         &mut state,
-                                    ) {
+                                    ).await {
                                         self.write_session_state(&thread_id).await;
                                     }
                                 }
@@ -1285,14 +1297,18 @@ impl CodexExecutor {
             }
         };
         if let Some(task) = stderr_task {
-            let _ = task.await;
+            // A surviving tool may still hold stderr open after the leader
+            // exits. Do not let its pipe prevent the process owner from dropping.
+            let _ = tokio::time::timeout(Duration::from_millis(500), task).await;
         }
         let stderr = stderr_tail.lock().await.clone();
 
         if cancelled {
-            events.emit(event_json(AgentEvent::Cancelled {
-                message: Some("Codex child cancelled".to_string()),
-            }));
+            events
+                .emit(event_json(AgentEvent::Cancelled {
+                    message: Some("Codex child cancelled".to_string()),
+                }))
+                .await;
             return (ChildOutcome::cancelled(), false);
         }
 
@@ -1334,7 +1350,7 @@ impl CodexExecutor {
         (outcome, exited_without_turn)
     }
 
-    fn emit_policy_bootstrap(
+    async fn emit_policy_bootstrap(
         &self,
         policy: &EffectiveCodexPolicy,
         permission: bamboo_domain::PermissionModeResolution,
@@ -1344,42 +1360,46 @@ impl CodexExecutor {
             "codex_exec:approval_policy={}",
             policy.approval_policy.as_str()
         );
-        events.emit(json!({
-            "type": "runner_progress",
-            "session_id": "codex",
-            "round_count": 0,
-            "executor": "codex",
-            "phase": "bootstrap",
-            "binary": self.binary,
-            "version": self.version,
-            "model": self.model,
-            "auth_mode": self.auth.mode().as_str(),
-            "codex_home_mode": self.codex_home_mode(),
-            "forward_env": self.forward_env,
-            "sandbox": policy.sandbox.as_str(),
-            "approval_policy": policy.approval_policy.as_str(),
-            "network_access": policy.network_access,
-            "policy_invocation": policy.invocation.as_str(),
-            "permission_profile": self.permissions.permission_profile.as_deref(),
-            "requested_mode": permission.requested.as_str(),
-            "effective_mode": permission.effective.as_str(),
-            "executor_mapping": executor_mapping,
-        }));
-        for warning in &policy.warnings {
-            tracing::warn!(message = %warning, "Codex spawn policy warning");
-            events.emit(json!({
+        events
+            .emit(json!({
                 "type": "runner_progress",
                 "session_id": "codex",
                 "round_count": 0,
                 "executor": "codex",
-                "phase": "policy_warning",
-                "level": "warning",
-                "message": warning,
+                "phase": "bootstrap",
+                "binary": self.binary,
+                "version": self.version,
+                "model": self.model,
+                "auth_mode": self.auth.mode().as_str(),
+                "codex_home_mode": self.codex_home_mode(),
+                "forward_env": self.forward_env,
                 "sandbox": policy.sandbox.as_str(),
                 "approval_policy": policy.approval_policy.as_str(),
                 "network_access": policy.network_access,
                 "policy_invocation": policy.invocation.as_str(),
-            }));
+                "permission_profile": self.permissions.permission_profile.as_deref(),
+                "requested_mode": permission.requested.as_str(),
+                "effective_mode": permission.effective.as_str(),
+                "executor_mapping": executor_mapping,
+            }))
+            .await;
+        for warning in &policy.warnings {
+            tracing::warn!(message = %warning, "Codex spawn policy warning");
+            events
+                .emit(json!({
+                    "type": "runner_progress",
+                    "session_id": "codex",
+                    "round_count": 0,
+                    "executor": "codex",
+                    "phase": "policy_warning",
+                    "level": "warning",
+                    "message": warning,
+                    "sandbox": policy.sandbox.as_str(),
+                    "approval_policy": policy.approval_policy.as_str(),
+                    "network_access": policy.network_access,
+                    "policy_invocation": policy.invocation.as_str(),
+                }))
+                .await;
         }
     }
 }
@@ -1413,44 +1433,54 @@ impl ChildExecutor for CodexExecutor {
         {
             Ok(activation) => activation,
             Err(error) => {
-                events.emit(event_json(AgentEvent::Error {
-                    message: error.clone(),
-                }));
+                events
+                    .emit(event_json(AgentEvent::Error {
+                        message: error.clone(),
+                    }))
+                    .await;
                 return ChildOutcome::error(error);
             }
         };
         if let Some(reason) = activation.explicit_deny_reason.as_ref() {
             let message =
                 format!("Codex exec cannot safely enforce Bamboo explicit-deny policy: {reason}");
-            events.emit(event_json(AgentEvent::PermissionPostureActivated {
-                session_id: logical_session_id,
-                policy_revision: activation.policy_revision,
-                requested_mode: activation.resolution.requested.as_str().to_string(),
-                effective_mode: activation.resolution.effective.as_str().to_string(),
-                executor_mapping: "codex_exec:blocked_explicit_deny".to_string(),
-            }));
-            events.emit(event_json(AgentEvent::Error {
-                message: message.clone(),
-            }));
+            events
+                .emit(event_json(AgentEvent::PermissionPostureActivated {
+                    session_id: logical_session_id,
+                    policy_revision: activation.policy_revision,
+                    requested_mode: activation.resolution.requested.as_str().to_string(),
+                    effective_mode: activation.resolution.effective.as_str().to_string(),
+                    executor_mapping: "codex_exec:blocked_explicit_deny".to_string(),
+                }))
+                .await;
+            events
+                .emit(event_json(AgentEvent::Error {
+                    message: message.clone(),
+                }))
+                .await;
             return ChildOutcome::error(message);
         }
         let bootstrap_policy = self
             .permissions
             .effective_for_session(activation.resolution, running_as_root());
-        events.emit(event_json(AgentEvent::PermissionPostureActivated {
-            session_id: logical_session_id,
-            policy_revision: activation.policy_revision,
-            requested_mode: activation.resolution.requested.as_str().to_string(),
-            effective_mode: activation.resolution.effective.as_str().to_string(),
-            executor_mapping: format!(
-                "codex_exec:approval_policy={}",
-                bootstrap_policy.approval_policy.as_str()
-            ),
-        }));
+        events
+            .emit(event_json(AgentEvent::PermissionPostureActivated {
+                session_id: logical_session_id,
+                policy_revision: activation.policy_revision,
+                requested_mode: activation.resolution.requested.as_str().to_string(),
+                effective_mode: activation.resolution.effective.as_str().to_string(),
+                executor_mapping: format!(
+                    "codex_exec:approval_policy={}",
+                    bootstrap_policy.approval_policy.as_str()
+                ),
+            }))
+            .await;
 
         // `codex exec` v1 has no mid-turn steering channel. Drain the inbox so
         // transport senders cannot build an unbounded backlog.
-        let steer_drain = tokio::spawn(async move { while steer.recv().await.is_some() {} });
+        let steer_drain = AbortOnDropHandle::new(tokio::spawn(async move {
+            while steer.recv().await.is_some() {}
+        }));
         if spec.messages.is_empty() {
             self.delete_session_state().await;
         }
@@ -1490,7 +1520,7 @@ impl ChildExecutor for CodexExecutor {
                 "executor": "codex",
                 "phase": "resume_fallback",
                 "message": "resume failed before turn progress; retrying once with rehydrated history",
-            }));
+            })).await;
             self.delete_session_state().await;
             let fallback_body = build_rehydrated_turn(&spec.messages, &spec.assignment);
             self.run_process(
@@ -1535,7 +1565,7 @@ impl RunState {
     }
 }
 
-fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunState) {
+async fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunState) {
     let item_type = item.get("type").and_then(Value::as_str).unwrap_or("");
     let item_id = item
         .get("id")
@@ -1553,7 +1583,8 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 &mut state.item_text,
                 |delta| AgentEvent::Token { content: delta },
                 events,
-            );
+            )
+            .await;
             if phase == "completed" && !text.is_empty() {
                 state.last_agent_message = text.to_string();
             }
@@ -1566,7 +1597,8 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 &mut state.item_text,
                 |delta| AgentEvent::ReasoningToken { content: delta },
                 events,
-            );
+            )
+            .await;
         }
         "command_execution" => {
             ensure_tool_started(
@@ -1575,34 +1607,39 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 json!({ "command": item.get("command").cloned().unwrap_or(Value::Null) }),
                 events,
                 state,
-            );
+            )
+            .await;
             let output = item
                 .get("aggregated_output")
                 .and_then(Value::as_str)
                 .unwrap_or("");
-            emit_tool_output_delta(&item_id, output, events, state);
+            emit_tool_output_delta(&item_id, output, events, state).await;
             if phase == "completed" {
                 let exit_code = item.get("exit_code").and_then(Value::as_i64);
                 let successful = exit_code == Some(0)
                     && item.get("status").and_then(Value::as_str) != Some("failed");
                 if successful {
-                    events.emit(event_json(AgentEvent::ToolComplete {
-                        tool_call_id: item_id,
-                        result: ToolResult::text(
-                            true,
-                            truncate_chars(output, TOOL_RESULT_TRUNCATE_CHARS),
-                        ),
-                    }));
+                    events
+                        .emit(event_json(AgentEvent::ToolComplete {
+                            tool_call_id: item_id,
+                            result: ToolResult::text(
+                                true,
+                                truncate_chars(output, TOOL_RESULT_TRUNCATE_CHARS),
+                            ),
+                        }))
+                        .await;
                 } else {
                     let error = if output.trim().is_empty() {
                         format!("command failed with exit code {exit_code:?}")
                     } else {
                         truncate_chars(output, TOOL_RESULT_TRUNCATE_CHARS)
                     };
-                    events.emit(event_json(AgentEvent::ToolError {
-                        tool_call_id: item_id,
-                        error,
-                    }));
+                    events
+                        .emit(event_json(AgentEvent::ToolError {
+                            tool_call_id: item_id,
+                            error,
+                        }))
+                        .await;
                     state.tool_error_emitted = true;
                 }
             }
@@ -1619,9 +1656,10 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 json!({ "changes": detail }),
                 events,
                 state,
-            );
+            )
+            .await;
             if phase == "completed" {
-                complete_structured_tool(&item_id, item, events, state);
+                complete_structured_tool(&item_id, item, events, state).await;
             }
         }
         "mcp_tool_call" => {
@@ -1637,9 +1675,9 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 .or_else(|| item.get("input"))
                 .cloned()
                 .unwrap_or_else(|| json!({}));
-            ensure_tool_started(&item_id, &tool_name, arguments, events, state);
+            ensure_tool_started(&item_id, &tool_name, arguments, events, state).await;
             if phase == "completed" {
-                complete_structured_tool(&item_id, item, events, state);
+                complete_structured_tool(&item_id, item, events, state).await;
             }
         }
         "web_search" => {
@@ -1650,19 +1688,22 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 json!({ "query": query }),
                 events,
                 state,
-            );
+            )
+            .await;
             if phase == "completed" {
-                complete_structured_tool(&item_id, item, events, state);
+                complete_structured_tool(&item_id, item, events, state).await;
             }
         }
         "todo_list" => {
-            events.emit(json!({
-                "type": "runner_progress",
-                "session_id": state.session_id(),
-                "round_count": 1,
-                "codex_item_type": "todo_list",
-                "item": item,
-            }));
+            events
+                .emit(json!({
+                    "type": "runner_progress",
+                    "session_id": state.session_id(),
+                    "round_count": 1,
+                    "codex_item_type": "todo_list",
+                    "item": item,
+                }))
+                .await;
         }
         other => {
             tracing::debug!(item_type = other, phase, "codex: unrecognized item type");
@@ -1670,7 +1711,7 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
     }
 }
 
-fn ensure_tool_started(
+async fn ensure_tool_started(
     item_id: &str,
     tool_name: &str,
     arguments: Value,
@@ -1678,15 +1719,22 @@ fn ensure_tool_started(
     state: &mut RunState,
 ) {
     if state.started_items.insert(item_id.to_string()) {
-        events.emit(event_json(AgentEvent::ToolStart {
-            tool_call_id: item_id.to_string(),
-            tool_name: tool_name.to_string(),
-            arguments,
-        }));
+        events
+            .emit(event_json(AgentEvent::ToolStart {
+                tool_call_id: item_id.to_string(),
+                tool_name: tool_name.to_string(),
+                arguments,
+            }))
+            .await;
     }
 }
 
-fn emit_tool_output_delta(item_id: &str, output: &str, events: &EventSink, state: &mut RunState) {
+async fn emit_tool_output_delta(
+    item_id: &str,
+    output: &str,
+    events: &EventSink,
+    state: &mut RunState,
+) {
     let previous = state.item_output.entry(item_id.to_string()).or_default();
     let delta = if output.starts_with(previous.as_str()) {
         &output[previous.len()..]
@@ -1694,20 +1742,29 @@ fn emit_tool_output_delta(item_id: &str, output: &str, events: &EventSink, state
         output
     };
     if !delta.is_empty() {
-        events.emit(event_json(AgentEvent::ToolToken {
-            tool_call_id: item_id.to_string(),
-            content: delta.to_string(),
-        }));
+        events
+            .emit(event_json(AgentEvent::ToolToken {
+                tool_call_id: item_id.to_string(),
+                content: delta.to_string(),
+            }))
+            .await;
     }
     *previous = output.to_string();
 }
 
-fn complete_structured_tool(item_id: &str, item: &Value, events: &EventSink, state: &mut RunState) {
+async fn complete_structured_tool(
+    item_id: &str,
+    item: &Value,
+    events: &EventSink,
+    state: &mut RunState,
+) {
     if let Some(error) = item.get("error").filter(|value| !value.is_null()) {
-        events.emit(event_json(AgentEvent::ToolError {
-            tool_call_id: item_id.to_string(),
-            error: value_text(error),
-        }));
+        events
+            .emit(event_json(AgentEvent::ToolError {
+                tool_call_id: item_id.to_string(),
+                error: value_text(error),
+            }))
+            .await;
         state.tool_error_emitted = true;
         return;
     }
@@ -1716,13 +1773,15 @@ fn complete_structured_tool(item_id: &str, item: &Value, events: &EventSink, sta
         .or_else(|| item.get("output"))
         .cloned()
         .unwrap_or_else(|| item.clone());
-    events.emit(event_json(AgentEvent::ToolComplete {
-        tool_call_id: item_id.to_string(),
-        result: ToolResult::text(
-            true,
-            truncate_chars(&value_text(&result), TOOL_RESULT_TRUNCATE_CHARS),
-        ),
-    }));
+    events
+        .emit(event_json(AgentEvent::ToolComplete {
+            tool_call_id: item_id.to_string(),
+            result: ToolResult::text(
+                true,
+                truncate_chars(&value_text(&result), TOOL_RESULT_TRUNCATE_CHARS),
+            ),
+        }))
+        .await;
 }
 
 fn looks_like_sandbox_denial(text: &str) -> bool {
@@ -1737,7 +1796,7 @@ fn looks_like_sandbox_denial(text: &str) -> bool {
     denied && operation
 }
 
-fn emit_text_delta<F>(
+async fn emit_text_delta<F>(
     item_id: &str,
     text: &str,
     seen: &mut HashMap<String, String>,
@@ -1753,7 +1812,7 @@ fn emit_text_delta<F>(
         text
     };
     if !delta.is_empty() {
-        events.emit(event_json(build(delta.to_string())));
+        events.emit(event_json(build(delta.to_string()))).await;
     }
     *previous = text.to_string();
 }
@@ -1910,6 +1969,64 @@ fn validate_codex_forward_env(mode: CodexAuthMode, names: &[String]) -> Result<(
     Ok(())
 }
 
+/// Owns a CLI process and its process group for the entire activation. Async
+/// TERM/KILL cleanup may itself be dropped by the transport cancellation bound;
+/// the fallback must therefore live in the owner, not only in that future.
+/// Commands wrapped here must be spawned with `process_group(0)` on Unix.
+pub(crate) struct ProcessTreeChild {
+    child: Child,
+    #[cfg(unix)]
+    pgid: Option<libc::pid_t>,
+    #[cfg(unix)]
+    terminating_descendants: Vec<libc::pid_t>,
+}
+
+impl ProcessTreeChild {
+    pub(crate) fn new(child: Child) -> Self {
+        Self {
+            #[cfg(unix)]
+            pgid: child.id().map(|pid| pid as libc::pid_t),
+            child,
+            #[cfg(unix)]
+            terminating_descendants: Vec::new(),
+        }
+    }
+}
+
+impl std::ops::Deref for ProcessTreeChild {
+    type Target = Child;
+
+    fn deref(&self) -> &Child {
+        &self.child
+    }
+}
+
+impl std::ops::DerefMut for ProcessTreeChild {
+    fn deref_mut(&mut self) -> &mut Child {
+        &mut self.child
+    }
+}
+
+impl Drop for ProcessTreeChild {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(pgid) = self.pgid {
+            // Capture descendants before killing the leader, including tools
+            // that created their own group. Retain the earlier TERM snapshot:
+            // those processes may already have been reparented during shutdown.
+            if self.child.id().is_some() {
+                self.terminating_descendants
+                    .extend(descendant_processes(pgid));
+            }
+            for &pid in self.terminating_descendants.iter().rev() {
+                signal_process(pid, ProcessSignal::Kill);
+            }
+            signal_process_group(pgid, ProcessSignal::Kill);
+        }
+        let _ = self.child.start_kill();
+    }
+}
+
 #[derive(Clone, Copy)]
 enum ProcessSignal {
     Term,
@@ -1988,7 +2105,7 @@ fn process_group_exists(pgid: libc::pid_t) -> bool {
 }
 
 #[cfg(unix)]
-pub(crate) async fn terminate_child(child: &mut Child) {
+pub(crate) async fn terminate_child(child: &mut ProcessTreeChild) {
     let Some(pgid) = child.id().map(|pid| pid as libc::pid_t) else {
         return;
     };
@@ -1996,6 +2113,7 @@ pub(crate) async fn terminate_child(child: &mut Child) {
     // the full descendant tree before terminating the Codex leader; otherwise
     // those commands are reparented to init and escape a group-only signal.
     let descendants = descendant_processes(pgid);
+    child.terminating_descendants = descendants.clone();
     for &pid in descendants.iter().rev() {
         signal_process(pid, ProcessSignal::Term);
     }
@@ -2007,6 +2125,8 @@ pub(crate) async fn terminate_child(child: &mut Child) {
         let _ = child.try_wait();
         if !process_group_exists(pgid) && !descendants.iter().copied().any(process_exists) {
             let _ = child.wait().await;
+            child.pgid = None;
+            child.terminating_descendants.clear();
             return;
         }
         if tokio::time::Instant::now() >= deadline {
@@ -2023,7 +2143,7 @@ pub(crate) async fn terminate_child(child: &mut Child) {
 }
 
 #[cfg(not(unix))]
-pub(crate) async fn terminate_child(child: &mut Child) {
+pub(crate) async fn terminate_child(child: &mut ProcessTreeChild) {
     if tokio::time::timeout(SIGTERM_WAIT, child.wait())
         .await
         .is_ok()
@@ -2097,6 +2217,108 @@ async fn drain_stderr_tail(stderr: tokio::process::ChildStderr, tail: Arc<Mutex<
                 }
             }
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+pub(crate) mod process_lifecycle_tests {
+    use super::*;
+    use bamboo_subagent::proto::{ChildFrame, ParentFrame, TerminalStatus};
+    use bamboo_subagent::transport::{ChildClient, WsServer};
+
+    struct Cleanup(std::path::PathBuf);
+
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            if let Ok(contents) = std::fs::read_to_string(&self.0) {
+                let pids: Vec<libc::pid_t> = contents
+                    .split_whitespace()
+                    .filter_map(|pid| pid.parse().ok())
+                    .collect();
+                for &pid in pids.iter().rev() {
+                    signal_process(pid, ProcessSignal::Kill);
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn assert_processes_gone(pids: &[libc::pid_t]) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while pids.iter().copied().any(process_exists) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the executor process and its tool descendants must exit");
+    }
+
+    /// Exercise actual transport cancellation, not just the executor's token.
+    /// Keeping the executor Arc alive reproduces warm-worker retention bugs.
+    pub(crate) async fn interrupt_over_websocket(
+        executor: Arc<dyn ChildExecutor>,
+        spec: RunSpec,
+        pid_file: &std::path::Path,
+        abort_owner: bool,
+    ) -> libc::pid_t {
+        let server = WsServer::bind_loopback().await.unwrap();
+        let endpoint = server.ws_endpoint();
+        let server_task =
+            AbortOnDropHandle::new(tokio::spawn(
+                async move { server.serve_one(executor).await },
+            ));
+        let _cleanup = Cleanup(pid_file.to_path_buf());
+        let mut client = ChildClient::connect(&endpoint).await.unwrap();
+        client.send(ParentFrame::Run(spec)).await.unwrap();
+        let pids = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Ok(contents) = std::fs::read_to_string(pid_file) {
+                    let pids: Vec<libc::pid_t> = contents
+                        .split_whitespace()
+                        .filter_map(|pid| pid.parse().ok())
+                        .collect();
+                    if pids.len() == 2 {
+                        break pids;
+                    }
+                }
+                tokio::select! {
+                    frame = client.next_frame() => {
+                        if let Some(ChildFrame::Terminal { status, result, error, .. }) = frame.unwrap() {
+                            panic!("stub terminated before process readiness: {status:?} {result:?} {error:?}");
+                        }
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+                }
+            }
+        })
+        .await
+        .expect("stub must record its process tree before cancellation");
+        if abort_owner {
+            server_task.abort();
+            assert!(server_task.await.unwrap_err().is_cancelled());
+        } else {
+            client.send(ParentFrame::Cancel).await.unwrap();
+            tokio::time::timeout(Duration::from_secs(8), async {
+                loop {
+                    match client.next_frame().await.unwrap().expect("terminal frame") {
+                        ChildFrame::Terminal { status, .. } => {
+                            assert_eq!(status, TerminalStatus::Cancelled);
+                            break;
+                        }
+                        _ => continue,
+                    }
+                }
+            })
+            .await
+            .expect("explicit cancellation must return a bounded terminal");
+            client.close().await.unwrap();
+            tokio::time::timeout(Duration::from_secs(5), server_task)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+        }
+        assert_processes_gone(&pids).await;
+        pids[0]
     }
 }
 
@@ -2248,18 +2470,20 @@ mod tests {
         }
     }
 
-    fn map_fixture(input: &str) -> (RunState, Vec<Value>) {
+    async fn map_fixture(input: &str) -> (RunState, Vec<Value>) {
         let executor = fixture_executor();
         let (sink, mut rx) = EventSink::channel();
         let mut state = RunState::default();
         let policy = default_policy(&executor);
         for line in input.lines().filter(|line| !line.trim().is_empty()) {
-            executor.handle_event(
-                serde_json::from_str(line).unwrap(),
-                &policy,
-                &sink,
-                &mut state,
-            );
+            executor
+                .handle_event(
+                    serde_json::from_str(line).unwrap(),
+                    &policy,
+                    &sink,
+                    &mut state,
+                )
+                .await;
         }
         let mut events = Vec::new();
         while let Ok(event) = rx.try_recv() {
@@ -2554,8 +2778,8 @@ mod tests {
         assert!(!args.iter().any(|argument| argument == "--full-auto"));
     }
 
-    #[test]
-    fn danger_bypass_emits_loud_audit_warning() {
+    #[tokio::test]
+    async fn danger_bypass_emits_loud_audit_warning() {
         let mut executor = fixture_executor();
         executor.permissions = permissions(
             Some("danger-full-access"),
@@ -2568,14 +2792,16 @@ mod tests {
         );
         let policy = executor.permissions.effective(true, false);
         let (sink, mut receiver) = EventSink::channel();
-        executor.emit_policy_bootstrap(
-            &policy,
-            bamboo_domain::resolve_permission_mode(
-                bamboo_domain::SessionPermissionMode::Bypass,
-                bamboo_domain::PermissionMode::Default,
-            ),
-            &sink,
-        );
+        executor
+            .emit_policy_bootstrap(
+                &policy,
+                bamboo_domain::resolve_permission_mode(
+                    bamboo_domain::SessionPermissionMode::Bypass,
+                    bamboo_domain::PermissionMode::Default,
+                ),
+                &sink,
+            )
+            .await;
 
         let events = std::iter::from_fn(|| receiver.try_recv().ok()).collect::<Vec<_>>();
         assert!(events.iter().any(|event| {
@@ -2850,8 +3076,8 @@ mod tests {
         assert_eq!(usage.total_tokens, 13_466);
     }
 
-    #[test]
-    fn recorded_jsonl_fixtures_map_agent_and_command_events() {
+    #[tokio::test]
+    async fn recorded_jsonl_fixtures_map_agent_and_command_events() {
         let cases = [
             (
                 include_str!("../tests/fixtures/codex-cli/0.144.5-simple.jsonl"),
@@ -2868,7 +3094,7 @@ mod tests {
         ];
 
         for (fixture, expected_final, expects_tool, total_tokens) in cases {
-            let (state, events) = map_fixture(fixture);
+            let (state, events) = map_fixture(fixture).await;
             assert!(state.completed);
             assert_eq!(state.last_agent_message, expected_final);
             assert_eq!(state.usage.total_tokens, total_tokens);
@@ -2888,8 +3114,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn item_mapping_table_covers_non_command_codex_items() {
+    #[tokio::test]
+    async fn item_mapping_table_covers_non_command_codex_items() {
         let cases = [
             (
                 json!({"id":"r1","type":"reasoning","text":"thinking"}),
@@ -2921,7 +3147,7 @@ mod tests {
         for (item, expected_type, expected_tool) in cases {
             let (sink, mut rx) = EventSink::channel();
             let mut state = RunState::default();
-            handle_item("completed", &item, &sink, &mut state);
+            handle_item("completed", &item, &sink, &mut state).await;
             let first = rx.try_recv().expect("mapping emitted an event");
             assert_eq!(first["type"], expected_type, "item: {item}");
             if let Some(tool) = expected_tool {
@@ -2933,31 +3159,35 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unknown_event_and_item_types_are_tolerated() {
+    #[tokio::test]
+    async fn unknown_event_and_item_types_are_tolerated() {
         let executor = fixture_executor();
         let (sink, mut rx) = EventSink::channel();
         let mut state = RunState::default();
         let policy = default_policy(&executor);
-        executor.handle_event(
-            json!({"type":"future.event","payload":{"schema":2}}),
-            &policy,
-            &sink,
-            &mut state,
-        );
-        executor.handle_event(
-            json!({"type":"item.completed","item":{"id":"x","type":"future_item"}}),
-            &policy,
-            &sink,
-            &mut state,
-        );
+        executor
+            .handle_event(
+                json!({"type":"future.event","payload":{"schema":2}}),
+                &policy,
+                &sink,
+                &mut state,
+            )
+            .await;
+        executor
+            .handle_event(
+                json!({"type":"item.completed","item":{"id":"x","type":"future_item"}}),
+                &policy,
+                &sink,
+                &mut state,
+            )
+            .await;
         assert!(rx.try_recv().is_err());
         assert!(!state.completed);
         assert!(state.failure.is_none());
     }
 
-    #[test]
-    fn sandbox_denial_report_without_cli_tool_item_becomes_tool_error() {
+    #[tokio::test]
+    async fn sandbox_denial_report_without_cli_tool_item_becomes_tool_error() {
         let executor = fixture_executor();
         let policy = executor.permissions.effective(false, false);
         let (sink, mut receiver) = EventSink::channel();
@@ -2974,7 +3204,7 @@ mod tests {
             &policy,
             &sink,
             &mut state,
-        );
+        ).await;
 
         let events = std::iter::from_fn(|| receiver.try_recv().ok()).collect::<Vec<_>>();
         assert!(events.iter().any(|event| event["type"] == "token"));
@@ -3721,6 +3951,32 @@ exit 1
                 1
             );
             assert!(!state_path.exists());
+        }
+
+        #[tokio::test]
+        async fn websocket_cancel_and_owner_abort_reap_codex_process_tree() {
+            for abort_owner in [false, true] {
+                let workspace = tempfile::tempdir().unwrap();
+                let bin_dir = tempfile::tempdir().unwrap();
+                let bin = write_stub(
+                    bin_dir.path(),
+                    r#"
+DIR=$(cd "$(dirname "$0")" && pwd)
+read -r prompt
+trap '' TERM
+(trap '' TERM; sleep 60) &
+printf '%s %s\n' "$$" "$!" > "$DIR/pids"
+wait
+"#,
+                );
+                process_lifecycle_tests::interrupt_over_websocket(
+                    Arc::new(executor(bin, workspace.path())),
+                    run_spec("wait"),
+                    &bin_dir.path().join("pids"),
+                    abort_owner,
+                )
+                .await;
+            }
         }
 
         #[tokio::test]

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -378,6 +378,16 @@ pub struct BambooRuntimeExecutor {
     child_runner: Option<Arc<dyn bamboo_engine::runtime::execution::ExternalChildRunner>>,
 }
 
+/// The reusable runner must release its current run's host bridge on every
+/// exit. Descendants already capture their own clone when they are spawned.
+struct RunEscalationBinding(Arc<dyn bamboo_engine::execution::ExternalChildRunner>);
+
+impl Drop for RunEscalationBinding {
+    fn drop(&mut self) {
+        self.0.set_escalation_bridge(None);
+    }
+}
+
 fn provisioned_permission_resolution(
     capabilities: &bamboo_subagent::provision::Capabilities,
 ) -> Result<bamboo_domain::PermissionModeResolution, String> {
@@ -1448,12 +1458,14 @@ impl ChildExecutor for BambooRuntimeExecutor {
                         delivery.envelope.id
                     ));
                 }
-                events.confirm_session_message(SessionMessageAdmissionConfirmation {
-                    target_session_id: delivery.target_session_id.clone(),
-                    envelope_id: delivery.envelope.id.as_str().to_string(),
-                    canonical_claim_generation: delivery.canonical_claim_generation,
-                    activation_run_id: delivery.activation_run_id.clone(),
-                });
+                events
+                    .confirm_session_message(SessionMessageAdmissionConfirmation {
+                        target_session_id: delivery.target_session_id.clone(),
+                        envelope_id: delivery.envelope.id.as_str().to_string(),
+                        canonical_claim_generation: delivery.canonical_claim_generation,
+                        activation_run_id: delivery.activation_run_id.clone(),
+                    })
+                    .await;
             }
         }
 
@@ -1466,8 +1478,9 @@ impl ChildExecutor for BambooRuntimeExecutor {
         let steer_events = events.clone();
         let steer_activation_run_id = expected_activation_run_id.clone();
         let steer_done = CancellationToken::new();
+        let _steer_cancel_on_drop = steer_done.clone().drop_guard();
         let steer_done_task = steer_done.clone();
-        let steer_task = tokio::spawn(async move {
+        let steer_task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(async move {
             loop {
                 let message = tokio::select! {
                     _ = steer_done_task.cancelled() => break,
@@ -1617,7 +1630,7 @@ impl ChildExecutor for BambooRuntimeExecutor {
                         .await
                     {
                         Ok(true) => {
-                            steer_events.confirm_session_message(confirmation);
+                            steer_events.confirm_session_message(confirmation).await;
                             break;
                         }
                         Ok(false) => {}
@@ -1637,7 +1650,7 @@ impl ChildExecutor for BambooRuntimeExecutor {
                     }
                 }
             }
-        });
+        }));
 
         // Phase 2: if the host wired an approval bridge, install a per-run
         // ApprovalProxy so this run's gated tools delegate the decision to the
@@ -1662,19 +1675,20 @@ impl ChildExecutor for BambooRuntimeExecutor {
         // a fire-and-forget grandchild outliving this run still escalates through
         // the run's own bridge rather than a stale/overwritten global. `None` for
         // a leaf worker (no spawn stack), which never drives grandchildren.
-        if let Some(runner) = &self.child_runner {
+        let _escalation_binding = self.child_runner.as_ref().map(|runner| {
             runner.set_escalation_bridge(events.host().cloned());
-        }
+            RunEscalationBinding(runner.clone())
+        });
 
         // AgentEvents stream to the parent verbatim (zero mapping).
         let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(256);
-        let forward = tokio::spawn(async move {
+        let forward = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(async move {
             while let Some(ev) = event_rx.recv().await {
                 if let Ok(value) = serde_json::to_value(&ev) {
-                    events.emit(value);
+                    events.emit(value).await;
                 }
             }
-        });
+        }));
         if let Some(audit) =
             bamboo_domain::PermissionAuditSnapshot::from_metadata(&session.metadata)
         {
@@ -1837,6 +1851,8 @@ mod tests {
     #[derive(Default)]
     struct RecordingWorkerProvider {
         calls: std::sync::Mutex<Vec<Vec<Message>>>,
+        hold: bool,
+        started: tokio::sync::Notify,
     }
 
     #[async_trait]
@@ -1849,6 +1865,10 @@ mod tests {
             _model: &str,
         ) -> Result<bamboo_llm::LLMStream, bamboo_llm::LLMError> {
             self.calls.lock().unwrap().push(messages.to_vec());
+            if self.hold {
+                self.started.notify_one();
+                std::future::pending::<()>().await;
+            }
             let chunks: Vec<bamboo_llm::provider::Result<LLMChunk>> =
                 vec![Ok(LLMChunk::Token("done".to_string())), Ok(LLMChunk::Done)];
             Ok(Box::pin(futures::stream::iter(chunks)))
@@ -1913,6 +1933,92 @@ mod tests {
             child_runner: None,
         };
         (temp, executor, store, inbox)
+    }
+
+    #[derive(Default)]
+    struct BridgeCapturingRunner(std::sync::Mutex<Option<bamboo_subagent::HostBridge>>);
+
+    #[async_trait]
+    impl bamboo_engine::execution::ExternalChildRunner for BridgeCapturingRunner {
+        async fn should_handle(&self, _session: &Session) -> bool {
+            false
+        }
+
+        async fn execute_external_child(
+            &self,
+            _session: &mut Session,
+            _job: &bamboo_engine::execution::SpawnJob,
+            _events: mpsc::Sender<AgentEvent>,
+            _cancel: CancellationToken,
+        ) -> bamboo_engine::runtime::runner::Result<()> {
+            unreachable!("fixture does not spawn descendants")
+        }
+
+        fn set_escalation_bridge(&self, bridge: Option<bamboo_subagent::HostBridge>) {
+            *self.0.lock().unwrap() = bridge;
+        }
+    }
+
+    #[tokio::test]
+    async fn completed_warm_run_releases_its_nested_escalation_bridge() {
+        let provider = Arc::new(RecordingWorkerProvider::default());
+        let (_temp, mut executor, _store, _inbox) = worker_protocol_fixture(provider).await;
+        let runner = Arc::new(BridgeCapturingRunner::default());
+        executor.child_runner = Some(runner.clone());
+        let (bridge, mut requests) = bamboo_subagent::HostBridge::channel();
+        let (events, _event_rx) = EventSink::channel();
+        let outcome = executor
+            .run(
+                protocol_run("child-bridge", "bridge-run", Vec::new()),
+                events.with_host_bridge(bridge),
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+        assert_eq!(outcome.status, bamboo_subagent::TerminalStatus::Completed);
+        assert!(runner.0.lock().unwrap().is_none());
+        assert!(
+            matches!(
+                requests.try_recv(),
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+            ),
+            "completed worker must let the broker's approval drain finish"
+        );
+    }
+
+    #[tokio::test]
+    async fn aborted_worker_run_releases_helpers_and_nested_escalation_bridge() {
+        let provider = Arc::new(RecordingWorkerProvider {
+            hold: true,
+            ..Default::default()
+        });
+        let (_temp, mut executor, _store, _inbox) = worker_protocol_fixture(provider.clone()).await;
+        let runner = Arc::new(BridgeCapturingRunner::default());
+        executor.child_runner = Some(runner.clone());
+        let (bridge, mut requests) = bamboo_subagent::HostBridge::channel();
+        let (events, _event_rx) = EventSink::channel();
+        let (_steer_sender, steer) = SteerInbox::channel();
+        let task = tokio::spawn(async move {
+            executor
+                .run(
+                    protocol_run("aborted-bridge", "bridge-run", Vec::new()),
+                    events.with_host_bridge(bridge),
+                    steer,
+                    CancellationToken::new(),
+                )
+                .await
+        });
+        tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            provider.started.notified(),
+        )
+        .await
+        .unwrap();
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert!(runner.0.lock().unwrap().is_none());
+        let request = tokio::time::timeout(std::time::Duration::from_secs(2), requests.recv()).await.expect("aborted worker must drop forwarding and steering tasks, including their HostBridge clones");
+        assert!(request.is_none());
     }
 
     fn protocol_run(

--- a/tests/e2e_claude_code_manual.rs
+++ b/tests/e2e_claude_code_manual.rs
@@ -45,7 +45,7 @@ fn spec(assignment: &str, messages: Vec<serde_json::Value>) -> RunSpec {
 }
 
 async fn drain_events(
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>,
+    mut rx: tokio::sync::mpsc::Receiver<serde_json::Value>,
 ) -> Vec<serde_json::Value> {
     let mut all = Vec::new();
     while let Some(ev) = rx.recv().await {

--- a/tests/e2e_codex_app_server_manual.rs
+++ b/tests/e2e_codex_app_server_manual.rs
@@ -15,6 +15,18 @@ use bamboo_subagent::proto::{PermissionPolicyContext, RunSecrets, RunSpec};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
+fn collect_events(
+    mut receiver: tokio::sync::mpsc::Receiver<serde_json::Value>,
+) -> tokio_util::task::AbortOnDropHandle<Vec<serde_json::Value>> {
+    tokio_util::task::AbortOnDropHandle::new(tokio::spawn(async move {
+        let mut events = Vec::new();
+        while let Some(event) = receiver.recv().await {
+            events.push(event);
+        }
+        events
+    }))
+}
+
 #[tokio::test]
 #[ignore = "requires an authenticated real Codex CLI and intentionally exercises allow/deny command approvals"]
 async fn live_app_server_relays_allow_and_deny_across_resume() {
@@ -49,7 +61,8 @@ async fn live_app_server_relays_allow_and_deny_across_resume() {
     .await
     .unwrap();
 
-    let (sink, mut event_rx) = EventSink::channel();
+    let (sink, event_rx) = EventSink::channel();
+    let event_rx = collect_events(event_rx);
     let (host, mut host_rx) = HostBridge::channel();
     let approvals = Arc::new(Mutex::new(Vec::new()));
     let seen = approvals.clone();
@@ -110,7 +123,7 @@ async fn live_app_server_relays_allow_and_deny_across_resume() {
     let _ = tokio::fs::remove_file(&marker).await;
     assert!(allowed_executed, "approved command did not execute");
     let mut saw_complete = false;
-    while let Ok(event) = event_rx.try_recv() {
+    for event in event_rx.await.unwrap() {
         saw_complete |= event["type"] == "complete";
     }
     assert!(saw_complete);
@@ -120,7 +133,8 @@ async fn live_app_server_relays_allow_and_deny_across_resume() {
         std::process::id()
     ));
     let _ = tokio::fs::remove_file(&denied_marker).await;
-    let (deny_sink, mut deny_events) = EventSink::channel();
+    let (deny_sink, deny_events) = EventSink::channel();
+    let deny_events = collect_events(deny_events);
     let deny_outcome = tokio::time::timeout(
         Duration::from_secs(180),
         executor.run(
@@ -179,7 +193,9 @@ async fn live_app_server_relays_allow_and_deny_across_resume() {
         approvals.lock().await.len() >= 2,
         "expected allow and deny approvals"
     );
-    assert!(
-        std::iter::from_fn(|| deny_events.try_recv().ok()).any(|event| event["type"] == "complete")
-    );
+    assert!(deny_events
+        .await
+        .unwrap()
+        .into_iter()
+        .any(|event| event["type"] == "complete"));
 }

--- a/tests/e2e_codex_cli_manual.rs
+++ b/tests/e2e_codex_cli_manual.rs
@@ -15,6 +15,18 @@ use bamboo_subagent::proto::{RunSpec, TerminalStatus};
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
 
+fn collect_events(
+    mut receiver: tokio::sync::mpsc::Receiver<serde_json::Value>,
+) -> tokio_util::task::AbortOnDropHandle<Vec<serde_json::Value>> {
+    tokio_util::task::AbortOnDropHandle::new(tokio::spawn(async move {
+        let mut events = Vec::new();
+        while let Some(event) = receiver.recv().await {
+            events.push(event);
+        }
+        events
+    }))
+}
+
 #[tokio::test]
 #[ignore = "requires an installed Codex CLI >= 0.144 on PATH"]
 async fn real_codex_discovery_reports_path_version_and_actionable_missing_error() {
@@ -67,7 +79,8 @@ async fn real_codex_completes_trivial_turn_and_reports_bootstrap_metadata() {
     )
     .await
     .expect("Codex preflight succeeds");
-    let (sink, mut rx) = EventSink::channel();
+    let (sink, rx) = EventSink::channel();
+    let rx = collect_events(rx);
     let outcome = tokio::time::timeout(
         Duration::from_secs(180),
         executor.run(
@@ -95,7 +108,7 @@ async fn real_codex_completes_trivial_turn_and_reports_bootstrap_metadata() {
     assert_eq!(outcome.result.as_deref().map(str::trim), Some("PONG"));
     let mut bootstrap = None;
     let mut usage = None;
-    while let Ok(event) = rx.try_recv() {
+    for event in rx.await.unwrap() {
         println!("EVENT: {event}");
         if event["executor"] == "codex" {
             bootstrap = Some(event);
@@ -172,7 +185,8 @@ async fn real_workspace_write_denies_outside_write_and_emits_tool_error() {
     )
     .await
     .expect("Codex preflight succeeds");
-    let (sink, mut receiver) = EventSink::channel();
+    let (sink, receiver) = EventSink::channel();
+    let receiver = collect_events(receiver);
     let outcome = tokio::time::timeout(
         Duration::from_secs(180),
         executor.run(
@@ -209,7 +223,7 @@ async fn real_workspace_write_denies_outside_write_and_emits_tool_error() {
         "sandbox allowed an outside-workspace write"
     );
 
-    let events = std::iter::from_fn(|| receiver.try_recv().ok()).collect::<Vec<_>>();
+    let events = receiver.await.unwrap();
     assert!(
         events.iter().any(|event| event["type"] == "tool_error"),
         "outside denial was not surfaced as a tool error: {events:?}"
@@ -251,7 +265,8 @@ async fn real_codex_second_activation_resumes_and_recalls_native_context() {
     .await
     .expect("Codex preflight succeeds");
 
-    let (sink, _events) = EventSink::channel();
+    let (sink, unused_events) = EventSink::channel();
+    drop(unused_events);
     let first = tokio::time::timeout(
         Duration::from_secs(180),
         executor.run(
@@ -287,7 +302,8 @@ async fn real_codex_second_activation_resumes_and_recalls_native_context() {
         .is_some_and(|thread_id| !thread_id.is_empty()));
 
     let current_task = "What exact nonce did I ask you to remember? Reply with that nonce only.";
-    let (sink, mut events) = EventSink::channel();
+    let (sink, events) = EventSink::channel();
+    let events = collect_events(events);
     let second = tokio::time::timeout(
         Duration::from_secs(180),
         executor.run(
@@ -316,7 +332,7 @@ async fn real_codex_second_activation_resumes_and_recalls_native_context() {
     assert_eq!(second.status, TerminalStatus::Completed, "{second:?}");
     assert_eq!(second.result.as_deref().map(str::trim), Some(NONCE));
 
-    let emitted = std::iter::from_fn(|| events.try_recv().ok()).collect::<Vec<_>>();
+    let emitted = events.await.unwrap();
     assert!(
         !emitted
             .iter()
@@ -367,7 +383,8 @@ async fn real_cancellation_kills_the_process_group_and_the_session_can_resume() 
     let pid_file = workspace.path().join("cancel-child.pid");
     let cancel = CancellationToken::new();
     let cancel_for_run = cancel.clone();
-    let (sink, _events) = EventSink::channel();
+    let (sink, unused_events) = EventSink::channel();
+    drop(unused_events);
     let first = executor.run(
         RunSpec {
             assignment: "Run this exact command now and wait for it to finish: /bin/sh -c 'echo $$ > ./cancel-child.pid; sleep 120'".to_string(),
@@ -429,7 +446,8 @@ async fn real_cancellation_kills_the_process_group_and_the_session_can_resume() 
     );
 
     let assignment = "Reply with exactly RECOVERED and nothing else.";
-    let (sink, _events) = EventSink::channel();
+    let (sink, unused_events) = EventSink::channel();
+    drop(unused_events);
     let resumed = tokio::time::timeout(
         Duration::from_secs(180),
         executor.run(


### PR DESCRIPTION
## Summary
Child executors could accumulate unlimited JSON events ahead of a slow transport, while disconnected or aborted owners left execution helpers, correlation waiters, escalation bridges or CLI descendants alive. Bound each worker event queue and its separate admission-control lane, and give connection/run owners responsibility for every spawned execution/helper task and registration.

Direct WebSocket cancellation has a bounded cooperative shutdown followed by abort/join. Broker handler panics release inflight ownership and preserve unacknowledged deliveries. CLI process owners clean their Unix process groups and tracked descendants even when the graceful-exit future is dropped. App-server takes an active connection out of the warm slot and returns it only after a completed turn and helper cleanup. A completed or aborted reusable Bamboo worker releases its nested escalation bridge.

EventSink emit/confirmation methods are now async; all built-in producers and manual fixtures are migrated. Reply-only Ask/Task closes its intentionally unused stream, so producing more than a queue capacity still returns the answer. The design document records the lock-free hot-path boundary and the retained durable/lifecycle coordination.

Closes #1047; completes the worker slice of #1044 after #1060 and #1062. No provider requests, durable schema migration or frontend changes.

## Test Plan
- 67/67 executor tests, including real Unix stub processes through WebSocket Cancel and owner-task abort for Claude, Codex CLI and app-server. Both leader and grandchild disappear; app-server establishes a new connection afterward and reuses it after a healthy completed turn.
- 15 worker tests cover normal and aborted escalation-bridge/helper release.
- 104/104 broker tests, including panic/caller-abort cleanup, 200 concurrent actor streams and 257-word Ask/Task completion. A pre-existing 100ms idle-startup fixture raced once under load and passed on unchanged full-suite rerun.
- 73 subagent tests include bounded event/control isolation, noncooperative cancellation and connection-owner abort.
- Full local all-features suite passed 8,429 tests before final review corrections; focused affected suites cover each later correction. All manual test targets compile. Full workspace CI Clippy command passed; locked metadata and MSRV dependency audit passed.
- Independent read-only review approved worker ownership and queue changes, then rechecked the review fixes and delivery tree. Required exact-head CI remains the merge gate.

## Compatibility
The lock-free guarantee covers the session cache and live event publication. Durable transactions and replay/lifecycle ordering retain their existing serialization. The 512-session fixtures validate in-process coordination; they do not represent 512 simultaneous paid model calls or OS workers. Unix process-tree cleanup is tested; non-Unix retains its existing direct-child fallback.
