### PR TITLE
fix: reclaim metrics collector tasks after final owner drop (#1079)

### DIFF
--- a/crates/infra/bamboo-metrics/src/collector.rs
+++ b/crates/infra/bamboo-metrics/src/collector.rs
@@ -85,15 +85,30 @@ enum CollectorCommand {
     },
 }
 
+// Shared only by external collector clones. The scheduler itself holds no
+// owner reference, so dropping the last clone cancels its timer without a cycle.
+struct PruneScheduler {
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for PruneScheduler {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
 #[derive(Clone)]
 pub struct MetricsCollector {
     tx: mpsc::UnboundedSender<CollectorCommand>,
+    _scheduler: Arc<PruneScheduler>,
 }
 
 impl MetricsCollector {
     pub fn spawn(storage: Arc<dyn MetricsStorage>, retention_days: u32) -> Self {
         let (tx, mut rx) = mpsc::unbounded_channel::<CollectorCommand>();
 
+        // Do not abort the consumer on owner release: closing the producers
+        // lets it finish initialization and drain accepted commands in order.
         tokio::spawn(async move {
             if let Err(error) = storage.init().await {
                 tracing::error!("metrics storage initialization failed: {}", error);
@@ -256,9 +271,11 @@ impl MetricsCollector {
             }
         });
 
-        let collector = Self { tx };
-        collector.schedule_prune(retention_days);
-        collector
+        let scheduler = Self::schedule_prune(tx.downgrade(), retention_days);
+        Self {
+            tx,
+            _scheduler: Arc::new(scheduler),
+        }
     }
 
     pub fn session_started(
@@ -476,15 +493,210 @@ impl MetricsCollector {
         });
     }
 
-    fn schedule_prune(&self, retention_days: u32) {
-        let tx = self.tx.clone();
-        tokio::spawn(async move {
+    fn schedule_prune(
+        sender: mpsc::WeakUnboundedSender<CollectorCommand>,
+        retention_days: u32,
+    ) -> PruneScheduler {
+        let task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(6 * 60 * 60));
             loop {
                 interval.tick().await;
+                // This temporary producer is dropped before the next timer
+                // wait, allowing the consumer to close after external owners go.
+                let Some(tx) = sender.upgrade() else {
+                    break;
+                };
                 let cutoff = Utc::now() - Duration::days(i64::from(retention_days));
-                let _ = tx.send(CollectorCommand::Prune { cutoff });
+                if tx.send(CollectorCommand::Prune { cutoff }).is_err() {
+                    break;
+                }
             }
         });
+        PruneScheduler { task }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Weak;
+    use std::time::Duration as StdDuration;
+
+    use crate::storage::SqliteMetricsStorage;
+
+    use super::*;
+
+    async fn wait_for_reclaimed(
+        storage: &Weak<SqliteMetricsStorage>,
+        scheduler: &tokio::task::AbortHandle,
+    ) {
+        tokio::time::timeout(StdDuration::from_secs(5), async {
+            while storage.strong_count() != 0 || !scheduler.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("collector should drain accepted commands and reclaim its tasks and storage");
+        assert!(scheduler.is_finished());
+        assert!(storage.upgrade().is_none());
+    }
+
+    #[tokio::test]
+    async fn final_owner_drop_before_initialization_drains_normal_and_prune_commands_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metrics.db");
+        let storage = Arc::new(SqliteMetricsStorage::new(&path));
+        let storage_weak = Arc::downgrade(&storage);
+        let collector = MetricsCollector::spawn(storage, 90);
+        let scheduler = collector._scheduler.task.abort_handle();
+        let now = Utc::now();
+        let old = now - Duration::days(40);
+
+        // This current-thread test does not yield until after the final drop:
+        // initialization is still pending and all these commands are queued.
+        collector.session_started("drain", "model", old);
+        collector.round_started("old-round", "drain", "model", old);
+        collector.round_completed(
+            "old-round",
+            old,
+            RoundStatus::Success,
+            TokenUsage {
+                prompt_tokens: 6,
+                completion_tokens: 4,
+                total_tokens: 10,
+            },
+            0,
+            0,
+            None,
+        );
+        collector
+            .tx
+            .send(CollectorCommand::Prune {
+                cutoff: now - Duration::days(30),
+            })
+            .unwrap();
+        collector.session_message_count("drain", 1, now);
+        collector.round_started("new-round", "drain", "model", now);
+        collector.round_completed(
+            "new-round",
+            now,
+            RoundStatus::Success,
+            TokenUsage {
+                prompt_tokens: 12,
+                completion_tokens: 8,
+                total_tokens: 20,
+            },
+            0,
+            0,
+            None,
+        );
+        collector.session_message_count("drain", 42, now);
+        collector.session_completed("drain", SessionStatus::Completed, now);
+        drop(collector);
+
+        wait_for_reclaimed(&storage_weak, &scheduler).await;
+        // Reopen without initializing: the drained consumer had to create the
+        // schema and persist the complete FIFO sequence before releasing it.
+        let reopened = SqliteMetricsStorage::new(&path);
+        let detail = reopened.session_detail("drain").await.unwrap().unwrap();
+        assert_eq!(detail.rounds.len(), 1);
+        assert_eq!(detail.rounds[0].round_id, "new-round");
+        assert_eq!(detail.rounds[0].status, RoundStatus::Success);
+        assert_eq!(detail.session.total_rounds, 1);
+        assert_eq!(detail.session.total_token_usage.total_tokens, 20);
+        assert_eq!(detail.session.message_count, 42);
+        assert_eq!(detail.session.status, SessionStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn remaining_clone_keeps_collection_and_periodic_retention_alive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metrics.db");
+        let storage = Arc::new(SqliteMetricsStorage::new(&path));
+        storage.init().await.unwrap();
+        let now = Utc::now();
+        let old = now - Duration::days(100);
+        storage
+            .upsert_session_start("stale", "model", old)
+            .await
+            .unwrap();
+        storage
+            .insert_round_start("stale-round", "stale", "model", old)
+            .await
+            .unwrap();
+
+        let storage_weak = Arc::downgrade(&storage);
+        let collector = MetricsCollector::spawn(storage.clone(), 90);
+        let remaining = collector.clone();
+        let scheduler = collector._scheduler.task.abort_handle();
+        drop(collector);
+        remaining.session_started("kept", "model", now);
+        remaining.session_message_count("kept", 23, now);
+
+        // The interval's first tick is immediate, so observing its real prune
+        // needs no clock manipulation or six-hour delay.
+        tokio::time::timeout(StdDuration::from_secs(5), async {
+            loop {
+                let stale = storage.session_detail("stale").await.unwrap().unwrap();
+                let kept = storage.session_detail("kept").await.unwrap();
+                if stale.rounds.is_empty()
+                    && kept.is_some_and(|detail| detail.session.message_count == 23)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("remaining collector clone should accept events and retain its scheduler");
+        assert!(!scheduler.is_finished());
+        assert_eq!(remaining.tx.strong_count(), 1);
+
+        drop(storage);
+        drop(remaining);
+        wait_for_reclaimed(&storage_weak, &scheduler).await;
+    }
+
+    #[tokio::test]
+    async fn repeated_collectors_in_one_runtime_release_storage_and_scheduler() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metrics.db");
+        for iteration in 0..32 {
+            let storage = Arc::new(SqliteMetricsStorage::new(&path));
+            let storage_weak = Arc::downgrade(&storage);
+            let collector = MetricsCollector::spawn(storage, 90);
+            let scheduler = collector._scheduler.task.abort_handle();
+            let session_id = format!("session-{iteration}");
+            collector.session_started(&session_id, "model", Utc::now());
+            collector.session_message_count(&session_id, iteration + 1, Utc::now());
+            drop(collector);
+
+            wait_for_reclaimed(&storage_weak, &scheduler).await;
+        }
+
+        let reopened = SqliteMetricsStorage::new(&path);
+        for iteration in 0..32 {
+            let detail = reopened
+                .session_detail(&format!("session-{iteration}"))
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(detail.session.message_count, iteration + 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn scheduler_stops_on_closed_receiver_while_producer_survives() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let scheduler = MetricsCollector::schedule_prune(tx.downgrade(), 90);
+        drop(rx);
+
+        tokio::time::timeout(StdDuration::from_secs(5), async {
+            while !scheduler.task.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("failed prune admission should terminate the scheduler");
+        assert_eq!(tx.strong_count(), 1);
     }
 }

--- a/crates/infra/bamboo-metrics/src/collector.rs
+++ b/crates/infra/bamboo-metrics/src/collector.rs
@@ -109,7 +109,7 @@ impl MetricsCollector {
 
         // Do not abort the consumer on owner release: closing the producers
         // lets it finish initialization and drain accepted commands in order.
-        tokio::spawn(async move {
+        let consumer = tokio::spawn(async move {
             if let Err(error) = storage.init().await {
                 tracing::error!("metrics storage initialization failed: {}", error);
             }
@@ -271,7 +271,7 @@ impl MetricsCollector {
             }
         });
 
-        let scheduler = Self::schedule_prune(tx.downgrade(), retention_days);
+        let scheduler = Self::schedule_prune(tx.downgrade(), consumer, retention_days);
         Self {
             tx,
             _scheduler: Arc::new(scheduler),
@@ -495,12 +495,19 @@ impl MetricsCollector {
 
     fn schedule_prune(
         sender: mpsc::WeakUnboundedSender<CollectorCommand>,
+        mut consumer: tokio::task::JoinHandle<()>,
         retention_days: u32,
     ) -> PruneScheduler {
         let task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(6 * 60 * 60));
             loop {
-                interval.tick().await;
+                // Observe consumer exit even between ticks. Aborting this
+                // scheduler only drops the JoinHandle, detaching the consumer
+                // so accepted work still drains after the final owner drops.
+                tokio::select! {
+                    _ = &mut consumer => break,
+                    _ = interval.tick() => {}
+                }
                 // This temporary producer is dropped before the next timer
                 // wait, allowing the consumer to close after external owners go.
                 let Some(tx) = sender.upgrade() else {
@@ -687,8 +694,8 @@ mod tests {
     #[tokio::test]
     async fn scheduler_stops_on_closed_receiver_while_producer_survives() {
         let (tx, rx) = mpsc::unbounded_channel();
-        let scheduler = MetricsCollector::schedule_prune(tx.downgrade(), 90);
-        drop(rx);
+        let consumer = tokio::spawn(async move { drop(rx) });
+        let scheduler = MetricsCollector::schedule_prune(tx.downgrade(), consumer, 90);
 
         tokio::time::timeout(StdDuration::from_secs(5), async {
             while !scheduler.task.is_finished() {
@@ -696,7 +703,39 @@ mod tests {
             }
         })
         .await
-        .expect("failed prune admission should terminate the scheduler");
+        .expect("closed receiver should terminate the scheduler");
+        assert_eq!(tx.strong_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn scheduler_stops_between_ticks_when_consumer_exits_with_live_producer() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let first_tick = Arc::new(tokio::sync::Notify::new());
+        let finish_consumer = Arc::new(tokio::sync::Notify::new());
+        let consumer = tokio::spawn({
+            let first_tick = first_tick.clone();
+            let finish_consumer = finish_consumer.clone();
+            async move {
+                assert!(matches!(
+                    rx.recv().await,
+                    Some(CollectorCommand::Prune { .. })
+                ));
+                first_tick.notify_one();
+                finish_consumer.notified().await;
+            }
+        });
+        let scheduler = MetricsCollector::schedule_prune(tx.downgrade(), consumer, 90);
+
+        tokio::time::timeout(StdDuration::from_secs(5), async {
+            first_tick.notified().await;
+            assert!(!scheduler.task.is_finished());
+            finish_consumer.notify_one();
+            while !scheduler.task.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("consumer exit should stop the scheduler before its next six-hour tick");
         assert_eq!(tx.strong_count(), 1);
     }
 }


### PR DESCRIPTION
## Summary
The periodic prune task retained a strong collector sender forever, so dropping every external MetricsCollector clone left the consumer and storage alive on a shared runtime. Give collector clones shared ownership of a scheduler guard, use a weak sender between timer ticks, and abort only the scheduler when the final external owner drops.

The consumer finishes initialization and drains already accepted FIFO commands before releasing storage. A remaining clone keeps collection and retention alive. The scheduler selects receiver task completion as well as timer ticks, so a receiver that ends between ticks also reclaims the scheduler promptly. Dropping the scheduler detaches the consumer handle and preserves accepted-work drain. This is the first bounded slice of #1083.

## Test Plan
- [x] Five lifecycle regressions with real bundled SQLite: final drop before init with queued normal/prune FIFO drain; surviving clone and real initial periodic prune; 32 creation/drop cycles verifying storage Weak release, task completion and persisted records; closed receiver with a live producer, including receiver exit after the first timer tick.
- [x] Full bamboo-metrics crate: 18 unit tests + 1 public API integration test passed; 3 existing doctests ignored.
- [x] Formatting and diff whitespace checks.
- [x] Exact workspace CI Clippy passed on the updated base.
- [x] Independent re-review approved head 747b11aaf63da387418eed90de5aafb259889c16 against dev beedbf2cfd01cabfa2535dc8b78a5251be383fdd.
- [x] Required dev CI and final live merge gates; all CodeQL analyses passed.
- [x] Initial Test attempt reproduced unchanged broker timing issue #878; same-head Test-only retry passed every stage. Evidence is recorded in #878.

## Scope
Only collector.rs changes. No schema, transaction/aggregation, queue admission, retention policy, public event API, daemon, dependency or user database changes. Accepted storage work is not aborted on owner release.

Known baseline: unchanged nonrequired Security Audit failure for yanked wnaf 0.14.0 is tracked in #1061.

Closes #1079
