### PR TITLE
fix: fence Root Project context against stale session writes (#1091)

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -380,7 +380,61 @@ impl Agent {
         let direct_lease = self.inner.begin_direct_execution(&session.id).await?;
         if session.project_id_meta().is_none() {
             if let Some(project_id) = self.project_id.as_ref() {
-                session.set_project_id_meta(project_id.to_string());
+                let existing = if session.kind == bamboo_domain::SessionKind::Root {
+                    match self.storage().load_root_authority(&session.id).await {
+                        // Preserve compatibility for custom Storage backends that
+                        // predate the strict Root port. V2 always uses its canonical
+                        // directory lookup, even when this instance's index is stale.
+                        Err(error) if error.kind() == std::io::ErrorKind::Unsupported => {
+                            self.storage().load_session(&session.id).await
+                        }
+                        result => result,
+                    }
+                    .map_err(|error| AgentError::ProjectContext(error.to_string()))?
+                } else {
+                    None
+                };
+                if let Some(current) = existing {
+                    if current.kind != bamboo_domain::SessionKind::Root
+                        || current.created_at != session.created_at
+                        || current.metadata_version != session.metadata_version
+                        || current.authority_identity != session.authority_identity
+                        || current.project_id_meta().is_some()
+                    {
+                        return Err(AgentError::ProjectContext(
+                            "Session context changed; reload before assigning its first Project"
+                                .to_string(),
+                        ));
+                    }
+                    let next_version =
+                        current.metadata_version.checked_add(1).ok_or_else(|| {
+                            AgentError::ProjectContext(
+                                "Session metadata revision cannot advance".to_string(),
+                            )
+                        })?;
+                    let mut candidate = session.clone();
+                    candidate.set_project_id_meta(project_id.to_string());
+                    candidate.metadata_version = next_version;
+                    candidate.updated_at = std::time::SystemTime::now().into();
+                    self.inner
+                        .prepare_external_project_assignment_read_only(&mut candidate)
+                        .await?;
+                    #[cfg(test)]
+                    reexecute_and_child_approval_tests::pause_project_assignment(&session.id).await;
+                    // Commit the narrow context change before publishing a runtime
+                    // workspace or replaying an approved tool. The final writer
+                    // fences an independent store's competing assignment. The
+                    // V2 runtime path leaves conversation history untouched.
+                    self.storage()
+                        .save_runtime_state(&candidate)
+                        .await
+                        .map_err(|error| AgentError::ProjectContext(error.to_string()))?;
+                    *session = candidate;
+                } else {
+                    // First creation keeps its existing revision and persistence
+                    // lifecycle; Child assignment keeps its prior SDK semantics.
+                    session.set_project_id_meta(project_id.to_string());
+                }
             }
         }
 
@@ -1334,9 +1388,46 @@ mod reexecute_and_child_approval_tests {
     use bamboo_agent_core::tools::{
         FunctionCall, Tool, ToolCall, ToolCtx, ToolError, ToolExecutionSessionFlags, ToolOutcome,
     };
+    use bamboo_domain::Storage as _;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex as StdMutex;
     use tokio::sync::Notify;
+
+    struct ProjectAssignmentHook {
+        reached: Notify,
+        resume: Notify,
+    }
+
+    fn project_assignment_hooks(
+    ) -> &'static StdMutex<std::collections::HashMap<String, Arc<ProjectAssignmentHook>>> {
+        static HOOKS: std::sync::OnceLock<
+            StdMutex<std::collections::HashMap<String, Arc<ProjectAssignmentHook>>>,
+        > = std::sync::OnceLock::new();
+        HOOKS.get_or_init(|| StdMutex::new(std::collections::HashMap::new()))
+    }
+
+    fn install_project_assignment_hook(session_id: &str) -> Arc<ProjectAssignmentHook> {
+        let hook = Arc::new(ProjectAssignmentHook {
+            reached: Notify::new(),
+            resume: Notify::new(),
+        });
+        project_assignment_hooks()
+            .lock()
+            .unwrap()
+            .insert(session_id.to_string(), hook.clone());
+        hook
+    }
+
+    pub(super) async fn pause_project_assignment(session_id: &str) {
+        let hook = project_assignment_hooks()
+            .lock()
+            .unwrap()
+            .remove(session_id);
+        if let Some(hook) = hook {
+            hook.reached.notify_one();
+            hook.resume.notified().await;
+        }
+    }
 
     /// A tool whose real output is trivially distinguishable from the
     /// synthetic "Selected response: Approve" placeholder `submit_pending_response`
@@ -1736,6 +1827,7 @@ mod reexecute_and_child_approval_tests {
             .expect("approve replay");
         let mut session = outcome.session;
         session.add_message(Message::user("continue after replay"));
+        let original_version = session.metadata_version;
 
         agent
             .run_session(&mut session)
@@ -1743,6 +1835,24 @@ mod reexecute_and_child_approval_tests {
             .expect("normal run should complete");
 
         assert_eq!(tool.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(session.metadata_version, original_version + 1);
+        let reopened = bamboo_storage::SessionStoreV2::new(
+            agent
+                .session_store
+                .as_ref()
+                .unwrap()
+                .bamboo_home_dir()
+                .to_path_buf(),
+        )
+        .await
+        .unwrap();
+        let persisted = reopened
+            .load_root_authority(&session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.metadata_version, original_version + 1);
+        assert_eq!(persisted.project_id_meta(), session.project_id_meta());
         let canonical = project_path
             .path()
             .canonicalize()
@@ -1797,6 +1907,191 @@ mod reexecute_and_child_approval_tests {
         assert!(workspace_context.contains(canonical.to_string_lossy().as_ref()));
         assert!(workspace_context.contains("Workspace source: project_default"));
         assert!(workspace_context.contains("Binding status: registered"));
+    }
+
+    async fn root_context_test_agent(
+        data_dir: &std::path::Path,
+        project_path: &std::path::Path,
+    ) -> (Agent, Arc<RealOutputTool>, Arc<CountingDoneProvider>) {
+        let project = bamboo_projects::ProjectStore::open(data_dir)
+            .unwrap()
+            .create_with_project_path(
+                "Context fence Project",
+                None,
+                project_path.to_string_lossy(),
+                Vec::new(),
+            )
+            .unwrap();
+        std::fs::write(
+            data_dir.join("config.json"),
+            r#"{
+            "provider":"anthropic",
+            "providers":{"anthropic":{"api_key":"test-key","model":"claude-test"}}
+        }"#,
+        )
+        .unwrap();
+        let tool = Arc::new(RealOutputTool::new());
+        let provider = Arc::new(CountingDoneProvider {
+            calls: AtomicUsize::new(0),
+        });
+        let agent = AgentBuilder::new()
+            .provider(provider.clone())
+            .model("claude-test")
+            .instruction("configured System")
+            .project_id(project.id.to_string())
+            .tool_shared(tool.clone())
+            .with_defaults_for_data_dir(data_dir.to_path_buf())
+            .await
+            .unwrap()
+            .build()
+            .unwrap();
+        (agent, tool, provider)
+    }
+
+    #[tokio::test]
+    async fn root_context_fence_sdk_first_project_assignment_rejects_final_store_race() {
+        let data = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let (agent, tool, provider) = root_context_test_agent(data.path(), workspace.path()).await;
+        let mut session = seed_gated_tool_session("sdk-root-context-race", "context-race-call");
+        session.metadata.insert(
+            PERMISSION_REEXECUTE_METADATA_KEY.to_string(),
+            "context-race-call".to_string(),
+        );
+        agent.storage().save_session(&session).await.unwrap();
+        let second = bamboo_storage::SessionStoreV2::new(data.path().to_path_buf())
+            .await
+            .unwrap();
+        let before = serde_json::to_vec(&session).unwrap();
+        let session_path = data
+            .path()
+            .join("sessions")
+            .join(&session.id)
+            .join("session.json");
+        let before_history = std::fs::read(&session_path).unwrap();
+        let before_workspace = bamboo_agent_core::workspace_state::get_workspace(&session.id);
+        let hook = install_project_assignment_hook(&session.id);
+        let mut winner = session.clone();
+        winner.set_project_id_meta("competing-project");
+        winner.metadata_version += 1;
+        let (tx, mut rx) = mpsc::channel(16);
+        let run = agent.execute_internal(&mut session, tx, CancellationToken::new());
+        let compete = async {
+            tokio::time::timeout(std::time::Duration::from_secs(5), hook.reached.notified())
+                .await
+                .unwrap();
+            second.save_runtime_state(&winner).await.unwrap();
+            hook.resume.notify_one();
+        };
+        let (result, ()) = tokio::join!(run, compete);
+        let error = result.expect_err("final V2 writer must reject the competing assignment");
+        assert!(
+            matches!(error, AgentError::ProjectContext(ref message) if message.contains("authority conflict")),
+            "{error}"
+        );
+        assert_eq!(serde_json::to_vec(&session).unwrap(), before);
+        assert_eq!(std::fs::read(&session_path).unwrap(), before_history);
+        assert_eq!(
+            bamboo_agent_core::workspace_state::get_workspace(&session.id),
+            before_workspace
+        );
+        assert_eq!(tool.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+        assert!(rx.try_recv().is_err());
+        let persisted = second
+            .load_root_authority(&session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.project_id_meta(), winner.project_id_meta());
+        assert_eq!(persisted.metadata_version, winner.metadata_version);
+    }
+
+    #[tokio::test]
+    async fn root_context_fence_sdk_first_project_assignment_uses_canonical_root_with_stale_index()
+    {
+        let data = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let (agent, _, _) = root_context_test_agent(data.path(), workspace.path()).await;
+        let second = bamboo_storage::SessionStoreV2::new(data.path().to_path_buf())
+            .await
+            .unwrap();
+        let mut session = Session::new("sdk-root-context-stale-index", "claude-test");
+        session.add_message(Message::user("continue"));
+        second.save_session(&session).await.unwrap();
+        assert!(
+            agent
+                .storage()
+                .load_session(&session.id)
+                .await
+                .unwrap()
+                .is_none(),
+            "SDK instance intentionally predates this Root"
+        );
+        agent.run_session(&mut session).await.unwrap();
+        let persisted = second
+            .load_root_authority(&session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.metadata_version, 1);
+        assert_eq!(
+            persisted.project_id_meta().as_deref(),
+            agent.project_id.as_ref().map(|id| id.as_str())
+        );
+        assert_eq!(session.metadata_version, 1);
+
+        let mut unsaved = Session::new("sdk-root-context-new", "claude-test");
+        unsaved.add_message(Message::user("first run"));
+        agent.run_session(&mut unsaved).await.unwrap();
+        assert_eq!(
+            unsaved.metadata_version, 0,
+            "new sessions retain the initial revision"
+        );
+        let persisted = second
+            .load_root_authority(&unsaved.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.metadata_version, 0);
+        assert_eq!(persisted.project_id_meta(), unsaved.project_id_meta());
+    }
+
+    #[tokio::test]
+    async fn root_context_fence_sdk_first_project_assignment_overflow_preserves_retry_state() {
+        let data = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let (agent, tool, provider) = root_context_test_agent(data.path(), workspace.path()).await;
+        let mut session = seed_gated_tool_session("sdk-root-context-overflow", "overflow-call");
+        session.metadata_version = u64::MAX;
+        session.metadata.insert(
+            PERMISSION_REEXECUTE_METADATA_KEY.to_string(),
+            "overflow-call".to_string(),
+        );
+        agent.storage().save_session(&session).await.unwrap();
+        let before = serde_json::to_vec(&session).unwrap();
+        let (tx, mut rx) = mpsc::channel(16);
+        let error = agent
+            .execute_internal(&mut session, tx, CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, AgentError::ProjectContext(ref message) if message.contains("revision cannot advance"))
+        );
+        assert_eq!(serde_json::to_vec(&session).unwrap(), before);
+        let persisted = agent
+            .storage()
+            .load_session(&session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            serde_json::to_value(&persisted).unwrap(),
+            serde_json::from_slice::<serde_json::Value>(&before).unwrap()
+        );
+        assert_eq!(tool.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server-tools/tests/session_context_view.rs
+++ b/crates/app/bamboo-server-tools/tests/session_context_view.rs
@@ -403,6 +403,7 @@ async fn optional_project_identity_must_match_exactly_and_be_valid() {
         let mut f = Fixture::new().await;
         if let Some(project) = root_project {
             f.root.set_project_id_meta(project);
+            f.root.metadata_version = f.root.metadata_version.checked_add(1).unwrap();
         }
         if let Some(project) = child_project {
             f.child.set_project_id_meta(project);

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -55,16 +55,17 @@ pub async fn init_storage(
         },
     )?);
 
-    // One-shot, idempotent migration: split each legacy session's runtime
-    // control-plane into a `runtime.json` sidecar so the O(1) runtime-save path
-    // (used heavily during sub-agent spawn) is active immediately. Run inline
+    // One-shot, idempotent migration of legacy Child runtime sidecars. A Root
+    // with a missing sidecar may have lost a newer Project revision, so startup
+    // must not reconstruct its authority from old history. Run inline
     // before the server starts serving so it cannot race concurrent saves; it is
     // a no-op on already-migrated stores (marker file).
     match session_store.migrate_runtime_sidecars().await {
         Ok(0) => {}
         Ok(count) => tracing::info!("Runtime sidecar migration created {count} sidecar(s)"),
         Err(error) => {
-            // Non-fatal: loading tolerates a missing sidecar. Log and continue.
+            // Non-fatal: history reads remain available. Root mutations require
+            // valid canonical runtime authority and fail closed until restored.
             tracing::warn!("Runtime sidecar migration failed (continuing): {error}");
         }
     }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -447,6 +447,16 @@ pub async fn patch_session(
                             bamboo_engine::project_context::WorkspaceSource::Explicit.as_str(),
                         )));
         if membership_changed || workspace_changed {
+            let Some(next_version) = session.metadata_version.checked_add(1) else {
+                return Ok(HttpResponse::Conflict().json(serde_json::json!({
+                    "error": {
+                        "type": "api_error",
+                        "code": "session_metadata_revision_exhausted",
+                        "message": "Session metadata revision cannot advance"
+                    },
+                    "session_id": session_id,
+                })));
+            };
             match target.as_ref() {
                 Some(project_id) if membership_changed => {
                     session.set_project_id_meta(project_id.to_string())
@@ -472,7 +482,7 @@ pub async fn patch_session(
                     );
                 }
             }
-            session.metadata_version = session.metadata_version.saturating_add(1);
+            session.metadata_version = next_version;
             session.updated_at = chrono::Utc::now();
 
             // Resolve and replace the stable Project/Workspace markers through
@@ -486,16 +496,30 @@ pub async fn patch_session(
                 return Ok(project_context_error_response(error));
             }
 
-            state
-                .persistence
-                .storage()
-                .save_session(&session)
-                .await
-                .map_err(|error| {
-                    crate::error::json_internal_server_error(format!(
-                        "Failed to save Project/Workspace update: {error}"
-                    ))
-                })?;
+            #[cfg(test)]
+            patch_test_hooks::pause_after_authoritative_fields(&format!(
+                "project-save:{session_id}"
+            ))
+            .await;
+
+            if let Err(error) = state.persistence.storage().save_session(&session).await {
+                if error
+                    .get_ref()
+                    .is_some_and(|cause| cause.is::<bamboo_domain::SessionAuthorityConflict>())
+                {
+                    return Ok(HttpResponse::Conflict().json(serde_json::json!({
+                        "error": {
+                            "type": "api_error",
+                            "code": "session_authority_conflict",
+                            "message": "Session context changed; reload before updating Project or Workspace"
+                        },
+                        "session_id": session_id,
+                    })));
+                }
+                return Err(crate::error::json_internal_server_error(format!(
+                    "Failed to save Project/Workspace update: {error}"
+                )));
+            }
             state.sessions.insert(
                 session_id.clone(),
                 std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone())),
@@ -1444,6 +1468,152 @@ mod tests {
         state.sessions.insert(
             session_id.to_string(),
             std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session)),
+        );
+    }
+
+    #[actix_web::test]
+    async fn root_context_fence_project_patch_rejects_final_store_race_without_publication() {
+        let state = new_state().await;
+        let workspace = tempdir().unwrap();
+        let project = state
+            .project_store
+            .create_with_project_path(
+                "Requested Project",
+                None,
+                workspace.path().to_string_lossy(),
+                Vec::new(),
+            )
+            .unwrap();
+        let winner_project = state
+            .project_store
+            .create("Competing Project", None)
+            .unwrap();
+        let id = "http-root-context-race";
+        seed_session(&state, id, None, None).await;
+        let cached_before = state.sessions.get(id).unwrap().value().clone();
+        let workspace_before = bamboo_agent_core::workspace_state::peek_workspace(id);
+        let second = bamboo_storage::SessionStoreV2::new(state.app_data_dir.clone())
+            .await
+            .unwrap();
+        let mut winner = second.load_session(id).await.unwrap().unwrap();
+        winner.set_project_id_meta(winner_project.id.to_string());
+        winner.metadata_version += 1;
+        let path = state
+            .app_data_dir
+            .join("sessions")
+            .join(id)
+            .join("session.json");
+        let history_before = std::fs::read(&path).unwrap();
+        let mut feed = state.account_sink.subscribe();
+        let hook = super::patch_test_hooks::install(&format!("project-save:{id}"));
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let patch = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/v1/sessions/{id}"))
+                .insert_header((header::IF_MATCH, "\"0\""))
+                .set_json(serde_json::json!({"project_id":project.id, "title":"Must not publish"}))
+                .to_request(),
+        );
+        let compete = async {
+            tokio::time::timeout(std::time::Duration::from_secs(5), hook.reached.notified())
+                .await
+                .unwrap();
+            second.save_runtime_state(&winner).await.unwrap();
+            hook.resume.notify_one();
+        };
+        let (response, ()) = tokio::join!(patch, compete);
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["error"]["code"], "session_authority_conflict");
+        assert!(std::sync::Arc::ptr_eq(
+            &cached_before,
+            state.sessions.get(id).unwrap().value()
+        ));
+        assert_eq!(
+            bamboo_agent_core::workspace_state::peek_workspace(id),
+            workspace_before
+        );
+        assert_eq!(std::fs::read(path).unwrap(), history_before);
+        let persisted = second.load_root_authority(id).await.unwrap().unwrap();
+        assert_eq!(
+            persisted.project_id_meta().as_deref(),
+            Some(winner_project.id.as_str())
+        );
+        assert_eq!(persisted.metadata_version, 1);
+        assert_eq!(persisted.title, "Original title");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), feed.recv())
+                .await
+                .is_err(),
+            "rejected Project/Title mutation must not publish an account event"
+        );
+    }
+
+    #[actix_web::test]
+    async fn root_context_fence_project_and_workspace_patch_overflow_preserves_state() {
+        let state = new_state().await;
+        let project_path = tempdir().unwrap();
+        let project = state
+            .project_store
+            .create_with_project_path(
+                "Overflow Project",
+                None,
+                project_path.path().to_string_lossy(),
+                Vec::new(),
+            )
+            .unwrap();
+        let workspace = tempdir().unwrap();
+        let id = "http-root-context-overflow";
+        let mut session = bamboo_agent_core::Session::new(id, "model");
+        session.metadata_version = u64::MAX;
+        state.storage.save_session(&session).await.unwrap();
+        let cached = std::sync::Arc::new(bamboo_engine::SessionSnapshot::new(session.clone()));
+        state.sessions.insert(id.to_string(), cached.clone());
+        let before = serde_json::to_vec(&session).unwrap();
+        let mut feed = state.account_sink.subscribe();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        for request in [
+            serde_json::json!({"project_id":project.id}),
+            serde_json::json!({"workspace_path":workspace.path().to_string_lossy()}),
+        ] {
+            let response = test::call_service(
+                &app,
+                test::TestRequest::patch()
+                    .uri(&format!("/api/v1/sessions/{id}"))
+                    .insert_header((header::IF_MATCH, format!("\"{}\"", u64::MAX)))
+                    .set_json(request)
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+            let body: Value = test::read_body_json(response).await;
+            assert_eq!(body["error"]["code"], "session_metadata_revision_exhausted");
+            let persisted = state.storage.load_session(id).await.unwrap().unwrap();
+            assert_eq!(
+                serde_json::to_value(&persisted).unwrap(),
+                serde_json::from_slice::<Value>(&before).unwrap()
+            );
+            assert!(std::sync::Arc::ptr_eq(
+                &cached,
+                state.sessions.get(id).unwrap().value()
+            ));
+        }
+        assert!(bamboo_agent_core::workspace_state::peek_workspace(id).is_none());
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), feed.recv())
+                .await
+                .is_err()
         );
     }
 

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -1721,6 +1721,8 @@ mod tests {
             .expect("load session")
             .expect("session exists");
         session.set_project_id_meta("../malformed");
+        session.metadata_version = session.metadata_version.checked_add(1).unwrap();
+        let malformed_version = session.metadata_version;
         state
             .storage
             .save_session(&session)
@@ -1731,7 +1733,7 @@ mod tests {
             &app,
             test::TestRequest::patch()
                 .uri(&format!("/api/v1/sessions/{id}"))
-                .insert_header((header::IF_MATCH, "\"0\""))
+                .insert_header((header::IF_MATCH, format!("\"{malformed_version}\"")))
                 .set_json(serde_json::json!({ "project_id": null }))
                 .to_request(),
         )
@@ -1748,7 +1750,7 @@ mod tests {
             reloaded.project_id_meta().is_none(),
             "explicit null must clear even a malformed legacy value"
         );
-        assert_eq!(reloaded.metadata_version, 1);
+        assert_eq!(reloaded.metadata_version, malformed_version + 1);
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/schedule_app/scheduler_tool.rs
+++ b/crates/app/bamboo-server/src/schedule_app/scheduler_tool.rs
@@ -966,6 +966,7 @@ mod tests {
                     .expect("test schedule Project")
                     .to_string(),
             );
+            caller.metadata_version = caller.metadata_version.checked_add(1).unwrap();
             state.storage.save_session(&caller).await.unwrap();
             let error = tool
                 .invoke(

--- a/crates/app/bamboo-server/src/session_app/metadata_tests.rs
+++ b/crates/app/bamboo-server/src/session_app/metadata_tests.rs
@@ -446,6 +446,7 @@ async fn manual_title_beats_generated_title_without_lying_event() {
 async fn set_pinned_then_runtime_save_does_not_clobber() {
     let state = make_state().await;
     seed_session(&state, "p1", "Title").await;
+    let mut runtime_copy = state.storage.load_session("p1").await.unwrap().unwrap();
 
     SessionMetadataService::set_pinned(&state, "p1", true, None)
         .await
@@ -455,11 +456,6 @@ async fn set_pinned_then_runtime_save_does_not_clobber() {
     let after_pin = state.storage.load_session("p1").await.unwrap().unwrap();
     assert!(after_pin.pinned);
     assert_eq!(after_pin.metadata_version, 1);
-
-    let mut runtime_copy = Session::new("p1".to_string(), "test-model");
-    runtime_copy.pinned = false;
-    runtime_copy.metadata_version = 0;
-    runtime_copy.title = "Title".to_string();
 
     state
         .persistence

--- a/crates/engine/bamboo-engine/src/runtime/agent.rs
+++ b/crates/engine/bamboo-engine/src/runtime/agent.rs
@@ -95,6 +95,29 @@ impl Agent {
         .await
     }
 
+    /// Resolve a proposed SDK Project assignment without publishing a runtime
+    /// workspace. The caller must persist the validated candidate before the
+    /// ordinary execution handoff publishes it or replays an approved tool.
+    pub async fn prepare_external_project_assignment_read_only(
+        &self,
+        session: &mut Session,
+    ) -> crate::runtime::runner::Result<()> {
+        let resolver = self
+            .runtime
+            .project_context_resolver
+            .as_deref()
+            .ok_or_else(|| {
+                bamboo_agent_core::AgentError::ProjectContext(
+                    "Project assignment requires a ProjectContextResolver".to_string(),
+                )
+            })?;
+        resolver
+            .refresh_session_prompt_read_only(session)
+            .await
+            .map(|_| ())
+            .map_err(|error| bamboo_agent_core::AgentError::ProjectContext(error.to_string()))
+    }
+
     /// Acquire direct logical-session ownership before an SDK facade performs
     /// pre-execution work such as replaying an approved mutating tool.
     pub async fn begin_direct_execution(

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -45,6 +45,13 @@ use dashmap::DashMap;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
 const AUTHORITATIVE_METADATA_KEYS: &[&str] = &["gold_config", "workflow.run_ids.v1"];
+const ROOT_PROJECT_CONTEXT_KEYS: &[&str] = &[
+    "workspace_source",
+    "workspace_binding_status",
+    "project_context_rendered",
+    "project_resources_rendered",
+    "runtime_prompt_snapshot",
+];
 const RESPONSE_CONTROL_METADATA_KEYS: &[&str] = &[
     CONSUMED_CLARIFICATION_IDS_KEY,
     CONSUMED_RESPONSE_OCCURRENCES_KEY,
@@ -1435,6 +1442,44 @@ fn apply_authoritative_metadata(session: &mut Session, latest: &Session) {
     if session.authority_identity.is_ordinary() && session.created_at == latest.created_at {
         session.authority_identity = latest.authority_identity.clone();
     }
+    // Project and its revision are one fence. Never stamp a newer disk revision
+    // onto the caller's old Project; that would manufacture a fresh-looking
+    // stale assignment. Equal-revision runtime workspace refreshes within the
+    // same Project remain valid, while an actual reassignment adopts its whole
+    // workspace context before the caller can be published to a cache.
+    if session.kind == bamboo_domain::SessionKind::Root
+        && latest.kind == bamboo_domain::SessionKind::Root
+        && session.created_at == latest.created_at
+        && latest.metadata_version >= session.metadata_version
+        && (latest.metadata_version > session.metadata_version
+            || latest.project_id_meta() != session.project_id_meta())
+    {
+        match latest.project_id_meta() {
+            Some(project) => session.set_project_id_meta(project),
+            None => session.clear_project_id_meta(),
+        }
+        match latest.workspace_path_meta() {
+            Some(workspace) => session.set_workspace_path_meta(workspace),
+            None => {
+                session.metadata.remove("workspace_path");
+                if let Some(metadata) = session.runtime_metadata.as_mut() {
+                    metadata.workspace_path = None;
+                }
+            }
+        }
+        session.workspace.clone_from(&latest.workspace);
+        for key in ROOT_PROJECT_CONTEXT_KEYS {
+            match latest.metadata.get(*key) {
+                Some(value) => {
+                    session.metadata.insert((*key).to_string(), value.clone());
+                }
+                None => {
+                    session.metadata.remove(*key);
+                }
+            }
+        }
+        session.prompt_snapshot.clone_from(&latest.prompt_snapshot);
+    }
     if latest.metadata_version >= session.metadata_version {
         session.title = latest.title.clone();
         session.title_version = latest.title_version;
@@ -1503,6 +1548,138 @@ mod tests {
         inner: Arc<SessionStoreV2>,
         reached: tokio::sync::Barrier,
         release: tokio::sync::Barrier,
+    }
+
+    #[tokio::test]
+    async fn root_project_merge_publishes_project_revision_and_workspace_together() {
+        for runtime_only in [false, true] {
+            for equal_revision in [false, true] {
+                let temp = tempfile::tempdir().unwrap();
+                let storage = Arc::new(SessionStoreV2::new(temp.path().into()).await.unwrap());
+                let mut stale = Session::new("root-project-merge", "model");
+                stale.set_project_id_meta("project-a");
+                stale.set_workspace_path_meta("/project-a");
+                stale.metadata.insert(
+                    "runtime_prompt_snapshot".into(),
+                    "old Project A prompt".into(),
+                );
+                stale.add_message(bamboo_domain::Message::user("Keep transcript"));
+                storage.save_session(&stale).await.unwrap();
+                let mut current = stale.clone();
+                current.metadata_version += 1;
+                current.set_project_id_meta("project-b");
+                current.set_workspace_path_meta("/project-b");
+                current.metadata.remove("runtime_prompt_snapshot");
+                current
+                    .metadata
+                    .insert("workspace_source".into(), "project_default".into());
+                current
+                    .metadata
+                    .insert("project_context_rendered".into(), "Project B".into());
+                storage.save_session(&current).await.unwrap();
+                if equal_revision {
+                    // The pre-fix merge could already have copied only the
+                    // version. Reconcile this equal-version divergent Project.
+                    stale.metadata_version = current.metadata_version;
+                }
+                let locked = LockedSessionStore::new(storage.clone());
+                let published = AtomicBool::new(false);
+                let publish = |saved: &Session| {
+                    assert!(!saved.metadata.contains_key("runtime_prompt_snapshot"));
+                    assert_eq!(saved.project_id_meta().as_deref(), Some("project-b"));
+                    assert_eq!(saved.workspace_path_meta().as_deref(), Some("/project-b"));
+                    assert_eq!(saved.metadata_version, current.metadata_version);
+                    assert_eq!(
+                        saved.metadata.get("workspace_source").map(String::as_str),
+                        Some("project_default")
+                    );
+                    assert_eq!(
+                        saved
+                            .metadata
+                            .get("project_context_rendered")
+                            .map(String::as_str),
+                        Some("Project B")
+                    );
+                    published.store(true, Ordering::SeqCst);
+                };
+                if runtime_only {
+                    locked
+                        .save_runtime_only_and_publish(&mut stale, publish)
+                        .await
+                        .unwrap();
+                } else {
+                    locked
+                        .merge_save_runtime_and_publish(&mut stale, |saved, committed| {
+                            assert!(committed);
+                            publish(saved);
+                        })
+                        .await
+                        .unwrap();
+                }
+                assert!(published.load(Ordering::SeqCst));
+                assert_eq!(stale.project_id_meta(), current.project_id_meta());
+                let loaded = storage.load_session(&stale.id).await.unwrap().unwrap();
+                assert_eq!(loaded.project_id_meta(), current.project_id_meta());
+                assert_eq!(loaded.messages.len(), 1);
+                storage.flush_search_index().await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn root_project_change_after_merge_read_rejects_without_cache_publication() {
+        for runtime_only in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let first = Arc::new(SessionStoreV2::new(temp.path().into()).await.unwrap());
+            let mut stale = Session::new("root-project-race", "model");
+            stale.set_project_id_meta("project-a");
+            stale.add_message(bamboo_domain::Message::user("Keep transcript"));
+            first.save_session(&stale).await.unwrap();
+            let second = SessionStoreV2::new(temp.path().into()).await.unwrap();
+            let mut current = stale.clone();
+            current.metadata_version += 1;
+            current.set_project_id_meta("project-b");
+            let paused = Arc::new(AuthoritySavePauseStorage {
+                inner: first.clone(),
+                reached: tokio::sync::Barrier::new(2),
+                release: tokio::sync::Barrier::new(2),
+            });
+            let locked = LockedSessionStore::new(paused.clone());
+            let published = AtomicBool::new(false);
+            let save = async {
+                if runtime_only {
+                    locked
+                        .save_runtime_only_and_publish(&mut stale, |_| {
+                            published.store(true, Ordering::SeqCst);
+                        })
+                        .await
+                } else {
+                    locked
+                        .merge_save_runtime_and_publish(&mut stale, |_, _| {
+                            published.store(true, Ordering::SeqCst);
+                        })
+                        .await
+                }
+            };
+            let update = async {
+                paused.reached.wait().await;
+                second.save_session(&current).await.unwrap();
+                paused.release.wait().await;
+            };
+            let (result, ()) = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                tokio::join!(save, update)
+            })
+            .await
+            .expect("deterministic Project/save race completes");
+            assert!(!may_publish_runtime_result(&Err(result.unwrap_err())));
+            assert!(!published.load(Ordering::SeqCst));
+            let loaded = first.load_session(&current.id).await.unwrap().unwrap();
+            assert_eq!(loaded.project_id_meta(), current.project_id_meta());
+            assert_eq!(loaded.metadata_version, current.metadata_version);
+            assert_eq!(loaded.messages.len(), 1);
+            first.flush_search_index().await;
+            second.flush_search_index().await;
+        }
     }
 
     #[async_trait::async_trait]
@@ -2013,6 +2190,7 @@ mod tests {
         storage.save_session(&durable).await.unwrap();
 
         let mut cached = fresh(session_id);
+        cached.created_at = durable.created_at;
         cached.title = "Stale cached title".to_string();
         cached.updated_at = durable.updated_at + chrono::Duration::seconds(1);
         cached.set_pending_question(
@@ -2265,9 +2443,11 @@ mod tests {
             ),
         ];
         let mut previous_revision = 0;
+        let created_at = fresh(session_id).created_at;
 
         for (index, (requested, configured, expected_effective)) in cases.into_iter().enumerate() {
             let mut activation = fresh(session_id);
+            activation.created_at = created_at;
             activation
                 .agent_runtime_state
                 .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
@@ -2630,6 +2810,7 @@ mod tests {
         storage.save_session(&durable).await.unwrap();
 
         let mut stale = fresh(session_id);
+        stale.created_at = durable.created_at;
         store.merge_save_runtime(&mut stale).await.unwrap();
         let saved = storage.load_session(session_id).await.unwrap().unwrap();
         assert_eq!(
@@ -3667,6 +3848,7 @@ mod tests {
         storage.save_session(&on_disk).await.unwrap();
 
         let mut runtime_copy = fresh(session_id);
+        runtime_copy.created_at = on_disk.created_at;
         runtime_copy.title = "Stale Default".to_string();
         runtime_copy.title_version = 0;
         runtime_copy.title_generated = false;
@@ -3697,6 +3879,7 @@ mod tests {
         storage.save_session(&on_disk).await.unwrap();
 
         let mut runtime_copy = fresh(session_id);
+        runtime_copy.created_at = on_disk.created_at;
         runtime_copy.title = "Stale".to_string();
         runtime_copy.title_version = 1;
         runtime_copy.metadata_version = 0;
@@ -3722,6 +3905,7 @@ mod tests {
         storage.save_session(&on_disk).await.unwrap();
 
         let mut runtime_copy = fresh(session_id);
+        runtime_copy.created_at = on_disk.created_at;
         runtime_copy.pinned = false;
         runtime_copy.metadata_version = 0;
 
@@ -3749,6 +3933,7 @@ mod tests {
         storage.save_session(&on_disk).await.unwrap();
 
         let mut authoritative_copy = fresh(session_id);
+        authoritative_copy.created_at = on_disk.created_at;
         authoritative_copy.title = "New Authoritative".to_string();
         authoritative_copy.title_version = 2;
         authoritative_copy.metadata_version = 4;
@@ -3777,6 +3962,7 @@ mod tests {
         storage.save_session(&on_disk).await.unwrap();
 
         let mut runtime_copy = fresh(session_id);
+        runtime_copy.created_at = on_disk.created_at;
         runtime_copy.title = "Stale".to_string();
         runtime_copy.metadata_version = 0;
         runtime_copy.messages = vec![bamboo_domain::session::types::Message {

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -43,6 +43,9 @@ use bamboo_domain::{
     SupervisorBootstrapReceipt, TaskList, TokenBudgetUsage, DEFAULT_SUPERVISOR_SESSION_ID,
 };
 
+mod root_context;
+#[cfg(test)]
+mod root_context_tests;
 mod supervisor;
 #[cfg(test)]
 mod supervisor_tests;
@@ -2750,6 +2753,7 @@ impl SessionStoreV2 {
         let mut session = overlay_runtime_sidecar(main, sidecar);
         session.messages.clear();
         session.clear_stale_root_token_budget();
+        self.validate_root_context_for_save(&session).await?;
         Ok(Some((abs_dir, session)))
     }
 
@@ -3358,6 +3362,7 @@ impl SessionStoreV2 {
         else {
             return Ok(false);
         };
+        self.validate_root_context_for_save(&current).await?;
         if current.authority_identity != original.authority_identity
             || !Self::runtime_task_owned_snapshot_matches(&current, original)?
         {
@@ -3448,6 +3453,8 @@ impl SessionStoreV2 {
         else {
             return Ok(false);
         };
+        self.validate_root_context_for_save(&current_first).await?;
+        self.validate_root_context_for_save(&current_second).await?;
         if current_first.authority_identity != first_original.authority_identity
             || current_second.authority_identity != second_original.authority_identity
             || !Self::runtime_task_owned_snapshot_matches(&current_first, first_original)?
@@ -3621,10 +3628,22 @@ impl SessionStoreV2 {
     /// their cache. Fail before any write so the locked persistence boundary
     /// can adopt the durable Task fields and retry with one coherent snapshot.
     async fn reject_regressing_runtime_task(&self, incoming: &Session) -> io::Result<()> {
-        if let Some(durable) = self
-            .load_runtime_control_plane_unchecked(&incoming.id)
+        let durable = if incoming.kind == SessionKind::Root {
+            // Root writers also operate with an out-of-date local index. The
+            // final Root fence has validated this canonical sidecar already.
+            Self::read_runtime_sidecar_at(
+                &self
+                    .sessions_dir
+                    .join(&incoming.id)
+                    .join(RUNTIME_SIDECAR_FILE),
+                &incoming.id,
+            )
             .await?
-        {
+        } else {
+            self.load_runtime_control_plane_unchecked(&incoming.id)
+                .await?
+        };
+        if let Some(durable) = durable {
             if Self::ordinary_task_write_would_regress(incoming, &durable)? {
                 return Err(io::Error::new(
                     io::ErrorKind::WouldBlock,
@@ -3663,6 +3682,7 @@ impl SessionStoreV2 {
     /// (potentially huge) `messages` history cleared. This is what makes
     /// runtime-only saves O(1) in conversation length.
     async fn write_runtime_sidecar(&self, abs_dir: &Path, session: &Session) -> io::Result<()> {
+        self.validate_root_context_for_save(session).await?;
         let path = abs_dir.join(RUNTIME_SIDECAR_FILE);
         let snapshot = runtime_sidecar_snapshot(session);
         let bytes =
@@ -3678,6 +3698,7 @@ impl SessionStoreV2 {
         abs_dir: &Path,
         session: &Session,
     ) -> io::Result<()> {
+        self.validate_root_context_for_save(session).await?;
         let path = abs_dir.join(RUNTIME_SIDECAR_FILE);
         let snapshot = runtime_sidecar_snapshot(session);
         let bytes = serde_json::to_vec_pretty(&snapshot)
@@ -3685,14 +3706,13 @@ impl SessionStoreV2 {
         durable_atomic_write(&path, &bytes).await
     }
 
-    /// One-shot migration: create the runtime sidecar (`runtime.json`) for every
-    /// existing session that predates the message/control-plane split.
+    /// One-shot migration of legacy Child sidecars (`runtime.json`).
     ///
     /// Loading already tolerates a missing sidecar (it falls back to the embedded
-    /// control-plane in `session.json`), so this is an *optimization* migration,
-    /// not a correctness one — but running it once means the fast runtime-save
-    /// path is in effect immediately for legacy sessions, and the denormalized
-    /// `children` id vectors (now `#[serde(skip)]`) drop out of the sidecar.
+    /// control-plane in `session.json`). A main-only Root is indistinguishable
+    /// from a Root that lost a newer Project revision, so it remains readable
+    /// but cannot be reconstructed here. Its canonical runtime must be restored
+    /// before any mutation; this migration cannot establish that authority.
     ///
     /// Idempotent and cheap on later boots: guarded by a marker file, and any
     /// session that already has a sidecar is skipped. Returns the number of
@@ -4320,6 +4340,8 @@ impl SessionStoreV2 {
             return Ok(false);
         };
 
+        self.validate_root_context_for_save(&session).await?;
+
         // Keep only the first System message if present; drop all other messages.
         let system_msg = session
             .messages
@@ -4836,6 +4858,7 @@ impl Storage for SessionStoreV2 {
             .acquire_session_write_lock(&session.id, SaveKind::Full)
             .await?;
         self.validate_authority_for_save(session).await?;
+        self.validate_root_context_for_full_save(session).await?;
         self.reject_regressing_runtime_task(session).await?;
 
         let mut stages = SaveStageDurations::default();
@@ -4919,7 +4942,27 @@ impl Storage for SessionStoreV2 {
         // session.json — which carries the full conversation history — untouched.
         // Ordinary sessions retain O(1) I/O in conversation length. Supervisor
         // validation additionally reads main-file bytes to verify its identity.
-        let Some(rel) = self.resolve_rel_path(&session.id).await else {
+        validate_session_id(&session.id)?;
+        let mut rel = self.resolve_rel_path(&session.id).await;
+        if rel.is_none() && session.kind == SessionKind::Root {
+            // The index is only a hint. Another Store may have created this
+            // Root since our index loaded. Keep the existing Root on the
+            // runtime path so a context update cannot overwrite its history.
+            // Either canonical file is enough to select this path, never to
+            // authorize it: the final guard requires the complete valid pair.
+            let directory = self.sessions_dir.join(&session.id);
+            for file in ["session.json", RUNTIME_SIDECAR_FILE] {
+                match fs::symlink_metadata(directory.join(file)).await {
+                    Ok(_) => {
+                        rel = Some(Self::root_rel_path(&session.id));
+                        break;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+        let Some(rel) = rel else {
             // Session was never fully persisted yet — fall back to a full save so
             // session.json and the index get created. Deliberately acquire no
             // shared Task guard before this call: `save_session` owns that
@@ -4932,6 +4975,7 @@ impl Storage for SessionStoreV2 {
             .acquire_session_write_lock(&session.id, SaveKind::Runtime)
             .await?;
         self.validate_authority_for_save(session).await?;
+        self.validate_root_context_for_save(session).await?;
         self.reject_regressing_runtime_task(session).await?;
         let abs_dir = self.abs_path_from_rel(&rel);
         let mut stages = SaveStageDurations::default();
@@ -4953,22 +4997,35 @@ impl Storage for SessionStoreV2 {
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
         let project_id = normalized_project_id(session);
-        let runtime_index_changed = self
-            .get_index_entry(&session.id)
-            .await
-            .is_some_and(|entry| {
-                entry.workspace_path != workspace_path || entry.project_id != project_id
-            });
+        let runtime_index_changed = self.get_index_entry(&session.id).await.is_none_or(|entry| {
+            entry.workspace_path != workspace_path || entry.project_id != project_id
+        });
         if runtime_index_changed {
             let index_started = Instant::now();
-            self.update_index(|index| {
-                if let Some(entry) = index.sessions.get_mut(&session.id) {
-                    entry.workspace_path = workspace_path;
-                    entry.project_id = project_id;
-                }
-                Ok(())
-            })
-            .await?;
+            let index_updated = self
+                .update_index(|index| {
+                    if let Some(entry) = index.sessions.get_mut(&session.id) {
+                        entry.workspace_path = workspace_path;
+                        entry.project_id = project_id;
+                        return Ok(true);
+                    }
+                    Ok(false)
+                })
+                .await?;
+            if !index_updated && session.kind == SessionKind::Root {
+                // Exceptional recovery of a globally missing index entry must
+                // preserve the real history count, not the caller's snapshot.
+                // Only this recovery path reads main; ordinary runtime saves
+                // and a merely stale local index remain transcript-independent.
+                let authoritative = self
+                    .load_authoritative_root_session(&session.id)
+                    .await?
+                    .ok_or_else(|| {
+                        other_io_error("runtime Root disappeared during index repair")
+                    })?;
+                self.repair_index_from_authoritative_session(&authoritative, rel.clone())
+                    .await?;
+            }
             stages.index_publication = index_started.elapsed();
         }
         let index_entry_count = self.index.read().await.sessions.len();
@@ -7090,6 +7147,7 @@ mod tests {
         );
 
         session.set_project_id_meta(" 01JPROJECTLATEST00000000000 ");
+        session.metadata_version += 1;
         storage.save_runtime_state(&session).await?;
         assert_eq!(
             storage
@@ -7247,15 +7305,21 @@ mod tests {
     // ── ⑤ Runtime sidecar migration ──────────────────────────────────────
 
     #[tokio::test]
-    async fn migration_backfills_sidecars_for_legacy_sessions() -> io::Result<()> {
+    async fn migration_backfills_sidecars_for_legacy_children() -> io::Result<()> {
         let temp_dir = TempDir::new().map_err(io::Error::other)?;
         let bamboo_home = temp_dir.path().to_path_buf();
         let storage = SessionStoreV2::new(bamboo_home.clone()).await?;
 
-        // Persist two sessions, then delete their sidecars to simulate the
-        // legacy on-disk layout (session.json only).
-        let a = session_with_history("mig-a", 3, "run-A");
-        let b = session_with_history("mig-b", 1, "run-B");
+        // Child migration remains compatible. A main-only Root is ambiguous
+        // and cannot establish a current Project revision through migration.
+        let parent = Session::new("migration-root", "model");
+        storage.save_session(&parent).await?;
+        let mut a = Session::new_child("mig-a", &parent.id, "model", "child");
+        a.messages = session_with_history("history-a", 3, "run-A").messages;
+        a.agent_runtime_state = Some(AgentRuntimeState::new("run-A"));
+        let mut b = Session::new_child("mig-b", &parent.id, "model", "child");
+        b.messages = session_with_history("history-b", 1, "run-B").messages;
+        b.agent_runtime_state = Some(AgentRuntimeState::new("run-B"));
         storage.save_session(&a).await?;
         storage.save_session(&b).await?;
         for id in ["mig-a", "mig-b"] {
@@ -7306,7 +7370,11 @@ mod tests {
         // old denormalized children id vectors. After migration the sidecar must
         // not contain them (they are now derived from the index).
         let (storage, _t) = create_temp_storage().await?;
-        let mut s = session_with_history("mig-legacy", 1, "run-L");
+        let parent = Session::new("migration-root", "model");
+        storage.save_session(&parent).await?;
+        let mut s = Session::new_child("mig-legacy", &parent.id, "model", "child");
+        s.messages = session_with_history("history-legacy", 1, "run-L").messages;
+        s.agent_runtime_state = Some(AgentRuntimeState::new("run-L"));
         storage.save_session(&s).await?;
 
         // Hand-write a legacy session.json containing children.active_ids and

--- a/crates/infra/bamboo-storage/src/v2/root_context.rs
+++ b/crates/infra/bamboo-storage/src/v2/root_context.rs
@@ -1,0 +1,149 @@
+//! Final writer fence for the existing Root context revision and birth marker.
+//! This uses the small canonical sidecar, never the transcript or index.
+
+use super::*;
+use bamboo_domain::SessionAuthorityConflict;
+
+fn conflict(message: impl Into<String>) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::WouldBlock,
+        SessionAuthorityConflict(format!(
+            "Root context changed or unavailable: {}",
+            message.into()
+        )),
+    )
+}
+
+async fn regular_file_exists(path: &Path) -> io::Result<bool> {
+    let metadata = match fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(conflict(format!("{}: {error}", path.display()))),
+    };
+    if !metadata.file_type().is_file() {
+        return Err(conflict("canonical Root context is not a regular file"));
+    }
+    Ok(true)
+}
+
+async fn empty_creation_layout(directory: &Path) -> io::Result<bool> {
+    let mut entries = fs::read_dir(directory).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        if !matches!(entry.file_name().to_str(), Some("children" | "attachments"))
+            || !entry.file_type().await?.is_dir()
+            || fs::read_dir(entry.path())
+                .await?
+                .next_entry()
+                .await?
+                .is_some()
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+impl SessionStoreV2 {
+    /// The caller holds either the ordinary per-session writer lock or the
+    /// exclusive Task/lifecycle boundary that excludes all ordinary writers.
+    /// A missing sidecar beside an existing main file is ambiguous: it may be
+    /// legacy, or may have lost a newer Project revision. History readers may
+    /// fall back to main, but no writer may republish that fallback as authority.
+    pub(super) async fn validate_root_context_for_save(
+        &self,
+        incoming: &Session,
+    ) -> io::Result<()> {
+        self.validate_root_context_for_write(incoming, false).await
+    }
+
+    /// A full save may finish an interrupted create, or restore a missing main
+    /// file from a still-valid runtime fence. It cannot advance that fence while
+    /// completing the pair. Ordinary runtime/Task writes cannot do this repair.
+    pub(super) async fn validate_root_context_for_full_save(
+        &self,
+        incoming: &Session,
+    ) -> io::Result<()> {
+        self.validate_root_context_for_write(incoming, true).await
+    }
+
+    async fn validate_root_context_for_write(
+        &self,
+        incoming: &Session,
+        full: bool,
+    ) -> io::Result<()> {
+        validate_session_id(&incoming.id)?;
+        let directory = self.sessions_dir.join(&incoming.id);
+        match fs::symlink_metadata(&directory).await {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(conflict(error.to_string())),
+            Ok(metadata) if !metadata.file_type().is_dir() => {
+                return Err(conflict("canonical Root directory is not a real directory"));
+            }
+            Ok(_) => {}
+        }
+        if incoming.kind != SessionKind::Root {
+            return Err(conflict(
+                "an existing Root cannot be overwritten as a Child",
+            ));
+        }
+        let has_main = regular_file_exists(&directory.join("session.json")).await?;
+        let runtime = directory.join(RUNTIME_SIDECAR_FILE);
+        let has_runtime = regular_file_exists(&runtime).await?;
+        if !has_main {
+            if !full {
+                return Err(conflict("canonical main file is missing"));
+            }
+            if !has_runtime
+                && empty_creation_layout(&directory)
+                    .await
+                    .map_err(|error| conflict(error.to_string()))?
+            {
+                return Ok(());
+            }
+        }
+        if !has_runtime {
+            return Err(conflict("canonical runtime file is missing"));
+        }
+        let bytes = fs::read(runtime)
+            .await
+            .map_err(|error| conflict(error.to_string()))?;
+        let current: Session = serde_json::from_slice(&bytes)
+            .map_err(|error| conflict(format!("invalid canonical runtime: {error}")))?;
+        if current.id != incoming.id
+            || current.kind != SessionKind::Root
+            || current.parent_session_id.is_some()
+            || current.spawn_depth != 0
+            || (!current.root_session_id.is_empty() && current.root_session_id != current.id)
+            || incoming.parent_session_id.is_some()
+            || incoming.spawn_depth != 0
+            || (!incoming.root_session_id.is_empty() && incoming.root_session_id != incoming.id)
+            || current.created_at != incoming.created_at
+            || current.authority_identity != incoming.authority_identity
+        {
+            return Err(conflict(
+                "writer does not match the durable Root creation identity",
+            ));
+        }
+        if incoming.metadata_version < current.metadata_version {
+            return Err(conflict(
+                "metadata revision regressed; reload before saving",
+            ));
+        }
+        if incoming.project_id_meta() != current.project_id_meta()
+            && current.metadata_version.checked_add(1) != Some(incoming.metadata_version)
+        {
+            return Err(conflict(
+                "Project changes require the next metadata revision",
+            ));
+        }
+        if !has_main
+            && (incoming.metadata_version != current.metadata_version
+                || incoming.project_id_meta() != current.project_id_meta())
+        {
+            return Err(conflict(
+                "completing a partial Root cannot advance its context",
+            ));
+        }
+        Ok(())
+    }
+}

--- a/crates/infra/bamboo-storage/src/v2/root_context_tests.rs
+++ b/crates/infra/bamboo-storage/src/v2/root_context_tests.rs
@@ -1,0 +1,717 @@
+//! Root Project revisions and creation identity at the raw storage boundary.
+
+use super::*;
+use bamboo_domain::{
+    AgentRuntimeState, Message, SessionAuthorityConflict, SessionPermissionMode, TaskItem,
+};
+use tempfile::TempDir;
+
+struct Fixture {
+    first: SessionStoreV2,
+    second: SessionStoreV2,
+    home: TempDir,
+}
+
+impl Fixture {
+    async fn new(initial: &Session, runtime: bool) -> Self {
+        let home = tempfile::tempdir().unwrap();
+        let first = SessionStoreV2::new(home.path().to_path_buf())
+            .await
+            .unwrap();
+        save(&first, initial, runtime).await.unwrap();
+        // Load the published index before testing a second independent writer.
+        // Otherwise its runtime save would take the new-session full-save fallback.
+        let second = SessionStoreV2::new(home.path().to_path_buf())
+            .await
+            .unwrap();
+        assert!(second.get_index_entry(&initial.id).await.is_some());
+        Self {
+            first,
+            second,
+            home,
+        }
+    }
+
+    async fn finish(self) {
+        self.first.flush_search_index().await;
+        self.second.flush_search_index().await;
+        drop(self.first);
+        drop(self.second);
+        self.home.close().unwrap();
+    }
+}
+
+fn root() -> Session {
+    let mut session = Session::new("project-root", "original-model");
+    session.metadata_version = 7;
+    session.set_project_id_meta("project-a");
+    session.set_workspace_path_meta("/workspace/project-a");
+    session.agent_runtime_state = Some(AgentRuntimeState::default());
+    session
+        .agent_runtime_state
+        .as_mut()
+        .unwrap()
+        .set_permission_mode(SessionPermissionMode::Auto);
+    session.add_message(Message::system("Preserved system context"));
+    session.add_message(Message::user("Preserved user history"));
+    session
+}
+
+fn directory(store: &SessionStoreV2, id: &str) -> PathBuf {
+    store.sessions_root_dir().join(id)
+}
+
+async fn files(store: &SessionStoreV2, id: &str) -> [Option<Vec<u8>>; 3] {
+    let directory = directory(store, id);
+    [
+        fs::read(directory.join("session.json")).await.ok(),
+        fs::read(directory.join(RUNTIME_SIDECAR_FILE)).await.ok(),
+        fs::read(store.index_path()).await.ok(),
+    ]
+}
+
+async fn save(store: &SessionStoreV2, session: &Session, runtime: bool) -> io::Result<()> {
+    if runtime {
+        store.save_runtime_state(session).await
+    } else {
+        store.save_session(session).await
+    }
+}
+
+async fn reject_without_writes(store: &SessionStoreV2, candidate: &Session) {
+    let before = files(store, &candidate.id).await;
+    for runtime in [false, true] {
+        let error = save(store, candidate, runtime).await.unwrap_err();
+        assert!(
+            error
+                .get_ref()
+                .is_some_and(|error| error.is::<SessionAuthorityConflict>()),
+            "runtime={runtime}: {error:?}"
+        );
+        assert_eq!(
+            files(store, &candidate.id).await,
+            before,
+            "rejected runtime={runtime} writer changed canonical files or the index"
+        );
+    }
+}
+
+async fn assert_context(store: &SessionStoreV2, expected: &Session) {
+    let current = store.load_session(&expected.id).await.unwrap().unwrap();
+    assert_eq!(current.project_id_meta(), expected.project_id_meta());
+    assert_eq!(current.metadata_version, expected.metadata_version);
+    assert_eq!(current.created_at, expected.created_at);
+    assert_eq!(current.model, expected.model);
+    assert_eq!(
+        serde_json::to_value(&current.messages).unwrap(),
+        serde_json::to_value(&expected.messages).unwrap()
+    );
+    assert_eq!(
+        current
+            .agent_runtime_state
+            .as_ref()
+            .unwrap()
+            .effective_permission_mode(),
+        expected
+            .agent_runtime_state
+            .as_ref()
+            .unwrap()
+            .effective_permission_mode()
+    );
+}
+
+#[tokio::test]
+async fn independent_stores_reject_stale_project_full_and_runtime_snapshots() {
+    for authoritative_runtime in [false, true] {
+        let initial = root();
+        let fixture = Fixture::new(&initial, false).await;
+        let mut stale = fixture
+            .second
+            .load_session(&initial.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut current = initial.clone();
+        current.metadata_version += 1;
+        current.set_project_id_meta("project-b");
+        current.set_workspace_path_meta("/workspace/project-b");
+        save(&fixture.first, &current, authoritative_runtime)
+            .await
+            .unwrap();
+
+        stale.model = "stale-model".into();
+        stale.messages.clear();
+        stale.agent_runtime_state = Some(AgentRuntimeState::default());
+        reject_without_writes(&fixture.second, &stale).await;
+        assert_context(&fixture.first, &current).await;
+        fixture.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn project_changes_require_exactly_the_next_revision() {
+    let initial = root();
+    let fixture = Fixture::new(&initial, false).await;
+    for revision in [initial.metadata_version, initial.metadata_version + 2] {
+        let mut divergent = initial.clone();
+        divergent.set_project_id_meta("project-b");
+        divergent.metadata_version = revision;
+        reject_without_writes(&fixture.second, &divergent).await;
+    }
+    assert_context(&fixture.first, &initial).await;
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn project_aba_removal_and_reassignment_advance_without_reviving_old_snapshots() {
+    for runtime in [false, true] {
+        let initial = root();
+        let fixture = Fixture::new(&initial, false).await;
+        let mut current = initial.clone();
+        for project in [
+            Some("project-b"),
+            Some("project-a"),
+            None,
+            Some("project-a"),
+        ] {
+            let previous = current.clone();
+            current.metadata_version = current.metadata_version.checked_add(1).unwrap();
+            if let Some(project) = project {
+                current.set_project_id_meta(project);
+            } else {
+                current.clear_project_id_meta();
+            }
+            save(&fixture.first, &current, runtime).await.unwrap();
+            reject_without_writes(&fixture.second, &previous).await;
+            reject_without_writes(&fixture.second, &initial).await;
+            assert_context(&fixture.first, &current).await;
+        }
+        fixture.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn unchanged_project_accepts_newer_ui_revision_and_rejects_lower_revision() {
+    for runtime in [false, true] {
+        let initial = root();
+        let fixture = Fixture::new(&initial, false).await;
+        let mut current = initial.clone();
+        current.metadata_version += 3;
+        current.title = "New UI title".into();
+        current.pinned = true;
+        save(&fixture.second, &current, runtime).await.unwrap();
+        let persisted = fixture
+            .first
+            .load_session(&current.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.title, "New UI title");
+        assert!(persisted.pinned);
+        assert_context(&fixture.first, &current).await;
+
+        let mut stale = current.clone();
+        stale.metadata_version -= 1;
+        reject_without_writes(&fixture.first, &stale).await;
+        current
+            .metadata
+            .insert("last_run_status".into(), "completed".into());
+        save(&fixture.first, &current, runtime).await.unwrap();
+        assert_context(&fixture.second, &current).await;
+        fixture.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn project_revision_overflow_cannot_publish_a_wrapped_or_equal_revision() {
+    let mut initial = root();
+    initial.metadata_version = u64::MAX;
+    let fixture = Fixture::new(&initial, false).await;
+    for revision in [0, u64::MAX] {
+        let mut candidate = initial.clone();
+        candidate.metadata_version = revision;
+        candidate.set_project_id_meta("project-b");
+        reject_without_writes(&fixture.second, &candidate).await;
+    }
+    assert_context(&fixture.first, &initial).await;
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn root_creation_time_is_immutable_even_with_a_newer_revision() {
+    let initial = root();
+    let fixture = Fixture::new(&initial, false).await;
+    let mut candidate = initial.clone();
+    candidate.created_at += chrono::Duration::seconds(1);
+    candidate.metadata_version += 1;
+    reject_without_writes(&fixture.second, &candidate).await;
+    assert_context(&fixture.first, &initial).await;
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn deleting_and_recreating_a_root_does_not_revalidate_its_old_snapshot() {
+    let initial = root();
+    let fixture = Fixture::new(&initial, false).await;
+    let stale = fixture
+        .second
+        .load_session(&initial.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(fixture.first.delete_session(&initial.id).await.unwrap());
+    let mut replacement = initial.clone();
+    replacement.created_at += chrono::Duration::seconds(1);
+    replacement.model = "replacement-model".into();
+    replacement.messages = vec![Message::user("Replacement history")];
+    fixture.first.save_session(&replacement).await.unwrap();
+
+    reject_without_writes(&fixture.second, &stale).await;
+    let mut stale_newer_revision = stale;
+    stale_newer_revision.metadata_version += 1;
+    reject_without_writes(&fixture.second, &stale_newer_revision).await;
+    assert_context(&fixture.first, &replacement).await;
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn strict_root_authority_rejects_divergent_main_and_runtime_creation_times() {
+    for file in ["session.json", RUNTIME_SIDECAR_FILE] {
+        let initial = root();
+        let fixture = Fixture::new(&initial, false).await;
+        let path = directory(&fixture.first, &initial.id).join(file);
+        let mut contents: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).await.unwrap()).unwrap();
+        contents["created_at"] =
+            serde_json::json!(initial.created_at + chrono::Duration::seconds(1));
+        fs::write(path, serde_json::to_vec(&contents).unwrap())
+            .await
+            .unwrap();
+        let before = files(&fixture.first, &initial.id).await;
+        assert!(
+            fixture
+                .second
+                .load_root_authority(&initial.id)
+                .await
+                .is_err(),
+            "{file}"
+        );
+        assert_eq!(files(&fixture.first, &initial.id).await, before);
+        fixture.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn history_fallback_cannot_revive_missing_or_corrupt_root_runtime_authority() {
+    for missing in [false, true] {
+        let initial = root();
+        let fixture = Fixture::new(&initial, false).await;
+        let mut current = initial.clone();
+        current.metadata_version += 1;
+        current.set_project_id_meta("project-b");
+        fixture.first.save_runtime_state(&current).await.unwrap();
+        let path = directory(&fixture.first, &initial.id).join(RUNTIME_SIDECAR_FILE);
+        if missing {
+            fs::remove_file(path).await.unwrap();
+        } else {
+            fs::write(path, b"invalid runtime JSON").await.unwrap();
+        }
+
+        let compatible = fixture
+            .second
+            .load_session(&initial.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_context(&fixture.second, &initial).await;
+        assert!(fixture
+            .second
+            .load_root_authority(&initial.id)
+            .await
+            .is_err());
+        reject_without_writes(&fixture.second, &compatible).await;
+        reject_without_writes(&fixture.second, &current).await;
+        fixture.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn new_roots_and_ordinary_runtime_updates_preserve_model_history_and_permissions() {
+    for runtime in [false, true] {
+        let initial = root();
+        let fixture = Fixture::new(&initial, runtime).await;
+        assert_context(&fixture.second, &initial).await;
+        let main_before = files(&fixture.first, &initial.id).await[0].clone();
+        let mut current = initial.clone();
+        current
+            .metadata
+            .insert("last_run_status".into(), "completed".into());
+        fixture.second.save_runtime_state(&current).await.unwrap();
+        assert_eq!(files(&fixture.first, &initial.id).await[0], main_before);
+        assert_context(&fixture.first, &current).await;
+        let authority = fixture
+            .first
+            .load_root_authority(&current.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(authority.created_at, current.created_at);
+        assert_eq!(authority.metadata_version, current.metadata_version);
+        assert_eq!(authority.project_id_meta(), current.project_id_meta());
+        assert!(authority.messages.is_empty());
+        fixture.finish().await;
+    }
+}
+
+async fn make_runtime_unavailable(store: &SessionStoreV2, id: &str, missing: bool) {
+    let path = directory(store, id).join(RUNTIME_SIDECAR_FILE);
+    if missing {
+        fs::remove_file(path).await.unwrap();
+    } else {
+        fs::write(path, b"invalid runtime authority").await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn clear_rejects_unavailable_root_authority_before_deleting_attachments() {
+    for missing in [false, true] {
+        let initial = root();
+        let fixture = Fixture::new(&initial, false).await;
+        let attachment = directory(&fixture.first, &initial.id)
+            .join("attachments")
+            .join("preserve.txt");
+        fs::write(&attachment, b"Preserved attachment")
+            .await
+            .unwrap();
+        make_runtime_unavailable(&fixture.first, &initial.id, missing).await;
+        let before = files(&fixture.first, &initial.id).await;
+
+        assert!(fixture.first.clear_session(&initial.id).await.is_err());
+        assert_eq!(files(&fixture.first, &initial.id).await, before);
+        assert_eq!(fs::read(attachment).await.unwrap(), b"Preserved attachment");
+        assert_context(&fixture.second, &initial).await;
+        fixture.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn migration_without_a_marker_cannot_reconstruct_missing_root_authority() {
+    let initial = root();
+    let fixture = Fixture::new(&initial, false).await;
+    let mut current = initial.clone();
+    current.metadata_version += 1;
+    current.set_project_id_meta("project-b");
+    fixture.first.save_runtime_state(&current).await.unwrap();
+    make_runtime_unavailable(&fixture.first, &initial.id, true).await;
+    let marker = fixture.home.path().join(RUNTIME_SIDECAR_MIGRATION_MARKER);
+    assert!(!marker.exists());
+    let before = files(&fixture.first, &initial.id).await;
+
+    assert!(fixture.first.migrate_runtime_sidecars().await.is_err());
+    assert_eq!(files(&fixture.first, &initial.id).await, before);
+    assert!(!marker.exists());
+    assert_context(&fixture.second, &initial).await;
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn task_cas_rejects_unavailable_root_authority_before_publishing_any_endpoint_or_journal() {
+    for missing in [false, true] {
+        let mut original = root();
+        original.task_list = Some(TaskList {
+            session_id: original.id.clone(),
+            title: "Original task".into(),
+            items: vec![TaskItem {
+                id: "task-1".into(),
+                description: "Original work".into(),
+                ..Default::default()
+            }],
+            created_at: original.created_at,
+            updated_at: original.updated_at,
+        });
+        original.set_task_list_version_meta("1");
+        let fixture = Fixture::new(&original, false).await;
+        let mut child = Session::new_child("child-context", &original.id, "model", "child");
+        child.task_list = original.task_list.clone();
+        child.set_task_list_version_meta("1");
+        child.add_message(Message::user("Preserved child history"));
+        fixture.first.save_session(&child).await.unwrap();
+
+        let mut updated = original.clone();
+        updated.task_list.as_mut().unwrap().items[0].description = "Stale task result".into();
+        updated.set_task_list_version_meta("2");
+        let mut child_updated = child.clone();
+        child_updated.task_list = updated.task_list.clone();
+        child_updated.set_task_list_version_meta("2");
+        let mut current = original.clone();
+        current.metadata_version += 1;
+        current.set_project_id_meta("project-b");
+        current.task_list.as_mut().unwrap().items[0].description = "Latest work".into();
+        current.set_task_list_version_meta("3");
+        fixture.first.save_runtime_state(&current).await.unwrap();
+        make_runtime_unavailable(&fixture.first, &original.id, missing).await;
+
+        let root_before = files(&fixture.first, &original.id).await;
+        let child_dir = directory(&fixture.first, &original.id)
+            .join("children")
+            .join(&child.id);
+        let child_main = fs::read(child_dir.join("session.json")).await.unwrap();
+        let child_runtime = fs::read(child_dir.join(RUNTIME_SIDECAR_FILE))
+            .await
+            .unwrap();
+        assert!(fixture
+            .first
+            .take_runtime_task_durability_events()
+            .is_empty());
+        assert!(fixture
+            .first
+            .save_task_control_plane_if_matches(&original, &updated)
+            .await
+            .is_err());
+        assert!(fixture
+            .first
+            .save_task_control_planes_atomically(&child, &child_updated, &original, &updated)
+            .await
+            .is_err());
+        assert!(fixture
+            .first
+            .take_runtime_task_durability_events()
+            .is_empty());
+        assert!(fixture
+            .first
+            .runtime_task_journal_paths()
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(files(&fixture.first, &original.id).await, root_before);
+        assert_eq!(
+            fs::read(child_dir.join("session.json")).await.unwrap(),
+            child_main
+        );
+        assert_eq!(
+            fs::read(child_dir.join(RUNTIME_SIDECAR_FILE))
+                .await
+                .unwrap(),
+            child_runtime
+        );
+        assert_context(&fixture.second, &original).await;
+        fixture.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn full_creation_retry_accepts_only_empty_known_directories_without_canonical_files() {
+    for contents in [
+        "empty",
+        "unknown-file",
+        "nonempty-children",
+        "nonempty-attachments",
+        "symlink",
+    ] {
+        if contents == "symlink" && !cfg!(unix) {
+            continue;
+        }
+        let initial = root();
+        let fixture = Fixture::new(&initial, false).await;
+        let mut candidate = initial.clone();
+        candidate.id = "partial-root".into();
+        candidate.root_session_id = candidate.id.clone();
+        let partial = directory(&fixture.first, &candidate.id);
+        fs::create_dir_all(partial.join("children")).await.unwrap();
+        fs::create_dir(partial.join("attachments")).await.unwrap();
+        let preserved_file = match contents {
+            "unknown-file" => Some(partial.join("unknown.json")),
+            "nonempty-children" => Some(partial.join("children").join("preserve.txt")),
+            "nonempty-attachments" => Some(partial.join("attachments").join("preserve.txt")),
+            "symlink" => {
+                #[cfg(unix)]
+                {
+                    let external = fixture.home.path().join("external-attachments");
+                    fs::create_dir(&external).await.unwrap();
+                    fs::remove_dir(partial.join("attachments")).await.unwrap();
+                    std::os::unix::fs::symlink(external, partial.join("attachments")).unwrap();
+                }
+                None
+            }
+            "empty" => None,
+            _ => unreachable!(),
+        };
+        if let Some(path) = preserved_file.as_ref() {
+            fs::write(path, b"Preserved partial-root bytes")
+                .await
+                .unwrap();
+        }
+
+        if contents == "empty" {
+            fixture.second.save_session(&candidate).await.unwrap();
+            assert_context(&fixture.second, &candidate).await;
+            let authority = fixture
+                .first
+                .load_root_authority(&candidate.id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(authority.created_at, candidate.created_at);
+            assert_eq!(authority.project_id_meta(), candidate.project_id_meta());
+        } else {
+            reject_without_writes(&fixture.second, &candidate).await;
+            if let Some(path) = preserved_file {
+                assert_eq!(
+                    fs::read(path).await.unwrap(),
+                    b"Preserved partial-root bytes"
+                );
+            }
+            if contents == "symlink" {
+                assert!(fs::symlink_metadata(partial.join("attachments"))
+                    .await
+                    .unwrap()
+                    .file_type()
+                    .is_symlink());
+            }
+        }
+        assert_context(&fixture.first, &initial).await;
+        fixture.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn missing_main_allows_only_full_retry_with_the_exact_runtime_root_context() {
+    let initial = root();
+    let fixture = Fixture::new(&initial, false).await;
+    let original_main = files(&fixture.first, &initial.id).await[0].clone();
+    fs::remove_file(directory(&fixture.first, &initial.id).join("session.json"))
+        .await
+        .unwrap();
+    let before = files(&fixture.first, &initial.id).await;
+    for changed in [
+        "created_at",
+        "identity",
+        "project",
+        "project-next",
+        "revision",
+    ] {
+        let mut candidate = initial.clone();
+        match changed {
+            "created_at" => candidate.created_at += chrono::Duration::seconds(1),
+            "identity" => candidate.root_session_id = "other-root".into(),
+            "project" => candidate.set_project_id_meta("project-b"),
+            "project-next" => {
+                candidate.set_project_id_meta("project-b");
+                candidate.metadata_version += 1;
+            }
+            "revision" => candidate.metadata_version += 1,
+            _ => unreachable!(),
+        }
+        reject_without_writes(&fixture.second, &candidate).await;
+    }
+
+    let error = fixture
+        .second
+        .save_runtime_state(&initial)
+        .await
+        .unwrap_err();
+    assert!(error
+        .get_ref()
+        .is_some_and(|error| error.is::<SessionAuthorityConflict>()));
+    assert_eq!(files(&fixture.first, &initial.id).await, before);
+    fixture.second.save_session(&initial).await.unwrap();
+    let completed = files(&fixture.first, &initial.id).await;
+    assert_eq!(completed[0], original_main);
+    assert_eq!(completed[1], before[1]);
+    assert_context(&fixture.first, &initial).await;
+    let authority = fixture
+        .first
+        .load_root_authority(&initial.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(authority.created_at, initial.created_at);
+    assert_eq!(authority.project_id_meta(), initial.project_id_meta());
+    assert_eq!(authority.metadata_version, initial.metadata_version);
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn runtime_save_with_a_stale_index_preserves_canonical_history_and_task_generation() {
+    for global_entry_missing in [false, true] {
+        let home = tempfile::tempdir().unwrap();
+        let stale_store = SessionStoreV2::new(home.path().to_path_buf())
+            .await
+            .unwrap();
+        let publisher = SessionStoreV2::new(home.path().to_path_buf())
+            .await
+            .unwrap();
+        let mut stale = root();
+        stale.task_list = Some(TaskList {
+            session_id: stale.id.clone(),
+            title: "Old task".into(),
+            items: vec![TaskItem::default()],
+            created_at: stale.created_at,
+            updated_at: stale.updated_at,
+        });
+        stale.set_task_list_version_meta("1");
+        let mut published = stale.clone();
+        published.add_message(Message::user(
+            "New history absent from the runtime candidate",
+        ));
+        published.task_list.as_mut().unwrap().title = "Current task".into();
+        published.set_task_list_version_meta("3");
+        publisher.save_session(&published).await.unwrap();
+        if global_entry_missing {
+            publisher
+                .update_index(|index| {
+                    index.sessions.remove(&published.id);
+                    Ok(())
+                })
+                .await
+                .unwrap();
+        }
+        assert!(stale_store.get_index_entry(&stale.id).await.is_none());
+        let before = files(&publisher, &published.id).await;
+        let error = stale_store.save_runtime_state(&stale).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert_eq!(files(&publisher, &published.id).await, before);
+        assert!(stale_store.get_index_entry(&stale.id).await.is_none());
+
+        let mut candidate = stale;
+        candidate.task_list = published.task_list.clone();
+        candidate.set_task_list_version_meta("3");
+        candidate.set_project_id_meta("project-b");
+        candidate.metadata_version += 1;
+        assert!(candidate.messages.len() < published.messages.len());
+        stale_store.save_runtime_state(&candidate).await.unwrap();
+        assert_eq!(files(&publisher, &published.id).await[0], before[0]);
+        let authority = publisher
+            .load_root_authority(&published.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(authority.project_id_meta().as_deref(), Some("project-b"));
+        assert_eq!(authority.metadata_version, candidate.metadata_version);
+        assert_eq!(authority.created_at, published.created_at);
+        assert_eq!(authority.task_list_version_meta().as_deref(), Some("3"));
+        let local_entry = stale_store.get_index_entry(&published.id).await.unwrap();
+        assert_eq!(local_entry.message_count, published.messages.len());
+        assert_eq!(local_entry.project_id.as_deref(), Some("project-b"));
+        let global: SessionsIndex =
+            serde_json::from_slice(&fs::read(stale_store.index_path()).await.unwrap()).unwrap();
+        assert_eq!(
+            global.sessions[&published.id].message_count,
+            published.messages.len()
+        );
+        assert_eq!(
+            global.sessions[&published.id].project_id.as_deref(),
+            Some("project-b")
+        );
+        published.set_project_id_meta("project-b");
+        published.metadata_version = candidate.metadata_version;
+        assert_context(&stale_store, &published).await;
+        Fixture {
+            first: publisher,
+            second: stale_store,
+            home,
+        }
+        .finish()
+        .await;
+    }
+}

--- a/crates/infra/bamboo-storage/src/v2/supervisor.rs
+++ b/crates/infra/bamboo-storage/src/v2/supervisor.rs
@@ -90,6 +90,7 @@ async fn read_regular(path: &Path) -> io::Result<Vec<u8>> {
 #[derive(Deserialize)]
 struct MainIdentity {
     id: String,
+    created_at: DateTime<Utc>,
     #[serde(default)]
     kind: SessionKind,
     #[serde(default)]
@@ -150,6 +151,7 @@ impl SessionStoreV2 {
             || main.spawn_depth != 0
             || side.spawn_depth != 0
             || main.authority_identity != side.authority_identity
+            || main.created_at != side.created_at
         {
             return Err(invalid("canonical Root identity mismatch"));
         }

--- a/crates/infra/bamboo-storage/src/v2/supervisor_tests.rs
+++ b/crates/infra/bamboo-storage/src/v2/supervisor_tests.rs
@@ -373,16 +373,9 @@ async fn strict_reads_distinguish_absence_from_legacy_compatibility_fallback() {
             .len(),
         1
     );
-    assert_eq!(store.migrate_runtime_sidecars().await.unwrap(), 1);
-    assert_eq!(
-        store
-            .load_root_authority(&legacy.id)
-            .await
-            .unwrap()
-            .unwrap()
-            .authority_identity,
-        SessionAuthorityIdentity::Ordinary
-    );
+    assert!(store.migrate_runtime_sidecars().await.is_err());
+    assert!(!path.exists());
+    assert!(store.load_root_authority(&legacy.id).await.is_err());
 }
 
 #[tokio::test]
@@ -483,6 +476,7 @@ async fn copying_supervisor_preserves_conversation_context_but_creates_ordinary_
         .unwrap();
     source.title = "Coordinator discussion".into();
     source.set_project_id_meta("project-original");
+    source.metadata_version += 1;
     source.set_workspace_path_meta("/workspace/original");
     source.agent_runtime_state = Some(bamboo_domain::AgentRuntimeState::default());
     source

--- a/docs/project-identity.md
+++ b/docs/project-identity.md
@@ -124,6 +124,37 @@ and revisions—never MCP headers, environment values, or credential secrets.
 
 ## Legacy Project assignment
 
+Root persistence protects Project membership with the existing
+`metadata_version` and `created_at`. Full and runtime writes revalidate the
+small canonical `runtime.json` under the cross-process session lock. An older
+revision, a changed creation time, or a different Project without exactly the
+next revision returns a typed storage conflict before files or caches publish.
+Project changes use checked revision increments, including removal and
+reassignment; overflow returns `409 session_metadata_revision_exhausted` from
+Project/Workspace PATCH. A concurrent context change caught at its final writer
+returns `409 session_authority_conflict` and requires reloading before retry.
+
+Merge-save adopts durable Project membership together with its revision and
+workspace context into the caller snapshot. The SDK's first assignment of an
+already persisted Unassigned Root validates the candidate without publishing a
+runtime workspace, advances the revision, commits its sidecar, and only then
+enters normal execution preparation. New unsaved sessions retain revision zero.
+These are stale-snapshot guarantees for trusted storage writers, not an ACL for
+arbitrary Rust callers that deliberately fabricate newer revisions.
+
+A Root with missing or corrupt runtime state remains readable through the
+legacy history fallback, but cannot be saved, cleared, or rebuilt by automatic
+sidecar migration or Task writes. A main-only legacy Root is indistinguishable
+from one that lost newer Project context. Restoring its correct canonical
+runtime state is required before mutation; reconstructing authority from old
+history is deliberately unavailable. Strict Root authority reads also require
+main/runtime creation times to match. Legacy Child sidecar migration remains
+available. No new identity registry, Project epoch or recovery journal is added.
+An interrupted first create with only empty layout directories can be retried.
+A full save can also complete a missing main file when the valid runtime still
+proves exactly the same creation identity, Project and revision; it cannot
+advance context during that repair. Runtime and Task writes require the pair.
+
 Migration dry-runs match only exact canonical bindings or a safely resolved
 common Git directory. Ambiguous names, missing paths, remote URLs, and path
 hashes remain Unassigned. When a dry-run session supplies only `workspace_path`,


### PR DESCRIPTION
## Summary

Fixes #1091. An ordinary Root snapshot captured before a Project change could overwrite the newer Project, metadata revision or creation identity. Merge-save could also combine an old Project with the new revision. Final V2 writers now reject those stale contexts under the existing cross-process lock, and merge publishes Project, revision, workspace and typed/legacy prompt context together.

SDK first assignment of an existing Unassigned Root uses strict canonical lookup, checked revision advancement and read-only Project preparation, committing before workspace publication or tool/model execution. HTTP Project/Workspace PATCH reports revision exhaustion or a final writer conflict as 409 before cache/events publish.

Normal history fallback remains readable. Existing Roots with missing/corrupt runtime cannot have stale authority reconstructed by ordinary saves, Task writes, clear or automatic migration. Full-save retry may complete an interrupted first create only when both canonical files are absent and the directory contains only empty expected layout directories. It may restore a missing main file only when a valid runtime proves exactly the same creation identity, Project and revision. Runtime saves with stale indexes preserve main history; exceptional global-index repair derives the real message count from canonical history.

This introduces no Supervisor links or new persistence registry/journal. #1071 remains a split tracker. The separate pre-existing fully-deleted-ID recreation case is tracked in #1093 and is excluded from this PR.

## Test Plan

- Deterministic regression on the original dev writer reproduced a stale independent-store save returning success; the fixed raw full/runtime paths reject without changing canonical/index bytes.
- Real V2 regression coverage: Project A→B→A and removal/reassignment, exact revisions/overflow, creation identity, strict pair mismatch, corrupt/missing runtime, clear before attachment deletion, Task CAS before any endpoint/journal publication, partial-create retries, stale/local and globally missing index recovery with preserved transcript counts.
- Merge races verify coherent caller/cache context and zero publication when another store changes Project after the merge read. SDK/HTTP races verify no workspace, tool/provider, cache or account-event publication after a rejected write.
- Formatting (`cargo fmt --all -- --check`) and the repository's exact all-features Clippy command passed on head `0ad309224f10a4b70c6e378c0f949fd025866568`, base `b539f9923701ce0f8648a684859256ce4755ac4b`.
- Full affected library/integration suites passed on reviewed head `0ad309224f10a4b70c6e378c0f949fd025866568`: engine 1,476; SDK 59 plus two facade integration tests; server 1,990 with one pre-existing installed-CLI test ignored; server integration suites 28; server-tools 153 plus 16 tool/export integration tests; storage 224. Command: `cargo test --locked -p bamboo-storage -p bamboo-engine -p bamboo-sdk -p bamboo-server -p bamboo-server-tools --lib --tests --no-fail-fast -- --nocapture`. The earlier default workspace sweep completed the remaining unchanged crates.
- The pre-existing fixed-80-ms account-feed test flake is tracked in #1082. It reproduced once locally, then passed both a focused rerun and the complete final server suite; event-forwarding code is unchanged.
- Current head `5f09c84fad708a7582e5de0f20ee3bc02976e3a9` integrates dev `486b6c02e68fc8118b74f49d91ae9eaab5cdb8a2` (merged metrics PR #1095). The complete #1091 diff is byte-for-byte identical after integration, and independent interface review found no affected Root/SDK/HTTP storage contract. Formatting and the exact CI Clippy command passed on this head. Full integrated storage/SDK/server-tools library and integration suites passed (454 tests); the server Root fence, complete metadata group and scheduler entrypoint tests also passed (18 tests). Complete CI is required on this exact current head before merge.
- Independent review is bound to current head `5f09c84fad708a7582e5de0f20ee3bc02976e3a9` and base `486b6c02e68fc8118b74f49d91ae9eaab5cdb8a2`; no unresolved blocking findings. Required Test, E2E Tests and Lint checks must pass before merge.

## Screenshots

Not applicable: no UI changes.
