### PR TITLE
perf: stabilize tool schemas and append activated guidance

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -351,6 +351,8 @@ impl From<&MemoryConfig> for PromptMemoryFlags {
 /// rather than widening the snapshot.
 #[non_exhaustive]
 pub struct AgentLoopConfig {
+    /// Keep tool guidance stable while activation updates append to model context.
+    pub freeze_tool_exposure_for_cache: bool,
     pub(crate) max_rounds: usize,
     pub(crate) system_prompt: Option<String>,
     /// Skill IDs that are disabled globally for this execution.
@@ -553,6 +555,7 @@ pub struct AgentLoopConfig {
 impl Default for AgentLoopConfig {
     fn default() -> Self {
         Self {
+            freeze_tool_exposure_for_cache: true,
             max_rounds: 200,
             system_prompt: None,
             disabled_skill_ids: BTreeSet::new(),

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -23,7 +23,9 @@ use crate::runtime::runner::loop_execution::startup::{
     resolve_auxiliary_models, InFlightTaskEvaluation, LoopRunState,
 };
 use crate::runtime::runner::prompt_context::PromptMemoryRuntimeContext;
-use crate::runtime::runner::session_setup::tool_schemas::resolve_available_tool_schemas_for_session;
+use crate::runtime::runner::session_setup::tool_schemas::{
+    resolve_available_tool_schemas_for_session, resolve_tool_schemas_for_round,
+};
 use crate::runtime::stream::handler::StreamHandlingOutput;
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::ToolExecutor;
@@ -2708,8 +2710,7 @@ async fn run_pipeline_inner(
         );
 
         // --- Resolve tool schemas ---
-        let tool_schemas =
-            resolve_available_tool_schemas_for_session(config, tools.as_ref(), session);
+        let tool_schemas = resolve_tool_schemas_for_round(config, tools.as_ref(), session);
 
         // --- LLM call with retry ---
         let mut overflow_recovery_attempted = false;

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -545,7 +545,9 @@ fn build_request_envelope_reconciled(
     if provider_changed {
         session.reset_model_context_epoch(ModelContextResetReason::ProviderSwitch);
     }
-    let activated = activated_discoverable_tools(session);
+    let activated = crate::runtime::runner::session_setup::tool_schemas::effective_guide_activation(
+        config, session,
+    );
     let (stable_frame, stable_prefix_sections) =
         build_stable_prompt_frame_with_sections(session, config, tool_schemas, &activated);
     let stable_instructions = stable_frame.stable_instructions.clone();
@@ -554,6 +556,45 @@ fn build_request_envelope_reconciled(
     // reconciled into durable typed events. Initial snapshots lead the real
     // transcript; later changes append after the prior request boundary.
     let mut context_blocks = Vec::new();
+    let newly_activated = activated_discoverable_tools(session)
+        .difference(&activated)
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    if !newly_activated.is_empty() {
+        let names = tool_schemas
+            .iter()
+            .filter(|schema| {
+                newly_activated.contains(&bamboo_domain::canonical_tool_name(&schema.function.name))
+            })
+            .map(|schema| schema.function.name.clone())
+            .collect::<Vec<_>>();
+        if !names.is_empty() {
+            let mut guide_context =
+                bamboo_tools::guide::context::GuideBuildContext::from_system_prompt(
+                    &stable_instructions,
+                );
+            guide_context.activated_discoverable_tools = newly_activated;
+            guide_context.include_best_practices = false;
+            let schemas = tool_schemas
+                .iter()
+                .filter(|schema| names.contains(&schema.function.name))
+                .cloned()
+                .collect::<Vec<_>>();
+            let content = bamboo_tools::guide::EnhancedPromptBuilder::build_for_tools(
+                Some(config.tool_registry.as_ref()),
+                &names,
+                &schemas,
+                &guide_context,
+            );
+            context_blocks.push(ContextBlock::new(
+                ContextBlockType::ToolGuide,
+                ContextBlockPriority::High,
+                ContextBlockStability::RoundDynamic,
+                "Activated Tool Guidance",
+                content,
+            ));
+        }
+    }
     if let Some(block) = build_active_workflow_context_block(session) {
         context_blocks.push(block);
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -4043,3 +4043,85 @@ fn overflow_error_detection_matches_common_provider_messages() {
         "authentication error: invalid api key"
     ));
 }
+
+#[test]
+fn activated_guidance_appends_to_transcript_without_rewriting_cached_head() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let mut session = Session::new("guide-cache", "test-model");
+    session.messages.push(Message::user("start"));
+    let config = test_config("system");
+    let tools = bamboo_tools::BuiltinToolExecutor::new();
+    let schemas =
+        crate::runtime::runner::session_setup::tool_schemas::resolve_tool_schemas_for_round(
+            &config,
+            &tools,
+            &mut session,
+        );
+    let prepare = |session: &Session| PreparedContext {
+        messages: session.messages.clone(),
+        token_usage: usage(0, 22),
+        truncation_occurred: false,
+        segments_removed: 0,
+        compressed_message_ids: Vec::new(),
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+    };
+    let prepared = prepare(&session);
+    let before = super::build_request_envelope_reconciled(
+        &mut session,
+        &prepared,
+        &config,
+        &schemas,
+        "test-model",
+    );
+    bamboo_tools::exposure::activate_discoverable_tools(&mut session, ["Sleep"]);
+    session.messages.push(Message::user("wait briefly"));
+    let schemas_after =
+        crate::runtime::runner::session_setup::tool_schemas::resolve_tool_schemas_for_round(
+            &config,
+            &tools,
+            &mut session,
+        );
+    let prepared = prepare(&session);
+    let after = super::build_request_envelope_reconciled(
+        &mut session,
+        &prepared,
+        &config,
+        &schemas_after,
+        "test-model",
+    );
+    assert_eq!(
+        serde_json::to_string(&schemas).unwrap(),
+        serde_json::to_string(&schemas_after).unwrap()
+    );
+    let prefix = |envelope: &super::PreparedRequestEnvelope| {
+        envelope
+            .ir
+            .run(bamboo_llm::SegmentRole::StablePrefix)
+            .iter()
+            .map(|m| m.content.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(before.ir.system_text, after.ir.system_text);
+    assert_eq!(prefix(&before), prefix(&after));
+    assert!(after
+        .ir
+        .run(bamboo_llm::SegmentRole::ModelTranscript)
+        .iter()
+        .any(|m| m.content.contains("Activated Tool Guidance") && m.content.contains("Sleep")));
+    assert!(!session
+        .messages
+        .iter()
+        .any(|m| m.content.contains("Activated Tool Guidance")));
+    let third = super::build_request_envelope_reconciled(
+        &mut session,
+        &prepared,
+        &config,
+        &schemas_after,
+        "test-model",
+    );
+    assert_eq!(
+        after.ir.run(bamboo_llm::SegmentRole::ModelTranscript).len(),
+        third.ir.run(bamboo_llm::SegmentRole::ModelTranscript).len()
+    );
+}

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
@@ -14,7 +14,6 @@ use bamboo_skills::runtime_metadata::{
     SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY, SKILL_RUNTIME_SELECTION_COUNT_KEY,
     SKILL_RUNTIME_SELECTION_SOURCE_KEY, SKILL_RUNTIME_SELECTION_TRACE_KEY,
 };
-use bamboo_tools::exposure::activated_discoverable_tools;
 
 use super::logging::DebugLogger;
 
@@ -310,11 +309,10 @@ The user explicitly selected `{skill_id}`. Your first response step MUST be exac
         }
     }
 
-    let tool_schemas =
-        tool_schemas::resolve_available_tool_schemas_for_session(config, tools, session);
+    let tool_schemas = tool_schemas::resolve_tool_schemas_for_round(config, tools, session);
     let base_prompt_for_language =
         prompt_setup::resolve_base_prompt_for_language(config, session).to_string();
-    let activated = activated_discoverable_tools(session);
+    let activated = tool_schemas::effective_guide_activation(config, session);
     let tool_guide_context = prompt_setup::build_tool_guide_context(
         config,
         &tool_schemas,

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -2225,3 +2225,46 @@ async fn runtime_skill_context_rejects_another_projects_workspace_overlay() {
         .metadata
         .contains_key(SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY));
 }
+
+#[test]
+fn cached_tool_descriptions_stay_stable_while_live_disables_still_apply() {
+    use super::tool_schemas::{effective_guide_activation, resolve_tool_schemas_for_round};
+    let mut config = crate::runtime::config::AgentLoopConfig::default();
+    let tools = StaticToolExecutor {
+        schemas: vec![schema("Read"), schema("Sleep")],
+    };
+    let mut session = Session::new("cache", "model");
+    let before = resolve_tool_schemas_for_round(&config, &tools, &mut session);
+    bamboo_tools::exposure::activate_discoverable_tools(&mut session, ["Sleep"]);
+    let after = resolve_tool_schemas_for_round(&config, &tools, &mut session);
+    assert_eq!(
+        serde_json::to_string(&before).unwrap(),
+        serde_json::to_string(&after).unwrap()
+    );
+    assert!(!effective_guide_activation(&config, &session).contains("Sleep"));
+    config.disabled_tools.insert("Sleep".into());
+    let disabled = resolve_tool_schemas_for_round(&config, &tools, &mut session);
+    assert!(!disabled.iter().any(|s| s.function.name == "Sleep"));
+    config.disabled_tools.clear();
+    let restored = resolve_tool_schemas_for_round(&config, &tools, &mut session);
+    assert!(restored.iter().any(|s| s.function.name == "Sleep"));
+    assert!(effective_guide_activation(&config, &session).contains("Sleep"));
+}
+
+#[test]
+fn disabling_cache_freeze_restores_live_guide_expansion() {
+    use super::tool_schemas::resolve_tool_schemas_for_round;
+    let mut config = crate::runtime::config::AgentLoopConfig::default();
+    let tools = StaticToolExecutor {
+        schemas: vec![schema("Sleep")],
+    };
+    let mut session = Session::new("cache", "model");
+    resolve_tool_schemas_for_round(&config, &tools, &mut session);
+    bamboo_tools::exposure::activate_discoverable_tools(&mut session, ["Sleep"]);
+    config.freeze_tool_exposure_for_cache = false;
+    let live = resolve_tool_schemas_for_round(&config, &tools, &mut session);
+    assert!(!live[0].function.description.contains("Discoverable"));
+    assert!(!session
+        .metadata
+        .contains_key("prompt_tool_exposure_activated"));
+}

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
@@ -11,6 +11,67 @@ use bamboo_skills::runtime_metadata::{
 };
 use bamboo_tools::exposure::{activated_discoverable_tools, expandable_tool_short_description};
 
+const EXPOSURE_SIGNATURE: &str = "prompt_tool_exposure_signature";
+const EXPOSURE_ACTIVATED: &str = "prompt_tool_exposure_activated";
+
+pub(crate) fn effective_guide_activation(
+    config: &AgentLoopConfig,
+    session: &Session,
+) -> std::collections::BTreeSet<String> {
+    if config.freeze_tool_exposure_for_cache {
+        if let Some(frozen) = session
+            .metadata
+            .get(EXPOSURE_ACTIVATED)
+            .and_then(|raw| serde_json::from_str(raw).ok())
+        {
+            return frozen;
+        }
+    }
+    activated_discoverable_tools(session)
+}
+
+/// Capture presentation only; the catalog and execution authority are rebuilt live.
+pub(crate) fn resolve_tool_schemas_for_round(
+    config: &AgentLoopConfig,
+    tools: &dyn ToolExecutor,
+    session: &mut Session,
+) -> Vec<ToolSchema> {
+    if config.freeze_tool_exposure_for_cache {
+        use sha2::{Digest, Sha256};
+        let catalog = resolve_catalog_with_activation(
+            config,
+            tools,
+            session,
+            &std::collections::BTreeSet::new(),
+        );
+        let schemas = catalog
+            .iter()
+            .map(|entry| entry.schema())
+            .collect::<Vec<_>>();
+        let value = serde_json::to_value(schemas).expect("tool schemas serialize");
+        let bytes =
+            bamboo_llm::providers::common::tool_schema::canonicalize_json_value(&value).to_string();
+        let signature = Sha256::digest(bytes.as_bytes())
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        if session.metadata.get(EXPOSURE_SIGNATURE) != Some(&signature) {
+            session
+                .metadata
+                .insert(EXPOSURE_SIGNATURE.into(), signature);
+            session.metadata.insert(
+                EXPOSURE_ACTIVATED.into(),
+                serde_json::to_string(&activated_discoverable_tools(session))
+                    .expect("activation names serialize"),
+            );
+        }
+    } else {
+        session.metadata.remove(EXPOSURE_SIGNATURE);
+        session.metadata.remove(EXPOSURE_ACTIVATED);
+    }
+    resolve_available_tool_schemas_for_session(config, tools, session)
+}
+
 const COPILOT_CONCLUSION_WITH_OPTIONS_ENHANCEMENT_METADATA_KEY: &str =
     "copilot_conclusion_with_options_enhancement_enabled";
 const CONCLUSION_WITH_OPTIONS_ENHANCED_DESCRIPTION: &str = "Ask the user a question with options and wait for the user to select or enter a custom answer. If you are wrapping up a task turn, asking the user to choose next steps, or handing off execution, you must call this tool instead of ending with plain assistant text. For completion confirmation, include a `conclusion` object with both `summary` and `mermaid.graph`, and include `OK` as one of the options.";
@@ -67,6 +128,20 @@ pub(crate) fn resolve_classified_tool_catalog_for_session(
     tools: &dyn ToolExecutor,
     session: &Session,
 ) -> Vec<ClassifiedToolSchema> {
+    resolve_catalog_with_activation(
+        config,
+        tools,
+        session,
+        &effective_guide_activation(config, session),
+    )
+}
+
+fn resolve_catalog_with_activation(
+    config: &AgentLoopConfig,
+    tools: &dyn ToolExecutor,
+    session: &Session,
+    activated: &std::collections::BTreeSet<String>,
+) -> Vec<ClassifiedToolSchema> {
     let mut tool_schemas = config.tool_registry.list_tools();
     if tool_schemas.is_empty() {
         tool_schemas = tools.list_tools();
@@ -119,8 +194,6 @@ pub(crate) fn resolve_classified_tool_catalog_for_session(
     if explicit_activation_is_current || explicit_activation_degraded {
         tool_schemas.retain(|schema| schema.function.name != "load_skill");
     }
-
-    let activated = activated_discoverable_tools(session);
 
     // Legacy providers keep Deferred schemas visible during migration;
     // activation only controls the depth of the existing tool-guide summaries.

--- a/crates/infra/bamboo-llm/src/protocol/anthropic.rs
+++ b/crates/infra/bamboo-llm/src/protocol/anthropic.rs
@@ -208,7 +208,9 @@ impl ToProvider<AnthropicTool> for ToolSchema {
         Ok(AnthropicTool {
             name: self.function.name.clone(),
             description: Some(self.function.description.clone()),
-            input_schema: self.function.parameters.clone(),
+            input_schema: crate::providers::common::tool_schema::canonicalize_json_value(
+                &self.function.parameters,
+            ),
         })
     }
 }

--- a/crates/infra/bamboo-llm/src/protocol/gemini.rs
+++ b/crates/infra/bamboo-llm/src/protocol/gemini.rs
@@ -468,7 +468,11 @@ impl ToProvider<GeminiTool> for ToolSchema {
             function_declarations: vec![GeminiFunctionDeclaration {
                 name: self.function.name.clone(),
                 description: Some(self.function.description.clone()),
-                parameters_json_schema: Some(self.function.parameters.clone()),
+                parameters_json_schema: Some(
+                    crate::providers::common::tool_schema::canonicalize_json_value(
+                        &self.function.parameters,
+                    ),
+                ),
                 parameters: None,
             }],
         })
@@ -487,7 +491,11 @@ impl ToProvider<Vec<GeminiTool>> for Vec<ToolSchema> {
             .map(|schema| GeminiFunctionDeclaration {
                 name: schema.function.name.clone(),
                 description: Some(schema.function.description.clone()),
-                parameters_json_schema: Some(schema.function.parameters.clone()),
+                parameters_json_schema: Some(
+                    crate::providers::common::tool_schema::canonicalize_json_value(
+                        &schema.function.parameters,
+                    ),
+                ),
                 parameters: None,
             })
             .collect();

--- a/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
@@ -1836,7 +1836,7 @@ fn tool_to_anthropic_json(tool: &ToolSchema) -> Value {
     json!({
         "name": tool.function.name,
         "description": tool.function.description,
-        "input_schema": tool.function.parameters,
+        "input_schema": crate::providers::common::tool_schema::canonicalize_json_value(&tool.function.parameters),
     })
 }
 

--- a/crates/infra/bamboo-llm/src/providers/common/tool_schema.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/tool_schema.rs
@@ -23,13 +23,45 @@ pub fn sanitize_openai_function_parameters_schema(parameters: &Value) -> Value {
         object.insert("properties".to_string(), json!({}));
     }
 
-    Value::Object(object)
+    canonicalize_json_value(&Value::Object(object))
+}
+
+/// Canonical object ordering for provider-visible schemas; array order is semantic.
+pub fn canonicalize_json_value(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut keys = object.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            Value::Object(
+                keys.into_iter()
+                    .map(|key| (key.clone(), canonicalize_json_value(&object[key])))
+                    .collect(),
+            )
+        }
+        Value::Array(values) => Value::Array(values.iter().map(canonicalize_json_value).collect()),
+        _ => value.clone(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_openai_function_parameters_schema;
+    use super::{canonicalize_json_value, sanitize_openai_function_parameters_schema};
     use serde_json::json;
+
+    #[test]
+    fn schema_bytes_are_independent_of_object_insertion_order() {
+        let a: serde_json::Value = serde_json::from_str(r#"{"properties":{"z":{"type":"string","description":"z"},"a":{"type":"number"}},"required":["z","a"]}"#).unwrap();
+        let b: serde_json::Value = serde_json::from_str(r#"{"required":["z","a"],"properties":{"a":{"type":"number"},"z":{"description":"z","type":"string"}}}"#).unwrap();
+        assert_eq!(
+            canonicalize_json_value(&a).to_string(),
+            canonicalize_json_value(&b).to_string()
+        );
+        assert_eq!(canonicalize_json_value(&a)["required"], json!(["z", "a"]));
+        assert_eq!(
+            sanitize_openai_function_parameters_schema(&a).to_string(),
+            sanitize_openai_function_parameters_schema(&b).to_string()
+        );
+    }
 
     #[test]
     fn sanitize_removes_forbidden_top_level_keywords() {


### PR DESCRIPTION
## Summary

Canonicalize tool schema objects and retain a stable tool-display snapshot for prompt caching. Newly activated tool guidance is appended to the current context; live permissions and disabled-tool filtering remain authoritative. This change makes no measured cache-hit claim.

## Test Plan

Engine and provider suites passed in integrated validation, including stable prefix, current-context activation, and no duplicate guidance growth.

Required CI and current-head independent review must pass before merge.
