### PR TITLE
feat: bound Goal timeout recovery with durable backoff

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -67,6 +67,8 @@ fn default_gold_min_confidence() -> GoldConfidence {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct GoldConfig {
+    #[serde(default)]
+    pub recovery: super::goal_recovery::GoalRecoveryPolicy,
     /// Master switch for Gold observe-only evaluation.
     #[serde(default)]
     pub enabled: bool,
@@ -115,6 +117,7 @@ pub struct GoldConfig {
 impl Default for GoldConfig {
     fn default() -> Self {
         Self {
+            recovery: Default::default(),
             enabled: false,
             auto_answer_enabled: false,
             auto_continue_enabled: false,

--- a/crates/engine/bamboo-engine/src/runtime/goal_recovery.rs
+++ b/crates/engine/bamboo-engine/src/runtime/goal_recovery.rs
@@ -1,0 +1,173 @@
+//! Bounded recovery of silent transport timeouts while a goal owner is running.
+use bamboo_agent_core::{AgentError, Session};
+use serde::{Deserialize, Serialize};
+
+const KEY: &str = "goal.recovery";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(default)]
+pub struct GoalRecoveryPolicy {
+    /// Additional retries across this goal, beyond the ordinary per-turn retries.
+    /// Zero disables recovery. The runtime caps this at ten.
+    pub max_attempts: u32,
+    /// Elapsed recovery window from the first extra retry. Capped at one hour.
+    pub max_elapsed_seconds: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RecoveryState {
+    goal_created_at: String,
+    objective: String,
+    attempts: u32,
+    started_at_ms: i64,
+    next_attempt_at_ms: i64,
+}
+
+/// Persist a retry reservation before waiting. Corrupt records fail closed;
+/// changing a goal's identity starts a fresh budget, while a restart does not.
+pub fn reserve_retry(
+    session: &mut Session,
+    policy: &GoalRecoveryPolicy,
+    error: &AgentError,
+    now_ms: i64,
+) -> Option<u64> {
+    if !matches!(error, AgentError::StreamTimeout(timeout) if timeout.retry_safe()) {
+        return None;
+    }
+    let goal = super::goal_state::read_goal_state(session)?;
+    if !goal.status.is_active() || goal.declared_status.is_some() || policy.max_attempts == 0 {
+        return None;
+    }
+    let mut record = match session.metadata.get(KEY) {
+        Some(raw) => serde_json::from_str::<RecoveryState>(raw).ok()?,
+        None => RecoveryState {
+            goal_created_at: goal.created_at.clone(),
+            objective: goal.objective.clone(),
+            attempts: 0,
+            started_at_ms: now_ms,
+            next_attempt_at_ms: now_ms,
+        },
+    };
+    if record.goal_created_at != goal.created_at || record.objective != goal.objective {
+        record = RecoveryState {
+            goal_created_at: goal.created_at,
+            objective: goal.objective,
+            attempts: 0,
+            started_at_ms: now_ms,
+            next_attempt_at_ms: now_ms,
+        };
+    }
+    let delay_ms = 5_000u64
+        .saturating_mul(1u64 << record.attempts.min(6))
+        .min(60_000);
+    let deadline = record
+        .started_at_ms
+        .saturating_add(policy.max_elapsed_seconds.min(3600).saturating_mul(1000) as i64);
+    if record.attempts >= policy.max_attempts.min(10)
+        || now_ms < record.started_at_ms
+        || now_ms.saturating_add(delay_ms as i64) >= deadline
+    {
+        return None;
+    }
+    record.attempts += 1;
+    record.next_attempt_at_ms = now_ms.saturating_add(delay_ms as i64);
+    session
+        .metadata
+        .insert(KEY.into(), serde_json::to_string(&record).ok()?);
+    Some(delay_ms)
+}
+
+/// Remaining persisted backoff, used when the same goal run is resumed.
+pub fn pending_delay(session: &Session, now_ms: i64) -> Option<u64> {
+    let goal = super::goal_state::read_goal_state(session)?;
+    let record: RecoveryState = serde_json::from_str(session.metadata.get(KEY)?).ok()?;
+    if !goal.status.is_active()
+        || goal.created_at != record.goal_created_at
+        || goal.objective != record.objective
+        || now_ms < record.started_at_ms
+    {
+        return None;
+    }
+    let remaining = record.next_attempt_at_ms.saturating_sub(now_ms);
+    (remaining > 0 && remaining <= 60_000).then_some(remaining as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::goal_state::{ensure_goal_state, write_goal_state};
+    use bamboo_agent_core::{StreamTimeoutError, StreamTimeoutPhase};
+    use std::time::Duration;
+    fn timeout() -> AgentError {
+        AgentError::StreamTimeout(StreamTimeoutError::new(
+            StreamTimeoutPhase::FirstSemantic,
+            Duration::from_secs(30),
+            None,
+            None,
+            Duration::ZERO,
+            None,
+            true,
+        ))
+    }
+    #[test]
+    fn retries_have_a_durable_bound_and_require_structured_safe_timeouts() {
+        let mut session = Session::new("s", "m");
+        let goal = ensure_goal_state(&mut session, "finish");
+        write_goal_state(&mut session, goal);
+        let policy = GoalRecoveryPolicy {
+            max_attempts: 2,
+            max_elapsed_seconds: 120,
+        };
+        assert!(
+            reserve_retry(&mut session, &policy, &AgentError::LLM("timeout".into()), 0).is_none()
+        );
+        assert_eq!(
+            reserve_retry(&mut session, &policy, &timeout(), 0),
+            Some(5000)
+        );
+        let mut reopened: Session =
+            serde_json::from_str(&serde_json::to_string(&session).unwrap()).unwrap();
+        assert_eq!(
+            reserve_retry(&mut reopened, &policy, &timeout(), 5000),
+            Some(10000)
+        );
+        assert_eq!(
+            reserve_retry(&mut reopened, &policy, &timeout(), 15000),
+            None
+        );
+        let unsafe_error = AgentError::StreamTimeout(StreamTimeoutError::new(
+            StreamTimeoutPhase::SemanticIdle,
+            Duration::from_secs(30),
+            None,
+            None,
+            Duration::ZERO,
+            Some(Duration::ZERO),
+            true,
+        ));
+        assert!(reserve_retry(&mut session, &policy, &unsafe_error, 0).is_none());
+    }
+    #[test]
+    fn deadline_and_corrupt_state_fail_closed() {
+        let mut session = Session::new("s", "m");
+        let goal = ensure_goal_state(&mut session, "finish");
+        write_goal_state(&mut session, goal);
+        let policy = GoalRecoveryPolicy {
+            max_attempts: 3,
+            max_elapsed_seconds: 5,
+        };
+        assert_eq!(reserve_retry(&mut session, &policy, &timeout(), 0), None);
+        session.metadata.insert(KEY.into(), "broken".into());
+        assert_eq!(
+            reserve_retry(
+                &mut session,
+                &GoalRecoveryPolicy {
+                    max_elapsed_seconds: 120,
+                    ..policy
+                },
+                &timeout(),
+                0
+            ),
+            None
+        );
+    }
+}

--- a/crates/engine/bamboo-engine/src/runtime/goal_recovery.rs
+++ b/crates/engine/bamboo-engine/src/runtime/goal_recovery.rs
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn retries_have_a_durable_bound_and_require_structured_safe_timeouts() {
         let mut session = Session::new("s", "m");
-        let goal = ensure_goal_state(&mut session, "finish");
+        let goal = ensure_goal_state(&session, "finish");
         write_goal_state(&mut session, goal);
         let policy = GoalRecoveryPolicy {
             max_attempts: 2,
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn deadline_and_corrupt_state_fail_closed() {
         let mut session = Session::new("s", "m");
-        let goal = ensure_goal_state(&mut session, "finish");
+        let goal = ensure_goal_state(&session, "finish");
         write_goal_state(&mut session, goal);
         let policy = GoalRecoveryPolicy {
             max_attempts: 3,

--- a/crates/engine/bamboo-engine/src/runtime/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/mod.rs
@@ -5,6 +5,7 @@ pub mod complexity_classifier;
 pub mod config;
 pub mod context;
 pub mod execution;
+pub mod goal_recovery;
 pub mod goal_state;
 pub mod gold_evaluation;
 pub mod guardian_state;

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -2933,6 +2933,9 @@ async fn run_pipeline_inner(
                             None
                         };
                         if let Some(delay_ms) = recovery_delay {
+                            // Persist billed activity with the retry reservation. The live
+                            // round accumulator is committed once at the terminal boundary.
+                            state_bridge::write_runtime_state(session, &recovery_budget_state);
                             config
                                 .persistence
                                 .as_ref()

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -2746,7 +2746,10 @@ async fn run_pipeline_inner(
                     Utc::now().timestamp_millis(),
                 ) {
                     tokio::select! {
-                        _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
+                        _ = cancel_token.cancelled() => {
+                            terminal_error = Some(AgentError::Cancelled);
+                            break;
+                        },
                         _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {}
                     }
                 }
@@ -2900,7 +2903,10 @@ async fn run_pipeline_inner(
                             delay_ms
                         );
                         tokio::select! {
-                            _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
+                            _ = cancel_token.cancelled() => {
+                                terminal_error = Some(AgentError::Cancelled);
+                                break;
+                            },
                             _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {}
                         }
                         continue;
@@ -2948,7 +2954,10 @@ async fn run_pipeline_inner(
                                     ))
                                 })?;
                             tokio::select! {
-                                _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
+                                _ = cancel_token.cancelled() => {
+                                    terminal_error = Some(AgentError::Cancelled);
+                                    break;
+                                },
                                 _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {}
                             }
                             continue;
@@ -6269,6 +6278,37 @@ mod tests {
         }
     }
 
+    struct BilledThenTimeoutProvider {
+        first: BilledRetryProvider,
+        calls: std::sync::atomic::AtomicUsize,
+        failed: Arc<tokio::sync::Notify>,
+        silent_stream: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for BilledThenTimeoutProvider {
+        async fn chat_stream(
+            &self,
+            messages: &[Message],
+            schemas: &[bamboo_agent_core::tools::ToolSchema],
+            max_output_tokens: Option<u32>,
+            model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return self
+                    .first
+                    .chat_stream(messages, schemas, max_output_tokens, model)
+                    .await;
+            }
+            self.failed.notify_one();
+            if self.silent_stream {
+                Ok(Box::pin(stream::pending()))
+            } else {
+                Err(LLMError::Api("retryable transport failure".into()))
+            }
+        }
+    }
+
     struct FailBeforeUsageProvider;
 
     #[async_trait::async_trait]
@@ -6649,6 +6689,147 @@ mod tests {
         assert_eq!(exposure.all_compact_exposed_count, 0);
         assert_eq!(state.runtime_state.round.total_prompt_tokens, 30);
         assert_eq!(state.runtime_state.round.total_completion_tokens, 8);
+    }
+
+    async fn assert_cancelled_backoff_preserves_billed_usage(goal_recovery: bool) {
+        let session_id = if goal_recovery {
+            "goal-backoff-billed"
+        } else {
+            "retry-backoff-billed"
+        };
+        let (directory, collector, metrics) = create_pipeline_metrics().await;
+        crate::runtime::runner::metrics_lifecycle::record_session_started(
+            Some(&collector),
+            session_id,
+            "model",
+            chrono::Utc::now(),
+            1,
+        );
+        let storage: Arc<dyn Storage> = Arc::new(
+            bamboo_storage::SessionStoreV2::new(directory.path().join("sessions"))
+                .await
+                .unwrap(),
+        );
+        let persistence: Arc<dyn bamboo_domain::RuntimeSessionPersistence> =
+            Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
+        let mut session = Session::new(session_id, "model");
+        session.add_message(Message::user("retain billed retries when stopped"));
+        session
+            .metadata
+            .insert(super::TEST_POST_LLM_RETRY_FAILURES_KEY.into(), "1".into());
+        storage.save_session(&session).await.unwrap();
+        let failed = Arc::new(tokio::sync::Notify::new());
+        let provider = Arc::new(BilledThenTimeoutProvider {
+            first: BilledRetryProvider {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            },
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            failed: failed.clone(),
+            silent_stream: goal_recovery,
+        });
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let trigger = cancel.clone();
+        let watched_storage = storage.clone();
+        let stopper = tokio::spawn(async move {
+            if goal_recovery {
+                // Cancellation occurs only after the durable recovery reservation,
+                // so this exercises the extra retry wait rather than a live stream.
+                tokio::time::timeout(Duration::from_secs(10), async {
+                    loop {
+                        if watched_storage
+                            .load_session(session_id)
+                            .await
+                            .unwrap()
+                            .is_some_and(|saved| saved.metadata.contains_key("goal.recovery"))
+                        {
+                            break;
+                        }
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                })
+                .await
+                .expect("goal recovery reservation persisted");
+            } else {
+                failed.notified().await;
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            trigger.cancel();
+        });
+        let mut config = canonical_usage_pipeline_config();
+        config.persistence = Some(persistence.clone());
+        config.metrics_collector = Some(collector.clone());
+        if goal_recovery {
+            config.stream_timeout.transport_idle_timeout_secs = 1;
+            config.gold_config = Some(crate::runtime::config::GoldConfig {
+                enabled: true,
+                auto_continue_enabled: true,
+                goal: Some("finish".into()),
+                recovery: crate::runtime::goal_recovery::GoalRecoveryPolicy {
+                    max_attempts: 1,
+                    max_elapsed_seconds: 120,
+                },
+                ..Default::default()
+            });
+        }
+        let mut state = e2e_loop_state(session_id);
+        state.metrics_collector = Some(collector);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let result = super::run_pipeline(
+            &mut session,
+            &tx,
+            provider.clone(),
+            Arc::new(AlwaysOkExecutor),
+            &cancel,
+            &config,
+            &mut state,
+        )
+        .await;
+        stopper.await.unwrap();
+        assert!(matches!(result, Err(AgentError::Cancelled)));
+        assert_eq!(
+            provider.calls.load(Ordering::SeqCst),
+            if goal_recovery { 3 } else { 2 }
+        );
+        assert_eq!(state.runtime_state.round.total_prompt_tokens, 10);
+        assert_eq!(state.runtime_state.round.total_completion_tokens, 3);
+        assert_eq!(state.runtime_state.round.total_tool_calls, 1);
+        // The outer hooks error path writes the live state before checkpointing.
+        // It must not overwrite the recovery checkpoint with pre-attempt totals.
+        state_bridge::write_runtime_state(&mut session, &state.runtime_state);
+        persistence
+            .checkpoint_runtime_session(&mut session)
+            .await
+            .unwrap();
+        let saved = storage.load_session(session_id).await.unwrap().unwrap();
+        let round = saved.agent_runtime_state.unwrap().round;
+        assert_eq!(round.total_prompt_tokens, 10);
+        assert_eq!(round.total_completion_tokens, 3);
+        assert_eq!(round.total_tool_calls, 1);
+        drop(tx);
+        drain(&mut rx).await;
+        let expected = MetricsTokenUsage {
+            prompt_tokens: 10,
+            completion_tokens: 3,
+            total_tokens: 13,
+        };
+        let detail = wait_for_pipeline_metrics(
+            metrics.as_ref(),
+            session_id,
+            MetricsRoundStatus::Cancelled,
+            expected,
+        )
+        .await;
+        assert_eq!(detail.rounds.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_ordinary_backoff_preserves_billed_usage() {
+        assert_cancelled_backoff_preserves_billed_usage(false).await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_goal_recovery_backoff_preserves_billed_usage() {
+        assert_cancelled_backoff_preserves_billed_usage(true).await;
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -2724,7 +2724,33 @@ async fn run_pipeline_inner(
         // that errors before streaming contributes 0.
         let mut round_activity = RoundActivity::default();
 
-        for attempt in 1..=MAX_LLM_TURN_ATTEMPTS {
+        if config.goal_loop_active() {
+            let goal = crate::runtime::goal_state::ensure_goal_state(
+                session,
+                config.active_goal().expect("active goal"),
+            );
+            crate::runtime::goal_state::write_goal_state(session, goal);
+        }
+        let extra_attempts = if config.goal_loop_active() {
+            config
+                .gold_config
+                .as_ref()
+                .map_or(0, |gold| gold.recovery.max_attempts.min(10)) as usize
+        } else {
+            0
+        };
+        for attempt in 1..=MAX_LLM_TURN_ATTEMPTS + extra_attempts {
+            if config.goal_loop_active() && extra_attempts > 0 {
+                if let Some(delay_ms) = crate::runtime::goal_recovery::pending_delay(
+                    session,
+                    Utc::now().timestamp_millis(),
+                ) {
+                    tokio::select! {
+                        _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
+                        _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {}
+                    }
+                }
+            }
             // Retry cleanup may remove only an interrupted record created by
             // THIS attempt.  An older durable interrupted tail can legitimately
             // be the session's starting point and must never be mistaken for a
@@ -2873,9 +2899,57 @@ async fn run_pipeline_inner(
                             error,
                             delay_ms
                         );
-                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                        tokio::select! {
+                            _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
+                            _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {}
+                        }
                         continue;
                     } else {
+                        let mut recovery_budget_state = state.runtime_state.clone();
+                        round_activity.commit_to_runtime(&mut recovery_budget_state);
+                        let recovery_delay = if attempt >= MAX_LLM_TURN_ATTEMPTS
+                            && config.goal_loop_active()
+                            && state.runtime_state.suspension.is_none()
+                            && state.runtime_state.waiting_for_children.is_none()
+                            && state.runtime_state.waiting_for_bash.is_none()
+                            && check_run_budget_exceeded(
+                                &recovery_budget_state.round,
+                                &config.run_budget,
+                            )
+                            .is_none()
+                            && config.persistence.is_some()
+                        {
+                            crate::runtime::goal_recovery::reserve_retry(
+                                session,
+                                &config
+                                    .gold_config
+                                    .as_ref()
+                                    .expect("active goal config")
+                                    .recovery,
+                                &error,
+                                Utc::now().timestamp_millis(),
+                            )
+                        } else {
+                            None
+                        };
+                        if let Some(delay_ms) = recovery_delay {
+                            config
+                                .persistence
+                                .as_ref()
+                                .expect("checked persistence")
+                                .checkpoint_runtime_session(session)
+                                .await
+                                .map_err(|error| {
+                                    AgentError::LLM(format!(
+                                        "Goal recovery checkpoint failed: {error}"
+                                    ))
+                                })?;
+                            tokio::select! {
+                                _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
+                                _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {}
+                            }
+                            continue;
+                        }
                         tracing::error!(
                             "[{}] Turn {} LLM call failed terminally (attempt {}/{}): {}",
                             state.session_id,
@@ -10220,5 +10294,67 @@ mod tests {
             "blank final content must not add a stray context block:\n{}",
             recorded[0]
         );
+    }
+    #[tokio::test]
+    async fn goal_recovery_backoff_stops_without_waiting_for_the_deadline() {
+        let mut session = Session::new("goal-backoff-stop", "model");
+        session.add_message(Message::user("finish"));
+        let goal = crate::runtime::goal_state::ensure_goal_state(&session, "finish");
+        crate::runtime::goal_state::write_goal_state(&mut session, goal);
+        let policy = crate::runtime::goal_recovery::GoalRecoveryPolicy {
+            max_attempts: 3,
+            max_elapsed_seconds: 900,
+        };
+        let timeout = AgentError::StreamTimeout(bamboo_agent_core::StreamTimeoutError::new(
+            bamboo_agent_core::StreamTimeoutPhase::FirstSemantic,
+            std::time::Duration::from_secs(30),
+            None,
+            None,
+            std::time::Duration::ZERO,
+            None,
+            true,
+        ));
+        assert_eq!(
+            crate::runtime::goal_recovery::reserve_retry(
+                &mut session,
+                &policy,
+                &timeout,
+                chrono::Utc::now().timestamp_millis()
+            ),
+            Some(5000)
+        );
+        let config = crate::runtime::config::AgentLoopConfig {
+            gold_config: Some(crate::runtime::config::GoldConfig {
+                enabled: true,
+                auto_continue_enabled: true,
+                goal: Some("finish".into()),
+                recovery: policy,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let trigger = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            trigger.cancel();
+        });
+        let (tx, _rx) = tokio::sync::mpsc::channel(64);
+        let mut state = e2e_loop_state("goal-backoff-stop");
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            super::run_pipeline(
+                &mut session,
+                &tx,
+                Arc::new(StubProvider),
+                Arc::new(AlwaysOkExecutor),
+                &cancel,
+                &config,
+                &mut state,
+            ),
+        )
+        .await
+        .expect("stop interrupts the persisted five-second backoff");
+        assert!(matches!(result, Err(AgentError::Cancelled)));
     }
 }

--- a/docs/goal-recovery.md
+++ b/docs/goal-recovery.md
@@ -1,0 +1,23 @@
+# Bounded goal timeout recovery
+
+Goal recovery is disabled by default. A session's `gold_config` can enable it:
+
+```json
+{
+  "enabled": true,
+  "auto_continue_enabled": true,
+  "goal": "Finish and verify the requested change",
+  "recovery": {
+    "max_attempts": 3,
+    "max_elapsed_seconds": 900
+  }
+}
+```
+
+Lotus Next exposes these choices in the goal editor. Recovery requires an active goal, no pending completion declaration, no input/child/Bash suspension, available run budget, and coordinated persistence.
+
+After the ordinary three turn attempts, only structured replay-safe stream timeouts can reserve an extra attempt. A timeout after any semantic output or a partially emitted tool call is ineligible. Formatted provider error strings never qualify for these extra attempts.
+
+A reservation records its counter, goal identity, start time and next attempt time in session metadata before waiting. Extra attempts use exponential backoff from five seconds up to sixty seconds. The policy caps attempts at ten and the recovery window at one hour even if a larger value is supplied. The run's accumulated token/tool/subagent limits still apply; recovery does not replenish them. The current run retains ownership, so no second execution is launched. Stop interrupts both ordinary retry waits and recovery waits.
+
+Counters persist across reloads and are scoped to the goal. A resumed goal respects any remaining recorded backoff. Recovery does not start an idle session after a process restart; an explicit resume retains the existing retry budget. Terminal goals, corrupt recovery records and elapsed recovery windows do not receive extra retries. No account routing, provider-specific message matching, or unrestricted watchdog is introduced.


### PR DESCRIPTION
## Summary

Allow an explicitly configured Goal to recover from safe transport timeouts with no semantic output after ordinary retries are exhausted. Persist attempt limits, elapsed-time bounds, usage and backoff. Default recovery is disabled. This does not introduce idle background wakeups or automatic resurrection after restart.

## Test Plan

Goal policy and real local controlled-provider acceptance passed. Fixed review finding: cancellation during backoff now uses common terminal accounting so billed usage is retained. Added ordinary and Goal recovery cancellation regressions checking live state, durable reload and metrics. Negative controls failed with the old branches. Final targeted checks: 22 cancellation tests, 4 Goal recovery tests and the existing billed-retry test passed. Formatting passed. Independent source review found no remaining blockers.

Required CI and current-head independent review must pass before merge.
