### PR TITLE
feat: queue multimodal messages at safe run boundaries

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/guidance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/guidance.rs
@@ -1,4 +1,4 @@
-//! Durable text guidance for the next available model turn.
+//! Durable multimodal guidance for a model boundary or successor run.
 use crate::app_state::AppState;
 use crate::error::json_error;
 use actix_web::{http::StatusCode, web, HttpResponse};
@@ -11,6 +11,18 @@ use serde_json::json;
 pub struct GuidanceRequest {
     pub id: String,
     pub text: String,
+    #[serde(default)]
+    pub mode: GuidanceMode,
+    #[serde(default)]
+    pub images: Vec<super::chat::ChatImage>,
+}
+
+#[derive(Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuidanceMode {
+    #[default]
+    AfterRound,
+    AfterRun,
 }
 
 fn inbox_error(error: SessionInboxError) -> HttpResponse {
@@ -36,7 +48,10 @@ pub async fn list(state: web::Data<AppState>, path: web::Path<String>) -> HttpRe
     match state.session_inbox.pending_guidance(&path).await {
         Ok(messages) => HttpResponse::Ok().json(json!({"messages": messages.into_iter().filter_map(|message| {
             let bamboo_domain::SessionMessageBody::Content(content) = message.body else { return None };
-            Some(json!({"id": message.id, "text": content.text, "created_at": message.created_at}))
+            Some(json!({"id": message.id, "text": content.text, "created_at": message.created_at, "images": content.parts.iter().filter_map(|part| {
+                let bamboo_domain::MessagePart::ImageUrl { image_url } = part else { return None };
+                image_url.url.strip_prefix(&format!("bamboo-attachment://{}/", message.target_session_id)).map(str::to_string)
+            }).collect::<Vec<_>>(), "mode": if message.correlation_id.as_deref().is_some_and(|value| value.starts_with("session-guidance-after-run")) { "after_run" } else { "after_round" }}))
         }).collect::<Vec<_>>()})),
         Err(error) => inbox_error(error),
     }
@@ -62,16 +77,84 @@ pub async fn send(
     let Ok(id) = SessionMessageId::parse(body.id.clone()) else {
         return json_error(StatusCode::BAD_REQUEST, "Invalid guidance message id");
     };
-    if body.text.trim().is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "Guidance cannot be empty");
+    if body.text.trim().is_empty() && body.images.is_empty() {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "A queued message needs text or an image",
+        );
     }
     if body.text.len() > 64 * 1024 {
         return json_error(StatusCode::PAYLOAD_TOO_LARGE, "Guidance exceeds 64 KiB");
     }
     let mut envelope = SessionMessageEnvelope::user_input(path.into_inner(), body.text.clone());
+    if body.images.len() > 16 {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "A queued message supports up to 16 images",
+        );
+    }
+    if !body.images.is_empty() {
+        let Some(session) = state.load_session_merged(&envelope.target_session_id).await else {
+            return json_error(StatusCode::NOT_FOUND, "Session not found");
+        };
+        let mut parts = vec![bamboo_domain::MessagePart::Text {
+            text: body.text.clone(),
+        }];
+        for image in &body.images {
+            let (_, url) = match state
+                .session_store
+                .write_image_attachment_deduplicated(
+                    &session,
+                    &image.base64,
+                    image.mime_type.as_deref(),
+                )
+                .await
+            {
+                Ok(stored) => stored,
+                Err(error) => {
+                    return json_error(
+                        StatusCode::BAD_REQUEST,
+                        format!("Failed to store image attachment: {error}"),
+                    )
+                }
+            };
+            parts.push(bamboo_domain::MessagePart::ImageUrl {
+                image_url: bamboo_domain::ImageUrlRef { url, detail: None },
+            });
+        }
+        envelope.body =
+            bamboo_domain::SessionMessageBody::Content(bamboo_domain::SessionMessageContent {
+                text: body.text.clone(),
+                parts,
+            });
+    }
     envelope.id = id;
-    envelope.correlation_id = Some("session-guidance".into());
-    match state.session_messenger.send(envelope).await {
+    envelope.correlation_id = Some(match body.mode {
+        GuidanceMode::AfterRound => "session-guidance".into(),
+        GuidanceMode::AfterRun => match state
+            .session_activation_router
+            .current_run_id(&envelope.target_session_id)
+            .await
+        {
+            Some(run_id) => format!("session-guidance-after-run:{run_id}"),
+            None => "session-guidance-after-run".into(),
+        },
+    });
+    let result = async {
+        let admission = state.session_messenger.admit(envelope).await?;
+        let policy = match body.mode {
+            GuidanceMode::AfterRound => {
+                bamboo_domain::SessionActivationPolicy::InterruptSpecificWait
+            }
+            GuidanceMode::AfterRun => bamboo_domain::SessionActivationPolicy::RespectSpecificWait,
+        };
+        state
+            .session_messenger
+            .activate_with_policy(&admission, policy)
+            .await
+    }
+    .await;
+    match result {
         Ok(receipt) => HttpResponse::Accepted()
             .json(json!({"id": receipt.delivery.id, "activation_pending": false})),
         Err(SessionMessengerError::Activation { receipt, .. }) => {
@@ -94,6 +177,108 @@ pub async fn send(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[actix_web::test]
+    async fn queued_images_use_durable_references_and_retries_do_not_duplicate_attachments() {
+        use bamboo_domain::{Session, SessionInboxLimits, Storage};
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state
+            .session_store
+            .save_session(&Session::new("queued-images", "model"))
+            .await
+            .unwrap();
+        let registration = state
+            .session_activation_router
+            .register_run("queued-images", "run-a")
+            .await
+            .unwrap();
+        let request = || {
+            web::Json(GuidanceRequest {
+                id: "image-guidance".into(),
+                text: String::new(),
+                mode: GuidanceMode::AfterRun,
+                images: vec![super::super::chat::ChatImage {
+                    base64: "data:image/png;base64,aGVsbG8=".into(),
+                    name: Some("test.png".into()),
+                    size: Some(5),
+                    mime_type: Some("image/png".into()),
+                }],
+            })
+        };
+        for _ in 0..2 {
+            assert_eq!(
+                send(
+                    state.clone(),
+                    web::Path::from("queued-images".to_string()),
+                    request()
+                )
+                .await
+                .status(),
+                StatusCode::ACCEPTED
+            );
+        }
+        let pending = state
+            .session_inbox
+            .pending_guidance("queued-images")
+            .await
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        let bamboo_domain::SessionMessageBody::Content(content) = &pending[0].body else {
+            panic!("content")
+        };
+        assert!(content.text.is_empty());
+        let bamboo_domain::MessagePart::ImageUrl { image_url } = &content.parts[1] else {
+            panic!("image")
+        };
+        assert!(image_url
+            .url
+            .starts_with("bamboo-attachment://queued-images/"));
+        assert!(!serde_json::to_string(&pending[0])
+            .unwrap()
+            .contains("aGVsbG8="));
+        let attachment_id = image_url.url.rsplit('/').next().unwrap();
+        assert_eq!(
+            state
+                .session_store
+                .read_attachment("queued-images", attachment_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .0,
+            b"hello"
+        );
+        let attachment_dir = dir.path().join("sessions/queued-images/attachments");
+        assert_eq!(std::fs::read_dir(&attachment_dir).unwrap().count(), 1);
+        assert!(state
+            .session_inbox
+            .claim_for_turn("queued-images", 128, Some("run-a"))
+            .await
+            .unwrap()
+            .is_empty());
+        let list_response = list(state.clone(), web::Path::from("queued-images".to_string())).await;
+        let list_bytes = actix_web::body::to_bytes(list_response.into_body())
+            .await
+            .unwrap();
+        let listed: serde_json::Value = serde_json::from_slice(&list_bytes).unwrap();
+        assert_eq!(listed["messages"][0]["images"][0], attachment_id);
+        let reopened = bamboo_storage::FileSessionInbox::new(
+            state.session_store.clone(),
+            SessionInboxLimits::default(),
+        );
+        use bamboo_domain::SessionInboxPort;
+        let claims = reopened
+            .claim_for_turn("queued-images", 128, Some("run-b"))
+            .await
+            .unwrap();
+        assert_eq!(claims.len(), 1);
+        let message = claims[0].envelope.to_provider_message().unwrap();
+        assert_eq!(message.content_parts.as_ref(), Some(&content.parts));
+        // The test owns this lease but does not run the provider. Keep cleanup
+        // from dispatching a real successor after checking the claimed payload.
+        reopened.ack("queued-images", &claims[0]).await.unwrap();
+        registration.finish(1).await.unwrap();
+    }
 
     #[actix_web::test]
     async fn inbox_errors_use_the_native_envelope_and_status() {

--- a/crates/app/bamboo-server/src/handlers/agent/guidance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/guidance.rs
@@ -1,6 +1,7 @@
 //! Durable text guidance for the next available model turn.
 use crate::app_state::AppState;
-use actix_web::{web, HttpResponse};
+use crate::error::json_error;
+use actix_web::{http::StatusCode, web, HttpResponse};
 use bamboo_domain::{SessionInboxError, SessionMessageEnvelope, SessionMessageId};
 use bamboo_engine::session_messaging::SessionMessengerError;
 use serde::Deserialize;
@@ -15,20 +16,18 @@ pub struct GuidanceRequest {
 fn inbox_error(error: SessionInboxError) -> HttpResponse {
     match error {
         SessionInboxError::TargetNotFound(_) => {
-            HttpResponse::NotFound().json(json!({"error": "Session not found"}))
+            json_error(StatusCode::NOT_FOUND, "Session not found")
         }
         SessionInboxError::PayloadTooLarge { .. } => {
-            HttpResponse::PayloadTooLarge().json(json!({"error": error.to_string()}))
+            json_error(StatusCode::PAYLOAD_TOO_LARGE, error.to_string())
         }
         SessionInboxError::BacklogFull { .. } => {
-            HttpResponse::TooManyRequests().json(json!({"error": error.to_string()}))
+            json_error(StatusCode::TOO_MANY_REQUESTS, error.to_string())
         }
-        SessionInboxError::InvalidClaim(_) => {
-            HttpResponse::Conflict().json(json!({"error": error.to_string()}))
-        }
+        SessionInboxError::InvalidClaim(_) => json_error(StatusCode::CONFLICT, error.to_string()),
         other => {
             tracing::error!(%other, "guidance queue failed");
-            HttpResponse::InternalServerError().finish()
+            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Guidance storage failed")
         }
     }
 }
@@ -46,13 +45,11 @@ pub async fn list(state: web::Data<AppState>, path: web::Path<String>) -> HttpRe
 pub async fn cancel(state: web::Data<AppState>, path: web::Path<(String, String)>) -> HttpResponse {
     let (session_id, message_id) = path.into_inner();
     let Ok(id) = SessionMessageId::parse(message_id) else {
-        return HttpResponse::BadRequest().finish();
+        return json_error(StatusCode::BAD_REQUEST, "Invalid guidance message id");
     };
     match state.session_inbox.cancel_guidance(&session_id, &id).await {
         Ok(true) => HttpResponse::NoContent().finish(),
-        Ok(false) => {
-            HttpResponse::Conflict().json(json!({"error": "Guidance is no longer pending"}))
-        }
+        Ok(false) => json_error(StatusCode::CONFLICT, "Guidance is no longer pending"),
         Err(error) => inbox_error(error),
     }
 }
@@ -63,13 +60,13 @@ pub async fn send(
     body: web::Json<GuidanceRequest>,
 ) -> HttpResponse {
     let Ok(id) = SessionMessageId::parse(body.id.clone()) else {
-        return HttpResponse::BadRequest().finish();
+        return json_error(StatusCode::BAD_REQUEST, "Invalid guidance message id");
     };
     if body.text.trim().is_empty() {
-        return HttpResponse::BadRequest().json(json!({"error": "Guidance cannot be empty"}));
+        return json_error(StatusCode::BAD_REQUEST, "Guidance cannot be empty");
     }
     if body.text.len() > 64 * 1024 {
-        return HttpResponse::PayloadTooLarge().finish();
+        return json_error(StatusCode::PAYLOAD_TOO_LARGE, "Guidance exceeds 64 KiB");
     }
     let mut envelope = SessionMessageEnvelope::user_input(path.into_inner(), body.text.clone());
     envelope.id = id;
@@ -80,14 +77,62 @@ pub async fn send(
         Err(SessionMessengerError::Activation { receipt, .. }) => {
             HttpResponse::Accepted().json(json!({"id": receipt.id, "activation_pending": true}))
         }
-        Err(SessionMessengerError::TargetNotFound(_)) => HttpResponse::NotFound().finish(),
+        Err(SessionMessengerError::TargetNotFound(_)) => {
+            json_error(StatusCode::NOT_FOUND, "Session not found")
+        }
         Err(SessionMessengerError::Inbox(error)) => inbox_error(error),
         Err(SessionMessengerError::InvalidEnvelope(error)) => {
-            HttpResponse::BadRequest().json(json!({"error": error}))
+            json_error(StatusCode::BAD_REQUEST, error)
         }
         Err(error) => {
             tracing::error!(%error, "guidance delivery failed");
-            HttpResponse::InternalServerError().finish()
+            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Guidance storage failed")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[actix_web::test]
+    async fn inbox_errors_use_the_native_envelope_and_status() {
+        for (error, expected) in [
+            (
+                SessionInboxError::TargetNotFound("missing".into()),
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                SessionInboxError::PayloadTooLarge {
+                    actual: 20,
+                    limit: 10,
+                },
+                StatusCode::PAYLOAD_TOO_LARGE,
+            ),
+            (
+                SessionInboxError::BacklogFull {
+                    current: 10,
+                    limit: 10,
+                },
+                StatusCode::TOO_MANY_REQUESTS,
+            ),
+            (
+                SessionInboxError::InvalidClaim("changed".into()),
+                StatusCode::CONFLICT,
+            ),
+            (
+                SessionInboxError::Storage("unavailable".into()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ] {
+            let response = inbox_error(error);
+            assert_eq!(response.status(), expected);
+            let bytes = actix_web::body::to_bytes(response.into_body())
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["error"]["type"], "api_error");
+            assert!(body["error"]["message"].is_string());
         }
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/guidance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/guidance.rs
@@ -1,0 +1,93 @@
+//! Durable text guidance for the next available model turn.
+use crate::app_state::AppState;
+use actix_web::{web, HttpResponse};
+use bamboo_domain::{SessionInboxError, SessionMessageEnvelope, SessionMessageId};
+use bamboo_engine::session_messaging::SessionMessengerError;
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Deserialize)]
+pub struct GuidanceRequest {
+    pub id: String,
+    pub text: String,
+}
+
+fn inbox_error(error: SessionInboxError) -> HttpResponse {
+    match error {
+        SessionInboxError::TargetNotFound(_) => {
+            HttpResponse::NotFound().json(json!({"error": "Session not found"}))
+        }
+        SessionInboxError::PayloadTooLarge { .. } => {
+            HttpResponse::PayloadTooLarge().json(json!({"error": error.to_string()}))
+        }
+        SessionInboxError::BacklogFull { .. } => {
+            HttpResponse::TooManyRequests().json(json!({"error": error.to_string()}))
+        }
+        SessionInboxError::InvalidClaim(_) => {
+            HttpResponse::Conflict().json(json!({"error": error.to_string()}))
+        }
+        other => {
+            tracing::error!(%other, "guidance queue failed");
+            HttpResponse::InternalServerError().finish()
+        }
+    }
+}
+
+pub async fn list(state: web::Data<AppState>, path: web::Path<String>) -> HttpResponse {
+    match state.session_inbox.pending_guidance(&path).await {
+        Ok(messages) => HttpResponse::Ok().json(json!({"messages": messages.into_iter().filter_map(|message| {
+            let bamboo_domain::SessionMessageBody::Content(content) = message.body else { return None };
+            Some(json!({"id": message.id, "text": content.text, "created_at": message.created_at}))
+        }).collect::<Vec<_>>()})),
+        Err(error) => inbox_error(error),
+    }
+}
+
+pub async fn cancel(state: web::Data<AppState>, path: web::Path<(String, String)>) -> HttpResponse {
+    let (session_id, message_id) = path.into_inner();
+    let Ok(id) = SessionMessageId::parse(message_id) else {
+        return HttpResponse::BadRequest().finish();
+    };
+    match state.session_inbox.cancel_guidance(&session_id, &id).await {
+        Ok(true) => HttpResponse::NoContent().finish(),
+        Ok(false) => {
+            HttpResponse::Conflict().json(json!({"error": "Guidance is no longer pending"}))
+        }
+        Err(error) => inbox_error(error),
+    }
+}
+
+pub async fn send(
+    state: web::Data<AppState>,
+    path: web::Path<String>,
+    body: web::Json<GuidanceRequest>,
+) -> HttpResponse {
+    let Ok(id) = SessionMessageId::parse(body.id.clone()) else {
+        return HttpResponse::BadRequest().finish();
+    };
+    if body.text.trim().is_empty() {
+        return HttpResponse::BadRequest().json(json!({"error": "Guidance cannot be empty"}));
+    }
+    if body.text.len() > 64 * 1024 {
+        return HttpResponse::PayloadTooLarge().finish();
+    }
+    let mut envelope = SessionMessageEnvelope::user_input(path.into_inner(), body.text.clone());
+    envelope.id = id;
+    envelope.correlation_id = Some("session-guidance".into());
+    match state.session_messenger.send(envelope).await {
+        Ok(receipt) => HttpResponse::Accepted()
+            .json(json!({"id": receipt.delivery.id, "activation_pending": false})),
+        Err(SessionMessengerError::Activation { receipt, .. }) => {
+            HttpResponse::Accepted().json(json!({"id": receipt.id, "activation_pending": true}))
+        }
+        Err(SessionMessengerError::TargetNotFound(_)) => HttpResponse::NotFound().finish(),
+        Err(SessionMessengerError::Inbox(error)) => inbox_error(error),
+        Err(SessionMessengerError::InvalidEnvelope(error)) => {
+            HttpResponse::BadRequest().json(json!({"error": error}))
+        }
+        Err(error) => {
+            tracing::error!(%error, "guidance delivery failed");
+            HttpResponse::InternalServerError().finish()
+        }
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mod.rs
@@ -10,6 +10,7 @@ pub mod delete;
 pub mod dev;
 pub mod events;
 pub mod execute;
+pub mod guidance;
 pub mod health;
 pub mod history;
 pub mod ledger;

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -111,6 +111,18 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
             "/subagents/snapshot",
             web::get().to(agent::subagent_snapshot::handler),
         )
+        .route(
+            "/sessions/{session_id}/guidance",
+            web::get().to(agent::guidance::list),
+        )
+        .route(
+            "/sessions/{session_id}/guidance",
+            web::post().to(agent::guidance::send),
+        )
+        .route(
+            "/sessions/{session_id}/guidance/{message_id}",
+            web::delete().to(agent::guidance::cancel),
+        )
         .route("/sessions", web::get().to(agent::sessions::list_sessions))
         .route("/sessions", web::post().to(agent::sessions::create_session))
         .route(

--- a/crates/core/bamboo-domain/src/session/inbox.rs
+++ b/crates/core/bamboo-domain/src/session/inbox.rs
@@ -247,6 +247,27 @@ pub struct SessionMessageEnvelope {
 }
 
 impl SessionMessageEnvelope {
+    /// Reserved user-guidance correlation markers include a server-selected
+    /// run fence. The fence controls scheduling, not the logical retry identity.
+    pub fn is_guidance(&self) -> bool {
+        self.source == SessionMessageSource::User
+            && self.kind == SessionMessageKind::UserInput
+            && self.correlation_id.as_deref().is_some_and(|value| {
+                value == "session-guidance"
+                    || value == "session-guidance-after-run"
+                    || value.starts_with("session-guidance-after-run:")
+            })
+    }
+
+    pub fn guidance_waits_for_run(&self, run_id: &str) -> bool {
+        self.is_guidance()
+            && self
+                .correlation_id
+                .as_deref()
+                .and_then(|value| value.strip_prefix("session-guidance-after-run:"))
+                == Some(run_id)
+    }
+
     pub fn user_input(target_session_id: impl Into<String>, text: impl Into<String>) -> Self {
         Self {
             id: SessionMessageId::new(),
@@ -376,6 +397,16 @@ impl SessionMessageEnvelope {
                 "data": instruction.data,
             }),
         };
+        let correlation_id = if self.is_guidance()
+            && self
+                .correlation_id
+                .as_deref()
+                .is_some_and(|value| value.starts_with("session-guidance-after-run:"))
+        {
+            Some("session-guidance-after-run")
+        } else {
+            self.correlation_id.as_deref()
+        };
         serde_json::json!({
             "source": &self.source,
             "target_session_id": &self.target_session_id,
@@ -383,7 +414,7 @@ impl SessionMessageEnvelope {
             "body": body,
             "thread_id": &self.thread_id,
             "in_reply_to": &self.in_reply_to,
-            "correlation_id": &self.correlation_id,
+            "correlation_id": correlation_id,
         })
     }
 
@@ -754,6 +785,23 @@ pub trait SessionInboxPort: Send + Sync {
         target_session_id: &str,
         limit: usize,
     ) -> Result<Vec<SessionInboxClaim>, SessionInboxError>;
+
+    /// Claim at a model boundary while leaving end-of-run guidance delivered
+    /// during this run pending for the successor owner.
+    async fn claim_for_turn(
+        &self,
+        target_session_id: &str,
+        limit: usize,
+        active_run_id: Option<&str>,
+    ) -> Result<Vec<SessionInboxClaim>, SessionInboxError> {
+        let claims = self.claim(target_session_id, limit).await?;
+        Ok(claims
+            .into_iter()
+            .filter(|claim| {
+                !active_run_id.is_some_and(|run_id| claim.envelope.guidance_waits_for_run(run_id))
+            })
+            .collect())
+    }
 
     /// Permanent durable receipt check. Unlike the bounded in-session cursor,
     /// this tombstone must remain true for the lifetime of the logical inbox.

--- a/crates/core/bamboo-domain/src/session/inbox.rs
+++ b/crates/core/bamboo-domain/src/session/inbox.rs
@@ -772,6 +772,27 @@ pub trait SessionInboxPort: Send + Sync {
         claim: &SessionInboxClaim,
     ) -> Result<(), SessionInboxError>;
 
+    /// List unclaimed user guidance in delivery order.
+    async fn pending_guidance(
+        &self,
+        _target_session_id: &str,
+    ) -> Result<Vec<SessionMessageEnvelope>, SessionInboxError> {
+        Err(SessionInboxError::Storage(
+            "guidance queue is unavailable".into(),
+        ))
+    }
+
+    /// Cancel only an unclaimed user envelope. False means it cannot be withdrawn.
+    async fn cancel_guidance(
+        &self,
+        _target_session_id: &str,
+        _id: &SessionMessageId,
+    ) -> Result<bool, SessionInboxError> {
+        Err(SessionInboxError::Storage(
+            "guidance cancellation is unavailable".into(),
+        ))
+    }
+
     async fn inspect(
         &self,
         target_session_id: &str,

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -2061,7 +2061,7 @@ async fn claim_canonical_deliveries(
 ) -> crate::runtime::runner::Result<Vec<(SessionInboxClaim, SessionMessageDelivery)>> {
     let claims = binding
         .inbox
-        .claim(&session.id, limit)
+        .claim_for_turn(&session.id, limit, Some(activation_run_id))
         .await
         .map_err(|error| {
             AgentError::LLM(format!(

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -377,6 +377,7 @@ pub struct AgentLoopConfig {
     /// Optional runtime persistence for non-authoritative session saves.
     /// When set, engine save sites use this instead of `storage` for writes.
     pub(crate) persistence: Option<Arc<dyn RuntimeSessionPersistence>>,
+    pub(crate) guidance_active_run_id: Option<String>,
     /// Durable logical-session inbox admitted at safe round boundaries.
     pub(crate) session_inbox: Option<Arc<dyn bamboo_domain::SessionInboxPort>>,
     /// Active-owner wake generation. The loop consumes this at the same safe
@@ -565,6 +566,7 @@ impl Default for AgentLoopConfig {
             skip_initial_user_message: false,
             storage: None,
             persistence: None,
+            guidance_active_run_id: None,
             session_inbox: None,
             session_activation_notifications: None,
             attachment_reader: None,

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_prelude.rs
@@ -115,11 +115,12 @@ pub(crate) async fn refresh_round_boundary_and_prompt_context(
         }
     }
 
-    let turn_refresh = super::state_bridge::refresh_turn_boundary_with_inbox(
+    let turn_refresh = super::state_bridge::refresh_turn_boundary_with_inbox_for_run(
         session,
         config.storage.as_ref(),
         config.persistence.as_ref(),
         config.session_inbox.as_ref(),
+        config.guidance_active_run_id.as_deref(),
     )
     .await;
     if turn_refresh.merged > 0 {

--- a/crates/engine/bamboo-engine/src/runtime/runner/state_bridge.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/state_bridge.rs
@@ -387,6 +387,7 @@ async fn admit_session_inbox(
     session: &mut Session,
     inbox: &Arc<dyn SessionInboxPort>,
     persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
+    active_run_id: Option<&str>,
 ) -> usize {
     let Some(persistence) = persistence else {
         tracing::warn!(
@@ -395,7 +396,7 @@ async fn admit_session_inbox(
         );
         return 0;
     };
-    let claims = match inbox.claim(&session.id, 128).await {
+    let claims = match inbox.claim_for_turn(&session.id, 128, active_run_id).await {
         Ok(claims) => claims,
         Err(error) => {
             tracing::warn!(session_id = %session.id, %error, "failed to claim SessionInbox");
@@ -599,6 +600,16 @@ pub async fn refresh_turn_boundary_with_inbox(
     persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
     inbox: Option<&Arc<dyn SessionInboxPort>>,
 ) -> TurnBoundaryRefresh {
+    refresh_turn_boundary_with_inbox_for_run(session, storage, persistence, inbox, None).await
+}
+
+pub(crate) async fn refresh_turn_boundary_with_inbox_for_run(
+    session: &mut Session,
+    storage: Option<&Arc<dyn bamboo_agent_core::storage::Storage>>,
+    persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
+    inbox: Option<&Arc<dyn SessionInboxPort>>,
+    active_run_id: Option<&str>,
+) -> TurnBoundaryRefresh {
     let latest = match storage {
         Some(storage) => match storage.load_session(&session.id).await {
             Ok(latest) => latest,
@@ -686,7 +697,7 @@ pub async fn refresh_turn_boundary_with_inbox(
     }
 
     if let Some(inbox) = inbox {
-        let merged = admit_session_inbox(session, inbox, persistence).await;
+        let merged = admit_session_inbox(session, inbox, persistence, active_run_id).await;
         return TurnBoundaryRefresh {
             merged,
             disk_permission_mode,
@@ -2093,6 +2104,90 @@ mod tests {
             .unwrap()
             .unwrap()
             .has_pending_injected_messages());
+    }
+
+    #[tokio::test]
+    async fn task_end_guidance_survives_later_round_admission_and_launches_one_successor() {
+        let (_temp, store, locked, inbox, mut running) =
+            durable_inbox_fixture("guidance-modes").await;
+        let storage: Arc<dyn Storage> = store;
+        let persistence: Arc<dyn bamboo_domain::RuntimeSessionPersistence> = locked;
+        let router = crate::SessionActivationRouter::new();
+        router.set_inbox(inbox.clone());
+        let reservations = Arc::new(AtomicUsize::new(0));
+        let launches = Arc::new(AtomicUsize::new(0));
+        router
+            .set_spawner(Arc::new(BacklogActivationSpawner {
+                inbox: inbox.clone(),
+                reservations: reservations.clone(),
+                launches: launches.clone(),
+            }))
+            .await;
+        let mut registration = router.register_run(&running.id, "run-a").await.unwrap();
+        let mut deferred = SessionMessageEnvelope::user_input(&running.id, "task end");
+        deferred.correlation_id = Some("session-guidance-after-run:run-a".into());
+        let mut immediate = SessionMessageEnvelope::user_input(&running.id, "round end");
+        immediate.correlation_id = Some("session-guidance".into());
+        for envelope in [&deferred, &immediate] {
+            let receipt = deliver_interrupt_eligible(&inbox, envelope).await;
+            router
+                .request_activation(&running.id, receipt.generation)
+                .await
+                .unwrap();
+        }
+        let result = refresh_turn_boundary_with_inbox_for_run(
+            &mut running,
+            Some(&storage),
+            Some(&persistence),
+            Some(&inbox),
+            Some("run-a"),
+        )
+        .await;
+        assert_eq!(result.merged, 1);
+        assert!(running
+            .messages
+            .iter()
+            .any(|message| message.id == immediate.id.as_str()));
+        assert!(!running
+            .messages
+            .iter()
+            .any(|message| message.id == deferred.id.as_str()));
+        let cursor = running
+            .session_inbox_admission()
+            .unwrap()
+            .last_admitted_sequence;
+        assert_eq!(cursor, 2);
+        assert_eq!(inbox.pending_guidance(&running.id).await.unwrap().len(), 1);
+        registration.begin_finalization().await;
+        assert_eq!(
+            registration.finish(cursor).await.unwrap(),
+            Some(SessionActivationDisposition::ActivationReserved)
+        );
+        assert_eq!(launches.load(Ordering::SeqCst), 1);
+        let mut next = router
+            .register_run(&running.id, "successor-1")
+            .await
+            .unwrap();
+        let result = refresh_turn_boundary_with_inbox_for_run(
+            &mut running,
+            Some(&storage),
+            Some(&persistence),
+            Some(&inbox),
+            Some("successor-1"),
+        )
+        .await;
+        assert_eq!(result.merged, 1);
+        assert_eq!(
+            running
+                .messages
+                .iter()
+                .filter(|message| message.id == deferred.id.as_str())
+                .count(),
+            1
+        );
+        next.begin_finalization().await;
+        assert_eq!(next.finish(cursor).await.unwrap(), None);
+        assert_eq!(reservations.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -714,6 +714,10 @@ impl AgentRuntime {
             ))),
             None => None,
         };
+        let guidance_active_run_id = match self.activation_router.as_ref() {
+            Some(router) => router.current_run_id(&session.id).await,
+            None => None,
+        };
         let system_prompt = extract_system_prompt(session);
         let config = self.config.read().await;
         let ExecuteRequest {
@@ -773,6 +777,7 @@ impl AgentRuntime {
         );
 
         let loop_config = AgentLoopConfig {
+            guidance_active_run_id,
             max_rounds: 200,
             system_prompt,
             // Snapshot the legacy model_limits from the live in-memory config so

--- a/crates/engine/bamboo-engine/src/session_activation.rs
+++ b/crates/engine/bamboo-engine/src/session_activation.rs
@@ -423,8 +423,10 @@ impl SessionRunRegistration {
             .router
             .finish_finalization(&self.target_session_id, &self.run_id, admitted_generation)
             .await;
-        self.armed = false;
-        self.abort_cleanup = None;
+        if result.is_ok() {
+            self.armed = false;
+            self.abort_cleanup = None;
+        }
         result
     }
 }
@@ -460,6 +462,15 @@ impl SessionActivationRouter {
     /// graph has been assembled.
     pub async fn set_spawner(&self, spawner: Arc<dyn SessionActivationSpawner>) {
         *self.spawner.write().await = Some(spawner);
+    }
+
+    /// Snapshot the current logical run, including its terminal handoff.
+    pub async fn current_run_id(&self, target_session_id: &str) -> Option<String> {
+        self.states
+            .lock()
+            .await
+            .get(target_session_id)
+            .and_then(|state| state.owner.as_ref().map(|owner| owner.run_id.clone()))
     }
 
     /// Bind the durable inbox used by abandoned-run reconciliation.
@@ -735,6 +746,22 @@ impl SessionActivationRouter {
         run_id: &str,
         admitted_generation: u64,
     ) -> Result<Option<SessionActivationDisposition>, SessionActivationError> {
+        // Deferred guidance may precede a later admitted message. A maximum
+        // transcript cursor alone cannot prove that this authorized queue is empty.
+        let inbox = self
+            .inbox
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let durable_pending = match inbox {
+            Some(inbox) => Some(
+                inbox
+                    .inspect(target_session_id)
+                    .await
+                    .map_err(|error| SessionActivationError::Internal(error.to_string()))?,
+            ),
+            None => None,
+        };
         let reservation_to_dispatch = {
             let mut states = self.states.lock().await;
             let state = states.entry(target_session_id.to_string()).or_default();
@@ -746,7 +773,14 @@ impl SessionActivationRouter {
                 return Ok(None);
             }
             state.owner = None;
-            if state.latest_generation > admitted_generation
+            let pending = durable_pending
+                .as_ref()
+                .is_some_and(|backlog| backlog.activation_pending());
+            if let Some(backlog) = durable_pending.as_ref() {
+                state.latest_generation =
+                    state.latest_generation.max(backlog.activation_generation);
+            }
+            if (pending || state.latest_generation > admitted_generation)
                 && state.latest_generation > state.last_dispatched_generation
                 && !state.activation_reserved
             {
@@ -759,6 +793,7 @@ impl SessionActivationRouter {
                 // caught up and no reservation exists, this target carries no
                 // live routing state and must not remain in AppState forever.
                 if state.latest_generation <= admitted_generation
+                    && !pending
                     && state.owner.is_none()
                     && !state.activation_reserved
                     && state.notify.receiver_count() == 0
@@ -1077,6 +1112,8 @@ mod tests {
     struct BlockingInspectInbox {
         entered: Arc<Notify>,
         release: Arc<Notify>,
+        drained: Arc<std::sync::atomic::AtomicBool>,
+        fail_once: Option<Arc<std::sync::atomic::AtomicBool>>,
     }
 
     #[async_trait]
@@ -1126,6 +1163,22 @@ mod tests {
             &self,
             _target_session_id: &str,
         ) -> Result<bamboo_domain::SessionInboxBacklog, bamboo_domain::SessionInboxError> {
+            if self
+                .fail_once
+                .as_ref()
+                .is_some_and(|flag| flag.swap(false, Ordering::SeqCst))
+            {
+                return Err(bamboo_domain::SessionInboxError::Storage(
+                    "injected inspect failure".into(),
+                ));
+            }
+            if self.drained.load(Ordering::SeqCst) {
+                return Ok(bamboo_domain::SessionInboxBacklog {
+                    generation: 1,
+                    activation_generation: 1,
+                    ..Default::default()
+                });
+            }
             self.entered.notify_one();
             self.release.notified().await;
             Ok(bamboo_domain::SessionInboxBacklog {
@@ -1569,9 +1622,12 @@ mod tests {
         router.set_spawner(spawner.clone()).await;
         let inspect_entered = Arc::new(Notify::new());
         let inspect_release = Arc::new(Notify::new());
+        let drained = Arc::new(std::sync::atomic::AtomicBool::new(false));
         router.set_inbox(Arc::new(BlockingInspectInbox {
             entered: inspect_entered.clone(),
             release: inspect_release.clone(),
+            drained: drained.clone(),
+            fail_once: None,
         }));
 
         let registration = router
@@ -1606,6 +1662,7 @@ mod tests {
         assert!(!router.owns_run("session", "run-abandoned").await);
 
         let mut successor = router.register_run("session", "run-1").await.unwrap();
+        drained.store(true, Ordering::SeqCst);
         successor.begin_finalization().await;
         assert_eq!(successor.finish(1).await.unwrap(), None);
     }
@@ -2023,10 +2080,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_terminal_inspection_keeps_the_exact_owner_cleanup_armed() {
+        let router = SessionActivationRouter::new();
+        let spawner = spawner();
+        router.set_spawner(spawner.clone()).await;
+        let inspect_release = Arc::new(Notify::new());
+        inspect_release.notify_one();
+        router.set_inbox(Arc::new(BlockingInspectInbox {
+            entered: Arc::new(Notify::new()),
+            release: inspect_release,
+            drained: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            fail_once: Some(Arc::new(std::sync::atomic::AtomicBool::new(true))),
+        }));
+        let mut registration = router
+            .register_run("session", "failed-inspect-run")
+            .await
+            .unwrap();
+        router.request_activation("session", 1).await.unwrap();
+        registration.begin_finalization().await;
+        assert!(registration.finish(1).await.is_err());
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while spawner.launches.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("failed inspection must not leave the old run owning the inbox");
+        assert!(!router.owns_run("session", "failed-inspect-run").await);
+        assert_eq!(spawner.launches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn poison_generation_launches_only_one_successor_until_new_work_arrives() {
         let router = SessionActivationRouter::new();
         let spawner = spawner();
         router.set_spawner(spawner.clone()).await;
+        let inspect_release = Arc::new(Notify::new());
+        router.set_inbox(Arc::new(BlockingInspectInbox {
+            entered: Arc::new(Notify::new()),
+            release: inspect_release.clone(),
+            drained: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            fail_once: None,
+        }));
         let mut registration = router
             .register_run("session", "run-original")
             .await
@@ -2036,6 +2131,7 @@ mod tests {
             SessionActivationDisposition::ActiveNotified
         );
         registration.begin_finalization().await;
+        inspect_release.notify_one();
         assert_eq!(
             registration.finish(0).await.unwrap(),
             Some(SessionActivationDisposition::ActivationReserved)
@@ -2047,6 +2143,7 @@ mod tests {
         // cannot recursively launch provider loops.
         let mut successor_registration = router.register_run("session", "run-1").await.unwrap();
         successor_registration.begin_finalization().await;
+        inspect_release.notify_one();
         assert_eq!(successor_registration.finish(0).await.unwrap(), None);
         assert_eq!(
             router.request_activation("session", 7).await.unwrap(),

--- a/crates/engine/bamboo-engine/src/session_messaging.rs
+++ b/crates/engine/bamboo-engine/src/session_messaging.rs
@@ -269,12 +269,21 @@ impl SessionMessenger {
         &self,
         admission: &SessionMessengerAdmission,
     ) -> Result<SessionMessengerReceipt, SessionMessengerError> {
+        self.activate_with_policy(admission, SessionActivationPolicy::InterruptSpecificWait)
+            .await
+    }
+
+    pub async fn activate_with_policy(
+        &self,
+        admission: &SessionMessengerAdmission,
+        policy: SessionActivationPolicy,
+    ) -> Result<SessionMessengerReceipt, SessionMessengerError> {
         if let Err(error) = self
             .inbox
             .mark_activation_eligible(
                 &admission.target_session_id,
                 admission.delivery.generation,
-                SessionActivationPolicy::InterruptSpecificWait,
+                policy,
             )
             .await
         {

--- a/crates/infra/bamboo-storage/src/session_inbox.rs
+++ b/crates/infra/bamboo-storage/src/session_inbox.rs
@@ -469,7 +469,7 @@ impl FileSessionInbox {
         }
         let id = &requested.id;
         let requested_digest = Self::semantic_digest(requested)?;
-        for queue in ["new", "cur"] {
+        for queue in ["new", "cur", "cancelled"] {
             for (generation, _name, path) in Self::valid_queue_entries(dir, queue).await? {
                 let Ok(bytes) = tokio::fs::read(path).await else {
                     continue;
@@ -851,6 +851,71 @@ impl SessionInboxPort for FileSessionInbox {
         }
     }
 
+    async fn pending_guidance(
+        &self,
+        target_session_id: &str,
+    ) -> Result<Vec<SessionMessageEnvelope>, SessionInboxError> {
+        let _lifecycle = self.lock_lifecycle().await?;
+        let dir = self.inbox_dir(target_session_id).await?;
+        let _guard = self.lock_operation(&dir).await?;
+        let mut entries = Self::valid_queue_entries(&dir, "new").await?;
+        entries.sort_by_key(|entry| entry.0);
+        let mut result = Vec::new();
+        for (_, _, path) in entries {
+            let bytes = tokio::fs::read(path)
+                .await
+                .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+            let wrapper: InboxMessage = serde_json::from_slice(&bytes)
+                .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+            let envelope: SessionMessageEnvelope = serde_json::from_value(wrapper.body)
+                .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+            if envelope.source == SessionMessageSource::User
+                && envelope.kind == bamboo_domain::SessionMessageKind::UserInput
+                && envelope.correlation_id.as_deref() == Some("session-guidance")
+                && envelope.target_session_id == target_session_id
+            {
+                result.push(envelope);
+            }
+        }
+        Ok(result)
+    }
+
+    async fn cancel_guidance(
+        &self,
+        target_session_id: &str,
+        id: &SessionMessageId,
+    ) -> Result<bool, SessionInboxError> {
+        let _lifecycle = self.lock_lifecycle().await?;
+        let dir = self.inbox_dir(target_session_id).await?;
+        let _guard = self.lock_operation(&dir).await?;
+        // The same operation lock protects claim and withdrawal across adapters.
+        // Retain the original envelope as a permanent deduplication tombstone.
+        for (_, name, path) in Self::valid_queue_entries(&dir, "new").await? {
+            let bytes = tokio::fs::read(&path)
+                .await
+                .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+            let wrapper: InboxMessage = serde_json::from_slice(&bytes)
+                .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+            let envelope: SessionMessageEnvelope = serde_json::from_value(wrapper.body)
+                .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+            if &envelope.id == id
+                && envelope.source == SessionMessageSource::User
+                && envelope.kind == bamboo_domain::SessionMessageKind::UserInput
+                && envelope.correlation_id.as_deref() == Some("session-guidance")
+                && envelope.target_session_id == target_session_id
+            {
+                tokio::fs::create_dir_all(dir.join("cancelled"))
+                    .await
+                    .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+                tokio::fs::rename(path, dir.join("cancelled").join(name))
+                    .await
+                    .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     async fn inspect(
         &self,
         target_session_id: &str,
@@ -904,6 +969,44 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn withdrawal_is_durable_and_never_retracts_a_claim() {
+        let (_temp, store, inbox) = fixture(SessionInboxLimits::default()).await;
+        let mut message = SessionMessageEnvelope::user_input("session-1", "guidance");
+        message.correlation_id = Some("session-guidance".into());
+        inbox.deliver(&message).await.unwrap();
+        assert_eq!(inbox.pending_guidance("session-1").await.unwrap().len(), 1);
+        assert!(inbox
+            .cancel_guidance("session-1", &message.id)
+            .await
+            .unwrap());
+        let reopened = FileSessionInbox::new(store, SessionInboxLimits::default());
+        reopened.deliver(&message).await.unwrap();
+        assert!(reopened
+            .pending_guidance("session-1")
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            reopened
+                .inspect("session-1")
+                .await
+                .unwrap()
+                .oldest_generation,
+            None
+        );
+        message.id = SessionMessageId::new();
+        reopened.deliver(&message).await.unwrap();
+        authorize_latest(&reopened).await;
+        let claims = reopened.claim("session-1", 1).await.unwrap();
+        assert_eq!(claims.len(), 1);
+        assert!(!reopened
+            .cancel_guidance("session-1", &message.id)
+            .await
+            .unwrap());
+        assert_eq!(reopened.inspect("session-1").await.unwrap().claimed, 1);
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-storage/src/session_inbox.rs
+++ b/crates/infra/bamboo-storage/src/session_inbox.rs
@@ -617,6 +617,15 @@ impl SessionInboxPort for FileSessionInbox {
         target_session_id: &str,
         limit: usize,
     ) -> Result<Vec<SessionInboxClaim>, SessionInboxError> {
+        self.claim_for_turn(target_session_id, limit, None).await
+    }
+
+    async fn claim_for_turn(
+        &self,
+        target_session_id: &str,
+        limit: usize,
+        active_run_id: Option<&str>,
+    ) -> Result<Vec<SessionInboxClaim>, SessionInboxError> {
         let _lifecycle = self.lock_lifecycle().await?;
         let dir = self.inbox_dir(target_session_id).await?;
         let _guard = self.lock_operation(&dir).await?;
@@ -639,6 +648,21 @@ impl SessionInboxPort for FileSessionInbox {
         for queue in ["cur", "new"] {
             for (generation, name, _) in Self::valid_queue_entries(&dir, queue).await? {
                 if generation <= activation_generation {
+                    if let Some(run_id) = active_run_id {
+                        let path = dir.join(queue).join(&name);
+                        let bytes = tokio::fs::read(&path)
+                            .await
+                            .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
+                        if let Ok(wrapper) = serde_json::from_slice::<InboxMessage>(&bytes) {
+                            if let Ok(envelope) =
+                                serde_json::from_value::<SessionMessageEnvelope>(wrapper.body)
+                            {
+                                if envelope.guidance_waits_for_run(run_id) {
+                                    continue;
+                                }
+                            }
+                        }
+                    }
                     eligible.push((generation, name, queue == "cur"));
                 }
             }
@@ -869,11 +893,7 @@ impl SessionInboxPort for FileSessionInbox {
                 .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
             let envelope: SessionMessageEnvelope = serde_json::from_value(wrapper.body)
                 .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
-            if envelope.source == SessionMessageSource::User
-                && envelope.kind == bamboo_domain::SessionMessageKind::UserInput
-                && envelope.correlation_id.as_deref() == Some("session-guidance")
-                && envelope.target_session_id == target_session_id
-            {
+            if envelope.is_guidance() && envelope.target_session_id == target_session_id {
                 result.push(envelope);
             }
         }
@@ -899,9 +919,7 @@ impl SessionInboxPort for FileSessionInbox {
             let envelope: SessionMessageEnvelope = serde_json::from_value(wrapper.body)
                 .map_err(|error| SessionInboxError::Storage(error.to_string()))?;
             if &envelope.id == id
-                && envelope.source == SessionMessageSource::User
-                && envelope.kind == bamboo_domain::SessionMessageKind::UserInput
-                && envelope.correlation_id.as_deref() == Some("session-guidance")
+                && envelope.is_guidance()
                 && envelope.target_session_id == target_session_id
             {
                 tokio::fs::create_dir_all(dir.join("cancelled"))
@@ -969,6 +987,51 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn deferred_guidance_keeps_its_run_fence_across_retries_and_reopen() {
+        let (_temp, sessions, inbox) = fixture(SessionInboxLimits::default()).await;
+        let mut deferred = SessionMessageEnvelope::user_input("session-1", "after task");
+        deferred.correlation_id = Some("session-guidance-after-run:run-a".into());
+        let original = inbox.deliver(&deferred).await.unwrap();
+        let mut later = SessionMessageEnvelope::user_input("session-1", "after round");
+        later.correlation_id = Some("session-guidance".into());
+        inbox.deliver(&later).await.unwrap();
+        authorize_latest(&inbox).await;
+        let claims = inbox
+            .claim_for_turn("session-1", 128, Some("run-a"))
+            .await
+            .unwrap();
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].envelope.id, later.id);
+        inbox.ack("session-1", &claims[0]).await.unwrap();
+        let mut retry = deferred.clone();
+        retry.correlation_id = Some("session-guidance-after-run:run-b".into());
+        assert_eq!(inbox.deliver(&retry).await.unwrap(), original);
+        let reopened = FileSessionInbox::new(sessions, SessionInboxLimits::default());
+        assert_eq!(
+            reopened.pending_guidance("session-1").await.unwrap()[0],
+            deferred
+        );
+        assert!(reopened
+            .claim_for_turn("session-1", 128, Some("run-a"))
+            .await
+            .unwrap()
+            .is_empty());
+        let claims = reopened
+            .claim_for_turn("session-1", 128, Some("run-b"))
+            .await
+            .unwrap();
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].envelope.id, deferred.id);
+        reopened.ack("session-1", &claims[0]).await.unwrap();
+        assert_eq!(reopened.deliver(&retry).await.unwrap(), original);
+        assert!(!reopened
+            .inspect("session-1")
+            .await
+            .unwrap()
+            .activation_pending());
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -3986,6 +3986,29 @@ impl SessionStoreV2 {
         raw_base64_or_data_url: &str,
         mime_hint: Option<&str>,
     ) -> io::Result<(String, String)> {
+        self.write_image_attachment_inner(session, raw_base64_or_data_url, mime_hint, false)
+            .await
+    }
+
+    /// Store immutable image content under a repeatable reference for durable
+    /// message admission retries. Ordinary chat attachment naming is unchanged.
+    pub async fn write_image_attachment_deduplicated(
+        &self,
+        session: &Session,
+        raw_base64_or_data_url: &str,
+        mime_hint: Option<&str>,
+    ) -> io::Result<(String, String)> {
+        self.write_image_attachment_inner(session, raw_base64_or_data_url, mime_hint, true)
+            .await
+    }
+
+    async fn write_image_attachment_inner(
+        &self,
+        session: &Session,
+        raw_base64_or_data_url: &str,
+        mime_hint: Option<&str>,
+        deduplicate: bool,
+    ) -> io::Result<(String, String)> {
         let _lifecycle = self.lock_session_lifecycle_shared().await?;
         let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
         let (mime, base64_data) =
@@ -4000,7 +4023,20 @@ impl SessionStoreV2 {
             .decode(base64_data.as_bytes())
             .map_err(|e| other_io_error(format!("invalid base64 image data: {e}")))?;
 
-        let attachment_id = Uuid::new_v4().to_string();
+        let attachment_id = if deduplicate {
+            use sha2::{Digest, Sha256};
+            let mut digest = Sha256::new();
+            digest.update(mime.as_bytes());
+            digest.update([0]);
+            digest.update(&bytes);
+            digest
+                .finalize()
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
+        } else {
+            Uuid::new_v4().to_string()
+        };
         let ext = mime_to_extension(mime.as_str()).unwrap_or("bin");
 
         let rel_path = self.ensure_session_dirs(session).await?;

--- a/docs/session-guidance.md
+++ b/docs/session-guidance.md
@@ -1,0 +1,39 @@
+# Queued user messages
+
+The composer can submit text and images while a run is active. These messages use
+`POST /api/v1/sessions/{session_id}/guidance` rather than modifying the running
+transcript directly. The request includes a stable `id`, `text`, optional `images`
+(the ordinary chat image shape), and `mode`:
+
+- `after_round` (default): admit before the next available model call.
+- `after_run`: leave the message pending while its recorded activation run owns
+  the session, then admit it under a successor run. This is a run boundary, not a
+  condition that the entire Goal has been achieved.
+
+The queue uses the normal durable inbox and single-owner activation router.
+Finalization checks authorized pending work as well as the transcript cursor, so
+later round messages cannot hide an earlier deferred message. The existing
+one-successor-per-generation guard remains in effect for failing checkpoints.
+Deferred messages respect specific child or background-task waits.
+
+Images are stored in the existing attachment directory. Immutable content and
+MIME produce repeatable attachment references so replaying a submission preserves
+its identity. Inbox envelopes contain multimodal parts with attachment references;
+the normal per-round image preparation resolves them for the provider. The HTTP
+body limit is unchanged and a queued message accepts at most 16 images.
+
+`GET` on the same route lists pending text, mode, image attachment ids and creation
+time. `DELETE /guidance/{id}` withdraws an unclaimed message. Cancellation retains
+the deduplication receipt; attachments are retained because another message may
+reference the same content.
+
+The UI keeps accepted items in a collapsed queue menu with image previews. It
+clears composer text and attachments only after a matching acknowledgement and
+only when their draft revisions are unchanged. Retry receipts store a payload
+fingerprint, not image bytes, in browser session storage. Queued content survives
+reload through the server inbox; unsubmitted image drafts remain browser-local.
+
+Goal commands use the existing chat command handler. `/goal` opens the settings
+for the current session; `/goal <objective>` sets and advances a goal, and control
+commands such as `/goal off` and `/goal clear` follow the server's response without
+starting an unwanted execution.


### PR DESCRIPTION
## Summary

Add durable pending messages with text and/or images, listing and withdrawal. after_round applies at the next eligible model call; after_run defers until the current activation finishes. Preserve request identity and attachment references across retries and restarts, and serialize successor execution.

## Test Plan

Integrated final engine suite: 1484 passed; storage: 234 passed. Server full mode-stage regression: 1991 passed, 1 existing ignore; final image endpoints and error contract passed separately. Real local Bamboo with a controlled streaming provider verified both timing modes, image payloads, pure images, retry/restart deduplication, cancellation and no concurrent model runs. See docs/session-guidance.md.

Required CI and current-head independent review must pass before merge.
