### PR TITLE
[bamboo] feat: persist trusted default Supervisor identity

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -85,7 +85,12 @@ pub use bamboo_domain::{
     SessionMessageEnvelope, SessionMessageId, SessionMessageKind, SessionMessageSource,
     SessionProviderMessage, SessionRuntimeInstruction, TaskItem, TaskItemStatus, TaskList,
 };
+pub use bamboo_domain::{
+    SessionAuthorityConflict, SessionAuthorityIdentity, SupervisorBootstrapReceipt,
+    DEFAULT_SUPERVISOR_SESSION_ID,
+};
 pub use bamboo_engine::session_app::respond::PlanModeTransition;
+pub use bamboo_engine::session_app::supervisor::SupervisorSessionService;
 pub use bamboo_engine::{
     Agent as RuntimeAgent, AgentBuilder as RuntimeAgentBuilder, ExecuteRequest, HookRunner,
     LifecycleHookEvent, LifecycleHookTestOutput, LifecycleScriptRunner, ScriptHook,
@@ -596,6 +601,12 @@ impl Agent {
     /// Access the shared storage backend.
     pub fn storage(&self) -> &Arc<dyn bamboo_agent_core::storage::Storage> {
         self.inner.storage()
+    }
+
+    /// Trusted identity bootstrap using this Agent's canonical Storage backend.
+    /// Creating this service does not create a Session or inherit SDK Project settings.
+    pub fn supervisor_sessions(&self) -> SupervisorSessionService {
+        SupervisorSessionService::new(self.storage().clone())
     }
 
     /// Access the runtime persistence adapter.

--- a/crates/app/bamboo-sdk/src/lib.rs
+++ b/crates/app/bamboo-sdk/src/lib.rs
@@ -30,6 +30,10 @@ pub use agent::{
     SessionRunRegistrationError, SessionRuntimeInstruction, ShellCommandHook, ShellHookEvent,
 };
 pub use agent::{FileSessionInbox, SessionIndexEntry};
+pub use agent::{
+    SessionAuthorityConflict, SessionAuthorityIdentity, SupervisorBootstrapReceipt,
+    SupervisorSessionService, DEFAULT_SUPERVISOR_SESSION_ID,
+};
 
 // Tool catalog surfaced by `agent::mod`.
 pub use agent::{

--- a/crates/app/bamboo-sdk/tests/supervisor_identity_facade.rs
+++ b/crates/app/bamboo-sdk/tests/supervisor_identity_facade.rs
@@ -1,0 +1,66 @@
+//! Public SDK bootstrap uses canonical storage without invoking an agent run.
+
+use bamboo_sdk::{Agent, SupervisorBootstrapReceipt, DEFAULT_SUPERVISOR_SESSION_ID};
+
+#[tokio::test]
+async fn supervisor_facade_reuses_identity_without_replacing_model_or_history() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(
+        home.path().join("config.json"),
+        r#"{
+        "provider":"anthropic",
+        "providers":{"anthropic":{"api_key":"test-key","model":"sdk-model"}}
+    }"#,
+    )
+    .unwrap();
+    let agent = Agent::builder()
+        .model("sdk-model")
+        .with_defaults_for_data_dir(home.path().to_path_buf())
+        .await
+        .unwrap()
+        .build()
+        .unwrap();
+    let service: bamboo_sdk::agent::SupervisorSessionService = agent.supervisor_sessions();
+    let first: SupervisorBootstrapReceipt = service
+        .get_or_create_default("initial-model")
+        .await
+        .unwrap();
+    assert!(first.created);
+    assert_eq!(first.session_id, DEFAULT_SUPERVISOR_SESSION_ID);
+    let mut session = agent
+        .storage()
+        .load_session(&first.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(session.model, "initial-model");
+    assert!(session.project_id_meta().is_none());
+    session.add_message(bamboo_sdk::agent::Message::user("preserved history"));
+    agent.storage().save_session(&session).await.unwrap();
+
+    let service = bamboo_sdk::SupervisorSessionService::new(agent.storage().clone());
+    let again: bamboo_sdk::agent::SupervisorBootstrapReceipt = service
+        .get_or_create_default("different-model")
+        .await
+        .unwrap();
+    assert!(!again.created);
+    assert_eq!(again.session_id, first.session_id);
+    assert_eq!(again.incarnation_id, first.incarnation_id);
+    let loaded = agent
+        .storage()
+        .load_session(&again.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(loaded.model, "initial-model");
+    assert_eq!(loaded.messages.last().unwrap().content, "preserved history");
+    assert_eq!(
+        loaded.authority_identity,
+        bamboo_sdk::SessionAuthorityIdentity::Supervisor {
+            incarnation_id: first.incarnation_id,
+        }
+    );
+    let value = serde_json::to_value(&again).unwrap();
+    assert_eq!(value.as_object().unwrap().len(), 3);
+    assert!(value.get("messages").is_none());
+}

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -674,6 +674,55 @@ mod optional_model_e2e {
         web::Data::new(app_state)
     }
 
+    #[actix_web::test]
+    async fn implicit_chat_at_reserved_id_is_ordinary_and_blocks_supervisor_bootstrap() {
+        let provider = BlockingTitleProvider::new();
+        provider.release.add_permits(1);
+        let state = title_test_state(provider).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let id = bamboo_domain::DEFAULT_SUPERVISOR_SESSION_ID;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id":id,"message":"ordinary chat","model":"chat-model",
+                    "authority_identity":{"kind":"supervisor","incarnation_id":uuid::Uuid::new_v4()}
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let persisted = state.storage.load_session(id).await.unwrap().unwrap();
+        assert!(persisted.authority_identity.is_ordinary());
+        assert!(persisted
+            .messages
+            .iter()
+            .any(|m| m.content == "ordinary chat"));
+        assert_eq!(
+            state
+                .storage
+                .get_or_create_default_supervisor("initial-model")
+                .await
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
+        assert!(state
+            .storage
+            .load_session(id)
+            .await
+            .unwrap()
+            .unwrap()
+            .authority_identity
+            .is_ordinary());
+    }
+
     /// #793: a durable user message is the trigger. No `/execute` request is
     /// made, and a second message while the provider is blocked must not start
     /// duplicate title work.

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -857,6 +857,47 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn ordinary_create_and_real_title_patch_cannot_forge_supervisor_identity() {
+        let state = new_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let forged = serde_json::json!({"kind":"supervisor","incarnation_id":uuid::Uuid::new_v4()});
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/sessions")
+                .set_json(serde_json::json!({"title":"Ordinary", "authority_identity":forged}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body: Value = test::read_body_json(response).await;
+        let id = body["session"]["id"].as_str().unwrap();
+        let before = state.storage.load_session(id).await.unwrap().unwrap();
+        assert!(before.authority_identity.is_ordinary());
+        let response = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/v1/sessions/{id}"))
+                .insert_header((header::IF_MATCH, format!("\"{}\"", before.metadata_version)))
+                .set_json(
+                    serde_json::json!({"title":"Really patched", "authority_identity":forged}),
+                )
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let persisted = state.storage.load_session(id).await.unwrap().unwrap();
+        assert_eq!(persisted.title, "Really patched");
+        assert!(persisted.metadata_version > before.metadata_version);
+        assert!(persisted.authority_identity.is_ordinary());
+    }
+
+    #[actix_web::test]
     async fn permission_mode_auto_persists_and_is_indexed_distinctly() {
         let state = new_state().await;
         let app = test::init_service(

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -196,6 +196,14 @@ async fn build_test_harness_with_options(
     subagent_model_resolver: crate::tools::OptionalSubagentModelResolver,
     workspace_resolver: Option<bamboo_agent_core::workspace_state::WorkspaceResolver>,
 ) -> TestHarness {
+    build_test_harness_with_storage(subagent_model_resolver, workspace_resolver, false).await
+}
+
+async fn build_test_harness_with_storage(
+    subagent_model_resolver: crate::tools::OptionalSubagentModelResolver,
+    workspace_resolver: Option<bamboo_agent_core::workspace_state::WorkspaceResolver>,
+    use_v2_storage: bool,
+) -> TestHarness {
     let bamboo_home = make_temp_dir("bamboo-sub-agent-test");
     tokio::fs::create_dir_all(&bamboo_home).await.unwrap();
     let workspace_path = bamboo_home.join("workspace");
@@ -205,11 +213,15 @@ async fn build_test_harness_with_options(
     let session_store = Arc::new(SessionStoreV2::new(bamboo_home.clone()).await.unwrap());
     let project_store =
         Arc::new(bamboo_projects::ProjectStore::open(&bamboo_home).expect("Project store"));
-    let storage_dir = bamboo_home.join("storage");
-    tokio::fs::create_dir_all(&storage_dir).await.unwrap();
-    let jsonl = bamboo_storage::JsonlStorage::new(&storage_dir);
-    jsonl.init().await.unwrap();
-    let storage: Arc<dyn Storage> = Arc::new(jsonl);
+    let storage: Arc<dyn Storage> = if use_v2_storage {
+        session_store.clone()
+    } else {
+        let storage_dir = bamboo_home.join("storage");
+        tokio::fs::create_dir_all(&storage_dir).await.unwrap();
+        let jsonl = bamboo_storage::JsonlStorage::new(&storage_dir);
+        jsonl.init().await.unwrap();
+        Arc::new(jsonl)
+    };
     let persistence = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
 
     let metrics_storage = Arc::new(SqliteMetricsStorage::new(bamboo_home.join("metrics.db")));
@@ -436,6 +448,86 @@ async fn child_publication_uses_the_validating_instance_workspace_root() {
     assert!(
         published.is_dir(),
         "the same instance resolver that validated the relocated target must materialize it"
+    );
+}
+
+#[tokio::test]
+async fn supervisor_common_child_constructor_keeps_ordinary_identity_for_all_role_labels() {
+    let harness = build_test_harness().await;
+    let store = &harness.adapter.session_store;
+    let receipt = store
+        .get_or_create_default_supervisor("test-model")
+        .await
+        .unwrap();
+    let root = store
+        .load_session(&receipt.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut nested_parent: Option<Session> = None;
+    // This matrix exercises common child construction, including cosmetic role
+    // labels; it does not invoke the separate GuardianSpawner entry point.
+    for (role, lifecycle, name) in [
+        ("worker", None, None),
+        ("resident", Some("resident"), Some("authority-resident")),
+        ("guardian", None, None),
+        ("nested", None, None),
+    ] {
+        let parent = if role == "nested" {
+            nested_parent.clone().unwrap()
+        } else {
+            root.clone()
+        };
+        let child_id = format!("ordinary-{role}-{}", Uuid::new_v4());
+        child_session::create_child_action(
+            harness.adapter.as_ref(),
+            child_session::CreateChildInput {
+                parent_session: parent,
+                child_id: child_id.clone(),
+                title: role.into(),
+                responsibility: "Inspect".into(),
+                assignment_prompt: "Inspect".into(),
+                subagent_type: role.into(),
+                workspace: harness.workspace_path.to_string_lossy().into_owned(),
+                workspace_source: bamboo_engine::project_context::WorkspaceSource::Explicit,
+                model_override: None,
+                model_ref_override: None,
+                runtime_metadata: HashMap::from([
+                    ("authority_identity".into(), "supervisor".into()),
+                    ("role".into(), "supervisor".into()),
+                ]),
+                auto_run: false,
+                reasoning_effort: None,
+                lifecycle: lifecycle.map(str::to_string),
+                resident_name: name.map(str::to_string),
+                resident_context: None,
+                disabled_tools: None,
+                context_fork: None,
+            },
+        )
+        .await
+        .unwrap();
+        let child = harness
+            .storage
+            .load_session(&child_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(child.authority_identity.is_ordinary(), "{role}");
+        assert_eq!(child.root_session_id, receipt.session_id);
+        assert_eq!(child.project_id_meta(), root.project_id_meta());
+        if role == "worker" {
+            nested_parent = Some(child);
+        }
+    }
+    assert_eq!(
+        store
+            .load_root_authority(&receipt.session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .authority_identity,
+        root.authority_identity
     );
 }
 
@@ -1167,6 +1259,107 @@ async fn create_uses_async_subagent_model_resolver() {
 }
 
 #[tokio::test]
+async fn supervisor_resident_reset_and_accumulate_stay_ordinary_in_canonical_v2() {
+    let harness = build_test_harness_with_storage(None, None, true).await;
+    let canonical: Arc<dyn Storage> = harness.adapter.session_store.clone();
+    assert!(Arc::ptr_eq(&harness.storage, &canonical));
+    let receipt = harness
+        .storage
+        .get_or_create_default_supervisor("gpt-5")
+        .await
+        .unwrap();
+    let expected_identity = bamboo_domain::SessionAuthorityIdentity::Supervisor {
+        incarnation_id: receipt.incarnation_id,
+    };
+    assert_eq!(
+        harness
+            .storage
+            .load_session(&receipt.session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .authority_identity,
+        expected_identity
+    );
+
+    let first_brief = "First Supervisor resident assignment";
+    let reset_brief = "Replacement Supervisor resident assignment";
+    let accumulated_brief = "Additional Supervisor resident assignment";
+    let mut resident_id = None;
+    for (step, context, brief) in [
+        (0, "reset", first_brief),
+        (1, "reset", reset_brief),
+        (2, "accumulate", accumulated_brief),
+    ] {
+        let result = invoke_completed(
+            &harness.tool,
+            json!({
+                "action": "create",
+                "lifecycle": "resident",
+                "name": "supervisor-resident",
+                "context": context,
+                "title": format!("Supervisor resident task {step}"),
+                "responsibility": "Inspect one bounded task",
+                "prompt": brief,
+                "workspace": harness.workspace_path.to_string_lossy(),
+                "auto_run": false
+            }),
+            subagent_test_ctx(&receipt.session_id, &format!("supervisor-resident-{step}")),
+        )
+        .await
+        .expect("real SubAgent create or reuse must succeed");
+        let payload: serde_json::Value = serde_json::from_str(&result.result).unwrap();
+        let id = payload["child_session_id"].as_str().unwrap().to_string();
+        assert_eq!(payload["reused"], json!(step != 0));
+        if let Some(previous_id) = resident_id.as_ref() {
+            assert_eq!(
+                &id, previous_id,
+                "reset and accumulate must reuse the resident"
+            );
+        } else {
+            resident_id = Some(id.clone());
+        }
+        // No manual index mirroring: the production V2 save must make the
+        // resident discoverable by the next real SubAgent invocation.
+        let child = harness.storage.load_session(&id).await.unwrap().unwrap();
+        assert!(child.authority_identity.is_ordinary(), "step {step}");
+        assert_eq!(
+            child.parent_session_id.as_deref(),
+            Some(receipt.session_id.as_str())
+        );
+        assert_eq!(child.root_session_id, receipt.session_id);
+        assert!(child.messages.last().unwrap().content.contains(brief));
+        if step > 0 {
+            assert!(!child
+                .messages
+                .iter()
+                .any(|message| message.content.contains(first_brief)));
+            assert_eq!(
+                child.metadata.get("assignment_prompt").map(String::as_str),
+                Some(reset_brief)
+            );
+        }
+        if step == 2 {
+            assert!(child
+                .messages
+                .iter()
+                .any(|message| message.content.contains(reset_brief)));
+        }
+        assert_eq!(
+            harness
+                .storage
+                .load_root_authority(&receipt.session_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .authority_identity,
+            expected_identity,
+            "resident provisioning must preserve the parent incarnation"
+        );
+    }
+}
+
+#[tokio::test]
 async fn resident_create_reuses_same_child_session() {
     let harness = build_test_harness().await;
     let workspace = tempfile::tempdir().expect("workspace");
@@ -1249,6 +1442,7 @@ async fn resident_create_reuses_same_child_session() {
         .await
         .unwrap()
         .expect("child exists");
+    assert!(child.authority_identity.is_ordinary());
     assert_eq!(
         child.metadata.get("lifecycle").map(String::as_str),
         Some("resident")

--- a/crates/core/bamboo-domain/src/session/authority.rs
+++ b/crates/core/bamboo-domain/src/session/authority.rs
@@ -1,0 +1,90 @@
+//! Trusted Session identity. Cosmetic metadata never grants this identity.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Reserved location for the default Supervisor. The ID alone grants no authority.
+pub const DEFAULT_SUPERVISOR_SESSION_ID: &str = "bamboo-default-supervisor";
+
+/// A snapshot cannot be committed against the durable Session authority.
+/// Persistence publishers must not cache a rejected identity, including when
+/// they normally publish runtime state after an unrelated I/O failure.
+#[derive(Debug, thiserror::Error)]
+#[error("Session authority conflict: {0}")]
+pub struct SessionAuthorityConflict(pub String);
+
+/// Persisted authority assigned only through the trusted bootstrap storage port.
+/// Ordinary constructors, copies and children must not inherit Supervisor identity.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SessionAuthorityIdentity {
+    #[default]
+    Ordinary,
+    Supervisor {
+        incarnation_id: Uuid,
+    },
+}
+
+impl SessionAuthorityIdentity {
+    pub fn is_ordinary(&self) -> bool {
+        matches!(self, Self::Ordinary)
+    }
+}
+
+/// Small bootstrap result, deliberately excluding Session history/control-plane
+/// snapshots so callers cannot install a history-free snapshot in a session cache.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SupervisorBootstrapReceipt {
+    pub session_id: String,
+    pub incarnation_id: Uuid,
+    pub created: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Session;
+
+    #[test]
+    fn legacy_metadata_and_child_constructors_do_not_grant_authority() {
+        let mut root = Session::new("root", "model");
+        root.metadata
+            .insert("authority_identity".into(), "supervisor".into());
+        root.metadata.insert("role".into(), "supervisor".into());
+        let raw = serde_json::to_value(&root).unwrap();
+        assert!(raw.get("authority_identity").is_none());
+        let loaded: Session = serde_json::from_value(raw).unwrap();
+        assert!(loaded.authority_identity.is_ordinary());
+
+        root.authority_identity = SessionAuthorityIdentity::Supervisor {
+            incarnation_id: Uuid::new_v4(),
+        };
+        let child = Session::new_child_of("child", &root, "model", "child");
+        let nested = Session::new_child_of("nested", &child, "model", "nested");
+        assert!(child.authority_identity.is_ordinary());
+        assert!(nested.authority_identity.is_ordinary());
+        assert_eq!(nested.root_session_id, root.id);
+        assert!(Session::new_child("flat", root.id, "model", "flat")
+            .authority_identity
+            .is_ordinary());
+    }
+
+    #[test]
+    fn supervisor_identity_round_trips_without_a_separate_role_field() {
+        let mut session = Session::new(DEFAULT_SUPERVISOR_SESSION_ID, "model");
+        session.authority_identity = SessionAuthorityIdentity::Supervisor {
+            incarnation_id: Uuid::new_v4(),
+        };
+        let raw = serde_json::to_value(&session).unwrap();
+        assert_eq!(raw["authority_identity"]["kind"], "supervisor");
+        let restored: Session = serde_json::from_value(raw).unwrap();
+        assert_eq!(restored.authority_identity, session.authority_identity);
+        for raw in [
+            serde_json::json!({"kind":"unknown"}),
+            serde_json::json!({"kind":"supervisor"}),
+            serde_json::json!({"kind":"supervisor","incarnation_id":"invalid"}),
+        ] {
+            assert!(serde_json::from_value::<SessionAuthorityIdentity>(raw).is_err());
+        }
+    }
+}

--- a/crates/core/bamboo-domain/src/session/mod.rs
+++ b/crates/core/bamboo-domain/src/session/mod.rs
@@ -1,5 +1,6 @@
 //! Bamboo session domain — Session, Message, Role, TaskList, and supporting types.
 
+pub mod authority;
 pub mod budget_types;
 pub mod composition;
 pub mod context_block;
@@ -20,6 +21,7 @@ pub mod tool_types;
 pub mod types;
 
 // Re-exports for ergonomic access
+pub use authority::*;
 pub use budget_types::{BudgetStrategy, TokenBudget, TokenBudgetUsage, TokenUsageBreakdown};
 pub use composition::*;
 pub use context_block::*;

--- a/crates/core/bamboo-domain/src/session/types.rs
+++ b/crates/core/bamboo-domain/src/session/types.rs
@@ -1,5 +1,6 @@
 use crate::provider_model_ref::ProviderModelRef;
 use crate::reasoning::ReasoningEffort;
+use crate::session::authority::SessionAuthorityIdentity;
 use crate::session::budget_types::{TokenBudget, TokenBudgetUsage};
 use crate::session::message_part::{ImageUrlRef, MessagePart};
 use crate::session::task::{TaskItemStatus, TaskList};
@@ -653,6 +654,9 @@ pub struct Session {
     pub metadata_version: u64,
     #[serde(default)]
     pub kind: SessionKind,
+    /// Trusted identity; raw metadata and ordinary persistence cannot assign it.
+    #[serde(default, skip_serializing_if = "SessionAuthorityIdentity::is_ordinary")]
+    pub authority_identity: SessionAuthorityIdentity,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_session_id: Option<String>,
     #[serde(default)]
@@ -787,6 +791,7 @@ impl Session {
             title_generated: false,
             metadata_version: 0,
             kind: SessionKind::Root,
+            authority_identity: SessionAuthorityIdentity::Ordinary,
             parent_session_id: None,
             root_session_id: id,
             spawn_depth: 0,
@@ -873,6 +878,7 @@ impl Session {
             title_generated: true,
             metadata_version: 0,
             kind: SessionKind::Child,
+            authority_identity: SessionAuthorityIdentity::Ordinary,
             parent_session_id: Some(parent_session_id),
             root_session_id,
             spawn_depth,

--- a/crates/core/bamboo-domain/src/storage.rs
+++ b/crates/core/bamboo-domain/src/storage.rs
@@ -4,6 +4,7 @@
 //! implementations. Concrete implementations live in infrastructure crates.
 
 use crate::session::types::Session;
+use crate::SupervisorBootstrapReceipt;
 
 /// Trait for session storage backends.
 ///
@@ -12,6 +13,33 @@ use crate::session::types::Session;
 /// (e.g., JSONL files, databases, cloud storage).
 #[async_trait::async_trait]
 pub trait Storage: Send + Sync {
+    /// Trusted host bootstrap for one stable default Supervisor Root. Only the
+    /// initial model is caller supplied and is used on first creation only.
+    /// Implementations must publish the complete identity atomically, protect it
+    /// from ordinary writers, and return a receipt rather than a partial Session.
+    async fn get_or_create_default_supervisor(
+        &self,
+        initial_model: &str,
+    ) -> std::io::Result<SupervisorBootstrapReceipt> {
+        let _ = initial_model;
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "storage backend does not support trusted Supervisor bootstrap",
+        ))
+    }
+
+    /// Strict canonical Root control-plane read for authority decisions.
+    /// `None` means absent; partial/corrupt/mismatched published authority is an
+    /// error, never a fallback to stale session.json. Returned messages are empty;
+    /// this observation must not replace a full Session in a history cache.
+    async fn load_root_authority(&self, session_id: &str) -> std::io::Result<Option<Session>> {
+        let _ = session_id;
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "storage backend does not support strict Root authority reads",
+        ))
+    }
+
     /// Saves a session's metadata.
     async fn save_session(&self, session: &Session) -> std::io::Result<()>;
 

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -969,7 +969,13 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
             // Save session via merge-save so any concurrent UI edits to
             // title / title_generated / pinned / title_version are preserved (the runtime is not
             // an authoritative title writer).
-            if let Err(error) = agent.persistence().save_runtime_session(&mut session).await {
+            let saved = agent.persistence().save_runtime_session(&mut session).await;
+            let authority_conflict = saved.as_ref().err().is_some_and(|error| {
+                error
+                    .get_ref()
+                    .is_some_and(|cause| cause.is::<bamboo_domain::SessionAuthorityConflict>())
+            });
+            if let Err(error) = saved {
                 tracing::warn!("[{}] Failed to save session: {}", session_id, error);
             }
 
@@ -1012,11 +1018,14 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
             let child_status = session.last_run_status();
             let child_error = session.last_run_error();
 
-            // Update memory cache.
-            sessions_cache.insert(
-                session_id.clone(),
-                Arc::new(crate::SessionSnapshot::new(session)),
-            );
+            // Preserve normal I/O failure behavior, but never overwrite a
+            // current Root's cache with a rejected authority/incarnation.
+            if !authority_conflict {
+                sessions_cache.insert(
+                    session_id.clone(),
+                    Arc::new(crate::SessionSnapshot::new(session)),
+                );
+            }
 
             if let (Some(handler), Some(parent_session_id), Some(status)) =
                 (child_completion, parent_session_id, child_status)

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -620,13 +620,18 @@ impl ChildCompletionCoordinator {
     }
 
     async fn save_and_cache(&self, session: &mut Session) {
-        if let Err(error) = self.persistence.merge_save_runtime(session).await {
+        if let Err(error) = self
+            .persistence
+            .merge_save_runtime_and_publish(session, |saved, _| {
+                self.sessions.insert(
+                    saved.id.clone(),
+                    Arc::new(crate::SessionSnapshot::new(saved.clone())),
+                );
+            })
+            .await
+        {
             tracing::warn!(session_id = %session.id, %error, "failed to persist session");
         }
-        self.sessions.insert(
-            session.id.clone(),
-            Arc::new(crate::SessionSnapshot::new(session.clone())),
-        );
     }
 }
 
@@ -3023,6 +3028,53 @@ mod tests {
             None,
         ));
         (temp, store, inbox, coordinator, reservations, launches)
+    }
+
+    #[tokio::test]
+    async fn supervisor_resume_rejects_old_incarnation_without_replacing_cache() {
+        let (_temp, store, _inbox, coordinator, _reservations, _launches) =
+            completion_inbox_fixture().await;
+        let original = store
+            .get_or_create_default_supervisor("model")
+            .await
+            .unwrap();
+        let mut stale = store
+            .load_session(&original.session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        store.delete_session(&original.session_id).await.unwrap();
+        let recreated = store
+            .get_or_create_default_supervisor("replacement")
+            .await
+            .unwrap();
+        assert_ne!(original.incarnation_id, recreated.incarnation_id);
+        let mut current = store
+            .load_session(&recreated.session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        coordinator.save_and_cache(&mut current).await;
+        let cached = coordinator
+            .sessions
+            .get(&current.id)
+            .unwrap()
+            .value()
+            .clone();
+        coordinator.save_and_cache(&mut stale).await;
+        assert!(Arc::ptr_eq(
+            &cached,
+            coordinator.sessions.get(&current.id).unwrap().value()
+        ));
+        assert_eq!(
+            store
+                .load_session(&current.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .authority_identity,
+            current.authority_identity
+        );
     }
 
     // ── child-wait watchdog pure helpers (issue #546) ────────────────────

--- a/crates/engine/bamboo-engine/src/session_app/mod.rs
+++ b/crates/engine/bamboo-engine/src/session_app/mod.rs
@@ -14,6 +14,7 @@ pub mod resolution;
 pub mod respond;
 pub mod resume;
 pub mod session_create;
+pub mod supervisor;
 pub mod system_prompt;
 pub mod truncation;
 pub mod types;

--- a/crates/engine/bamboo-engine/src/session_app/supervisor.rs
+++ b/crates/engine/bamboo-engine/src/session_app/supervisor.rs
@@ -1,0 +1,72 @@
+//! Host-facing Supervisor identity bootstrap over the canonical Storage port.
+
+use std::{io, sync::Arc};
+
+use bamboo_domain::{Storage, SupervisorBootstrapReceipt};
+
+/// Trusted host service; not a model tool or an automatic Session startup hook.
+/// Storage owns atomic publication and identity validation. This service never
+/// creates an ordinary Session, changes a cache, or launches a run.
+#[derive(Clone)]
+pub struct SupervisorSessionService {
+    storage: Arc<dyn Storage>,
+}
+
+impl SupervisorSessionService {
+    pub fn new(storage: Arc<dyn Storage>) -> Self {
+        Self { storage }
+    }
+
+    /// Get the stable identity, using `initial_model` only on first creation.
+    pub async fn get_or_create_default(
+        &self,
+        initial_model: &str,
+    ) -> io::Result<SupervisorBootstrapReceipt> {
+        self.storage
+            .get_or_create_default_supervisor(initial_model)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_domain::Session;
+
+    struct UnsupportedStore;
+
+    #[async_trait::async_trait]
+    impl Storage for UnsupportedStore {
+        async fn save_session(&self, _: &Session) -> io::Result<()> {
+            panic!("bootstrap must not fall back to ordinary save")
+        }
+        async fn load_session(&self, _: &str) -> io::Result<Option<Session>> {
+            panic!("authority must not fall back to ordinary load")
+        }
+        async fn delete_session(&self, _: &str) -> io::Result<bool> {
+            panic!("bootstrap must not delete sessions")
+        }
+    }
+
+    #[tokio::test]
+    async fn unsupported_authority_ports_fail_without_ordinary_fallback() {
+        let storage: Arc<dyn Storage> = Arc::new(UnsupportedStore);
+        let service = SupervisorSessionService::new(storage.clone());
+        assert_eq!(
+            service
+                .get_or_create_default("model")
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            storage
+                .load_root_authority("root")
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Unsupported
+        );
+    }
+}

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -61,6 +61,14 @@ const RESPONSE_CONTROL_METADATA_KEYS: &[&str] = &[
 const TASK_CONTROL_PLANE_CONFLICT_PREFIX: &str = "Task control-plane changed while saving session ";
 const MAX_TASK_CONTROL_PLANE_REBASE_RETRIES: usize = 3;
 
+fn may_publish_runtime_result(result: &std::io::Result<()>) -> bool {
+    !result.as_ref().err().is_some_and(|error| {
+        error
+            .get_ref()
+            .is_some_and(|cause| cause.is::<bamboo_domain::SessionAuthorityConflict>())
+    })
+}
+
 /// A pending response is an authoritative compare-and-consume transaction.
 /// When a stale runner still carries the consumed ask, its terminal save must
 /// adopt the durable response control plane instead of resurrecting the ask or
@@ -412,7 +420,8 @@ impl LockedSessionStore {
     /// guard across an await. The callback also runs when the durable save
     /// fails, preserving [`RuntimeSessionPersistence::save_runtime_control_plane`]
     /// implementations that publish current runtime authorization state while
-    /// still returning the storage error.
+    /// still returning the storage error. Authority conflicts are excluded:
+    /// publishing a rejected identity would disagree with durable authority.
     pub async fn save_runtime_only_and_publish<F>(
         &self,
         session: &mut Session,
@@ -436,7 +445,9 @@ impl LockedSessionStore {
         let result = self
             .save_runtime_state_rebasing_task_conflicts(session)
             .await;
-        publish(session);
+        if may_publish_runtime_result(&result) {
+            publish(session);
+        }
         result
     }
 
@@ -660,9 +671,10 @@ impl LockedSessionStore {
     /// Merge-save a runtime session and synchronously publish the resulting
     /// snapshot before releasing its per-session serialization lock.
     ///
-    /// The callback receives whether the durable save committed. It always runs
+    /// The callback receives whether the durable save committed. It runs
     /// after the save attempt so repository callers can preserve their existing
-    /// cache-on-failure policy without reopening a durable-to-cache race.
+    /// cache-on-failure policy without reopening a durable-to-cache race,
+    /// except when authority validation rejects the snapshot.
     pub async fn merge_save_runtime_and_publish<F>(
         &self,
         session: &mut Session,
@@ -726,7 +738,9 @@ impl LockedSessionStore {
         }
 
         let result = self.save_session_rebasing_task_conflicts(session).await;
-        publish(session, result.is_ok());
+        if may_publish_runtime_result(&result) {
+            publish(session, result.is_ok());
+        }
         result
     }
 
@@ -813,7 +827,9 @@ impl LockedSessionStore {
             adopt_fresher_durable_model_context_state(session, latest);
         }
         let result = self.save_session_rebasing_task_conflicts(session).await;
-        publish(session, result.is_ok());
+        if may_publish_runtime_result(&result) {
+            publish(session, result.is_ok());
+        }
         result
     }
 
@@ -874,7 +890,9 @@ impl LockedSessionStore {
         incoming_audit.write_to(&mut session.metadata);
 
         let result = self.save_session_rebasing_task_conflicts(session).await;
-        publish(session, result.is_ok());
+        if may_publish_runtime_result(&result) {
+            publish(session, result.is_ok());
+        }
         result
     }
 
@@ -1408,6 +1426,15 @@ fn adopt_fresher_disk_permission_posture(session: &mut Session, latest: &Session
 /// disk copy (e.g. [`LockedSessionStore::merge_save_runtime`]) don't pay for a
 /// second read.
 fn apply_authoritative_metadata(session: &mut Session, latest: &Session) {
+    // Identity is independent of the UI metadata revision. Preserve it in the
+    // caller snapshot too, so a successful merge-save cannot downgrade the cache.
+    // Never replace an explicit Supervisor incarnation: the final storage guard
+    // must reject stale identities after deletion/recreation rather than hiding them.
+    // A newly constructed or previously deleted Ordinary session with this ID
+    // is not a snapshot of the current Root and must not be rebound to it.
+    if session.authority_identity.is_ordinary() && session.created_at == latest.created_at {
+        session.authority_identity = latest.authority_identity.clone();
+    }
     if latest.metadata_version >= session.metadata_version {
         session.title = latest.title.clone();
         session.title_version = latest.title_version;
@@ -1452,6 +1479,197 @@ mod tests {
     use crate::v2::{RuntimeTaskTransactionFault, SessionStoreV2};
     use bamboo_domain::{session::types::Session, PermissionMode};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    #[test]
+    fn authority_merge_updates_ordinary_cache_but_does_not_hide_stale_incarnation() {
+        let mut latest = Session::new(bamboo_domain::DEFAULT_SUPERVISOR_SESSION_ID, "model");
+        latest.authority_identity = bamboo_domain::SessionAuthorityIdentity::Supervisor {
+            incarnation_id: uuid::Uuid::new_v4(),
+        };
+        let mut stale = latest.clone();
+        stale.authority_identity = bamboo_domain::SessionAuthorityIdentity::Ordinary;
+        stale.metadata_version = 100;
+        apply_authoritative_metadata(&mut stale, &latest);
+        assert_eq!(stale.authority_identity, latest.authority_identity);
+        let old_identity = bamboo_domain::SessionAuthorityIdentity::Supervisor {
+            incarnation_id: uuid::Uuid::new_v4(),
+        };
+        stale.authority_identity = old_identity.clone();
+        apply_authoritative_metadata(&mut stale, &latest);
+        assert_eq!(stale.authority_identity, old_identity);
+    }
+
+    struct AuthoritySavePauseStorage {
+        inner: Arc<SessionStoreV2>,
+        reached: tokio::sync::Barrier,
+        release: tokio::sync::Barrier,
+    }
+
+    #[async_trait::async_trait]
+    impl Storage for AuthoritySavePauseStorage {
+        async fn load_session(&self, id: &str) -> std::io::Result<Option<Session>> {
+            self.inner.load_session(id).await
+        }
+        async fn load_runtime_control_plane(&self, id: &str) -> std::io::Result<Option<Session>> {
+            self.inner.load_runtime_control_plane(id).await
+        }
+        async fn delete_session(&self, id: &str) -> std::io::Result<bool> {
+            self.inner.delete_session(id).await
+        }
+        async fn save_session(&self, session: &Session) -> std::io::Result<()> {
+            self.reached.wait().await;
+            self.release.wait().await;
+            self.inner.save_session(session).await
+        }
+        async fn save_runtime_state(&self, session: &Session) -> std::io::Result<()> {
+            self.reached.wait().await;
+            self.release.wait().await;
+            self.inner.save_runtime_state(session).await
+        }
+    }
+
+    #[tokio::test]
+    async fn supervisor_bootstrap_between_merge_read_and_save_rejects_without_publishing() {
+        for runtime_only in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let first = Arc::new(SessionStoreV2::new(temp.path().into()).await.unwrap());
+            let second = SessionStoreV2::new(temp.path().into()).await.unwrap();
+            let paused = Arc::new(AuthoritySavePauseStorage {
+                inner: first.clone(),
+                reached: tokio::sync::Barrier::new(2),
+                release: tokio::sync::Barrier::new(2),
+            });
+            let store = LockedSessionStore::new(paused.clone());
+            let mut stale = Session::new(bamboo_domain::DEFAULT_SUPERVISOR_SESSION_ID, "stale");
+            stale.add_message(bamboo_domain::Message::user(
+                "must not enter new Supervisor",
+            ));
+            let published = AtomicBool::new(false);
+            let save = async {
+                if runtime_only {
+                    store
+                        .save_runtime_only_and_publish(&mut stale, |_| {
+                            published.store(true, Ordering::SeqCst);
+                        })
+                        .await
+                } else {
+                    store
+                        .merge_save_runtime_and_publish(&mut stale, |_, _| {
+                            published.store(true, Ordering::SeqCst);
+                        })
+                        .await
+                }
+            };
+            let bootstrap = async {
+                // The merge read saw None. Publish from an independent V2 store
+                // before allowing the loser to take its final filesystem lock.
+                paused.reached.wait().await;
+                let receipt = second
+                    .get_or_create_default_supervisor("supervisor")
+                    .await
+                    .unwrap();
+                paused.release.wait().await;
+                receipt
+            };
+            let (result, receipt) =
+                tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                    tokio::join!(save, bootstrap)
+                })
+                .await
+                .expect("deterministic bootstrap/save race completes");
+            let error = result.unwrap_err();
+            assert!(!may_publish_runtime_result(&Err(error)));
+            assert!(!published.load(Ordering::SeqCst));
+            assert!(stale.authority_identity.is_ordinary());
+            let observed = first
+                .load_root_authority(&receipt.session_id)
+                .await
+                .unwrap()
+                .unwrap();
+            // The independent store's ordinary lookup index can remain stale;
+            // strict authority must observe canonical publication without it.
+            let durable = second
+                .load_session(&receipt.session_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(durable.model, "supervisor");
+            assert_eq!(observed.authority_identity, durable.authority_identity);
+            assert!(durable.messages.is_empty());
+            assert_eq!(
+                durable.authority_identity,
+                bamboo_domain::SessionAuthorityIdentity::Supervisor {
+                    incarnation_id: receipt.incarnation_id,
+                }
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn supervisor_merge_publishes_adopted_identity_but_never_a_rejected_incarnation() {
+        for runtime_only in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let storage = Arc::new(SessionStoreV2::new(temp.path().into()).await.unwrap());
+            let receipt = storage
+                .get_or_create_default_supervisor("model")
+                .await
+                .unwrap();
+            let baseline = storage
+                .load_session(&receipt.session_id)
+                .await
+                .unwrap()
+                .unwrap();
+            let expected = baseline.authority_identity.clone();
+            let store = LockedSessionStore::new(storage.clone());
+            for case in 0..3 {
+                let rejected = case != 0;
+                let mut snapshot = baseline.clone();
+                snapshot.authority_identity = if case == 1 {
+                    bamboo_domain::SessionAuthorityIdentity::Supervisor {
+                        incarnation_id: uuid::Uuid::new_v4(),
+                    }
+                } else {
+                    bamboo_domain::SessionAuthorityIdentity::Ordinary
+                };
+                if case == 2 {
+                    snapshot.created_at -= chrono::Duration::seconds(1);
+                    snapshot.model = "stale Ordinary instance".into();
+                    snapshot.add_message(bamboo_domain::Message::user("must not be rebound"));
+                }
+                let published = AtomicBool::new(false);
+                let callback = |saved: &Session| {
+                    assert_eq!(saved.authority_identity, expected);
+                    published.store(true, Ordering::SeqCst);
+                };
+                let result = if runtime_only {
+                    store
+                        .save_runtime_only_and_publish(&mut snapshot, callback)
+                        .await
+                } else {
+                    store
+                        .merge_save_runtime_and_publish(&mut snapshot, |saved, committed| {
+                            assert!(committed);
+                            callback(saved);
+                        })
+                        .await
+                };
+                assert_eq!(result.is_err(), rejected);
+                assert_eq!(published.load(Ordering::SeqCst), !rejected);
+                if !rejected {
+                    assert_eq!(snapshot.authority_identity, expected);
+                }
+                let durable = storage
+                    .load_session(&receipt.session_id)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(durable.authority_identity, expected);
+                assert_eq!(durable.created_at, baseline.created_at);
+                assert_eq!(durable.model, baseline.model);
+                assert!(durable.messages.is_empty());
+            }
+        }
+    }
 
     struct CountingControlPlaneStorage {
         inner: Arc<SessionStoreV2>,

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -39,8 +39,13 @@ use uuid::Uuid;
 use bamboo_domain::ProviderModelRef;
 use bamboo_domain::ReasoningEffort;
 use bamboo_domain::{
-    MessagePart, ProjectId, Role, Session, SessionKind, TaskList, TokenBudgetUsage,
+    MessagePart, ProjectId, Role, Session, SessionAuthorityIdentity, SessionKind,
+    SupervisorBootstrapReceipt, TaskList, TokenBudgetUsage, DEFAULT_SUPERVISOR_SESSION_ID,
 };
+
+mod supervisor;
+#[cfg(test)]
+mod supervisor_tests;
 
 use crate::search_index::{should_index_session, SessionSearchIndex};
 use bamboo_domain::AttachmentReader;
@@ -1034,6 +1039,8 @@ pub struct SessionStoreV2 {
     runtime_task_durability_events: std::sync::Mutex<Vec<RuntimeTaskDurabilityEvent>>,
     #[cfg(any(test, feature = "test-utils"))]
     full_save_pause: std::sync::Mutex<Option<FullSavePause>>,
+    #[cfg(test)]
+    supervisor_bootstrap_fault: std::sync::Mutex<Option<supervisor::SupervisorBootstrapFault>>,
 }
 
 const COPY_TRANSIENT_METADATA_KEYS: &[&str] = &[
@@ -1088,6 +1095,7 @@ const COPY_TRANSIENT_METADATA_KEYS: &[&str] = &[
 fn copied_session_snapshot(source: &Session, new_id: &str) -> Session {
     let now = Utc::now();
     let mut copy = source.clone();
+    copy.authority_identity = SessionAuthorityIdentity::Ordinary;
     copy.id = new_id.to_string();
     copy.kind = SessionKind::Root;
     copy.parent_session_id = None;
@@ -1328,6 +1336,8 @@ impl SessionStoreV2 {
             runtime_task_durability_events: std::sync::Mutex::new(Vec::new()),
             #[cfg(any(test, feature = "test-utils"))]
             full_save_pause: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            supervisor_bootstrap_fault: std::sync::Mutex::new(None),
         };
 
         // Create and permission the private journal directory once at store
@@ -1565,6 +1575,10 @@ impl SessionStoreV2 {
                     None
                 }
             };
+        if let Err(error) = supervisor::validate_overlay(&main, sidecar.as_ref()) {
+            tracing::warn!("index rebuild: skipping invalid authority for {id}: {error}");
+            return None;
+        }
         let mut session = overlay_runtime_sidecar(main, sidecar);
         session.clear_stale_root_token_budget();
         Some(session)
@@ -1639,6 +1653,7 @@ impl SessionStoreV2 {
             Err(error) if error.kind() == io::ErrorKind::NotFound => None,
             Err(error) => return Err(error),
         };
+        supervisor::validate_overlay(&main, sidecar.as_ref())?;
         let mut session = overlay_runtime_sidecar(main, sidecar);
         session.clear_stale_root_token_budget();
         Ok(Some(session))
@@ -2143,6 +2158,7 @@ impl SessionStoreV2 {
         })?;
         let sidecar =
             Self::read_runtime_sidecar_at(&abs_dir.join(RUNTIME_SIDECAR_FILE), session_id).await?;
+        supervisor::validate_overlay(&main, sidecar.as_ref())?;
         let mut session = overlay_runtime_sidecar(main, sidecar);
         session.clear_stale_root_token_budget();
         if session.id != session_id || session.kind != SessionKind::Root {
@@ -2393,6 +2409,9 @@ impl SessionStoreV2 {
         session_id: &str,
     ) -> io::Result<Option<Session>> {
         validate_session_id(session_id)?;
+        if session_id == DEFAULT_SUPERVISOR_SESSION_ID {
+            return self.load_root_authority_unchecked(session_id).await;
+        }
         if let Some(side) = self.read_runtime_sidecar(session_id).await? {
             return Ok(Some(side));
         }
@@ -2406,6 +2425,7 @@ impl SessionStoreV2 {
         };
         let mut session: Session = serde_json::from_str(&raw)
             .map_err(|error| other_io_error(format!("invalid session.json: {error}")))?;
+        supervisor::validate_identity(&session)?;
         session.messages.clear();
         session.clear_stale_root_token_budget();
         Ok(Some(session))
@@ -2722,6 +2742,7 @@ impl SessionStoreV2 {
                 ));
             }
         }
+        supervisor::validate_overlay(&main, sidecar.as_ref())?;
         let mut session = overlay_runtime_sidecar(main, sidecar);
         session.messages.clear();
         session.clear_stale_root_token_budget();
@@ -3333,7 +3354,9 @@ impl SessionStoreV2 {
         else {
             return Ok(false);
         };
-        if !Self::runtime_task_owned_snapshot_matches(&current, original)? {
+        if current.authority_identity != original.authority_identity
+            || !Self::runtime_task_owned_snapshot_matches(&current, original)?
+        {
             return Ok(false);
         }
         let mut committed = current;
@@ -3421,7 +3444,9 @@ impl SessionStoreV2 {
         else {
             return Ok(false);
         };
-        if !Self::runtime_task_owned_snapshot_matches(&current_first, first_original)?
+        if current_first.authority_identity != first_original.authority_identity
+            || current_second.authority_identity != second_original.authority_identity
+            || !Self::runtime_task_owned_snapshot_matches(&current_first, first_original)?
             || !Self::runtime_task_owned_snapshot_matches(&current_second, second_original)?
         {
             return Ok(false);
@@ -3702,6 +3727,16 @@ impl SessionStoreV2 {
                     continue;
                 }
             };
+            supervisor::validate_identity(&session)?;
+            if !matches!(
+                session.authority_identity,
+                SessionAuthorityIdentity::Ordinary
+            ) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "cannot reconstruct missing Supervisor authority from session.json",
+                ));
+            }
             self.write_runtime_sidecar(&abs_dir, &session).await?;
             migrated += 1;
         }
@@ -3730,7 +3765,8 @@ impl SessionStoreV2 {
 
     /// Read + deserialize a runtime sidecar (`runtime.json`) from a known path.
     /// A missing file yields `None`; a corrupt one is ignored with a warning
-    /// (the authoritative copy still lives in `session.json`). Shared by
+    /// for Ordinary compatibility. Supervisor callers validate the canonical
+    /// pair and reject missing or corrupt runtime authority. Shared by
     /// [`Self::read_runtime_sidecar`] (index-resolved path) and the index
     /// rebuild (directory-scanned path) so both overlay the sidecar identically.
     async fn read_runtime_sidecar_at(path: &Path, id: &str) -> io::Result<Option<Session>> {
@@ -3740,14 +3776,15 @@ impl SessionStoreV2 {
         let raw = fs::read_to_string(path).await?;
         match serde_json::from_str::<Session>(&raw) {
             Ok(mut side) => {
+                supervisor::validate_identity(&side)?;
                 // The control-plane path (`load_runtime_control_plane`) returns
                 // this directly, so migrate a stale Root token_budget here too (#230).
                 side.clear_stale_root_token_budget();
                 Ok(Some(side))
             }
             Err(error) => {
-                // A corrupt sidecar must never make a session unloadable — the
-                // authoritative copy still lives in session.json. Warn and ignore.
+                // Ordinary Sessions may recover from session.json. Supervisor
+                // pair validation rejects this fallback before use or writes.
                 tracing::warn!("ignoring corrupt runtime sidecar for {id}: {error}");
                 Ok(None)
             }
@@ -4764,6 +4801,7 @@ impl SessionStoreV2 {
         let session: Session = serde_json::from_str(&raw)
             .map_err(|e| other_io_error(format!("invalid session.json: {e}")))?;
         let sidecar = self.read_runtime_sidecar(session_id).await?;
+        supervisor::validate_overlay(&session, sidecar.as_ref())?;
         let mut session = overlay_runtime_sidecar(session, sidecar);
         // Drop a stale pre-#180 Root token_budget cache so it re-resolves (#230).
         session.clear_stale_root_token_budget();
@@ -4773,12 +4811,27 @@ impl SessionStoreV2 {
 
 #[async_trait::async_trait]
 impl Storage for SessionStoreV2 {
+    async fn get_or_create_default_supervisor(
+        &self,
+        initial_model: &str,
+    ) -> io::Result<SupervisorBootstrapReceipt> {
+        self.bootstrap_default_supervisor(initial_model).await
+    }
+
+    async fn load_root_authority(&self, session_id: &str) -> io::Result<Option<Session>> {
+        let _lifecycle = self.lock_session_lifecycle_shared().await?;
+        let _task = self.lock_runtime_task_sidecar_shared().await?;
+        let _session = self.acquire_session_maintenance_lock(session_id).await?;
+        self.load_root_authority_unchecked(session_id).await
+    }
+
     async fn save_session(&self, session: &Session) -> io::Result<()> {
         let total_started = Instant::now();
         let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
         let _session_write = self
             .acquire_session_write_lock(&session.id, SaveKind::Full)
             .await?;
+        self.validate_authority_for_save(session).await?;
         self.reject_regressing_runtime_task(session).await?;
 
         let mut stages = SaveStageDurations::default();
@@ -4860,7 +4913,8 @@ impl Storage for SessionStoreV2 {
     async fn save_runtime_state(&self, session: &Session) -> io::Result<()> {
         // Fast path: write ONLY the small runtime sidecar (no messages), leaving
         // session.json — which carries the full conversation history — untouched.
-        // This is O(1) in conversation length, unlike `save_session`.
+        // Ordinary sessions retain O(1) I/O in conversation length. Supervisor
+        // validation additionally reads main-file bytes to verify its identity.
         let Some(rel) = self.resolve_rel_path(&session.id).await else {
             // Session was never fully persisted yet — fall back to a full save so
             // session.json and the index get created. Deliberately acquire no
@@ -4873,6 +4927,7 @@ impl Storage for SessionStoreV2 {
         let _session_write = self
             .acquire_session_write_lock(&session.id, SaveKind::Runtime)
             .await?;
+        self.validate_authority_for_save(session).await?;
         self.reject_regressing_runtime_task(session).await?;
         let abs_dir = self.abs_path_from_rel(&rel);
         let mut stages = SaveStageDurations::default();

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -2410,7 +2410,11 @@ impl SessionStoreV2 {
     ) -> io::Result<Option<Session>> {
         validate_session_id(session_id)?;
         if session_id == DEFAULT_SUPERVISOR_SESSION_ID {
-            return self.load_root_authority_unchecked(session_id).await;
+            if let Some(root) = self.load_root_authority_unchecked(session_id).await? {
+                return Ok(Some(root));
+            }
+            // An Ordinary Child may already own this ID in another tree.
+            // Only canonical Root absence permits its normal control-plane read.
         }
         if let Some(side) = self.read_runtime_sidecar(session_id).await? {
             return Ok(Some(side));

--- a/crates/infra/bamboo-storage/src/v2/supervisor.rs
+++ b/crates/infra/bamboo-storage/src/v2/supervisor.rs
@@ -1,0 +1,327 @@
+//! Trusted singleton identity. Canonical Session files are the only authority;
+//! the global index and unpublished staging directories never grant a role.
+
+use super::*;
+use bamboo_domain::{
+    SessionAuthorityConflict, SessionAuthorityIdentity, SupervisorBootstrapReceipt,
+    DEFAULT_SUPERVISOR_SESSION_ID,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SupervisorBootstrapFault {
+    BeforePublish,
+    BeforeIndex,
+}
+
+fn invalid(message: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("session_authority: {message}"),
+    )
+}
+
+fn writer_conflict(error: io::Error) -> io::Error {
+    io::Error::new(error.kind(), SessionAuthorityConflict(error.to_string()))
+}
+
+pub(super) fn validate_identity(session: &Session) -> io::Result<()> {
+    if let SessionAuthorityIdentity::Supervisor { incarnation_id } = &session.authority_identity {
+        if incarnation_id.is_nil()
+            || session.id != DEFAULT_SUPERVISOR_SESSION_ID
+            || session.kind != SessionKind::Root
+            || session.root_session_id != session.id
+            || session.parent_session_id.is_some()
+            || session.spawn_depth != 0
+        {
+            return Err(invalid("invalid Supervisor identity or Root lineage"));
+        }
+    }
+    Ok(())
+}
+
+/// All overlay/recovery paths must reject a missing or divergent authority.
+/// Ordinary legacy Sessions keep their existing compatibility semantics.
+pub(super) fn validate_overlay(main: &Session, side: Option<&Session>) -> io::Result<()> {
+    validate_identity(main)?;
+    if let Some(side) = side {
+        validate_identity(side)?;
+    }
+    let has_authority = !matches!(main.authority_identity, SessionAuthorityIdentity::Ordinary)
+        || side.is_some_and(|side| {
+            !matches!(side.authority_identity, SessionAuthorityIdentity::Ordinary)
+        });
+    if has_authority {
+        let side =
+            side.ok_or_else(|| invalid("published Supervisor is missing runtime authority"))?;
+        if main.id != side.id || main.authority_identity != side.authority_identity {
+            return Err(invalid(
+                "runtime authority does not match the published Session",
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn real_directory(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path).await {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(true),
+        Ok(_) => Err(invalid("expected a real authority directory")),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+async fn read_regular(path: &Path) -> io::Result<Vec<u8>> {
+    let metadata = fs::symlink_metadata(path).await.map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            invalid("published Root has missing canonical files")
+        } else {
+            error
+        }
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(invalid("canonical authority is not a regular file"));
+    }
+    fs::read(path).await
+}
+
+// Deserialize only identity fields from main. In particular, this does not
+// allocate its potentially large message history or use it as a fallback.
+#[derive(Deserialize)]
+struct MainIdentity {
+    id: String,
+    #[serde(default)]
+    kind: SessionKind,
+    #[serde(default)]
+    root_session_id: String,
+    #[serde(default)]
+    parent_session_id: Option<String>,
+    #[serde(default)]
+    spawn_depth: u32,
+    #[serde(default)]
+    authority_identity: SessionAuthorityIdentity,
+}
+
+impl SessionStoreV2 {
+    /// Caller owns the guards for its storage operation. Never consult the
+    /// rebuildable index, and never recover a runtime authority from main.
+    pub(super) async fn load_root_authority_unchecked(
+        &self,
+        id: &str,
+    ) -> io::Result<Option<Session>> {
+        validate_session_id(id)?;
+        if !real_directory(&self.sessions_dir).await? {
+            return Err(invalid("sessions directory is missing"));
+        }
+        let directory = self.sessions_dir.join(id);
+        if !real_directory(&directory).await? {
+            return Ok(None);
+        }
+        let main: MainIdentity =
+            serde_json::from_slice(&read_regular(&directory.join("session.json")).await?)
+                .map_err(|_| invalid("invalid canonical session.json"))?;
+        let mut side: Session =
+            serde_json::from_slice(&read_regular(&directory.join(RUNTIME_SIDECAR_FILE)).await?)
+                .map_err(|_| invalid("invalid canonical runtime.json"))?;
+        validate_identity(&side)?;
+        let ordinary_legacy_root =
+            matches!(main.authority_identity, SessionAuthorityIdentity::Ordinary)
+                && main.root_session_id.is_empty();
+        let main_root = if ordinary_legacy_root {
+            id
+        } else {
+            &main.root_session_id
+        };
+        let side_root = if matches!(side.authority_identity, SessionAuthorityIdentity::Ordinary)
+            && side.root_session_id.is_empty()
+        {
+            id
+        } else {
+            &side.root_session_id
+        };
+        if main.id != id
+            || side.id != id
+            || main.kind != SessionKind::Root
+            || side.kind != SessionKind::Root
+            || main_root != id
+            || side_root != id
+            || main.parent_session_id.is_some()
+            || side.parent_session_id.is_some()
+            || main.spawn_depth != 0
+            || side.spawn_depth != 0
+            || main.authority_identity != side.authority_identity
+        {
+            return Err(invalid("canonical Root identity mismatch"));
+        }
+        side.root_session_id = id.to_string();
+        side.messages.clear();
+        side.clear_stale_root_token_budget();
+        Ok(Some(side))
+    }
+
+    /// The only code path allowed to assign Supervisor authority. The fixed ID
+    /// is protected by the same per-session file lock as ordinary writers.
+    pub(super) async fn bootstrap_default_supervisor(
+        &self,
+        initial_model: &str,
+    ) -> io::Result<SupervisorBootstrapReceipt> {
+        let _lifecycle = self.lock_session_lifecycle_shared().await?;
+        let _task = self.lock_runtime_task_sidecar_shared().await?;
+        let _session = self
+            .acquire_session_maintenance_lock(DEFAULT_SUPERVISOR_SESSION_ID)
+            .await?;
+        let existing = self
+            .load_root_authority_unchecked(DEFAULT_SUPERVISOR_SESSION_ID)
+            .await;
+        if existing.is_err() {
+            // A legacy Ordinary owner is a conflict even without a sidecar.
+            // This classification never repairs or grants authority, and the
+            // strict authority port still rejects the incomplete file pair.
+            let directory = self.sessions_dir.join(DEFAULT_SUPERVISOR_SESSION_ID);
+            if matches!(fs::symlink_metadata(directory.join(RUNTIME_SIDECAR_FILE)).await,
+                Err(error) if error.kind() == io::ErrorKind::NotFound)
+            {
+                if let Ok(bytes) = read_regular(&directory.join("session.json")).await {
+                    if let Ok(main) = serde_json::from_slice::<Session>(&bytes) {
+                        if main.id == DEFAULT_SUPERVISOR_SESSION_ID
+                            && main.kind == SessionKind::Root
+                            && main.parent_session_id.is_none()
+                            && main.spawn_depth == 0
+                            && (main.root_session_id.is_empty() || main.root_session_id == main.id)
+                            && main.authority_identity.is_ordinary()
+                        {
+                            return Err(io::Error::new(
+                                io::ErrorKind::AlreadyExists,
+                                "default Supervisor ID is occupied by a legacy Ordinary Session",
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(existing) = existing? {
+            let SessionAuthorityIdentity::Supervisor { incarnation_id } =
+                existing.authority_identity
+            else {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "default Supervisor ID is occupied by an Ordinary Session",
+                ));
+            };
+            // Authority is already strictly verified. The rebuildable index
+            // still needs the real transcript count, never the empty CP view.
+            let full = self
+                .load_authoritative_root_session(DEFAULT_SUPERVISOR_SESSION_ID)
+                .await?
+                .ok_or_else(|| invalid("published Supervisor disappeared"))?;
+            self.repair_index_from_authoritative_session(
+                &full,
+                Self::root_rel_path(DEFAULT_SUPERVISOR_SESSION_ID),
+            )
+            .await?;
+            return Ok(SupervisorBootstrapReceipt {
+                session_id: existing.id,
+                incarnation_id,
+                created: false,
+            });
+        }
+        if initial_model.trim().is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "a model is required to bootstrap the default Supervisor",
+            ));
+        }
+        let incarnation_id = Uuid::new_v4();
+        let mut session = Session::new(DEFAULT_SUPERVISOR_SESSION_ID, initial_model.trim());
+        session.title = "Supervisor".to_string();
+        session.title_generated = true;
+        session.authority_identity = SessionAuthorityIdentity::Supervisor { incarnation_id };
+        let staging = self
+            .bamboo_home_dir
+            .join(format!(".supervisor-bootstrap-{}", Uuid::new_v4()));
+        let destination = self.sessions_dir.join(DEFAULT_SUPERVISOR_SESSION_ID);
+        fs::create_dir(&staging).await?;
+        let result = async {
+            fs::create_dir(staging.join("children")).await?;
+            fs::create_dir(staging.join("attachments")).await?;
+            let bytes = serde_json::to_vec_pretty(&session)
+                .map_err(|error| other_io_error(error.to_string()))?;
+            durable_atomic_write(&staging.join("session.json"), &bytes).await?;
+            durable_atomic_write(&staging.join(RUNTIME_SIDECAR_FILE), &bytes).await?;
+            sync_directory(&staging).await?;
+            self.maybe_fail_supervisor_bootstrap(SupervisorBootstrapFault::BeforePublish)?;
+            atomic_rename(&staging, &destination).await?;
+            sync_parent_directory_entry(&staging).await?;
+            sync_parent_directory_entry(&destination).await?;
+            self.maybe_fail_supervisor_bootstrap(SupervisorBootstrapFault::BeforeIndex)?;
+            self.repair_index_from_authoritative_session(
+                &session,
+                Self::root_rel_path(DEFAULT_SUPERVISOR_SESSION_ID),
+            )
+            .await?;
+            Ok(SupervisorBootstrapReceipt {
+                session_id: session.id.clone(),
+                incarnation_id,
+                created: true,
+            })
+        }
+        .await;
+        if result.is_err() {
+            // Only this call's unpublished directory is removable. A complete
+            // published Root survives index failures and is repaired on retry.
+            let _ = fs::remove_dir_all(&staging).await;
+        }
+        result
+    }
+
+    fn maybe_fail_supervisor_bootstrap(&self, fault: SupervisorBootstrapFault) -> io::Result<()> {
+        #[cfg(test)]
+        {
+            let mut pending = self
+                .supervisor_bootstrap_fault
+                .lock()
+                .expect("supervisor fault lock");
+            if pending.as_ref() == Some(&fault) {
+                *pending = None;
+                return Err(other_io_error(format!(
+                    "injected Supervisor bootstrap failure: {fault:?}"
+                )));
+            }
+        }
+        #[cfg(not(test))]
+        let _ = fault;
+        Ok(())
+    }
+
+    /// Called inside the final cross-process write lock. Merging callers must
+    /// adopt durable authority in their own snapshot before entering this writer;
+    /// silently repairing only the serialized copy would leave their cache stale.
+    pub(super) async fn validate_authority_for_save(&self, incoming: &Session) -> io::Result<()> {
+        validate_identity(incoming).map_err(writer_conflict)?;
+        if incoming.id != DEFAULT_SUPERVISOR_SESSION_ID {
+            return Ok(());
+        }
+        let current = self
+            .load_root_authority_unchecked(&incoming.id)
+            .await
+            .map_err(writer_conflict)?;
+        match current {
+            Some(current) if current.authority_identity == incoming.authority_identity => Ok(()),
+            Some(_) => Err(writer_conflict(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "writer identity does not match the durable Session; reload before saving",
+            ))),
+            None if matches!(
+                incoming.authority_identity,
+                SessionAuthorityIdentity::Ordinary
+            ) =>
+            {
+                Ok(())
+            }
+            None => Err(writer_conflict(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "only trusted bootstrap can create Supervisor authority",
+            ))),
+        }
+    }
+}

--- a/crates/infra/bamboo-storage/src/v2/supervisor.rs
+++ b/crates/infra/bamboo-storage/src/v2/supervisor.rs
@@ -225,6 +225,27 @@ impl SessionStoreV2 {
                 created: false,
             });
         }
+        // The ID namespace also includes children. Only cold bootstrap scans
+        // their canonical placements; the rebuildable index cannot prove absence.
+        let mut roots = fs::read_dir(&self.sessions_dir).await?;
+        while let Some(root) = roots.next_entry().await? {
+            let kind = root.file_type().await?;
+            if kind.is_file() {
+                continue;
+            }
+            if !kind.is_dir() {
+                return Err(invalid("non-directory canonical Root placement"));
+            }
+            let children = root.path().join("children");
+            if real_directory(&children).await?
+                && real_directory(&children.join(DEFAULT_SUPERVISOR_SESSION_ID)).await?
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "default Supervisor ID is occupied by a Child placement",
+                ));
+            }
+        }
         if initial_model.trim().is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,

--- a/crates/infra/bamboo-storage/src/v2/supervisor_tests.rs
+++ b/crates/infra/bamboo-storage/src/v2/supervisor_tests.rs
@@ -181,6 +181,67 @@ async fn ordinary_reserved_id_is_a_conflict_and_cannot_be_promoted() {
 }
 
 #[tokio::test]
+async fn child_reserved_id_blocks_bootstrap_despite_missing_or_stale_index() {
+    for index_state in ["indexed", "missing", "stale"] {
+        let (store, home) = fixture().await;
+        let stale = SessionStoreV2::new(home.path().to_path_buf())
+            .await
+            .unwrap();
+        let root = Session::new("other-root", "model");
+        store.save_session(&root).await.unwrap();
+        let id = DEFAULT_SUPERVISOR_SESSION_ID;
+        let mut child = Session::new_child_of(id, &root, "model", "child");
+        child.add_message(Message::user("existing child history"));
+        store.save_session(&child).await.unwrap();
+        let control = store.load_runtime_control_plane(id).await.unwrap().unwrap();
+        assert_eq!(control.kind, SessionKind::Child);
+        assert!(control.authority_identity.is_ordinary());
+        assert!(control.messages.is_empty());
+        if index_state == "missing" {
+            store
+                .update_index(|index| {
+                    index.sessions.remove(id);
+                    Ok(())
+                })
+                .await
+                .unwrap();
+        }
+        let child_dir = store
+            .sessions_root_dir()
+            .join(&root.id)
+            .join("children")
+            .join(id);
+        let paths = [
+            child_dir.join("session.json"),
+            child_dir.join(RUNTIME_SIDECAR_FILE),
+            store.index_path().to_path_buf(),
+        ];
+        let mut before = Vec::new();
+        for path in &paths {
+            before.push(fs::read(path).await.unwrap());
+        }
+        let caller = if index_state == "stale" {
+            &stale
+        } else {
+            &store
+        };
+        assert_eq!(
+            caller
+                .get_or_create_default_supervisor("supervisor")
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::AlreadyExists,
+            "{index_state}"
+        );
+        for (path, expected) in paths.iter().zip(before) {
+            assert_eq!(fs::read(path).await.unwrap(), expected, "{index_state}");
+        }
+        assert!(!directory(&store).exists(), "{index_state}");
+    }
+}
+
+#[tokio::test]
 async fn ordinary_save_cannot_forge_supervisor_identity_on_new_or_existing_root() {
     for id in ["forged-supervisor", DEFAULT_SUPERVISOR_SESSION_ID] {
         let (store, _home) = fixture().await;

--- a/crates/infra/bamboo-storage/src/v2/supervisor_tests.rs
+++ b/crates/infra/bamboo-storage/src/v2/supervisor_tests.rs
@@ -1,0 +1,664 @@
+//! Trusted singleton identity, strict reads, and ordinary-writer regression tests.
+
+use super::*;
+use bamboo_domain::{
+    Message, SessionAuthorityConflict, SessionAuthorityIdentity, SessionPermissionMode,
+    SupervisorBootstrapReceipt, TaskItem, DEFAULT_SUPERVISOR_SESSION_ID,
+};
+use tempfile::TempDir;
+
+async fn fixture() -> (SessionStoreV2, TempDir) {
+    let home = tempfile::tempdir().unwrap();
+    let store = SessionStoreV2::new(home.path().to_path_buf())
+        .await
+        .unwrap();
+    (store, home)
+}
+
+fn directory(store: &SessionStoreV2) -> PathBuf {
+    store
+        .sessions_root_dir()
+        .join(DEFAULT_SUPERVISOR_SESSION_ID)
+}
+
+async fn bootstrap(store: &SessionStoreV2) -> SupervisorBootstrapReceipt {
+    store
+        .get_or_create_default_supervisor("initial-model")
+        .await
+        .unwrap()
+}
+
+async fn authority(store: &SessionStoreV2) -> Session {
+    store
+        .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap()
+}
+
+fn incarnation(session: &Session) -> Uuid {
+    match &session.authority_identity {
+        SessionAuthorityIdentity::Supervisor { incarnation_id } => *incarnation_id,
+        SessionAuthorityIdentity::Ordinary => panic!("expected trusted Supervisor identity"),
+    }
+}
+
+async fn files(store: &SessionStoreV2) -> (Vec<u8>, Vec<u8>) {
+    let path = directory(store);
+    (
+        fs::read(path.join("session.json")).await.unwrap(),
+        fs::read(path.join(RUNTIME_SIDECAR_FILE)).await.unwrap(),
+    )
+}
+
+async fn save(store: &SessionStoreV2, session: &Session, runtime: bool) -> io::Result<()> {
+    if runtime {
+        store.save_runtime_state(session).await
+    } else {
+        store.save_session(session).await
+    }
+}
+
+async fn reject_without_writes(store: &SessionStoreV2, candidate: &Session) {
+    let before = files(store).await;
+    for runtime in [false, true] {
+        let error = save(store, candidate, runtime).await.unwrap_err();
+        assert!(
+            error
+                .get_ref()
+                .is_some_and(|error| error.is::<SessionAuthorityConflict>()),
+            "runtime={runtime}"
+        );
+        assert_eq!(
+            files(store).await,
+            before,
+            "rejected writer changed authoritative files"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn independent_stores_bootstrap_one_incarnation_and_restart_reuses_it() {
+    let (first, home) = fixture().await;
+    let second = SessionStoreV2::new(home.path().to_path_buf())
+        .await
+        .unwrap();
+    let (a, b) = tokio::join!(
+        first.get_or_create_default_supervisor("model-a"),
+        second.get_or_create_default_supervisor("model-b"),
+    );
+    let (a, b) = (a.unwrap(), b.unwrap());
+    assert_eq!(a.session_id, DEFAULT_SUPERVISOR_SESSION_ID);
+    assert_eq!(b.session_id, a.session_id);
+    assert_eq!(a.incarnation_id, b.incarnation_id);
+    assert_ne!(
+        a.created, b.created,
+        "exactly one caller created the singleton"
+    );
+    let current = authority(&first).await;
+    assert_eq!(current.kind, SessionKind::Root);
+    assert_eq!(current.root_session_id, DEFAULT_SUPERVISOR_SESSION_ID);
+    assert!(current.parent_session_id.is_none());
+    assert_eq!(current.spawn_depth, 0);
+    assert!(current.project_id_meta().is_none());
+    assert!(current.messages.is_empty());
+    assert!(matches!(current.model.as_str(), "model-a" | "model-b"));
+    let before = files(&first).await;
+    let restarted = SessionStoreV2::new(home.path().to_path_buf())
+        .await
+        .unwrap();
+    let replay = restarted
+        .get_or_create_default_supervisor("ignored-new-model")
+        .await
+        .unwrap();
+    assert!(!replay.created);
+    assert_eq!(replay.incarnation_id, a.incarnation_id);
+    assert_eq!(incarnation(&authority(&restarted).await), a.incarnation_id);
+    assert_eq!(
+        files(&restarted).await,
+        before,
+        "replay overwrote creation defaults"
+    );
+    assert!(restarted
+        .get_index_entry(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .is_some());
+}
+
+#[tokio::test]
+async fn ordinary_reserved_id_is_a_conflict_and_cannot_be_promoted() {
+    let (store, _home) = fixture().await;
+    let mut ordinary = Session::new(DEFAULT_SUPERVISOR_SESSION_ID, "ordinary-model");
+    ordinary.add_message(Message::user("caller-owned history"));
+    ordinary.set_project_id_meta("original-project");
+    store.save_session(&ordinary).await.unwrap();
+    let before = files(&store).await;
+    assert_eq!(
+        store
+            .get_or_create_default_supervisor("requested-model")
+            .await
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::AlreadyExists
+    );
+    assert_eq!(files(&store).await, before);
+    let persisted = store
+        .load_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        persisted.authority_identity,
+        SessionAuthorityIdentity::Ordinary
+    );
+    assert_eq!(
+        persisted.project_id_meta().as_deref(),
+        Some("original-project")
+    );
+    assert_eq!(persisted.messages[0].content, "caller-owned history");
+    fs::remove_file(directory(&store).join(RUNTIME_SIDECAR_FILE))
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_or_create_default_supervisor("requested-model")
+            .await
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::AlreadyExists
+    );
+    assert!(store
+        .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .is_err());
+    assert_eq!(
+        fs::read(directory(&store).join("session.json"))
+            .await
+            .unwrap(),
+        before.0
+    );
+    assert!(!directory(&store).join(RUNTIME_SIDECAR_FILE).exists());
+}
+
+#[tokio::test]
+async fn ordinary_save_cannot_forge_supervisor_identity_on_new_or_existing_root() {
+    for id in ["forged-supervisor", DEFAULT_SUPERVISOR_SESSION_ID] {
+        let (store, _home) = fixture().await;
+        let mut candidate = Session::new(id, "model");
+        candidate.authority_identity = SessionAuthorityIdentity::Supervisor {
+            incarnation_id: Uuid::new_v4(),
+        };
+        for runtime in [false, true] {
+            assert!(save(&store, &candidate, runtime).await.is_err());
+            assert!(!store.sessions_root_dir().join(id).exists());
+            assert!(store.get_index_entry(id).await.is_none());
+        }
+    }
+    let (store, _home) = fixture().await;
+    let mut existing = Session::new("existing-ordinary", "model");
+    store.save_session(&existing).await.unwrap();
+    let path = store.sessions_root_dir().join(&existing.id);
+    let before = fs::read(path.join(RUNTIME_SIDECAR_FILE)).await.unwrap();
+    existing.authority_identity = SessionAuthorityIdentity::Supervisor {
+        incarnation_id: Uuid::new_v4(),
+    };
+    for runtime in [false, true] {
+        assert!(save(&store, &existing, runtime).await.is_err());
+        assert_eq!(
+            fs::read(path.join(RUNTIME_SIDECAR_FILE)).await.unwrap(),
+            before
+        );
+    }
+}
+
+#[tokio::test]
+async fn strict_authority_rejects_missing_corrupt_and_mismatched_sidecars() {
+    for fault in [
+        "missing",
+        "corrupt",
+        "id",
+        "root",
+        "kind",
+        "incarnation",
+        "ordinary",
+    ] {
+        let (store, _home) = fixture().await;
+        bootstrap(&store).await;
+        let path = directory(&store).join(RUNTIME_SIDECAR_FILE);
+        let original_main = fs::read(directory(&store).join("session.json"))
+            .await
+            .unwrap();
+        match fault {
+            "missing" => fs::remove_file(&path).await.unwrap(),
+            "corrupt" => fs::write(&path, b"not valid runtime JSON").await.unwrap(),
+            _ => {
+                let mut sidecar: serde_json::Value =
+                    serde_json::from_slice(&fs::read(&path).await.unwrap()).unwrap();
+                match fault {
+                    "id" => sidecar["id"] = serde_json::json!("different-root"),
+                    "root" => sidecar["root_session_id"] = serde_json::json!("different-root"),
+                    "kind" => sidecar["kind"] = serde_json::json!("child"),
+                    "incarnation" => {
+                        sidecar["authority_identity"]["incarnation_id"] =
+                            serde_json::json!(Uuid::new_v4())
+                    }
+                    "ordinary" => {
+                        sidecar["authority_identity"] = serde_json::json!({"kind":"ordinary"})
+                    }
+                    _ => unreachable!(),
+                }
+                fs::write(&path, serde_json::to_vec(&sidecar).unwrap())
+                    .await
+                    .unwrap();
+            }
+        }
+        assert!(
+            store
+                .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+                .await
+                .is_err(),
+            "{fault}"
+        );
+        assert!(
+            store
+                .get_or_create_default_supervisor("replacement-model")
+                .await
+                .is_err(),
+            "{fault}"
+        );
+        assert_eq!(
+            fs::read(directory(&store).join("session.json"))
+                .await
+                .unwrap(),
+            original_main
+        );
+    }
+}
+
+#[tokio::test]
+async fn strict_reads_distinguish_absence_from_legacy_compatibility_fallback() {
+    let (store, _home) = fixture().await;
+    assert!(store
+        .load_root_authority("absent-root")
+        .await
+        .unwrap()
+        .is_none());
+    let mut legacy = Session::new("legacy-root", "legacy-model");
+    legacy.add_message(Message::user("legacy transcript stays available"));
+    store.save_session(&legacy).await.unwrap();
+    let path = store
+        .sessions_root_dir()
+        .join(&legacy.id)
+        .join(RUNTIME_SIDECAR_FILE);
+    fs::remove_file(&path).await.unwrap();
+    assert!(store.load_root_authority(&legacy.id).await.is_err());
+    let compatible = store
+        .load_runtime_control_plane(&legacy.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        compatible.authority_identity,
+        SessionAuthorityIdentity::Ordinary
+    );
+    assert_eq!(compatible.model, "legacy-model");
+    assert_eq!(
+        store
+            .load_session(&legacy.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .messages
+            .len(),
+        1
+    );
+    assert_eq!(store.migrate_runtime_sidecars().await.unwrap(), 1);
+    assert_eq!(
+        store
+            .load_root_authority(&legacy.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .authority_identity,
+        SessionAuthorityIdentity::Ordinary
+    );
+}
+
+#[tokio::test]
+async fn strict_authority_reads_identity_without_deserializing_full_conversation() {
+    let (store, _home) = fixture().await;
+    let receipt = bootstrap(&store).await;
+    let path = directory(&store).join("session.json");
+    let mut main: serde_json::Value =
+        serde_json::from_slice(&fs::read(&path).await.unwrap()).unwrap();
+    main["messages"] = serde_json::json!({"invalid": "transcript shape"});
+    fs::write(&path, serde_json::to_vec(&main).unwrap())
+        .await
+        .unwrap();
+    assert!(store
+        .load_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .is_err());
+    let current = authority(&store).await;
+    assert_eq!(incarnation(&current), receipt.incarnation_id);
+    assert!(current.messages.is_empty());
+}
+
+#[tokio::test]
+async fn raw_ordinary_writers_must_reload_authority_before_saving_supervisor() {
+    let (store, _home) = fixture().await;
+    let receipt = bootstrap(&store).await;
+    let mut stale = store
+        .load_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    stale.authority_identity = SessionAuthorityIdentity::Ordinary;
+    stale.add_message(Message::user("unbound writer history"));
+    stale.set_last_run_status("running");
+    reject_without_writes(&store, &stale).await;
+    assert!(stale.authority_identity.is_ordinary());
+    assert_eq!(
+        incarnation(&authority(&store).await),
+        receipt.incarnation_id
+    );
+}
+
+#[tokio::test]
+async fn wrong_incarnation_full_and_runtime_writers_fail_without_mutating_files() {
+    let (store, _home) = fixture().await;
+    bootstrap(&store).await;
+    let mut candidate = store
+        .load_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    candidate.authority_identity = SessionAuthorityIdentity::Supervisor {
+        incarnation_id: Uuid::new_v4(),
+    };
+    candidate.add_message(Message::user("must not enter current history"));
+    candidate.set_last_run_status("cancelled");
+    reject_without_writes(&store, &candidate).await;
+    candidate.spawn_depth = 1;
+    reject_without_writes(&store, &candidate).await;
+}
+
+#[tokio::test]
+async fn deleted_and_recreated_supervisor_rejects_the_previous_incarnation_history() {
+    let (store, _home) = fixture().await;
+    let first = bootstrap(&store).await;
+    let mut old = store
+        .load_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    old.add_message(Message::user("old incarnation history"));
+    store.save_session(&old).await.unwrap();
+    assert!(store
+        .delete_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap());
+    let second = bootstrap(&store).await;
+    assert!(second.created);
+    assert_ne!(second.incarnation_id, first.incarnation_id);
+    reject_without_writes(&store, &old).await;
+    assert!(store
+        .load_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap()
+        .messages
+        .is_empty());
+}
+
+#[tokio::test]
+async fn copying_supervisor_preserves_conversation_context_but_creates_ordinary_root() {
+    let (store, _home) = fixture().await;
+    let receipt = bootstrap(&store).await;
+    let mut source = store
+        .load_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    source.title = "Coordinator discussion".into();
+    source.set_project_id_meta("project-original");
+    source.set_workspace_path_meta("/workspace/original");
+    source.agent_runtime_state = Some(bamboo_domain::AgentRuntimeState::default());
+    source
+        .agent_runtime_state
+        .as_mut()
+        .unwrap()
+        .set_permission_mode(SessionPermissionMode::Auto);
+    source.add_message(Message::system("Preserved system context"));
+    source.add_message(Message::user("Preserved user context"));
+    store.save_session(&source).await.unwrap();
+    let before = files(&store).await;
+    let copied = store
+        .copy_session(&source.id, "ordinary-copy")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        copied.authority_identity,
+        SessionAuthorityIdentity::Ordinary
+    );
+    assert_eq!(copied.kind, SessionKind::Root);
+    assert_eq!(copied.root_session_id, "ordinary-copy");
+    assert!(copied.parent_session_id.is_none());
+    assert_eq!(copied.project_id_meta(), source.project_id_meta());
+    assert_eq!(copied.workspace_path_meta(), source.workspace_path_meta());
+    assert_eq!(copied.model, source.model);
+    assert_eq!(copied.messages.len(), source.messages.len());
+    for (copied, original) in copied.messages.iter().zip(&source.messages) {
+        assert_eq!(copied.content, original.content);
+    }
+    assert_eq!(
+        copied
+            .agent_runtime_state
+            .unwrap()
+            .effective_permission_mode(),
+        SessionPermissionMode::Auto
+    );
+    assert_eq!(files(&store).await, before);
+    assert_eq!(
+        incarnation(&authority(&store).await),
+        receipt.incarnation_id
+    );
+}
+
+#[tokio::test]
+async fn legacy_sidecar_migration_cannot_recreate_missing_supervisor_authority() {
+    let (store, _home) = fixture().await;
+    bootstrap(&store).await;
+    let path = directory(&store).join(RUNTIME_SIDECAR_FILE);
+    fs::remove_file(&path).await.unwrap();
+    let before = fs::read(directory(&store).join("session.json"))
+        .await
+        .unwrap();
+    // Skipping or explicitly failing is safe; restoring authority from the
+    // conversation snapshot would resurrect a non-authoritative identity.
+    let _ = store.migrate_runtime_sidecars().await;
+    assert!(!path.exists());
+    assert!(store
+        .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .is_err());
+    assert_eq!(
+        fs::read(directory(&store).join("session.json"))
+            .await
+            .unwrap(),
+        before
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_failure_before_publish_leaves_no_final_identity_and_can_retry() {
+    let (store, _home) = fixture().await;
+    *store.supervisor_bootstrap_fault.lock().unwrap() =
+        Some(supervisor::SupervisorBootstrapFault::BeforePublish);
+    assert!(store
+        .get_or_create_default_supervisor("model")
+        .await
+        .is_err());
+    assert!(!directory(&store).exists());
+    assert!(store
+        .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .get_index_entry(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .is_none());
+    assert!(bootstrap(&store).await.created);
+}
+
+#[tokio::test]
+async fn bootstrap_failure_before_index_keeps_complete_identity_and_retry_repairs_index() {
+    let (store, home) = fixture().await;
+    *store.supervisor_bootstrap_fault.lock().unwrap() =
+        Some(supervisor::SupervisorBootstrapFault::BeforeIndex);
+    assert!(store
+        .get_or_create_default_supervisor("first-model")
+        .await
+        .is_err());
+    let current = authority(&store).await;
+    let original_incarnation = incarnation(&current);
+    assert_eq!(current.model, "first-model");
+    assert!(store
+        .get_index_entry(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .is_none());
+    let before = files(&store).await;
+    let restarted = SessionStoreV2::new(home.path().to_path_buf())
+        .await
+        .unwrap();
+    let result = restarted
+        .get_or_create_default_supervisor("ignored-model")
+        .await
+        .unwrap();
+    assert!(!result.created);
+    assert_eq!(result.incarnation_id, original_incarnation);
+    assert_eq!(files(&restarted).await, before);
+    assert!(restarted
+        .get_index_entry(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .is_some());
+}
+
+fn task_seed(mut session: Session) -> Session {
+    session.task_list = Some(TaskList {
+        session_id: session.id.clone(),
+        title: "One task".into(),
+        items: vec![TaskItem {
+            id: "task-1".into(),
+            description: "Original task".into(),
+            ..Default::default()
+        }],
+        created_at: session.created_at,
+        updated_at: session.updated_at,
+    });
+    session.set_task_list_version_meta("1");
+    session
+}
+
+#[tokio::test]
+async fn broken_authority_cannot_be_recovered_by_ordinary_lifecycle_or_task_operations() {
+    for missing in [true, false] {
+        let (store, _home) = fixture().await;
+        let id = DEFAULT_SUPERVISOR_SESSION_ID;
+        bootstrap(&store).await;
+        let original = task_seed(authority(&store).await);
+        store.save_session(&original).await.unwrap();
+        let mut updated = original.clone();
+        updated.task_list.as_mut().unwrap().items[0].description = "Changed task".into();
+        updated.set_task_list_version_meta("2");
+        let sidecar = directory(&store).join(RUNTIME_SIDECAR_FILE);
+        if missing {
+            fs::remove_file(&sidecar).await.unwrap();
+        } else {
+            fs::write(&sidecar, b"corrupt runtime authority")
+                .await
+                .unwrap();
+        }
+        let main_before = fs::read(directory(&store).join("session.json"))
+            .await
+            .unwrap();
+        let side_before = fs::read(&sidecar).await.ok();
+        for runtime in [false, true] {
+            let error = save(&store, &original, runtime).await.unwrap_err();
+            assert!(error
+                .get_ref()
+                .is_some_and(|error| error.is::<SessionAuthorityConflict>()));
+        }
+        assert!(store.load_session(id).await.is_err());
+        assert!(store.load_runtime_control_plane(id).await.is_err());
+        assert!(store.clear_session(id).await.is_err());
+        assert!(store.copy_session(id, "bypass-copy").await.is_err());
+        assert!(store.recover_root_session_from_disk(id).await.is_err());
+        assert!(store
+            .save_task_control_plane_if_matches(&original, &updated)
+            .await
+            .is_err());
+        assert_eq!(fs::read(&sidecar).await.ok(), side_before);
+        assert_eq!(
+            fs::read(directory(&store).join("session.json"))
+                .await
+                .unwrap(),
+            main_before
+        );
+        assert!(!store.sessions_root_dir().join("bypass-copy").exists());
+    }
+}
+
+#[tokio::test]
+async fn bootstrap_replay_and_index_repair_preserve_existing_message_count() {
+    let (store, _home) = fixture().await;
+    let id = DEFAULT_SUPERVISOR_SESSION_ID;
+    bootstrap(&store).await;
+    let mut session = authority(&store).await;
+    for index in 0..3 {
+        session.add_message(Message::user(format!("history {index}")));
+    }
+    store.save_session(&session).await.unwrap();
+    let before = files(&store).await;
+    for remove_index in [false, true] {
+        if remove_index {
+            store
+                .update_index(|index| {
+                    index.sessions.remove(id);
+                    Ok(())
+                })
+                .await
+                .unwrap();
+        }
+        assert!(!bootstrap(&store).await.created);
+        assert_eq!(store.get_index_entry(id).await.unwrap().message_count, 3);
+        assert_eq!(files(&store).await, before);
+    }
+}
+
+#[tokio::test]
+async fn task_cas_rejects_old_incarnation_despite_matching_task_shape_and_generation() {
+    let (store, _home) = fixture().await;
+    let id = DEFAULT_SUPERVISOR_SESSION_ID;
+    bootstrap(&store).await;
+    let original = task_seed(authority(&store).await);
+    store.save_session(&original).await.unwrap();
+    assert!(store.delete_session(id).await.unwrap());
+    bootstrap(&store).await;
+    let mut replacement = authority(&store).await;
+    replacement.task_list = original.task_list.clone();
+    replacement.set_task_list_version_meta("1");
+    store.save_session(&replacement).await.unwrap();
+    assert_ne!(incarnation(&replacement), incarnation(&original));
+    let mut updated = original.clone();
+    updated.task_list.as_mut().unwrap().items[0].description = "Stale task result".into();
+    updated.set_task_list_version_meta("2");
+    let before = files(&store).await;
+    assert!(!store
+        .save_task_control_plane_if_matches(&original, &updated)
+        .await
+        .unwrap());
+    assert_eq!(files(&store).await, before);
+}

--- a/docs/supervisor-identity.md
+++ b/docs/supervisor-identity.md
@@ -1,0 +1,76 @@
+# Trusted default Supervisor identity
+
+Bamboo provides a host/SDK bootstrap service for one stable Supervisor Root in
+each local data domain. It establishes identity; management links and control
+of other Roots are separate capabilities tracked by #1071 and #1051–#1058.
+
+```rust,no_run
+use bamboo_sdk::Agent;
+
+async fn supervisor(agent: &Agent) -> std::io::Result<()> {
+    let identity = agent.supervisor_sessions()
+        .get_or_create_default("configured-model")
+        .await?;
+    println!("{} {}", identity.session_id, identity.incarnation_id);
+    Ok(())
+}
+```
+
+Hosts can also construct `SupervisorSessionService::new(agent.storage().clone())`.
+Both entry points use the same canonical Storage port. Bootstrap does not call
+the model, launch an agent, inherit the SDK's Project/workspace, or replace a
+Session cache entry. `initial_model` is used on first creation only; repeat calls
+preserve the existing model, history and other context.
+
+The receipt contains only `session_id`, `incarnation_id` and `created`. Keep the
+incarnation with the ID: explicitly deleting and recreating the default Root
+produces a new incarnation. A receipt is an observation, not a transferable
+grant to inspect or control another Session.
+
+`Session.authority_identity` is a typed `Ordinary` or
+`Supervisor { incarnation_id }` value, separate from Root/Child kind and raw
+metadata. Old serialized sessions default to Ordinary. Normal create, Chat,
+metadata PATCH and all Child constructors do not assign authority. Copies are
+Ordinary Roots; workers, residents, Guardians and nested children remain Ordinary.
+
+The reserved ID is `bamboo-default-supervisor`; possession of this string is
+not authority. If an ordinary Session already occupies it, bootstrap returns an
+explicit conflict and preserves that Session. The host must resolve that
+conflict through its normal Session management policy; bootstrap never promotes
+or deletes the existing conversation.
+
+The V2 implementation publishes a complete `session.json`/`runtime.json` pair
+through one staged-directory publication. Existing lifecycle, Task and per-Session
+cross-process locks serialize it with ordinary writers. The session index remains
+rebuildable; a complete published identity can repair its missing index entry.
+There is no second identity registry, singleton pointer or recovery journal.
+
+`Storage::load_root_authority` is the strict Root control-plane port. It returns
+no messages and must never be used to replace a full conversation in a cache.
+Absent and damaged published state are distinct: missing/corrupt/mismatched
+Supervisor authority fails closed, including during repair and writeback. It
+does not recover authority from an older `session.json` when the runtime sidecar
+is unavailable. Pair validation still reads the canonical main file's bytes;
+the control-plane return type does not promise partial or constant-size disk I/O.
+Generic Ordinary-session compatibility reads retain their
+existing fallback behavior. Unsupported Storage implementations return
+`ErrorKind::Unsupported` for both new ports, without ordinary load/save fallback.
+
+Merge/save adopts durable identity into an Ordinary snapshot of the same Root
+(matching creation time) before committing; it does not rebind a different Root.
+The final full/runtime writer rejects mismatching identities with a typed
+`SessionAuthorityConflict`; it never silently substitutes identity in an internal
+copy. This also rejects an explicit different Supervisor incarnation, so a
+snapshot from a deleted incarnation cannot overwrite a recreated Root. If
+bootstrap wins a concurrent first save, that stale save fails without publishing
+its rejected identity to a cache. Unrelated I/O failures keep their existing
+runtime publication behavior. Task writes, migration, clear, copy and recovery
+must respect the same authority integrity boundary.
+
+This API is for trusted in-process hosts. It is not a model-callable bootstrap
+tool or a new HTTP route. It does not provide a Project allowlist, management
+relationships, cross-Root reads, followups, cancellation, Tracker subscriptions
+or Plan delegation. Those operations must use their subsequent trusted authority
+checks; neither raw metadata, cached role labels nor a bootstrap receipt replaces
+them. Like the existing Session store, this is not an OS sandbox against arbitrary
+modification of the data directory by the same operating-system user.

--- a/docs/supervisor-identity.md
+++ b/docs/supervisor-identity.md
@@ -39,6 +39,10 @@ explicit conflict and preserves that Session. The host must resolve that
 conflict through its normal Session management policy; bootstrap never promotes
 or deletes the existing conversation.
 
+Cold bootstrap also checks canonical child placements on disk, so a missing or
+stale index cannot make an occupied child ID available. This scans Root directories
+only when no default Supervisor Root exists; ordinary repeat calls avoid the scan.
+
 The V2 implementation publishes a complete `session.json`/`runtime.json` pair
 through one staged-directory publication. Existing lifecycle, Task and per-Session
 cross-process locks serialize it with ordinary writers. The session index remains
@@ -52,8 +56,8 @@ Supervisor authority fails closed, including during repair and writeback. It
 does not recover authority from an older `session.json` when the runtime sidecar
 is unavailable. Pair validation still reads the canonical main file's bytes;
 the control-plane return type does not promise partial or constant-size disk I/O.
-Generic Ordinary-session compatibility reads retain their
-existing fallback behavior. Unsupported Storage implementations return
+Ordinary sessions outside the reserved Root keep their existing compatibility
+reads. Unsupported Storage implementations return
 `ErrorKind::Unsupported` for both new ports, without ordinary load/save fallback.
 
 Merge/save adopts durable identity into an Ordinary snapshot of the same Root


### PR DESCRIPTION
## Summary

Hosts can now obtain one durable default Supervisor Root through `Agent::supervisor_sessions().get_or_create_default(initial_model)`. Independent V2 instances and restarts return the same typed identity and incarnation; the compact receipt does not replace conversation history in a cache.

The reserved ID alone grants no authority. Bootstrap atomically publishes the canonical Session/runtime pair, repairs only a valid Root's rebuildable index, and refuses an existing Ordinary owner or damaged published authority. Final full/runtime writers reject identity conflicts, old incarnations and damaged authority under the existing cross-process Session lock. Merge and parent-resume cache publication cannot publish those rejected snapshots. Copies and all child constructors remain Ordinary. Cold bootstrap checks canonical child placements independently of the index, so an existing Child cannot lose its global ID to a new Supervisor; its ordinary runtime lookup remains available.

This is the identity slice of #1048. Management links, cross-root export/control, subscriptions, Tracker, Plan integration and UI remain separate issues. No new registry, journal, broker or model-callable bootstrap entry point is introduced. Strict reads omit history from their result but still read canonical main-file bytes; they do not promise constant-size disk I/O.

Closes #1050.

## Test Plan

- Deterministic tests cover independent-store bootstrap/restart, staged publication failure and index recovery, Ordinary reserved-ID conflicts, strict authority corruption, stale full/runtime writes, deletion/recreation, Task CAS/recovery, copy stripping, and merge/cache races.
- Actual service tests exercise successful HTTP create/PATCH/implicit Chat and the real SubAgent resident create/reset/accumulate path with one canonical V2 store. Guardian role coverage is through shared child construction, not a separate GuardianSpawner integration test.
- SDK consumer test builds an Agent and checks bootstrap receipts, model and persisted history preservation. Unsupported backends fail through the dedicated ports.
- Current head is `00a46481e85d4744b3b9c2f2171d3c2e28e65844` on dev `4307d5a6ac5b5f0cb531f359a614c360a2c3ab35`. Local validation passed on this exact head: the full all-features Storage library (195 tests), SDK bootstrap integration (1), engine Supervisor tests (2), server Supervisor tests (6), formatting, exact CI Clippy and example builds. Independent integration review and required Test, E2E Tests and Lint passed on this exact head. Test attempt 3 passed both all-features and default configurations, real SSH/SFTP transport and example builds; Rust CodeQL and platform-specific checks also passed.
- The Supervisor patch is unchanged across both upstream updates (stable patch-id `db8bb9f5c8d7d6ab71584f5fe13617fdf02eda9c`). Prior intermittent lifecycle failures are tracked by #878; the account-feed test synchronization gap is tracked separately by #1082. Their source and assertions were not changed by this PR, and the current-head required Test job passed on retry.
- Security Audit reports the unchanged yanked `wnaf 0.14.0` dependency tracked by #1061. Cargo.lock and dependencies are unchanged; this check is not a required dev protection gate.

## Review scope

Independent review passed on exact head `00a46481e85d4744b3b9c2f2171d3c2e28e65844`. It confirmed the 19 feature blobs remain identical after both upstream updates, and the derived metrics/search stores cannot grant identity or write back Session authority.

One backend acceptance path, 13 production files plus tests/documentation. Review found a final-writer/cache identity race; the candidate rejects conflicting commits and suppresses only authority-error publication, including parent completion/resume and execution finalization. Normal runtime I/O failure behavior is preserved. A final acceptance review also found the reserved Child-ID collision; the final candidate narrows bootstrap to reject occupied placements without changing files or indexes.

No UI change; screenshots are not applicable.
