### PR TITLE
feat: add revisioned SQLite session shadow store

### DIFF
--- a/crates/infra/bamboo-storage/examples/v3_shadow.rs
+++ b/crates/infra/bamboo-storage/examples/v3_shadow.rs
@@ -1,0 +1,29 @@
+//! Import a captured Session tree into an explicitly named shadow database.
+use bamboo_domain::Session;
+use bamboo_storage::v3::SessionStoreV3;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args_os().skip(1);
+    let source = args
+        .next()
+        .ok_or("usage: v3_shadow <session-tree.json> <shadow.sqlite>")?;
+    let target = args
+        .next()
+        .ok_or("usage: v3_shadow <session-tree.json> <shadow.sqlite>")?;
+    if args.next().is_some() {
+        return Err("unexpected arguments".into());
+    }
+    let sessions: Vec<Session> = serde_json::from_slice(&std::fs::read(source)?)?;
+    let store = SessionStoreV3::open(target)?;
+    store.import_tree_shadow(&sessions)?;
+    for session in &sessions {
+        if !store.verify_shadow(session)? {
+            return Err("shadow verification mismatch".into());
+        }
+    }
+    println!(
+        "Verified {} session snapshots. Runtime authority is unchanged.",
+        sessions.len()
+    );
+    Ok(())
+}

--- a/crates/infra/bamboo-storage/src/lib.rs
+++ b/crates/infra/bamboo-storage/src/lib.rs
@@ -12,6 +12,7 @@ pub mod search_index;
 pub mod session_inbox;
 pub mod session_merge;
 pub mod v2;
+pub mod v3;
 
 pub use jsonl::JsonlStorage;
 pub use search_index::{SessionSearchIndex, SessionSearchMatch};

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -272,7 +272,7 @@ pub struct SessionCopyProjectionGuard {
 /// Build the sidecar snapshot: the full session minus its `messages` history.
 /// Every field except `messages` is authoritative in the sidecar; on load the
 /// message history is taken back from `session.json`.
-fn runtime_sidecar_snapshot(session: &Session) -> Session {
+pub(crate) fn runtime_sidecar_snapshot(session: &Session) -> Session {
     let mut snapshot = session.clone();
     snapshot.messages.clear();
     // Native transcript groups are committed atomically with the ordinary

--- a/crates/infra/bamboo-storage/src/v3/mod.rs
+++ b/crates/infra/bamboo-storage/src/v3/mod.rs
@@ -325,6 +325,13 @@ fn validate_session(session: &Session) -> Result<()> {
     if session.id.trim().is_empty() {
         return Err(V3Error::Invalid("empty session id".into()));
     }
+    if session.kind == bamboo_domain::SessionKind::Root
+        && (session.parent_session_id.is_some()
+            || session.spawn_depth != 0
+            || root_id(session) != session.id)
+    {
+        return Err(V3Error::Invalid("invalid root identity".into()));
+    }
     let mut ids = HashSet::new();
     for message in &session.messages {
         if message.id.is_empty() || !ids.insert(&message.id) {

--- a/crates/infra/bamboo-storage/src/v3/mod.rs
+++ b/crates/infra/bamboo-storage/src/v3/mod.rs
@@ -1,0 +1,455 @@
+//! Opt-in SQLite session snapshots and shadow imports.
+//!
+//! This store is not a runtime authority selector. Opening it never changes V2
+//! files or activates a session. Call synchronous methods on a blocking worker
+//! when embedding this offline/shadow API in an async application.
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
+use std::time::Duration;
+
+use bamboo_domain::{Message, Session, SessionInboxAdmissionState};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+const APPLICATION_ID: i64 = 0x424d4233;
+const VERSION: i64 = 3;
+
+#[derive(Debug, thiserror::Error)]
+pub enum V3Error {
+    #[error(transparent)]
+    Sql(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("session revision or creation identity changed")]
+    Conflict,
+    #[error("session snapshot not found")]
+    NotFound,
+    #[error("invalid session snapshot: {0}")]
+    Invalid(String),
+    #[error("unsupported session database")]
+    UnsupportedDatabase,
+    #[error("session database lock was poisoned")]
+    Poisoned,
+}
+type Result<T> = std::result::Result<T, V3Error>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct V3Revision {
+    pub history: i64,
+    pub runtime: i64,
+}
+
+#[derive(Debug)]
+pub struct V3Snapshot {
+    pub session: Session,
+    pub revision: V3Revision,
+}
+
+#[derive(Serialize, Deserialize)]
+struct HistoryProof {
+    provider_transcript: bamboo_domain::ProviderTranscriptState,
+    admission: Option<SessionInboxAdmissionState>,
+}
+
+pub struct SessionStoreV3 {
+    connection: Mutex<Connection>,
+}
+
+impl SessionStoreV3 {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let mut connection = Connection::open(path)?;
+        connection.busy_timeout(Duration::from_secs(5))?;
+        let application: i64 =
+            connection.pragma_query_value(None, "application_id", |row| row.get(0))?;
+        let version: i64 = connection.pragma_query_value(None, "user_version", |row| row.get(0))?;
+        let tables: i64 = connection.query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+            [],
+            |row| row.get(0),
+        )?;
+        if !(application == APPLICATION_ID && version == VERSION)
+            && !(application == 0 && version == 0 && tables == 0)
+        {
+            return Err(V3Error::UnsupportedDatabase);
+        }
+        connection.pragma_update(None, "journal_mode", "WAL")?;
+        connection.pragma_update(None, "synchronous", "FULL")?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS sessions (
+            session_id TEXT PRIMARY KEY,
+            root_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            history_rev INTEGER NOT NULL CHECK(history_rev > 0),
+            runtime_rev INTEGER NOT NULL CHECK(runtime_rev > 0),
+            runtime_json BLOB NOT NULL,
+            proof_json BLOB NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+            ordinal INTEGER NOT NULL CHECK(ordinal >= 0),
+            payload BLOB NOT NULL,
+            PRIMARY KEY(session_id, ordinal)
+        );",
+        )?;
+        tx.pragma_update(None, "application_id", APPLICATION_ID)?;
+        tx.pragma_update(None, "user_version", VERSION)?;
+        tx.commit()?;
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    fn connection(&self) -> Result<MutexGuard<'_, Connection>> {
+        self.connection.lock().map_err(|_| V3Error::Poisoned)
+    }
+
+    /// Full snapshot CAS. None creates; Some requires both current revisions.
+    /// Only changed message rows are written, even when an earlier row is edited.
+    pub fn put(&self, session: &Session, expected: Option<V3Revision>) -> Result<V3Revision> {
+        let mut connection = self.connection()?;
+        let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let revision = put_in_transaction(&tx, session, expected)?;
+        tx.commit()?;
+        Ok(revision)
+    }
+
+    /// Replace control state without loading or writing messages or history proof.
+    /// Pass the message-free snapshot returned by `load_runtime`. A runtime CAS
+    /// and immutable root/creation identity protect against stale updates.
+    pub fn put_runtime(&self, session: &Session, expected_runtime: i64) -> Result<V3Revision> {
+        if session.id.trim().is_empty() {
+            return Err(V3Error::Invalid("empty session id".into()));
+        }
+        if !session.messages.is_empty()
+            || !session.provider_transcript.is_empty()
+            || session
+                .runtime_metadata
+                .as_ref()
+                .is_some_and(|metadata| metadata.session_inbox_admission.is_some())
+        {
+            return Err(V3Error::Invalid(
+                "runtime updates require a message-free runtime snapshot".into(),
+            ));
+        }
+        let bytes = runtime_bytes(session)?;
+        let mut connection = self.connection()?;
+        let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let stored = runtime_header(&tx, &session.id)?.ok_or(V3Error::NotFound)?;
+        check_identity(session, &stored)?;
+        if stored.revision.runtime != expected_runtime {
+            return Err(V3Error::Conflict);
+        }
+        let mut revision = stored.revision;
+        if stored.runtime != bytes {
+            revision.runtime = next_revision(revision.runtime)?;
+            tx.execute(
+                "UPDATE sessions SET runtime_json=?1, runtime_rev=?2 WHERE session_id=?3",
+                params![bytes, revision.runtime, session.id],
+            )?;
+        }
+        tx.commit()?;
+        Ok(revision)
+    }
+
+    /// Read a coherent control/history snapshot across independent connections.
+    pub fn load(&self, id: &str) -> Result<Option<V3Snapshot>> {
+        let mut connection = self.connection()?;
+        let tx = connection.transaction()?;
+        let Some(stored) = header(&tx, id)? else {
+            return Ok(None);
+        };
+        let mut session: Session = serde_json::from_slice(&stored.runtime)?;
+        if session.id != id {
+            return Err(V3Error::Invalid("runtime identity mismatch".into()));
+        }
+        let proof: HistoryProof = serde_json::from_slice(&stored.proof)?;
+        session.provider_transcript = proof.provider_transcript;
+        if let Some(admission) = proof.admission {
+            session
+                .runtime_metadata
+                .get_or_insert_with(Default::default)
+                .session_inbox_admission = Some(admission);
+        }
+        let rows = message_rows(&tx, id)?;
+        session.messages = rows
+            .into_iter()
+            .map(|row| serde_json::from_slice(&row))
+            .collect::<std::result::Result<_, _>>()?;
+        validate_session(&session)?;
+        check_identity(&session, &stored)?;
+        tx.commit()?;
+        Ok(Some(V3Snapshot {
+            session,
+            revision: stored.revision,
+        }))
+    }
+
+    /// Small control snapshot; no history or provider transcript is returned.
+    pub fn load_runtime(&self, id: &str) -> Result<Option<V3Snapshot>> {
+        let connection = self.connection()?;
+        let Some(stored) = runtime_header(&connection, id)? else {
+            return Ok(None);
+        };
+        let session: Session = serde_json::from_slice(&stored.runtime)?;
+        if session.id != id {
+            return Err(V3Error::Invalid("runtime identity mismatch".into()));
+        }
+        check_identity(&session, &stored)?;
+        Ok(Some(V3Snapshot {
+            session,
+            revision: stored.revision,
+        }))
+    }
+
+    /// Pagination fails if history changed since the caller obtained its revision.
+    pub fn message_page(
+        &self,
+        id: &str,
+        offset: u64,
+        limit: usize,
+        history_revision: i64,
+    ) -> Result<Vec<Message>> {
+        if limit == 0 || limit > 1000 || offset > i64::MAX as u64 {
+            return Err(V3Error::Invalid("invalid page bounds".into()));
+        }
+        let mut connection = self.connection()?;
+        let tx = connection.transaction()?;
+        let revision: Option<i64> = tx
+            .query_row(
+                "SELECT history_rev FROM sessions WHERE session_id=?1",
+                [id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if revision.ok_or(V3Error::NotFound)? != history_revision {
+            return Err(V3Error::Conflict);
+        }
+        let result = {
+            let mut query = tx.prepare("SELECT payload FROM messages WHERE session_id=?1 AND ordinal>=?2 ORDER BY ordinal LIMIT ?3")?;
+            let rows = query.query_map(params![id, offset as i64, limit as i64], |row| {
+                row.get::<_, Vec<u8>>(0)
+            })?;
+            rows.map(|row| Ok(serde_json::from_slice(&row?)?))
+                .collect::<Result<Vec<_>>>()?
+        };
+        tx.commit()?;
+        Ok(result)
+    }
+
+    /// Import one complete tree atomically into an empty shadow namespace.
+    /// A duplicate, missing parent, cycle, or existing id aborts the entire tree.
+    pub fn import_tree_shadow(&self, sessions: &[Session]) -> Result<Vec<V3Revision>> {
+        validate_tree(sessions)?;
+        let mut connection = self.connection()?;
+        let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let mut revisions = Vec::new();
+        for session in sessions {
+            revisions.push(put_in_transaction(&tx, session, None)?);
+        }
+        tx.commit()?;
+        Ok(revisions)
+    }
+
+    /// Exact semantic comparison for a captured source snapshot. This grants no
+    /// write-authority switch; active V2 writers may advance after capture.
+    pub fn verify_shadow(&self, source: &Session) -> Result<bool> {
+        let Some(snapshot) = self.load(&source.id)? else {
+            return Ok(false);
+        };
+        Ok(
+            bamboo_domain::canonical_json_bytes(&serde_json::to_value(source)?)
+                == bamboo_domain::canonical_json_bytes(&serde_json::to_value(snapshot.session)?),
+        )
+    }
+}
+
+struct Header {
+    root: String,
+    created_at: String,
+    revision: V3Revision,
+    runtime: Vec<u8>,
+    proof: Vec<u8>,
+}
+fn header(connection: &Connection, id: &str) -> Result<Option<Header>> {
+    Ok(connection.query_row("SELECT root_id,created_at,history_rev,runtime_rev,runtime_json,proof_json FROM sessions WHERE session_id=?1", [id], |row| {
+        Ok(Header { root: row.get(0)?, created_at: row.get(1)?, revision: V3Revision { history: row.get(2)?, runtime: row.get(3)? }, runtime: row.get(4)?, proof: row.get(5)? })
+    }).optional()?)
+}
+fn runtime_header(connection: &Connection, id: &str) -> Result<Option<Header>> {
+    Ok(connection.query_row("SELECT root_id,created_at,history_rev,runtime_rev,runtime_json FROM sessions WHERE session_id=?1", [id], |row| {
+        Ok(Header { root: row.get(0)?, created_at: row.get(1)?, revision: V3Revision { history: row.get(2)?, runtime: row.get(3)? }, runtime: row.get(4)?, proof: Vec::new() })
+    }).optional()?)
+}
+fn root_id(session: &Session) -> &str {
+    if session.root_session_id.is_empty() {
+        &session.id
+    } else {
+        &session.root_session_id
+    }
+}
+fn check_identity(session: &Session, stored: &Header) -> Result<()> {
+    let current: Session = serde_json::from_slice(&stored.runtime)?;
+    if session.id != current.id
+        || root_id(session) != stored.root
+        || session.created_at.to_rfc3339() != stored.created_at
+        || session.authority_identity != current.authority_identity
+        || session.kind != current.kind
+        || session.parent_session_id != current.parent_session_id
+        || session.spawn_depth != current.spawn_depth
+        || session.metadata_version < current.metadata_version
+        || (session.project_id_meta() != current.project_id_meta()
+            && current.metadata_version.checked_add(1) != Some(session.metadata_version))
+    {
+        return Err(V3Error::Conflict);
+    }
+    Ok(())
+}
+fn canonical<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    Ok(bamboo_domain::canonical_json_bytes(&serde_json::to_value(
+        value,
+    )?))
+}
+fn runtime_bytes(session: &Session) -> Result<Vec<u8>> {
+    canonical(&crate::v2::runtime_sidecar_snapshot(session))
+}
+fn message_rows(connection: &Connection, id: &str) -> Result<Vec<Vec<u8>>> {
+    let mut query =
+        connection.prepare("SELECT payload FROM messages WHERE session_id=?1 ORDER BY ordinal")?;
+    let rows = query.query_map([id], |row| row.get(0))?;
+    Ok(rows.collect::<std::result::Result<_, _>>()?)
+}
+fn validate_session(session: &Session) -> Result<()> {
+    if session.id.trim().is_empty() {
+        return Err(V3Error::Invalid("empty session id".into()));
+    }
+    let mut ids = HashSet::new();
+    for message in &session.messages {
+        if message.id.is_empty() || !ids.insert(&message.id) {
+            return Err(V3Error::Invalid("empty or duplicate message id".into()));
+        }
+    }
+    Ok(())
+}
+fn next_revision(value: i64) -> Result<i64> {
+    value
+        .checked_add(1)
+        .filter(|next| *next > 0)
+        .ok_or(V3Error::Conflict)
+}
+fn put_in_transaction(
+    tx: &Transaction<'_>,
+    session: &Session,
+    expected: Option<V3Revision>,
+) -> Result<V3Revision> {
+    validate_session(session)?;
+    let existing = header(tx, &session.id)?;
+    if existing.as_ref().map(|header| header.revision) != expected {
+        return Err(V3Error::Conflict);
+    }
+    if let Some(stored) = &existing {
+        check_identity(session, stored)?;
+    }
+    let runtime = runtime_bytes(session)?;
+    let proof = canonical(&HistoryProof {
+        provider_transcript: session.provider_transcript.clone(),
+        admission: session
+            .runtime_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.session_inbox_admission.clone()),
+    })?;
+    let messages = session
+        .messages
+        .iter()
+        .map(canonical)
+        .collect::<Result<Vec<_>>>()?;
+    let previous = message_rows(tx, &session.id)?;
+    let history_changed =
+        previous != messages || existing.as_ref().is_none_or(|stored| stored.proof != proof);
+    let runtime_changed = existing
+        .as_ref()
+        .is_none_or(|stored| stored.runtime != runtime);
+    let revision = match &existing {
+        Some(stored) => V3Revision {
+            history: if history_changed {
+                next_revision(stored.revision.history)?
+            } else {
+                stored.revision.history
+            },
+            runtime: if runtime_changed {
+                next_revision(stored.revision.runtime)?
+            } else {
+                stored.revision.runtime
+            },
+        },
+        None => V3Revision {
+            history: 1,
+            runtime: 1,
+        },
+    };
+    if history_changed || runtime_changed {
+        tx.execute("INSERT INTO sessions(session_id,root_id,created_at,history_rev,runtime_rev,runtime_json,proof_json) VALUES(?1,?2,?3,?4,?5,?6,?7)
+            ON CONFLICT(session_id) DO UPDATE SET history_rev=excluded.history_rev,runtime_rev=excluded.runtime_rev,runtime_json=excluded.runtime_json,proof_json=excluded.proof_json",
+            params![session.id, root_id(session), session.created_at.to_rfc3339(), revision.history, revision.runtime, runtime, proof])?;
+    }
+    for (ordinal, payload) in messages.iter().enumerate() {
+        if previous.get(ordinal) != Some(payload) {
+            tx.execute("INSERT INTO messages(session_id,ordinal,payload) VALUES(?1,?2,?3) ON CONFLICT(session_id,ordinal) DO UPDATE SET payload=excluded.payload",
+                params![session.id, ordinal as i64, payload])?;
+        }
+    }
+    if previous.len() > messages.len() {
+        tx.execute(
+            "DELETE FROM messages WHERE session_id=?1 AND ordinal>=?2",
+            params![session.id, messages.len() as i64],
+        )?;
+    }
+    Ok(revision)
+}
+fn validate_tree(sessions: &[Session]) -> Result<()> {
+    let Some(first) = sessions.first() else {
+        return Err(V3Error::Invalid("empty tree".into()));
+    };
+    let root = root_id(first);
+    let mut ids = HashSet::new();
+    for session in sessions {
+        validate_session(session)?;
+        if root_id(session) != root || !ids.insert(session.id.as_str()) {
+            return Err(V3Error::Invalid("mixed roots or duplicate sessions".into()));
+        }
+    }
+    if !ids.contains(root) {
+        return Err(V3Error::Invalid("missing root".into()));
+    }
+    for session in sessions {
+        let mut seen = HashSet::new();
+        let mut current = session;
+        loop {
+            if !seen.insert(current.id.as_str()) {
+                return Err(V3Error::Invalid("parent cycle".into()));
+            }
+            if current.id == root {
+                if current.parent_session_id.is_some()
+                    || current.kind != bamboo_domain::SessionKind::Root
+                {
+                    return Err(V3Error::Invalid("invalid root".into()));
+                }
+                break;
+            }
+            let parent = current
+                .parent_session_id
+                .as_deref()
+                .ok_or_else(|| V3Error::Invalid("missing parent".into()))?;
+            current = sessions
+                .iter()
+                .find(|candidate| candidate.id == parent)
+                .ok_or_else(|| V3Error::Invalid("parent outside tree".into()))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/infra/bamboo-storage/src/v3/tests.rs
+++ b/crates/infra/bamboo-storage/src/v3/tests.rs
@@ -1,0 +1,218 @@
+use super::*;
+use bamboo_domain::{Message, SessionMessageEnvelope};
+use tempfile::TempDir;
+
+fn fixture() -> (TempDir, SessionStoreV3, Session) {
+    let temp = TempDir::new().unwrap();
+    let store = SessionStoreV3::open(temp.path().join("shadow.sqlite")).unwrap();
+    let mut session = Session::new("root", "model");
+    session.add_message(Message::user("first"));
+    session.add_message(Message::assistant("answer", None));
+    (temp, store, session)
+}
+
+#[test]
+fn round_trip_runtime_updates_and_reopen_preserve_history_proof() {
+    let (temp, store, mut session) = fixture();
+    let envelope = SessionMessageEnvelope::user_input("root", "additional guidance");
+    session.add_message(envelope.to_provider_message().unwrap());
+    session
+        .runtime_metadata
+        .get_or_insert_with(Default::default)
+        .session_inbox_admission
+        .get_or_insert_with(Default::default)
+        .record(envelope.id.clone(), 7);
+    let revision = store.put(&session, None).unwrap();
+    assert!(store.verify_shadow(&session).unwrap());
+    let mut runtime = store.load_runtime("root").unwrap().unwrap();
+    assert!(runtime.session.messages.is_empty());
+    assert!(runtime
+        .session
+        .runtime_metadata
+        .as_ref()
+        .unwrap()
+        .session_inbox_admission
+        .is_none());
+    runtime.session.title = "updated title".into();
+    let updated = store
+        .put_runtime(&runtime.session, revision.runtime)
+        .unwrap();
+    assert_eq!(updated.history, revision.history);
+    assert_eq!(updated.runtime, revision.runtime + 1);
+    drop(store);
+    let reopened = SessionStoreV3::open(temp.path().join("shadow.sqlite")).unwrap();
+    let snapshot = reopened.load("root").unwrap().unwrap();
+    assert_eq!(snapshot.session.messages.len(), 3);
+    assert_eq!(snapshot.session.title, "updated title");
+    assert!(snapshot
+        .session
+        .runtime_metadata
+        .unwrap()
+        .session_inbox_admission
+        .unwrap()
+        .contains(&envelope.id));
+}
+
+#[test]
+fn edits_touch_only_changed_rows_and_stale_writers_fail() {
+    let (_temp, store, mut session) = fixture();
+    let first = store.put(&session, None).unwrap();
+    assert_eq!(store.put(&session, Some(first)).unwrap(), first);
+    let before = store.connection().unwrap().total_changes();
+    session.messages[0].content = "edited".into();
+    let second = store.put(&session, Some(first)).unwrap();
+    let after = store.connection().unwrap().total_changes();
+    assert_eq!(after - before, 2, "one header and one message row");
+    assert_eq!(second.history, first.history + 1);
+    assert_eq!(second.runtime, first.runtime);
+    assert!(matches!(
+        store.put(&session, Some(first)),
+        Err(V3Error::Conflict)
+    ));
+    assert!(matches!(
+        store.message_page("root", 0, 1, first.history),
+        Err(V3Error::Conflict)
+    ));
+    assert_eq!(
+        store.message_page("root", 1, 1, second.history).unwrap()[0].content,
+        "answer"
+    );
+    session.messages.pop();
+    let third = store.put(&session, Some(second)).unwrap();
+    assert_eq!(
+        store
+            .message_page("root", 0, 10, third.history)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn independent_connections_have_one_cas_winner() {
+    let (temp, first, session) = fixture();
+    let revision = first.put(&session, None).unwrap();
+    let second = SessionStoreV3::open(temp.path().join("shadow.sqlite")).unwrap();
+    let session = first.load_runtime(&session.id).unwrap().unwrap().session;
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let handles = [first, second]
+        .into_iter()
+        .enumerate()
+        .map(|(index, store)| {
+            let barrier = barrier.clone();
+            let mut session = session.clone();
+            std::thread::spawn(move || {
+                session.title = format!("writer {index}");
+                barrier.wait();
+                store.put_runtime(&session, revision.runtime)
+            })
+        })
+        .collect::<Vec<_>>();
+    let results = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, Err(V3Error::Conflict)))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn import_is_atomic_and_validates_the_whole_tree() {
+    let (_temp, store, root) = fixture();
+    let mut child = Session::new("child", "model");
+    child.kind = bamboo_domain::SessionKind::Child;
+    child.parent_session_id = Some(root.id.clone());
+    child.root_session_id = root.id.clone();
+    store.put(&root, None).unwrap();
+    assert!(matches!(
+        store.import_tree_shadow(&[child.clone(), root.clone()]),
+        Err(V3Error::Conflict)
+    ));
+    assert!(
+        store.load("child").unwrap().is_none(),
+        "first insert rolls back when root conflicts"
+    );
+    child.parent_session_id = Some(child.id.clone());
+    assert!(matches!(
+        store.import_tree_shadow(&[child, root]),
+        Err(V3Error::Invalid(_))
+    ));
+}
+
+#[test]
+fn project_and_creation_identity_cannot_be_replaced_by_runtime_cas() {
+    let (_temp, store, mut root) = fixture();
+    let first = store.put(&root, None).unwrap();
+    root = store.load_runtime(&root.id).unwrap().unwrap().session;
+    root.set_project_id_meta("project-b");
+    assert!(matches!(
+        store.put_runtime(&root, first.runtime),
+        Err(V3Error::Conflict)
+    ));
+    root.metadata_version += 1;
+    let second = store.put_runtime(&root, first.runtime).unwrap();
+    root.created_at += chrono::Duration::seconds(1);
+    assert!(matches!(
+        store.put_runtime(&root, second.runtime),
+        Err(V3Error::Conflict)
+    ));
+}
+
+#[test]
+fn unrelated_databases_and_duplicate_message_ids_are_rejected() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("other.sqlite");
+    Connection::open(&path)
+        .unwrap()
+        .execute_batch("CREATE TABLE unrelated (value TEXT)")
+        .unwrap();
+    assert!(matches!(
+        SessionStoreV3::open(&path),
+        Err(V3Error::UnsupportedDatabase)
+    ));
+    let (_temp, store, mut session) = fixture();
+    session.messages[1].id = session.messages[0].id.clone();
+    assert!(matches!(
+        store.put(&session, None),
+        Err(V3Error::Invalid(_))
+    ));
+    assert!(store.load("root").unwrap().is_none());
+}
+
+#[tokio::test]
+async fn v2_captured_tree_import_matches_every_session_and_preserves_source() {
+    use bamboo_domain::Storage;
+    let home = TempDir::new().unwrap();
+    let v2 = crate::SessionStoreV2::new(home.path().join("v2"))
+        .await
+        .unwrap();
+    let mut root = Session::new("tree", "model");
+    root.add_message(Message::user("root history"));
+    let mut child = Session::new("tree-child", "model");
+    child.kind = bamboo_domain::SessionKind::Child;
+    child.parent_session_id = Some(root.id.clone());
+    child.root_session_id = root.id.clone();
+    child.add_message(Message::assistant("child history", None));
+    v2.save_session(&root).await.unwrap();
+    v2.save_session(&child).await.unwrap();
+    let source = vec![
+        v2.load_session(&child.id).await.unwrap().unwrap(),
+        v2.load_session(&root.id).await.unwrap().unwrap(),
+    ];
+    let v3 = SessionStoreV3::open(home.path().join("v3.sqlite")).unwrap();
+    v3.import_tree_shadow(&source).unwrap();
+    for snapshot in &source {
+        assert!(v3.verify_shadow(snapshot).unwrap());
+        assert_eq!(
+            serde_json::to_value(v2.load_session(&snapshot.id).await.unwrap().unwrap()).unwrap(),
+            serde_json::to_value(snapshot).unwrap()
+        );
+    }
+    v2.flush_search_index().await;
+}

--- a/crates/infra/bamboo-storage/src/v3/tests.rs
+++ b/crates/infra/bamboo-storage/src/v3/tests.rs
@@ -216,3 +216,20 @@ async fn v2_captured_tree_import_matches_every_session_and_preserves_source() {
     }
     v2.flush_search_index().await;
 }
+
+#[test]
+fn malformed_root_identity_is_rejected_before_the_first_write() {
+    let (_temp, store, mut session) = fixture();
+    session.spawn_depth = 1;
+    assert!(matches!(
+        store.put(&session, None),
+        Err(V3Error::Invalid(_))
+    ));
+    session.spawn_depth = 0;
+    session.parent_session_id = Some("parent".into());
+    assert!(matches!(
+        store.put(&session, None),
+        Err(V3Error::Invalid(_))
+    ));
+    assert!(store.load(&session.id).unwrap().is_none());
+}

--- a/docs/session-storage-v3.md
+++ b/docs/session-storage-v3.md
@@ -1,0 +1,25 @@
+# Session storage V3 shadow evaluation
+
+`bamboo_storage::v3::SessionStoreV3` provides an opt-in SQLite WAL store for captured session snapshots. The server and SDK continue using their existing V2 authority. Opening a V3 database does not switch a session, launch a run, modify V2 files, or migrate user data.
+
+The store keeps messages in ordered rows and stores control state separately. A full snapshot transaction commits changed message rows together with the provider transcript and inbox admission proof. A runtime-only transaction accepts the message-free snapshot returned by `load_runtime`; it does not load or rewrite message rows or provider history.
+
+Full snapshots use a pair of history/runtime revisions. Runtime writes compare only their runtime revision, while immutable creation identity and Project metadata revision checks remain required. History pagination includes a revision, so a client cannot silently combine pages from different histories. Independent SQLite connections compete through an immediate transaction; stale writers receive `V3Error::Conflict`.
+
+## Captured-tree import
+
+Capture one complete logical tree as a JSON array of current `Session` values. Then run:
+
+```sh
+cargo run -p bamboo-storage --example v3_shadow -- session-tree.json shadow.sqlite
+```
+
+The target must have no existing session ids from the import. The importer checks the root, parent closure, duplicate ids and cycles, then inserts the tree in one transaction. Any conflict rolls back the entire import. The example reloads and compares every imported snapshot using canonical JSON and reports success only when all snapshots match. This comparison describes the captured source; it is not a live cutover guarantee when another process continues writing V2.
+
+SQLite connections are retained by the store. The API is synchronous for offline/shadow workloads; async applications must invoke it on a blocking worker. The database has a distinct application id and schema version and rejects unrelated databases.
+
+## Current boundary
+
+This slice implements the transactional store, revisioned reads/writes, and verified shadow import. It does not select runtime read/write authority. Attachments remain unchanged message payloads or existing references; referenced files are not copied into a new attachment store. Search indexing, fork/delete lifecycle, live catch-up and authority switching remain on the current V2 path. V3 has no destructive rollback command. Do not treat disabling a future selector as a rollback procedure.
+
+Tests cover V2 captured-tree equivalence, reopening, admission proof retention, per-row edits and truncation, revisioned pagination, concurrent CAS, Project/creation fences, and whole-tree rollback. Synthetic measurements must be reported with their history size and build mode; these tests establish consistency, not production performance.


### PR DESCRIPTION
## Summary

Add an explicit SQLite shadow storage API with separate history/runtime versions, compare-and-swap writes, stable pagination, transactional tree import and content verification. Validate root, creation and Project context identity. Canonical runtime storage and user data are not switched or migrated.

## Test Plan

Final integrated storage suite: 234 passed, covering revisions, stale writes, import rollback, identity guards and reopen behavior. See docs/session-storage-v3.md and the v3_shadow example.

Required CI and current-head independent review must pass before merge.
