### PR TITLE
perf: write session search changes by stable row ID (#1084)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ A global `--log-level <error|warn|info|debug|trace>` sets the default log level 
 - Data dir: `BAMBOO_DATA_DIR` or `${HOME}/.bamboo`
 - Default provider: `anthropic`
 
+**Search-index upgrade:** Before upgrading `session_search.db` from schema 3 to 4, stop all older Bamboo servers, workers, and embedded writers that share the data directory. Startup migrates this derived search cache in one atomic transaction; a failed migration preserves the previous schema and cache contents. Running old and new writers together during a rolling upgrade is unsupported because older writers can reset the schema version and do not preserve the new search row identities. Canonical session data is unchanged; do not delete it to perform or recover this upgrade.
+
 ### Call the agent loop
 
 Once the server is running, driving the **full agent loop** — the LLM plans, calls tools, and streams its work — is three HTTP calls: create the turn with `POST /api/v1/chat`, **start the loop** with `POST /api/v1/execute/{session_id}`, then watch the SSE feed `GET /api/v1/events/{session_id}`.

--- a/crates/infra/bamboo-storage/src/search_index.rs
+++ b/crates/infra/bamboo-storage/src/search_index.rs
@@ -7,6 +7,11 @@ use tokio::task;
 
 use bamboo_domain::{Role, Session, SessionKind};
 
+mod delta;
+#[cfg(test)]
+mod incremental_tests;
+mod schema;
+
 const INDEX_RECENT_DAYS: i64 = 7;
 const PURGE_OLDER_THAN_DAYS: i64 = 10;
 const VACUUM_MIN_DB_BYTES: u64 = 256 * 1024 * 1024;
@@ -105,7 +110,7 @@ impl SessionSearchIndex {
     pub async fn upsert_session(&self, session: &Session) -> std::io::Result<()> {
         let db_path = self.db_path.clone();
         let session = session.clone();
-        task::spawn_blocking(move || upsert_session_db(&db_path, &session, None))
+        task::spawn_blocking(move || upsert_session_db(&db_path, &session, None).map(|_| ()))
             .await
             .map_err(|error| to_io_error(format!("session search upsert join error: {error}")))?
     }
@@ -122,11 +127,13 @@ impl SessionSearchIndex {
             path: revision_path.to_path_buf(),
             expected: expected_revision.to_string(),
         };
-        task::spawn_blocking(move || upsert_session_db(&db_path, &session, Some(&revision)))
-            .await
-            .map_err(|error| {
-                to_io_error(format!("guarded session search upsert join error: {error}"))
-            })?
+        task::spawn_blocking(move || {
+            upsert_session_db(&db_path, &session, Some(&revision)).map(|_| ())
+        })
+        .await
+        .map_err(|error| {
+            to_io_error(format!("guarded session search upsert join error: {error}"))
+        })?
     }
 
     pub async fn delete_session(&self, session_id: &str) -> std::io::Result<()> {
@@ -213,71 +220,17 @@ fn init_db(db_path: &Path) -> std::io::Result<()> {
     if let Some(parent) = db_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let conn = open_db(db_path)?;
+    let mut conn = open_db(db_path)?;
     conn.pragma_update(None, "journal_mode", "WAL")
         .map_err(|e| to_io_error(format!("sqlite pragma journal_mode failed: {e}")))?;
-    conn.execute_batch(
-        r#"
-        CREATE TABLE IF NOT EXISTS session_search_meta (
-            key TEXT PRIMARY KEY,
-            value TEXT NOT NULL
-        );
-
-        CREATE TABLE IF NOT EXISTS sessions_search (
-            session_id TEXT PRIMARY KEY,
-            title TEXT NOT NULL,
-            kind TEXT NOT NULL,
-            root_session_id TEXT NOT NULL,
-            parent_session_id TEXT,
-            pinned INTEGER NOT NULL,
-            updated_at TEXT NOT NULL,
-            summary TEXT
-        );
-
-        CREATE TABLE IF NOT EXISTS session_messages_search (
-            session_id TEXT NOT NULL,
-            message_id TEXT NOT NULL,
-            message_index INTEGER NOT NULL,
-            role TEXT NOT NULL,
-            content TEXT NOT NULL,
-            compressed INTEGER NOT NULL,
-            created_at TEXT NOT NULL,
-            PRIMARY KEY (session_id, message_id)
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_session_messages_search_session_id
-        ON session_messages_search(session_id, message_index);
-
-        CREATE VIRTUAL TABLE IF NOT EXISTS sessions_search_fts USING fts5(
-            session_id UNINDEXED,
-            title,
-            summary
-        );
-
-        CREATE VIRTUAL TABLE IF NOT EXISTS session_messages_search_fts USING fts5(
-            session_id UNINDEXED,
-            message_id UNINDEXED,
-            message_index UNINDEXED,
-            role UNINDEXED,
-            content
-        );
-        "#,
-    )
-    .map_err(|e| to_io_error(format!("sqlite schema init failed: {e}")))?;
-    conn.execute(
-        r#"INSERT INTO session_search_meta (key, value) VALUES ('schema_version', '3')
-           ON CONFLICT(key) DO UPDATE SET value = excluded.value"#,
-        [],
-    )
-    .map_err(|e| to_io_error(format!("sqlite meta init failed: {e}")))?;
-    Ok(())
+    schema::initialize(&mut conn)
 }
 
 fn upsert_session_db(
     db_path: &Path,
     session: &Session,
     source_revision: Option<&SearchSourceRevision>,
-) -> std::io::Result<()> {
+) -> std::io::Result<delta::Changes> {
     let conn = open_db(db_path)?;
     conn.execute_batch("BEGIN IMMEDIATE TRANSACTION;")
         .map_err(|e| to_io_error(format!("sqlite begin transaction failed: {e}")))?;
@@ -290,13 +243,13 @@ fn upsert_session_db(
                     conn.execute_batch("COMMIT;").map_err(|e| {
                         to_io_error(format!("sqlite commit superseded no-op failed: {e}"))
                     })?;
-                    return Ok(());
+                    return Ok(delta::Changes::default());
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                     conn.execute_batch("COMMIT;").map_err(|e| {
                         to_io_error(format!("sqlite commit deleted-source no-op failed: {e}"))
                     })?;
-                    return Ok(());
+                    return Ok(delta::Changes::default());
                 }
                 Err(error) => return Err(error),
             }
@@ -318,114 +271,22 @@ fn upsert_session_db(
         if indexed_updated_at.is_some_and(|updated_at| updated_at > session.updated_at) {
             conn.execute_batch("COMMIT;")
                 .map_err(|e| to_io_error(format!("sqlite commit stale no-op failed: {e}")))?;
-            return Ok(());
+            return Ok(delta::Changes::default());
         }
 
         if !should_index_session(session.updated_at) {
             delete_session_rows(&conn, &session.id)?;
             conn.execute_batch("COMMIT;")
                 .map_err(|e| to_io_error(format!("sqlite commit expiry delete failed: {e}")))?;
-            return Ok(());
+            return Ok(delta::Changes::default());
         }
 
-        conn.execute(
-            r#"
-            INSERT INTO sessions_search (
-                session_id, title, kind, root_session_id, parent_session_id, pinned, updated_at, summary
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-            ON CONFLICT(session_id) DO UPDATE SET
-                title = excluded.title,
-                kind = excluded.kind,
-                root_session_id = excluded.root_session_id,
-                parent_session_id = excluded.parent_session_id,
-                pinned = excluded.pinned,
-                updated_at = excluded.updated_at,
-                summary = excluded.summary
-            "#,
-            params![
-                session.id,
-                session.title,
-                match session.kind {
-                    SessionKind::Root => "root",
-                    SessionKind::Child => "child",
-                },
-                session.root_session_id,
-                session.parent_session_id,
-                if session.pinned { 1 } else { 0 },
-                session.updated_at.to_rfc3339(),
-                session.conversation_summary.as_ref().map(|summary| summary.content.as_str()),
-            ],
-        )
-        .map_err(|e| to_io_error(format!("sqlite upsert session failed: {e}")))?;
-
-        conn.execute(
-            "DELETE FROM session_messages_search WHERE session_id = ?1",
-            params![session.id],
-        )
-        .map_err(|e| to_io_error(format!("sqlite delete old message rows failed: {e}")))?;
-        conn.execute(
-            "DELETE FROM sessions_search_fts WHERE session_id = ?1",
-            params![session.id],
-        )
-        .map_err(|e| to_io_error(format!("sqlite delete old session fts rows failed: {e}")))?;
-        conn.execute(
-            "DELETE FROM session_messages_search_fts WHERE session_id = ?1",
-            params![session.id],
-        )
-        .map_err(|e| to_io_error(format!("sqlite delete old message fts rows failed: {e}")))?;
-
-        conn.execute(
-            "INSERT INTO sessions_search_fts (session_id, title, summary) VALUES (?1, ?2, ?3)",
-            params![
-                session.id,
-                session.title,
-                session
-                    .conversation_summary
-                    .as_ref()
-                    .map(|summary| summary.content.as_str())
-                    .unwrap_or_default(),
-            ],
-        )
-        .map_err(|e| to_io_error(format!("sqlite insert session fts row failed: {e}")))?;
-
-        for (index, message) in session.messages.iter().enumerate() {
-            let role = match message.role {
-                Role::System => "system",
-                Role::User => "user",
-                Role::Assistant => "assistant",
-                Role::Tool => "tool",
-            };
-            conn.execute(
-                r#"
-                INSERT INTO session_messages_search (
-                    session_id, message_id, message_index, role, content, compressed, created_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-                "#,
-                params![
-                    session.id,
-                    message.id,
-                    index as i64,
-                    role,
-                    message.content,
-                    if message.compressed { 1 } else { 0 },
-                    message.created_at.to_rfc3339(),
-                ],
-            )
-            .map_err(|e| to_io_error(format!("sqlite insert message row failed: {e}")))?;
-            conn.execute(
-                r#"
-                INSERT INTO session_messages_search_fts (
-                    session_id, message_id, message_index, role, content
-                ) VALUES (?1, ?2, ?3, ?4, ?5)
-                "#,
-                params![session.id, message.id, index as i64, role, message.content],
-            )
-            .map_err(|e| to_io_error(format!("sqlite insert message fts row failed: {e}")))?;
-        }
+        let changes = delta::sync_session(&conn, session)
+            .map_err(|e| to_io_error(format!("sqlite synchronize session search failed: {e}")))?;
 
         conn.execute_batch("COMMIT;")
             .map_err(|e| to_io_error(format!("sqlite commit failed: {e}")))?;
-        Ok(())
+        Ok(changes)
     })();
 
     if result.is_err() {
@@ -467,27 +328,8 @@ fn delete_session_db(
 }
 
 fn delete_session_rows(conn: &Connection, session_id: &str) -> std::io::Result<()> {
-    conn.execute(
-        "DELETE FROM sessions_search WHERE session_id = ?1",
-        params![session_id],
-    )
-    .map_err(|e| to_io_error(format!("sqlite delete session row failed: {e}")))?;
-    conn.execute(
-        "DELETE FROM session_messages_search WHERE session_id = ?1",
-        params![session_id],
-    )
-    .map_err(|e| to_io_error(format!("sqlite delete message rows failed: {e}")))?;
-    conn.execute(
-        "DELETE FROM sessions_search_fts WHERE session_id = ?1",
-        params![session_id],
-    )
-    .map_err(|e| to_io_error(format!("sqlite delete session fts row failed: {e}")))?;
-    conn.execute(
-        "DELETE FROM session_messages_search_fts WHERE session_id = ?1",
-        params![session_id],
-    )
-    .map_err(|e| to_io_error(format!("sqlite delete message fts rows failed: {e}")))?;
-    Ok(())
+    delta::delete_session(conn, session_id)
+        .map_err(|e| to_io_error(format!("sqlite delete session search rows failed: {e}")))
 }
 
 fn prune_stale_sessions_db(db_path: &Path) -> std::io::Result<usize> {

--- a/crates/infra/bamboo-storage/src/search_index/delta.rs
+++ b/crates/infra/bamboo-storage/src/search_index/delta.rs
@@ -1,0 +1,242 @@
+use std::collections::{HashMap, HashSet};
+
+use super::{params, Connection, OptionalExtension, Role, Session, SessionKind};
+
+// Counts come from sqlite3_changes for the top-level statements, excluding
+// FTS shadow-table internals. They keep differential-write tests independent of
+// FTS5's internal storage implementation; callers need no public metrics API.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct Changes {
+    pub sessions: usize,
+    pub messages: usize,
+    pub session_fts: usize,
+    pub message_fts: usize,
+}
+
+pub(super) const DELETE_SESSION_FTS: &str = "DELETE FROM sessions_search_fts WHERE rowid IN
+    (SELECT search_rowid FROM sessions_search WHERE session_id = ?1)";
+pub(super) const DELETE_MESSAGE_FTS: &str = "DELETE FROM session_messages_search_fts WHERE rowid IN
+    (SELECT search_rowid FROM session_messages_search WHERE session_id = ?1)";
+const DELETE_MESSAGE_FTS_ROW: &str = "DELETE FROM session_messages_search_fts WHERE rowid = ?1";
+
+#[derive(Debug, PartialEq, Eq)]
+struct MessageRow {
+    rowid: i64,
+    index: i64,
+    role: String,
+    content: String,
+    compressed: bool,
+    created_at: String,
+}
+
+fn sync_session_row(conn: &Connection, session: &Session) -> rusqlite::Result<Changes> {
+    let summary = session
+        .conversation_summary
+        .as_ref()
+        .map(|summary| summary.content.as_str());
+    let sessions = conn.execute(
+        "INSERT INTO sessions_search
+            (session_id, title, kind, root_session_id, parent_session_id, pinned, updated_at, summary)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(session_id) DO UPDATE SET
+            title=excluded.title, kind=excluded.kind, root_session_id=excluded.root_session_id,
+            parent_session_id=excluded.parent_session_id, pinned=excluded.pinned,
+            updated_at=excluded.updated_at, summary=excluded.summary
+         WHERE title IS NOT excluded.title OR kind IS NOT excluded.kind
+            OR root_session_id IS NOT excluded.root_session_id
+            OR parent_session_id IS NOT excluded.parent_session_id
+            OR pinned IS NOT excluded.pinned OR updated_at IS NOT excluded.updated_at
+            OR summary IS NOT excluded.summary",
+        params![
+            session.id,
+            session.title,
+            match session.kind {
+                SessionKind::Root => "root",
+                SessionKind::Child => "child",
+            },
+            session.root_session_id,
+            session.parent_session_id,
+            session.pinned,
+            session.updated_at.to_rfc3339(),
+            summary,
+        ],
+    )?;
+    let mut changes = Changes {
+        sessions,
+        ..Default::default()
+    };
+    let rowid: i64 = conn.query_row(
+        "SELECT search_rowid FROM sessions_search WHERE session_id = ?1",
+        [&session.id],
+        |row| row.get(0),
+    )?;
+    let fts_matches = conn
+        .query_row(
+            "SELECT session_id, title, summary FROM sessions_search_fts WHERE rowid = ?1",
+            [rowid],
+            |row| {
+                Ok(
+                    row.get::<_, Option<String>>(0)?.as_deref() == Some(&session.id)
+                        && row.get::<_, Option<String>>(1)?.as_deref() == Some(&session.title)
+                        && row.get::<_, Option<String>>(2)?.as_deref()
+                            == Some(summary.unwrap_or_default()),
+                )
+            },
+        )
+        .optional()?
+        .unwrap_or(false);
+    if !fts_matches {
+        changes.session_fts = conn.execute(
+            "INSERT OR REPLACE INTO sessions_search_fts (rowid, session_id, title, summary)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                rowid,
+                session.id,
+                session.title,
+                summary.unwrap_or_default()
+            ],
+        )?;
+    }
+    Ok(changes)
+}
+
+pub(super) fn sync_session(conn: &Connection, session: &Session) -> rusqlite::Result<Changes> {
+    let mut ids = HashSet::with_capacity(session.messages.len());
+    if session
+        .messages
+        .iter()
+        .any(|message| !ids.insert(&message.id))
+    {
+        return Err(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY),
+            Some("duplicate message ID in search snapshot".to_string()),
+        ));
+    }
+    let mut changes = sync_session_row(conn, session)?;
+    let mut stored = conn
+        .prepare(
+            "SELECT message_id, search_rowid, message_index, role, content, compressed, created_at
+            FROM session_messages_search WHERE session_id = ?1",
+        )?
+        .query_map([&session.id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                MessageRow {
+                    rowid: row.get(1)?,
+                    index: row.get(2)?,
+                    role: row.get(3)?,
+                    content: row.get(4)?,
+                    compressed: row.get(5)?,
+                    created_at: row.get(6)?,
+                },
+            ))
+        })?
+        .collect::<rusqlite::Result<HashMap<_, _>>>()?;
+
+    let mut insert = conn.prepare(
+        "INSERT INTO session_messages_search
+        (session_id, message_id, message_index, role, content, compressed, created_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+    )?;
+    let mut update = conn.prepare(
+        "UPDATE session_messages_search
+        SET message_index=?2, role=?3, content=?4, compressed=?5, created_at=?6
+        WHERE search_rowid=?1",
+    )?;
+    let mut fts_read = conn.prepare(
+        "SELECT session_id, message_id, message_index, role, content
+        FROM session_messages_search_fts WHERE rowid=?1",
+    )?;
+    let mut fts_write = conn.prepare(
+        "INSERT OR REPLACE INTO session_messages_search_fts
+        (rowid, session_id, message_id, message_index, role, content)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+    )?;
+    for (index, message) in session.messages.iter().enumerate() {
+        let old = stored.remove(&message.id);
+        let mut next = MessageRow {
+            rowid: old.as_ref().map_or(0, |row| row.rowid),
+            index: index as i64,
+            role: match message.role {
+                Role::System => "system",
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::Tool => "tool",
+            }
+            .to_string(),
+            content: message.content.clone(),
+            compressed: message.compressed,
+            created_at: message.created_at.to_rfc3339(),
+        };
+        if let Some(old) = old {
+            if old != next {
+                changes.messages += update.execute(params![
+                    next.rowid,
+                    next.index,
+                    next.role,
+                    next.content,
+                    next.compressed,
+                    next.created_at
+                ])?;
+            }
+        } else {
+            changes.messages += insert.execute(params![
+                session.id,
+                message.id,
+                next.index,
+                next.role,
+                next.content,
+                next.compressed,
+                next.created_at
+            ])?;
+            next.rowid = conn.last_insert_rowid();
+        }
+        // Compare the point-addressed FTS projection too. Unchanged normal rows
+        // must still repair missing/stale FTS during upsert or startup rebuild.
+        let fts_matches = fts_read
+            .query_row([next.rowid], |row| {
+                Ok(
+                    row.get::<_, Option<String>>(0)?.as_deref() == Some(&session.id)
+                        && row.get::<_, Option<String>>(1)?.as_deref() == Some(&message.id)
+                        && row.get::<_, Option<i64>>(2)? == Some(next.index)
+                        && row.get::<_, Option<String>>(3)?.as_deref() == Some(&next.role)
+                        && row.get::<_, Option<String>>(4)?.as_deref() == Some(&next.content),
+                )
+            })
+            .optional()?
+            .unwrap_or(false);
+        if !fts_matches {
+            changes.message_fts += fts_write.execute(params![
+                next.rowid,
+                session.id,
+                message.id,
+                next.index,
+                next.role,
+                next.content
+            ])?;
+        }
+    }
+    let mut fts_delete = conn.prepare(DELETE_MESSAGE_FTS_ROW)?;
+    let mut delete = conn.prepare("DELETE FROM session_messages_search WHERE search_rowid=?1")?;
+    for removed in stored.into_values() {
+        changes.message_fts += fts_delete.execute([removed.rowid])?;
+        changes.messages += delete.execute([removed.rowid])?;
+    }
+    Ok(changes)
+}
+
+pub(super) fn delete_session(conn: &Connection, session_id: &str) -> rusqlite::Result<()> {
+    // Resolve FTS rowids through indexed ordinary identity columns before
+    // deleting those ordinary rows. UNINDEXED FTS session_id is never scanned.
+    conn.execute(DELETE_SESSION_FTS, [session_id])?;
+    conn.execute(DELETE_MESSAGE_FTS, [session_id])?;
+    conn.execute(
+        "DELETE FROM session_messages_search WHERE session_id=?1",
+        [session_id],
+    )?;
+    conn.execute(
+        "DELETE FROM sessions_search WHERE session_id=?1",
+        [session_id],
+    )?;
+    Ok(())
+}

--- a/crates/infra/bamboo-storage/src/search_index/incremental_tests.rs
+++ b/crates/infra/bamboo-storage/src/search_index/incremental_tests.rs
@@ -1,0 +1,763 @@
+use std::collections::BTreeMap;
+
+use bamboo_domain::{ConversationSummary, Message};
+use rusqlite::types::Value;
+use tempfile::TempDir;
+
+use super::*;
+
+fn fixture(id: &str) -> Session {
+    let mut session = Session::new(id, "model");
+    session.title = "search beacon".to_string();
+    for index in 0..3 {
+        let mut message = Message::user(format!("quartz message {index}"));
+        message.id = format!("m{index}");
+        session.messages.push(message);
+    }
+    session
+}
+
+fn rows(conn: &Connection, sql: &str) -> Vec<Vec<Value>> {
+    let mut statement = conn.prepare(sql).unwrap();
+    let columns = statement.column_count();
+    statement
+        .query_map([], |row| (0..columns).map(|index| row.get(index)).collect())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap()
+}
+
+fn identity_rows(conn: &Connection) -> BTreeMap<(String, String), i64> {
+    conn.prepare("SELECT session_id, message_id, search_rowid FROM session_messages_search")
+        .unwrap()
+        .query_map([], |row| Ok(((row.get(0)?, row.get(1)?), row.get(2)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap()
+}
+
+// Deliberately independent of schema.rs: this is the actual populated schema
+// shipped before this migration, including independent ordinary/FTS rowids.
+fn legacy_db(path: &Path) -> Connection {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE session_search_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+         INSERT INTO session_search_meta VALUES ('schema_version', '3');
+         CREATE TABLE sessions_search (
+            session_id TEXT PRIMARY KEY, title TEXT NOT NULL, kind TEXT NOT NULL,
+            root_session_id TEXT NOT NULL, parent_session_id TEXT, pinned INTEGER NOT NULL,
+            updated_at TEXT NOT NULL, summary TEXT);
+         CREATE TABLE session_messages_search (
+            session_id TEXT NOT NULL, message_id TEXT NOT NULL, message_index INTEGER NOT NULL,
+            role TEXT NOT NULL, content TEXT NOT NULL, compressed INTEGER NOT NULL,
+            created_at TEXT NOT NULL, PRIMARY KEY(session_id, message_id));
+         CREATE INDEX idx_session_messages_search_session_id
+            ON session_messages_search(session_id, message_index);
+         CREATE VIRTUAL TABLE sessions_search_fts USING fts5(session_id UNINDEXED, title, summary);
+         CREATE VIRTUAL TABLE session_messages_search_fts USING fts5(
+            session_id UNINDEXED, message_id UNINDEXED, message_index UNINDEXED, role UNINDEXED, content);
+         CREATE TABLE user_audit (kind TEXT NOT NULL);
+         CREATE TABLE unrelated (value TEXT NOT NULL);
+         INSERT INTO unrelated VALUES ('preserve this table');",
+    ).unwrap();
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO sessions_search VALUES
+        ('legacy', 'legacy beacon', 'child', 'root', 'parent', 1, ?1, 'archived summary')",
+        [&now],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO session_messages_search (rowid, session_id, message_id,
+        message_index, role, content, compressed, created_at)
+        VALUES (7, 'legacy', 'a', 0, 'user', 'quartz legacy message', 1, ?1),
+               (29, 'legacy', 'b', 1, 'assistant', 'unrelated answer', 0, ?1)",
+        [&now],
+    )
+    .unwrap();
+    conn.execute_batch("INSERT INTO sessions_search_fts (rowid, session_id, title, summary)
+        VALUES (900, 'legacy', 'legacy beacon', 'archived summary');
+        INSERT INTO session_messages_search_fts (rowid, session_id, message_id, message_index, role, content)
+        VALUES (901, 'legacy', 'a', 0, 'user', 'quartz legacy message'),
+               (905, 'legacy', 'b', 1, 'assistant', 'unrelated answer');
+        CREATE INDEX user_title_index ON sessions_search(title COLLATE NOCASE);
+        CREATE UNIQUE INDEX user_message_expression ON session_messages_search(length(content), message_id);
+        CREATE TRIGGER user_session_update AFTER UPDATE ON sessions_search BEGIN
+            INSERT INTO user_audit VALUES ('session'); END;
+        CREATE TRIGGER user_message_update AFTER UPDATE ON session_messages_search BEGIN
+            INSERT INTO user_audit SELECT title FROM sessions_search WHERE session_id=NEW.session_id; END;")
+        .unwrap();
+    conn
+}
+
+fn assert_identity_alignment(conn: &Connection) {
+    for (normal, fts) in [
+        ("sessions_search", "sessions_search_fts"),
+        ("session_messages_search", "session_messages_search_fts"),
+    ] {
+        let mut columns = "session_id".to_string();
+        if normal == "session_messages_search" {
+            columns.push_str(", message_id");
+        }
+        assert_eq!(
+            rows(
+                conn,
+                &format!("SELECT search_rowid, {columns} FROM {normal} ORDER BY search_rowid")
+            ),
+            rows(
+                conn,
+                &format!("SELECT rowid, {columns} FROM {fts} ORDER BY rowid")
+            )
+        );
+    }
+}
+
+#[test]
+fn independent_v3_migration_preserves_search_cache_and_user_objects() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("search.db");
+    let conn = legacy_db(&path);
+    let object_sql = rows(
+        &conn,
+        "SELECT name, sql FROM sqlite_schema
+        WHERE name LIKE 'user_%' OR name='idx_session_messages_search_session_id' ORDER BY name",
+    );
+    let before_search = serde_json::to_value(search_db(&path, "quartz", 10).unwrap()).unwrap();
+    let before_session = serde_json::to_value(search_db(&path, "beacon", 10).unwrap()).unwrap();
+    let before_cache =
+        serde_json::to_value(read_compressed_cache_db(&path, "legacy", 0, 20, 100).unwrap())
+            .unwrap();
+    drop(conn);
+
+    for _ in 0..3 {
+        init_db(&path).unwrap();
+        let conn = open_db(&path).unwrap();
+        assert_eq!(
+            conn.query_row(
+                "SELECT value FROM session_search_meta WHERE key='schema_version'",
+                [],
+                |row| row.get::<_, String>(0)
+            )
+            .unwrap(),
+            "4"
+        );
+        assert_identity_alignment(&conn);
+        assert_eq!(
+            identity_rows(&conn).values().copied().collect::<Vec<_>>(),
+            vec![7, 29]
+        );
+        assert_eq!(rows(&conn, "SELECT name, sql FROM sqlite_schema
+            WHERE name LIKE 'user_%' OR name='idx_session_messages_search_session_id' ORDER BY name"), object_sql);
+        assert_eq!(
+            rows(&conn, "SELECT * FROM unrelated"),
+            vec![vec![Value::Text("preserve this table".into())]]
+        );
+        assert_eq!(
+            serde_json::to_value(search_db(&path, "quartz", 10).unwrap()).unwrap(),
+            before_search
+        );
+        assert_eq!(
+            serde_json::to_value(search_db(&path, "beacon", 10).unwrap()).unwrap(),
+            before_session
+        );
+        assert_eq!(
+            serde_json::to_value(read_compressed_cache_db(&path, "legacy", 0, 20, 100).unwrap())
+                .unwrap(),
+            before_cache
+        );
+    }
+    let conn = open_db(&path).unwrap();
+    conn.execute(
+        "UPDATE session_messages_search SET compressed=0 WHERE message_id='a'",
+        [],
+    )
+    .unwrap();
+    conn.execute("UPDATE sessions_search SET pinned=0", [])
+        .unwrap();
+    assert_eq!(
+        rows(&conn, "SELECT * FROM user_audit ORDER BY rowid"),
+        vec![
+            vec![Value::Text("legacy beacon".into())],
+            vec![Value::Text("session".into())]
+        ]
+    );
+}
+
+#[test]
+fn migration_failure_rolls_back_tables_fts_objects_and_version() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("search.db");
+    let conn = legacy_db(&path);
+    conn.execute_batch(
+        "CREATE TRIGGER reject_version BEFORE UPDATE ON session_search_meta BEGIN
+        SELECT RAISE(ABORT, 'injected publication failure'); END;",
+    )
+    .unwrap();
+    let schema_before = rows(&conn, "SELECT name, sql FROM sqlite_schema ORDER BY name");
+    let fts_before = rows(
+        &conn,
+        "SELECT rowid, * FROM session_messages_search_fts ORDER BY rowid",
+    );
+    let normal_before = rows(
+        &conn,
+        "SELECT rowid, * FROM session_messages_search ORDER BY rowid",
+    );
+    assert!(init_db(&path)
+        .unwrap_err()
+        .to_string()
+        .contains("injected publication failure"));
+    assert_eq!(
+        rows(&conn, "SELECT name, sql FROM sqlite_schema ORDER BY name"),
+        schema_before
+    );
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT rowid, * FROM session_messages_search_fts ORDER BY rowid"
+        ),
+        fts_before
+    );
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT rowid, * FROM session_messages_search ORDER BY rowid"
+        ),
+        normal_before
+    );
+    assert!(!search_db(&path, "quartz", 10).unwrap().is_empty());
+    conn.execute_batch("DROP TRIGGER reject_version").unwrap();
+    init_db(&path).unwrap();
+    assert_identity_alignment(&conn);
+}
+
+#[test]
+fn unsupported_version_and_shape_fail_without_republishing_schema() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("search.db");
+    let conn = legacy_db(&path);
+    conn.execute("UPDATE session_search_meta SET value='99'", [])
+        .unwrap();
+    let before = rows(&conn, "SELECT name, sql FROM sqlite_schema ORDER BY name");
+    assert!(init_db(&path).unwrap_err().to_string().contains("99"));
+    assert_eq!(
+        rows(&conn, "SELECT name, sql FROM sqlite_schema ORDER BY name"),
+        before
+    );
+    assert_eq!(
+        rows(&conn, "SELECT value FROM session_search_meta"),
+        vec![vec![Value::Text("99".into())]]
+    );
+    conn.execute("UPDATE session_search_meta SET value='4'", [])
+        .unwrap();
+    assert!(init_db(&path).unwrap_err().to_string().contains("shape"));
+    assert_eq!(
+        rows(&conn, "SELECT name, sql FROM sqlite_schema ORDER BY name"),
+        before
+    );
+}
+
+fn assert_shape_rejected_without_mutation(path: &Path, conn: &Connection, reason: &str) {
+    let snapshot = || {
+        [
+            "SELECT name, sql FROM sqlite_schema ORDER BY name",
+            "SELECT * FROM session_search_meta ORDER BY key",
+            "SELECT rowid, * FROM sessions_search ORDER BY rowid",
+            "SELECT rowid, * FROM session_messages_search ORDER BY rowid",
+            "SELECT rowid, * FROM sessions_search_fts ORDER BY rowid",
+            "SELECT rowid, * FROM session_messages_search_fts ORDER BY rowid",
+        ]
+        .map(|sql| rows(conn, sql))
+    };
+    let before = snapshot();
+    let error = init_db(path).unwrap_err().to_string();
+    assert!(error.contains(reason), "{error}");
+    assert_eq!(
+        snapshot(),
+        before,
+        "rejection must preserve schema, version and payloads"
+    );
+}
+
+#[test]
+fn v4_rejects_changed_fts_indexing_tokenizer_and_content_mode() {
+    for definition in [
+        "session_id, title, summary",
+        "session_id UNINDEXED, title, summary, tokenize='porter'",
+        "session_id UNINDEXED, title, summary, content=''",
+    ] {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("search.db");
+        init_db(&path).unwrap();
+        upsert_session_db(&path, &fixture("fts-shape"), None).unwrap();
+        let conn = open_db(&path).unwrap();
+        // Keep the same visible columns and populated ordinary rows. A
+        // column-name-only check would incorrectly accept all three variants.
+        conn.execute_batch(&format!("DROP TABLE sessions_search_fts;
+            CREATE VIRTUAL TABLE sessions_search_fts USING fts5({definition});
+            INSERT INTO sessions_search_fts(rowid, session_id, title, summary)
+                SELECT search_rowid, session_id, title, COALESCE(summary, '') FROM sessions_search;"))
+            .unwrap();
+        assert_shape_rejected_without_mutation(&path, &conn, "unsupported search FTS shape");
+    }
+}
+
+#[test]
+fn v4_rejects_non_alias_primary_key_and_missing_or_invalid_identity_uniqueness() {
+    for (table, from, to, extra_sql, reason) in [
+        (
+            "sessions_search",
+            "INTEGER PRIMARY KEY",
+            "INTEGER PRIMARY KEY DESC",
+            "",
+            "must alias rowid",
+        ),
+        (
+            "sessions_search",
+            "TEXT NOT NULL UNIQUE",
+            "TEXT NOT NULL",
+            "",
+            "missing search identity constraint",
+        ),
+        (
+            "sessions_search",
+            "TEXT NOT NULL UNIQUE",
+            "TEXT NOT NULL",
+            "CREATE UNIQUE INDEX partial_identity ON sessions_search(session_id) WHERE pinned=1;",
+            "missing search identity constraint",
+        ),
+        (
+            "session_messages_search",
+            "UNIQUE(session_id, message_id)",
+            "UNIQUE(message_id)",
+            "",
+            "missing search identity constraint",
+        ),
+    ] {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("search.db");
+        init_db(&path).unwrap();
+        upsert_session_db(&path, &fixture("identity-shape"), None).unwrap();
+        let conn = open_db(&path).unwrap();
+        let original: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_schema WHERE name=?1",
+                [table],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let changed = original.replace(from, to);
+        assert_ne!(
+            original, changed,
+            "fixture must alter the actual v4 definition"
+        );
+        conn.execute_batch(&format!(
+            "CREATE TEMP TABLE saved_rows AS SELECT * FROM {table};
+            DROP TABLE {table}; {changed}; INSERT INTO {table} SELECT * FROM saved_rows;
+            DROP TABLE saved_rows; {extra_sql}"
+        ))
+        .unwrap();
+        assert_shape_rejected_without_mutation(&path, &conn, reason);
+    }
+}
+
+fn install_audit(conn: &Connection) {
+    conn.execute_batch("CREATE TABLE write_audit (table_name TEXT, operation TEXT)")
+        .unwrap();
+    for table in ["sessions_search", "session_messages_search"] {
+        for operation in ["INSERT", "UPDATE", "DELETE"] {
+            conn.execute_batch(&format!(
+                "CREATE TRIGGER audit_{table}_{operation} AFTER {operation} ON {table}
+                BEGIN INSERT INTO write_audit VALUES ('{table}', '{operation}'); END;"
+            ))
+            .unwrap();
+        }
+    }
+}
+
+fn apply_checked(path: &Path, session: &Session, expected: delta::Changes) {
+    let conn = open_db(path).unwrap();
+    conn.execute("DELETE FROM write_audit", []).unwrap();
+    let before_ids = identity_rows(&conn);
+    assert_eq!(upsert_session_db(path, session, None).unwrap(), expected);
+    for (identity, rowid) in identity_rows(&conn) {
+        if let Some(previous) = before_ids.get(&identity) {
+            assert_eq!(*previous, rowid);
+        }
+    }
+    for (table, count) in [
+        ("sessions_search", expected.sessions),
+        ("session_messages_search", expected.messages),
+    ] {
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM write_audit WHERE table_name=?1",
+                [table],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+            count as i64
+        );
+    }
+    assert_identity_alignment(&conn);
+}
+
+#[test]
+fn differential_writes_cover_identical_metadata_append_edit_order_role_and_delete() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("search.db");
+    init_db(&path).unwrap();
+    let conn = open_db(&path).unwrap();
+    install_audit(&conn);
+    let mut session = fixture("delta");
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            sessions: 1,
+            messages: 3,
+            session_fts: 1,
+            message_fts: 3,
+        },
+    );
+    apply_checked(&path, &session, delta::Changes::default());
+    session.title = "updated beacon".into();
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            sessions: 1,
+            session_fts: 1,
+            ..Default::default()
+        },
+    );
+    session.conversation_summary = Some(ConversationSummary::new("summary recollection", 1, 2));
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            sessions: 1,
+            session_fts: 1,
+            ..Default::default()
+        },
+    );
+    session.kind = SessionKind::Child;
+    session.root_session_id = "root".into();
+    session.parent_session_id = Some("parent".into());
+    session.pinned = true;
+    session.updated_at += Duration::seconds(1);
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            sessions: 1,
+            ..Default::default()
+        },
+    );
+    let metadata = search_db(&path, "beacon", 10).unwrap();
+    assert!(metadata[0].pinned);
+    assert_eq!(metadata[0].parent_session_id.as_deref(), Some("parent"));
+    session.messages[0].compressed = true;
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            messages: 1,
+            ..Default::default()
+        },
+    );
+    session.messages[0].created_at += Duration::seconds(1);
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            messages: 1,
+            ..Default::default()
+        },
+    );
+    let cache = read_compressed_cache_db(&path, &session.id, 0, 10, 100).unwrap();
+    assert_eq!(cache.messages[0].created_at, session.messages[0].created_at);
+    let mut appended = Message::assistant("appended zircon", None);
+    appended.id = "m3".into();
+    session.messages.push(appended);
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            messages: 1,
+            message_fts: 1,
+            ..Default::default()
+        },
+    );
+    session.messages[1].content = "amended sapphire".into();
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            messages: 1,
+            message_fts: 1,
+            ..Default::default()
+        },
+    );
+    session.messages[2].role = Role::Tool;
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            messages: 1,
+            message_fts: 1,
+            ..Default::default()
+        },
+    );
+    session.messages.swap(0, 2);
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            messages: 2,
+            message_fts: 2,
+            ..Default::default()
+        },
+    );
+    let hits = search_db(&path, "quartz", 10).unwrap();
+    assert!(hits
+        .iter()
+        .any(|hit| hit.message_id.as_deref() == Some("m2")
+            && hit.message_index == Some(0)
+            && hit.role.as_deref() == Some("tool")));
+    session.messages.remove(1);
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            messages: 3,
+            message_fts: 3,
+            ..Default::default()
+        },
+    );
+    assert!(search_db(&path, "sapphire", 10).unwrap().is_empty());
+    session.messages.clear();
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            messages: 3,
+            message_fts: 3,
+            ..Default::default()
+        },
+    );
+    assert!(search_db(&path, "quartz", 10).unwrap().is_empty());
+    apply_checked(&path, &session, delta::Changes::default());
+}
+
+#[test]
+fn unchanged_projection_repairs_missing_stale_and_null_fts_payloads() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("search.db");
+    init_db(&path).unwrap();
+    let session = fixture("repair");
+    upsert_session_db(&path, &session, None).unwrap();
+    let conn = open_db(&path).unwrap();
+    install_audit(&conn);
+    conn.execute_batch("UPDATE sessions_search_fts SET title='corrupt', summary=NULL;
+        DELETE FROM session_messages_search_fts WHERE rowid=1;
+        UPDATE session_messages_search_fts SET content='stale payload', role=NULL, message_index=99 WHERE rowid=2;").unwrap();
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            session_fts: 1,
+            message_fts: 2,
+            ..Default::default()
+        },
+    );
+    assert_eq!(search_db(&path, "quartz", 10).unwrap().len(), 3);
+    assert!(search_db(&path, "corrupt", 10).unwrap().is_empty());
+    assert!(search_db(&path, "stale", 10).unwrap().is_empty());
+    conn.execute_batch("DELETE FROM sessions_search_fts; DELETE FROM session_messages_search_fts;")
+        .unwrap();
+    apply_checked(
+        &path,
+        &session,
+        delta::Changes {
+            session_fts: 1,
+            message_fts: 3,
+            ..Default::default()
+        },
+    );
+    apply_checked(&path, &session, delta::Changes::default());
+}
+
+#[test]
+fn duplicate_ids_and_fts_payload_failure_leave_entire_snapshot_unchanged() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("search.db");
+    init_db(&path).unwrap();
+    let session = fixture("rollback");
+    upsert_session_db(&path, &session, None).unwrap();
+    let conn = open_db(&path).unwrap();
+    let normal = rows(
+        &conn,
+        "SELECT * FROM session_messages_search ORDER BY search_rowid",
+    );
+    let titles = rows(&conn, "SELECT * FROM sessions_search ORDER BY search_rowid");
+    let mut duplicate = session.clone();
+    duplicate.title = "must rollback".into();
+    duplicate.messages.push(duplicate.messages[0].clone());
+    assert!(upsert_session_db(&path, &duplicate, None).is_err());
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT * FROM session_messages_search ORDER BY search_rowid"
+        ),
+        normal
+    );
+    assert_eq!(
+        rows(&conn, "SELECT * FROM sessions_search ORDER BY search_rowid"),
+        titles
+    );
+
+    // Substitute a rejecting content table only in this test. The production
+    // FTS INSERT executes after ordinary/session-FTS changes and must fail the
+    // same encompassing transaction; no FTS shadow-table details are involved.
+    conn.execute_batch("ALTER TABLE session_messages_search_fts RENAME TO saved_fts;
+        CREATE TABLE session_messages_search_fts (session_id, message_id, message_index, role,
+            content CHECK(content NOT LIKE '%rejectpayload%'));
+        INSERT INTO session_messages_search_fts (rowid, session_id, message_id, message_index, role, content)
+            SELECT rowid, session_id, message_id, message_index, role, content FROM saved_fts;").unwrap();
+    let fts_before = rows(
+        &conn,
+        "SELECT rowid, * FROM session_messages_search_fts ORDER BY rowid",
+    );
+    let mut changed = session.clone();
+    changed.title = "must rollback".into();
+    changed.messages[0].content = "rejectpayload".into();
+    assert!(upsert_session_db(&path, &changed, None).is_err());
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT * FROM session_messages_search ORDER BY search_rowid"
+        ),
+        normal
+    );
+    assert_eq!(
+        rows(&conn, "SELECT * FROM sessions_search ORDER BY search_rowid"),
+        titles
+    );
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT rowid, * FROM session_messages_search_fts ORDER BY rowid"
+        ),
+        fts_before
+    );
+    assert!(search_db(&path, "beacon", 1).unwrap()[0].session_title == session.title);
+    conn.execute_batch(
+        "DROP TABLE session_messages_search_fts;
+        ALTER TABLE saved_fts RENAME TO session_messages_search_fts;",
+    )
+    .unwrap();
+    assert_eq!(search_db(&path, "quartz", 10).unwrap().len(), 3);
+}
+
+#[test]
+fn explicit_ids_survive_vacuum_holes_restart_and_later_delta_writes() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("search.db");
+    init_db(&path).unwrap();
+    for id in ["hole", "kept", "unrelated"] {
+        upsert_session_db(&path, &fixture(id), None).unwrap();
+    }
+    delete_session_db(&path, "hole", None).unwrap();
+    let conn = open_db(&path).unwrap();
+    let before = identity_rows(&conn);
+    let session_ids = rows(
+        &conn,
+        "SELECT search_rowid, session_id FROM sessions_search ORDER BY search_rowid",
+    );
+    conn.execute_batch("VACUUM").unwrap();
+    drop(conn);
+    init_db(&path).unwrap();
+    let conn = open_db(&path).unwrap();
+    assert_eq!(identity_rows(&conn), before);
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT search_rowid, session_id FROM sessions_search ORDER BY search_rowid"
+        ),
+        session_ids
+    );
+    assert_identity_alignment(&conn);
+    let unrelated = rows(
+        &conn,
+        "SELECT * FROM session_messages_search WHERE session_id='unrelated' ORDER BY search_rowid",
+    );
+    let mut updated = fixture("kept");
+    updated.messages[0].content = "edited postvacuum".into();
+    updated.messages.remove(1);
+    let mut new = Message::user("added postvacuum");
+    new.id = "new".into();
+    updated.messages.push(new);
+    upsert_session_db(&path, &updated, None).unwrap();
+    for (identity, rowid) in identity_rows(&conn) {
+        if let Some(previous) = before.get(&identity) {
+            assert_eq!(*previous, rowid);
+        }
+    }
+    assert_identity_alignment(&conn);
+    assert_eq!(rows(&conn, "SELECT * FROM session_messages_search WHERE session_id='unrelated' ORDER BY search_rowid"), unrelated);
+    assert_eq!(search_db(&path, "postvacuum", 10).unwrap().len(), 2);
+}
+
+#[test]
+fn deletion_and_pruning_use_keyed_fts_access_among_unrelated_sessions() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("search.db");
+    init_db(&path).unwrap();
+    for index in 0..128 {
+        upsert_session_db(&path, &fixture(&format!("s{index}")), None).unwrap();
+    }
+    let conn = open_db(&path).unwrap();
+    for sql in [delta::DELETE_SESSION_FTS, delta::DELETE_MESSAGE_FTS] {
+        let plan = conn
+            .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+            .unwrap()
+            .query_map(["s0"], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        println!("Production keyed FTS deletion plan: {plan:?}");
+        assert!(
+            plan.iter()
+                .any(|detail| detail.contains("VIRTUAL TABLE INDEX") && detail.contains('=')),
+            "{plan:?}"
+        );
+        assert!(
+            plan.iter().any(|detail| detail.contains("SEARCH")
+                && detail.contains("INDEX")
+                && detail.contains("session_id=?")),
+            "{plan:?}"
+        );
+    }
+    let unrelated = rows(&conn, "SELECT * FROM session_messages_search WHERE session_id NOT IN ('s0', 's1') ORDER BY search_rowid");
+    delete_session_db(&path, "s0", None).unwrap();
+    conn.execute(
+        "UPDATE sessions_search SET updated_at=?1 WHERE session_id='s1'",
+        [(Utc::now() - Duration::days(11)).to_rfc3339()],
+    )
+    .unwrap();
+    assert_eq!(prune_stale_sessions_db(&path).unwrap(), 1);
+    assert_identity_alignment(&conn);
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT * FROM session_messages_search ORDER BY search_rowid"
+        ),
+        unrelated
+    );
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM sessions_search", [], |row| row
+            .get::<_, i64>(0))
+            .unwrap(),
+        126
+    );
+}

--- a/crates/infra/bamboo-storage/src/search_index/schema.rs
+++ b/crates/infra/bamboo-storage/src/search_index/schema.rs
@@ -1,0 +1,329 @@
+use super::{to_io_error, Connection, OptionalExtension};
+
+const VERSION: &str = "4";
+const SESSION_COLUMNS: &str =
+    "session_id, title, kind, root_session_id, parent_session_id, pinned, updated_at, summary";
+const MESSAGE_COLUMNS: &str =
+    "session_id, message_id, message_index, role, content, compressed, created_at";
+const SESSION_FIELDS: &str = "session_id TEXT NOT NULL UNIQUE, title TEXT NOT NULL,
+    kind TEXT NOT NULL, root_session_id TEXT NOT NULL, parent_session_id TEXT,
+    pinned INTEGER NOT NULL, updated_at TEXT NOT NULL, summary TEXT";
+const MESSAGE_FIELDS: &str = "session_id TEXT NOT NULL, message_id TEXT NOT NULL,
+    message_index INTEGER NOT NULL, role TEXT NOT NULL, content TEXT NOT NULL,
+    compressed INTEGER NOT NULL, created_at TEXT NOT NULL, UNIQUE(session_id, message_id)";
+const FTS_SCHEMA: &str = "
+    CREATE VIRTUAL TABLE IF NOT EXISTS sessions_search_fts USING fts5(
+        session_id UNINDEXED, title, summary
+    );
+    CREATE VIRTUAL TABLE IF NOT EXISTS session_messages_search_fts USING fts5(
+        session_id UNINDEXED, message_id UNINDEXED, message_index UNINDEXED,
+        role UNINDEXED, content
+    );";
+
+fn sql_error(error: rusqlite::Error) -> std::io::Error {
+    to_io_error(format!("sqlite search schema failed: {error}"))
+}
+
+fn create_table(conn: &Connection, name: &str, fields: &str) -> std::io::Result<()> {
+    // Names/fields are static application definitions, never database input.
+    conn.execute_batch(&format!(
+        "CREATE TABLE {name} (search_rowid INTEGER PRIMARY KEY, {fields});"
+    ))
+    .map_err(sql_error)
+}
+
+fn validate_fts(conn: &Connection) -> std::io::Result<()> {
+    for (table, expected, definition) in [
+        (
+            "sessions_search_fts",
+            "session_id,title,summary",
+            "session_idunindexed,title,summary",
+        ),
+        (
+            "session_messages_search_fts",
+            "session_id,message_id,message_index,role,content",
+            "session_idunindexed,message_idunindexed,message_indexunindexed,roleunindexed,content",
+        ),
+    ] {
+        let sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_schema WHERE name=?1",
+                [table],
+                |row| row.get(0),
+            )
+            .map_err(sql_error)?;
+        let columns = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .map_err(sql_error)?
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sql_error)?;
+        let compact_sql: String = sql
+            .to_ascii_lowercase()
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect();
+        if columns.join(",") != expected
+            || !compact_sql.contains(&format!("usingfts5({definition})"))
+        {
+            return Err(to_io_error(format!(
+                "unsupported search FTS shape: {table}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_columns(
+    conn: &Connection,
+    table: &str,
+    columns: &str,
+    stable_ids: bool,
+) -> std::io::Result<()> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(sql_error)?;
+    let actual = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, bool>(3)?,
+            ))
+        })
+        .map_err(sql_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sql_error)?;
+    let expected = columns.split(", ").collect::<Vec<_>>();
+    let offset = usize::from(stable_ids);
+    if actual.len() != expected.len() + offset
+        || !actual[offset..]
+            .iter()
+            .map(|column| column.0.as_str())
+            .eq(expected)
+        || (stable_ids
+            && (actual[0].0 != "search_rowid"
+                || !actual[0].1.eq_ignore_ascii_case("INTEGER")
+                || actual[0].2 != 1))
+    {
+        return Err(to_io_error(format!(
+            "unsupported search index table shape: {table}"
+        )));
+    }
+    for (name, kind, primary_key, not_null) in &actual[offset..] {
+        let expected_type = match name.as_str() {
+            "pinned" | "message_index" | "compressed" => "INTEGER",
+            _ => "TEXT",
+        };
+        let expected_pk = if stable_ids {
+            0
+        } else {
+            match name.as_str() {
+                "session_id" => 1,
+                "message_id" => 2,
+                _ => 0,
+            }
+        };
+        let expected_not_null = !matches!(name.as_str(), "parent_session_id" | "summary")
+            && (stable_ids || table != "sessions_search" || name != "session_id");
+        if !kind.eq_ignore_ascii_case(expected_type)
+            || *primary_key != expected_pk
+            || *not_null != expected_not_null
+        {
+            return Err(to_io_error(format!(
+                "unsupported search column: {table}.{name}"
+            )));
+        }
+    }
+    if stable_ids {
+        let unique_keys = conn
+            .prepare(&format!("PRAGMA index_list({table})"))
+            .map_err(sql_error)?
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(1)?,
+                    row.get::<_, bool>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, bool>(4)?,
+                ))
+            })
+            .map_err(sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sql_error)?;
+        let expected_key: &[&str] = if table == "sessions_search" {
+            &["session_id"]
+        } else {
+            &["session_id", "message_id"]
+        };
+        let mut found_key = false;
+        for (name, unique, origin, partial) in unique_keys {
+            // INTEGER PRIMARY KEY DESC is not a rowid alias and creates a PK
+            // index. Reject it (and composite PKs) rather than trust VACUUM.
+            if origin == "pk" {
+                return Err(to_io_error(format!(
+                    "search_rowid must alias rowid: {table}"
+                )));
+            }
+            if unique && !partial {
+                let names = conn
+                    .prepare("SELECT name FROM pragma_index_info(?1) ORDER BY seqno")
+                    .map_err(sql_error)?
+                    .query_map([name], |row| row.get::<_, Option<String>>(0))
+                    .map_err(sql_error)?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(sql_error)?;
+                found_key |= names
+                    .iter()
+                    .map(Option::as_deref)
+                    .eq(expected_key.iter().copied().map(Some));
+            }
+        }
+        if !found_key {
+            return Err(to_io_error(format!(
+                "missing search identity constraint: {table}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn migrate_v3(conn: &Connection) -> std::io::Result<()> {
+    validate_columns(conn, "sessions_search", SESSION_COLUMNS, false)?;
+    validate_columns(conn, "session_messages_search", MESSAGE_COLUMNS, false)?;
+
+    // DROP TABLE removes its indexes/triggers. Preserve their exact SQL,
+    // including user objects; SQLite-owned autoindexes come from constraints.
+    let objects = conn
+        .prepare(
+            "SELECT type, name, sql FROM sqlite_schema WHERE tbl_name IN
+            ('sessions_search', 'session_messages_search')
+            AND type IN ('index', 'trigger') AND sql IS NOT NULL ORDER BY type, name",
+        )
+        .map_err(sql_error)?
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(sql_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sql_error)?;
+
+    // Remove attached triggers together before either table is replaced: a
+    // trigger on one table can reference the other during schema validation.
+    for (kind, name, _) in &objects {
+        if kind == "trigger" {
+            conn.execute_batch(&format!("DROP TRIGGER \"{}\"", name.replace('"', "\"\"")))
+                .map_err(sql_error)?;
+        }
+    }
+    for (table, fields, columns) in [
+        ("sessions_search", SESSION_FIELDS, SESSION_COLUMNS),
+        ("session_messages_search", MESSAGE_FIELDS, MESSAGE_COLUMNS),
+    ] {
+        let replacement = format!("{table}_v4");
+        create_table(conn, &replacement, fields)?;
+        conn.execute_batch(&format!(
+            "INSERT INTO {replacement} (search_rowid, {columns})
+                SELECT rowid, {columns} FROM {table};
+             DROP TABLE {table};
+             ALTER TABLE {replacement} RENAME TO {table};"
+        ))
+        .map_err(sql_error)?;
+    }
+    for (_, _, sql) in objects {
+        conn.execute_batch(&sql).map_err(sql_error)?;
+    }
+
+    // The legacy FTS rowids were independent. Rebuild only this derived cache
+    // once so every FTS row uses the corresponding explicit ordinary-table ID.
+    conn.execute_batch(FTS_SCHEMA).map_err(sql_error)?;
+    validate_fts(conn)?;
+    conn.execute_batch(
+        "DELETE FROM sessions_search_fts;
+         INSERT INTO sessions_search_fts (rowid, session_id, title, summary)
+            SELECT search_rowid, session_id, title, COALESCE(summary, '') FROM sessions_search;
+         DELETE FROM session_messages_search_fts;
+         INSERT INTO session_messages_search_fts
+            (rowid, session_id, message_id, message_index, role, content)
+            SELECT search_rowid, session_id, message_id, message_index, role, content
+            FROM session_messages_search;",
+    )
+    .map_err(sql_error)
+}
+
+pub(super) fn initialize(conn: &mut Connection) -> std::io::Result<()> {
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(sql_error)?;
+    let has_meta: bool = tx
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name = 'session_search_meta')",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(sql_error)?;
+    let version: Option<String> = if has_meta {
+        tx.query_row(
+            "SELECT value FROM session_search_meta WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(sql_error)?
+    } else {
+        None
+    };
+    match version.as_deref() {
+        Some("3") => migrate_v3(&tx)?,
+        Some(VERSION) => {
+            validate_columns(&tx, "sessions_search", SESSION_COLUMNS, true)?;
+            validate_columns(&tx, "session_messages_search", MESSAGE_COLUMNS, true)?;
+        }
+        None => {
+            // Never overwrite an unversioned/partial owned schema as a new DB.
+            let existing: bool = tx
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name IN
+                    ('sessions_search', 'session_messages_search',
+                     'sessions_search_fts', 'session_messages_search_fts'))",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(sql_error)?;
+            if existing {
+                return Err(to_io_error("unversioned existing search index schema"));
+            }
+            tx.execute_batch(
+                "CREATE TABLE IF NOT EXISTS session_search_meta
+                (key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+            )
+            .map_err(sql_error)?;
+            create_table(&tx, "sessions_search", SESSION_FIELDS)?;
+            create_table(&tx, "session_messages_search", MESSAGE_FIELDS)?;
+        }
+        Some(unknown) => {
+            return Err(to_io_error(format!(
+                "unsupported search index schema version: {unknown}"
+            )));
+        }
+    }
+    tx.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_session_messages_search_session_id
+        ON session_messages_search(session_id, message_index);",
+    )
+    .map_err(sql_error)?;
+    tx.execute_batch(FTS_SCHEMA).map_err(sql_error)?;
+    validate_fts(&tx)?;
+    tx.execute(
+        "INSERT INTO session_search_meta (key, value) VALUES ('schema_version', ?1)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value WHERE value != excluded.value",
+        [VERSION],
+    )
+    .map_err(sql_error)?;
+    tx.commit().map_err(sql_error)
+}

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -6763,6 +6763,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_rebuild_repairs_unchanged_snapshots_without_replacing_message_ids(
+    ) -> io::Result<()> {
+        let (storage, temp) = create_temp_storage().await?;
+        let mut session = session_with_history("search-repair", 2, "run-a");
+        session.title = "repairable beacon".into();
+        session.messages[0].content = "repairable quartz".into();
+        storage.save_session(&session).await?;
+        storage.flush_search_index().await;
+        let conn = rusqlite::Connection::open(storage.search_index().db_path()).unwrap();
+        let identities = |conn: &rusqlite::Connection| {
+            conn.prepare(
+                "SELECT message_id, search_rowid FROM session_messages_search ORDER BY message_id",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+        };
+        let before = identities(&conn);
+        conn.execute_batch(
+            "DELETE FROM sessions_search_fts;
+            UPDATE session_messages_search_fts SET content='stale payload';",
+        )
+        .unwrap();
+        drop(storage);
+
+        // Reopen the store and run the same rebuild used by server startup.
+        let reopened = SessionStoreV2::new(temp.path().to_path_buf()).await?;
+        reopened.rebuild_search_index().await?;
+        assert_eq!(identities(&conn), before);
+        assert_eq!(reopened.search_index().search("beacon", 10).await?.len(), 1);
+        assert_eq!(reopened.search_index().search("quartz", 10).await?.len(), 1);
+        assert!(reopened
+            .search_index()
+            .search("stale", 10)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn persistence_metrics_report_bounded_create_latency_percentiles() -> io::Result<()> {
         let (storage, _temp) = create_temp_storage().await?;
         for millis in [10, 20, 30, 40, 50] {


### PR DESCRIPTION
## Summary
Saving a session previously deleted and rebuilt every cached message and FTS row, including unchanged snapshots, and deleted FTS rows by their unindexed session ID. Give both ordinary search tables stable integer row identities and update only changed projections; resolve FTS deletions through indexed ordinary identities. An unchanged snapshot performs zero ordinary/FTS row writes, while missing or stale FTS projections are repaired by rowid.

Migrate the existing derived search cache atomically from schema 3 to 4, preserving data and attached indexes/triggers, rebuilding matching FTS identities, and publishing the version last. Explicit IDs survive VACUUM. Existing public APIs, search ranking/snippets, compressed-cache behavior, source-revision/time fences, retention rules and transaction boundaries remain intact.

## Test Plan
- [x] Full bamboo-storage suite on rebased head: 206 passed; 3 existing doctests ignored.
- [x] Populated independent legacy schema fixture, repeated init, migration-publication failure rollback, unknown versions and seven incompatible populated schema-4 definitions rejected without mutation.
- [x] Actual affected-row counts plus independent ordinary-table audit triggers for identical snapshot, metadata, title/summary, compression/time, append/edit/role, reorder/remove/empty snapshots; stable row IDs and duplicate/error rollback.
- [x] Missing/stale FTS repair, startup rebuild, existing coalescing/source-revision/delete-recreate fences, deletion holes followed by VACUUM/restart and later edits.
- [x] Production delete/prune query plans among 128 unrelated sessions use FTS rowid constraints fed by ordinary identity indexes.
- [x] Exact workspace CI Clippy, formatting and whitespace checks passed on base 42cf35fb924d43d1ea39537ef1204e5c7f018e38.
- [x] Independent final exact-head review approved 519a9030c72049969e8bea3dbdfbc333ff86d6ee; 22 distinct regressions independently passed.
- [x] Required dev CI and live merge gates; all platform fixtures and CodeQL analyses passed.
- [x] First Test attempt reproduced unchanged HTTP graceful-drain issue #878; the same-head Test-only retry passed all stages. Independent local CI-feature reproduction and ten further repeats passed 11/11 without code changes; evidence recorded in #878.

## Local performance evidence
Two fresh-database pairs used the actual public API with 256 sessions × 128 messages, identical fixed fixtures/dependency versions/dev profile, in baseline→optimized then optimized→baseline order. Every ordinary/FTS projection and public search was validated after all 12 phases. For each 256-call sweep, unchanged saves measured baseline 8.039/17.702 s versus optimized 0.562/0.580 s; appending one message per session measured 8.163/19.780 s versus 0.861/0.834 s. Baseline variance is substantial; these are raw single-host synthetic samples, not a stable production speedup or latency guarantee. Migration and concurrent writers were not benchmarked.

## Upgrade and scope
Stop older Bamboo writers sharing the data directory before schema 3→4 upgrade, as documented in README. Mixed old/new writers are unsupported; a failed migration preserves the previous cache, and canonical session data is unchanged. Reads/comparisons remain O(messages in the target session); only write volume tracks changed rows. No additional store, daemon, queue, source format, dependency or real user database change.

Six files, 1,222 net lines. This is the FTS slice of #1083. Known unchanged nonrequired Security Audit baseline: yanked wnaf 0.14.0 (#1061).

Closes #1084
