### PR TITLE
fix: reject disabling the default provider instance (#1097)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -590,6 +590,17 @@ pub async fn update_provider_instance(
                     })?;
 
                 let updated = apply_instance_update(&existing, &payload_inner)?;
+                // This closure runs under config_io_lock, before either the
+                // metadata or credential transaction can commit. Keep the
+                // explicit default valid instead of failing its reload after
+                // publishing a disabled instance (#1097).
+                if !updated.enabled
+                    && config.default_provider_instance.as_deref() == Some(&instance_id)
+                {
+                    return Err(AppError::BadRequest(format!(
+                        "Cannot disable default provider instance '{instance_id}'; set another enabled provider instance as default first"
+                    )));
+                }
                 config
                     .provider_instances
                     .insert(instance_id.clone(), updated);

--- a/crates/app/bamboo-server/tests/provider_instance_default_disable.rs
+++ b/crates/app/bamboo-server/tests/provider_instance_default_disable.rs
@@ -1,0 +1,499 @@
+//! #1097: invalid instance PUTs must fail before metadata/credential commit.
+//! All provider traffic and all Bamboo/Jiandu data belong to these fixtures.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use actix_web::http::{Method, StatusCode};
+use actix_web::{test, web, App};
+use bamboo_domain::{Message, ProviderModelRef, Role};
+use bamboo_llm::LLMChunk;
+use bamboo_server::{configure_routes, AppState};
+use futures::StreamExt;
+use serde_json::{json, Value};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const INSTANCES: &str = "/api/v1/bamboo/settings/provider-instances";
+const SETTINGS: &str = "/api/v1/bamboo/config/provider-settings";
+const DEFAULT_ID: &str = "fixture-a";
+const OTHER_ID: &str = "fixture-b";
+const MODEL: &str = "fixture-chat";
+
+async fn request(
+    state: &web::Data<AppState>,
+    method: Method,
+    uri: &str,
+    payload: Option<Value>,
+) -> (StatusCode, Value) {
+    let app = test::init_service(
+        App::new()
+            .app_data(state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+    let mut request = test::TestRequest::default().method(method).uri(uri);
+    if let Some(payload) = payload {
+        request = request.set_json(payload);
+    }
+    let response = test::call_service(&app, request.to_request()).await;
+    let status = response.status();
+    (status, test::read_body_json(response).await)
+}
+
+async fn state_from_fixture(data_dir: &Path) -> web::Data<AppState> {
+    web::Data::new(
+        AppState::new_with_memory_store(
+            data_dir.to_path_buf(),
+            bamboo_memory::memory_store::MemoryStore::new(data_dir.join("jiandu")),
+        )
+        .await
+        .expect("synthetic app state"),
+    )
+}
+
+async fn fixture() -> (tempfile::TempDir, MockServer, web::Data<AppState>) {
+    let data_dir = tempfile::tempdir().unwrap();
+    bamboo_config::paths::init_bamboo_dir(data_dir.path().to_path_buf());
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            concat!(
+                "data: {\"id\":\"fixture-response\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"fixture response\"}}]}\n\n",
+                "data: {\"id\":\"fixture-response\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+                "data: [DONE]\n\n"
+            ),
+            "text/event-stream",
+        ))
+        .mount(&upstream)
+        .await;
+    let config: bamboo_config::Config = serde_json::from_value(json!({
+        "headless_auth": true,
+        "features": {"provider_model_ref": true},
+        "default_provider_instance": DEFAULT_ID,
+        "defaults": {
+            "chat": {"provider": DEFAULT_ID, "model": MODEL},
+            "fast": {"provider": DEFAULT_ID, "model": MODEL}
+        },
+        "provider_instances": {
+            DEFAULT_ID: {
+                "provider_type": "openai", "enabled": true,
+                "label": "Synthetic A", "model": MODEL,
+                "base_url": format!("{}/v1", upstream.uri()),
+                "api_key": "synthetic-a-not-a-real-key"
+            },
+            OTHER_ID: {
+                "provider_type": "openai", "enabled": false,
+                "label": "Synthetic B", "model": MODEL,
+                "base_url": format!("{}/v1", upstream.uri()),
+                "api_key": "synthetic-b-not-a-real-key"
+            }
+        }
+    }))
+    .unwrap();
+    let state = state_from_fixture(data_dir.path()).await;
+    state
+        .update_config_with_provider_credentials(
+            move |candidate| {
+                candidate.provider_instances = config.provider_instances.clone();
+                candidate.default_provider_instance = config.default_provider_instance.clone();
+                candidate.defaults = config.defaults.clone();
+                candidate.features = config.features.clone();
+                Ok(())
+            },
+            BTreeSet::new(),
+            BTreeSet::from([DEFAULT_ID.to_string(), OTHER_ID.to_string()]),
+            bamboo_server::app_state::ConfigUpdateEffects {
+                reload_provider: bamboo_config::patch::ReloadMode::Strict,
+                reconcile_mcp: bamboo_config::patch::ReloadMode::None,
+            },
+        )
+        .await
+        .expect("seed synthetic instances through the existing credential transaction");
+    (data_dir, upstream, state)
+}
+
+fn durable_documents(data_dir: &Path) -> BTreeMap<String, Option<Vec<u8>>> {
+    [
+        "config.json",
+        "providers.json",
+        "credentials.json",
+        "model-policy.json",
+        "model_limits.json",
+    ]
+    .into_iter()
+    .flat_map(|name| [name.to_string(), format!("{name}.bak")])
+    .map(|name| {
+        let bytes = match std::fs::read(data_dir.join(&name)) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => panic!("cannot inspect fixture document {name}: {error}"),
+        };
+        (name, bytes)
+    })
+    .collect()
+}
+
+async fn assert_provider_responds(state: &web::Data<AppState>, instance: &str) {
+    let provider = state
+        .get_provider_for_model_ref(&ProviderModelRef::new(instance, MODEL))
+        .expect("configured instance remains routable");
+    let mut stream = provider
+        .chat_stream(&[Message::user("synthetic test message")], &[], None, MODEL)
+        .await
+        .expect("loopback provider accepts chat");
+    let mut text = String::new();
+    while let Some(chunk) = stream.next().await {
+        if let LLMChunk::Token(token) = chunk.unwrap() {
+            text.push_str(&token);
+        }
+    }
+    assert_eq!(text, "fixture response");
+}
+
+async fn assert_execution_completed(state: &web::Data<AppState>, chat: &Value) {
+    let session_id = chat["session_id"].as_str().unwrap();
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let status = state
+                .agent_runners
+                .read()
+                .await
+                .get(session_id)
+                .map(|runner| runner.status.clone());
+            match status {
+                Some(bamboo_server::app_state::AgentStatus::Completed) => break,
+                Some(bamboo_server::app_state::AgentStatus::Error(error)) => {
+                    panic!("synthetic native execution failed: {error}")
+                }
+                Some(bamboo_server::app_state::AgentStatus::Cancelled) => {
+                    panic!("synthetic execution unexpectedly cancelled")
+                }
+                _ => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+    })
+    .await
+    .expect("synthetic native execution completes promptly");
+    let session = state
+        .storage
+        .load_session(session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(session
+        .messages
+        .iter()
+        .any(|message| message.role == Role::Assistant && message.content == "fixture response"));
+}
+
+async fn assert_native_chat(state: &web::Data<AppState>, instance: Option<&str>, message: &str) {
+    let mut chat_payload = json!({"message": message});
+    let mut execute_payload = json!({});
+    if let Some(instance) = instance {
+        let model_ref = json!({"provider": instance, "model": MODEL});
+        chat_payload["model_ref"] = model_ref.clone();
+        execute_payload["model_ref"] = model_ref;
+    }
+    let (status, chat) = request(state, Method::POST, "/api/v1/chat", Some(chat_payload)).await;
+    assert_eq!(status, StatusCode::CREATED);
+    let execution = request(
+        state,
+        Method::POST,
+        &format!("/api/v1/execute/{}", chat["session_id"].as_str().unwrap()),
+        Some(execute_payload),
+    )
+    .await;
+    assert!(
+        execution.0.is_success(),
+        "synthetic native execution must start"
+    );
+    assert_execution_completed(state, &chat).await;
+}
+
+async fn assert_valid_disable_and_default_switch(state: &web::Data<AppState>) {
+    // Having another enabled provider must not silently change the explicit
+    // default; the user must choose the replacement before disabling A.
+    let other_path = format!("{INSTANCES}/{OTHER_ID}");
+    assert_eq!(
+        request(
+            state,
+            Method::PUT,
+            &other_path,
+            Some(json!({"enabled": true}))
+        )
+        .await
+        .0,
+        StatusCode::OK
+    );
+    let enabled = request(state, Method::GET, SETTINGS, None).await;
+    let rejected = request(
+        state,
+        Method::PUT,
+        &format!("{INSTANCES}/{DEFAULT_ID}"),
+        Some(json!({"enabled": false})),
+    )
+    .await;
+    assert_eq!(rejected.0, StatusCode::BAD_REQUEST);
+    assert_eq!(request(state, Method::GET, SETTINGS, None).await, enabled);
+
+    assert_eq!(
+        request(
+            state,
+            Method::PUT,
+            &other_path,
+            Some(json!({"enabled": false}))
+        )
+        .await
+        .0,
+        StatusCode::OK
+    );
+    let disabled = request(state, Method::GET, SETTINGS, None).await.1;
+    assert_eq!(
+        disabled["data"]["provider_instances"][OTHER_ID]["enabled"],
+        false
+    );
+    assert_eq!(disabled["data"]["default_provider_instance_id"], DEFAULT_ID);
+    assert_native_chat(
+        state,
+        Some(DEFAULT_ID),
+        "chat after valid non-default disable",
+    )
+    .await;
+
+    assert_eq!(
+        request(
+            state,
+            Method::PUT,
+            &other_path,
+            Some(json!({"enabled": true}))
+        )
+        .await
+        .0,
+        StatusCode::OK
+    );
+    assert_eq!(
+        request(
+            state,
+            Method::POST,
+            &format!("{INSTANCES}/default"),
+            Some(json!({"default_provider_instance_id": OTHER_ID}))
+        )
+        .await
+        .0,
+        StatusCode::OK
+    );
+    let selected = request(state, Method::GET, SETTINGS, None).await.1;
+    assert_eq!(selected["data"]["default_provider_instance_id"], OTHER_ID);
+    assert_eq!(state.provider_registry.default_provider_name(), OTHER_ID);
+    // Model assignments are an explicit, separate settings choice. Do not
+    // infer a new model-selection policy from changing the default instance.
+    let mut data = selected["data"].clone();
+    data["defaults"]["chat"]["provider"] = json!(OTHER_ID);
+    data["defaults"]["fast"]["provider"] = json!(OTHER_ID);
+    assert_eq!(
+        request(
+            state,
+            Method::PUT,
+            SETTINGS,
+            Some(json!({
+                "expected_revision": selected["revision"], "data": data
+            }))
+        )
+        .await
+        .0,
+        StatusCode::OK
+    );
+    assert_eq!(
+        request(
+            state,
+            Method::PUT,
+            &format!("{INSTANCES}/{DEFAULT_ID}"),
+            Some(json!({"enabled": false}))
+        )
+        .await
+        .0,
+        StatusCode::OK
+    );
+    let settings = request(state, Method::GET, SETTINGS, None).await.1;
+    assert_eq!(settings["data"]["default_provider_instance_id"], OTHER_ID);
+    assert_eq!(state.provider_registry.default_provider_name(), OTHER_ID);
+    assert_eq!(
+        settings["data"]["provider_instances"][DEFAULT_ID]["enabled"],
+        false
+    );
+    assert_eq!(
+        settings["data"]["provider_instances"][OTHER_ID]["enabled"],
+        true
+    );
+    assert_eq!(settings["data"]["defaults"]["chat"]["provider"], OTHER_ID);
+    assert_eq!(settings["data"]["defaults"]["fast"]["provider"], OTHER_ID);
+    let instances = request(state, Method::GET, INSTANCES, None).await.1;
+    assert_eq!(instances["default_provider_instance_id"], OTHER_ID);
+    for instance in instances["instances"].as_array().unwrap() {
+        let id = instance["id"].as_str().unwrap();
+        assert_eq!(
+            instance["enabled"],
+            settings["data"]["provider_instances"][id]["enabled"]
+        );
+    }
+    assert_native_chat(
+        state,
+        None,
+        "implicit-default chat after explicit default switch and old-provider disable",
+    )
+    .await;
+}
+
+#[actix_web::test]
+async fn default_disable_retries_preserve_durable_live_and_restart_state() {
+    let (data_dir, _upstream, state) = fixture().await;
+    assert_provider_responds(&state, DEFAULT_ID).await;
+    assert_native_chat(
+        &state,
+        Some(DEFAULT_ID),
+        "working native chat before invalid disable",
+    )
+    .await;
+    let before = request(&state, Method::GET, SETTINGS, None).await;
+    assert_eq!(before.0, StatusCode::OK);
+    let durable_before = durable_documents(data_dir.path());
+    let live_before = serde_json::to_value(state.config.read().await.clone()).unwrap();
+    // Config serialization deliberately skips plaintext credentials, so the
+    // live snapshot needs an explicit comparison for this synthetic key.
+    let live_key_before = state.config.read().await.provider_instances[DEFAULT_ID]
+        .api_key
+        .clone();
+    assert_eq!(live_key_before, "synthetic-a-not-a-real-key");
+    let provider_before = state.provider.read().await.clone();
+    let registry_before = state.provider_registry.get_default().unwrap();
+    let health_before =
+        serde_json::to_value(state.config_live_health.read().unwrap().clone()).unwrap();
+    let event_seq_before = state.account_sink.latest_seq();
+    let mut statuses = Vec::new();
+    for _ in 0..3 {
+        let (status, body) = request(
+            &state,
+            Method::PUT,
+            &format!("{INSTANCES}/{DEFAULT_ID}"),
+            Some(json!({"enabled": false})),
+        )
+        .await;
+        statuses.push(status);
+        if status == StatusCode::BAD_REQUEST {
+            let message = body["error"]["message"].as_str().unwrap();
+            assert!(message.contains("set another enabled provider instance as default first"));
+            assert_eq!(durable_documents(data_dir.path()), durable_before);
+        }
+    }
+    // The same rejection must precede the credential-owning transaction too,
+    // including both replacement and clear intents carried by an instance PUT.
+    for key in [json!("synthetic-rejected-replacement"), Value::Null] {
+        for _ in 0..3 {
+            let rejected = request(
+                &state,
+                Method::PUT,
+                &format!("{INSTANCES}/{DEFAULT_ID}"),
+                Some(json!({
+                    "enabled": false, "label": "rejected label", "config": {"api_key": key}
+                })),
+            )
+            .await;
+            assert_eq!(rejected.0, StatusCode::BAD_REQUEST);
+            assert!(rejected.1["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("set another enabled provider instance as default first"));
+            assert_eq!(durable_documents(data_dir.path()), durable_before);
+            assert_eq!(request(&state, Method::GET, SETTINGS, None).await, before);
+            assert_eq!(
+                state.config.read().await.provider_instances[DEFAULT_ID].api_key,
+                live_key_before
+            );
+        }
+    }
+    let after = request(&state, Method::GET, SETTINGS, None).await;
+    let chat = request(
+        &state,
+        Method::POST,
+        "/api/v1/chat",
+        Some(json!({
+            "message": "chat after rejected default disable",
+            "model_ref": {"provider": DEFAULT_ID, "model": MODEL}
+        })),
+    )
+    .await;
+    let execution = request(
+        &state,
+        Method::POST,
+        &format!("/api/v1/execute/{}", chat.1["session_id"].as_str().unwrap()),
+        Some(json!({"model_ref": {"provider": DEFAULT_ID, "model": MODEL}})),
+    )
+    .await;
+    eprintln!(
+        "default-disable retries: statuses={statuses:?}, revision_before={}, revision_after={}, live_enabled={}, durable_changed={}, subsequent_chat={}, execution={}",
+        before.1["revision"], after.1["revision"],
+        state.config.read().await.provider_instances[DEFAULT_ID].enabled,
+        durable_documents(data_dir.path()) != durable_before, chat.0, execution.0
+    );
+    assert!(statuses
+        .iter()
+        .all(|status| *status == StatusCode::BAD_REQUEST));
+    assert_eq!(after, before, "canonical provider settings must not change");
+    assert_eq!(durable_documents(data_dir.path()), durable_before);
+    assert_eq!(
+        serde_json::to_value(state.config.read().await.clone()).unwrap(),
+        live_before
+    );
+    assert!(Arc::ptr_eq(
+        &state.provider.read().await.clone(),
+        &provider_before
+    ));
+    assert!(Arc::ptr_eq(
+        &state.provider_registry.get_default().unwrap(),
+        &registry_before
+    ));
+    assert_eq!(state.provider_registry.default_provider_name(), DEFAULT_ID);
+    assert_eq!(
+        serde_json::to_value(state.config_live_health.read().unwrap().clone()).unwrap(),
+        health_before
+    );
+    assert_eq!(
+        chat.0,
+        StatusCode::CREATED,
+        "subsequent native chat must remain available"
+    );
+    assert!(
+        execution.0.is_success(),
+        "native execution must remain available"
+    );
+    assert_execution_completed(&state, &chat.1).await;
+    assert_provider_responds(&state, DEFAULT_ID).await;
+    let provider_events = bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), event_seq_before)
+        .unwrap().into_iter().filter(|entry| matches!(&entry.event,
+            bamboo_agent_core::AgentEvent::ConfigChanged { section, .. }
+            | bamboo_agent_core::AgentEvent::ConfigInvalid { section, .. }
+            | bamboo_agent_core::AgentEvent::ConfigRecovered { section, .. } if section == "providers"
+        )).collect::<Vec<_>>();
+    assert!(
+        provider_events.is_empty(),
+        "rejected PUTs must not publish provider generations"
+    );
+    assert_eq!(
+        state.config.read().await.provider_instances[DEFAULT_ID].api_key,
+        live_key_before
+    );
+    state.shutdown().await;
+    drop(state);
+    let restarted = state_from_fixture(data_dir.path()).await;
+    let restarted_settings = request(&restarted, Method::GET, SETTINGS, None).await;
+    assert_eq!(restarted_settings.1["revision"], before.1["revision"]);
+    assert_eq!(restarted_settings.1["data"], before.1["data"]);
+    assert_provider_responds(&restarted, DEFAULT_ID).await;
+    assert_native_chat(&restarted, Some(DEFAULT_ID), "chat after restart").await;
+    assert_valid_disable_and_default_switch(&restarted).await;
+    restarted.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Fixes #1097.

- Reject a provider-instance PUT that would leave the explicitly selected default disabled. Return canonical HTTP 400 with guidance to select another enabled default first.
- Validate the cloned candidate under the existing configuration lock, before metadata or credential persistence, provider revision changes, live publication, or runtime provider replacement.
- Preserve valid non-default disable and explicit enabled-default switching. No automatic default reselection, new persistence/recovery protocol, frontend change, or unrelated QA repair.

Scope: **two files, 510 insertions: 11 production lines and one focused 499-line regression**. Candidate `46905bda9021632593465b5ec4fd999a160c50d4` is based directly on true dependency-fix merge `5d2077c789ad1b785e8059fc2759a94909d238ba` from #1061 / PR #1099. The production and test blobs, and stable patch identity, are identical to the earlier reviewed `a64dbe7d448f95776968ff3f31d32054ec5ed970`; the old and refreshed candidates differ only in the inherited dependency lockfile. This PR introduces no dependency change relative to its new base.

## Test Plan — refreshed exact head

- [x] Full `cargo metadata --locked --all-features --format-version 1`, formatting, diff checks, exact workspace CI clippy allowances, and strict regression-target clippy passed.
- [x] Unchanged security/dependency gates passed: cargo-audit 0.22.2 `audit --deny warnings`, cargo-deny 0.20.2 `cargo deny check`, and the existing declared-MSRV metadata policy audit. Existing allowed duplicate-version warnings are not represented as resolved; this metadata audit is not a new compiler/MSRV or all-platform proof.
- [x] Default-feature HTTP regression: 1 passed, 0 failed. It covers three rejected metadata retries and credential replacement/clear rejection; durable primary/backup bytes, live synthetic plaintext key, defaults/model preferences, revision, runtime provider identity, health and provider-generation events remain unchanged.
- [x] The same regression verifies subsequent chat, normal shutdown/restart, valid non-default disable and valid explicit default switching followed by implicit/default-routed chat with no supplied model reference.
- [x] Default-feature provider suite: 99 passed. Complete config transaction module: 64 passed. These per-command selections overlap and are not a count of unique tests.
- [x] All-feature focused provider/config transaction selection: 152 library tests plus the HTTP regression passed. Existing cancellation, CAS/stale-revision, invalid-candidate and credential-redaction paths are included.
- [x] `cargo test --locked --workspace --all-features --lib --no-fail-fast`: actual exit 0; **30 top-level targets, 8,110 passed, 0 failed, 1 existing ignored**. Nested helper results are not counted twice. Includes the full server, configuration, engine, LLM, analytics and recorder library suites.
- [x] `cargo test --locked --tests --no-fail-fast`: one natural run, actual exit 0; **75 top-level targets, 8,555 passed, 0 failed, 11 existing ignored**. Includes 208 API E2E tests, 1,990 server library passes plus 1 existing ignored server test, and the new HTTP regression (1 passed, 20.22s). Nested helper results are not counted twice. No local retry, skip change or source repair was needed.
- [x] Exact candidate API-only arm64 CLI build passed; the frozen build artifact was copied into a separate, signed local Bodhi acceptance bundle. The executable-code section matches the frozen artifact; Bodhi executable code and the complete packaged frontend are unchanged. Neither the installed app nor the user's real data stores was modified.
- [x] In the actual refreshed native Bodhi app, repeat Disable on the real default provider. Rejection leaves it enabled; revision **9 -> 9**, default assignments and model preferences remain identical. Without a reload/re-enable or recovery operation, actual `glm-5.3-flash` execution completes with `26 x 17 = 442` / `BODHI_1097_REFRESHED_OK`.
- [x] Fully quit that native app; confirm both app and managed sidecar exit and the port refuses connections. Relaunch the same candidate; settings and history persist and a second actual native model request completes with `27 x 19 = 513` / `BODHI_1097_REFRESHED_RESTART_OK`.
- [x] A supplemental browser recording against the same app-owned backend observes **one PUT / HTTP 400**, not the original three HTTP 500 retries. A fresh settings read and browser reload preserve the enabled/default/model state and revision 9. The browser did not submit either real-model request.
- [x] [Independent exact-head review recorded](https://github.com/bigduu/Bamboo-agent/pull/1098#pullrequestreview-5125540059) on refreshed published head `46905bda9021632593465b5ec4fd999a160c50d4`: PASS, zero blocking or nonblocking code findings. This is agent review, not human approval or a pending-CI waiver.
- [x] All applicable remote CI checks passed on `46905bda9021632593465b5ec4fd999a160c50d4`: 18 successful checks and 3 expected skips (promotion-only Build/Promotion Source and unrequested Claude). [CI run 34037529042](https://github.com/bigduu/Bamboo-agent/actions/runs/34037529042) and [CodeQL run 34037526559](https://github.com/bigduu/Bamboo-agent/actions/runs/34037526559) both completed successfully on attempt 1. Required Test/E2E Tests/Lint, all three OS recorder/TLS jobs, actual Rust 1.95 workspace check, audits, documentation and all CodeQL languages passed. Current head/base, protection, review/thread state and clean mergeability were reverified; the final merge remains expected-head guarded.

All refreshed local commands use isolated synthetic storage and deny access to real Bamboo/Jiandu stores and the complete private native QA fixture. The initial zero-match config filter is recorded as zero tests and is **not** counted as coverage; the corrected full `live_reload_tests` module is the 64-test result above. No old-head or dependency-PR suite result is relabeled as a refreshed-head test.

## Independent Review

Independent code review of `46905bda9021632593465b5ec4fd999a160c50d4` found no code findings after tracing the candidate validation and existing transaction seam. The reviewer independently checked the unchanged two-file patch, inherited lockfile, and renewed native/restart evidence. Final stable test-evidence and published-head reviews are complete, with no findings. All applicable remote checks are now complete and successful; no prior failed run was waived or rerun for this refreshed candidate.

The original review strengthened only the regression assertions for actionable error guidance, explicit live synthetic-credential comparison, and implicit routing after a valid default switch. Those assertions are preserved byte-for-byte in this refreshed candidate.

## Screenshots / Runtime Evidence

Backend-only source change; no frontend visual source change. Refreshed native accessibility/screenshots, separate before/rejected/reloaded/history screenshots, supplemental setting-action video, and allowlisted exact-head/native/restart metadata are retained in the local QA report. The original candidate's evidence is preserved separately. Browser observations corroborate the managed backend and history; they are not substituted for the actual native app actions.

No real credential, private provider endpoint, request headers, raw configuration or private runtime log is included in GitHub or the source. The existing frontend's generic rejection wording, completed-tool false-interruption banner, and broken permission-dialog response routing are separate findings and remain outside this PR.

## Prior CI / dependency hold

The initial `a64dbe7d...` CI run preserved two pre-existing failures: the dependency audit from #1061 and the service-shutdown test tracked by [#878](https://github.com/bigduu/Bamboo-agent/issues/878#issuecomment-5558524060). The user selected retaining this PR while fixing #1061 independently first. That dependency change has now merged through #1099 with all applicable gates passing. This refresh inherits it and restarts exact-head validation; no failed check is waived and no Actix/lifecycle repair is imported into the provider branch.

A separate [post-merge push run on base `5d2077c...`](https://github.com/bigduu/Bamboo-agent/actions/runs/34032586358/job/101484776470) subsequently passed its all-feature stage but failed the default-feature cluster watcher ordering test with `[1]` instead of `[1, 2]`, matching existing [#984](https://github.com/bigduu/Bamboo-agent/issues/984). That base does not contain this provider guard, and the relevant config-runtime blob is unchanged here. This is preserved as a base-only comparison, not a result or waiver for the refreshed candidate; no watcher/assertion/timing repair is added to this PR.

The successful debug CLI build has an existing nonfatal macOS `__eh_frame` size warning. No source, policy or dependency change is added for that unrelated warning.
