### PR TITLE
feat: persist prompt-memory exposure observations (#1077)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,31 @@ Jiandu owns canonical persistence, derived indexes, lexical recall, and the pers
 
 Jiandu defaults to the independent `~/.jiandu` data root. Bamboo configuration, sessions, and the prospective-record Ledger remain under `~/.bamboo`; the two stores are not mixed.
 
+**Prompt-memory observations.** The canonical native agent loop can record which
+compact relevant-memory records it supplied when a provider stream successfully
+bootstraps. Schema v1 keeps the first such observation for an execution-scoped
+logical round: retries do not increase its frequency or replace its membership,
+while a new execution/resume has a new round identity. This is host-side prompt
+exposure, not proof of provider processing, model adoption, or a full `memory get`.
+
+- Only trusted Project item IDs, lifecycle status, final rank and character
+  counts are retained. Headers also distinguish empty/disabled/failed recall and
+  count Global fallback without storing Global IDs. Jiandu v0.2.0 currently
+  chooses Project hits or Global fallback, not a mixed set; the observation
+  schema can represent mixed counts without assigning Global IDs to a Project.
+  Overall recall eligibility is not a Project lookup attempt or a Project
+  retrieval hit-rate denominator.
+- Records use the existing best-effort metrics collector and `metrics.db`, with
+  the existing 90-day round retention. Queued observations can be lost on a crash
+  or storage failure; this is not complete lifetime history or crash-exact delivery.
+- This captures the current round's fresh compact selection, not old memory text
+  retained in the append-only transcript. Management browsing and direct tool
+  execution do not emit observations; execution adapters without provenance are
+  unsupported coverage, not observed zeroes. There is no historical backfill.
+
+This producer does not add an aggregation endpoint or dashboard, alter Jiandu's
+canonical data, or store memory bodies, summaries, queries, prompts or outputs.
+
 **Gardener** (`bamboo-engine/src/gardener.rs`) specializes in splitting multi-topic blobs and consolidating duplicates. It has a hard per-run cap and **calls no LLM when the deterministic pre-screen finds no candidates**; only the model-reviewed maintenance decision has model cost.
 
 > Why it matters: the memory system lets the assistant understand your project better over long-term use, while keeping cost controlled and data local.

--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use bamboo_agent_core::storage::Storage;
 use bamboo_agent_core::tools::{ToolCtx, ToolExecutionContext};
+use bamboo_metrics::storage::MetricsStorage;
 use bamboo_storage::LockedSessionStore;
 use tokio::sync::RwLock;
 
@@ -691,6 +692,14 @@ async fn multilingual_retrieval_metadata_round_trips_through_query_and_get() {
     let dir = tempfile::tempdir().expect("tempdir");
     let tool = build_memory_tool(dir.path());
     let session_id = "multilingual-memory-session";
+    let round_id = "management-only-round";
+    let metrics_storage = Arc::new(bamboo_metrics::SqliteMetricsStorage::new(
+        dir.path().join("metrics.db"),
+    ));
+    metrics_storage.init().await.expect("metrics init");
+    let collector = bamboo_metrics::MetricsCollector::spawn(metrics_storage.clone(), 7);
+    collector.session_started(session_id, "test-model", chrono::Utc::now());
+    collector.round_started(round_id, session_id, "test-model", chrono::Utc::now());
 
     let written = invoke_json(
         &tool,
@@ -743,6 +752,42 @@ async fn multilingual_retrieval_metadata_round_trips_through_query_and_get() {
     assert!(entities.contains(&json!("Project Suzaku")));
     assert_eq!(fetched["memory"]["body_truncated"], false);
     assert_eq!(fetched["memory"]["retrieval_metadata_truncated"], false);
+    invoke_json(
+        &tool,
+        json!({"action": "inspect", "scope": "global"}),
+        session_id,
+    )
+    .await;
+    invoke_json(
+        &tool,
+        json!({"action": "purge", "id": id, "mode": "archived"}),
+        session_id,
+    )
+    .await;
+
+    collector.session_message_count(session_id, 1, chrono::Utc::now());
+    let mut barrier_reached = false;
+    for _ in 0..100 {
+        if metrics_storage
+            .session_detail(session_id)
+            .await
+            .expect("metrics barrier query")
+            .is_some_and(|detail| detail.session.message_count == 1)
+        {
+            barrier_reached = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(barrier_reached, "metrics FIFO barrier did not persist");
+    assert!(
+        metrics_storage
+            .prompt_memory_exposure(round_id)
+            .await
+            .expect("query management exposure")
+            .is_none(),
+        "MemoryTool management actions must not count as provider prompt exposure"
+    );
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm.rs
@@ -43,6 +43,11 @@ impl LlmManager for DefaultLlmManager {
             session_id,
             model_name,
             tool_schemas,
+            // This dormant lifecycle adapter does not yet carry the trusted
+            // execution-local prompt-memory provenance. `None` is unsupported
+            // coverage, not a zero-exposure observation; #1077 covers the
+            // canonical runner pipeline only.
+            None,
         )
         .await?;
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -2661,15 +2661,16 @@ async fn run_pipeline_inner(
                 .unwrap_or_else(|| llm.clone()),
             background_model_name: state.auxiliary_models.background_model_name.clone(),
         };
-        crate::runtime::runner::round_prelude::refresh_round_boundary_and_prompt_context(
-            session,
-            &mut state.runtime_state,
-            config,
-            cancel_token,
-            state.metrics_collector.as_ref(),
-            Some(&runtime_context),
-        )
-        .await?;
+        let prompt_memory_exposure =
+            crate::runtime::runner::round_prelude::refresh_round_boundary_and_prompt_context(
+                session,
+                &mut state.runtime_state,
+                config,
+                cancel_token,
+                state.metrics_collector.as_ref(),
+                Some(&runtime_context),
+            )
+            .await?;
 
         // --- Task round state ---
         if let Some(ctx) = state.task_context.as_mut() {
@@ -2739,6 +2740,12 @@ async fn run_pipeline_inner(
                 &state.session_id,
                 &state.model_name,
                 &tool_schemas,
+                Some(
+                    crate::runtime::runner::round_lifecycle::PromptMemoryExposureFrame {
+                        round_id: &round_id,
+                        provenance: &prompt_memory_exposure,
+                    },
+                ),
             )
             .await
             {
@@ -2815,6 +2822,12 @@ async fn run_pipeline_inner(
                                 &state.session_id,
                                 &state.model_name,
                                 &tool_schemas_after_recovery,
+                                Some(
+                                    crate::runtime::runner::round_lifecycle::PromptMemoryExposureFrame {
+                                        round_id: &round_id,
+                                        provenance: &prompt_memory_exposure,
+                                    },
+                                ),
                             )
                             .await
                             {
@@ -6509,7 +6522,9 @@ mod tests {
         });
         let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
         let mut state = e2e_loop_state(session_id);
-        state.metrics_collector = Some(collector);
+        state.metrics_collector = Some(collector.clone());
+        let mut config = canonical_usage_pipeline_config();
+        config.metrics_collector = Some(collector);
 
         super::run_pipeline(
             &mut session,
@@ -6517,7 +6532,7 @@ mod tests {
             provider.clone(),
             tools,
             &tokio_util::sync::CancellationToken::new(),
-            &canonical_usage_pipeline_config(),
+            &config,
             &mut state,
         )
         .await
@@ -6545,6 +6560,16 @@ mod tests {
         assert_eq!(detail.rounds.len(), 1, "both attempts belong to one round");
         assert_eq!(detail.rounds[0].token_usage, expected);
         assert_eq!(detail.session.total_token_usage, expected);
+        let exposure = storage
+            .prompt_memory_exposure(&detail.rounds[0].round_id)
+            .await
+            .expect("query retry exposure")
+            .expect("both successful bootstraps share one first-wins observation");
+        assert_eq!(
+            exposure.recall_outcome,
+            bamboo_metrics::types::PromptMemoryRecallOutcome::Disabled
+        );
+        assert_eq!(exposure.all_compact_exposed_count, 0);
         assert_eq!(state.runtime_state.round.total_prompt_tokens, 30);
         assert_eq!(state.runtime_state.round.total_completion_tokens, 8);
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context.rs
@@ -8,7 +8,9 @@ mod plan_runtime;
 mod system_sections;
 mod task;
 
-pub(crate) use external_memory::{PromptMemoryRuntimeContext, PROMPT_MEMORY_OBSERVABILITY_KEY};
+pub(crate) use external_memory::{
+    PromptMemoryExposureProvenance, PromptMemoryRuntimeContext, PROMPT_MEMORY_OBSERVABILITY_KEY,
+};
 // Only tests reference this through the `prompt_context` re-export, so gate it to
 // `cfg(test)` — otherwise the lib-only clippy check flags it as an unused import.
 #[cfg(test)]
@@ -21,7 +23,7 @@ pub(crate) async fn refresh_external_memory_context(
     runtime_context: Option<&PromptMemoryRuntimeContext>,
     project_context_resolver: Option<&crate::project_context::ProjectContextResolver>,
     app_data_dir: Option<&std::path::Path>,
-) {
+) -> PromptMemoryExposureProvenance {
     external_memory::refresh_external_memory_context(
         session,
         memory,
@@ -30,7 +32,7 @@ pub(crate) async fn refresh_external_memory_context(
         project_context_resolver,
         app_data_dir,
     )
-    .await;
+    .await
 }
 
 #[cfg(test)]
@@ -39,14 +41,14 @@ pub(super) async fn refresh_external_memory_context_with_store(
     memory: &bamboo_memory::memory_store::MemoryStore,
     prompt_memory_flags: crate::runtime::config::PromptMemoryFlags,
     runtime_context: Option<&PromptMemoryRuntimeContext>,
-) {
+) -> PromptMemoryExposureProvenance {
     external_memory::refresh_external_memory_context_with_store(
         session,
         memory,
         prompt_memory_flags,
         runtime_context,
     )
-    .await;
+    .await
 }
 
 #[cfg(test)]
@@ -56,7 +58,7 @@ pub(super) async fn refresh_external_memory_context_with_stores(
     ledger_data_dir: &std::path::Path,
     prompt_memory_flags: crate::runtime::config::PromptMemoryFlags,
     runtime_context: Option<&PromptMemoryRuntimeContext>,
-) {
+) -> PromptMemoryExposureProvenance {
     external_memory::refresh_external_memory_context_with_stores(
         session,
         memory,
@@ -64,7 +66,7 @@ pub(super) async fn refresh_external_memory_context_with_stores(
         prompt_memory_flags,
         runtime_context,
     )
-    .await;
+    .await
 }
 
 #[cfg(test)]
@@ -75,7 +77,7 @@ pub(super) async fn refresh_external_memory_context_with_store_and_resolver(
     prompt_memory_flags: crate::runtime::config::PromptMemoryFlags,
     runtime_context: Option<&PromptMemoryRuntimeContext>,
     project_context_resolver: Option<&crate::project_context::ProjectContextResolver>,
-) {
+) -> PromptMemoryExposureProvenance {
     external_memory::refresh_external_memory_context_with_store_and_resolver(
         session,
         memory,
@@ -83,7 +85,7 @@ pub(super) async fn refresh_external_memory_context_with_store_and_resolver(
         runtime_context,
         project_context_resolver,
     )
-    .await;
+    .await
 }
 
 pub(super) fn strip_existing_external_memory(prompt: &str) -> String {

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/external_memory.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/external_memory.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -11,6 +12,9 @@ use bamboo_memory::ledger_store::{AgendaItem, AgendaSnapshot, LedgerStore};
 use bamboo_memory::memory_store::{
     render_memory_freshness_note, truncate_chars as memory_truncate_chars, FreshnessKind,
     MemoryRecallCandidate, MemoryRecallOptions, MemoryScope, MemoryStore, TemporalGranularity,
+};
+use bamboo_metrics::types::{
+    PromptMemoryExposureItem, PromptMemoryExposureObservation, PromptMemoryRecallOutcome,
 };
 
 use super::memory_rerank::{
@@ -104,6 +108,7 @@ struct RelevantMemorySnippet {
 struct RelevantMemoryLoadResult {
     snippets: Vec<RelevantMemorySnippet>,
     strategy: MemoryRecallStrategy,
+    outcome: PromptMemoryRecallOutcome,
 }
 
 #[derive(Debug, Clone)]
@@ -118,12 +123,75 @@ pub(crate) struct PromptMemoryRuntimeContext {
     pub background_model_name: Option<String>,
 }
 
+/// Engine-private, execution-local provenance for the final compact memories
+/// selected during this round's trusted prompt refresh.
+///
+/// This value is returned directly to the runner and never stored in Session
+/// metadata, so an HTTP metadata patch cannot forge the metrics observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PromptMemoryExposureProvenance {
+    project_id: Option<String>,
+    recall_enabled: bool,
+    query_present: bool,
+    recall_outcome: PromptMemoryRecallOutcome,
+    all_compact_exposed_count: u32,
+    project_exposed_count: u32,
+    out_of_project_only: bool,
+    compact_section_chars: u32,
+    project_items: Vec<PromptMemoryExposureItem>,
+}
+
+impl PromptMemoryExposureProvenance {
+    pub(crate) fn observation(
+        &self,
+        round_id: &str,
+        session_id: &str,
+        observed_at: chrono::DateTime<chrono::Utc>,
+    ) -> PromptMemoryExposureObservation {
+        PromptMemoryExposureObservation {
+            schema_version: 1,
+            round_id: round_id.to_string(),
+            session_id: session_id.to_string(),
+            project_id: self.project_id.clone(),
+            observed_at,
+            recall_enabled: self.recall_enabled,
+            query_present: self.query_present,
+            recall_outcome: self.recall_outcome,
+            all_compact_exposed_count: self.all_compact_exposed_count,
+            project_exposed_count: self.project_exposed_count,
+            out_of_project_only: self.out_of_project_only,
+            compact_section_chars: self.compact_section_chars,
+            project_items: self.project_items.clone(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn supported_empty_for_test(project_id: Option<&str>) -> Self {
+        Self {
+            project_id: project_id.map(str::to_string),
+            recall_enabled: false,
+            query_present: false,
+            recall_outcome: PromptMemoryRecallOutcome::Disabled,
+            all_compact_exposed_count: 0,
+            project_exposed_count: 0,
+            out_of_project_only: false,
+            compact_section_chars: 0,
+            project_items: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ExternalMemoryRenderParts {
     session_note_section: String,
     #[allow(dead_code)]
     ledger_agenda_section: String,
     relevant_memory_section: String,
+    /// Typed records that survived the final granularity reorder and render
+    /// budget, in their provider-visible order. This is deliberately separate
+    /// from the rendered markdown so exposure telemetry never reparses prompt
+    /// text (including older compact text retained in the context ledger).
+    rendered_relevant_memories: Vec<RelevantMemorySnippet>,
     project_memory_index_section: String,
     project_dream_section: String,
     global_dream_fallback_section: String,
@@ -180,7 +248,7 @@ pub(super) async fn refresh_external_memory_context(
     runtime_context: Option<&PromptMemoryRuntimeContext>,
     project_context_resolver: Option<&ProjectContextResolver>,
     app_data_dir: Option<&Path>,
-) {
+) -> PromptMemoryExposureProvenance {
     refresh_external_memory_context_with_store_resolver_and_ledger(
         session,
         memory,
@@ -189,7 +257,7 @@ pub(super) async fn refresh_external_memory_context(
         project_context_resolver,
         app_data_dir,
     )
-    .await;
+    .await
 }
 
 #[cfg(test)]
@@ -198,7 +266,7 @@ pub(super) async fn refresh_external_memory_context_with_store(
     memory: &MemoryStore,
     prompt_memory_flags: PromptMemoryFlags,
     runtime_context: Option<&PromptMemoryRuntimeContext>,
-) {
+) -> PromptMemoryExposureProvenance {
     refresh_external_memory_context_with_store_resolver_and_ledger(
         session,
         memory,
@@ -207,7 +275,7 @@ pub(super) async fn refresh_external_memory_context_with_store(
         None,
         None,
     )
-    .await;
+    .await
 }
 
 #[cfg(test)]
@@ -217,7 +285,7 @@ pub(super) async fn refresh_external_memory_context_with_stores(
     ledger_data_dir: &Path,
     prompt_memory_flags: PromptMemoryFlags,
     runtime_context: Option<&PromptMemoryRuntimeContext>,
-) {
+) -> PromptMemoryExposureProvenance {
     refresh_external_memory_context_with_store_resolver_and_ledger(
         session,
         memory,
@@ -226,7 +294,7 @@ pub(super) async fn refresh_external_memory_context_with_stores(
         None,
         Some(ledger_data_dir),
     )
-    .await;
+    .await
 }
 
 #[cfg(test)]
@@ -236,7 +304,7 @@ pub(super) async fn refresh_external_memory_context_with_store_and_resolver(
     prompt_memory_flags: PromptMemoryFlags,
     runtime_context: Option<&PromptMemoryRuntimeContext>,
     project_context_resolver: Option<&ProjectContextResolver>,
-) {
+) -> PromptMemoryExposureProvenance {
     refresh_external_memory_context_with_store_resolver_and_ledger(
         session,
         memory,
@@ -245,7 +313,7 @@ pub(super) async fn refresh_external_memory_context_with_store_and_resolver(
         project_context_resolver,
         None,
     )
-    .await;
+    .await
 }
 
 async fn refresh_external_memory_context_with_store_resolver_and_ledger(
@@ -255,7 +323,7 @@ async fn refresh_external_memory_context_with_store_resolver_and_ledger(
     runtime_context: Option<&PromptMemoryRuntimeContext>,
     project_context_resolver: Option<&ProjectContextResolver>,
     ledger_data_dir: Option<&Path>,
-) {
+) -> PromptMemoryExposureProvenance {
     // Computed each round and cached in a session field (NOT injected into the
     // system message), so a per-round memory change never invalidates the cached
     // system prefix; the request assembler reads the field to build a volatile
@@ -316,6 +384,7 @@ async fn refresh_external_memory_context_with_store_resolver_and_ledger(
         RelevantMemoryLoadResult {
             snippets: Vec::new(),
             strategy: MemoryRecallStrategy::Lexical,
+            outcome: PromptMemoryRecallOutcome::Disabled,
         }
     };
     let relevant_memory_snippets = relevant_memory_result.snippets.clone();
@@ -345,6 +414,34 @@ async fn refresh_external_memory_context_with_store_resolver_and_ledger(
         project_dream.as_ref(),
         global_dream_fallback.as_ref(),
     );
+    let all_compact_exposed_count = render_parts.rendered_relevant_memories.len() as u32;
+    let project_items = render_parts
+        .rendered_relevant_memories
+        .iter()
+        .enumerate()
+        .filter(|(_, snippet)| {
+            resolved_project_scope.is_some() && snippet.scope.as_str() == "project"
+        })
+        .map(|(index, snippet)| PromptMemoryExposureItem {
+            memory_id: snippet.id.clone(),
+            scope: "project".to_string(),
+            status_at_observation: snippet.status.clone(),
+            rank: index as u32 + 1,
+            rendered_chars: count_chars(&render_relevant_memory_item(snippet)) as u32,
+        })
+        .collect::<Vec<_>>();
+    let project_exposed_count = project_items.len() as u32;
+    let prompt_memory_exposure = PromptMemoryExposureProvenance {
+        project_id: resolved_project_key.clone(),
+        recall_enabled: prompt_memory_flags.relevant_recall,
+        query_present: latest_user_query_present,
+        recall_outcome: relevant_memory_result.outcome,
+        all_compact_exposed_count,
+        project_exposed_count,
+        out_of_project_only: all_compact_exposed_count > 0 && project_exposed_count == 0,
+        compact_section_chars: count_chars(&render_parts.relevant_memory_section) as u32,
+        project_items,
+    };
     if let Some(agenda) = &ledger_agenda {
         tracing::debug!(
             "[{}] Ledger agenda injected: items={}, chars={}",
@@ -409,6 +506,7 @@ async fn refresh_external_memory_context_with_store_resolver_and_ledger(
         observability.dream_source,
         observability.external_memory_section_chars,
     );
+    prompt_memory_exposure
 }
 
 /// Load the agenda from Bamboo's ledger store. Jiandu memory owns a separate
@@ -610,6 +708,7 @@ async fn load_relevant_memory_snippets(
         return RelevantMemoryLoadResult {
             snippets: Vec::new(),
             strategy: MemoryRecallStrategy::Lexical,
+            outcome: PromptMemoryRecallOutcome::NoQuery,
         };
     };
 
@@ -652,8 +751,16 @@ async fn load_relevant_memory_snippets(
             return RelevantMemoryLoadResult {
                 snippets: Vec::new(),
                 strategy: MemoryRecallStrategy::Lexical,
+                outcome: PromptMemoryRecallOutcome::LookupError,
             };
         }
+    };
+
+    let outcome = match (selection.strategy, selection.candidates.is_empty()) {
+        (MemoryRecallStrategy::Lexical, true) => PromptMemoryRecallOutcome::NoMatch,
+        (MemoryRecallStrategy::Lexical, false) => PromptMemoryRecallOutcome::Lexical,
+        (MemoryRecallStrategy::Reranked, _) => PromptMemoryRecallOutcome::Reranked,
+        (MemoryRecallStrategy::RerankFallback, _) => PromptMemoryRecallOutcome::RerankFallback,
     };
 
     let mut rendered = Vec::new();
@@ -677,6 +784,7 @@ async fn load_relevant_memory_snippets(
     RelevantMemoryLoadResult {
         snippets: rendered,
         strategy: selection.strategy,
+        outcome,
     }
 }
 
@@ -805,11 +913,15 @@ fn build_external_memory_render_parts(
     let ledger_agenda_section = ledger_agenda
         .map(render_ledger_agenda_section)
         .unwrap_or_default();
-    let relevant_memory_section = if relevant_memory_snippets.is_empty() {
-        String::new()
+    let relevant_memory_render = if relevant_memory_snippets.is_empty() {
+        RelevantMemoryRender::default()
     } else {
-        render_relevant_memory_section(relevant_memory_snippets)
+        render_relevant_memory_section_with_budget(
+            relevant_memory_snippets,
+            RELEVANT_MEMORY_TOTAL_MAX_CHARS,
+        )
     };
+    let relevant_memory_section = relevant_memory_render.section;
     let project_memory_index_section = project_memory_index
         .map(render_project_memory_index_section)
         .unwrap_or_default();
@@ -896,6 +1008,7 @@ fn build_external_memory_render_parts(
         session_note_section,
         ledger_agenda_section,
         relevant_memory_section,
+        rendered_relevant_memories: relevant_memory_render.kept_snippets,
         project_memory_index_section,
         project_dream_section,
         global_dream_fallback_section,
@@ -1171,7 +1284,16 @@ fn render_relevant_memory_item(snippet: &RelevantMemorySnippet) -> String {
 /// `TemporalGranularity::is_high_churn`), the suffix segment is empty and
 /// `segments.combined()` degenerates to exactly the old flat concatenation in the
 /// same relative order, with no separator inserted.
-fn render_relevant_memory_section(snippets: &[RelevantMemorySnippet]) -> String {
+#[derive(Debug, Clone, Default)]
+struct RelevantMemoryRender {
+    section: String,
+    kept_snippets: Vec<RelevantMemorySnippet>,
+}
+
+fn render_relevant_memory_section_with_budget(
+    snippets: &[RelevantMemorySnippet],
+    total_budget_chars: usize,
+) -> RelevantMemoryRender {
     let mut section = String::new();
     section.push_str("### Relevant Durable Memories\n");
     section.push_str(
@@ -1188,13 +1310,38 @@ fn render_relevant_memory_section(snippets: &[RelevantMemorySnippet]) -> String 
             )
         })
         .collect();
-    let segments = segment_by_granularity_budget(&items, RELEVANT_MEMORY_TOTAL_MAX_CHARS);
+    let segments = segment_by_granularity_budget(&items, total_budget_chars);
+    let dropped_ids = segments
+        .prefix_dropped_ids
+        .iter()
+        .chain(segments.suffix_dropped_ids.iter())
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let kept_snippets = snippets
+        .iter()
+        .filter(|snippet| !TemporalGranularity::is_high_churn(snippet.granularity))
+        .chain(
+            snippets
+                .iter()
+                .filter(|snippet| TemporalGranularity::is_high_churn(snippet.granularity)),
+        )
+        .filter(|snippet| !dropped_ids.contains(snippet.id.as_str()))
+        .cloned()
+        .collect();
     // `combined()` is prefix followed by suffix with no separator — for the
     // all-coarse case the suffix is empty and this is byte-identical to the old
     // flat per-snippet loop.
     section.push_str(&segments.combined());
     section.push('\n');
-    section
+    RelevantMemoryRender {
+        section,
+        kept_snippets,
+    }
+}
+
+#[cfg(test)]
+fn render_relevant_memory_section(snippets: &[RelevantMemorySnippet]) -> String {
+    render_relevant_memory_section_with_budget(snippets, RELEVANT_MEMORY_TOTAL_MAX_CHARS).section
 }
 
 fn render_project_memory_index_section(snippet: &ProjectMemoryIndexSnippet) -> String {
@@ -1421,7 +1568,11 @@ mod granularity_prompt_wiring_tests {
             "year summary",
         );
 
-        let section = render_relevant_memory_section(&[day, year]);
+        let rendered = render_relevant_memory_section_with_budget(
+            &[day, year],
+            RELEVANT_MEMORY_TOTAL_MAX_CHARS,
+        );
+        let section = rendered.section;
 
         let day_pos = section
             .find("Day Title Marker")
@@ -1433,6 +1584,53 @@ mod granularity_prompt_wiring_tests {
             year_pos < day_pos,
             "coarse (year) memory must render before fine (day) memory"
         );
+        assert_eq!(
+            rendered
+                .kept_snippets
+                .iter()
+                .map(|snippet| snippet.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["year-1", "day-1"],
+            "typed provenance order must match final provider-visible render order"
+        );
+    }
+
+    #[test]
+    fn typed_provenance_excludes_items_dropped_by_the_final_render_budget() {
+        let day = snippet(
+            "day-dropped",
+            Some(TemporalGranularity::Day),
+            "Day Dropped Marker",
+            "day summary",
+        );
+        let year = snippet(
+            "year-kept",
+            Some(TemporalGranularity::Year),
+            "Year Kept Marker",
+            "year summary",
+        );
+        let quarter = snippet(
+            "quarter-dropped",
+            Some(TemporalGranularity::Quarter),
+            "Quarter Dropped Marker",
+            "quarter summary",
+        );
+        let year_chars = count_chars(&render_relevant_memory_item(&year));
+
+        let rendered =
+            render_relevant_memory_section_with_budget(&[day, year, quarter], year_chars);
+
+        assert_eq!(
+            rendered
+                .kept_snippets
+                .iter()
+                .map(|snippet| snippet.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["year-kept"],
+        );
+        assert!(rendered.section.contains("Year Kept Marker"));
+        assert!(!rendered.section.contains("Quarter Dropped Marker"));
+        assert!(!rendered.section.contains("Day Dropped Marker"));
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
@@ -762,13 +762,40 @@ async fn external_memory_omits_relevant_memory_section_when_no_match_exists() {
         "this query should not match anything relevant",
     ));
 
-    super::refresh_external_memory_context_with_store(
+    let exposure = super::refresh_external_memory_context_with_store(
         &mut session,
         &store,
         crate::runtime::config::PromptMemoryFlags::default(),
         None,
     )
     .await;
+    let observation = exposure.observation("no-match-round", &session.id, chrono::Utc::now());
+    assert_eq!(
+        observation.recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::NoMatch
+    );
+    assert_eq!(observation.all_compact_exposed_count, 0);
+    assert!(observation.project_items.is_empty());
+
+    let invalid_root = temp_dir.path().join("not-a-directory");
+    let invalid_index = invalid_root.join("memory/v1/scopes/global/indexes/lexical.json");
+    std::fs::create_dir_all(invalid_index.parent().expect("index parent")).expect("index dir");
+    std::fs::write(&invalid_index, "not-json").expect("write corrupt lexical index");
+    let invalid_store = bamboo_memory::memory_store::MemoryStore::new(&invalid_root);
+    let mut error_session = bamboo_agent_core::Session::new("lookup-error", "test-model");
+    error_session.add_message(bamboo_agent_core::Message::user("lookup error query"));
+    let lookup_error = super::refresh_external_memory_context_with_store(
+        &mut error_session,
+        &invalid_store,
+        crate::runtime::config::PromptMemoryFlags::default(),
+        None,
+    )
+    .await
+    .observation("lookup-error-round", &error_session.id, chrono::Utc::now());
+    assert_eq!(
+        lookup_error.recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::LookupError
+    );
 
     let system_prompt = super::render_external_memory_section(&session)
         .expect("external memory section should be rendered");
@@ -786,8 +813,9 @@ async fn external_memory_limits_relevant_memories_to_top_k() {
     std::fs::create_dir_all(&workspace).expect("workspace dir");
     let project_key = project_id.to_string();
 
+    let mut written_ids = Vec::new();
     for idx in 0..4 {
-        project_memory
+        let written = project_memory
             .write_memory(
                 bamboo_memory::memory_store::MemoryScope::Project,
                 Some(project_key.as_str()),
@@ -802,6 +830,7 @@ async fn external_memory_limits_relevant_memories_to_top_k() {
             )
             .await
             .expect("save project memory");
+        written_ids.push(written.frontmatter.id);
         std::thread::sleep(std::time::Duration::from_millis(5));
     }
 
@@ -814,13 +843,34 @@ async fn external_memory_limits_relevant_memories_to_top_k() {
     );
     session.add_message(bamboo_agent_core::Message::user("release freeze"));
 
-    super::refresh_external_memory_context_with_store(
+    let exposure = super::refresh_external_memory_context_with_store(
         &mut session,
         &store,
         crate::runtime::config::PromptMemoryFlags::default(),
         None,
     )
     .await;
+    let observation = exposure.observation("top-k-round", &session.id, chrono::Utc::now());
+    assert_eq!(
+        observation.recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::Lexical
+    );
+    assert_eq!(observation.all_compact_exposed_count, 3);
+    assert_eq!(observation.project_items.len(), 3);
+    let observed_ids = observation
+        .project_items
+        .iter()
+        .map(|item| item.memory_id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(observed_ids.len(), 3);
+    assert_eq!(
+        written_ids
+            .iter()
+            .filter(|id| !observed_ids.contains(id.as_str()))
+            .count(),
+        1,
+        "the fourth recall candidate must not be counted as provider-visible"
+    );
 
     let system_prompt = super::render_external_memory_section(&session)
         .expect("external memory section should be rendered");
@@ -886,13 +936,22 @@ async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_
     );
     session.add_message(bamboo_agent_core::Message::user("release checklist"));
 
-    super::refresh_external_memory_context_with_store(
+    let exposure = super::refresh_external_memory_context_with_store(
         &mut session,
         &store,
         crate::runtime::config::PromptMemoryFlags::default(),
         None,
     )
     .await;
+    let observation = exposure.observation("global-only-round", &session.id, chrono::Utc::now());
+    assert_eq!(
+        observation.recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::Lexical
+    );
+    assert_eq!(observation.all_compact_exposed_count, 1);
+    assert_eq!(observation.project_exposed_count, 0);
+    assert!(observation.out_of_project_only);
+    assert!(observation.project_items.is_empty());
 
     let system_prompt = super::render_external_memory_section(&session)
         .expect("external memory section should be rendered");
@@ -970,13 +1029,19 @@ async fn external_memory_uses_global_dream_fallback_when_project_dream_and_index
         workspace.to_string_lossy().to_string(),
     );
 
-    super::refresh_external_memory_context_with_store(
+    let exposure = super::refresh_external_memory_context_with_store(
         &mut session,
         &store,
         crate::runtime::config::PromptMemoryFlags::default(),
         None,
     )
     .await;
+    assert_eq!(
+        exposure
+            .observation("no-query-round", &session.id, chrono::Utc::now())
+            .recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::NoQuery
+    );
 
     let system_prompt = super::render_external_memory_section(&session)
         .expect("external memory section should be rendered");
@@ -1105,7 +1170,7 @@ async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_projec
     );
     session.add_message(bamboo_agent_core::Message::user("concise answers"));
 
-    super::refresh_external_memory_context_with_store(
+    let exposure = super::refresh_external_memory_context_with_store(
         &mut session,
         &store,
         crate::runtime::config::PromptMemoryFlags {
@@ -1116,6 +1181,12 @@ async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_projec
         None,
     )
     .await;
+    assert_eq!(
+        exposure
+            .observation("disabled-round", &session.id, chrono::Utc::now())
+            .recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::Disabled
+    );
 
     let system_prompt = super::render_external_memory_section(&session)
         .expect("external memory section should be rendered");
@@ -1203,7 +1274,7 @@ async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() 
         "release freeze for mobile launch",
     ));
 
-    super::refresh_external_memory_context_with_store(
+    let exposure = super::refresh_external_memory_context_with_store(
         &mut session,
         &store,
         crate::runtime::config::PromptMemoryFlags {
@@ -1213,6 +1284,12 @@ async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() 
         Some(&runtime_context),
     )
     .await;
+    assert_eq!(
+        exposure
+            .observation("reranked-round", &session.id, chrono::Utc::now())
+            .recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::Reranked
+    );
 
     let system_prompt = super::render_external_memory_section(&session)
         .expect("external memory section should be rendered");
@@ -1238,6 +1315,26 @@ async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() 
     assert_eq!(
         requested_models.lock().expect("lock poisoned").as_slice(),
         ["rerank-fast-model"]
+    );
+
+    let fallback_context = super::PromptMemoryRuntimeContext {
+        llm: Arc::new(StaticResponseProvider::new("not a rerank response")),
+        background_model_name: Some("rerank-fallback-model".to_string()),
+    };
+    let fallback = super::refresh_external_memory_context_with_store(
+        &mut session,
+        &store,
+        crate::runtime::config::PromptMemoryFlags {
+            relevant_recall_rerank: true,
+            ..crate::runtime::config::PromptMemoryFlags::default()
+        },
+        Some(&fallback_context),
+    )
+    .await
+    .observation("rerank-fallback-round", &session.id, chrono::Utc::now());
+    assert_eq!(
+        fallback.recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::RerankFallback
     );
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
@@ -71,6 +71,17 @@ pub(crate) struct RoundLlmExecutionOutput {
     pub terminal_validation_error: Option<AgentError>,
 }
 
+/// Trusted execution-local prompt-memory snapshot paired with the stable
+/// execution-scoped round identity used for durable metrics deduplication.
+///
+/// `None` means this execution path does not implement #1077 capture. It must
+/// not be converted into a supported zero-exposure observation.
+#[derive(Clone, Copy)]
+pub(crate) struct PromptMemoryExposureFrame<'a> {
+    pub round_id: &'a str,
+    pub provenance: &'a crate::runtime::runner::prompt_context::PromptMemoryExposureProvenance,
+}
+
 /// Resolve one billed attempt's canonical token usage.
 ///
 /// Availability is decided independently for prompt and completion tokens:
@@ -114,6 +125,7 @@ pub(crate) async fn execute_llm_round(
     session_id: &str,
     model_name: &str,
     tool_schemas: &[ToolSchema],
+    prompt_memory_exposure: Option<PromptMemoryExposureFrame<'_>>,
 ) -> Result<RoundLlmExecutionOutput, AgentError> {
     let required_tool = required_tool_for_session(session);
     let capability_loading_mode = llm.capability_loading_mode(model_name, required_tool).await;
@@ -147,6 +159,7 @@ pub(crate) async fn execute_llm_round(
         reasoning_effort: config.reasoning_effort,
         max_context_tokens: prepared.budget.max_context_tokens,
         max_output_tokens: prepared.budget.max_output_tokens,
+        prompt_memory_exposure,
     };
 
     let (stream_output, llm_duration) = stream_execution::execute_llm_stream(
@@ -343,6 +356,7 @@ mod tests {
             "sticky-round-tools",
             "chat-model",
             &tools,
+            None,
         )
         .await
         .unwrap();
@@ -388,6 +402,7 @@ mod tests {
             "sticky-round-tools",
             "chat-model",
             &tools,
+            None,
         )
         .await
         .unwrap();

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -38,6 +38,8 @@ use bamboo_llm::{
 use bamboo_tools::exposure::activated_discoverable_tools;
 use sha2::{Digest, Sha256};
 
+use super::PromptMemoryExposureFrame;
+
 /// LLM-stream frame bundling per-request identification, observability, and
 /// model configuration parameters.  Passed into [`execute_llm_stream`] to
 /// keep its parameter count below the clippy threshold.
@@ -51,6 +53,7 @@ pub(in crate::runtime::runner) struct LlmStreamFrame<'a> {
     pub reasoning_effort: Option<ReasoningEffort>,
     pub max_context_tokens: u32,
     pub max_output_tokens: u32,
+    pub prompt_memory_exposure: Option<PromptMemoryExposureFrame<'a>>,
 }
 
 const SESSION_RESPONSES_PREVIOUS_RESPONSE_ID_KEY: &str = "responses.previous_response_id";
@@ -1189,6 +1192,23 @@ pub(super) async fn execute_llm_stream(
             AgentError::LLM(message)
         }
     })?;
+
+    // A successful stream bootstrap is the first point at which the final
+    // provider-visible PromptIR is known to have been accepted. Capture the
+    // typed fresh-selection snapshot once here; retries with the same round id
+    // are harmless because SQLite atomically preserves the first snapshot.
+    // Historical compact text already present in the append-only context ledger
+    // is intentionally not reparsed or backfilled into this round's observation.
+    if let (Some(collector), Some(exposure)) = (
+        config.metrics_collector.as_ref(),
+        frame.prompt_memory_exposure,
+    ) {
+        collector.prompt_memory_exposure(exposure.provenance.observation(
+            exposure.round_id,
+            session_id,
+            chrono::Utc::now(),
+        ));
+    }
 
     // Send token budget update AFTER LLM call succeeds.
     // This timing gives frontend time to subscribe to /events endpoint.

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -18,7 +18,10 @@ use bamboo_llm::{
     Config, LLMChunk, LLMProvider, LLMRequestOptions, LLMStream, ProviderVisibleToolFootprint,
     ProviderVisibleToolSegment, ProviderVisibleToolSegmentKind,
 };
+use bamboo_metrics::storage::MetricsStorage;
 use chrono::Utc;
+
+use super::super::PromptMemoryExposureFrame;
 
 fn isolate_prompt_safe_env_cache() -> MutexGuard<'static, ()> {
     let guard = crate::runtime::tests::env_cache_lock_acquire();
@@ -197,6 +200,75 @@ fn test_config(system_prompt: &str) -> crate::runtime::config::AgentLoopConfig {
     }
 }
 
+async fn prompt_exposure_metrics(
+    session_id: &str,
+    round_id: &str,
+) -> (
+    tempfile::TempDir,
+    bamboo_metrics::MetricsCollector,
+    Arc<bamboo_metrics::SqliteMetricsStorage>,
+) {
+    let directory = tempfile::tempdir().expect("metrics tempdir");
+    let storage = Arc::new(bamboo_metrics::SqliteMetricsStorage::new(
+        directory.path().join("metrics.db"),
+    ));
+    storage.init().await.expect("initialize metrics storage");
+    storage
+        .upsert_session_start(session_id, "test-model", Utc::now())
+        .await
+        .expect("insert owning session");
+    storage
+        .insert_round_start(round_id, session_id, "test-model", Utc::now())
+        .await
+        .expect("insert owning round");
+    let collector = bamboo_metrics::MetricsCollector::spawn(storage.clone(), 90);
+    (directory, collector, storage)
+}
+
+async fn wait_for_prompt_exposure(
+    storage: &bamboo_metrics::SqliteMetricsStorage,
+    round_id: &str,
+) -> bamboo_metrics::types::PromptMemoryExposureObservation {
+    for _ in 0..100 {
+        if let Some(observation) = storage
+            .prompt_memory_exposure(round_id)
+            .await
+            .expect("query prompt-memory exposure")
+        {
+            return observation;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("prompt-memory observation was not persisted for {round_id}");
+}
+
+async fn assert_no_prompt_exposure_after_collector_barrier(
+    collector: &bamboo_metrics::MetricsCollector,
+    storage: &bamboo_metrics::SqliteMetricsStorage,
+    session_id: &str,
+    round_id: &str,
+) {
+    const BARRIER_MESSAGE_COUNT: u32 = 42_077_107;
+    collector.session_message_count(session_id, BARRIER_MESSAGE_COUNT, Utc::now());
+    for _ in 0..100 {
+        let barrier_reached = storage
+            .session_detail(session_id)
+            .await
+            .expect("query collector barrier")
+            .is_some_and(|detail| detail.session.message_count == BARRIER_MESSAGE_COUNT);
+        if barrier_reached {
+            assert!(storage
+                .prompt_memory_exposure(round_id)
+                .await
+                .expect("query prompt-memory exposure after barrier")
+                .is_none());
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("metrics collector barrier was not observed for {session_id}");
+}
+
 /// The system field that a base prompt resolves to once the framework-invariant
 /// agent directives are folded in — mirrors what `build_stable_prompt_frame_*`
 /// produces for a bare base (no workspace/env/skill/tool-guide contexts).
@@ -307,6 +379,7 @@ async fn execute_llm_stream_sets_session_usage_and_emits_budget_event() {
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -376,6 +449,110 @@ async fn execute_llm_stream_sets_session_usage_and_emits_budget_event() {
 }
 
 #[tokio::test]
+async fn prompt_exposure_starts_only_after_successful_provider_bootstrap() {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum BoundaryCase {
+        BootstrapError,
+        PreCancelled,
+        StreamError,
+    }
+
+    struct BoundaryProvider(BoundaryCase);
+
+    #[async_trait]
+    impl LLMProvider for BoundaryProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            match self.0 {
+                BoundaryCase::BootstrapError => Err(bamboo_llm::provider::LLMError::Api(
+                    "injected bootstrap error".to_string(),
+                )),
+                BoundaryCase::PreCancelled => Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)]))),
+                BoundaryCase::StreamError => Ok(Box::pin(stream::iter(vec![Err(
+                    bamboo_llm::provider::LLMError::Stream("injected frame error".to_string()),
+                )]))),
+            }
+        }
+    }
+
+    let _env_lock = isolate_prompt_safe_env_cache();
+    for case in [
+        BoundaryCase::BootstrapError,
+        BoundaryCase::PreCancelled,
+        BoundaryCase::StreamError,
+    ] {
+        let session_id = format!("prompt-exposure-boundary-{case:?}");
+        let round_id = format!("{session_id}-run-test-round-1");
+        let (_metrics_dir, collector, storage) =
+            prompt_exposure_metrics(&session_id, &round_id).await;
+        let mut config = test_config("system");
+        config.metrics_collector = Some(collector.clone());
+        let provenance = crate::runtime::runner::prompt_context::PromptMemoryExposureProvenance::supported_empty_for_test(None);
+        let prepared_context = PreparedContext {
+            messages: vec![Message::system("system")],
+            token_usage: usage(0, 22),
+            truncation_occurred: false,
+            segments_removed: 0,
+            compressed_message_ids: Vec::new(),
+            prompt_cached_tool_outputs: 0,
+            prompt_cached_tool_tokens_saved: 0,
+        };
+        let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(16);
+        let cancel = CancellationToken::new();
+        if case == BoundaryCase::PreCancelled {
+            cancel.cancel();
+        }
+        let provider: Arc<dyn LLMProvider> = Arc::new(BoundaryProvider(case));
+        let mut session = Session::new(&session_id, "test-model");
+
+        let result = execute_llm_stream(
+            &mut session,
+            &config,
+            &provider,
+            &prepared_context,
+            &[],
+            &LlmStreamFrame {
+                event_tx: &event_tx,
+                cancel_token: &cancel,
+                session_id: &session_id,
+                model: "test-model",
+                provider_name: None,
+                provider_type: None,
+                reasoning_effort: None,
+                max_context_tokens: 400_000,
+                max_output_tokens: 128,
+                prompt_memory_exposure: Some(PromptMemoryExposureFrame {
+                    round_id: &round_id,
+                    provenance: &provenance,
+                }),
+            },
+        )
+        .await;
+        assert!(result.is_err(), "{case:?} must fail the stream execution");
+
+        if case == BoundaryCase::StreamError {
+            assert!(wait_for_prompt_exposure(storage.as_ref(), &round_id)
+                .await
+                .project_items
+                .is_empty());
+        } else {
+            assert_no_prompt_exposure_after_collector_barrier(
+                &collector,
+                storage.as_ref(),
+                &session_id,
+                &round_id,
+            )
+            .await;
+        }
+    }
+}
+
+#[tokio::test]
 async fn ledger_checkpoint_failure_stops_before_provider_dispatch() {
     struct FailOncePersistence(std::sync::atomic::AtomicUsize);
 
@@ -392,7 +569,9 @@ async fn ledger_checkpoint_failure_stops_before_provider_dispatch() {
     }
 
     let _env_lock = isolate_prompt_safe_env_cache();
-    let mut session = Session::new("session-ledger-checkpoint-failure", "test-model");
+    let session_id = "session-ledger-checkpoint-failure";
+    let round_id = "session-ledger-checkpoint-failure-run-test-round-1";
+    let mut session = Session::new(session_id, "test-model");
     let assistant = Message::assistant("prior native response", None);
     let anchor = assistant.id.clone();
     session.add_message(assistant);
@@ -421,6 +600,9 @@ async fn ledger_checkpoint_failure_stops_before_provider_dispatch() {
     let mut config = test_config("system");
     let persistence = Arc::new(FailOncePersistence(std::sync::atomic::AtomicUsize::new(0)));
     config.persistence = Some(persistence.clone());
+    let (_metrics_dir, collector, storage) = prompt_exposure_metrics(session_id, round_id).await;
+    config.metrics_collector = Some(collector.clone());
+    let provenance = crate::runtime::runner::prompt_context::PromptMemoryExposureProvenance::supported_empty_for_test(None);
     let prepared_context = PreparedContext {
         messages: vec![Message::system("system"), Message::user("continue")],
         token_usage: usage(0, 22),
@@ -442,13 +624,17 @@ async fn ledger_checkpoint_failure_stops_before_provider_dispatch() {
         &LlmStreamFrame {
             event_tx: &event_tx,
             cancel_token: &CancellationToken::new(),
-            session_id: "session-ledger-checkpoint-failure",
+            session_id,
             model: "test-model",
             provider_name: Some("openai"),
             provider_type: Some("openai"),
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: Some(PromptMemoryExposureFrame {
+                round_id,
+                provenance: &provenance,
+            }),
         },
     )
     .await;
@@ -473,6 +659,13 @@ async fn ledger_checkpoint_failure_stops_before_provider_dispatch() {
         session.provider_transcript, previous_provider_transcript,
         "native invalidation and model-context reset must roll back together"
     );
+    assert_no_prompt_exposure_after_collector_barrier(
+        &collector,
+        storage.as_ref(),
+        session_id,
+        round_id,
+    )
+    .await;
 
     execute_llm_stream(
         &mut session,
@@ -483,13 +676,17 @@ async fn ledger_checkpoint_failure_stops_before_provider_dispatch() {
         &LlmStreamFrame {
             event_tx: &event_tx,
             cancel_token: &CancellationToken::new(),
-            session_id: "session-ledger-checkpoint-failure",
+            session_id,
             model: "test-model",
             provider_name: Some("openai"),
             provider_type: Some("openai"),
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: Some(PromptMemoryExposureFrame {
+                round_id,
+                provenance: &provenance,
+            }),
         },
     )
     .await
@@ -500,6 +697,12 @@ async fn ledger_checkpoint_failure_stops_before_provider_dispatch() {
         "retry must not bypass the failed durable checkpoint"
     );
     assert!(*llm.ir_invoked.lock().expect("ir_invoked lock"));
+    assert_eq!(
+        wait_for_prompt_exposure(storage.as_ref(), round_id)
+            .await
+            .recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::Disabled
+    );
 }
 
 #[tokio::test]
@@ -647,6 +850,7 @@ async fn mock_responses_provider_captures_four_exact_prefix_final_bodies() {
                     reasoning_effort: None,
                     max_context_tokens: 400_000,
                     max_output_tokens: 128,
+                    prompt_memory_exposure: None,
                 },
             )
             .await
@@ -760,6 +964,7 @@ async fn explicit_activation_pending_suppresses_answer_tokens() {
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -1152,6 +1357,7 @@ async fn execute_llm_stream_emits_final_budget_event_with_provider_usage() {
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -1244,6 +1450,7 @@ async fn execute_llm_stream_includes_task_block_in_full_request() {
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -1283,7 +1490,9 @@ async fn execute_llm_stream_includes_task_block_in_full_request() {
 #[tokio::test]
 async fn final_ir_guard_rejects_unbudgeted_large_ledger_before_provider_dispatch() {
     let _env_lock = isolate_prompt_safe_env_cache();
-    let mut session = Session::new("session-ledger-final-budget", "test-model");
+    let session_id = "session-ledger-final-budget";
+    let round_id = "session-ledger-final-budget-run-test-round-1";
+    let mut session = Session::new(session_id, "test-model");
     session.task_list = Some(TaskList {
         session_id: session.id.clone(),
         title: "Agent Tasks".to_string(),
@@ -1296,7 +1505,10 @@ async fn final_ir_guard_rejects_unbudgeted_large_ledger_before_provider_dispatch
         created_at: Utc::now(),
         updated_at: Utc::now(),
     });
-    let config = test_config("system");
+    let mut config = test_config("system");
+    let (_metrics_dir, collector, storage) = prompt_exposure_metrics(session_id, round_id).await;
+    config.metrics_collector = Some(collector.clone());
+    let provenance = crate::runtime::runner::prompt_context::PromptMemoryExposureProvenance::supported_empty_for_test(None);
     let prepared_context = PreparedContext {
         messages: vec![Message::system("system"), Message::user("continue")],
         token_usage: usage(0, 24),
@@ -1334,13 +1546,17 @@ async fn final_ir_guard_rejects_unbudgeted_large_ledger_before_provider_dispatch
         &LlmStreamFrame {
             event_tx: &event_tx,
             cancel_token: &CancellationToken::new(),
-            session_id: "session-ledger-final-budget",
+            session_id,
             model: "test-model",
             provider_name: Some("openai"),
             provider_type: Some("openai"),
             reasoning_effort: None,
             max_context_tokens: 2_000,
             max_output_tokens: 200,
+            prompt_memory_exposure: Some(PromptMemoryExposureFrame {
+                round_id,
+                provenance: &provenance,
+            }),
         },
     )
     .await;
@@ -1352,13 +1568,25 @@ async fn final_ir_guard_rejects_unbudgeted_large_ledger_before_provider_dispatch
         .expect("messages lock")
         .is_empty());
     assert_eq!(session.model_context_state, inflated_state);
+    assert_no_prompt_exposure_after_collector_barrier(
+        &collector,
+        storage.as_ref(),
+        session_id,
+        round_id,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn final_guard_rejects_an_oversized_provider_visible_schema_before_dispatch() {
     let _env_lock = isolate_prompt_safe_env_cache();
-    let mut session = Session::new("session-schema-final-budget", "test-model");
-    let config = test_config("system");
+    let session_id = "session-schema-final-budget";
+    let round_id = "session-schema-final-budget-run-test-round-1";
+    let mut session = Session::new(session_id, "test-model");
+    let mut config = test_config("system");
+    let (_metrics_dir, collector, storage) = prompt_exposure_metrics(session_id, round_id).await;
+    config.metrics_collector = Some(collector.clone());
+    let provenance = crate::runtime::runner::prompt_context::PromptMemoryExposureProvenance::supported_empty_for_test(None);
     let prepared_context = PreparedContext {
         messages: vec![Message::system("system"), Message::user("continue")],
         token_usage: usage(0, 24),
@@ -1395,13 +1623,17 @@ async fn final_guard_rejects_an_oversized_provider_visible_schema_before_dispatc
         &LlmStreamFrame {
             event_tx: &event_tx,
             cancel_token: &CancellationToken::new(),
-            session_id: "session-schema-final-budget",
+            session_id,
             model: "test-model",
             provider_name: Some("test"),
             provider_type: Some("test"),
             reasoning_effort: None,
             max_context_tokens: 1_000,
             max_output_tokens: 200,
+            prompt_memory_exposure: Some(PromptMemoryExposureFrame {
+                round_id,
+                provenance: &provenance,
+            }),
         },
     )
     .await;
@@ -1425,6 +1657,13 @@ async fn final_guard_rejects_an_oversized_provider_visible_schema_before_dispatc
         .lock()
         .expect("messages lock")
         .is_empty());
+    assert_no_prompt_exposure_after_collector_barrier(
+        &collector,
+        storage.as_ref(),
+        session_id,
+        round_id,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1543,6 +1782,7 @@ async fn projected_epoch_reseed_refits_and_dispatches_an_idempotent_request() {
         reasoning_effort: None,
         max_context_tokens: prepared.budget.max_context_tokens,
         max_output_tokens: prepared.budget.max_output_tokens,
+        prompt_memory_exposure: None,
     };
     execute_llm_stream(
         &mut session,
@@ -1982,6 +2222,7 @@ async fn execute_llm_stream_routes_normal_request_through_lanes_with_relocated_g
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -3204,6 +3445,7 @@ async fn execute_llm_stream_ignores_previous_response_id_under_stateless_store_p
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -3367,6 +3609,7 @@ async fn execute_llm_stream_includes_external_memory_volatile_block() {
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -3462,6 +3705,7 @@ async fn execute_llm_stream_includes_plan_mode_and_runtime_volatile_blocks() {
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -3548,6 +3792,7 @@ async fn execute_llm_stream_sends_full_request_with_summary_when_compression_is_
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -3648,6 +3893,7 @@ async fn execute_llm_stream_disables_previous_response_id_for_copilot() {
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await
@@ -3757,6 +4003,7 @@ async fn execute_llm_stream_disables_previous_response_id_for_copilot_instance_p
             reasoning_effort: None,
             max_context_tokens: 400_000,
             max_output_tokens: 128,
+            prompt_memory_exposure: None,
         },
     )
     .await

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -239,7 +239,7 @@ async fn wait_for_prompt_exposure(
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
-    panic!("prompt-memory observation was not persisted for {round_id}");
+    panic!("prompt-memory observation was not persisted");
 }
 
 async fn assert_no_prompt_exposure_after_collector_barrier(
@@ -266,7 +266,7 @@ async fn assert_no_prompt_exposure_after_collector_barrier(
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
-    panic!("metrics collector barrier was not observed for {session_id}");
+    panic!("metrics collector barrier was not observed");
 }
 
 /// The system field that a base prompt resolves to once the framework-invariant

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
@@ -14,7 +14,8 @@ use bamboo_llm::LLMProvider;
 use bamboo_metrics::MetricsCollector;
 
 use super::prompt_context::{
-    refresh_external_memory_context, PromptMemoryRuntimeContext, PROMPT_MEMORY_OBSERVABILITY_KEY,
+    refresh_external_memory_context, PromptMemoryExposureProvenance, PromptMemoryRuntimeContext,
+    PROMPT_MEMORY_OBSERVABILITY_KEY,
 };
 use super::session_setup::prompt_setup::{persist_prompt_snapshot_metadata, PromptAssemblyReport};
 use bamboo_agent_core::PromptSnapshot;
@@ -46,9 +47,9 @@ pub(crate) async fn refresh_round_prompt_context(
     runtime_context: Option<&PromptMemoryRuntimeContext>,
     project_context_resolver: Option<&crate::project_context::ProjectContextResolver>,
     app_data_dir: Option<&std::path::Path>,
-) -> Result<(), AgentError> {
+) -> Result<PromptMemoryExposureProvenance, AgentError> {
     refresh_project_context(session, project_context_resolver).await?;
-    refresh_external_memory_context(
+    let prompt_memory_exposure = refresh_external_memory_context(
         session,
         memory,
         prompt_memory_flags,
@@ -72,7 +73,7 @@ pub(crate) async fn refresh_round_prompt_context(
         persist_round_prompt_metadata(session, &prompt);
         log_round_prompt_refresh_summary(session_id.as_str(), &prompt);
     }
-    Ok(())
+    Ok(prompt_memory_exposure)
 }
 
 async fn refresh_project_context(
@@ -101,7 +102,7 @@ pub(crate) async fn refresh_round_boundary_and_prompt_context(
     cancel_token: &CancellationToken,
     metrics_collector: Option<&MetricsCollector>,
     runtime_context: Option<&PromptMemoryRuntimeContext>,
-) -> Result<(), AgentError> {
+) -> Result<PromptMemoryExposureProvenance, AgentError> {
     if let Some(notifications) = config.session_activation_notifications.as_ref() {
         let mut receiver = notifications.lock();
         if receiver.has_changed().unwrap_or(false) {
@@ -143,7 +144,7 @@ pub(crate) async fn refresh_round_boundary_and_prompt_context(
         session.messages.len(),
     )?;
 
-    refresh_round_prompt_context(
+    let prompt_memory_exposure = refresh_round_prompt_context(
         session,
         &config.memory_store,
         config.prompt_memory_flags,
@@ -162,7 +163,8 @@ pub(crate) async fn refresh_round_boundary_and_prompt_context(
         metrics_collector,
         &session.id,
         session.messages.len(),
-    )
+    )?;
+    Ok(prompt_memory_exposure)
 }
 
 // ---- round_state functions ----

--- a/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
@@ -860,17 +860,19 @@ async fn unsuccessful_model_issued_explicit_activation_stops_before_answer_and_r
 
 struct MetricsQueueProvider {
     queue: Mutex<Vec<Vec<bamboo_llm::provider::Result<LLMChunk>>>>,
+    requested_messages: Mutex<Vec<Vec<Message>>>,
 }
 
 #[async_trait]
 impl LLMProvider for MetricsQueueProvider {
     async fn chat_stream(
         &self,
-        _messages: &[Message],
+        messages: &[Message],
         _tools: &[bamboo_agent_core::tools::ToolSchema],
         _max_output_tokens: Option<u32>,
         _model: &str,
     ) -> bamboo_llm::provider::Result<LLMStream> {
+        self.requested_messages.lock().await.push(messages.to_vec());
         let mut queue = self.queue.lock().await;
         assert!(!queue.is_empty(), "metrics provider queue exhausted");
         Ok(Box::pin(stream::iter(queue.remove(0))))
@@ -973,6 +975,7 @@ async fn repeated_execution_of_one_session_keeps_both_metric_rounds() {
                 Ok(LLMChunk::Done),
             ],
         ]),
+        requested_messages: Mutex::new(Vec::new()),
     });
     let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> =
         Arc::new(bamboo_tools::BuiltinToolExecutor::new());
@@ -1062,6 +1065,16 @@ async fn repeated_execution_of_one_session_keeps_both_metric_rounds() {
             total_tokens: 23,
         }
     );
+    assert!(storage
+        .prompt_memory_exposure(&first.round_id)
+        .await
+        .expect("query first execution exposure")
+        .is_some());
+    assert!(storage
+        .prompt_memory_exposure(&second.round_id)
+        .await
+        .expect("query second execution exposure")
+        .is_some());
     assert_eq!(
         session
             .agent_runtime_state
@@ -1069,6 +1082,268 @@ async fn repeated_execution_of_one_session_keeps_both_metric_rounds() {
             .and_then(|state| state.round.last_round_id.as_deref()),
         Some(second.round_id.as_str())
     );
+}
+
+#[tokio::test]
+async fn provider_bootstrap_persists_exact_project_ids_and_redacts_global_ids() {
+    let session_id = "metrics-prompt-memory-exposure";
+    let (_directory, collector, storage) = create_runner_metrics().await;
+    let memory_directory = tempfile::tempdir().expect("memory tempdir");
+    let memory_store = bamboo_memory::memory_store::MemoryStore::new(memory_directory.path());
+    let project_a =
+        bamboo_domain::ProjectId::parse("prompt-memory-project-a").expect("valid Project A id");
+    let project_b =
+        bamboo_domain::ProjectId::parse("prompt-memory-project-b").expect("valid Project B id");
+    let project_c = bamboo_domain::ProjectId::parse("prompt-memory-project-c").expect("Project C");
+    let project_a_store = memory_store.for_project(&project_a);
+    let project_b_store = memory_store.for_project(&project_b);
+    let query = "exposuretoken1077";
+    let first = project_a_store
+        .write_memory(
+            bamboo_memory::memory_store::MemoryScope::Project,
+            Some(project_a.as_str()),
+            bamboo_memory::memory_store::DurableMemoryType::Project,
+            "Exposuretoken1077 canonical Project A decision",
+            &format!(
+                "Project A compact summary. {} FULL_PRIVATE_BODY_A_MUST_NOT_RENDER",
+                "a".repeat(300)
+            ),
+            &[query.to_string()],
+            Some(session_id),
+            "test-model",
+            false,
+            Some(bamboo_memory::memory_store::TemporalGranularity::Year),
+        )
+        .await
+        .expect("write Project A memory");
+    let mut project_a_ids = vec![first.frontmatter.id];
+    for (index, granularity) in [
+        bamboo_memory::memory_store::TemporalGranularity::Day,
+        bamboo_memory::memory_store::TemporalGranularity::Quarter,
+        bamboo_memory::memory_store::TemporalGranularity::Week,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let written = project_a_store
+            .write_memory(
+                bamboo_memory::memory_store::MemoryScope::Project,
+                Some(project_a.as_str()),
+                bamboo_memory::memory_store::DurableMemoryType::Project,
+                &format!("Exposuretoken1077 Project A decision {}", index + 2),
+                &format!(
+                    "Project A compact summary {}. {} FULL_PRIVATE_BODY_A_MUST_NOT_RENDER",
+                    index + 2,
+                    "a".repeat(300)
+                ),
+                &[query.to_string()],
+                Some(session_id),
+                "test-model",
+                false,
+                Some(granularity),
+            )
+            .await
+            .expect("write another Project A memory");
+        project_a_ids.push(written.frontmatter.id);
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    let excluded = project_b_store
+        .write_memory(
+            bamboo_memory::memory_store::MemoryScope::Project,
+            Some(project_b.as_str()),
+            bamboo_memory::memory_store::DurableMemoryType::Project,
+            "Exposuretoken1077 other Project decision",
+            &format!(
+                "Project B compact summary. {} FULL_PRIVATE_BODY_B_MUST_NOT_RENDER",
+                "b".repeat(300)
+            ),
+            &[query.to_string()],
+            Some("other-session"),
+            "test-model",
+            false,
+            Some(bamboo_memory::memory_store::TemporalGranularity::Day),
+        )
+        .await
+        .expect("write Project B memory");
+    let global = memory_store
+        .write_memory(
+            bamboo_memory::memory_store::MemoryScope::Global,
+            None,
+            bamboo_memory::memory_store::DurableMemoryType::Reference,
+            "Exposuretoken1077 global fallback",
+            &format!(
+                "Global compact summary. {} FULL_PRIVATE_GLOBAL_BODY_MUST_NOT_RENDER",
+                "g".repeat(300)
+            ),
+            &[query.to_string()],
+            Some("global-session"),
+            "test-model",
+            false,
+            None,
+        )
+        .await
+        .expect("write Global fallback memory");
+
+    let provider = Arc::new(MetricsQueueProvider {
+        queue: Mutex::new(vec![
+            vec![
+                Ok(provider_usage(17, 3)),
+                Ok(LLMChunk::Token("observed answer".to_string())),
+                Ok(LLMChunk::Done),
+            ],
+            vec![
+                Ok(provider_usage(5, 1)),
+                Ok(LLMChunk::Token("global answer".to_string())),
+                Ok(LLMChunk::Done),
+            ],
+        ]),
+        requested_messages: Mutex::new(Vec::new()),
+    });
+    let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> =
+        Arc::new(bamboo_tools::BuiltinToolExecutor::new());
+    let mut session = Session::new(session_id, "test-model");
+    session.set_project_id_meta(project_a.to_string());
+    session.metadata.insert(
+        "runtime_prompt_memory_observability".to_string(),
+        serde_json::json!({"relevant_memory_ids":["forged-metadata-id"]}).to_string(),
+    );
+    session.metadata.insert(
+        "external_memory_rendered".to_string(),
+        "If selected: `memory` action=get id=forged-rendered-id".to_string(),
+    );
+    let mut config = runner_metrics_config(&collector);
+    config.memory_store = memory_store.clone();
+    config.prompt_memory_flags.relevant_recall = true;
+
+    let (event_tx, _event_rx) = mpsc::channel(64);
+    super::run_agent_loop_with_config(
+        &mut session,
+        format!("recall {query}"),
+        event_tx,
+        provider.clone(),
+        tools,
+        CancellationToken::new(),
+        config,
+    )
+    .await
+    .expect("provider-backed execution");
+
+    let detail = wait_for_runner_metrics(
+        storage.as_ref(),
+        session_id,
+        1,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 17,
+            completion_tokens: 3,
+            total_tokens: 20,
+        },
+    )
+    .await;
+    let observation = storage
+        .prompt_memory_exposure(&detail.rounds[0].round_id)
+        .await
+        .expect("query prompt-memory observation")
+        .expect("successful bootstrap persists an observation");
+    assert_eq!(observation.project_id.as_deref(), Some(project_a.as_str()));
+    assert_eq!(
+        observation.recall_outcome,
+        bamboo_metrics::types::PromptMemoryRecallOutcome::Lexical
+    );
+    assert_eq!(observation.all_compact_exposed_count, 3);
+    assert_eq!(observation.project_exposed_count, 3);
+    assert!(!observation.out_of_project_only);
+    assert_eq!(observation.project_items.len(), 3);
+
+    let requests = provider.requested_messages.lock().await;
+    assert_eq!(requests.len(), 1);
+    let provider_text = requests[0]
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut provider_ids = project_a_ids
+        .iter()
+        .filter(|id| provider_text.contains(id.as_str()))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    provider_ids.sort_by_key(|id| provider_text.find(*id).expect("provider-visible id"));
+    assert_eq!(
+        provider_ids.len(),
+        3,
+        "one of four candidates stays outside top-k"
+    );
+    assert_eq!(
+        observation
+            .project_items
+            .iter()
+            .map(|item| item.memory_id.as_str())
+            .collect::<Vec<_>>(),
+        provider_ids,
+        "persisted IDs and ranks must match final provider-visible order"
+    );
+    assert!(observation
+        .project_items
+        .iter()
+        .enumerate()
+        .all(|(index, item)| item.rank == index as u32 + 1));
+    assert!(!provider_text.contains(&excluded.frontmatter.id));
+    assert!(!provider_text.contains("forged-metadata-id"));
+    assert!(!provider_text.contains("forged-rendered-id"));
+    assert!(!provider_text.contains("FULL_PRIVATE_BODY_A_MUST_NOT_RENDER"));
+    assert!(!provider_text.contains("FULL_PRIVATE_BODY_B_MUST_NOT_RENDER"));
+    assert!(!provider_text.contains(&global.frontmatter.id));
+    drop(requests);
+
+    let global_session_id = "metrics-prompt-memory-global-fallback";
+    let mut global_session = Session::new(global_session_id, "test-model");
+    global_session.set_project_id_meta(project_c.to_string());
+    let mut global_config = runner_metrics_config(&collector);
+    global_config.memory_store = memory_store;
+    global_config.prompt_memory_flags.relevant_recall = true;
+    let (global_tx, _global_rx) = mpsc::channel(64);
+    super::run_agent_loop_with_config(
+        &mut global_session,
+        format!("recall {query}"),
+        global_tx,
+        provider.clone(),
+        Arc::new(bamboo_tools::BuiltinToolExecutor::new()),
+        CancellationToken::new(),
+        global_config,
+    )
+    .await
+    .expect("Global-fallback provider execution");
+    let global_detail = wait_for_runner_metrics(
+        storage.as_ref(),
+        global_session_id,
+        1,
+        bamboo_metrics::types::TokenUsage {
+            prompt_tokens: 5,
+            completion_tokens: 1,
+            total_tokens: 6,
+        },
+    )
+    .await;
+    let global_observation = storage
+        .prompt_memory_exposure(&global_detail.rounds[0].round_id)
+        .await
+        .expect("query Global-only observation")
+        .expect("Global-only provider bootstrap persists a header");
+    assert_eq!(
+        global_observation.project_id.as_deref(),
+        Some(project_c.as_str())
+    );
+    assert_eq!(global_observation.all_compact_exposed_count, 1);
+    assert_eq!(global_observation.project_exposed_count, 0);
+    assert!(global_observation.out_of_project_only);
+    assert!(global_observation.project_items.is_empty());
+    let requests = provider.requested_messages.lock().await;
+    let global_text = requests[1]
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(global_text.contains(&global.frontmatter.id));
+    assert!(!global_text.contains("FULL_PRIVATE_GLOBAL_BODY_MUST_NOT_RENDER"));
 }
 
 struct PauseForHumanTool;
@@ -1180,6 +1455,7 @@ async fn suspended_session_resume_uses_a_new_metric_round_and_preserves_tool_lin
                 Ok(LLMChunk::Done),
             ],
         ]),
+        requested_messages: Mutex::new(Vec::new()),
     });
     let tools = BuiltinToolExecutorBuilder::new()
         .with_tool(PauseForHumanTool)

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
@@ -91,8 +91,10 @@ use thiserror::Error;
 use crate::metrics::types::{
     DailyMetrics, ForwardEndpointMetrics, ForwardMetricsFilter, ForwardMetricsSummary,
     ForwardRequestMetrics, ForwardStatus, ForwardTokenDetails, MetricsDateFilter, MetricsSummary,
-    ModelMetrics, ModelMetricsDateFilter, RoundMetrics, RoundStatus, SessionDetail, SessionMetrics,
-    SessionMetricsFilter, SessionStatus, TokenUsage, ToolCallMetrics,
+    ModelMetrics, ModelMetricsDateFilter, PromptMemoryExposureItem,
+    PromptMemoryExposureObservation, PromptMemoryRecallOutcome, RoundMetrics, RoundStatus,
+    SessionDetail, SessionMetrics, SessionMetricsFilter, SessionStatus, TokenUsage,
+    ToolCallMetrics,
 };
 
 /// Result type for metrics storage operations.
@@ -313,6 +315,23 @@ pub trait MetricsStorage: Send + Sync {
         model: &str,
         started_at: DateTime<Utc>,
     ) -> MetricsResult<()>;
+
+    /// Persists the first successfully bootstrapped prompt-memory observation
+    /// for one logical round.
+    ///
+    /// Storage implementations that do not support this additive metric fail
+    /// explicitly instead of treating an unobserved path as an observed empty
+    /// round. The live collector logs that best-effort failure without blocking
+    /// agent execution.
+    async fn record_prompt_memory_exposure(
+        &self,
+        _observation: &PromptMemoryExposureObservation,
+    ) -> MetricsResult<()> {
+        Err(MetricsError::InvalidData(
+            "prompt-memory exposure observations are not supported by this metrics storage"
+                .to_string(),
+        ))
+    }
 
     /// Completes a round with final metrics and status.
     ///
@@ -941,6 +960,19 @@ impl SqliteMetricsStorage {
         }
     }
 
+    /// Loads one persisted prompt-memory observation by logical round.
+    ///
+    /// This is a narrow storage primitive used by producer verification. Public
+    /// Project-authoritative aggregation remains a separate API slice.
+    pub async fn prompt_memory_exposure(
+        &self,
+        round_id: &str,
+    ) -> MetricsResult<Option<PromptMemoryExposureObservation>> {
+        let round_id = round_id.to_string();
+        self.with_connection(move |connection| load_prompt_memory_exposure(connection, &round_id))
+            .await
+    }
+
     /// Executes a function with a database connection in a blocking context.
     ///
     /// This helper method handles:
@@ -1021,6 +1053,47 @@ impl MetricsStorage for SqliteMetricsStorage {
                     FOREIGN KEY(session_id) REFERENCES session_metrics(session_id) ON DELETE CASCADE
                 );
 
+                CREATE TABLE IF NOT EXISTS prompt_memory_round_observations (
+                    round_id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    project_id TEXT,
+                    observed_at TEXT NOT NULL,
+                    schema_version INTEGER NOT NULL,
+                    recall_enabled INTEGER NOT NULL,
+                    query_present INTEGER NOT NULL,
+                    recall_outcome TEXT NOT NULL,
+                    all_compact_exposed_count INTEGER NOT NULL,
+                    project_exposed_count INTEGER NOT NULL,
+                    out_of_project_only INTEGER NOT NULL,
+                    compact_section_chars INTEGER NOT NULL,
+                    FOREIGN KEY(round_id) REFERENCES round_metrics(round_id) ON DELETE CASCADE,
+                    FOREIGN KEY(session_id) REFERENCES session_metrics(session_id) ON DELETE CASCADE,
+                    CHECK(schema_version = 1),
+                    CHECK(recall_enabled IN (0, 1)),
+                    CHECK(query_present IN (0, 1)),
+                    CHECK(recall_outcome IN ('disabled', 'no_query', 'no_match', 'lookup_error', 'lexical', 'reranked', 'rerank_fallback')),
+                    CHECK(all_compact_exposed_count >= 0),
+                    CHECK(project_exposed_count >= 0),
+                    CHECK(project_exposed_count <= all_compact_exposed_count),
+                    CHECK(out_of_project_only IN (0, 1)),
+                    CHECK(compact_section_chars >= 0)
+                );
+
+                CREATE TABLE IF NOT EXISTS prompt_memory_project_exposures (
+                    round_id TEXT NOT NULL,
+                    memory_id TEXT NOT NULL,
+                    scope TEXT NOT NULL,
+                    status_at_observation TEXT NOT NULL,
+                    rank INTEGER NOT NULL,
+                    rendered_chars INTEGER NOT NULL,
+                    PRIMARY KEY(round_id, memory_id),
+                    FOREIGN KEY(round_id) REFERENCES prompt_memory_round_observations(round_id) ON DELETE CASCADE,
+                    CHECK(scope = 'project'),
+                    CHECK(status_at_observation IN ('active', 'stale', 'superseded', 'contradicted', 'archived')),
+                    CHECK(rank > 0),
+                    CHECK(rendered_chars > 0)
+                );
+
                 CREATE TABLE IF NOT EXISTS tool_call_metrics (
                     tool_call_id TEXT PRIMARY KEY,
                     round_id TEXT NOT NULL,
@@ -1041,6 +1114,8 @@ impl MetricsStorage for SqliteMetricsStorage {
                 -- Repeated or interrupted initialization always retains a session lookup.
                 DROP INDEX IF EXISTS idx_round_session;
                 CREATE INDEX IF NOT EXISTS idx_round_started_at ON round_metrics(started_at);
+                CREATE INDEX IF NOT EXISTS idx_prompt_memory_project_observed_at ON prompt_memory_round_observations(project_id, observed_at, round_id);
+                CREATE INDEX IF NOT EXISTS idx_prompt_memory_item_memory_round ON prompt_memory_project_exposures(memory_id, round_id);
                 CREATE INDEX IF NOT EXISTS idx_tool_session ON tool_call_metrics(session_id);
                 CREATE INDEX IF NOT EXISTS idx_tool_round_started_at ON tool_call_metrics(round_id, started_at);
                 CREATE INDEX IF NOT EXISTS idx_tool_started_at ON tool_call_metrics(started_at);
@@ -1221,6 +1296,102 @@ impl MetricsStorage for SqliteMetricsStorage {
                     params![round_id, session_id, model, started_at_str],
                 )?;
                 refresh_session_aggregates(connection, &session_id, started_at)?;
+                Ok(())
+            })
+        })
+        .await
+    }
+
+    async fn record_prompt_memory_exposure(
+        &self,
+        observation: &PromptMemoryExposureObservation,
+    ) -> MetricsResult<()> {
+        let observation = observation.clone();
+        self.with_connection(move |connection| {
+            with_immediate_transaction(connection, || {
+                validate_prompt_memory_exposure(&observation)?;
+
+                let round_session_id = connection
+                    .query_row(
+                        "SELECT session_id FROM round_metrics WHERE round_id = ?1",
+                        params![observation.round_id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?
+                    .ok_or_else(|| {
+                        MetricsError::InvalidData(format!(
+                            "prompt-memory observation references unknown round '{}'",
+                            observation.round_id
+                        ))
+                    })?;
+                if round_session_id != observation.session_id {
+                    return Err(MetricsError::InvalidData(format!(
+                        "prompt-memory observation session '{}' does not own round '{}'",
+                        observation.session_id, observation.round_id
+                    )));
+                }
+
+                if let Some(existing) =
+                    load_prompt_memory_exposure(connection, &observation.round_id)?
+                {
+                    // First successful bootstrap owns the logical round. Later
+                    // retries by that same Session/Project are harmless no-ops,
+                    // even if request membership changed after recovery.
+                    if existing.session_id == observation.session_id
+                        && existing.project_id == observation.project_id
+                    {
+                        return Ok(());
+                    }
+                    return Err(MetricsError::InvalidData(format!(
+                        "prompt-memory observation ownership conflict for round '{}'",
+                        observation.round_id
+                    )));
+                }
+
+                connection.execute(
+                    r#"
+                    INSERT INTO prompt_memory_round_observations (
+                        round_id, session_id, project_id, observed_at,
+                        schema_version, recall_enabled, query_present,
+                        recall_outcome, all_compact_exposed_count,
+                        project_exposed_count, out_of_project_only,
+                        compact_section_chars
+                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                    "#,
+                    params![
+                        observation.round_id,
+                        observation.session_id,
+                        observation.project_id,
+                        format_timestamp(observation.observed_at),
+                        i64::from(observation.schema_version),
+                        i64::from(observation.recall_enabled),
+                        i64::from(observation.query_present),
+                        observation.recall_outcome.as_str(),
+                        i64::from(observation.all_compact_exposed_count),
+                        i64::from(observation.project_exposed_count),
+                        i64::from(observation.out_of_project_only),
+                        i64::from(observation.compact_section_chars),
+                    ],
+                )?;
+
+                for item in &observation.project_items {
+                    connection.execute(
+                        r#"
+                        INSERT INTO prompt_memory_project_exposures (
+                            round_id, memory_id, scope, status_at_observation,
+                            rank, rendered_chars
+                        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                        "#,
+                        params![
+                            observation.round_id,
+                            item.memory_id,
+                            item.scope,
+                            item.status_at_observation,
+                            i64::from(item.rank),
+                            i64::from(item.rendered_chars),
+                        ],
+                    )?;
+                }
                 Ok(())
             })
         })
@@ -2518,6 +2689,289 @@ fn parse_timestamp(raw: String) -> MetricsResult<DateTime<Utc>> {
     Ok(DateTime::parse_from_rfc3339(&raw)?.with_timezone(&Utc))
 }
 
+fn validate_prompt_memory_exposure(
+    observation: &PromptMemoryExposureObservation,
+) -> MetricsResult<()> {
+    if observation.schema_version != 1 {
+        return Err(MetricsError::InvalidData(format!(
+            "unsupported prompt-memory observation schema version {}",
+            observation.schema_version
+        )));
+    }
+    if observation.round_id.trim().is_empty() || observation.session_id.trim().is_empty() {
+        return Err(MetricsError::InvalidData(
+            "prompt-memory observation requires non-empty round and session identities".to_string(),
+        ));
+    }
+    if observation
+        .project_id
+        .as_deref()
+        .is_some_and(|project_id| project_id.trim().is_empty())
+    {
+        return Err(MetricsError::InvalidData(
+            "prompt-memory observation Project identity cannot be blank".to_string(),
+        ));
+    }
+    if observation.project_exposed_count > observation.all_compact_exposed_count {
+        return Err(MetricsError::InvalidData(
+            "Project prompt-memory exposure count exceeds the complete compact count".to_string(),
+        ));
+    }
+    let item_count = u32::try_from(observation.project_items.len()).map_err(|_| {
+        MetricsError::InvalidData("too many Project prompt-memory exposure items".to_string())
+    })?;
+    if observation.project_exposed_count != item_count {
+        return Err(MetricsError::InvalidData(format!(
+            "Project prompt-memory exposure count {} does not match {} items",
+            observation.project_exposed_count, item_count
+        )));
+    }
+    if item_count > 0 && observation.project_id.is_none() {
+        return Err(MetricsError::InvalidData(
+            "Project prompt-memory items require a server-resolved Project identity".to_string(),
+        ));
+    }
+    let expected_out_of_project_only =
+        observation.all_compact_exposed_count > 0 && observation.project_exposed_count == 0;
+    if observation.out_of_project_only != expected_out_of_project_only {
+        return Err(MetricsError::InvalidData(
+            "out-of-Project-only flag does not match prompt-memory exposure counts".to_string(),
+        ));
+    }
+
+    match observation.recall_outcome {
+        PromptMemoryRecallOutcome::Disabled if observation.recall_enabled => {
+            return Err(MetricsError::InvalidData(
+                "disabled recall outcome requires recall to be disabled".to_string(),
+            ));
+        }
+        PromptMemoryRecallOutcome::NoQuery
+            if !observation.recall_enabled || observation.query_present =>
+        {
+            return Err(MetricsError::InvalidData(
+                "no-query recall outcome requires enabled recall without a query".to_string(),
+            ));
+        }
+        PromptMemoryRecallOutcome::NoMatch
+        | PromptMemoryRecallOutcome::LookupError
+        | PromptMemoryRecallOutcome::Lexical
+        | PromptMemoryRecallOutcome::Reranked
+        | PromptMemoryRecallOutcome::RerankFallback
+            if !observation.recall_enabled || !observation.query_present =>
+        {
+            return Err(MetricsError::InvalidData(
+                "observed recall outcome requires enabled recall and a query".to_string(),
+            ));
+        }
+        _ => {}
+    }
+    if matches!(
+        observation.recall_outcome,
+        PromptMemoryRecallOutcome::Disabled
+            | PromptMemoryRecallOutcome::NoQuery
+            | PromptMemoryRecallOutcome::NoMatch
+            | PromptMemoryRecallOutcome::LookupError
+    ) && observation.all_compact_exposed_count != 0
+    {
+        return Err(MetricsError::InvalidData(
+            "non-selection recall outcome cannot contain compact exposures".to_string(),
+        ));
+    }
+
+    let mut memory_ids = BTreeSet::new();
+    let mut ranks = BTreeSet::new();
+    let mut rendered_item_chars = 0_u64;
+    for item in &observation.project_items {
+        if item.memory_id.trim().is_empty() {
+            return Err(MetricsError::InvalidData(
+                "prompt-memory item identity cannot be blank".to_string(),
+            ));
+        }
+        if !matches!(
+            item.status_at_observation.as_str(),
+            "active" | "stale" | "superseded" | "contradicted" | "archived"
+        ) {
+            return Err(MetricsError::InvalidData(
+                "invalid prompt-memory lifecycle status".to_string(),
+            ));
+        }
+        if item.scope != "project" {
+            return Err(MetricsError::InvalidData(
+                "schema v1 persists only Project prompt-memory item identities".to_string(),
+            ));
+        }
+        if item.rank == 0 || item.rendered_chars == 0 {
+            return Err(MetricsError::InvalidData(
+                "prompt-memory item rank and rendered characters must be positive".to_string(),
+            ));
+        }
+        if item.rank > observation.all_compact_exposed_count {
+            return Err(MetricsError::InvalidData(
+                "prompt-memory item rank exceeds the complete compact exposure count".to_string(),
+            ));
+        }
+        rendered_item_chars = rendered_item_chars.saturating_add(u64::from(item.rendered_chars));
+        if !memory_ids.insert(item.memory_id.as_str()) || !ranks.insert(item.rank) {
+            return Err(MetricsError::InvalidData(
+                "prompt-memory item identities and ranks must be unique within a round".to_string(),
+            ));
+        }
+    }
+    if observation.all_compact_exposed_count > 0 && observation.compact_section_chars == 0 {
+        return Err(MetricsError::InvalidData(
+            "non-empty compact exposure requires a rendered section".to_string(),
+        ));
+    }
+    if u64::from(observation.compact_section_chars) < rendered_item_chars {
+        return Err(MetricsError::InvalidData(
+            "compact section characters cannot be smaller than its Project items".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn load_prompt_memory_exposure(
+    connection: &Connection,
+    round_id: &str,
+) -> MetricsResult<Option<PromptMemoryExposureObservation>> {
+    type HeaderRow = (
+        String,
+        String,
+        Option<String>,
+        String,
+        i64,
+        i64,
+        i64,
+        String,
+        i64,
+        i64,
+        i64,
+        i64,
+    );
+    let header: Option<HeaderRow> = connection
+        .query_row(
+            r#"
+            SELECT round_id, session_id, project_id, observed_at,
+                   schema_version, recall_enabled, query_present, recall_outcome,
+                   all_compact_exposed_count, project_exposed_count,
+                   out_of_project_only, compact_section_chars
+            FROM prompt_memory_round_observations
+            WHERE round_id = ?1
+            "#,
+            params![round_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                    row.get(8)?,
+                    row.get(9)?,
+                    row.get(10)?,
+                    row.get(11)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((
+        round_id,
+        session_id,
+        project_id,
+        observed_at,
+        schema_version,
+        recall_enabled,
+        query_present,
+        recall_outcome,
+        all_compact_exposed_count,
+        project_exposed_count,
+        out_of_project_only,
+        compact_section_chars,
+    )) = header
+    else {
+        return Ok(None);
+    };
+
+    let mut statement = connection.prepare(
+        r#"
+        SELECT memory_id, scope, status_at_observation, rank, rendered_chars
+        FROM prompt_memory_project_exposures
+        WHERE round_id = ?1
+        ORDER BY rank ASC, memory_id ASC
+        "#,
+    )?;
+    let project_items = statement
+        .query_map(params![round_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        })?
+        .map(|row| {
+            let (memory_id, scope, status_at_observation, rank, rendered_chars) = row?;
+            Ok(PromptMemoryExposureItem {
+                memory_id,
+                scope,
+                status_at_observation,
+                rank: metric_i64_to_u32(rank, "prompt-memory item rank")?,
+                rendered_chars: metric_i64_to_u32(
+                    rendered_chars,
+                    "prompt-memory item rendered characters",
+                )?,
+            })
+        })
+        .collect::<MetricsResult<Vec<_>>>()?;
+
+    let observation = PromptMemoryExposureObservation {
+        schema_version: metric_i64_to_u32(
+            schema_version,
+            "prompt-memory observation schema version",
+        )?,
+        round_id,
+        session_id,
+        project_id,
+        observed_at: parse_timestamp(observed_at)?,
+        recall_enabled: metric_i64_to_bool(recall_enabled, "recall-enabled flag")?,
+        query_present: metric_i64_to_bool(query_present, "query-present flag")?,
+        recall_outcome: PromptMemoryRecallOutcome::from_db(&recall_outcome).ok_or_else(|| {
+            MetricsError::InvalidData("unknown prompt-memory recall outcome".to_string())
+        })?,
+        all_compact_exposed_count: metric_i64_to_u32(
+            all_compact_exposed_count,
+            "all compact exposure count",
+        )?,
+        project_exposed_count: metric_i64_to_u32(project_exposed_count, "Project exposure count")?,
+        out_of_project_only: metric_i64_to_bool(out_of_project_only, "out-of-Project-only flag")?,
+        compact_section_chars: metric_i64_to_u32(
+            compact_section_chars,
+            "compact section characters",
+        )?,
+        project_items,
+    };
+    validate_prompt_memory_exposure(&observation)?;
+    Ok(Some(observation))
+}
+
+fn metric_i64_to_u32(value: i64, field: &str) -> MetricsResult<u32> {
+    u32::try_from(value).map_err(|_| MetricsError::InvalidData(format!("invalid {field}: {value}")))
+}
+
+fn metric_i64_to_bool(value: i64, field: &str) -> MetricsResult<bool> {
+    match value {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(MetricsError::InvalidData(format!(
+            "invalid {field}: {value}"
+        ))),
+    }
+}
+
 /// Parses an optional RFC3339 timestamp string.
 ///
 /// # Arguments
@@ -3448,6 +3902,10 @@ fn load_execute_sync_mismatch_breakdown(
 const LOAD_ROUNDS_SQL: &str = "SELECT round_id, session_id, model, started_at, completed_at, status, prompt_tokens, completion_tokens, total_tokens, prompt_cached_tool_outputs, prompt_cached_tool_tokens_saved, compression_count, tokens_saved, error FROM round_metrics WHERE session_id = ?1 ORDER BY started_at ASC";
 
 const LOAD_TOOL_CALLS_SQL: &str = "SELECT tool_call_id, tool_name, started_at, completed_at, success, error FROM tool_call_metrics WHERE round_id = ?1 ORDER BY started_at ASC";
+
+#[cfg(test)]
+#[path = "storage/prompt_memory_tests.rs"]
+mod prompt_memory_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage/prompt_memory_tests.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage/prompt_memory_tests.rs
@@ -1,0 +1,520 @@
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use rusqlite::Connection;
+use tempfile::{tempdir, TempDir};
+
+use super::{open_connection, MetricsStorage, SqliteMetricsStorage};
+use crate::metrics::types::{
+    PromptMemoryExposureItem, PromptMemoryExposureObservation, PromptMemoryRecallOutcome,
+};
+
+fn observed_at() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 9, 5, 10, 0, 0).unwrap()
+}
+
+fn observation(round: &str, project: &str, ids: &[&str]) -> PromptMemoryExposureObservation {
+    PromptMemoryExposureObservation {
+        schema_version: 1,
+        round_id: round.to_string(),
+        session_id: "session-a".to_string(),
+        project_id: Some(project.to_string()),
+        observed_at: observed_at(),
+        recall_enabled: true,
+        query_present: true,
+        recall_outcome: PromptMemoryRecallOutcome::Lexical,
+        all_compact_exposed_count: ids.len() as u32,
+        project_exposed_count: ids.len() as u32,
+        out_of_project_only: false,
+        compact_section_chars: 80 + 60 * ids.len() as u32,
+        project_items: ids
+            .iter()
+            .enumerate()
+            .map(|(index, id)| PromptMemoryExposureItem {
+                memory_id: (*id).to_string(),
+                scope: "project".to_string(),
+                status_at_observation: "active".to_string(),
+                rank: index as u32 + 1,
+                rendered_chars: 60,
+            })
+            .collect(),
+    }
+}
+
+async fn fixture() -> (TempDir, SqliteMetricsStorage) {
+    let dir = tempdir().unwrap();
+    let storage = SqliteMetricsStorage::new(dir.path().join("metrics.db"));
+    storage.init().await.unwrap();
+    storage
+        .upsert_session_start("session-a", "test-model", observed_at())
+        .await
+        .unwrap();
+    (dir, storage)
+}
+
+async fn start_round(storage: &SqliteMetricsStorage, round: &str, when: DateTime<Utc>) {
+    storage
+        .insert_round_start(round, "session-a", "test-model", when)
+        .await
+        .unwrap();
+}
+
+fn counts(connection: &Connection) -> (i64, i64) {
+    connection
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM prompt_memory_round_observations),
+                    (SELECT COUNT(*) FROM prompt_memory_project_exposures)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap()
+}
+
+fn assert_no_orphans(connection: &Connection) {
+    assert_eq!(
+        connection
+            .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn prompt_memory_first_snapshot_survives_retries_and_conflicting_owners() {
+    let (dir, storage) = fixture().await;
+    let round = "session-a-run-execution-one-round-1";
+    start_round(&storage, round, observed_at()).await;
+    let first = observation(round, "project-a", &["memory-a", "memory-b"]);
+    storage.record_prompt_memory_exposure(&first).await.unwrap();
+    storage.record_prompt_memory_exposure(&first).await.unwrap();
+    let mut retry = observation(round, "project-a", &["memory-c"]);
+    retry.observed_at += Duration::minutes(1);
+    retry.recall_outcome = PromptMemoryRecallOutcome::RerankFallback;
+    storage.record_prompt_memory_exposure(&retry).await.unwrap();
+    for owner in [Some("project-b".to_string()), None] {
+        retry.project_id = owner;
+        retry.project_items.clear();
+        retry.project_exposed_count = 0;
+        retry.out_of_project_only = true;
+        assert!(storage.record_prompt_memory_exposure(&retry).await.is_err());
+    }
+    retry = first.clone();
+    retry.session_id = "session-b".to_string();
+    assert!(storage.record_prompt_memory_exposure(&retry).await.is_err());
+    assert_eq!(
+        storage.prompt_memory_exposure(round).await.unwrap(),
+        Some(first)
+    );
+
+    let restarted = "session-a-run-execution-two-round-1";
+    start_round(&storage, restarted, observed_at()).await;
+    let next = observation(restarted, "project-a", &["memory-a"]);
+    storage.record_prompt_memory_exposure(&next).await.unwrap();
+    let connection = open_connection(&dir.path().join("metrics.db")).unwrap();
+    assert_eq!(counts(&connection), (2, 3));
+    assert_eq!(
+        connection.query_row(
+            "SELECT COUNT(DISTINCT round_id) FROM prompt_memory_project_exposures WHERE memory_id = 'memory-a'",
+            [], |row| row.get::<_, i64>(0),
+        ).unwrap(),
+        2
+    );
+    assert_no_orphans(&connection);
+}
+
+#[tokio::test]
+async fn prompt_memory_concurrent_same_round_delivery_keeps_one_complete_snapshot() {
+    let (dir, storage) = fixture().await;
+    start_round(&storage, "round-race", observed_at()).await;
+    let one = observation("round-race", "project-a", &["memory-a"]);
+    let two = observation("round-race", "project-a", &["memory-b", "memory-c"]);
+    let (a, b) = tokio::join!(
+        storage.record_prompt_memory_exposure(&one),
+        storage.record_prompt_memory_exposure(&two)
+    );
+    a.unwrap();
+    b.unwrap();
+    let stored = storage
+        .prompt_memory_exposure("round-race")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        stored == one || stored == two,
+        "membership must never be a union"
+    );
+    let connection = open_connection(&dir.path().join("metrics.db")).unwrap();
+    assert_eq!(
+        counts(&connection),
+        (1, i64::from(stored.project_exposed_count))
+    );
+    assert_no_orphans(&connection);
+}
+
+#[tokio::test]
+async fn prompt_memory_second_item_sql_failure_rolls_back_header_and_first_item() {
+    let (dir, storage) = fixture().await;
+    start_round(&storage, "round-atomic", observed_at()).await;
+    let connection = open_connection(&dir.path().join("metrics.db")).unwrap();
+    connection
+        .execute_batch(
+            "CREATE TRIGGER fail_second_memory BEFORE INSERT ON prompt_memory_project_exposures
+         WHEN NEW.memory_id = 'memory-b'
+         BEGIN SELECT RAISE(ABORT, 'injected second-item failure'); END;",
+        )
+        .unwrap();
+    let value = observation("round-atomic", "project-a", &["memory-a", "memory-b"]);
+    assert!(storage.record_prompt_memory_exposure(&value).await.is_err());
+    assert_eq!(counts(&connection), (0, 0));
+    assert!(storage
+        .prompt_memory_exposure("round-atomic")
+        .await
+        .unwrap()
+        .is_none());
+    assert_no_orphans(&connection);
+    connection
+        .execute_batch("DROP TRIGGER fail_second_memory")
+        .unwrap();
+    storage.record_prompt_memory_exposure(&value).await.unwrap();
+    assert_eq!(counts(&connection), (1, 2));
+}
+
+#[tokio::test]
+async fn prompt_memory_invalid_or_unowned_observations_never_leave_rows() {
+    let (dir, storage) = fixture().await;
+    let mut value = observation("round-validation", "project-a", &["memory-a"]);
+    assert!(storage.record_prompt_memory_exposure(&value).await.is_err());
+    start_round(&storage, &value.round_id, observed_at()).await;
+    for kind in 0..14 {
+        let mut invalid = value.clone();
+        match kind {
+            0 => invalid.project_items[0].scope = "global".to_string(),
+            1 => invalid.project_exposed_count = 2,
+            2 => invalid.project_id = None,
+            3 => invalid.project_items[0].rank = 0,
+            4 => invalid.project_items[0].rendered_chars = 0,
+            5 => invalid.schema_version = 2,
+            6 => invalid.session_id = "another-session".to_string(),
+            7 => invalid.project_items[0].rank = 99,
+            8 => invalid.compact_section_chars = 0,
+            9 => invalid.compact_section_chars = 59,
+            10 => {
+                invalid.project_items[0].status_at_observation = "query/body sentinel".to_string()
+            }
+            11 => invalid.project_items[0].status_at_observation = " ".to_string(),
+            12 => invalid.project_items[0].status_at_observation = "unknown".to_string(),
+            _ => {
+                invalid.project_items.clear();
+                invalid.project_exposed_count = 0;
+                invalid.out_of_project_only = true;
+                invalid.compact_section_chars = 0;
+            }
+        }
+        let error = storage
+            .record_prompt_memory_exposure(&invalid)
+            .await
+            .expect_err("invalid observations must be rejected");
+        assert!(
+            !error.to_string().contains("query/body sentinel"),
+            "case {kind}: rejected content must not leak into collector error logs"
+        );
+    }
+    value.project_items.push(value.project_items[0].clone());
+    value.all_compact_exposed_count = 2;
+    value.project_exposed_count = 2;
+    assert!(storage.record_prompt_memory_exposure(&value).await.is_err());
+    let connection = open_connection(&dir.path().join("metrics.db")).unwrap();
+    assert_eq!(counts(&connection), (0, 0));
+    assert_no_orphans(&connection);
+}
+
+#[tokio::test]
+async fn prompt_memory_status_is_a_coarse_lifecycle_in_rust_and_sqlite() {
+    let (dir, storage) = fixture().await;
+    for status in ["active", "stale", "superseded", "contradicted", "archived"] {
+        start_round(&storage, status, observed_at()).await;
+        let mut value = observation(status, "project-a", &["memory-a"]);
+        value.project_items[0].status_at_observation = status.to_string();
+        storage.record_prompt_memory_exposure(&value).await.unwrap();
+        assert_eq!(
+            storage.prompt_memory_exposure(status).await.unwrap(),
+            Some(value)
+        );
+    }
+    let connection = open_connection(&dir.path().join("metrics.db")).unwrap();
+    assert!(connection.execute(
+        "UPDATE prompt_memory_project_exposures SET status_at_observation = 'query/body sentinel'",
+        [],
+    ).is_err(), "the database also rejects non-lifecycle text");
+    assert_eq!(counts(&connection), (5, 5));
+    assert_eq!(
+        storage
+            .prompt_memory_exposure("active")
+            .await
+            .unwrap()
+            .unwrap()
+            .project_items[0]
+            .status_at_observation,
+        "active"
+    );
+}
+
+#[tokio::test]
+async fn prompt_memory_empty_outcomes_and_global_only_headers_remain_distinguishable() {
+    let (dir, storage) = fixture().await;
+    for outcome in [
+        PromptMemoryRecallOutcome::Disabled,
+        PromptMemoryRecallOutcome::NoQuery,
+        PromptMemoryRecallOutcome::NoMatch,
+        PromptMemoryRecallOutcome::LookupError,
+        PromptMemoryRecallOutcome::Lexical,
+        PromptMemoryRecallOutcome::Reranked,
+        PromptMemoryRecallOutcome::RerankFallback,
+    ] {
+        let mut value = observation(outcome.as_str(), "project-a", &[]);
+        value.recall_outcome = outcome;
+        value.recall_enabled = outcome != PromptMemoryRecallOutcome::Disabled;
+        value.query_present = outcome != PromptMemoryRecallOutcome::NoQuery;
+        value.compact_section_chars = 0;
+        start_round(&storage, &value.round_id, observed_at()).await;
+        storage.record_prompt_memory_exposure(&value).await.unwrap();
+        assert_eq!(
+            storage
+                .prompt_memory_exposure(&value.round_id)
+                .await
+                .unwrap(),
+            Some(value)
+        );
+    }
+    let mut global = observation("global-only", "project-a", &[]);
+    global.all_compact_exposed_count = 2;
+    global.out_of_project_only = true;
+    start_round(&storage, &global.round_id, observed_at()).await;
+    storage
+        .record_prompt_memory_exposure(&global)
+        .await
+        .unwrap();
+    assert_eq!(
+        storage
+            .prompt_memory_exposure(&global.round_id)
+            .await
+            .unwrap(),
+        Some(global)
+    );
+    let mut mixed = observation("mixed", "project-b", &["project-b-memory"]);
+    mixed.all_compact_exposed_count = 3;
+    mixed.project_items[0].rank = 2; // A Global item leads the actual compact set.
+    start_round(&storage, &mixed.round_id, observed_at()).await;
+    storage.record_prompt_memory_exposure(&mixed).await.unwrap();
+    assert_eq!(
+        storage
+            .prompt_memory_exposure(&mixed.round_id)
+            .await
+            .unwrap(),
+        Some(mixed)
+    );
+    let connection = open_connection(&dir.path().join("metrics.db")).unwrap();
+    assert_eq!(counts(&connection), (9, 1));
+    assert_no_orphans(&connection);
+}
+
+#[tokio::test]
+async fn prompt_memory_retention_uses_round_cutoff_and_cascades_both_tables() {
+    let (dir, storage) = fixture().await;
+    let cutoff = observed_at() - Duration::days(90);
+    for (round, started) in [
+        ("old", cutoff - Duration::seconds(1)),
+        ("boundary", cutoff),
+        ("recent", cutoff + Duration::seconds(1)),
+    ] {
+        start_round(&storage, round, started).await;
+        // An old round's late telemetry still expires with its parent round.
+        storage
+            .record_prompt_memory_exposure(&observation(round, "project-a", &["memory-a"]))
+            .await
+            .unwrap();
+    }
+    assert_eq!(storage.prune_rounds_before(cutoff).await.unwrap(), 1);
+    assert_eq!(storage.prune_rounds_before(cutoff).await.unwrap(), 0);
+    assert!(storage
+        .prompt_memory_exposure("old")
+        .await
+        .unwrap()
+        .is_none());
+    assert!(storage
+        .prompt_memory_exposure("boundary")
+        .await
+        .unwrap()
+        .is_some());
+    assert!(storage
+        .prompt_memory_exposure("recent")
+        .await
+        .unwrap()
+        .is_some());
+    let connection = open_connection(&dir.path().join("metrics.db")).unwrap();
+    assert_eq!(counts(&connection), (2, 2));
+    assert_no_orphans(&connection);
+    connection
+        .execute(
+            "DELETE FROM session_metrics WHERE session_id='session-a'",
+            [],
+        )
+        .unwrap();
+    assert_eq!(counts(&connection), (0, 0));
+    assert_no_orphans(&connection);
+}
+
+// Independent populated pre-#1077 schema: never derived by creating the new
+// schema then dropping its tables, so additions and migrations are exercised.
+const PRE_EXPOSURE_SCHEMA: &str = r#"
+CREATE TABLE session_metrics (
+ session_id TEXT PRIMARY KEY, model TEXT NOT NULL, started_at TEXT NOT NULL, completed_at TEXT,
+ status TEXT NOT NULL DEFAULT 'running', total_rounds INTEGER NOT NULL DEFAULT 0,
+ prompt_tokens INTEGER NOT NULL DEFAULT 0, completion_tokens INTEGER NOT NULL DEFAULT 0,
+ total_tokens INTEGER NOT NULL DEFAULT 0, prompt_cached_tool_outputs INTEGER NOT NULL DEFAULT 0,
+ prompt_cached_tool_tokens_saved INTEGER NOT NULL DEFAULT 0, total_compression_events INTEGER NOT NULL DEFAULT 0,
+ total_tokens_saved INTEGER NOT NULL DEFAULT 0, tool_call_count INTEGER NOT NULL DEFAULT 0,
+ message_count INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL
+);
+CREATE TABLE round_metrics (
+ round_id TEXT PRIMARY KEY, session_id TEXT NOT NULL, model TEXT NOT NULL, started_at TEXT NOT NULL,
+ completed_at TEXT, status TEXT NOT NULL DEFAULT 'running', prompt_tokens INTEGER NOT NULL DEFAULT 0,
+ completion_tokens INTEGER NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0,
+ prompt_cached_tool_outputs INTEGER NOT NULL DEFAULT 0, prompt_cached_tool_tokens_saved INTEGER NOT NULL DEFAULT 0,
+ compression_count INTEGER NOT NULL DEFAULT 0, tokens_saved INTEGER NOT NULL DEFAULT 0, error TEXT,
+ FOREIGN KEY(session_id) REFERENCES session_metrics(session_id) ON DELETE CASCADE
+);
+CREATE TABLE tool_call_metrics (
+ tool_call_id TEXT PRIMARY KEY, round_id TEXT NOT NULL, session_id TEXT NOT NULL, tool_name TEXT NOT NULL,
+ started_at TEXT NOT NULL, completed_at TEXT, success INTEGER, error TEXT,
+ FOREIGN KEY(round_id) REFERENCES round_metrics(round_id) ON DELETE CASCADE,
+ FOREIGN KEY(session_id) REFERENCES session_metrics(session_id) ON DELETE CASCADE
+);
+CREATE INDEX idx_round_session_started_at ON round_metrics(session_id, started_at);
+CREATE INDEX idx_round_started_at ON round_metrics(started_at);
+CREATE INDEX idx_tool_round_started_at ON tool_call_metrics(round_id, started_at);
+CREATE INDEX custom_tool_success ON tool_call_metrics(success);
+INSERT INTO session_metrics(session_id,model,started_at,updated_at) VALUES ('session-a','legacy','2026-09-05T10:00:00+00:00','2026-09-05T10:00:00+00:00');
+INSERT INTO round_metrics(round_id,session_id,model,started_at,total_tokens) VALUES ('legacy-round','session-a','legacy','2026-09-05T10:00:00+00:00',42);
+INSERT INTO tool_call_metrics(tool_call_id,round_id,session_id,tool_name,started_at,success) VALUES ('legacy-tool','legacy-round','session-a','fixture','2026-09-05T10:00:00+00:00',1);
+"#;
+
+fn legacy_rows(connection: &Connection) -> Vec<Vec<Vec<rusqlite::types::Value>>> {
+    ["session_metrics", "round_metrics", "tool_call_metrics"]
+        .iter()
+        .map(|table| {
+            let mut statement = connection
+                .prepare(&format!("SELECT * FROM {table} ORDER BY 1"))
+                .unwrap();
+            let columns = statement.column_count();
+            statement
+                .query_map([], |row| {
+                    (0..columns)
+                        .map(|column| row.get(column))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn prompt_memory_populated_migration_and_restart_preserve_rows_indexes_and_exposure() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("metrics.db");
+    let connection = open_connection(&path).unwrap();
+    connection.execute_batch(PRE_EXPOSURE_SCHEMA).unwrap();
+    let before = legacy_rows(&connection);
+    drop(connection);
+    let value = observation("legacy-round", "project-a", &["memory-a"]);
+    for pass in 0..3 {
+        let storage = SqliteMetricsStorage::new(&path);
+        storage.init().await.unwrap();
+        if pass == 0 {
+            storage.record_prompt_memory_exposure(&value).await.unwrap();
+        }
+        assert_eq!(
+            storage
+                .prompt_memory_exposure(&value.round_id)
+                .await
+                .unwrap(),
+            Some(value.clone())
+        );
+        let connection = open_connection(&path).unwrap();
+        assert_eq!(legacy_rows(&connection), before);
+        assert_eq!(counts(&connection), (1, 1));
+        for index in [
+            "idx_round_session_started_at",
+            "idx_round_started_at",
+            "idx_tool_round_started_at",
+            "custom_tool_success",
+        ] {
+            assert_eq!(
+                connection
+                    .query_row(
+                        "SELECT COUNT(*) FROM sqlite_schema WHERE type='index' AND name=?1",
+                        [index],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap(),
+                1,
+                "preserve {index}"
+            );
+        }
+        assert_no_orphans(&connection);
+    }
+}
+
+#[test]
+fn prompt_memory_serialization_contains_only_the_v1_allowlisted_fields() {
+    let value = observation("round-serde", "project-a", &["memory-a"]);
+    let json = serde_json::to_value(&value).unwrap();
+    let mut keys = json
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        [
+            "all_compact_exposed_count",
+            "compact_section_chars",
+            "observed_at",
+            "out_of_project_only",
+            "project_exposed_count",
+            "project_id",
+            "project_items",
+            "query_present",
+            "recall_enabled",
+            "recall_outcome",
+            "round_id",
+            "schema_version",
+            "session_id"
+        ]
+    );
+    let mut item_keys = json["project_items"][0]
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    item_keys.sort_unstable();
+    assert_eq!(
+        item_keys,
+        [
+            "memory_id",
+            "rank",
+            "rendered_chars",
+            "scope",
+            "status_at_observation"
+        ]
+    );
+    assert_eq!(
+        serde_json::from_value::<PromptMemoryExposureObservation>(json).unwrap(),
+        value
+    );
+}

--- a/crates/infra/bamboo-infrastructure/src/metrics/types.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/types.rs
@@ -191,6 +191,100 @@ pub struct SessionDetail {
     pub rounds: Vec<RoundMetrics>,
 }
 
+/// Outcome of Bamboo's automatic compact-memory recall at the prompt boundary.
+///
+/// This describes host-side selection only. It does not claim that a provider
+/// processed the request or that the model adopted any recalled fact.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptMemoryRecallOutcome {
+    /// Automatic relevant-memory recall was disabled for this round.
+    Disabled,
+    /// Recall was enabled, but there was no user query to search with.
+    NoQuery,
+    /// Recall completed successfully and found no candidate.
+    NoMatch,
+    /// The canonical memory lookup failed.
+    LookupError,
+    /// Deterministic lexical selection was used.
+    Lexical,
+    /// Model reranking selected the final compact records.
+    Reranked,
+    /// Model reranking failed and lexical selection was used instead.
+    RerankFallback,
+}
+
+impl PromptMemoryRecallOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::NoQuery => "no_query",
+            Self::NoMatch => "no_match",
+            Self::LookupError => "lookup_error",
+            Self::Lexical => "lexical",
+            Self::Reranked => "reranked",
+            Self::RerankFallback => "rerank_fallback",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "disabled" => Some(Self::Disabled),
+            "no_query" => Some(Self::NoQuery),
+            "no_match" => Some(Self::NoMatch),
+            "lookup_error" => Some(Self::LookupError),
+            "lexical" => Some(Self::Lexical),
+            "reranked" => Some(Self::Reranked),
+            "rerank_fallback" => Some(Self::RerankFallback),
+            _ => None,
+        }
+    }
+}
+
+/// One Project-scoped compact memory included in an observed provider request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptMemoryExposureItem {
+    /// Opaque canonical Jiandu record identity.
+    pub memory_id: String,
+    /// Scope at observation time. Schema v1 accepts only `project` items.
+    pub scope: String,
+    /// Coarse lifecycle status at observation time.
+    pub status_at_observation: String,
+    /// One-based position in the final compact-memory request ordering.
+    pub rank: u32,
+    /// Characters in this item's final rendered compact representation.
+    pub rendered_chars: u32,
+}
+
+/// First successfully bootstrapped compact-memory prompt observation for one
+/// execution-scoped logical round.
+///
+/// Metrics delivery remains best-effort. A row proves only that Bamboo reached
+/// its provider-stream bootstrap boundary with these compact records; it is not
+/// a durable delivery acknowledgement or evidence of model adoption.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptMemoryExposureObservation {
+    pub schema_version: u32,
+    pub round_id: String,
+    pub session_id: String,
+    /// Server-resolved Project identity, absent for an unbound round.
+    pub project_id: Option<String>,
+    pub observed_at: DateTime<Utc>,
+    pub recall_enabled: bool,
+    pub query_present: bool,
+    pub recall_outcome: PromptMemoryRecallOutcome,
+    /// All final compact relevant-memory records, including Global fallback.
+    pub all_compact_exposed_count: u32,
+    /// Final Project records persisted in `project_items`.
+    pub project_exposed_count: u32,
+    /// True when the final compact set was non-empty but contained no Project item.
+    pub out_of_project_only: bool,
+    /// Characters in the final rendered relevant-memory section.
+    pub compact_section_chars: u32,
+    /// Project-only opaque identities. Global identities are never persisted.
+    pub project_items: Vec<PromptMemoryExposureItem>,
+}
+
 /// Aggregated metrics for a single day
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DailyMetrics {

--- a/crates/infra/bamboo-metrics/src/collector.rs
+++ b/crates/infra/bamboo-metrics/src/collector.rs
@@ -5,7 +5,9 @@ use chrono::{DateTime, Duration, Utc};
 use tokio::sync::mpsc;
 
 use crate::storage::{MetricsStorage, ToolCallCompletion};
-use crate::types::{ForwardTokenDetails, RoundStatus, SessionStatus, TokenUsage};
+use crate::types::{
+    ForwardTokenDetails, PromptMemoryExposureObservation, RoundStatus, SessionStatus, TokenUsage,
+};
 
 #[derive(Debug)]
 enum CollectorCommand {
@@ -38,6 +40,9 @@ enum CollectorCommand {
         prompt_cached_tool_outputs: u32,
         prompt_cached_tool_tokens_saved: u32,
         error: Option<String>,
+    },
+    PromptMemoryExposure {
+        observation: PromptMemoryExposureObservation,
     },
     ToolStarted {
         tool_call_id: String,
@@ -173,6 +178,9 @@ impl MetricsCollector {
                                 error,
                             )
                             .await
+                    }
+                    CollectorCommand::PromptMemoryExposure { observation } => {
+                        storage.record_prompt_memory_exposure(&observation).await
                     }
                     CollectorCommand::ToolStarted {
                         tool_call_id,
@@ -352,6 +360,17 @@ impl MetricsCollector {
             prompt_cached_tool_tokens_saved,
             error,
         });
+    }
+
+    /// Queues a host-observed compact-memory prompt exposure.
+    ///
+    /// This is intentionally best-effort like the rest of the live metrics
+    /// collector. It neither blocks provider execution nor creates a durable
+    /// delivery acknowledgement protocol.
+    pub fn prompt_memory_exposure(&self, observation: PromptMemoryExposureObservation) {
+        let _ = self
+            .tx
+            .send(CollectorCommand::PromptMemoryExposure { observation });
     }
 
     pub fn record_agent_event(&self, session_id: &str, round_id: &str, event: &AgentEvent) {


### PR DESCRIPTION
## Summary

Closes #1077. Producer slice of bigduu/Zenith#199; the aggregation API (#1078) and Lotus Next dashboard (bigduu/lotus-next#74) remain separate, unclaimed work.

- Carry engine-private, execution-local typed provenance from the final compact-memory render selection to successful provider-stream bootstrap. Do not recover IDs from Markdown or trust caller-editable Session metadata.
- Preserve the first observation per execution-scoped logical round atomically in the existing metrics database. Same-owner retries cannot replace or union membership; conflicting ownership is rejected. New executions use new round identities.
- Persist Project-only item IDs, coarse lifecycle status, final rank and character counts. Round headers retain the actual all-scope/Project counts and distinguish disabled, no-query, no-match, lookup-error, lexical, reranked and rerank-fallback outcomes. Global-only fallback is not a Project hit or `no_match`.
- Reuse the existing best-effort collector and 90-day round retention, including the newly merged collector ownership fix (#1085). Header/items commit together and cascade with their parent round. No Jiandu dependency, canonical bytes, indexes, ranking, API or UI changes.

Schema v1 records host-observed fresh compact prompt exposure, **not** provider processing, model adoption, a full `memory get`, complete lifetime history or crash-exact delivery. Unsupported adapters do not silently become observed zeroes. Old text retained in a transcript is not backfilled. Jiandu v0.2.0 currently returns Project hits or Global fallback, not a mixed native set; mixed counts are covered at the storage contract without changing recall behavior. Overall recall eligibility is not a Project retrieval hit-rate denominator.

## Scope

One producer acceptance slice: 16 total files, including production wiring, README and focused tests; +2,111/-63 (2,048 net lines). The patch is at the approximate 2,000-line scope boundary because of atomicity, migration, provider and negative-path tests; it introduces no additional subsystem or delivery/recovery protocol. No further feature expansion is included.

Candidate: `4793f1aea37dceb4613edacee2f15279b7944c20`, based on `e1a6ce1dbd3417174c54f71723a9ee7b8237b5a1`. Both rebases retained an identical feature patch. The collector integration from #1085 was independently re-reviewed; the later #1088 search-cache change is production-file-disjoint and is included in integration validation, without taking over that separate Issue. The final follow-up changes only two test panic messages to fixed strings, addressing CodeQL alerts 213/214 without production changes or suppressions.

## Test Plan

All fixtures use temporary Bamboo/Project/Jiandu/SQLite roots. Local backend runs also deny access to the user's live Jiandu and Bamboo directories.

- Deterministic provider fixture compares the actual accepted request with persisted IDs and final order: Project A has four candidates but only three admitted records; Project B, forged metadata IDs and full-body sentinels are excluded. Empty trusted Project C exercises real Global fallback without storing a Global ID.
- Final render character-budget exclusion and granularity reorder; all seven recall outcomes, including a genuinely corrupt temporary lexical index for lookup error.
- Budget/tool-footprint/checkpoint failure, pre-dispatch cancellation and bootstrap error produce no observation; post-bootstrap stream failure retains one. Negative checks wait for an existing collector FIFO barrier.
- Same-round retry and differing membership preserve the first snapshot; new executions get distinct rounds; conflicting ownership rejects; concurrent inserts select one whole snapshot; injected second-item SQL failure rolls back header and first item.
- Real MemoryTool write/query/get/inspect/archive calls remain zero-exposure after a collector FIFO barrier.
- Populated pre-feature SQLite schema migration, repeated initialization, restart reads, legacy rows/indexes, exact retention cutoff and cascade deletion; lifecycle/rank/count validation and allowlisted serialization.

Completed local verification on predecessor `6ce82f67257b83f0123e34fe34a7b2c04f73344f` (base `42cf35fb`), before the unrelated #1088 search-cache merge:

- `cargo test --all-features --lib --tests`: **8,501 passed, 0 failed, 11 ignored**, 74 completed test groups. Includes all 208 E2E tests and all 1,989 server library tests. The final management inspect/archive fixture and the new base's collector lifecycle regressions passed.
- `cargo test -p bamboo-engine -p bamboo-infrastructure -p bamboo-metrics -p bamboo-server-tools`: **1,780 passed, 0 failed, 24 existing ignored doctests**, 13 completed test groups under default features.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Exact CI `cargo clippy --all-features -- -D warnings` with the workflow's unchanged `-A` allowlist: passed (1m 06s).
- `cargo build --examples`: passed (1m 42s).

Local validation on feature predecessor `50b9337a`:

- `cargo test --all-features -p bamboo-engine -p bamboo-infrastructure -p bamboo-metrics -p bamboo-server-tools -p bamboo-storage`: **1,987 passed, 0 failed, 27 existing ignored doctests**, 15 completed test groups.
- The same five full module suites under default features: **1,986 passed, 0 failed, 27 existing ignored doctests**, 15 completed test groups.
- Format and diff checks passed. Exact CI Clippy passed (39.00s); `cargo build --examples` passed (52.90s).

These suites include engine/server-tools integration with the newly changed SessionStore/search cache. Repository-wide CI on `50b9337a` also passed Test (all-feature and default suites, live SSH/SFTP and examples), E2E Tests, Lint, MSRV, documentation, license checks, all TLS/Recorder platforms and CodeQL analysis. Two automated review findings on test diagnostic strings were addressed by the final follow-up.

Final-head validation on `4793f1ae`:

- Local `cargo test --all-features --lib --tests`: **8,512 passed, 0 failed, 11 ignored**, 74 completed groups; exited successfully. Includes all 1,989 server library tests and the previously flaky schedule-start test.
- The complete affected stream-execution group passed **52/52**; format/diff checks and exact CI Clippy passed.
- Independent exact-head review passed without P0/P1/P2 findings.
- Final-head CI: required Test, E2E Tests and Lint passed; Test completed all-feature/default suites, live SSH/SFTP and example builds. MSRV, documentation, license checks and all TLS/Recorder platforms passed.
- Final-head CodeQL, including Rust analysis, passed. Both original review threads are resolved/outdated, with no open PR scan alerts or unresolved review discussion.

Predecessor totals above remain explicitly identified and are not substituted for these final-head results.

The first full run exposed an existing test assumption that the temporary Bamboo directory ends in `.bamboo`; rerunning with that isolated directory name passed without changing code or accessing user data. Repository-wide default `cargo test --tests`, live SSH/SFTP and all required remote checks subsequently passed on the final head. The guarded merge still rechecks exact head/base, live authentication, review threads and mergeability.

## Known baseline check

The existing non-required Security Audit failure is tracked by #1061 (`wnaf 0.14.0` is yanked). This patch does not change Cargo dependencies or weaken any audit. The [final-head Security Audit job](https://github.com/bigduu/Bamboo-agent/actions/runs/33968064196/job/101311583847) was inspected: it fails `cargo audit --deny warnings` on that single yanked-crate warning, matching the tracked baseline rather than a new #1077 finding. Required Test/E2E Tests/Lint remain independent merge gates.

Final-head Test attempt 1 encountered an adjacent two-second scheduler-start fixture timeout, now recorded separately in #1090. The fixture is byte-identical to the base, the preceding head passed full CI with identical production code, and the final-head local all-feature run passed this exact test. Independent triage confirmed a wall-clock startup assumption under runner load; the [same-head Test-only rerun](https://github.com/bigduu/Bamboo-agent/actions/runs/33968064196/job/101312567830) passed all its steps. No scheduler changes, timeout increases or assertion weakening are included here.

## Screenshots

Not applicable: backend-only producer; no UI changes.
