### PR TITLE
perf: reuse SQLite connections for bounded metrics dispatch (#1086)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,7 @@ dependencies = [
  "bamboo-domain",
  "bamboo-infrastructure",
  "chrono",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/infra/bamboo-infrastructure/src/metrics/mod.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/mod.rs
@@ -5,6 +5,7 @@
 //! rusqlite dependency); the live metrics pipeline (bus / collector / worker)
 //! lives in the engine and depends on these abstractions.
 
+mod mutations;
 pub mod storage;
 pub mod types;
 

--- a/crates/infra/bamboo-infrastructure/src/metrics/mutations.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/mutations.rs
@@ -1,0 +1,199 @@
+use super::storage::{MetricsResult, MetricsStorage, ToolCallCompletion};
+use super::types::{ForwardStatus, ForwardTokenDetails, RoundStatus, SessionStatus, TokenUsage};
+use chrono::{DateTime, Utc};
+
+/// Maximum ready ordinary mutations dispatched in one connection segment.
+pub const MAX_METRICS_BATCH_SIZE: usize = 32;
+
+/// Owned ordinary metrics writes. Payloads remain raw for custom storage backends.
+/// Retention, compression and prompt-memory observations retain singleton paths.
+#[derive(Debug, Clone)]
+pub enum MetricsMutation {
+    SessionStarted {
+        session_id: String,
+        model: String,
+        started_at: DateTime<Utc>,
+    },
+    SessionMessageCount {
+        session_id: String,
+        message_count: u32,
+        updated_at: DateTime<Utc>,
+    },
+    SessionCompleted {
+        session_id: String,
+        status: SessionStatus,
+        completed_at: DateTime<Utc>,
+    },
+    RoundStarted {
+        round_id: String,
+        session_id: String,
+        model: String,
+        started_at: DateTime<Utc>,
+    },
+    RoundCompleted {
+        round_id: String,
+        completed_at: DateTime<Utc>,
+        status: RoundStatus,
+        usage: TokenUsage,
+        prompt_cached_tool_outputs: u32,
+        prompt_cached_tool_tokens_saved: u32,
+        error: Option<String>,
+    },
+    ToolStarted {
+        tool_call_id: String,
+        round_id: String,
+        session_id: String,
+        tool_name: String,
+        started_at: DateTime<Utc>,
+    },
+    ToolCompleted {
+        tool_call_id: String,
+        completion: ToolCallCompletion,
+    },
+    ExecuteSyncMismatch {
+        reason: String,
+        occurred_at: DateTime<Utc>,
+    },
+    ForwardStarted {
+        forward_id: String,
+        endpoint: String,
+        model: String,
+        is_stream: bool,
+        started_at: DateTime<Utc>,
+    },
+    ForwardCompleted {
+        forward_id: String,
+        completed_at: DateTime<Utc>,
+        status_code: Option<u16>,
+        status: ForwardStatus,
+        usage: Option<TokenUsage>,
+        token_details: Option<ForwardTokenDetails>,
+        error: Option<String>,
+    },
+}
+
+impl MetricsMutation {
+    pub(crate) async fn apply<S: MetricsStorage + ?Sized>(self, storage: &S) -> MetricsResult<()> {
+        match self {
+            Self::SessionStarted {
+                session_id,
+                model,
+                started_at,
+            } => {
+                storage
+                    .upsert_session_start(&session_id, &model, started_at)
+                    .await
+            }
+            Self::SessionMessageCount {
+                session_id,
+                message_count,
+                updated_at,
+            } => {
+                storage
+                    .update_session_message_count(&session_id, message_count, updated_at)
+                    .await
+            }
+            Self::SessionCompleted {
+                session_id,
+                status,
+                completed_at,
+            } => {
+                storage
+                    .complete_session(&session_id, status, completed_at)
+                    .await
+            }
+            Self::RoundStarted {
+                round_id,
+                session_id,
+                model,
+                started_at,
+            } => {
+                storage
+                    .insert_round_start(&round_id, &session_id, &model, started_at)
+                    .await
+            }
+            Self::RoundCompleted {
+                round_id,
+                completed_at,
+                status,
+                usage,
+                prompt_cached_tool_outputs,
+                prompt_cached_tool_tokens_saved,
+                error,
+            } => {
+                storage
+                    .complete_round(
+                        &round_id,
+                        completed_at,
+                        status,
+                        usage,
+                        prompt_cached_tool_outputs,
+                        prompt_cached_tool_tokens_saved,
+                        error,
+                    )
+                    .await
+            }
+            Self::ToolStarted {
+                tool_call_id,
+                round_id,
+                session_id,
+                tool_name,
+                started_at,
+            } => {
+                storage
+                    .insert_tool_start(
+                        &tool_call_id,
+                        &round_id,
+                        &session_id,
+                        &tool_name,
+                        started_at,
+                    )
+                    .await
+            }
+            Self::ToolCompleted {
+                tool_call_id,
+                completion,
+            } => storage.complete_tool_call(&tool_call_id, completion).await,
+            Self::ExecuteSyncMismatch {
+                reason,
+                occurred_at,
+            } => {
+                storage
+                    .increment_execute_sync_mismatch(&reason, occurred_at)
+                    .await
+            }
+            Self::ForwardStarted {
+                forward_id,
+                endpoint,
+                model,
+                is_stream,
+                started_at,
+            } => {
+                storage
+                    .insert_forward_start(&forward_id, &endpoint, &model, is_stream, started_at)
+                    .await
+            }
+            Self::ForwardCompleted {
+                forward_id,
+                completed_at,
+                status_code,
+                status,
+                usage,
+                token_details,
+                error,
+            } => {
+                storage
+                    .complete_forward(
+                        &forward_id,
+                        completed_at,
+                        status_code,
+                        status,
+                        usage,
+                        token_details,
+                        error,
+                    )
+                    .await
+            }
+        }
+    }
+}

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage.rs
@@ -77,8 +77,9 @@
 //! # Thread Safety
 //!
 //! All storage operations are thread-safe and can be called from multiple
-//! async tasks concurrently. SQLite connections are opened per-operation
-//! to avoid blocking the async runtime.
+//! async tasks concurrently. Each standalone operation or bounded batch segment
+//! opens a connection on the blocking pool. Commands retain their individual
+//! transaction boundaries; a segment does not create an outer transaction.
 
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -96,6 +97,15 @@ use crate::metrics::types::{
     SessionDetail, SessionMetrics, SessionMetricsFilter, SessionStatus, TokenUsage,
     ToolCallMetrics,
 };
+
+pub use super::mutations::{MetricsMutation, MAX_METRICS_BATCH_SIZE};
+
+mod batch;
+#[cfg(test)]
+mod batch_probe;
+#[cfg(test)]
+mod batch_tests;
+mod writes;
 
 /// Result type for metrics storage operations.
 ///
@@ -232,6 +242,25 @@ pub struct ToolCallCompletion {
 /// ```
 #[async_trait]
 pub trait MetricsStorage: Send + Sync {
+    /// Apply ordinary writes in input order, preserving one result per item.
+    ///
+    /// The default calls the existing single-item API and continues after an
+    /// error. SQLite segments at 32 items and retains each command's original
+    /// commit boundary. An outer error means the blocking task failed outside
+    /// item isolation: a prefix may have committed, so do not replay the batch.
+    /// Runtime teardown is not a successful drain. Custom backend panics keep
+    /// their existing behavior; this default adds no new unwind boundary.
+    async fn apply_batch(
+        &self,
+        mutations: Vec<MetricsMutation>,
+    ) -> MetricsResult<Vec<MetricsResult<()>>> {
+        let mut results = Vec::with_capacity(mutations.len());
+        for mutation in mutations {
+            results.push(mutation.apply(self).await);
+        }
+        Ok(results)
+    }
+
     /// Initializes the storage backend.
     ///
     /// This must be called before any other storage operations.
@@ -928,8 +957,9 @@ pub trait MetricsStorage: Send + Sync {
 ///
 /// # Thread Safety
 ///
-/// The storage can be safely cloned and shared across threads. Each operation
-/// opens its own database connection to avoid blocking and ensure thread safety.
+/// The storage can be safely cloned and shared across threads. Each standalone
+/// operation or bounded batch segment opens its own connection on the blocking
+/// pool. Each command retains its original transaction boundary.
 #[derive(Debug, Clone)]
 pub struct SqliteMetricsStorage {
     /// Path to the SQLite database file
@@ -973,6 +1003,13 @@ impl SqliteMetricsStorage {
             .await
     }
 
+    async fn write_one(&self, mutation: MetricsMutation) -> MetricsResult<()> {
+        self.with_connection(move |connection| {
+            writes::apply_mutation_on_connection(connection, mutation)
+        })
+        .await
+    }
+
     /// Executes a function with a database connection in a blocking context.
     ///
     /// This helper method handles:
@@ -1002,6 +1039,8 @@ impl SqliteMetricsStorage {
     {
         let db_path = self.db_path.clone();
         tokio::task::spawn_blocking(move || {
+            #[cfg(test)]
+            batch_probe::task_started(&db_path);
             let connection = open_connection(&db_path)?;
             func(&connection)
         })
@@ -1012,6 +1051,13 @@ impl SqliteMetricsStorage {
 
 #[async_trait]
 impl MetricsStorage for SqliteMetricsStorage {
+    async fn apply_batch(
+        &self,
+        mutations: Vec<MetricsMutation>,
+    ) -> MetricsResult<Vec<MetricsResult<()>>> {
+        self.apply_mutations(mutations).await
+    }
+
     async fn init(&self) -> MetricsResult<()> {
         self.with_connection(|connection| {
             connection.execute_batch(
@@ -1204,29 +1250,10 @@ impl MetricsStorage for SqliteMetricsStorage {
         model: &str,
         started_at: DateTime<Utc>,
     ) -> MetricsResult<()> {
-        let session_id = session_id.to_string();
-        let model = model.to_string();
-        let started_at = format_timestamp(started_at);
-
-        self.with_connection(move |connection| {
-            connection.execute(
-                r#"
-                INSERT INTO session_metrics (
-                    session_id, model, started_at, status, updated_at
-                ) VALUES (?1, ?2, ?3, 'running', ?3)
-                ON CONFLICT(session_id) DO UPDATE SET
-                    model = excluded.model,
-                    started_at = CASE
-                        WHEN session_metrics.started_at <= excluded.started_at THEN session_metrics.started_at
-                        ELSE excluded.started_at
-                    END,
-                    completed_at = NULL,
-                    status = 'running',
-                    updated_at = excluded.updated_at
-                "#,
-                params![session_id, model, started_at],
-            )?;
-            Ok(())
+        self.write_one(MetricsMutation::SessionStarted {
+            session_id: session_id.to_string(),
+            model: model.to_string(),
+            started_at,
         })
         .await
     }
@@ -1237,15 +1264,10 @@ impl MetricsStorage for SqliteMetricsStorage {
         message_count: u32,
         updated_at: DateTime<Utc>,
     ) -> MetricsResult<()> {
-        let session_id = session_id.to_string();
-        let updated_at = format_timestamp(updated_at);
-
-        self.with_connection(move |connection| {
-            connection.execute(
-                "UPDATE session_metrics SET message_count = ?1, updated_at = ?2 WHERE session_id = ?3",
-                params![i64::from(message_count), updated_at, session_id],
-            )?;
-            Ok(())
+        self.write_one(MetricsMutation::SessionMessageCount {
+            session_id: session_id.to_string(),
+            message_count,
+            updated_at,
         })
         .await
     }
@@ -1256,18 +1278,10 @@ impl MetricsStorage for SqliteMetricsStorage {
         status: SessionStatus,
         completed_at: DateTime<Utc>,
     ) -> MetricsResult<()> {
-        let session_id = session_id.to_string();
-        let completed_at_str = format_timestamp(completed_at);
-
-        self.with_connection(move |connection| {
-            with_immediate_transaction(connection, || {
-                refresh_session_aggregates(connection, &session_id, completed_at)?;
-                connection.execute(
-                    "UPDATE session_metrics SET status = ?1, completed_at = ?2, updated_at = ?2 WHERE session_id = ?3",
-                    params![status.as_str(), completed_at_str, session_id],
-                )?;
-                Ok(())
-            })
+        self.write_one(MetricsMutation::SessionCompleted {
+            session_id: session_id.to_string(),
+            status,
+            completed_at,
         })
         .await
     }
@@ -1279,25 +1293,11 @@ impl MetricsStorage for SqliteMetricsStorage {
         model: &str,
         started_at: DateTime<Utc>,
     ) -> MetricsResult<()> {
-        let round_id = round_id.to_string();
-        let session_id = session_id.to_string();
-        let model = model.to_string();
-        let started_at_str = format_timestamp(started_at);
-
-        self.with_connection(move |connection| {
-            with_immediate_transaction(connection, || {
-                connection.execute(
-                    r#"
-                    INSERT INTO round_metrics (
-                        round_id, session_id, model, started_at, status
-                    ) VALUES (?1, ?2, ?3, ?4, 'running')
-                    ON CONFLICT(round_id) DO NOTHING
-                    "#,
-                    params![round_id, session_id, model, started_at_str],
-                )?;
-                refresh_session_aggregates(connection, &session_id, started_at)?;
-                Ok(())
-            })
+        self.write_one(MetricsMutation::RoundStarted {
+            round_id: round_id.to_string(),
+            session_id: session_id.to_string(),
+            model: model.to_string(),
+            started_at,
         })
         .await
     }
@@ -1408,64 +1408,14 @@ impl MetricsStorage for SqliteMetricsStorage {
         prompt_cached_tool_tokens_saved: u32,
         error: Option<String>,
     ) -> MetricsResult<()> {
-        let round_id = round_id.to_string();
-        let completed_at_str = format_timestamp(completed_at);
-        // SQLite INTEGER is signed 64-bit. Normalize before conversion so
-        // extreme provider values saturate instead of wrapping negative.
-        let usage = usage.clamped_for_durable_metrics();
-        let prompt_tokens = durable_token_to_i64(usage.prompt_tokens);
-        let completion_tokens = durable_token_to_i64(usage.completion_tokens);
-        let total_tokens = durable_token_to_i64(usage.total_tokens);
-
-        self.with_connection(move |connection| {
-            with_immediate_transaction(connection, || {
-                #[cfg(test)]
-                signal_complete_round_transaction_entered(&round_id);
-
-                let session_id: String = connection.query_row(
-                    "SELECT session_id FROM round_metrics WHERE round_id = ?1",
-                    params![round_id],
-                    |row| row.get(0),
-                )?;
-
-                connection.execute(
-                    r#"
-                    UPDATE round_metrics
-                    SET completed_at = ?1,
-                        status = ?2,
-                        prompt_tokens = ?3,
-                        completion_tokens = ?4,
-                        total_tokens = ?5,
-                        prompt_cached_tool_outputs = ?6,
-                        prompt_cached_tool_tokens_saved = ?7,
-                        -- `RoundCompleted` may be replayed. Replace its prompt-
-                        -- cache contribution while preserving tokens recorded by
-                        -- separate compression events, rather than adding the
-                        -- same completion payload again.
-                        tokens_saved = MAX(
-                            COALESCE(tokens_saved, 0) - COALESCE(prompt_cached_tool_tokens_saved, 0),
-                            0
-                        ) + ?8,
-                        error = ?9
-                    WHERE round_id = ?10
-                    "#,
-                    params![
-                        completed_at_str,
-                        status.as_str(),
-                        prompt_tokens,
-                        completion_tokens,
-                        total_tokens,
-                        i64::from(prompt_cached_tool_outputs),
-                        i64::from(prompt_cached_tool_tokens_saved),
-                        i64::from(prompt_cached_tool_tokens_saved),
-                        error,
-                        round_id,
-                    ],
-                )?;
-
-                refresh_session_aggregates(connection, &session_id, completed_at)?;
-                Ok(())
-            })
+        self.write_one(MetricsMutation::RoundCompleted {
+            round_id: round_id.to_string(),
+            completed_at,
+            status,
+            usage,
+            prompt_cached_tool_outputs,
+            prompt_cached_tool_tokens_saved,
+            error,
         })
         .await
     }
@@ -1511,33 +1461,12 @@ impl MetricsStorage for SqliteMetricsStorage {
         tool_name: &str,
         started_at: DateTime<Utc>,
     ) -> MetricsResult<()> {
-        let tool_call_id = tool_call_id.to_string();
-        let round_id = round_id.to_string();
-        let session_id = session_id.to_string();
-        let tool_name = tool_name.to_string();
-        let started_at_str = format_timestamp(started_at);
-
-        self.with_connection(move |connection| {
-            connection.execute(
-                r#"
-                INSERT INTO tool_call_metrics (
-                    tool_call_id, round_id, session_id, tool_name, started_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5)
-                ON CONFLICT(tool_call_id) DO UPDATE SET
-                    round_id = excluded.round_id,
-                    session_id = excluded.session_id,
-                    tool_name = excluded.tool_name,
-                    started_at = excluded.started_at
-                "#,
-                params![
-                    tool_call_id,
-                    round_id,
-                    session_id,
-                    tool_name,
-                    started_at_str
-                ],
-            )?;
-            Ok(())
+        self.write_one(MetricsMutation::ToolStarted {
+            tool_call_id: tool_call_id.to_string(),
+            round_id: round_id.to_string(),
+            session_id: session_id.to_string(),
+            tool_name: tool_name.to_string(),
+            started_at,
         })
         .await
     }
@@ -1547,27 +1476,9 @@ impl MetricsStorage for SqliteMetricsStorage {
         tool_call_id: &str,
         completion: ToolCallCompletion,
     ) -> MetricsResult<()> {
-        let tool_call_id = tool_call_id.to_string();
-        let completed_at = format_timestamp(completion.completed_at);
-        let success = if completion.success { 1_i64 } else { 0_i64 };
-        let error = completion.error;
-
-        self.with_connection(move |connection| {
-            with_immediate_transaction(connection, || {
-                let session_id: String = connection.query_row(
-                    "SELECT session_id FROM tool_call_metrics WHERE tool_call_id = ?1",
-                    params![tool_call_id],
-                    |row| row.get(0),
-                )?;
-
-                connection.execute(
-                    "UPDATE tool_call_metrics SET completed_at = ?1, success = ?2, error = ?3 WHERE tool_call_id = ?4",
-                    params![completed_at, success, error, tool_call_id],
-                )?;
-
-                refresh_session_aggregates(connection, &session_id, completion.completed_at)?;
-                Ok(())
-            })
+        self.write_one(MetricsMutation::ToolCompleted {
+            tool_call_id: tool_call_id.to_string(),
+            completion,
         })
         .await
     }
@@ -1580,39 +1491,12 @@ impl MetricsStorage for SqliteMetricsStorage {
         is_stream: bool,
         started_at: DateTime<Utc>,
     ) -> MetricsResult<()> {
-        let forward_id = forward_id.to_string();
-        let endpoint = endpoint.to_string();
-        let model = model.to_string();
-        let is_stream_int = if is_stream { 1_i64 } else { 0_i64 };
-        let started_at_str = format_timestamp(started_at);
-
-        self.with_connection(move |connection| {
-            connection.execute(
-                r#"
-                INSERT INTO forward_request_metrics (
-                    forward_id, endpoint, model, is_stream, started_at, status, updated_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, 'pending', ?5)
-                ON CONFLICT(forward_id) DO UPDATE SET
-                    endpoint = excluded.endpoint,
-                    model = excluded.model,
-                    is_stream = excluded.is_stream,
-                    started_at = excluded.started_at,
-                    completed_at = NULL,
-                    status_code = NULL,
-                    status = 'pending',
-                    prompt_tokens = NULL,
-                    completion_tokens = NULL,
-                    total_tokens = NULL,
-                    cache_creation_input_tokens = NULL,
-                    cache_read_input_tokens = NULL,
-                    cache_write_input_tokens = NULL,
-                    reasoning_output_tokens = NULL,
-                    error = NULL,
-                    updated_at = excluded.updated_at
-                "#,
-                params![forward_id, endpoint, model, is_stream_int, started_at_str],
-            )?;
-            Ok(())
+        self.write_one(MetricsMutation::ForwardStarted {
+            forward_id: forward_id.to_string(),
+            endpoint: endpoint.to_string(),
+            model: model.to_string(),
+            is_stream,
+            started_at,
         })
         .await
     }
@@ -1627,65 +1511,14 @@ impl MetricsStorage for SqliteMetricsStorage {
         token_details: Option<ForwardTokenDetails>,
         error: Option<String>,
     ) -> MetricsResult<()> {
-        let forward_id = forward_id.to_string();
-        let completed_at_str = format_timestamp(completed_at);
-        let status_code_int = status_code.map(|s| s as i64);
-        let (prompt, completion, total) = match usage {
-            Some(u) => (
-                Some(u.prompt_tokens as i64),
-                Some(u.completion_tokens as i64),
-                Some(u.total_tokens as i64),
-            ),
-            None => (None, None, None),
-        };
-        let token_details = token_details.unwrap_or_default();
-        let cache_creation = token_details
-            .cache_creation_input_tokens
-            .map(|value| value as i64);
-        let cache_read = token_details
-            .cache_read_input_tokens
-            .map(|value| value as i64);
-        let cache_write = token_details
-            .cache_write_input_tokens
-            .map(|value| value as i64);
-        let reasoning_output = token_details
-            .reasoning_output_tokens
-            .map(|value| value as i64);
-
-        self.with_connection(move |connection| {
-            connection.execute(
-                r#"
-                UPDATE forward_request_metrics
-                SET completed_at = ?1,
-                    status_code = ?2,
-                    status = ?3,
-                    prompt_tokens = ?4,
-                    completion_tokens = ?5,
-                    total_tokens = ?6,
-                    cache_creation_input_tokens = ?7,
-                    cache_read_input_tokens = ?8,
-                    cache_write_input_tokens = ?9,
-                    reasoning_output_tokens = ?10,
-                    error = ?11,
-                    updated_at = ?1
-                WHERE forward_id = ?12
-                "#,
-                params![
-                    completed_at_str,
-                    status_code_int,
-                    status.as_str(),
-                    prompt,
-                    completion,
-                    total,
-                    cache_creation,
-                    cache_read,
-                    cache_write,
-                    reasoning_output,
-                    error,
-                    forward_id,
-                ],
-            )?;
-            Ok(())
+        self.write_one(MetricsMutation::ForwardCompleted {
+            forward_id: forward_id.to_string(),
+            completed_at,
+            status_code,
+            status,
+            usage,
+            token_details,
+            error,
         })
         .await
     }
@@ -2431,22 +2264,9 @@ impl MetricsStorage for SqliteMetricsStorage {
         reason: &str,
         occurred_at: DateTime<Utc>,
     ) -> MetricsResult<()> {
-        let reason = reason.to_string();
-        let mismatch_date = occurred_at.date_naive().to_string();
-        let updated_at = format_timestamp(occurred_at);
-
-        self.with_connection(move |connection| {
-            connection.execute(
-                r#"
-                INSERT INTO execute_sync_mismatch_metrics (reason, mismatch_date, count, updated_at)
-                VALUES (?1, ?2, 1, ?3)
-                ON CONFLICT(reason, mismatch_date) DO UPDATE SET
-                    count = count + 1,
-                    updated_at = excluded.updated_at
-                "#,
-                params![reason, mismatch_date, updated_at],
-            )?;
-            Ok(())
+        self.write_one(MetricsMutation::ExecuteSyncMismatch {
+            reason: reason.to_string(),
+            occurred_at,
         })
         .await
     }
@@ -2644,6 +2464,8 @@ impl MetricsStorage for SqliteMetricsStorage {
 /// - Database file cannot be opened
 /// - PRAGMA settings fail to apply
 fn open_connection(path: &Path) -> MetricsResult<Connection> {
+    #[cfg(test)]
+    batch_probe::before_open(path)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -2660,6 +2482,9 @@ fn open_connection(path: &Path) -> MetricsResult<Connection> {
         PRAGMA busy_timeout = 5000;
         "#,
     )?;
+    connection.set_prepared_statement_cache_capacity(32);
+    #[cfg(test)]
+    batch_probe::opened(path);
     Ok(connection)
 }
 
@@ -3402,7 +3227,11 @@ fn with_immediate_transaction<T>(
     connection.execute_batch("BEGIN IMMEDIATE")?;
     match operation() {
         Ok(value) => match connection.execute_batch("COMMIT") {
-            Ok(()) => Ok(value),
+            Ok(()) => {
+                #[cfg(test)]
+                batch_probe::committed(connection);
+                Ok(value)
+            }
             Err(error) => {
                 let _ = connection.execute_batch("ROLLBACK");
                 Err(error.into())
@@ -3457,6 +3286,8 @@ fn refresh_session_aggregates_in_transaction(
     session_id: &str,
     updated_at: DateTime<Utc>,
 ) -> MetricsResult<()> {
+    #[cfg(test)]
+    batch_probe::aggregated(connection, session_id);
     // Do not use SQLite SUM for token counters: summing otherwise-valid i64
     // round rows can overflow before an outer MIN/CASE can clamp it. Fold in
     // Rust with the same signed-64 saturation policy used by the runtime.
@@ -3464,7 +3295,8 @@ fn refresh_session_aggregates_in_transaction(
     #[cfg(test)]
     pause_after_session_token_fold(session_id);
     let updated_at = format_timestamp(updated_at);
-    connection.execute(
+    writes::execute_cached(
+        connection,
         r#"
         UPDATE session_metrics
         SET
@@ -3508,7 +3340,7 @@ fn load_session_token_aggregate(
     connection: &Connection,
     session_id: &str,
 ) -> MetricsResult<TokenUsage> {
-    let mut stmt = connection.prepare(
+    let mut stmt = connection.prepare_cached(
         "SELECT prompt_tokens, completion_tokens, total_tokens FROM round_metrics WHERE session_id = ?1",
     )?;
     let mut rows = stmt.query(params![session_id])?;

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage/batch.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage/batch.rs
@@ -1,0 +1,73 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use super::*;
+
+impl SqliteMetricsStorage {
+    pub(super) async fn apply_mutations(
+        &self,
+        mutations: Vec<MetricsMutation>,
+    ) -> MetricsResult<Vec<MetricsResult<()>>> {
+        let mut results = Vec::with_capacity(mutations.len());
+        let mut mutations = mutations.into_iter();
+        loop {
+            let segment = mutations
+                .by_ref()
+                .take(MAX_METRICS_BATCH_SIZE)
+                .collect::<Vec<_>>();
+            if segment.is_empty() {
+                return Ok(results);
+            }
+            let path = self.db_path.clone();
+            let completed = tokio::task::spawn_blocking(move || {
+                #[cfg(test)]
+                batch_probe::task_started(&path);
+                apply_segment(&path, segment)
+            })
+            .await
+            .map_err(|error| MetricsError::Task(error.to_string()))?;
+            results.extend(completed);
+        }
+    }
+}
+
+fn apply_segment(path: &Path, mutations: Vec<MetricsMutation>) -> Vec<MetricsResult<()>> {
+    let mut results = Vec::with_capacity(mutations.len());
+    let mut connection = None;
+    for mutation in mutations {
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            if connection.is_none() {
+                connection = Some(open_connection(path)?);
+            }
+            let connection = connection.as_ref().expect("connection just opened");
+            writes::apply_mutation_on_connection(connection, mutation)?;
+            if !connection.is_autocommit() {
+                return Err(MetricsError::Task(
+                    "metrics command left a transaction open".into(),
+                ));
+            }
+            Ok(())
+        }));
+        let result = match outcome {
+            Ok(result) => result,
+            Err(payload) => {
+                let detail = payload
+                    .downcast_ref::<String>()
+                    .map(String::as_str)
+                    .or_else(|| payload.downcast_ref::<&str>().copied())
+                    .unwrap_or("non-string panic");
+                Err(MetricsError::Task(format!(
+                    "metrics command panicked: {}",
+                    detail.chars().take(512).collect::<String>()
+                )))
+            }
+        };
+        if result.is_err() {
+            // A dropped connection rolls back anything left by a panic or
+            // failed rollback. Reopen for the next item, without replaying any
+            // command or letting it join the failed item's transaction.
+            drop(connection.take());
+        }
+        results.push(result);
+    }
+    results
+}

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage/batch_probe.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage/batch_probe.rs
@@ -1,0 +1,160 @@
+//! Per-database test instrumentation; no production state or callbacks.
+use std::sync::{mpsc, Arc, Mutex, OnceLock, Weak};
+
+use super::*;
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct Stats {
+    pub tasks: usize,
+    pub attempts: usize,
+    pub opens: usize,
+    pub commits: usize,
+    pub cache_reuses: usize,
+    pub events: Vec<String>,
+}
+
+#[derive(Default)]
+struct State {
+    stats: Stats,
+    successes: usize,
+    fail_opens: usize,
+    panic_round: Option<String>,
+    pause: Option<(usize, mpsc::Sender<()>, mpsc::Receiver<()>)>,
+}
+
+#[derive(Default)]
+pub(super) struct Probe(Mutex<State>);
+
+fn registry() -> &'static Mutex<HashMap<PathBuf, Weak<Probe>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<PathBuf, Weak<Probe>>>> = OnceLock::new();
+    REGISTRY.get_or_init(Default::default)
+}
+
+fn lookup(path: &Path) -> Option<Arc<Probe>> {
+    let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    registry()
+        .lock()
+        .unwrap()
+        .get(&path)
+        .and_then(Weak::upgrade)
+}
+
+fn for_connection(connection: &Connection) -> Option<Arc<Probe>> {
+    connection.path().and_then(|path| lookup(Path::new(path)))
+}
+
+impl Probe {
+    pub(super) fn install(path: &Path) -> Arc<Self> {
+        let probe = Arc::new(Self::default());
+        registry().lock().unwrap().insert(
+            std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()),
+            Arc::downgrade(&probe),
+        );
+        probe
+    }
+
+    pub(super) fn stats(&self) -> Stats {
+        self.0.lock().unwrap().stats.clone()
+    }
+    pub(super) fn reset(&self) {
+        *self.0.lock().unwrap() = State::default();
+    }
+    pub(super) fn fail_next_open(&self) {
+        self.0.lock().unwrap().fail_opens = 1;
+    }
+    pub(super) fn panic_after_round_update(&self, round: &str) {
+        self.0.lock().unwrap().panic_round = Some(round.into());
+    }
+    pub(super) fn pause_after(&self, successes: usize) -> (mpsc::Receiver<()>, mpsc::Sender<()>) {
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        self.0.lock().unwrap().pause = Some((successes, entered_tx, release_rx));
+        (entered_rx, release_tx)
+    }
+}
+
+pub(super) fn task_started(path: &Path) {
+    if let Some(probe) = lookup(path) {
+        probe.0.lock().unwrap().stats.tasks += 1;
+    }
+}
+
+pub(super) fn before_open(path: &Path) -> MetricsResult<()> {
+    if let Some(probe) = lookup(path) {
+        let mut state = probe.0.lock().unwrap();
+        state.stats.attempts += 1;
+        if state.fail_opens != 0 {
+            state.fail_opens -= 1;
+            return Err(std::io::Error::other("injected metrics open failure").into());
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn opened(path: &Path) {
+    if let Some(probe) = lookup(path) {
+        probe.0.lock().unwrap().stats.opens += 1;
+    }
+}
+
+pub(super) fn committed(connection: &Connection) {
+    if let Some(probe) = for_connection(connection) {
+        let mut state = probe.0.lock().unwrap();
+        state.stats.commits += 1;
+        state.stats.events.push("commit".into());
+    }
+}
+
+pub(super) fn aggregated(connection: &Connection, session_id: &str) {
+    if let Some(probe) = for_connection(connection) {
+        probe
+            .0
+            .lock()
+            .unwrap()
+            .stats
+            .events
+            .push(format!("aggregate:{session_id}"));
+    }
+}
+
+pub(super) fn cached_statement(connection: &Connection, previous_runs: i32) {
+    if previous_runs > 0 {
+        if let Some(probe) = for_connection(connection) {
+            probe.0.lock().unwrap().stats.cache_reuses += 1;
+        }
+    }
+}
+
+pub(super) fn after_round_update(connection: &Connection, round_id: &str) {
+    let panic_now = for_connection(connection).is_some_and(|probe| {
+        let mut state = probe.0.lock().unwrap();
+        if state.panic_round.as_deref() == Some(round_id) {
+            state.panic_round.take();
+            true
+        } else {
+            false
+        }
+    });
+    assert!(!panic_now, "injected panic after metrics child update");
+}
+
+pub(super) fn after_item(connection: &Connection) {
+    let pause = for_connection(connection).and_then(|probe| {
+        let mut state = probe.0.lock().unwrap();
+        state.successes += 1;
+        state.stats.events.push("success".into());
+        if state
+            .pause
+            .as_ref()
+            .is_some_and(|(after, _, _)| *after == state.successes)
+        {
+            state.pause.take()
+        } else {
+            None
+        }
+    });
+    if let Some((_, entered, release)) = pause {
+        entered.send(()).unwrap();
+        release.recv().unwrap();
+    }
+}

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage/batch_tests.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage/batch_tests.rs
@@ -1,0 +1,626 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::TimeZone;
+use rusqlite::types::Value;
+use tempfile::TempDir;
+
+use super::batch_probe::Probe;
+use super::*;
+
+fn at(seconds: i64) -> DateTime<Utc> {
+    Utc.timestamp_opt(1_700_000_000 + seconds, 0).unwrap()
+}
+fn start(id: &str) -> MetricsMutation {
+    MetricsMutation::SessionStarted {
+        session_id: id.into(),
+        model: format!("model-{id}"),
+        started_at: at(0),
+    }
+}
+fn round(id: &str, session: &str, second: i64) -> MetricsMutation {
+    MetricsMutation::RoundStarted {
+        round_id: id.into(),
+        session_id: session.into(),
+        model: "round-model".into(),
+        started_at: at(second),
+    }
+}
+fn done(id: &str, tokens: u64, saved: u32) -> MetricsMutation {
+    MetricsMutation::RoundCompleted {
+        round_id: id.into(),
+        completed_at: at(10),
+        status: RoundStatus::Success,
+        usage: TokenUsage {
+            prompt_tokens: tokens,
+            completion_tokens: 0,
+            total_tokens: tokens,
+        },
+        prompt_cached_tool_outputs: 2,
+        prompt_cached_tool_tokens_saved: saved,
+        error: None,
+    }
+}
+fn mismatch(reason: &str, second: i64) -> MetricsMutation {
+    MetricsMutation::ExecuteSyncMismatch {
+        reason: reason.into(),
+        occurred_at: at(second),
+    }
+}
+fn tool(round: &str, session: &str) -> MetricsMutation {
+    MetricsMutation::ToolStarted {
+        tool_call_id: "tool".into(),
+        round_id: round.into(),
+        session_id: session.into(),
+        tool_name: format!("tool-{session}"),
+        started_at: at(11),
+    }
+}
+
+async fn store() -> (TempDir, SqliteMetricsStorage, Arc<Probe>) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("metrics.db");
+    let storage = SqliteMetricsStorage::new(&path);
+    storage.init().await.unwrap();
+    let probe = Probe::install(&path);
+    (dir, storage, probe)
+}
+fn rows(conn: &Connection, sql: &str) -> Vec<Vec<Value>> {
+    let mut statement = conn.prepare(sql).unwrap();
+    let count = statement.column_count();
+    statement
+        .query_map([], |row| (0..count).map(|column| row.get(column)).collect())
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap()
+}
+fn snapshot(storage: &SqliteMetricsStorage) -> Vec<(String, Vec<Vec<Value>>)> {
+    let conn = Connection::open(&storage.db_path).unwrap();
+    let tables = conn.prepare("SELECT name FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+        .unwrap().query_map([], |row| row.get::<_, String>(0)).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+    tables
+        .into_iter()
+        .map(|table| {
+            let data = rows(&conn, &format!("SELECT * FROM {table} ORDER BY rowid"));
+            (table, data)
+        })
+        .collect()
+}
+async fn compare(
+    serial: &SqliteMetricsStorage,
+    batch: &SqliteMetricsStorage,
+    items: Vec<MetricsMutation>,
+) {
+    let mut reference = Vec::new();
+    for item in items.iter().cloned() {
+        reference.push(item.apply(serial).await);
+    }
+    let actual = batch.apply_batch(items).await.unwrap();
+    assert_eq!(
+        actual
+            .iter()
+            .map(|r| r.as_ref().err().map(std::mem::discriminant))
+            .collect::<Vec<_>>(),
+        reference
+            .iter()
+            .map(|r| r.as_ref().err().map(std::mem::discriminant))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(snapshot(serial), snapshot(batch));
+}
+
+#[tokio::test]
+async fn serial_oracle_preserves_replay_ownership_aggregate_positions_and_raw_sqlite_conversions() {
+    let (_sd, serial, sp) = store().await;
+    let (_bd, batch, bp) = store().await;
+    let forward_start = MetricsMutation::ForwardStarted {
+        forward_id: "forward".into(),
+        endpoint: "endpoint".into(),
+        model: "fmodel".into(),
+        is_stream: true,
+        started_at: at(1),
+    };
+    let forward_done = |usage, token_details| MetricsMutation::ForwardCompleted {
+        forward_id: "forward".into(),
+        completed_at: at(20),
+        status_code: Some(200),
+        status: ForwardStatus::Success,
+        usage,
+        token_details,
+        error: None,
+    };
+    compare(
+        &serial,
+        &batch,
+        vec![
+            start("a"),
+            start("b"),
+            round("ra", "a", 1),
+            round("rb", "b", 1),
+            done("ra", u64::MAX, 3),
+            tool("ra", "a"),
+            forward_start.clone(),
+            forward_done(
+                Some(TokenUsage {
+                    prompt_tokens: u64::MAX,
+                    completion_tokens: u64::MAX,
+                    total_tokens: u64::MAX,
+                }),
+                Some(ForwardTokenDetails {
+                    cache_creation_input_tokens: Some(u64::MAX),
+                    cache_read_input_tokens: Some(u64::MAX),
+                    cache_write_input_tokens: Some(u64::MAX),
+                    reasoning_output_tokens: Some(u64::MAX),
+                }),
+            ),
+            mismatch("additive", 4),
+            mismatch("additive", 3),
+        ],
+    )
+    .await;
+    let conn = Connection::open(&batch.db_path).unwrap();
+    // RoundCompleted clamps, while forward fields intentionally retain their
+    // pre-existing signed casts. ToolStarted does not refresh session counters.
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT total_tokens, tool_call_count FROM session_metrics WHERE session_id='a'"
+        ),
+        vec![vec![Value::Integer(i64::MAX), Value::Integer(0)]]
+    );
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT total_tokens, cache_read_input_tokens FROM forward_request_metrics"
+        ),
+        vec![vec![Value::Integer(-1), Value::Integer(-1)]]
+    );
+    assert_eq!(sp.stats().events, bp.stats().events);
+    assert_eq!(sp.stats().commits, bp.stats().commits);
+    for storage in [&serial, &batch] {
+        storage
+            .record_round_compression("ra", at(12), 5)
+            .await
+            .unwrap();
+        storage
+            .complete_tool_call(
+                "tool",
+                ToolCallCompletion {
+                    completed_at: at(13),
+                    success: true,
+                    error: Some("preserved".into()),
+                },
+            )
+            .await
+            .unwrap();
+    }
+    compare(
+        &serial,
+        &batch,
+        vec![
+            done("ra", 100, 7),
+            done("ra", 100, 7),
+            tool("rb", "b"),
+            round("ra", "b", 30),
+            MetricsMutation::SessionMessageCount {
+                session_id: "a".into(),
+                message_count: 9,
+                updated_at: at(-5),
+            },
+            forward_done(None, None),
+            forward_done(
+                Some(TokenUsage {
+                    prompt_tokens: 2,
+                    completion_tokens: 3,
+                    total_tokens: 5,
+                }),
+                Some(ForwardTokenDetails {
+                    cache_read_input_tokens: Some(7),
+                    ..Default::default()
+                }),
+            ),
+            forward_done(None, None),
+        ],
+    )
+    .await;
+    assert_eq!(rows(&conn, "SELECT session_id, tokens_saved, compression_count FROM round_metrics WHERE round_id='ra'"),
+        vec![vec![Value::Text("a".into()), Value::Integer(12), Value::Integer(1)]]);
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT session_id, success, error, completed_at FROM tool_call_metrics"
+        ),
+        vec![vec![
+            Value::Text("b".into()),
+            Value::Integer(1),
+            Value::Text("preserved".into()),
+            Value::Text(format_timestamp(at(13)))
+        ]]
+    );
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT updated_at FROM session_metrics WHERE session_id='b'"
+        ),
+        vec![vec![Value::Text(format_timestamp(at(30)))]]
+    );
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT updated_at FROM session_metrics WHERE session_id='a'"
+        ),
+        vec![vec![Value::Text(format_timestamp(at(-5)))]]
+    );
+    assert_eq!(rows(&conn, "SELECT total_tokens, cache_read_input_tokens, reasoning_output_tokens FROM forward_request_metrics"), vec![vec![Value::Null; 3]]);
+    compare(
+        &serial,
+        &batch,
+        vec![
+            forward_start,
+            MetricsMutation::SessionCompleted {
+                session_id: "a".into(),
+                status: SessionStatus::Completed,
+                completed_at: at(40),
+            },
+            start("a"),
+        ],
+    )
+    .await;
+    assert_eq!(rows(&conn, "SELECT status, completed_at, status_code, total_tokens, error FROM forward_request_metrics"),
+        vec![vec![Value::Text("pending".into()), Value::Null, Value::Null, Value::Null, Value::Null]]);
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT status, completed_at, started_at FROM session_metrics WHERE session_id='a'"
+        ),
+        vec![vec![
+            Value::Text("running".into()),
+            Value::Null,
+            Value::Text(format_timestamp(at(0)))
+        ]]
+    );
+    assert_eq!(sp.stats().events, bp.stats().events);
+}
+
+#[tokio::test]
+async fn missing_rows_preserve_existing_noop_and_lookup_error_behavior() {
+    let (_sd, serial, _) = store().await;
+    let (_bd, batch, _) = store().await;
+    let items = vec![
+        MetricsMutation::ForwardCompleted {
+            forward_id: "missing".into(),
+            completed_at: at(1),
+            status_code: None,
+            status: ForwardStatus::Success,
+            usage: None,
+            token_details: None,
+            error: None,
+        },
+        MetricsMutation::SessionMessageCount {
+            session_id: "missing".into(),
+            message_count: 4,
+            updated_at: at(1),
+        },
+        done("missing", 3, 0),
+        MetricsMutation::ToolCompleted {
+            tool_call_id: "missing".into(),
+            completion: ToolCallCompletion {
+                completed_at: at(1),
+                success: true,
+                error: None,
+            },
+        },
+    ];
+    compare(&serial, &batch, items.clone()).await;
+    let results = batch.apply_batch(items).await.unwrap();
+    assert!(results[..2].iter().all(Result::is_ok));
+    for result in &results[2..] {
+        assert!(matches!(
+            result,
+            Err(MetricsError::Sqlite(rusqlite::Error::QueryReturnedNoRows))
+        ));
+    }
+    assert_eq!(snapshot(&serial), snapshot(&batch));
+}
+
+#[tokio::test]
+async fn negative_sibling_error_rolls_back_then_later_items_repair_and_complete() {
+    let (_sd, serial, _) = store().await;
+    let (_bd, batch, probe) = store().await;
+    compare(
+        &serial,
+        &batch,
+        vec![start("s"), round("bad", "s", 1), round("target", "s", 2)],
+    )
+    .await;
+    for storage in [&serial, &batch] {
+        Connection::open(&storage.db_path)
+            .unwrap()
+            .execute(
+                "UPDATE round_metrics SET prompt_tokens=-1 WHERE round_id='bad'",
+                [],
+            )
+            .unwrap();
+    }
+    let items = vec![
+        done("target", 100, 0),
+        done("bad", 10, 0),
+        done("target", 100, 0),
+    ];
+    let mut reference = Vec::new();
+    for item in items.iter().cloned() {
+        reference.push(item.apply(&serial).await);
+    }
+    probe.reset();
+    let (entered, release) = probe.pause_after(1);
+    let path = batch.db_path.clone();
+    let running = tokio::spawn(async move { batch.apply_batch(items).await });
+    tokio::task::spawn_blocking(move || entered.recv_timeout(Duration::from_secs(5)).unwrap())
+        .await
+        .unwrap();
+    let conn = Connection::open(&path).unwrap();
+    let observed = rows(
+        &conn,
+        "SELECT completed_at, total_tokens FROM round_metrics WHERE round_id='target'",
+    );
+    let aggregate = rows(
+        &conn,
+        "SELECT total_tokens FROM session_metrics WHERE session_id='s'",
+    );
+    release.send(()).unwrap();
+    let actual = running.await.unwrap().unwrap();
+    assert_eq!(observed, vec![vec![Value::Null, Value::Integer(0)]]);
+    assert_eq!(aggregate, vec![vec![Value::Integer(10)]]);
+    assert!(matches!(actual[0], Err(MetricsError::InvalidData(_))));
+    assert!(actual[1..].iter().all(Result::is_ok));
+    assert_eq!(
+        reference.iter().map(Result::is_ok).collect::<Vec<_>>(),
+        actual.iter().map(Result::is_ok).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        snapshot(&serial),
+        snapshot(&SqliteMetricsStorage::new(path))
+    );
+    assert_eq!(probe.stats().opens, 2);
+    assert_eq!(probe.stats().commits, 2);
+}
+
+#[tokio::test]
+async fn item_open_sql_and_panic_failures_preserve_suffix_without_retry() {
+    let (_dir, storage, probe) = store().await;
+    probe.fail_next_open();
+    let result = storage
+        .apply_batch(vec![mismatch("open-failed", 1), mismatch("counter", 2)])
+        .await
+        .unwrap();
+    assert!(matches!(result[0], Err(MetricsError::Io(_))));
+    assert!(result[1].is_ok());
+    assert_eq!(
+        (
+            probe.stats().tasks,
+            probe.stats().attempts,
+            probe.stats().opens
+        ),
+        (1, 2, 1)
+    );
+    probe.reset();
+    // Foreign-key failure is a single-statement/autocommit error. It must also
+    // discard its connection, rather than only discarding active transactions.
+    let result = storage
+        .apply_batch(vec![tool("missing", "missing"), mismatch("counter", 3)])
+        .await
+        .unwrap();
+    assert!(matches!(result[0], Err(MetricsError::Sqlite(_))));
+    assert!(result[1].is_ok());
+    assert_eq!(probe.stats().opens, 2);
+    storage
+        .apply_batch(vec![
+            start("s"),
+            round("panic", "s", 1),
+            round("good", "s", 2),
+        ])
+        .await
+        .unwrap()
+        .into_iter()
+        .for_each(|r| r.unwrap());
+    probe.reset();
+    probe.panic_after_round_update("panic");
+    let result = storage
+        .apply_batch(vec![
+            mismatch("counter", 4),
+            done("panic", 99, 1),
+            mismatch("counter", 5),
+            done("good", 10, 2),
+        ])
+        .await
+        .unwrap();
+    assert!(result[0].is_ok());
+    assert!(matches!(result[1], Err(MetricsError::Task(_))));
+    assert!(result[2..].iter().all(Result::is_ok));
+    let conn = Connection::open(&storage.db_path).unwrap();
+    assert_eq!(rows(&conn, "SELECT completed_at, total_tokens, tokens_saved FROM round_metrics WHERE round_id='panic'"), vec![vec![Value::Null, Value::Integer(0), Value::Integer(0)]]);
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT reason, count FROM execute_sync_mismatch_metrics"
+        ),
+        vec![vec![Value::Text("counter".into()), Value::Integer(4)]]
+    );
+    assert_eq!(
+        (
+            probe.stats().tasks,
+            probe.stats().opens,
+            probe.stats().commits
+        ),
+        (1, 2, 1)
+    );
+}
+
+#[tokio::test]
+async fn successful_segments_reuse_connections_and_cached_statements_with_changed_bindings() {
+    let (_dir, storage, probe) = store().await;
+    assert!(storage.apply_batch(Vec::new()).await.unwrap().is_empty());
+    assert_eq!((probe.stats().tasks, probe.stats().opens), (0, 0));
+    for length in [31_usize, 32, 33, 96] {
+        probe.reset();
+        let items = (0..length)
+            .map(|i| mismatch(&format!("key-{length}-{i}"), i as i64))
+            .collect();
+        assert!(storage
+            .apply_batch(items)
+            .await
+            .unwrap()
+            .iter()
+            .all(Result::is_ok));
+        let segments = length.div_ceil(32);
+        let stats = probe.stats();
+        assert_eq!(
+            (stats.tasks, stats.opens, stats.attempts),
+            (segments, segments, segments)
+        );
+        assert_eq!(
+            stats.commits, 0,
+            "single statements retain SQLite autocommit"
+        );
+        assert_eq!(stats.cache_reuses, length - segments);
+    }
+    let conn = Connection::open(&storage.db_path).unwrap();
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT COUNT(*), SUM(count) FROM execute_sync_mismatch_metrics"
+        ),
+        vec![vec![Value::Integer(192), Value::Integer(192)]]
+    );
+    for length in [31_usize, 32, 33, 96] {
+        for i in 0..length {
+            assert_eq!(
+                conn.query_row(
+                    "SELECT updated_at FROM execute_sync_mismatch_metrics WHERE reason=?1",
+                    [format!("key-{length}-{i}")],
+                    |row| row.get::<_, String>(0)
+                )
+                .unwrap(),
+                format_timestamp(at(i as i64))
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn second_writer_commits_between_items_and_next_aggregate_observes_it() {
+    let (_dir, storage, probe) = store().await;
+    storage
+        .apply_batch(vec![start("s"), round("r", "s", 1)])
+        .await
+        .unwrap()
+        .into_iter()
+        .for_each(|r| r.unwrap());
+    probe.reset();
+    let (entered, release) = probe.pause_after(1);
+    let path = storage.db_path.clone();
+    let running = tokio::spawn(async move {
+        storage
+            .apply_batch(vec![
+                done("r", 10, 0),
+                MetricsMutation::SessionCompleted {
+                    session_id: "s".into(),
+                    status: SessionStatus::Completed,
+                    completed_at: at(40),
+                },
+            ])
+            .await
+    });
+    tokio::task::spawn_blocking(move || entered.recv_timeout(Duration::from_secs(5)).unwrap())
+        .await
+        .unwrap();
+    let conn = Connection::open(&path).unwrap();
+    conn.busy_timeout(Duration::from_secs(1)).unwrap();
+    let external = conn.execute_batch("BEGIN IMMEDIATE; UPDATE round_metrics SET prompt_tokens=42, total_tokens=42 WHERE round_id='r'; COMMIT;");
+    release.send(()).unwrap();
+    assert!(running.await.unwrap().unwrap().iter().all(Result::is_ok));
+    external.unwrap();
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT total_tokens FROM session_metrics WHERE session_id='s'"
+        ),
+        vec![vec![Value::Integer(42)]]
+    );
+    assert_eq!(
+        (
+            probe.stats().tasks,
+            probe.stats().opens,
+            probe.stats().commits
+        ),
+        (1, 1, 2)
+    );
+}
+
+#[tokio::test]
+async fn burst_of_256_independent_sessions_preserves_records_and_bounds_resource_use() {
+    let (_dir, storage, probe) = store().await;
+    let mut items = Vec::new();
+    for index in 0..256 {
+        let id = format!("s{index}");
+        let rid = format!("r{index}");
+        let tid = format!("t{index}");
+        items.extend([
+            start(&id),
+            round(&rid, &id, 1),
+            done(&rid, index + 1, 3),
+            MetricsMutation::ToolStarted {
+                tool_call_id: tid.clone(),
+                round_id: rid,
+                session_id: id.clone(),
+                tool_name: format!("tool{index}"),
+                started_at: at(11),
+            },
+            MetricsMutation::ToolCompleted {
+                tool_call_id: tid,
+                completion: ToolCallCompletion {
+                    completed_at: at(12),
+                    success: true,
+                    error: None,
+                },
+            },
+            MetricsMutation::SessionCompleted {
+                session_id: id,
+                status: SessionStatus::Completed,
+                completed_at: at(13),
+            },
+        ]);
+    }
+    let count = items.len();
+    let now = Instant::now();
+    assert!(storage
+        .apply_batch(items)
+        .await
+        .unwrap()
+        .iter()
+        .all(Result::is_ok));
+    let elapsed = now.elapsed();
+    let stats = probe.stats();
+    assert_eq!(
+        (stats.tasks, stats.opens),
+        (count.div_ceil(32), count.div_ceil(32))
+    );
+    assert_eq!(stats.commits, 256 * 4);
+    let conn = Connection::open(&storage.db_path).unwrap();
+    assert_eq!(rows(&conn, "SELECT COUNT(*), SUM(total_rounds), SUM(tool_call_count) FROM session_metrics WHERE status='completed'"), vec![vec![Value::Integer(256); 3]]);
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT COUNT(*), SUM(total_tokens) FROM round_metrics WHERE status='success'"
+        ),
+        vec![vec![Value::Integer(256), Value::Integer(256 * 257 / 2)]]
+    );
+    assert_eq!(
+        rows(
+            &conn,
+            "SELECT COUNT(*) FROM tool_call_metrics WHERE success=1"
+        ),
+        vec![vec![Value::Integer(256)]]
+    );
+    println!("metrics burst: commands={count}, tasks={}, opens={}, explicit_commits={}, elapsed={elapsed:?}", stats.tasks, stats.opens, stats.commits);
+}

--- a/crates/infra/bamboo-infrastructure/src/metrics/storage/writes.rs
+++ b/crates/infra/bamboo-infrastructure/src/metrics/storage/writes.rs
@@ -1,0 +1,378 @@
+use super::*;
+
+pub(super) fn execute_cached<P: rusqlite::Params>(
+    connection: &Connection,
+    sql: &str,
+    params: P,
+) -> rusqlite::Result<usize> {
+    let mut statement = connection.prepare_cached(sql)?;
+    #[cfg(test)]
+    batch_probe::cached_statement(
+        connection,
+        statement.get_status(rusqlite::StatementStatus::Run),
+    );
+    statement.execute(params)
+}
+
+fn query_row_cached<
+    T,
+    P: rusqlite::Params,
+    F: FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+>(
+    connection: &Connection,
+    sql: &str,
+    params: P,
+    map: F,
+) -> rusqlite::Result<T> {
+    let mut statement = connection.prepare_cached(sql)?;
+    #[cfg(test)]
+    batch_probe::cached_statement(
+        connection,
+        statement.get_status(rusqlite::StatementStatus::Run),
+    );
+    statement.query_row(params, map)
+}
+
+pub(super) fn apply_mutation_on_connection(
+    connection: &Connection,
+    mutation: MetricsMutation,
+) -> MetricsResult<()> {
+    let result = match mutation {
+        MetricsMutation::SessionStarted {
+            session_id,
+            model,
+            started_at,
+        } => {
+            let started_at = format_timestamp(started_at);
+
+            execute_cached(
+                connection,
+                r#"
+                INSERT INTO session_metrics (
+                    session_id, model, started_at, status, updated_at
+                ) VALUES (?1, ?2, ?3, 'running', ?3)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    model = excluded.model,
+                    started_at = CASE
+                        WHEN session_metrics.started_at <= excluded.started_at THEN session_metrics.started_at
+                        ELSE excluded.started_at
+                    END,
+                    completed_at = NULL,
+                    status = 'running',
+                    updated_at = excluded.updated_at
+                "#,
+                params![session_id, model, started_at],
+            )?;
+            Ok(())
+        }
+        MetricsMutation::SessionMessageCount {
+            session_id,
+            message_count,
+            updated_at,
+        } => {
+            let updated_at = format_timestamp(updated_at);
+
+            execute_cached(connection,
+                "UPDATE session_metrics SET message_count = ?1, updated_at = ?2 WHERE session_id = ?3",
+                params![i64::from(message_count), updated_at, session_id],
+            )?;
+            Ok(())
+        }
+        MetricsMutation::SessionCompleted {
+            session_id,
+            status,
+            completed_at,
+        } => {
+            let completed_at_str = format_timestamp(completed_at);
+
+            with_immediate_transaction(connection, || {
+                refresh_session_aggregates(connection, &session_id, completed_at)?;
+                execute_cached(connection,
+                    "UPDATE session_metrics SET status = ?1, completed_at = ?2, updated_at = ?2 WHERE session_id = ?3",
+                    params![status.as_str(), completed_at_str, session_id],
+                )?;
+                Ok(())
+            })
+        }
+        MetricsMutation::RoundStarted {
+            round_id,
+            session_id,
+            model,
+            started_at,
+        } => {
+            let started_at_str = format_timestamp(started_at);
+
+            with_immediate_transaction(connection, || {
+                execute_cached(
+                    connection,
+                    r#"
+                    INSERT INTO round_metrics (
+                        round_id, session_id, model, started_at, status
+                    ) VALUES (?1, ?2, ?3, ?4, 'running')
+                    ON CONFLICT(round_id) DO NOTHING
+                    "#,
+                    params![round_id, session_id, model, started_at_str],
+                )?;
+                refresh_session_aggregates(connection, &session_id, started_at)?;
+                Ok(())
+            })
+        }
+        MetricsMutation::RoundCompleted {
+            round_id,
+            completed_at,
+            status,
+            usage,
+            prompt_cached_tool_outputs,
+            prompt_cached_tool_tokens_saved,
+            error,
+        } => {
+            let completed_at_str = format_timestamp(completed_at);
+            // SQLite INTEGER is signed 64-bit. Normalize before conversion so
+            // extreme provider values saturate instead of wrapping negative.
+            let usage = usage.clamped_for_durable_metrics();
+            let prompt_tokens = durable_token_to_i64(usage.prompt_tokens);
+            let completion_tokens = durable_token_to_i64(usage.completion_tokens);
+            let total_tokens = durable_token_to_i64(usage.total_tokens);
+
+            with_immediate_transaction(connection, || {
+                #[cfg(test)]
+                signal_complete_round_transaction_entered(&round_id);
+
+                let session_id: String = query_row_cached(
+                    connection,
+                    "SELECT session_id FROM round_metrics WHERE round_id = ?1",
+                    params![round_id],
+                    |row| row.get(0),
+                )?;
+
+                execute_cached(
+                    connection,
+                    r#"
+                    UPDATE round_metrics
+                    SET completed_at = ?1,
+                        status = ?2,
+                        prompt_tokens = ?3,
+                        completion_tokens = ?4,
+                        total_tokens = ?5,
+                        prompt_cached_tool_outputs = ?6,
+                        prompt_cached_tool_tokens_saved = ?7,
+                        -- `RoundCompleted` may be replayed. Replace its prompt-
+                        -- cache contribution while preserving tokens recorded by
+                        -- separate compression events, rather than adding the
+                        -- same completion payload again.
+                        tokens_saved = MAX(
+                            COALESCE(tokens_saved, 0) - COALESCE(prompt_cached_tool_tokens_saved, 0),
+                            0
+                        ) + ?8,
+                        error = ?9
+                    WHERE round_id = ?10
+                    "#,
+                    params![
+                        completed_at_str,
+                        status.as_str(),
+                        prompt_tokens,
+                        completion_tokens,
+                        total_tokens,
+                        i64::from(prompt_cached_tool_outputs),
+                        i64::from(prompt_cached_tool_tokens_saved),
+                        i64::from(prompt_cached_tool_tokens_saved),
+                        error,
+                        round_id,
+                    ],
+                )?;
+
+                #[cfg(test)]
+                batch_probe::after_round_update(connection, &round_id);
+                refresh_session_aggregates(connection, &session_id, completed_at)?;
+                Ok(())
+            })
+        }
+        MetricsMutation::ToolStarted {
+            tool_call_id,
+            round_id,
+            session_id,
+            tool_name,
+            started_at,
+        } => {
+            let started_at_str = format_timestamp(started_at);
+
+            execute_cached(
+                connection,
+                r#"
+                INSERT INTO tool_call_metrics (
+                    tool_call_id, round_id, session_id, tool_name, started_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5)
+                ON CONFLICT(tool_call_id) DO UPDATE SET
+                    round_id = excluded.round_id,
+                    session_id = excluded.session_id,
+                    tool_name = excluded.tool_name,
+                    started_at = excluded.started_at
+                "#,
+                params![
+                    tool_call_id,
+                    round_id,
+                    session_id,
+                    tool_name,
+                    started_at_str
+                ],
+            )?;
+            Ok(())
+        }
+        MetricsMutation::ToolCompleted {
+            tool_call_id,
+            completion,
+        } => {
+            let completed_at = format_timestamp(completion.completed_at);
+            let success = if completion.success { 1_i64 } else { 0_i64 };
+            let error = completion.error;
+
+            with_immediate_transaction(connection, || {
+                let session_id: String = query_row_cached(
+                    connection,
+                    "SELECT session_id FROM tool_call_metrics WHERE tool_call_id = ?1",
+                    params![tool_call_id],
+                    |row| row.get(0),
+                )?;
+
+                execute_cached(connection,
+                    "UPDATE tool_call_metrics SET completed_at = ?1, success = ?2, error = ?3 WHERE tool_call_id = ?4",
+                    params![completed_at, success, error, tool_call_id],
+                )?;
+
+                refresh_session_aggregates(connection, &session_id, completion.completed_at)?;
+                Ok(())
+            })
+        }
+        MetricsMutation::ExecuteSyncMismatch {
+            reason,
+            occurred_at,
+        } => {
+            let mismatch_date = occurred_at.date_naive().to_string();
+            let updated_at = format_timestamp(occurred_at);
+
+            execute_cached(
+                connection,
+                r#"
+                INSERT INTO execute_sync_mismatch_metrics (reason, mismatch_date, count, updated_at)
+                VALUES (?1, ?2, 1, ?3)
+                ON CONFLICT(reason, mismatch_date) DO UPDATE SET
+                    count = count + 1,
+                    updated_at = excluded.updated_at
+                "#,
+                params![reason, mismatch_date, updated_at],
+            )?;
+            Ok(())
+        }
+        MetricsMutation::ForwardStarted {
+            forward_id,
+            endpoint,
+            model,
+            is_stream,
+            started_at,
+        } => {
+            let is_stream_int = if is_stream { 1_i64 } else { 0_i64 };
+            let started_at_str = format_timestamp(started_at);
+
+            execute_cached(
+                connection,
+                r#"
+                INSERT INTO forward_request_metrics (
+                    forward_id, endpoint, model, is_stream, started_at, status, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, 'pending', ?5)
+                ON CONFLICT(forward_id) DO UPDATE SET
+                    endpoint = excluded.endpoint,
+                    model = excluded.model,
+                    is_stream = excluded.is_stream,
+                    started_at = excluded.started_at,
+                    completed_at = NULL,
+                    status_code = NULL,
+                    status = 'pending',
+                    prompt_tokens = NULL,
+                    completion_tokens = NULL,
+                    total_tokens = NULL,
+                    cache_creation_input_tokens = NULL,
+                    cache_read_input_tokens = NULL,
+                    cache_write_input_tokens = NULL,
+                    reasoning_output_tokens = NULL,
+                    error = NULL,
+                    updated_at = excluded.updated_at
+                "#,
+                params![forward_id, endpoint, model, is_stream_int, started_at_str],
+            )?;
+            Ok(())
+        }
+        MetricsMutation::ForwardCompleted {
+            forward_id,
+            completed_at,
+            status_code,
+            status,
+            usage,
+            token_details,
+            error,
+        } => {
+            let completed_at_str = format_timestamp(completed_at);
+            let status_code_int = status_code.map(|s| s as i64);
+            let (prompt, completion, total) = match usage {
+                Some(u) => (
+                    Some(u.prompt_tokens as i64),
+                    Some(u.completion_tokens as i64),
+                    Some(u.total_tokens as i64),
+                ),
+                None => (None, None, None),
+            };
+            let token_details = token_details.unwrap_or_default();
+            let cache_creation = token_details
+                .cache_creation_input_tokens
+                .map(|value| value as i64);
+            let cache_read = token_details
+                .cache_read_input_tokens
+                .map(|value| value as i64);
+            let cache_write = token_details
+                .cache_write_input_tokens
+                .map(|value| value as i64);
+            let reasoning_output = token_details
+                .reasoning_output_tokens
+                .map(|value| value as i64);
+
+            execute_cached(
+                connection,
+                r#"
+                UPDATE forward_request_metrics
+                SET completed_at = ?1,
+                    status_code = ?2,
+                    status = ?3,
+                    prompt_tokens = ?4,
+                    completion_tokens = ?5,
+                    total_tokens = ?6,
+                    cache_creation_input_tokens = ?7,
+                    cache_read_input_tokens = ?8,
+                    cache_write_input_tokens = ?9,
+                    reasoning_output_tokens = ?10,
+                    error = ?11,
+                    updated_at = ?1
+                WHERE forward_id = ?12
+                "#,
+                params![
+                    completed_at_str,
+                    status_code_int,
+                    status.as_str(),
+                    prompt,
+                    completion,
+                    total,
+                    cache_creation,
+                    cache_read,
+                    cache_write,
+                    reasoning_output,
+                    error,
+                    forward_id,
+                ],
+            )?;
+            Ok(())
+        }
+    };
+    #[cfg(test)]
+    if result.is_ok() {
+        batch_probe::after_item(connection);
+    }
+    result
+}

--- a/crates/infra/bamboo-infrastructure/tests/metrics_batch_compatibility.rs
+++ b/crates/infra/bamboo-infrastructure/tests/metrics_batch_compatibility.rs
@@ -1,0 +1,400 @@
+//! An external adapter deliberately implementing only the pre-batch required API.
+use async_trait::async_trait;
+use bamboo_infrastructure::metrics::storage::{
+    MetricsError, MetricsMutation, MetricsResult, MetricsStorage, ToolCallCompletion,
+};
+use bamboo_infrastructure::metrics::types::*;
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct ExistingAdapter {
+    calls: Mutex<Vec<MetricsMutation>>,
+}
+impl ExistingAdapter {
+    fn record(&self, mutation: MetricsMutation) -> MetricsResult<()> {
+        let fail = matches!(
+            &mutation,
+            MetricsMutation::SessionMessageCount {
+                message_count: 777,
+                ..
+            }
+        );
+        self.calls.lock().unwrap().push(mutation);
+        if fail {
+            Err(MetricsError::InvalidData(
+                "one deliberately failed call".into(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// Neither apply_batch nor record_prompt_memory_exposure is overridden. A new
+// required method or a Self: Sized restriction would break this external crate.
+#[async_trait]
+impl MetricsStorage for ExistingAdapter {
+    async fn init(&self) -> MetricsResult<()> {
+        Ok(())
+    }
+    async fn upsert_session_start(
+        &self,
+        session_id: &str,
+        model: &str,
+        started_at: DateTime<Utc>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::SessionStarted {
+            session_id: session_id.to_string(),
+            model: model.to_string(),
+            started_at,
+        })
+    }
+    async fn update_session_message_count(
+        &self,
+        session_id: &str,
+        message_count: u32,
+        updated_at: DateTime<Utc>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::SessionMessageCount {
+            session_id: session_id.to_string(),
+            message_count,
+            updated_at,
+        })
+    }
+    async fn complete_session(
+        &self,
+        session_id: &str,
+        status: SessionStatus,
+        completed_at: DateTime<Utc>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::SessionCompleted {
+            session_id: session_id.to_string(),
+            status,
+            completed_at,
+        })
+    }
+    async fn insert_round_start(
+        &self,
+        round_id: &str,
+        session_id: &str,
+        model: &str,
+        started_at: DateTime<Utc>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::RoundStarted {
+            round_id: round_id.to_string(),
+            session_id: session_id.to_string(),
+            model: model.to_string(),
+            started_at,
+        })
+    }
+    async fn complete_round(
+        &self,
+        round_id: &str,
+        completed_at: DateTime<Utc>,
+        status: RoundStatus,
+        usage: TokenUsage,
+        prompt_cached_tool_outputs: u32,
+        prompt_cached_tool_tokens_saved: u32,
+        error: Option<String>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::RoundCompleted {
+            round_id: round_id.to_string(),
+            completed_at,
+            status,
+            usage,
+            prompt_cached_tool_outputs,
+            prompt_cached_tool_tokens_saved,
+            error,
+        })
+    }
+    async fn record_round_compression(
+        &self,
+        _round_id: &str,
+        _compressed_at: DateTime<Utc>,
+        _tokens_saved: u32,
+    ) -> MetricsResult<()> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn insert_tool_start(
+        &self,
+        tool_call_id: &str,
+        round_id: &str,
+        session_id: &str,
+        tool_name: &str,
+        started_at: DateTime<Utc>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::ToolStarted {
+            tool_call_id: tool_call_id.to_string(),
+            round_id: round_id.to_string(),
+            session_id: session_id.to_string(),
+            tool_name: tool_name.to_string(),
+            started_at,
+        })
+    }
+    async fn complete_tool_call(
+        &self,
+        tool_call_id: &str,
+        completion: ToolCallCompletion,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::ToolCompleted {
+            tool_call_id: tool_call_id.to_string(),
+            completion,
+        })
+    }
+    async fn insert_forward_start(
+        &self,
+        forward_id: &str,
+        endpoint: &str,
+        model: &str,
+        is_stream: bool,
+        started_at: DateTime<Utc>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::ForwardStarted {
+            forward_id: forward_id.to_string(),
+            endpoint: endpoint.to_string(),
+            model: model.to_string(),
+            is_stream,
+            started_at,
+        })
+    }
+    async fn complete_forward(
+        &self,
+        forward_id: &str,
+        completed_at: DateTime<Utc>,
+        status_code: Option<u16>,
+        status: ForwardStatus,
+        usage: Option<TokenUsage>,
+        token_details: Option<ForwardTokenDetails>,
+        error: Option<String>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::ForwardCompleted {
+            forward_id: forward_id.to_string(),
+            completed_at,
+            status_code,
+            status,
+            usage,
+            token_details,
+            error,
+        })
+    }
+    async fn forward_summary(
+        &self,
+        _filter: ForwardMetricsFilter,
+    ) -> MetricsResult<ForwardMetricsSummary> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn forward_by_endpoint(
+        &self,
+        _filter: ForwardMetricsFilter,
+    ) -> MetricsResult<Vec<ForwardEndpointMetrics>> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn forward_requests(
+        &self,
+        _filter: ForwardMetricsFilter,
+    ) -> MetricsResult<Vec<ForwardRequestMetrics>> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn forward_daily_metrics(
+        &self,
+        _days: u32,
+        _end_date: Option<NaiveDate>,
+    ) -> MetricsResult<Vec<DailyMetrics>> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn summary(&self, _filter: MetricsDateFilter) -> MetricsResult<MetricsSummary> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn by_model(&self, _filter: MetricsDateFilter) -> MetricsResult<Vec<ModelMetrics>> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn sessions(&self, _filter: SessionMetricsFilter) -> MetricsResult<Vec<SessionMetrics>> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn session_detail(&self, _session_id: &str) -> MetricsResult<Option<SessionDetail>> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn increment_execute_sync_mismatch(
+        &self,
+        reason: &str,
+        occurred_at: DateTime<Utc>,
+    ) -> MetricsResult<()> {
+        self.record(MetricsMutation::ExecuteSyncMismatch {
+            reason: reason.to_string(),
+            occurred_at,
+        })
+    }
+    async fn daily_metrics(
+        &self,
+        _days: u32,
+        _end_date: Option<NaiveDate>,
+    ) -> MetricsResult<Vec<DailyMetrics>> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn prune_rounds_before(&self, _cutoff: DateTime<Utc>) -> MetricsResult<u64> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+    async fn reconcile_stale_executions(
+        &self,
+        _active_session_ids: &[String],
+        _awaiting_response_session_ids: &[String],
+    ) -> MetricsResult<()> {
+        unreachable!("not part of this write-only external adapter fixture")
+    }
+}
+
+#[tokio::test]
+async fn existing_trait_object_receives_all_raw_payloads_and_continues_after_error() {
+    let adapter = Arc::new(ExistingAdapter::default());
+    let storage: Arc<dyn MetricsStorage> = adapter.clone();
+    storage.init().await.unwrap();
+    let when = Utc.with_ymd_and_hms(2026, 9, 5, 10, 0, 0).unwrap();
+    let usage = TokenUsage {
+        prompt_tokens: u64::MAX,
+        completion_tokens: u64::MAX - 1,
+        total_tokens: u64::MAX - 2,
+    };
+    let details = ForwardTokenDetails {
+        cache_creation_input_tokens: Some(u64::MAX),
+        cache_read_input_tokens: Some(u64::MAX - 1),
+        cache_write_input_tokens: Some(u64::MAX - 2),
+        reasoning_output_tokens: Some(u64::MAX - 3),
+    };
+    let mutations = vec![
+        MetricsMutation::SessionStarted {
+            session_id: "session".into(),
+            model: "session-model".into(),
+            started_at: when,
+        },
+        MetricsMutation::SessionMessageCount {
+            session_id: "session".into(),
+            message_count: 777,
+            updated_at: when,
+        },
+        MetricsMutation::RoundStarted {
+            round_id: "round".into(),
+            session_id: "session".into(),
+            model: "round-model".into(),
+            started_at: when,
+        },
+        MetricsMutation::RoundCompleted {
+            round_id: "round".into(),
+            completed_at: when,
+            status: RoundStatus::Error,
+            usage,
+            prompt_cached_tool_outputs: u32::MAX,
+            prompt_cached_tool_tokens_saved: u32::MAX - 1,
+            error: Some("round-error".into()),
+        },
+        MetricsMutation::ToolStarted {
+            tool_call_id: "tool".into(),
+            round_id: "round".into(),
+            session_id: "session".into(),
+            tool_name: "tool-name".into(),
+            started_at: when,
+        },
+        MetricsMutation::ToolCompleted {
+            tool_call_id: "tool".into(),
+            completion: ToolCallCompletion {
+                completed_at: when,
+                success: false,
+                error: Some("tool-error".into()),
+            },
+        },
+        MetricsMutation::ForwardStarted {
+            forward_id: "forward".into(),
+            endpoint: "endpoint".into(),
+            model: "forward-model".into(),
+            is_stream: true,
+            started_at: when,
+        },
+        MetricsMutation::ForwardCompleted {
+            forward_id: "forward".into(),
+            completed_at: when,
+            status_code: Some(503),
+            status: ForwardStatus::Error,
+            usage: Some(usage),
+            token_details: Some(details),
+            error: Some("forward-error".into()),
+        },
+        MetricsMutation::ForwardCompleted {
+            forward_id: "empty-forward".into(),
+            completed_at: when,
+            status_code: None,
+            status: ForwardStatus::Success,
+            usage: None,
+            token_details: None,
+            error: None,
+        },
+        MetricsMutation::ExecuteSyncMismatch {
+            reason: "additive".into(),
+            occurred_at: when,
+        },
+        MetricsMutation::ExecuteSyncMismatch {
+            reason: "additive".into(),
+            occurred_at: when,
+        },
+        MetricsMutation::SessionCompleted {
+            session_id: "session".into(),
+            status: SessionStatus::Completed,
+            completed_at: when,
+        },
+    ];
+    let results = storage.apply_batch(mutations.clone()).await.unwrap();
+    assert_eq!(results.len(), mutations.len());
+    for (index, result) in results.iter().enumerate() {
+        if index == 1 {
+            assert!(matches!(result, Err(MetricsError::InvalidData(_))));
+        } else {
+            assert!(result.is_ok(), "call {index}: {result:?}");
+        }
+    }
+    // Debug includes every field of this non-Serialize command type. This is
+    // an exact payload/order assertion, not a snapshot of a formatting API.
+    assert_eq!(
+        format!("{:?}", *adapter.calls.lock().unwrap()),
+        format!("{mutations:?}")
+    );
+    assert!(storage.apply_batch(Vec::new()).await.unwrap().is_empty());
+    assert_eq!(adapter.calls.lock().unwrap().len(), mutations.len());
+
+    let observation = PromptMemoryExposureObservation {
+        schema_version: 1,
+        round_id: "round".into(),
+        session_id: "session".into(),
+        project_id: None,
+        observed_at: when,
+        recall_enabled: false,
+        query_present: false,
+        recall_outcome: PromptMemoryRecallOutcome::Disabled,
+        all_compact_exposed_count: 0,
+        project_exposed_count: 0,
+        out_of_project_only: false,
+        compact_section_chars: 0,
+        project_items: Vec::new(),
+    };
+    assert!(matches!(
+        storage.record_prompt_memory_exposure(&observation).await,
+        Err(MetricsError::InvalidData(_))
+    ));
+    let suffix = storage
+        .apply_batch(vec![MetricsMutation::SessionMessageCount {
+            session_id: "session".into(),
+            message_count: 42,
+            updated_at: when,
+        }])
+        .await
+        .unwrap();
+    assert_eq!(suffix.len(), 1);
+    assert!(suffix[0].is_ok());
+    let calls = adapter.calls.lock().unwrap();
+    assert_eq!(calls.len(), mutations.len() + 1);
+    assert!(matches!(
+        calls.last(),
+        Some(MetricsMutation::SessionMessageCount {
+            message_count: 42,
+            ..
+        })
+    ));
+}

--- a/crates/infra/bamboo-metrics/Cargo.toml
+++ b/crates/infra/bamboo-metrics/Cargo.toml
@@ -20,3 +20,4 @@ anyhow = "1"
 
 [dev-dependencies]
 tempfile = "3"
+rusqlite = { version = "0.40", features = ["bundled", "chrono"] }

--- a/crates/infra/bamboo-metrics/src/collector.rs
+++ b/crates/infra/bamboo-metrics/src/collector.rs
@@ -4,60 +4,16 @@ use bamboo_agent_core::AgentEvent;
 use chrono::{DateTime, Duration, Utc};
 use tokio::sync::mpsc;
 
-use crate::storage::{MetricsStorage, ToolCallCompletion};
+use crate::storage::{MetricsMutation, MetricsStorage, ToolCallCompletion, MAX_METRICS_BATCH_SIZE};
 use crate::types::{
     ForwardTokenDetails, PromptMemoryExposureObservation, RoundStatus, SessionStatus, TokenUsage,
 };
 
 #[derive(Debug)]
 enum CollectorCommand {
-    SessionStarted {
-        session_id: String,
-        model: String,
-        started_at: DateTime<Utc>,
-    },
-    SessionMessageCount {
-        session_id: String,
-        message_count: u32,
-        updated_at: DateTime<Utc>,
-    },
-    SessionCompleted {
-        session_id: String,
-        status: SessionStatus,
-        completed_at: DateTime<Utc>,
-    },
-    RoundStarted {
-        round_id: String,
-        session_id: String,
-        model: String,
-        started_at: DateTime<Utc>,
-    },
-    RoundCompleted {
-        round_id: String,
-        completed_at: DateTime<Utc>,
-        status: RoundStatus,
-        usage: TokenUsage,
-        prompt_cached_tool_outputs: u32,
-        prompt_cached_tool_tokens_saved: u32,
-        error: Option<String>,
-    },
+    Mutation(MetricsMutation),
     PromptMemoryExposure {
         observation: PromptMemoryExposureObservation,
-    },
-    ToolStarted {
-        tool_call_id: String,
-        round_id: String,
-        session_id: String,
-        tool_name: String,
-        started_at: DateTime<Utc>,
-    },
-    ToolCompleted {
-        tool_call_id: String,
-        completion: ToolCallCompletion,
-    },
-    ExecuteSyncMismatch {
-        reason: String,
-        occurred_at: DateTime<Utc>,
     },
     ContextCompressed {
         session_id: String,
@@ -68,22 +24,6 @@ enum CollectorCommand {
         usage_after_percent: f64,
         trigger_type: String,
         latency_ms: u64,
-    },
-    ForwardStarted {
-        forward_id: String,
-        endpoint: String,
-        model: String,
-        is_stream: bool,
-        started_at: DateTime<Utc>,
-    },
-    ForwardCompleted {
-        forward_id: String,
-        completed_at: DateTime<Utc>,
-        status_code: Option<u16>,
-        status: crate::types::ForwardStatus,
-        usage: Option<TokenUsage>,
-        token_details: Option<ForwardTokenDetails>,
-        error: Option<String>,
     },
     Prune {
         cutoff: DateTime<Utc>,
@@ -106,11 +46,17 @@ impl Drop for PruneScheduler {
 pub struct MetricsCollector {
     tx: mpsc::UnboundedSender<CollectorCommand>,
     _scheduler: Arc<PruneScheduler>,
+    #[cfg(test)]
+    received_count: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl MetricsCollector {
     pub fn spawn(storage: Arc<dyn MetricsStorage>, retention_days: u32) -> Self {
         let (tx, mut rx) = mpsc::unbounded_channel::<CollectorCommand>();
+        #[cfg(test)]
+        let received_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        #[cfg(test)]
+        let consumer_received_count = received_count.clone();
 
         // Do not abort the consumer on owner release: closing the producers
         // lets it finish initialization and drain accepted commands in order.
@@ -119,163 +65,56 @@ impl MetricsCollector {
                 tracing::error!("metrics storage initialization failed: {}", error);
             }
 
-            while let Some(command) = rx.recv().await {
-                let outcome = match command {
-                    CollectorCommand::SessionStarted {
-                        session_id,
-                        model,
-                        started_at,
-                    } => {
-                        storage
-                            .upsert_session_start(&session_id, &model, started_at)
-                            .await
+            let mut buffer = Vec::with_capacity(MAX_METRICS_BATCH_SIZE);
+            loop {
+                let received = rx.recv_many(&mut buffer, MAX_METRICS_BATCH_SIZE).await;
+                if received == 0 {
+                    break;
+                }
+                #[cfg(test)]
+                consumer_received_count.fetch_add(received, std::sync::atomic::Ordering::SeqCst);
+                let mut pending = Vec::with_capacity(buffer.len());
+                for command in buffer.drain(..) {
+                    if let CollectorCommand::Mutation(mutation) = command {
+                        pending.push(mutation);
+                        continue;
                     }
-                    CollectorCommand::SessionMessageCount {
-                        session_id,
-                        message_count,
-                        updated_at,
-                    } => {
-                        storage
-                            .update_session_message_count(&session_id, message_count, updated_at)
-                            .await
-                    }
-                    CollectorCommand::SessionCompleted {
-                        session_id,
-                        status,
-                        completed_at,
-                    } => {
-                        storage
-                            .complete_session(&session_id, status, completed_at)
-                            .await
-                    }
-                    CollectorCommand::RoundStarted {
-                        round_id,
-                        session_id,
-                        model,
-                        started_at,
-                    } => {
-                        storage
-                            .insert_round_start(&round_id, &session_id, &model, started_at)
-                            .await
-                    }
-                    CollectorCommand::RoundCompleted {
-                        round_id,
-                        completed_at,
-                        status,
-                        usage,
-                        prompt_cached_tool_outputs,
-                        prompt_cached_tool_tokens_saved,
-                        error,
-                    } => {
-                        storage
-                            .complete_round(
-                                &round_id,
-                                completed_at,
-                                status,
-                                usage,
-                                prompt_cached_tool_outputs,
-                                prompt_cached_tool_tokens_saved,
-                                error,
-                            )
-                            .await
-                    }
-                    CollectorCommand::PromptMemoryExposure { observation } => {
-                        storage.record_prompt_memory_exposure(&observation).await
-                    }
-                    CollectorCommand::ToolStarted {
-                        tool_call_id,
-                        round_id,
-                        session_id,
-                        tool_name,
-                        started_at,
-                    } => {
-                        storage
-                            .insert_tool_start(
-                                &tool_call_id,
-                                &round_id,
-                                &session_id,
-                                &tool_name,
-                                started_at,
-                            )
-                            .await
-                    }
-                    CollectorCommand::ToolCompleted {
-                        tool_call_id,
-                        completion,
-                    } => storage.complete_tool_call(&tool_call_id, completion).await,
-                    CollectorCommand::ExecuteSyncMismatch {
-                        reason,
-                        occurred_at,
-                    } => {
-                        storage
-                            .increment_execute_sync_mismatch(&reason, occurred_at)
-                            .await
-                    }
-                    CollectorCommand::ContextCompressed {
-                        session_id,
-                        round_id,
-                        messages_compressed,
-                        tokens_saved,
-                        usage_before_percent,
-                        usage_after_percent,
-                        trigger_type,
-                        latency_ms,
-                    } => {
-                        tracing::info!(
+                    Self::flush_mutations(storage.as_ref(), std::mem::take(&mut pending)).await;
+                    let outcome = match command {
+                        CollectorCommand::PromptMemoryExposure { observation } => {
+                            storage.record_prompt_memory_exposure(&observation).await
+                        }
+                        CollectorCommand::ContextCompressed {
+                            session_id,
+                            round_id,
+                            messages_compressed,
+                            tokens_saved,
+                            usage_before_percent,
+                            usage_after_percent,
+                            trigger_type,
+                            latency_ms,
+                        } => {
+                            tracing::info!(
                             "[{}] metrics: context compressed — round={}, messages={}, tokens_saved={}, before={:.1}%, after={:.1}%, trigger={}, latency={}ms",
                             session_id, round_id, messages_compressed, tokens_saved,
                             usage_before_percent, usage_after_percent, trigger_type, latency_ms,
                         );
-                        storage
-                            .record_round_compression(&round_id, Utc::now(), tokens_saved)
-                            .await
+                            storage
+                                .record_round_compression(&round_id, Utc::now(), tokens_saved)
+                                .await
+                        }
+                        CollectorCommand::Prune { cutoff } => {
+                            storage.prune_rounds_before(cutoff).await.map(|_| ())
+                        }
+                        CollectorCommand::Mutation(_) => {
+                            unreachable!("ordinary mutations handled above")
+                        }
+                    };
+                    if let Err(error) = outcome {
+                        tracing::warn!("metrics collector command failed: {}", error);
                     }
-                    CollectorCommand::ForwardStarted {
-                        forward_id,
-                        endpoint,
-                        model,
-                        is_stream,
-                        started_at,
-                    } => {
-                        storage
-                            .insert_forward_start(
-                                &forward_id,
-                                &endpoint,
-                                &model,
-                                is_stream,
-                                started_at,
-                            )
-                            .await
-                    }
-                    CollectorCommand::ForwardCompleted {
-                        forward_id,
-                        completed_at,
-                        status_code,
-                        status,
-                        usage,
-                        token_details,
-                        error,
-                    } => {
-                        storage
-                            .complete_forward(
-                                &forward_id,
-                                completed_at,
-                                status_code,
-                                status,
-                                usage,
-                                token_details,
-                                error,
-                            )
-                            .await
-                    }
-                    CollectorCommand::Prune { cutoff } => {
-                        storage.prune_rounds_before(cutoff).await.map(|_| ())
-                    }
-                };
-
-                if let Err(error) = outcome {
-                    tracing::warn!("metrics collector command failed: {}", error);
                 }
+                Self::flush_mutations(storage.as_ref(), pending).await;
             }
         });
 
@@ -283,6 +122,35 @@ impl MetricsCollector {
         Self {
             tx,
             _scheduler: Arc::new(scheduler),
+            #[cfg(test)]
+            received_count,
+        }
+    }
+
+    async fn flush_mutations(storage: &dyn MetricsStorage, mutations: Vec<MetricsMutation>) {
+        if mutations.is_empty() {
+            return;
+        }
+        let expected = mutations.len();
+        match storage.apply_batch(mutations).await {
+            Ok(results) => {
+                if results.len() != expected {
+                    tracing::error!(
+                        expected,
+                        actual = results.len(),
+                        "metrics backend violated batch result count; no replay is safe"
+                    );
+                }
+                for result in results {
+                    if let Err(error) = result {
+                        tracing::warn!("metrics collector command failed: {}", error);
+                    }
+                }
+            }
+            Err(error) => tracing::warn!(
+                "metrics batch task failed; committed prefix cannot be replayed: {}",
+                error
+            ),
         }
     }
 
@@ -292,11 +160,13 @@ impl MetricsCollector {
         model: impl Into<String>,
         started_at: DateTime<Utc>,
     ) {
-        let _ = self.tx.send(CollectorCommand::SessionStarted {
-            session_id: session_id.into(),
-            model: model.into(),
-            started_at,
-        });
+        let _ = self.tx.send(CollectorCommand::Mutation(
+            MetricsMutation::SessionStarted {
+                session_id: session_id.into(),
+                model: model.into(),
+                started_at,
+            },
+        ));
     }
 
     pub fn session_message_count(
@@ -305,11 +175,13 @@ impl MetricsCollector {
         message_count: u32,
         updated_at: DateTime<Utc>,
     ) {
-        let _ = self.tx.send(CollectorCommand::SessionMessageCount {
-            session_id: session_id.into(),
-            message_count,
-            updated_at,
-        });
+        let _ = self.tx.send(CollectorCommand::Mutation(
+            MetricsMutation::SessionMessageCount {
+                session_id: session_id.into(),
+                message_count,
+                updated_at,
+            },
+        ));
     }
 
     pub fn session_completed(
@@ -318,11 +190,13 @@ impl MetricsCollector {
         status: SessionStatus,
         completed_at: DateTime<Utc>,
     ) {
-        let _ = self.tx.send(CollectorCommand::SessionCompleted {
-            session_id: session_id.into(),
-            status,
-            completed_at,
-        });
+        let _ = self.tx.send(CollectorCommand::Mutation(
+            MetricsMutation::SessionCompleted {
+                session_id: session_id.into(),
+                status,
+                completed_at,
+            },
+        ));
     }
 
     pub fn round_started(
@@ -332,12 +206,14 @@ impl MetricsCollector {
         model: impl Into<String>,
         started_at: DateTime<Utc>,
     ) {
-        let _ = self.tx.send(CollectorCommand::RoundStarted {
-            round_id: round_id.into(),
-            session_id: session_id.into(),
-            model: model.into(),
-            started_at,
-        });
+        let _ = self
+            .tx
+            .send(CollectorCommand::Mutation(MetricsMutation::RoundStarted {
+                round_id: round_id.into(),
+                session_id: session_id.into(),
+                model: model.into(),
+                started_at,
+            }));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -351,15 +227,17 @@ impl MetricsCollector {
         prompt_cached_tool_tokens_saved: u32,
         error: Option<String>,
     ) {
-        let _ = self.tx.send(CollectorCommand::RoundCompleted {
-            round_id: round_id.into(),
-            completed_at,
-            status,
-            usage,
-            prompt_cached_tool_outputs,
-            prompt_cached_tool_tokens_saved,
-            error,
-        });
+        let _ = self.tx.send(CollectorCommand::Mutation(
+            MetricsMutation::RoundCompleted {
+                round_id: round_id.into(),
+                completed_at,
+                status,
+                usage,
+                prompt_cached_tool_outputs,
+                prompt_cached_tool_tokens_saved,
+                error,
+            },
+        ));
     }
 
     /// Queues a host-observed compact-memory prompt exposure.
@@ -380,43 +258,49 @@ impl MetricsCollector {
                 tool_name,
                 ..
             } => {
-                let _ = self.tx.send(CollectorCommand::ToolStarted {
-                    tool_call_id: tool_call_id.clone(),
-                    round_id: round_id.to_string(),
-                    session_id: session_id.to_string(),
-                    tool_name: tool_name.clone(),
-                    started_at: Utc::now(),
-                });
+                let _ = self
+                    .tx
+                    .send(CollectorCommand::Mutation(MetricsMutation::ToolStarted {
+                        tool_call_id: tool_call_id.clone(),
+                        round_id: round_id.to_string(),
+                        session_id: session_id.to_string(),
+                        tool_name: tool_name.clone(),
+                        started_at: Utc::now(),
+                    }));
             }
             AgentEvent::ToolComplete {
                 tool_call_id,
                 result,
             } => {
-                let _ = self.tx.send(CollectorCommand::ToolCompleted {
-                    tool_call_id: tool_call_id.clone(),
-                    completion: ToolCallCompletion {
-                        completed_at: Utc::now(),
-                        success: result.success,
-                        error: if result.success {
-                            None
-                        } else {
-                            Some(result.result.clone())
+                let _ = self
+                    .tx
+                    .send(CollectorCommand::Mutation(MetricsMutation::ToolCompleted {
+                        tool_call_id: tool_call_id.clone(),
+                        completion: ToolCallCompletion {
+                            completed_at: Utc::now(),
+                            success: result.success,
+                            error: if result.success {
+                                None
+                            } else {
+                                Some(result.result.clone())
+                            },
                         },
-                    },
-                });
+                    }));
             }
             AgentEvent::ToolError {
                 tool_call_id,
                 error,
             } => {
-                let _ = self.tx.send(CollectorCommand::ToolCompleted {
-                    tool_call_id: tool_call_id.clone(),
-                    completion: ToolCallCompletion {
-                        completed_at: Utc::now(),
-                        success: false,
-                        error: Some(error.clone()),
-                    },
-                });
+                let _ = self
+                    .tx
+                    .send(CollectorCommand::Mutation(MetricsMutation::ToolCompleted {
+                        tool_call_id: tool_call_id.clone(),
+                        completion: ToolCallCompletion {
+                            completed_at: Utc::now(),
+                            success: false,
+                            error: Some(error.clone()),
+                        },
+                    }));
             }
             _ => {}
         }
@@ -430,13 +314,15 @@ impl MetricsCollector {
         is_stream: bool,
         started_at: DateTime<Utc>,
     ) {
-        let _ = self.tx.send(CollectorCommand::ForwardStarted {
-            forward_id: forward_id.into(),
-            endpoint: endpoint.into(),
-            model: model.into(),
-            is_stream,
-            started_at,
-        });
+        let _ = self.tx.send(CollectorCommand::Mutation(
+            MetricsMutation::ForwardStarted {
+                forward_id: forward_id.into(),
+                endpoint: endpoint.into(),
+                model: model.into(),
+                is_stream,
+                started_at,
+            },
+        ));
     }
 
     pub fn forward_completed(
@@ -470,22 +356,26 @@ impl MetricsCollector {
         token_details: Option<ForwardTokenDetails>,
         error: Option<String>,
     ) {
-        let _ = self.tx.send(CollectorCommand::ForwardCompleted {
-            forward_id: forward_id.into(),
-            completed_at,
-            status_code,
-            status,
-            usage,
-            token_details,
-            error,
-        });
+        let _ = self.tx.send(CollectorCommand::Mutation(
+            MetricsMutation::ForwardCompleted {
+                forward_id: forward_id.into(),
+                completed_at,
+                status_code,
+                status,
+                usage,
+                token_details,
+                error,
+            },
+        ));
     }
 
     pub fn execute_sync_mismatch(&self, reason: impl Into<String>, occurred_at: DateTime<Utc>) {
-        let _ = self.tx.send(CollectorCommand::ExecuteSyncMismatch {
-            reason: reason.into(),
-            occurred_at,
-        });
+        let _ = self.tx.send(CollectorCommand::Mutation(
+            MetricsMutation::ExecuteSyncMismatch {
+                reason: reason.into(),
+                occurred_at,
+            },
+        ));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -758,3 +648,6 @@ mod tests {
         assert_eq!(tx.strong_count(), 1);
     }
 }
+
+#[cfg(test)]
+mod batch_tests;

--- a/crates/infra/bamboo-metrics/src/collector/batch_tests.rs
+++ b/crates/infra/bamboo-metrics/src/collector/batch_tests.rs
@@ -1,0 +1,412 @@
+use std::sync::atomic::Ordering;
+use std::sync::Weak;
+use std::time::{Duration as StdDuration, Instant};
+
+use crate::storage::{MetricsMutation, SqliteMetricsStorage};
+use crate::types::{MetricsDateFilter, PromptMemoryExposureItem, PromptMemoryRecallOutcome};
+
+use super::*;
+
+async fn reclaimed(storage: &Weak<SqliteMetricsStorage>, scheduler: &tokio::task::AbortHandle) {
+    tokio::time::timeout(StdDuration::from_secs(30), async {
+        while storage.strong_count() != 0 || !scheduler.is_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("accepted local buffers and queued commands must drain before storage is released");
+    assert!(storage.upgrade().is_none());
+}
+
+#[tokio::test]
+async fn final_owner_drop_drains_additive_commands_at_every_segment_boundary() {
+    for count in [31, 32, 33, 96] {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.db");
+        let storage = Arc::new(SqliteMetricsStorage::new(&path));
+        let weak = Arc::downgrade(&storage);
+        let collector = MetricsCollector::spawn(storage, 90);
+        let scheduler = collector._scheduler.task.abort_handle();
+        let now = Utc::now();
+        // Current-thread runtime: all N ordinary events are ready before init
+        // or either spawned task can run. The scheduler is cancelled at Drop.
+        for index in 0..count {
+            collector.execute_sync_mismatch(
+                if index % 2 == 0 { "even" } else { "odd" },
+                now + Duration::milliseconds(i64::from(index)),
+            );
+        }
+        drop(collector);
+        reclaimed(&weak, &scheduler).await;
+        let reopened = SqliteMetricsStorage::new(&path);
+        let summary = reopened
+            .summary(MetricsDateFilter::default())
+            .await
+            .unwrap();
+        assert_eq!(summary.total_sync_mismatches, count as u64);
+        assert_eq!(
+            summary.sync_mismatch_breakdown["even"],
+            ((count + 1) / 2) as u64
+        );
+        assert_eq!(summary.sync_mismatch_breakdown["odd"], (count / 2) as u64);
+    }
+}
+
+fn observation(when: DateTime<Utc>, memory: &str) -> PromptMemoryExposureObservation {
+    PromptMemoryExposureObservation {
+        schema_version: 1,
+        round_id: "reused-round".to_string(),
+        session_id: "barriers".to_string(),
+        project_id: Some("project".to_string()),
+        observed_at: when,
+        recall_enabled: true,
+        query_present: true,
+        recall_outcome: PromptMemoryRecallOutcome::Lexical,
+        all_compact_exposed_count: 1,
+        project_exposed_count: 1,
+        out_of_project_only: false,
+        compact_section_chars: 120,
+        project_items: vec![PromptMemoryExposureItem {
+            memory_id: memory.to_string(),
+            scope: "project".to_string(),
+            status_at_observation: "active".to_string(),
+            rank: 1,
+            rendered_chars: 60,
+        }],
+    }
+}
+
+#[tokio::test]
+async fn singleton_barriers_preserve_fifo_across_segments_and_retention_cascades() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("metrics.db");
+    let storage = Arc::new(SqliteMetricsStorage::new(&path));
+    storage.init().await.unwrap();
+    let audit = rusqlite::Connection::open(&path).unwrap();
+    audit
+        .execute_batch(
+            "CREATE TABLE compression_order_audit (status TEXT NOT NULL);
+         CREATE TRIGGER audit_compression_order
+         AFTER UPDATE OF compression_count ON round_metrics
+         WHEN NEW.round_id = 'reused-round'
+         BEGIN INSERT INTO compression_order_audit VALUES (NEW.status); END;",
+        )
+        .unwrap();
+    drop(audit);
+    let weak = Arc::downgrade(&storage);
+    let collector = MetricsCollector::spawn(storage, 90);
+    let scheduler = collector._scheduler.task.abort_handle();
+    let now = Utc::now();
+    let old = now - Duration::days(40);
+    collector.session_started("barriers", "model", old);
+    collector.round_started("reused-round", "barriers", "model", old);
+    // Place the first exposure exactly after 31 ready ordinary commands.
+    for _ in 0..29 {
+        collector.execute_sync_mismatch("padding", now);
+    }
+    collector.prompt_memory_exposure(observation(old, "old-memory"));
+    collector
+        .tx
+        .send(CollectorCommand::Prune {
+            cutoff: now - Duration::days(30),
+        })
+        .unwrap();
+    // Reusing the ID makes a deferred/reordered exposure observable: the old
+    // snapshot must cascade away before the new round's first observation.
+    collector.round_started("reused-round", "barriers", "model", now);
+    collector.context_compressed("barriers", "reused-round", 4, 50, 80.0, 40.0, "test", 1);
+    collector.round_completed(
+        "reused-round",
+        now,
+        RoundStatus::Success,
+        TokenUsage {
+            prompt_tokens: 6,
+            completion_tokens: 4,
+            total_tokens: 10,
+        },
+        2,
+        20,
+        None,
+    );
+    let expected = observation(now, "new-memory");
+    collector.prompt_memory_exposure(expected.clone());
+    collector.session_message_count("barriers", 42, now);
+    collector.session_completed("barriers", SessionStatus::Completed, now);
+    drop(collector);
+    reclaimed(&weak, &scheduler).await;
+    let reopened = SqliteMetricsStorage::new(&path);
+    assert_eq!(
+        reopened
+            .prompt_memory_exposure("reused-round")
+            .await
+            .unwrap(),
+        Some(expected)
+    );
+    let detail = reopened.session_detail("barriers").await.unwrap().unwrap();
+    assert_eq!(detail.rounds.len(), 1);
+    assert_eq!(detail.rounds[0].started_at, now);
+    assert_eq!(detail.rounds[0].status, RoundStatus::Success);
+    assert_eq!(detail.rounds[0].compression_count, 1);
+    assert_eq!(detail.rounds[0].tokens_saved, 70);
+    assert_eq!(detail.session.total_rounds, 1);
+    assert_eq!(detail.session.total_compression_events, 1);
+    assert_eq!(detail.session.total_tokens_saved, 70);
+    assert_eq!(detail.session.message_count, 42);
+    assert_eq!(detail.session.status, SessionStatus::Completed);
+    let audit = rusqlite::Connection::open(&path).unwrap();
+    let statuses: Vec<String> = audit
+        .prepare("SELECT status FROM compression_order_audit")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<rusqlite::Result<_>>()
+        .unwrap();
+    assert_eq!(
+        statuses,
+        ["running"],
+        "compression must run exactly once before round completion"
+    );
+    let updated_at: String = audit
+        .query_row(
+            "SELECT updated_at FROM session_metrics WHERE session_id = 'barriers'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        updated_at,
+        now.to_rfc3339(),
+        "final explicit completion remains the last refresh"
+    );
+    assert_eq!(
+        reopened
+            .summary(MetricsDateFilter::default())
+            .await
+            .unwrap()
+            .total_sync_mismatches,
+        29
+    );
+}
+
+#[tokio::test]
+async fn failed_ordinary_and_special_commands_do_not_discard_accepted_suffix() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("metrics.db");
+    let storage = Arc::new(SqliteMetricsStorage::new(&path));
+    let weak = Arc::downgrade(&storage);
+    let collector = MetricsCollector::spawn(storage, 90);
+    let scheduler = collector._scheduler.task.abort_handle();
+    let now = Utc::now();
+    collector.execute_sync_mismatch("kept", now);
+    collector.round_completed(
+        "missing",
+        now,
+        RoundStatus::Success,
+        TokenUsage::default(),
+        0,
+        0,
+        None,
+    );
+    collector.execute_sync_mismatch("kept", now);
+    collector.prompt_memory_exposure(observation(now, "missing-round"));
+    collector.context_compressed("missing", "missing", 1, 10, 80.0, 40.0, "test", 1);
+    collector.execute_sync_mismatch("kept", now);
+    collector.session_started("suffix", "model", now);
+    collector.session_message_count("suffix", 71, now);
+    drop(collector);
+    reclaimed(&weak, &scheduler).await;
+    let reopened = SqliteMetricsStorage::new(&path);
+    assert_eq!(
+        reopened
+            .summary(MetricsDateFilter::default())
+            .await
+            .unwrap()
+            .total_sync_mismatches,
+        3
+    );
+    assert_eq!(
+        reopened
+            .session_detail("suffix")
+            .await
+            .unwrap()
+            .unwrap()
+            .session
+            .message_count,
+        71
+    );
+    assert!(reopened
+        .prompt_memory_exposure("reused-round")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn burst_of_256_independent_sessions_drains_complete_rounds_and_tools() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("metrics.db");
+    let storage = Arc::new(SqliteMetricsStorage::new(&path));
+    let weak = Arc::downgrade(&storage);
+    let collector = MetricsCollector::spawn(storage, 90);
+    let scheduler = collector._scheduler.task.abort_handle();
+    let now = Utc::now();
+    let started = Instant::now();
+    for index in 0..256 {
+        let session = format!("session-{index}");
+        let round = format!("round-{index}");
+        let tool = format!("tool-{index}");
+        collector.session_started(&session, "model", now);
+        collector.round_started(&round, &session, "model", now);
+        collector
+            .tx
+            .send(CollectorCommand::Mutation(MetricsMutation::ToolStarted {
+                tool_call_id: tool.clone(),
+                round_id: round.clone(),
+                session_id: session.clone(),
+                tool_name: "test_tool".to_string(),
+                started_at: now,
+            }))
+            .unwrap();
+        collector
+            .tx
+            .send(CollectorCommand::Mutation(MetricsMutation::ToolCompleted {
+                tool_call_id: tool,
+                completion: ToolCallCompletion {
+                    completed_at: now,
+                    success: true,
+                    error: None,
+                },
+            }))
+            .unwrap();
+        collector.round_completed(
+            &round,
+            now,
+            RoundStatus::Success,
+            TokenUsage {
+                prompt_tokens: 6,
+                completion_tokens: 4,
+                total_tokens: 10,
+            },
+            0,
+            0,
+            None,
+        );
+        collector.session_completed(&session, SessionStatus::Completed, now);
+    }
+    drop(collector);
+    reclaimed(&weak, &scheduler).await;
+    let elapsed = started.elapsed();
+    let reopened = SqliteMetricsStorage::new(&path);
+    let summary = reopened
+        .summary(MetricsDateFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(summary.total_sessions, 256);
+    assert_eq!(summary.completed_sessions, 256);
+    assert_eq!(summary.total_tokens.total_tokens, 2560);
+    assert_eq!(summary.total_tool_calls, 256);
+    for index in 0..256 {
+        let detail = reopened
+            .session_detail(&format!("session-{index}"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(detail.rounds.len(), 1);
+        assert_eq!(detail.rounds[0].round_id, format!("round-{index}"));
+        assert_eq!(detail.rounds[0].tool_calls.len(), 1);
+        assert_eq!(
+            detail.rounds[0].tool_calls[0].tool_call_id,
+            format!("tool-{index}")
+        );
+        assert_eq!(detail.rounds[0].status, RoundStatus::Success);
+        assert_eq!(detail.session.status, SessionStatus::Completed);
+        assert_eq!(detail.session.tool_call_count, 1);
+    }
+    eprintln!("256-session collector burst: 1536 ready ordinary commands drained in {elapsed:?}");
+}
+
+#[tokio::test]
+async fn final_owner_drop_preserves_in_flight_segment_and_channel_suffix() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("metrics.db");
+    let storage = Arc::new(SqliteMetricsStorage::new(&path));
+    storage.init().await.unwrap();
+    let now = Utc::now();
+    let old = now - Duration::days(100);
+    storage
+        .upsert_session_start("stale", "model", old)
+        .await
+        .unwrap();
+    storage
+        .insert_round_start("stale-round", "stale", "model", old)
+        .await
+        .unwrap();
+    let collector = MetricsCollector::spawn(storage.clone(), 90);
+    let scheduler = collector._scheduler.task.abort_handle();
+    collector.session_started("ready", "model", now);
+    collector.session_message_count("ready", 42, now);
+    // Observe both initialization and the scheduler's real initial prune before
+    // acquiring the writer. No timer command can precede the tested segment.
+    tokio::time::timeout(StdDuration::from_secs(10), async {
+        loop {
+            let ready = storage.session_detail("ready").await.unwrap();
+            let stale = storage.session_detail("stale").await.unwrap().unwrap();
+            if ready.is_some_and(|detail| detail.session.message_count == 42)
+                && stale.rounds.is_empty()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    let writer = rusqlite::Connection::open(&path).unwrap();
+    writer.execute_batch("BEGIN IMMEDIATE").unwrap();
+    let received_before = collector.received_count.load(Ordering::SeqCst);
+    for _ in 0..96 {
+        collector.execute_sync_mismatch("in-flight", now);
+    }
+    tokio::time::timeout(StdDuration::from_secs(5), async {
+        while collector.received_count.load(Ordering::SeqCst) == received_before {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("consumer must take a ready segment while the SQLite writer is occupied");
+    assert_eq!(
+        collector.received_count.load(Ordering::SeqCst) - received_before,
+        32,
+        "only 32 commands may leave the channel before the blocked segment completes"
+    );
+    let weak = Arc::downgrade(&storage);
+    drop(storage);
+    drop(collector);
+    tokio::task::yield_now().await;
+    assert!(
+        weak.upgrade().is_some(),
+        "consumer retains storage until in-flight and queued commands finish"
+    );
+    writer.execute_batch("COMMIT").unwrap();
+    drop(writer);
+    reclaimed(&weak, &scheduler).await;
+    let reopened = SqliteMetricsStorage::new(&path);
+    assert_eq!(
+        reopened
+            .summary(MetricsDateFilter::default())
+            .await
+            .unwrap()
+            .total_sync_mismatches,
+        96
+    );
+    assert_eq!(
+        reopened
+            .session_detail("ready")
+            .await
+            .unwrap()
+            .unwrap()
+            .session
+            .message_count,
+        42
+    );
+}


### PR DESCRIPTION
## Summary

Metrics bursts currently create a new SQLite connection and blocking task for every event. Dispatch up to 32 already-ready ordinary events through one connection/task, with shared cached-statement helpers for the existing single-item API and the new backward-compatible `MetricsStorage::apply_batch` default.

Each event retains its original transaction, aggregate-refresh position and failure behavior. There is no outer batch transaction or replay: SQL/open/panic failures discard the affected connection before the next event, and successful items must leave autocommit enabled. Prune, ContextCompressed and PromptMemoryExposure remain awaited FIFO barriers; compression keeps its processing-time timestamp. The existing final-owner scheduler cancellation and consumer drain remain intact, including already received segments and queued suffixes.

The synthetic 256-session fixture processes 1,536 ordinary commands with **48 connection opens / 48 blocking tasks**, preserving the original **1,024 explicit COMMITs**. A second writer commits between items, and cached-statement run counters verify reuse with changing bindings. The segment cap does not bound total queue admission, and this change does not group commits or consolidate aggregate scans. Scope is 12 files / 1,976 net lines, with no production schema or additional writer lifecycle.

## Test Plan

- Complete `cargo test -p bamboo-infrastructure -p bamboo-metrics`: **147 passed**, no failures; 24 pre-existing ignored doctests.
- Serial/batch comparison of every business table plus explicit prior-behavior assertions: completion replay/compression, tool ownership and preserved completion fields, forward reset/null/raw-number behavior, missing rows, additive counters, aggregate timing and negative-token rollback followed by repair.
- Failed open, SQL error and panic after a child update: prior commits survive, failed transactions roll back, the suffix reopens safely and is not replayed. Empty and oversized inputs, prepared-cache reuse, original COMMIT/aggregate positions and another writer between commands are covered.
- Collector 31/32/33/96 boundaries, all three special-event barriers and exposure retention cascades, failure continuation, pre-init final-owner release, and a writer-blocked received segment of 32 with 64 still queued at final-owner drop. A temporary-DB trigger verifies compression runs once while the round is still running. The 256-session burst verifies all persisted rounds/tools and resource reclamation.
- External adapter implements only the pre-existing required trait methods and runs through `Arc<dyn MetricsStorage>`: raw `u64::MAX` payloads, aligned errors, suffix continuation, empty input and the pre-existing unsupported exposure default.
- Locked full-feature dependency metadata passed; Cargo.lock adds only the existing rusqlite test dependency membership, with no version changes.
- Final format, exact CI Clippy, independent exact-head review and required dev CI are recorded in the review/checks before merge.

Closes #1086. Part of #1083; aggregate scan consolidation remains separately scoped in #1087.
