### PR TITLE
fix: bound tool input and preserve exact MCP arguments

### DIFF
--- a/crates/app/bamboo-server-tools/src/overlay_executor.rs
+++ b/crates/app/bamboo-server-tools/src/overlay_executor.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use bamboo_agent_core::tools::input_guard::{check_parsed_tool_input, check_raw_tool_input};
 
 use bamboo_agent_core::tools::{
     parse_tool_args_best_effort, Tool, ToolCall, ToolError, ToolExecutionContext, ToolExecutor,
@@ -70,7 +71,9 @@ impl OverlayToolExecutor {
         call: &ToolCall,
         ctx: ToolExecutionContext<'_>,
     ) -> Result<ToolOutcome, ToolError> {
+        check_raw_tool_input(self.overlay.name(), &call.function.arguments)?;
         let args = self.resolve_args(call, &ctx);
+        check_parsed_tool_input(self.overlay.name(), &args)?;
         if let Some(outcome) = self
             .base
             .check_permissions_for_resolved(call, self.overlay.name(), &args, &ctx)
@@ -342,6 +345,29 @@ mod tests {
                 arguments: "{}".to_string(),
             },
         }
+    }
+
+    #[tokio::test]
+    async fn oversized_overlay_arguments_are_rejected_before_invocation() {
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(BaseExecutor),
+            std::sync::Arc::new(SubAgentOverlayTool),
+        );
+        let mut call = make_call("sub_task");
+        call.function.arguments = json!({"prompt": "x".repeat(256 * 1024)}).to_string();
+        assert!(matches!(
+            overlay.execute(&call).await,
+            Err(ToolError::InvalidArguments(_))
+        ));
+
+        call.function.arguments = "{}".into();
+        let args = json!({"prompt": "x".repeat(256 * 1024)});
+        let mut ctx = ToolExecutionContext::none(&call.id);
+        ctx.pre_parsed_args = Some(&args);
+        assert!(matches!(
+            overlay.execute_with_context(&call, ctx).await,
+            Err(ToolError::InvalidArguments(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/core/bamboo-agent-core/src/tools/input_guard.rs
+++ b/crates/core/bamboo-agent-core/src/tools/input_guard.rs
@@ -1,0 +1,74 @@
+//! Reject oversized arguments before invoking a tool; never truncate a request.
+
+use super::ToolError;
+use serde_json::Value;
+
+const DEFAULT_LIMIT: usize = 256 * 1024;
+const WRITE_LIMIT: usize = 1024 * 1024;
+const QUERY_LIMIT: usize = 64 * 1024;
+
+/// Limits use resolved execution identities, so a namespaced custom tool cannot
+/// inherit the policy of an unrelated built-in with the same suffix.
+pub fn tool_input_limit(execution_name: &str) -> usize {
+    match execution_name {
+        "Write" | "Edit" | "NotebookEdit" => WRITE_LIMIT,
+        "Bash" | "Read" | "Grep" | "Glob" => QUERY_LIMIT,
+        _ => DEFAULT_LIMIT,
+    }
+}
+
+pub fn check_raw_tool_input(execution_name: &str, raw: &str) -> Result<(), ToolError> {
+    check_size(execution_name, raw.len())
+}
+
+/// Check synthesized/preparsed arguments too. The wire check alone does not
+/// constrain values supplied by callers through ToolExecutionContext.
+pub fn check_parsed_tool_input(execution_name: &str, args: &Value) -> Result<(), ToolError> {
+    let size = serde_json::to_vec(args)
+        .map_err(|_| ToolError::InvalidArguments("Could not measure tool arguments".into()))?
+        .len();
+    check_size(execution_name, size)
+}
+
+fn check_size(execution_name: &str, size: usize) -> Result<(), ToolError> {
+    let limit = tool_input_limit(execution_name);
+    if size <= limit {
+        return Ok(());
+    }
+    let advice = match execution_name {
+        "Write" | "Edit" | "NotebookEdit" => "Split the content into smaller writes or patches.",
+        "Bash" | "js_repl" => "Move large inline content into a file and shorten the command.",
+        _ => "Split the request or pass a file reference instead of inline content.",
+    };
+    Err(ToolError::InvalidArguments(format!(
+        "Tool {execution_name} arguments contain {size} bytes; the limit is {limit} bytes. {advice}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn exact_boundary_is_allowed_but_one_more_byte_is_rejected() {
+        let raw = "x".repeat(tool_input_limit("Bash"));
+        assert!(check_raw_tool_input("Bash", &raw).is_ok());
+        let error = check_raw_tool_input("Bash", &(raw + "x")).unwrap_err();
+        assert!(error.to_string().contains("65537 bytes"));
+    }
+
+    #[test]
+    fn utf8_bytes_and_preparsed_values_are_both_bounded() {
+        assert!(check_raw_tool_input("Read", &"字".repeat(30_000)).is_err());
+        assert!(check_parsed_tool_input("Read", &json!({"path":"x".repeat(QUERY_LIMIT)})).is_err());
+        assert!(check_parsed_tool_input("Write", &json!({"content":"字".repeat(30_000)})).is_ok());
+    }
+
+    #[test]
+    fn custom_names_do_not_inherit_builtin_limits() {
+        assert_eq!(tool_input_limit("Write"), WRITE_LIMIT);
+        assert_eq!(tool_input_limit("vendor::Write"), DEFAULT_LIMIT);
+        assert_eq!(tool_input_limit("BashOutput"), DEFAULT_LIMIT);
+    }
+}

--- a/crates/core/bamboo-agent-core/src/tools/mod.rs
+++ b/crates/core/bamboo-agent-core/src/tools/mod.rs
@@ -95,6 +95,7 @@ pub mod agentic;
 pub mod bash_completion;
 pub mod context;
 pub mod executor;
+pub mod input_guard;
 pub mod registry;
 pub mod result_handler;
 pub mod smart_code_review;

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -3,6 +3,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bamboo_agent_core::tools::input_guard::{check_parsed_tool_input, check_raw_tool_input};
 use bamboo_agent_core::{
     parse_tool_args_best_effort, Tool, ToolCall, ToolError, ToolExecutionContext, ToolExecutor,
     ToolOutcome, ToolResult, ToolSchema,
@@ -411,7 +412,9 @@ impl BuiltinToolExecutor {
             .registry
             .get(execution_name)
             .ok_or_else(|| ToolError::NotFound(format!("Tool '{}' not found", execution_name)))?;
+        check_raw_tool_input(execution_name, &call.function.arguments)?;
         let mut args = self.parse_execution_args(call, &ctx);
+        check_parsed_tool_input(execution_name, &args)?;
         self.normalize_registered_builtin_args(
             &call.function.name,
             execution_name,
@@ -1004,6 +1007,22 @@ mod tests {
 
     fn make_tool_call(name: &str, args: serde_json::Value) -> ToolCall {
         make_tool_call_with_id("call_1", name, args)
+    }
+
+    #[tokio::test]
+    async fn oversized_write_is_rejected_before_creating_a_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("oversized.txt");
+        let call = make_tool_call(
+            "write_file",
+            json!({
+                "path": file,
+                "content": "x".repeat(1024 * 1024),
+            }),
+        );
+        let error = BuiltinToolExecutor::new().execute(&call).await.unwrap_err();
+        assert!(matches!(error, ToolError::InvalidArguments(_)));
+        assert!(!file.exists());
     }
 
     fn make_tool_call_with_id(id: &str, name: &str, args: serde_json::Value) -> ToolCall {

--- a/crates/infra/bamboo-mcp/src/arg_coercion.rs
+++ b/crates/infra/bamboo-mcp/src/arg_coercion.rs
@@ -1,0 +1,185 @@
+//! Correct scalar spelling only when the schema has one unambiguous type.
+
+use serde_json::Value;
+
+pub(crate) fn coerce_args_to_schema(value: &mut Value, schema: &Value) {
+    if ["$ref", "anyOf", "oneOf", "allOf", "enum", "const"]
+        .iter()
+        .any(|key| schema.get(key).is_some())
+    {
+        return;
+    }
+    let target = match schema.get("type") {
+        Some(Value::String(t)) => Some(t.as_str()),
+        Some(Value::Array(types)) => {
+            let mut types = types
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|t| *t != "null");
+            let first = types.next();
+            if types.next().is_some() {
+                None
+            } else {
+                first
+            }
+        }
+        _ => None,
+    };
+    match value {
+        Value::Object(fields) => {
+            if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+                for (key, value) in fields {
+                    if let Some(property) = properties.get(key) {
+                        coerce_args_to_schema(value, property);
+                    }
+                }
+            }
+        }
+        Value::Array(items) => {
+            if let Some(item_schema) = schema.get("items").filter(|s| s.is_object()) {
+                for item in items {
+                    coerce_args_to_schema(item, item_schema);
+                }
+            }
+        }
+        Value::String(text) => {
+            let trimmed = text.trim();
+            let replacement = match target {
+                Some("integer") => exact_integer(trimmed),
+                Some("number") => serde_json::from_str::<Value>(trimmed)
+                    .ok()
+                    .filter(Value::is_number),
+                Some("boolean") if trimmed.eq_ignore_ascii_case("true") => Some(Value::Bool(true)),
+                Some("boolean") if trimmed.eq_ignore_ascii_case("false") => {
+                    Some(Value::Bool(false))
+                }
+                _ => None,
+            };
+            if let Some(replacement) = replacement {
+                *value = replacement;
+            }
+        }
+        Value::Number(number) if target == Some("integer") && number.is_f64() => {
+            // Outside this range the parsed float may already have lost digits.
+            if let Some(n) = number
+                .as_f64()
+                .filter(|n| n.fract() == 0.0 && n.abs() <= 9_007_199_254_740_991.0)
+            {
+                *value = Value::from(n as i64);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn exact_integer(text: &str) -> Option<Value> {
+    if let Ok(n) = text.parse::<i64>() {
+        return Some(Value::from(n));
+    }
+    if let Ok(n) = text.parse::<u64>() {
+        return Some(Value::from(n));
+    }
+    if text.len() > 128 {
+        return None;
+    }
+    let (negative, unsigned) = match text.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, text),
+    };
+    let (mantissa, exponent) = match unsigned.split_once(['e', 'E']) {
+        Some((m, e)) => (m, e.parse::<i32>().ok()?),
+        None => (unsigned, 0),
+    };
+    let (whole, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    if whole.is_empty()
+        || !whole
+            .bytes()
+            .chain(fraction.bytes())
+            .all(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+    let mut digits = format!("{whole}{fraction}");
+    let scale = exponent.checked_sub(i32::try_from(fraction.len()).ok()?)?;
+    if scale < 0 {
+        let removed = usize::try_from(scale.checked_neg()?).ok()?;
+        if removed > digits.len() || !digits[digits.len() - removed..].bytes().all(|b| b == b'0') {
+            return None;
+        }
+        digits.truncate(digits.len() - removed);
+    }
+    let digits = digits.trim_start_matches('0');
+    if digits.is_empty() {
+        return Some(Value::from(0));
+    }
+    let zeros = usize::try_from(scale.max(0)).ok()?;
+    if digits.len().checked_add(zeros)? > 20 {
+        return None;
+    }
+    let normalized = format!(
+        "{}{digits}{}",
+        if negative { "-" } else { "" },
+        "0".repeat(zeros)
+    );
+    normalized
+        .parse::<i64>()
+        .map(Value::from)
+        .ok()
+        .or_else(|| normalized.parse::<u64>().map(Value::from).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn large_integers_are_exact_or_left_untouched() {
+        for (input, expected) in [
+            ("9007199254740993.0", json!(9_007_199_254_740_993u64)),
+            ("18446744073709551615", json!(u64::MAX)),
+            ("18446744073709551616", json!("18446744073709551616")),
+            ("-9223372036854775809", json!("-9223372036854775809")),
+            ("1.20e2", json!(120)),
+            ("1.2", json!("1.2")),
+            ("1e999999999", json!("1e999999999")),
+        ] {
+            let mut value = json!(input);
+            coerce_args_to_schema(&mut value, &json!({"type":"integer"}));
+            assert_eq!(value, expected, "{input}");
+        }
+    }
+
+    #[test]
+    fn nested_fields_follow_schema_without_rewriting_strings_or_unions() {
+        let mut value = json!({"count":"200", "on":"TRUE", "name":"200", "union":"200", "items":["3.0"], "unknown":"1"});
+        coerce_args_to_schema(
+            &mut value,
+            &json!({"properties":{
+                "count":{"type":["integer","null"]}, "on":{"type":"boolean"},
+                "name":{"type":"string"}, "union":{"type":["integer","string"]},
+                "items":{"type":"array","items":{"type":"integer"}}
+            }}),
+        );
+        assert_eq!(
+            value,
+            json!({"count":200,"on":true,"name":"200","union":"200","items":[3],"unknown":"1"})
+        );
+    }
+
+    #[test]
+    fn constraints_and_imprecise_numeric_values_are_not_guessed() {
+        for schema in [
+            json!({"type":"integer","enum":[1]}),
+            json!({"oneOf":[{"type":"integer"}]}),
+            json!({"$ref":"#/$defs/n"}),
+        ] {
+            let mut value = json!("1");
+            coerce_args_to_schema(&mut value, &schema);
+            assert_eq!(value, json!("1"));
+        }
+        let mut value = json!(9_007_199_254_740_992.0);
+        coerce_args_to_schema(&mut value, &json!({"type":"integer"}));
+        assert!(value.as_number().unwrap().is_f64());
+    }
+}

--- a/crates/infra/bamboo-mcp/src/executor.rs
+++ b/crates/infra/bamboo-mcp/src/executor.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use bamboo_agent_core::tools::input_guard::{check_parsed_tool_input, check_raw_tool_input};
 use bamboo_agent_core::{
     parse_tool_args_best_effort, ToolCall, ToolError, ToolExecutionContext, ToolExecutor,
     ToolOutcome, ToolResult, ToolResultImage, ToolSchema,
@@ -175,9 +176,10 @@ impl ToolExecutor for McpToolExecutor {
             resolved.original_name()
         );
 
+        check_raw_tool_input(resolved.canonical_name(), &call.function.arguments)?;
         // Parse arguments
         let args_raw = call.function.arguments.trim();
-        let (args, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
+        let (mut args, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
         if let Some(warning) = parse_warning {
             warn!(
                 "MCP tool argument parsing fallback applied: tool_call_id={}, tool_name={}, server_id={}, args_len={}, args_preview=\"{}\", warning={}",
@@ -190,6 +192,10 @@ impl ToolExecutor for McpToolExecutor {
             );
         }
 
+        check_parsed_tool_input(resolved.canonical_name(), &args)?;
+        if let Some(tool) = snapshot.tool(resolved.server_id(), resolved.original_name()) {
+            crate::arg_coercion::coerce_args_to_schema(&mut args, &tool.parameters);
+        }
         // Execute via manager
         match self.manager.call_resolved_tool(&resolved, args).await {
             Ok(result) => {

--- a/crates/infra/bamboo-mcp/src/lib.rs
+++ b/crates/infra/bamboo-mcp/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate provides MCP client functionality allowing the agent to connect
 //! to MCP servers and use their tools.
 
+mod arg_coercion;
 pub mod config;
 pub mod error;
 pub mod executor;


### PR DESCRIPTION
## Summary

Oversized built-in, overlay, and MCP tool requests are rejected before invocation. Limits follow the resolved execution identity. Unambiguous MCP scalar coercion preserves exact integer strings and leaves constrained or ambiguous schemas unchanged.

## Test Plan

Input guard, native/overlay/MCP invocation and coercion tests passed in the integrated validation. No dependency changes.

Required CI and current-head independent review must pass before merge.
