### PR TITLE
chore: replace yanked crypto dependencies (#1061)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,9 +2511,9 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -8343,13 +8343,14 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff",
  "group",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #1061.

- Replace the two withdrawn versions already present on `dev`: `der 0.8.0 → 0.8.2` and `wnaf 0.14.0 → 0.14.1`.
- Change only `Cargo.lock` (5 additions, 4 deletions). The one new edge is `wnaf → primefield 0.14.0`, which is already locked; the resolved graph remains 780 packages / 30 workspace members.
- Keep manifests, application code, MSRV and audit/security policy unchanged. No exemption or skipped security gate is added.
- Keep provider-instance repair #1097 / PR #1098 separate and held until this dependency change merges; that PR must then be refreshed, independently reviewed and revalidated.

Exact local-tested head: `22a08c86f1c7053100c3b657e192021155e2c798`. Base at local verification: `9c66fb8cd7e71b604e31da26d7778c84873c3c94`. Candidate lock blob: `731c47e24c86fe08f31112c7805835775c81b0b2`.

## Compatibility and risk

This is a minimal dependency graph update, **not** a claim that upstream behavior is unchanged.

- [DER upstream changelog](https://github.com/RustCrypto/formats/blob/master/der/CHANGELOG.md): the update includes corrected SET OF duplicate handling, a 64-level nesting limit, and rejection of nested trailing data. Valid key/signature roundtrips and these boundary cases were exercised.
- [wnaf upstream changelog](https://github.com/RustCrypto/elliptic-curves/blob/master/wnaf/CHANGELOG.md): the stronger `PrimeFieldExt` bound is an upstream source-breaking correction tied to explicit little-endian scalar representation. Compatibility was checked against the actual locked `russh → p256/p384/p521 → primeorder → wnaf` arithmetic paths, not inferred from the patch version.
- Both selected versions are non-yanked in the current crates.io index and declare Rust 1.85, below Bamboo's required Rust 1.95.
- `der` also affects PKCS/SPKI/SEC1/ECDSA encodings and the existing plugin-signature key path. No new cryptographic or persistence protocol is introduced in this PR.

## Test Plan

Completed local evidence:

- [x] Reproduce exact base audit: `cargo audit --deny warnings` reports precisely the existing `der` and `wnaf` yanked warnings.
- [x] Full before/after `cargo metadata --locked --all-features --format-version 1`, including all dependencies; compare resolved identities, features and edges.
- [x] Actual macOS Rust 1.95 full workspace / all-target-kind / all-feature check; MSRV graph audit and its 3 unit tests. The graph audit checks 587 declared requirements and skips 193 undeclared ones; the independent compile is the local compatibility evidence, not a cross-platform claim.
- [x] CI-pinned `cargo-audit 0.22.2`: updated graph passes `--deny warnings`.
- [x] `cargo-deny 0.20.2`: advisories, bans, licenses and sources pass with existing policy unchanged. Pre-existing policy-allowed duplicate-version warnings remain visible.
- [x] Full all-feature suite: 75 top-level Cargo targets, **8,556 passed**, 11 pre-existing ignored, zero failed. The config target's nested child result is not counted twice.
- [x] Broker: 104 library + 3 bus + 14 WebSocket + 4 secure-WebSocket tests.
- [x] Real Docker-backed SSH/SFTP/reverse-tunnel fixture explicitly runs the normally ignored live test and passes.
- [x] macOS TLS/unwind guard: 5 passed.
- [x] Supplementary exact-artifact crypto probe: 9 passed, covering all three curves, boundary/endian scalar arithmetic, signatures/key encodings, and DER malformed-input handling.
- [x] Non-default analytics workspace member: 5 passed on Rust 1.95.
- [x] Exact CI Clippy allowances with warnings denied; formatting and diff checks; example build.
- [x] Recorder target: updated lock / unchanged source passes 2 unit + 2 lifecycle tests from a neutral source path.
- [x] Default-feature CI test suite: 74 top-level Cargo targets, **8,554 passed**, 11 pre-existing ignored, zero failed. Totals use the same nested-result deduplication rule.
- [x] Independent exact-head review of `22a08c86f1c7053100c3b657e192021155e2c798`: zero blocking or nonblocking code findings; evidence and remote lock identity independently checked.
- [x] All applicable remote CI: [CI run 34030245528, attempt 2](https://github.com/bigduu/Bamboo-agent/actions/runs/34030245528/attempts/2) and [CodeQL run 34030243768](https://github.com/bigduu/Bamboo-agent/actions/runs/34030243768) completed successfully. Test includes both feature suites, real SSH and examples. Three-platform TLS/recorder checks, MSRV, audit/deny, Lint and Documentation pass. Promotion/release-only and unrequested Claude jobs are expected skips. The live head/base, protection, review threads and mergeability are rechecked before protected merge.

### Preserved environment finding

The recorder lifecycle test initially failed at its authorized-path assertion when its fixture was under the task's `.codex` worktree. The existing privacy policy deliberately redacts any path containing that component. An independent archive of the **exact base with the original lock** reproduces the same failure; an identical source snapshot with only this candidate lock, at a neutral path, passes the unchanged command. The two source snapshots differ only in `Cargo.lock`. Original failures are retained; no fixture, privacy rule, or test assertion was changed. This pre-existing fixture-location portability issue is outside #1061. Remote recorder checks on Linux/macOS/Windows must still pass.

The first remote CI attempt failed the unchanged `subagent_create_runs_actor_process_through_the_server` at line 147 (completed child without an assistant reply). Main and independent review verified exact historical same-head/same-lock fail/pass evidence and the current base's passing actor test. This is the existing #983 intermittent handoff failure, not the separate graceful-shutdown test #878; [fresh evidence is recorded on #983](https://github.com/bigduu/Bamboo-agent/issues/983#issuecomment-5558992090). One retry of only the failed Test job passed on the unchanged head, including both complete feature suites, real SSH and examples. The original failure remains visible and is not waived or described as fixed. No actor, Actix, lifecycle, assertion or timeout change is bundled.

## Screenshots

Not applicable: this PR changes only the dependency lockfile and has no UI changes.
