### PR TITLE
fix: fence deleted Root lifetimes (#1093)

### DIFF
--- a/crates/core/bamboo-domain/src/storage.rs
+++ b/crates/core/bamboo-domain/src/storage.rs
@@ -13,6 +13,23 @@ use crate::SupervisorBootstrapReceipt;
 /// (e.g., JSONL files, databases, cloud storage).
 #[async_trait::async_trait]
 pub trait Storage: Send + Sync {
+    /// Trusted explicit recreation of a previously deleted Ordinary Root ID.
+    /// The backend constructs a blank Root and assigns a fresh birth marker;
+    /// callers cannot supply an old snapshot or choose its lifetime. Retrying
+    /// after a complete publication returns that surviving lifetime unchanged.
+    /// This is a host/SDK port, never a model-callable creation capability.
+    async fn recreate_root_session(
+        &self,
+        session_id: &str,
+        initial_model: &str,
+    ) -> std::io::Result<Session> {
+        let _ = (session_id, initial_model);
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "storage backend does not support trusted Root recreation",
+        ))
+    }
+
     /// Trusted host bootstrap for one stable default Supervisor Root. Only the
     /// initial model is caller supplied and is used on first creation only.
     /// Implementations must publish the complete identity atomically, protect it
@@ -40,7 +57,9 @@ pub trait Storage: Send + Sync {
         ))
     }
 
-    /// Saves a session's metadata.
+    /// Saves a session's metadata. A backend may allow initial creation for a
+    /// never-deleted ID, but an ordinary snapshot must not recreate a deleted
+    /// lifetime. Use the trusted recreation port for an explicitly reused ID.
     async fn save_session(&self, session: &Session) -> std::io::Result<()>;
 
     /// Loads a session by ID, returns None if not found.

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -1706,6 +1706,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn root_deleted_after_merge_read_rejects_without_cache_or_event_publication() {
+        for runtime_only in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let first = Arc::new(SessionStoreV2::new(temp.path().into()).await.unwrap());
+            let mut stale = Session::new("root-delete-race", "model");
+            stale.set_project_id_meta("project-a");
+            stale.add_message(bamboo_domain::Message::user("Old lifetime"));
+            first.save_session(&stale).await.unwrap();
+            let id = stale.id.clone();
+            let second = SessionStoreV2::new(temp.path().into()).await.unwrap();
+            let paused = Arc::new(AuthoritySavePauseStorage {
+                inner: first.clone(),
+                reached: tokio::sync::Barrier::new(2),
+                release: tokio::sync::Barrier::new(2),
+            });
+            let locked = LockedSessionStore::new(paused.clone());
+            let published = AtomicBool::new(false);
+            let save = async {
+                if runtime_only {
+                    locked
+                        .save_runtime_only_and_publish(&mut stale, |_| {
+                            published.store(true, Ordering::SeqCst);
+                        })
+                        .await
+                } else {
+                    locked
+                        .merge_save_runtime_and_publish(&mut stale, |_, _| {
+                            published.store(true, Ordering::SeqCst);
+                        })
+                        .await
+                }
+            };
+            let delete = async {
+                paused.reached.wait().await;
+                assert!(second.delete_session(&id).await.unwrap());
+                paused.release.wait().await;
+            };
+            let (result, ()) = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                tokio::join!(save, delete)
+            })
+            .await
+            .expect("deterministic delete/save race completes");
+            assert!(!may_publish_runtime_result(&Err(result.unwrap_err())));
+            assert!(!published.load(Ordering::SeqCst));
+            assert!(first.load_root_authority(&id).await.unwrap().is_none());
+            assert!(!first.sessions_root_dir().join(&id).exists());
+            first.flush_search_index().await;
+            second.flush_search_index().await;
+        }
+    }
+
+    #[tokio::test]
     async fn supervisor_bootstrap_between_merge_read_and_save_rejects_without_publishing() {
         for runtime_only in [false, true] {
             let temp = tempfile::tempdir().unwrap();

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -46,6 +46,9 @@ use bamboo_domain::{
 mod root_context;
 #[cfg(test)]
 mod root_context_tests;
+mod root_lifetime;
+#[cfg(test)]
+mod root_lifetime_tests;
 mod supervisor;
 #[cfg(test)]
 mod supervisor_tests;
@@ -1043,7 +1046,7 @@ pub struct SessionStoreV2 {
     #[cfg(any(test, feature = "test-utils"))]
     full_save_pause: std::sync::Mutex<Option<FullSavePause>>,
     #[cfg(test)]
-    supervisor_bootstrap_fault: std::sync::Mutex<Option<supervisor::SupervisorBootstrapFault>>,
+    root_publication_fault: std::sync::Mutex<Option<root_lifetime::RootPublicationFault>>,
 }
 
 const COPY_TRANSIENT_METADATA_KEYS: &[&str] = &[
@@ -1340,7 +1343,7 @@ impl SessionStoreV2 {
             #[cfg(any(test, feature = "test-utils"))]
             full_save_pause: std::sync::Mutex::new(None),
             #[cfg(test)]
-            supervisor_bootstrap_fault: std::sync::Mutex::new(None),
+            root_publication_fault: std::sync::Mutex::new(None),
         };
 
         // Create and permission the private journal directory once at store
@@ -1362,10 +1365,24 @@ impl SessionStoreV2 {
             storage
                 .recover_all_session_copy_transactions_locked()
                 .await?;
+            storage.reconcile_root_revocations().await?;
         }
 
         if needs_rebuild {
             storage.rebuild_index_from_disk().await?;
+            // Compatibility rebuild reads can recover children or a main-file
+            // fallback from an unavailable recreated Root. Reconcile the same
+            // canonical revocation evidence after the scan as well, without
+            // introducing another durable quarantine or recovery state.
+            let _lifecycle = storage.lock_session_lifecycle_exclusive().await?;
+            let _runtime_task = storage.lock_runtime_task_transaction_exclusive().await?;
+            storage
+                .recover_all_runtime_task_transactions_locked()
+                .await?;
+            storage
+                .recover_all_session_copy_transactions_locked()
+                .await?;
+            storage.reconcile_root_revocations().await?;
         }
 
         Ok(storage)
@@ -1537,7 +1554,7 @@ impl SessionStoreV2 {
     ) -> io::Result<bool> {
         let _lifecycle = self.lock_session_lifecycle_shared().await?;
         let _runtime_task = self.lock_runtime_task_sidecar_shared().await?;
-        let Some(session) = Self::load_session_from_dir(abs_dir, session_id).await else {
+        let Some(session) = self.load_session_from_dir(abs_dir, session_id).await else {
             return Ok(false);
         };
         self.repair_index_from_authoritative_session(&session, rel_path)
@@ -1554,7 +1571,7 @@ impl SessionStoreV2 {
     /// missing `session.json` yields `None` silently; a corrupt/unreadable one is
     /// skipped with a warning; a sidecar read error degrades to "no sidecar"
     /// rather than failing recovery. `id` is used only for log context.
-    async fn load_session_from_dir(abs_dir: &Path, id: &str) -> Option<Session> {
+    async fn load_session_from_dir(&self, abs_dir: &Path, id: &str) -> Option<Session> {
         let raw = match fs::read_to_string(abs_dir.join("session.json")).await {
             Ok(raw) => raw,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return None,
@@ -1570,6 +1587,14 @@ impl SessionStoreV2 {
                 return None;
             }
         };
+        match self.session_lifetime_is_live(&main).await {
+            Ok(true) => {}
+            Ok(false) => return None,
+            Err(error) => {
+                tracing::warn!("index rebuild: skipping unavailable Root lifetime {id}: {error}");
+                return None;
+            }
+        }
         let sidecar =
             match Self::read_runtime_sidecar_at(&abs_dir.join(RUNTIME_SIDECAR_FILE), id).await {
                 Ok(sidecar) => sidecar,
@@ -1591,6 +1616,7 @@ impl SessionStoreV2 {
     /// a missing source from corrupt/unreadable authoritative state and must
     /// never silently fall back to stale `session.json` control-plane data.
     async fn load_session_from_dir_strict(
+        &self,
         abs_dir: &Path,
         id: &str,
         expected_kind: SessionKind,
@@ -1625,6 +1651,9 @@ impl SessionStoreV2 {
         // normalize it before comparing/overlaying the runtime sidecar.
         if canonical_legacy_root {
             main.root_session_id = id.to_string();
+        }
+        if !self.session_lifetime_is_live(&main).await? {
+            return Ok(None);
         }
         let runtime_path = abs_dir.join(RUNTIME_SIDECAR_FILE);
         let sidecar = match fs::read_to_string(&runtime_path).await {
@@ -2147,6 +2176,9 @@ impl SessionStoreV2 {
         &self,
         session_id: &str,
     ) -> io::Result<Option<Session>> {
+        if self.root_directory_is_revoked(session_id).await? {
+            return Ok(None);
+        }
         let abs_dir = self.sessions_dir.join(session_id);
         let raw = match fs::read_to_string(abs_dir.join("session.json")).await {
             Ok(raw) => raw,
@@ -2420,7 +2452,7 @@ impl SessionStoreV2 {
             // Only canonical Root absence permits its normal control-plane read.
         }
         if let Some(side) = self.read_runtime_sidecar(session_id).await? {
-            return Ok(Some(side));
+            return Ok(self.session_lifetime_is_live(&side).await?.then_some(side));
         }
         let Some(path) = self.session_json_path(session_id).await? else {
             return Ok(None);
@@ -2433,6 +2465,9 @@ impl SessionStoreV2 {
         let mut session: Session = serde_json::from_str(&raw)
             .map_err(|error| other_io_error(format!("invalid session.json: {error}")))?;
         supervisor::validate_identity(&session)?;
+        if !self.session_lifetime_is_live(&session).await? {
+            return Ok(None);
+        }
         session.messages.clear();
         session.clear_stale_root_token_budget();
         Ok(Some(session))
@@ -3193,19 +3228,20 @@ impl SessionStoreV2 {
         })?;
         if state == SessionCopyJournalMarkerState::Committed {
             let target_dir = self.sessions_dir.join(&journal.target_id);
-            let target = Self::load_session_from_dir_strict(
-                &target_dir,
-                &journal.target_id,
-                SessionKind::Root,
-                &journal.target_id,
-            )
-            .await?
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "committed copied session target is missing",
+            let target = self
+                .load_session_from_dir_strict(
+                    &target_dir,
+                    &journal.target_id,
+                    SessionKind::Root,
+                    &journal.target_id,
                 )
-            })?;
+                .await?
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "committed copied session target is missing",
+                    )
+                })?;
             if target.kind != SessionKind::Root || target.root_session_id != target.id {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -4146,21 +4182,28 @@ impl SessionStoreV2 {
                 "copied session id already exists",
             ));
         }
+        if self.root_revocation(new_id).await?.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "copied session ID was deleted; use a new ID or trusted Root recreation",
+            ));
+        }
 
         let source_dir = self.abs_path_from_rel(&source_rel);
-        let source = Self::load_session_from_dir_strict(
-            &source_dir,
-            source_id,
-            expected_source_kind,
-            &expected_source_root,
-        )
-        .await?
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                "indexed source session.json is missing",
+        let source = self
+            .load_session_from_dir_strict(
+                &source_dir,
+                source_id,
+                expected_source_kind,
+                &expected_source_root,
             )
-        })?;
+            .await?
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "indexed source session.json is missing",
+                )
+            })?;
         let target_rel = Self::root_rel_path(new_id);
         let target_dir = self.abs_path_from_rel(&target_rel);
         if fs::try_exists(&target_dir).await? {
@@ -4365,13 +4408,9 @@ impl SessionStoreV2 {
         };
         let rel_path = entry.rel_path.clone();
         let abs_dir = self.abs_path_from_rel(&rel_path);
-        let Some(mut session) = Self::load_session_from_dir_strict(
-            &abs_dir,
-            session_id,
-            entry.kind,
-            &entry.root_session_id,
-        )
-        .await?
+        let Some(mut session) = self
+            .load_session_from_dir_strict(&abs_dir, session_id, entry.kind, &entry.root_session_id)
+            .await?
         else {
             return Ok(false);
         };
@@ -4530,9 +4569,12 @@ impl SessionStoreV2 {
 
     /// Development-only: hard reset all sessions and the index.
     ///
-    /// This is the supported "greenfield" mechanism. It deletes:
+    /// This is the supported "greenfield" history/index mechanism. It deletes:
     /// - `bamboo_home_dir/sessions/`
     /// - `bamboo_home_dir/sessions.json` (rewritten to empty index)
+    ///
+    /// Root revocations remain canonical so surviving processes cannot restore
+    /// their deleted snapshots after this reset.
     pub async fn dev_reset(&self) -> io::Result<()> {
         let _lifecycle = self.lock_session_lifecycle_exclusive().await?;
         let _runtime_task = self.lock_runtime_task_transaction_exclusive().await?;
@@ -4554,9 +4596,24 @@ impl SessionStoreV2 {
             })
             .collect::<Vec<_>>();
 
-        // Remove the sessions directory entirely.
-        let _ = fs::remove_dir_all(&self.sessions_dir).await;
+        // Revoke canonical Roots before removing the tree, including Roots
+        // omitted by this process's stale index. Preserve the revocations
+        // outside sessions/: stale writers may survive this development reset.
+        let mut roots = fs::read_dir(&self.sessions_dir).await?;
+        while let Some(root) = roots.next_entry().await? {
+            if root.file_type().await?.is_dir() {
+                if let Some(id) = root.file_name().to_str() {
+                    self.revoke_root_lifetime(id).await?;
+                }
+            }
+        }
+        match fs::remove_dir_all(&self.sessions_dir).await {
+            Ok(()) => sync_parent_directory_entry(&self.sessions_dir).await?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
         fs::create_dir_all(&self.sessions_dir).await?;
+        sync_parent_directory_entry(&self.sessions_dir).await?;
 
         // Reset through the same cross-process rebase/publish boundary as every
         // other index mutation; dev reset must not race a stale direct writer.
@@ -4594,7 +4651,65 @@ impl SessionStoreV2 {
         session_id: &str,
         force: bool,
     ) -> io::Result<bool> {
+        validate_session_id(session_id)?;
         let entry = self.get_index_entry(session_id).await;
+        let root_birth = self.canonical_root_birth(session_id).await?;
+        let revoked_directory = root_birth.is_none()
+            && self.root_revocation(session_id).await?.is_some()
+            && fs::try_exists(self.sessions_dir.join(session_id)).await?;
+        if root_birth.is_some()
+            || revoked_directory
+            || entry
+                .as_ref()
+                .is_some_and(|entry| entry.kind == SessionKind::Root)
+        {
+            if !force
+                && (entry.as_ref().is_some_and(|entry| entry.pinned)
+                    || self
+                        .load_authoritative_root_session(session_id)
+                        .await?
+                        .is_some_and(|root| root.pinned))
+            {
+                return Err(other_io_error(
+                    "refusing to delete pinned session without force",
+                ));
+            }
+            if !self.revoke_root_lifetime(session_id).await? {
+                return Err(other_io_error(
+                    "cannot revoke Root without canonical birth evidence",
+                ));
+            }
+            let directory = self.sessions_dir.join(session_id);
+            match fs::remove_dir_all(&directory).await {
+                Ok(()) => sync_parent_directory_entry(&directory).await?,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            let removed = self
+                .update_index(|index| {
+                    let removed = index
+                        .sessions
+                        .values()
+                        .filter(|entry| {
+                            entry.id == session_id || entry.root_session_id == session_id
+                        })
+                        .map(|entry| (entry.id.clone(), entry.rel_path.clone()))
+                        .collect::<Vec<_>>();
+                    for (id, _) in &removed {
+                        index.sessions.remove(id);
+                    }
+                    Ok(removed)
+                })
+                .await?;
+            for (id, rel) in removed {
+                self.search_index_queue.enqueue_delete(
+                    &id,
+                    self.abs_path_from_rel(&rel)
+                        .join(SEARCH_INDEX_REVISION_FILE),
+                );
+            }
+            return Ok(true);
+        }
         let Some(entry) = entry else {
             return Ok(false);
         };
@@ -4618,40 +4733,7 @@ impl SessionStoreV2 {
                     .enqueue_delete(session_id, abs_dir.join(SEARCH_INDEX_REVISION_FILE));
                 Ok(true)
             }
-            SessionKind::Root => {
-                let root_id = entry.id.clone();
-                let abs_dir = self.abs_path_from_rel(&entry.rel_path);
-                let _ = fs::remove_dir_all(&abs_dir).await;
-
-                let to_remove = {
-                    let index = self.index.read().await;
-                    index
-                        .sessions
-                        .values()
-                        .filter(|e| e.root_session_id == root_id)
-                        .map(|entry| {
-                            (
-                                entry.id.clone(),
-                                self.abs_path_from_rel(&entry.rel_path)
-                                    .join(SEARCH_INDEX_REVISION_FILE),
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                };
-
-                self.update_index(|index| {
-                    for (id, _) in &to_remove {
-                        index.sessions.remove(id);
-                    }
-                    Ok(())
-                })
-                .await?;
-
-                for (id, revision_path) in to_remove {
-                    self.search_index_queue.enqueue_delete(&id, revision_path);
-                }
-                Ok(true)
-            }
+            SessionKind::Root => unreachable!("Root deletion handled from canonical placement"),
         }
     }
 }
@@ -4862,6 +4944,9 @@ impl SessionStoreV2 {
         let raw = fs::read_to_string(path).await?;
         let session: Session = serde_json::from_str(&raw)
             .map_err(|e| other_io_error(format!("invalid session.json: {e}")))?;
+        if !self.session_lifetime_is_live(&session).await? {
+            return Ok(None);
+        }
         let sidecar = self.read_runtime_sidecar(session_id).await?;
         supervisor::validate_overlay(&session, sidecar.as_ref())?;
         let mut session = overlay_runtime_sidecar(session, sidecar);
@@ -4873,6 +4958,14 @@ impl SessionStoreV2 {
 
 #[async_trait::async_trait]
 impl Storage for SessionStoreV2 {
+    async fn recreate_root_session(
+        &self,
+        session_id: &str,
+        initial_model: &str,
+    ) -> io::Result<Session> {
+        self.recreate_ordinary_root(session_id, initial_model).await
+    }
+
     async fn get_or_create_default_supervisor(
         &self,
         initial_model: &str,
@@ -6840,6 +6933,9 @@ mod tests {
             .iter()
             .all(|entry| entry.session_id != "search-generation"));
 
+        session = storage
+            .recreate_root_session(&session.id, &session.model)
+            .await?;
         session.title = "recreated searchable title".to_string();
         session.updated_at = Utc::now() + chrono::Duration::milliseconds(2);
         storage.save_session(&session).await?;

--- a/crates/infra/bamboo-storage/src/v2/root_context.rs
+++ b/crates/infra/bamboo-storage/src/v2/root_context.rs
@@ -72,6 +72,7 @@ impl SessionStoreV2 {
         full: bool,
     ) -> io::Result<()> {
         validate_session_id(&incoming.id)?;
+        self.validate_root_lifetime_for_write(incoming).await?;
         let directory = self.sessions_dir.join(&incoming.id);
         match fs::symlink_metadata(&directory).await {
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),

--- a/crates/infra/bamboo-storage/src/v2/root_context_tests.rs
+++ b/crates/infra/bamboo-storage/src/v2/root_context_tests.rs
@@ -260,9 +260,12 @@ async fn deleting_and_recreating_a_root_does_not_revalidate_its_old_snapshot() {
         .unwrap()
         .unwrap();
     assert!(fixture.first.delete_session(&initial.id).await.unwrap());
-    let mut replacement = initial.clone();
-    replacement.created_at += chrono::Duration::seconds(1);
-    replacement.model = "replacement-model".into();
+    let mut replacement = fixture
+        .first
+        .recreate_root_session(&initial.id, "replacement-model")
+        .await
+        .unwrap();
+    replacement.agent_runtime_state = initial.agent_runtime_state.clone();
     replacement.messages = vec![Message::user("Replacement history")];
     fixture.first.save_session(&replacement).await.unwrap();
 

--- a/crates/infra/bamboo-storage/src/v2/root_lifetime.rs
+++ b/crates/infra/bamboo-storage/src/v2/root_lifetime.rs
@@ -1,0 +1,433 @@
+//! Canonical evidence for deleted Root lifetimes. This records revocation only;
+//! active Sessions and Supervisor grants still have no separate registry.
+
+use super::*;
+use bamboo_domain::SessionAuthorityConflict;
+
+const ROOT_REVOCATIONS_DIR: &str = ".root-revocations";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RootPublicationFault {
+    BeforePublish,
+    BeforeIndex,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RootRevocation {
+    version: u32,
+    session_id: String,
+    revoked_through: DateTime<Utc>,
+}
+
+#[derive(Deserialize)]
+struct RootBirth {
+    id: String,
+    created_at: DateTime<Utc>,
+    #[serde(default)]
+    kind: SessionKind,
+    #[serde(default)]
+    root_session_id: String,
+    #[serde(default)]
+    parent_session_id: Option<String>,
+    #[serde(default)]
+    spawn_depth: u32,
+}
+
+fn invalid(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn conflict(error: impl std::fmt::Display) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::WouldBlock,
+        SessionAuthorityConflict(format!("Root lifetime is revoked or unavailable: {error}")),
+    )
+}
+
+async fn real_directory(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path).await {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(true),
+        Ok(_) => Err(invalid("Root lifetime directory is not a real directory")),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+async fn regular_file_exists(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path).await {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(true),
+        Ok(_) => Err(invalid("Root lifetime evidence is not a regular file")),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+async fn read_regular(path: &Path) -> io::Result<Option<Vec<u8>>> {
+    if regular_file_exists(path).await? {
+        fs::read(path).await.map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+impl SessionStoreV2 {
+    pub(super) fn maybe_fail_root_publication(
+        &self,
+        fault: RootPublicationFault,
+    ) -> io::Result<()> {
+        #[cfg(test)]
+        {
+            let mut pending = self
+                .root_publication_fault
+                .lock()
+                .expect("Root publication fault lock");
+            if pending.as_ref() == Some(&fault) {
+                *pending = None;
+                return Err(other_io_error(format!(
+                    "injected Root publication failure: {fault:?}"
+                )));
+            }
+        }
+        #[cfg(not(test))]
+        let _ = fault;
+        Ok(())
+    }
+
+    fn root_revocation_path(&self, session_id: &str) -> PathBuf {
+        self.bamboo_home_dir
+            .join(ROOT_REVOCATIONS_DIR)
+            .join(format!("{session_id}.json"))
+    }
+
+    pub(super) async fn root_revocation(
+        &self,
+        session_id: &str,
+    ) -> io::Result<Option<DateTime<Utc>>> {
+        validate_session_id(session_id)?;
+        let directory = self.bamboo_home_dir.join(ROOT_REVOCATIONS_DIR);
+        if !real_directory(&directory).await? {
+            return Ok(None);
+        }
+        let Some(bytes) = read_regular(&self.root_revocation_path(session_id)).await? else {
+            return Ok(None);
+        };
+        let evidence: RootRevocation = serde_json::from_slice(&bytes)
+            .map_err(|error| invalid(format!("invalid Root revocation: {error}")))?;
+        if evidence.version != 1 || evidence.session_id != session_id {
+            return Err(invalid("Root revocation identity or version mismatch"));
+        }
+        Ok(Some(evidence.revoked_through))
+    }
+
+    /// Read birth markers directly from canonical files, never the index. Both
+    /// markers are revoked if an interrupted/corrupt pair disagrees. Unreadable
+    /// or unparseable files fail closed before deletion changes anything.
+    pub(super) async fn canonical_root_birth(
+        &self,
+        session_id: &str,
+    ) -> io::Result<Option<DateTime<Utc>>> {
+        validate_session_id(session_id)?;
+        let directory = self.sessions_dir.join(session_id);
+        if !real_directory(&directory).await? {
+            return Ok(None);
+        }
+        let mut birth = None;
+        for name in ["session.json", RUNTIME_SIDECAR_FILE] {
+            let Some(bytes) = read_regular(&directory.join(name)).await? else {
+                continue;
+            };
+            let identity: RootBirth = serde_json::from_slice(&bytes)
+                .map_err(|error| invalid(format!("invalid Root deletion identity: {error}")))?;
+            if identity.id != session_id
+                || identity.kind != SessionKind::Root
+                || (!identity.root_session_id.is_empty() && identity.root_session_id != session_id)
+                || identity.parent_session_id.is_some()
+                || identity.spawn_depth != 0
+            {
+                return Err(invalid(
+                    "Root deletion identity does not match canonical placement",
+                ));
+            }
+            birth = Some(
+                birth.map_or(identity.created_at, |previous: DateTime<Utc>| {
+                    previous.max(identity.created_at)
+                }),
+            );
+        }
+        Ok(birth)
+    }
+
+    /// Caller owns lifecycle + Task exclusivity. Publication is the logical
+    /// deletion point: a crash before file/index removal cannot restore access.
+    pub(super) async fn revoke_root_lifetime(&self, session_id: &str) -> io::Result<bool> {
+        let previous = self.root_revocation(session_id).await?;
+        let birth = self.canonical_root_birth(session_id).await?;
+        let Some(birth) = birth else {
+            return Ok(previous.is_some());
+        };
+        let revoked_through = previous.map_or(birth, |previous| previous.max(birth));
+        let directory = self.bamboo_home_dir.join(ROOT_REVOCATIONS_DIR);
+        if !real_directory(&directory).await? {
+            fs::create_dir(&directory).await?;
+            sync_parent_directory_entry(&directory).await?;
+        }
+        let bytes = serde_json::to_vec(&RootRevocation {
+            version: 1,
+            session_id: session_id.to_string(),
+            revoked_through,
+        })
+        .map_err(|error| invalid(error.to_string()))?;
+        durable_atomic_write(&self.root_revocation_path(session_id), &bytes).await?;
+        Ok(true)
+    }
+
+    pub(super) async fn root_birth_is_live(
+        &self,
+        session_id: &str,
+        created_at: DateTime<Utc>,
+    ) -> io::Result<bool> {
+        Ok(self
+            .root_revocation(session_id)
+            .await?
+            .is_none_or(|cutoff| created_at > cutoff))
+    }
+
+    pub(super) async fn root_directory_is_revoked(&self, session_id: &str) -> io::Result<bool> {
+        let Some(cutoff) = self.root_revocation(session_id).await? else {
+            return Ok(false);
+        };
+        Ok(self
+            .canonical_root_birth(session_id)
+            .await?
+            .is_none_or(|birth| birth <= cutoff))
+    }
+
+    /// Repair only the derived index after a crash between revocation and its
+    /// removal. The caller already owns startup lifecycle/Task exclusivity.
+    pub(super) async fn reconcile_root_revocations(&self) -> io::Result<()> {
+        let directory = self.bamboo_home_dir.join(ROOT_REVOCATIONS_DIR);
+        if !real_directory(&directory).await? {
+            return Ok(());
+        }
+        let mut entries = fs::read_dir(&directory).await?;
+        let mut revoked = HashSet::new();
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                continue; // Unpublished atomic-write temporary files are inert.
+            }
+            let id = path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| invalid("invalid Root revocation filename"))?;
+            match self.root_directory_is_revoked(id).await {
+                Ok(true) => {
+                    revoked.insert(id.to_string());
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    // A damaged Root must remain unavailable without making
+                    // unrelated canonical Sessions unavailable at startup.
+                    // Keep its evidence/files intact for strict refusal and
+                    // targeted repair; only its derived rows are removable.
+                    tracing::warn!(
+                        "Root revocation reconciliation: unavailable Root {id}: {error}"
+                    );
+                    revoked.insert(id.to_string());
+                }
+            }
+        }
+        if !revoked.is_empty() {
+            self.update_index(|index| {
+                index.sessions.retain(|id, entry| {
+                    !revoked.contains(id) && !revoked.contains(&entry.root_session_id)
+                });
+                Ok(())
+            })
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// All historical/rebuild/recovery readers suppress a revoked Root and its
+    /// remaining children after interrupted removal. A Child cannot occupy a
+    /// former Root ID, even when the former Root directory is absent.
+    pub(super) async fn session_lifetime_is_live(&self, session: &Session) -> io::Result<bool> {
+        if session.kind == SessionKind::Root {
+            return self
+                .root_birth_is_live(&session.id, session.created_at)
+                .await;
+        }
+        if self.root_revocation(&session.id).await?.is_some() {
+            return Ok(false);
+        }
+        let root_id = &session.root_session_id;
+        let Some(cutoff) = self.root_revocation(root_id).await? else {
+            return Ok(true);
+        };
+        // This only fences a Child against a deleted parent. It grants no
+        // Root/Supervisor authority, so never read the parent's potentially
+        // large transcript here. Strict Root authorization still validates
+        // the complete canonical main/runtime pair through its separate port.
+        let directory = self.sessions_dir.join(root_id);
+        if !real_directory(&self.sessions_dir).await?
+            || !real_directory(&directory).await?
+            || !regular_file_exists(&directory.join("session.json")).await?
+        {
+            return Ok(false);
+        }
+        let Some(bytes) = read_regular(&directory.join(RUNTIME_SIDECAR_FILE)).await? else {
+            return Ok(false);
+        };
+        let parent: Session = serde_json::from_slice(&bytes)
+            .map_err(|error| invalid(format!("invalid parent Root runtime: {error}")))?;
+        supervisor::validate_identity(&parent)?;
+        if parent.id != *root_id
+            || parent.kind != SessionKind::Root
+            || (!parent.root_session_id.is_empty() && parent.root_session_id != *root_id)
+            || parent.parent_session_id.is_some()
+            || parent.spawn_depth != 0
+        {
+            return Err(invalid(
+                "parent Root runtime identity does not match canonical placement",
+            ));
+        }
+        Ok(parent.created_at > cutoff)
+    }
+
+    /// Called under the final ordinary writer or exclusive lifecycle boundary.
+    /// An absent/empty directory is creation only for a never-deleted ID. Even
+    /// a newly constructed ordinary snapshot must use explicit recreation once
+    /// deletion provenance exists.
+    pub(super) async fn validate_root_lifetime_for_write(
+        &self,
+        incoming: &Session,
+    ) -> io::Result<()> {
+        let evidence = self.root_revocation(&incoming.id).await.map_err(conflict)?;
+        if let Some(cutoff) = evidence {
+            if incoming.kind != SessionKind::Root || incoming.created_at <= cutoff {
+                return Err(conflict("writer belongs to a deleted Root lifetime"));
+            }
+            let directory = self.sessions_dir.join(&incoming.id);
+            if !regular_file_exists(&directory.join("session.json"))
+                .await
+                .map_err(conflict)?
+                && !regular_file_exists(&directory.join(RUNTIME_SIDECAR_FILE))
+                    .await
+                    .map_err(conflict)?
+            {
+                return Err(conflict(
+                    "a deleted Root ID requires trusted explicit recreation",
+                ));
+            }
+        }
+        if incoming.kind == SessionKind::Child
+            && !self
+                .session_lifetime_is_live(incoming)
+                .await
+                .map_err(conflict)?
+        {
+            return Err(conflict("child belongs to a deleted Root"));
+        }
+        Ok(())
+    }
+
+    /// Generate the new birth at the trusted host boundary. Clock rollback and
+    /// a future old marker cannot reuse any revoked lifetime; overflow is an
+    /// error before staging/publication.
+    pub(super) async fn fresh_root_birth(&self, session_id: &str) -> io::Result<DateTime<Utc>> {
+        let now = Utc::now();
+        match self.root_revocation(session_id).await? {
+            Some(cutoff) if now <= cutoff => cutoff
+                .checked_add_signed(chrono::Duration::nanoseconds(1))
+                .ok_or_else(|| invalid("Root lifetime birth marker exhausted")),
+            _ => Ok(now),
+        }
+    }
+
+    /// A revoked directory may survive a crash after the revocation commit.
+    /// Remove only that old publication while holding lifecycle/Task exclusivity.
+    pub(super) async fn remove_revoked_root_directory(&self, session_id: &str) -> io::Result<()> {
+        let Some(cutoff) = self.root_revocation(session_id).await? else {
+            return Ok(());
+        };
+        if self
+            .canonical_root_birth(session_id)
+            .await?
+            .is_some_and(|birth| birth > cutoff)
+        {
+            return Err(invalid("cannot remove a live Root during recreation"));
+        }
+        let directory = self.sessions_dir.join(session_id);
+        match fs::remove_dir_all(&directory).await {
+            Ok(()) => sync_parent_directory_entry(&directory).await,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(super) async fn recreate_ordinary_root(
+        &self,
+        session_id: &str,
+        initial_model: &str,
+    ) -> io::Result<Session> {
+        validate_session_id(session_id)?;
+        if session_id == DEFAULT_SUPERVISOR_SESSION_ID || initial_model.trim().is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "ordinary Root recreation requires a non-reserved ID and a model",
+            ));
+        }
+        let _lifecycle = self.lock_session_lifecycle_exclusive().await?;
+        let _task = self.lock_runtime_task_transaction_exclusive().await?;
+        self.recover_all_runtime_task_transactions_locked().await?;
+        self.recover_all_session_copy_transactions_locked().await?;
+        if self.root_revocation(session_id).await?.is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Root ID has not been deleted; use ordinary first creation",
+            ));
+        }
+        if let Some(existing) = self.load_root_authority_unchecked(session_id).await? {
+            let full = self
+                .load_authoritative_root_session(session_id)
+                .await?
+                .ok_or_else(|| invalid("recreated Root disappeared"))?;
+            self.repair_index_from_authoritative_session(&full, Self::root_rel_path(session_id))
+                .await?;
+            debug_assert_eq!(existing.created_at, full.created_at);
+            return Ok(full);
+        }
+        self.remove_revoked_root_directory(session_id).await?;
+        let mut session = Session::new(session_id, initial_model.trim());
+        session.created_at = self.fresh_root_birth(session_id).await?;
+        session.updated_at = session.created_at;
+        let staging = self
+            .bamboo_home_dir
+            .join(format!(".root-recreation-{}", Uuid::new_v4()));
+        let destination = self.sessions_dir.join(session_id);
+        fs::create_dir(&staging).await?;
+        let result = async {
+            fs::create_dir(staging.join("children")).await?;
+            fs::create_dir(staging.join("attachments")).await?;
+            let bytes =
+                serde_json::to_vec_pretty(&session).map_err(|error| invalid(error.to_string()))?;
+            durable_atomic_write(&staging.join("session.json"), &bytes).await?;
+            durable_atomic_write(&staging.join(RUNTIME_SIDECAR_FILE), &bytes).await?;
+            sync_directory(&staging).await?;
+            self.maybe_fail_root_publication(RootPublicationFault::BeforePublish)?;
+            atomic_rename(&staging, &destination).await?;
+            sync_parent_directory_entry(&staging).await?;
+            sync_parent_directory_entry(&destination).await?;
+            self.maybe_fail_root_publication(RootPublicationFault::BeforeIndex)?;
+            self.repair_index_from_authoritative_session(&session, Self::root_rel_path(session_id))
+                .await?;
+            Ok(session.clone())
+        }
+        .await;
+        if result.is_err() {
+            let _ = fs::remove_dir_all(&staging).await;
+        }
+        result
+    }
+}

--- a/crates/infra/bamboo-storage/src/v2/root_lifetime_tests.rs
+++ b/crates/infra/bamboo-storage/src/v2/root_lifetime_tests.rs
@@ -1,0 +1,732 @@
+//! Independent-store acceptance for the deletion commit, not index-only mocks.
+
+use super::*;
+use bamboo_domain::{Message, SessionAuthorityConflict};
+
+async fn store(home: &Path) -> SessionStoreV2 {
+    SessionStoreV2::new(home.to_path_buf()).await.unwrap()
+}
+
+fn original() -> Session {
+    let mut root = Session::new("lifetime-root", "original-model");
+    root.set_project_id_meta("project-a");
+    root.metadata_version = 7;
+    root.add_message(Message::user("Original lifetime history"));
+    root
+}
+
+async fn reject(store: &SessionStoreV2, snapshot: &Session) {
+    let index = fs::read(store.index_path()).await.unwrap();
+    let revision = store.persistence_metrics().full_save.total.count;
+    for runtime in [false, true] {
+        let error = if runtime {
+            store.save_runtime_state(snapshot).await
+        } else {
+            store.save_session(snapshot).await
+        }
+        .unwrap_err();
+        assert!(
+            error
+                .get_ref()
+                .is_some_and(|cause| cause.is::<SessionAuthorityConflict>()),
+            "{error:?}"
+        );
+        assert_eq!(fs::read(store.index_path()).await.unwrap(), index);
+    }
+    assert_eq!(store.persistence_metrics().full_save.total.count, revision);
+}
+
+async fn revoke_without_removing(store: &SessionStoreV2, id: &str) {
+    let _lifecycle = store.lock_session_lifecycle_exclusive().await.unwrap();
+    let _task = store
+        .lock_runtime_task_transaction_exclusive()
+        .await
+        .unwrap();
+    assert!(store.revoke_root_lifetime(id).await.unwrap());
+}
+
+#[tokio::test]
+async fn deleted_root_rejects_old_full_and_warm_or_cold_runtime_snapshots_across_restart() {
+    let home = tempfile::tempdir().unwrap();
+    let first = store(home.path()).await;
+    let old = original();
+    first.save_session(&old).await.unwrap();
+    let warm = store(home.path()).await;
+    let snapshot = warm.load_session(&old.id).await.unwrap().unwrap();
+    assert!(first.delete_session(&old.id).await.unwrap());
+    first.flush_search_index().await;
+    let cold = store(home.path()).await;
+    for independent in [&warm, &cold] {
+        reject(independent, &snapshot).await;
+        assert!(independent
+            .load_root_authority(&old.id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(independent.load_session(&old.id).await.unwrap().is_none());
+        assert!(independent
+            .load_runtime_control_plane(&old.id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(!independent.sessions_root_dir().join(&old.id).exists());
+    }
+    let revocation = cold.root_revocation(&old.id).await.unwrap().unwrap();
+    assert_eq!(revocation, old.created_at);
+}
+
+#[tokio::test]
+async fn trusted_recreation_generates_a_blank_birth_and_preserves_complete_retry() {
+    let home = tempfile::tempdir().unwrap();
+    let first = store(home.path()).await;
+    let old = original();
+    first.save_runtime_state(&old).await.unwrap(); // Never-persisted runtime fallback.
+    assert!(first.load_root_authority(&old.id).await.unwrap().is_some());
+    assert!(first.recreate_root_session(&old.id, "model").await.is_err());
+    first.delete_session(&old.id).await.unwrap();
+
+    // Even a fresh arbitrary snapshot cannot claim a reused ID through save.
+    reject(&first, &Session::new(&old.id, "new-model")).await;
+    let mut replacement = first
+        .recreate_root_session(&old.id, "new-model")
+        .await
+        .unwrap();
+    assert!(replacement.created_at > old.created_at);
+    assert!(replacement.messages.is_empty());
+    assert_eq!(replacement.project_id_meta(), None);
+    assert_eq!(replacement.metadata_version, 0);
+    assert!(replacement.authority_identity.is_ordinary());
+    replacement.add_message(Message::user("New lifetime history"));
+    first.save_session(&replacement).await.unwrap();
+    let independent = store(home.path()).await;
+    let retry = independent
+        .recreate_root_session(&old.id, "ignored-model")
+        .await
+        .unwrap();
+    assert_eq!(retry.created_at, replacement.created_at);
+    assert_eq!(retry.model, "new-model");
+    assert_eq!(retry.messages.len(), 1);
+    reject(&independent, &old).await;
+
+    independent.delete_session(&old.id).await.unwrap();
+    reject(&first, &old).await;
+    reject(&first, &replacement).await;
+    let third = first
+        .recreate_root_session(&old.id, "third-model")
+        .await
+        .unwrap();
+    assert!(third.created_at > replacement.created_at);
+    assert_ne!(third.created_at, old.created_at);
+    reject(&independent, &old).await;
+    reject(&independent, &replacement).await;
+    first.flush_search_index().await;
+    independent.flush_search_index().await;
+}
+
+#[tokio::test]
+async fn committed_revocation_hides_partial_deletion_from_read_rebuild_copy_and_migration() {
+    for corrupt_index in [false, true] {
+        let home = tempfile::tempdir().unwrap();
+        let first = store(home.path()).await;
+        let old = original();
+        let child = Session::new_child_of("lifetime-child", &old, "model", "child");
+        first.save_session(&old).await.unwrap();
+        first.save_session(&child).await.unwrap();
+        first.flush_search_index().await;
+        revoke_without_removing(&first, &old.id).await;
+        assert!(first
+            .sessions_root_dir()
+            .join(&old.id)
+            .join("session.json")
+            .exists());
+        for id in [&old.id, &child.id] {
+            assert!(first.load_session(id).await.unwrap().is_none());
+            assert!(first
+                .load_runtime_control_plane(id)
+                .await
+                .unwrap()
+                .is_none());
+        }
+        assert!(first.load_root_authority(&old.id).await.unwrap().is_none());
+        assert!(first
+            .probe_root_session_from_disk(&old.id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(first
+            .recover_root_session_from_disk(&old.id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(first
+            .copy_session(&old.id, "copy-of-revoked")
+            .await
+            .is_err());
+        reject(&first, &old).await;
+        reject(&first, &child).await;
+
+        // An interrupted physical removal can leave only the old main file.
+        let runtime = first
+            .sessions_root_dir()
+            .join(&old.id)
+            .join(RUNTIME_SIDECAR_FILE);
+        fs::remove_file(&runtime).await.unwrap();
+        assert!(first.migrate_runtime_sidecars().await.is_err());
+        assert!(!runtime.exists());
+        if corrupt_index {
+            fs::write(first.index_path(), b"{invalid").await.unwrap();
+        }
+        let restarted = store(home.path()).await;
+        assert!(restarted.get_index_entry(&old.id).await.is_none());
+        assert!(restarted.get_index_entry(&child.id).await.is_none());
+        assert!(restarted
+            .load_root_authority(&old.id)
+            .await
+            .unwrap()
+            .is_none());
+        let recreated = restarted
+            .recreate_root_session(&old.id, "recreated")
+            .await
+            .unwrap();
+        assert!(recreated.created_at > old.created_at);
+        assert!(!restarted
+            .sessions_root_dir()
+            .join(&old.id)
+            .join("children")
+            .join(&child.id)
+            .exists());
+        first.flush_search_index().await;
+        restarted.flush_search_index().await;
+    }
+}
+
+#[tokio::test]
+async fn stale_index_delete_revokes_canonical_birth_and_reset_preserves_all_revocations() {
+    let home = tempfile::tempdir().unwrap();
+    let stale = store(home.path()).await;
+    let writer = store(home.path()).await;
+    let old = original();
+    writer.save_session(&old).await.unwrap();
+    assert!(stale.get_index_entry(&old.id).await.is_none());
+    assert!(stale.delete_session(&old.id).await.unwrap());
+    reject(&writer, &old).await;
+    let new = writer
+        .recreate_root_session(&old.id, "recreated")
+        .await
+        .unwrap();
+    let unindexed = Session::new("reset-unindexed", "model");
+    writer.save_session(&unindexed).await.unwrap();
+    stale.dev_reset().await.unwrap();
+    for snapshot in [&old, &new, &unindexed] {
+        reject(&writer, snapshot).await;
+        assert!(writer
+            .load_root_authority(&snapshot.id)
+            .await
+            .unwrap()
+            .is_none());
+    }
+    let restarted = store(home.path()).await;
+    assert!(restarted.root_revocation(&old.id).await.unwrap().unwrap() >= new.created_at);
+    assert!(restarted
+        .root_revocation(&unindexed.id)
+        .await
+        .unwrap()
+        .is_some());
+    writer.flush_search_index().await;
+    stale.flush_search_index().await;
+}
+
+#[tokio::test]
+async fn deletion_retry_removes_remaining_files_after_birth_files_and_index_are_gone() {
+    let home = tempfile::tempdir().unwrap();
+    let first = store(home.path()).await;
+    let old = original();
+    first.save_session(&old).await.unwrap();
+    first.flush_search_index().await;
+    revoke_without_removing(&first, &old.id).await;
+    let directory = first.sessions_root_dir().join(&old.id);
+    fs::write(
+        directory.join("attachments").join("remaining.txt"),
+        b"remaining",
+    )
+    .await
+    .unwrap();
+    fs::remove_file(directory.join("session.json"))
+        .await
+        .unwrap();
+    fs::remove_file(directory.join(RUNTIME_SIDECAR_FILE))
+        .await
+        .unwrap();
+    let restarted = store(home.path()).await;
+    assert!(restarted.get_index_entry(&old.id).await.is_none());
+    assert!(restarted.delete_session(&old.id).await.unwrap());
+    assert!(!directory.exists());
+    assert!(!restarted.delete_session(&old.id).await.unwrap());
+    reject(&first, &old).await;
+}
+
+#[tokio::test]
+async fn recreation_index_failure_preserves_complete_pair_for_restart_retry() {
+    let home = tempfile::tempdir().unwrap();
+    let first = store(home.path()).await;
+    let old = original();
+    first.save_session(&old).await.unwrap();
+    first.delete_session(&old.id).await.unwrap();
+    first.flush_search_index().await;
+    let index = fs::read(first.index_path()).await.unwrap();
+    fs::remove_file(first.index_path()).await.unwrap();
+    fs::create_dir(first.index_path()).await.unwrap();
+    assert!(first
+        .recreate_root_session(&old.id, "new-model")
+        .await
+        .is_err());
+    let published = first.load_root_authority(&old.id).await.unwrap().unwrap();
+    assert!(published.created_at > old.created_at);
+    fs::remove_dir(first.index_path()).await.unwrap();
+    fs::write(first.index_path(), index).await.unwrap();
+    let restarted = store(home.path()).await;
+    let retry = restarted
+        .recreate_root_session(&old.id, "ignored-model")
+        .await
+        .unwrap();
+    assert_eq!(retry.created_at, published.created_at);
+    assert_eq!(retry.model, "new-model");
+    assert!(restarted.get_index_entry(&old.id).await.is_some());
+    reject(&restarted, &old).await;
+}
+
+async fn recreate_for_fault_test(
+    store: &SessionStoreV2,
+    id: &str,
+    model: &str,
+    supervisor: bool,
+) -> io::Result<Session> {
+    if supervisor {
+        store.get_or_create_default_supervisor(model).await?;
+        Ok(store.probe_root_session_from_disk(id).await?.unwrap())
+    } else {
+        store.recreate_root_session(id, model).await
+    }
+}
+
+#[tokio::test]
+async fn ordinary_and_supervisor_recreation_crash_boundaries_keep_one_published_lifetime() {
+    use root_lifetime::RootPublicationFault;
+
+    for supervisor in [false, true] {
+        for fault in [
+            RootPublicationFault::BeforePublish,
+            RootPublicationFault::BeforeIndex,
+        ] {
+            let home = tempfile::tempdir().unwrap();
+            let first = store(home.path()).await;
+            let mut old = if supervisor {
+                first
+                    .get_or_create_default_supervisor("old-model")
+                    .await
+                    .unwrap();
+                first
+                    .probe_root_session_from_disk(DEFAULT_SUPERVISOR_SESSION_ID)
+                    .await
+                    .unwrap()
+                    .unwrap()
+            } else {
+                original()
+            };
+            old.add_message(Message::user("Old conversation"));
+            first.save_session(&old).await.unwrap();
+            first.flush_search_index().await;
+            revoke_without_removing(&first, &old.id).await;
+            assert!(first.sessions_root_dir().join(&old.id).exists());
+            *first.root_publication_fault.lock().unwrap() = Some(fault);
+            assert!(
+                recreate_for_fault_test(&first, &old.id, "new-model", supervisor)
+                    .await
+                    .is_err()
+            );
+            reject(&first, &old).await;
+
+            let published = first.load_root_authority(&old.id).await.unwrap();
+            if fault == RootPublicationFault::BeforePublish {
+                assert!(published.is_none());
+                // Model an abrupt process exit leaving a complete but
+                // unpublished staging directory outside canonical sessions/.
+                let staging = home
+                    .path()
+                    .join(format!(".root-recreation-{}", Uuid::new_v4()));
+                fs::create_dir(&staging).await.unwrap();
+                let mut staged = Session::new(&old.id, "unpublished-model");
+                staged.created_at = Utc::now() + chrono::Duration::days(365);
+                if supervisor {
+                    staged.authority_identity = SessionAuthorityIdentity::Supervisor {
+                        incarnation_id: Uuid::new_v4(),
+                    };
+                }
+                let bytes = serde_json::to_vec(&staged).unwrap();
+                fs::write(staging.join("session.json"), &bytes)
+                    .await
+                    .unwrap();
+                fs::write(staging.join(RUNTIME_SIDECAR_FILE), &bytes)
+                    .await
+                    .unwrap();
+            } else {
+                let mut full = first
+                    .probe_root_session_from_disk(&old.id)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert!(full.created_at > old.created_at);
+                full.add_message(Message::user("New conversation preserved on retry"));
+                first.save_session(&full).await.unwrap();
+            }
+
+            let restarted = store(home.path()).await;
+            if fault == RootPublicationFault::BeforePublish {
+                assert!(restarted
+                    .load_root_authority(&old.id)
+                    .await
+                    .unwrap()
+                    .is_none());
+            }
+            let retry = recreate_for_fault_test(&restarted, &old.id, "new-model", supervisor)
+                .await
+                .unwrap();
+            assert!(retry.created_at > old.created_at);
+            assert_eq!(retry.model, "new-model");
+            if let Some(published) = published {
+                assert_eq!(retry.created_at, published.created_at);
+                assert_eq!(retry.authority_identity, published.authority_identity);
+                assert_eq!(retry.messages.len(), 1);
+            } else {
+                assert!(retry.messages.is_empty());
+            }
+            reject(&restarted, &old).await;
+            first.flush_search_index().await;
+            restarted.flush_search_index().await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn old_root_cannot_bypass_revocation_as_a_child_or_an_empty_creation_layout() {
+    let home = tempfile::tempdir().unwrap();
+    let first = store(home.path()).await;
+    let old = original();
+    first.save_session(&old).await.unwrap();
+    first.delete_session(&old.id).await.unwrap();
+    let other = Session::new("other-root", "model");
+    first.save_session(&other).await.unwrap();
+    let as_child = Session::new_child_of(&old.id, &other, "model", "old-root-as-child");
+    reject(&first, &as_child).await;
+    let empty = first.sessions_root_dir().join(&old.id);
+    fs::create_dir_all(empty.join("children")).await.unwrap();
+    fs::create_dir(empty.join("attachments")).await.unwrap();
+    reject(&first, &old).await;
+    reject(&first, &Session::new(&old.id, "new-model")).await;
+    first.flush_search_index().await;
+}
+
+#[tokio::test]
+async fn damaged_revocation_fails_closed_without_writes_or_authority() {
+    for damage in ["corrupt", "wrong-id", "version", "directory"] {
+        let home = tempfile::tempdir().unwrap();
+        let first = store(home.path()).await;
+        let old = original();
+        first.save_session(&old).await.unwrap();
+        first.delete_session(&old.id).await.unwrap();
+        let evidence = home
+            .path()
+            .join(".root-revocations")
+            .join(format!("{}.json", old.id));
+        match damage {
+            "directory" => {
+                fs::remove_file(&evidence).await.unwrap();
+                fs::create_dir(&evidence).await.unwrap();
+            }
+            "corrupt" => fs::write(&evidence, b"{invalid").await.unwrap(),
+            _ => {
+                let mut value: serde_json::Value =
+                    serde_json::from_slice(&fs::read(&evidence).await.unwrap()).unwrap();
+                value[if damage == "wrong-id" {
+                    "session_id"
+                } else {
+                    "version"
+                }] = if damage == "wrong-id" {
+                    serde_json::json!("other")
+                } else {
+                    serde_json::json!(9)
+                };
+                fs::write(&evidence, serde_json::to_vec(&value).unwrap())
+                    .await
+                    .unwrap();
+            }
+        }
+        reject(&first, &old).await;
+        assert!(first.load_root_authority(&old.id).await.is_err());
+        assert!(first
+            .recreate_root_session(&old.id, "new-model")
+            .await
+            .is_err());
+        assert!(!first.sessions_root_dir().join(&old.id).exists());
+        first.flush_search_index().await;
+    }
+}
+
+#[tokio::test]
+async fn recreation_survives_clock_rollback_and_rejects_birth_overflow() {
+    for birth in [
+        Utc::now() + chrono::Duration::days(365),
+        DateTime::<Utc>::MAX_UTC,
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        let first = store(home.path()).await;
+        let mut old = original();
+        old.created_at = birth;
+        first.save_session(&old).await.unwrap();
+        first.delete_session(&old.id).await.unwrap();
+        let recreated = first.recreate_root_session(&old.id, "new-model").await;
+        if birth == DateTime::<Utc>::MAX_UTC {
+            assert!(recreated.is_err());
+            assert!(!first.sessions_root_dir().join(&old.id).exists());
+        } else {
+            assert!(recreated.unwrap().created_at > birth);
+        }
+        reject(&first, &old).await;
+        first.flush_search_index().await;
+    }
+}
+
+#[tokio::test]
+async fn child_runtime_lifetime_probe_uses_small_parent_runtime_when_history_is_large_and_invalid()
+{
+    let home = tempfile::tempdir().unwrap();
+    let first = store(home.path()).await;
+    let old = original();
+    first.save_session(&old).await.unwrap();
+    first.delete_session(&old.id).await.unwrap();
+    let parent = first
+        .recreate_root_session(&old.id, "new-model")
+        .await
+        .unwrap();
+    let mut child = Session::new_child_of("runtime-child", &parent, "model", "child");
+    first.save_session(&child).await.unwrap();
+    let child_directory = first
+        .sessions_root_dir()
+        .join(&parent.id)
+        .join("children")
+        .join(&child.id);
+    let original_child_main = fs::read(child_directory.join("session.json"))
+        .await
+        .unwrap();
+    let parent_main = first
+        .sessions_root_dir()
+        .join(&parent.id)
+        .join("session.json");
+    fs::write(&parent_main, vec![b'x'; 8 * 1024 * 1024])
+        .await
+        .unwrap();
+    child.model = "updated-runtime-model".into();
+    first.save_runtime_state(&child).await.unwrap();
+    let loaded = first
+        .load_runtime_control_plane(&child.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(loaded.model, "updated-runtime-model");
+    assert_eq!(
+        fs::read(child_directory.join("session.json"))
+            .await
+            .unwrap(),
+        original_child_main
+    );
+    assert_eq!(
+        fs::metadata(&parent_main).await.unwrap().len(),
+        8 * 1024 * 1024
+    );
+    assert!(first.load_root_authority(&parent.id).await.is_err());
+    first.flush_search_index().await;
+}
+
+#[tokio::test]
+async fn child_runtime_lifetime_probe_fails_closed_without_publishing_unavailable_parent_state() {
+    for damage in [
+        "revoked-birth",
+        "missing-runtime",
+        "corrupt-runtime",
+        "nonregular-runtime",
+        "wrong-root",
+        "missing-main",
+        "nonregular-main",
+        "corrupt-cutoff",
+        "nonregular-cutoff",
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        let first = Arc::new(store(home.path()).await);
+        let old = original();
+        first.save_session(&old).await.unwrap();
+        first.delete_session(&old.id).await.unwrap();
+        let parent = first
+            .recreate_root_session(&old.id, "new-model")
+            .await
+            .unwrap();
+        let mut child = Session::new_child_of("runtime-child", &parent, "model", "child");
+        first.save_session(&child).await.unwrap();
+        first.flush_search_index().await;
+        let parent_directory = first.sessions_root_dir().join(&parent.id);
+        let parent_runtime = parent_directory.join(RUNTIME_SIDECAR_FILE);
+        let parent_main = parent_directory.join("session.json");
+        let cutoff_path = home
+            .path()
+            .join(".root-revocations")
+            .join(format!("{}.json", parent.id));
+        let child_directory = parent_directory.join("children").join(&child.id);
+        let original_child_main = fs::read(child_directory.join("session.json"))
+            .await
+            .unwrap();
+        let original_child_runtime = fs::read(child_directory.join(RUNTIME_SIDECAR_FILE))
+            .await
+            .unwrap();
+        match damage {
+            "missing-runtime" => fs::remove_file(&parent_runtime).await.unwrap(),
+            "corrupt-runtime" => fs::write(&parent_runtime, b"{invalid").await.unwrap(),
+            "nonregular-runtime" => {
+                fs::remove_file(&parent_runtime).await.unwrap();
+                fs::create_dir(&parent_runtime).await.unwrap();
+            }
+            "missing-main" => fs::remove_file(&parent_main).await.unwrap(),
+            "nonregular-main" => {
+                fs::remove_file(&parent_main).await.unwrap();
+                fs::create_dir(&parent_main).await.unwrap();
+            }
+            "corrupt-cutoff" => fs::write(&cutoff_path, b"{invalid").await.unwrap(),
+            "nonregular-cutoff" => {
+                fs::remove_file(&cutoff_path).await.unwrap();
+                fs::create_dir(&cutoff_path).await.unwrap();
+            }
+            _ => {
+                let mut damaged = parent.clone();
+                if damage == "revoked-birth" {
+                    damaged.created_at = old.created_at;
+                } else {
+                    damaged.root_session_id = "wrong-root".into();
+                }
+                fs::write(&parent_runtime, serde_json::to_vec(&damaged).unwrap())
+                    .await
+                    .unwrap();
+            }
+        }
+        reject(&first, &child).await;
+        let published = AtomicBool::new(false);
+        let locked = crate::session_merge::LockedSessionStore::new(first.clone());
+        assert!(locked
+            .save_runtime_only_and_publish(&mut child, |_| {
+                published.store(true, Ordering::SeqCst);
+            })
+            .await
+            .is_err());
+        assert!(!published.load(Ordering::SeqCst));
+        assert_eq!(
+            fs::read(child_directory.join("session.json"))
+                .await
+                .unwrap(),
+            original_child_main
+        );
+        assert_eq!(
+            fs::read(child_directory.join(RUNTIME_SIDECAR_FILE))
+                .await
+                .unwrap(),
+            original_child_runtime
+        );
+    }
+}
+
+#[tokio::test]
+async fn startup_isolates_a_corrupt_recreated_root_and_preserves_full_save_repair() {
+    for rebuild in [false, true] {
+        for corrupt_runtime in [false, true] {
+            let home = tempfile::tempdir().unwrap();
+            let first = store(home.path()).await;
+            let old = original();
+            first.save_session(&old).await.unwrap();
+            first.delete_session(&old.id).await.unwrap();
+            let mut recreated = first
+                .recreate_root_session(&old.id, "recreated-model")
+                .await
+                .unwrap();
+            recreated.add_message(Message::user("Repairable new lifetime history"));
+            first.save_session(&recreated).await.unwrap();
+            let child =
+                Session::new_child_of("repairable-child", &recreated, "child-model", "child");
+            first.save_session(&child).await.unwrap();
+            let mut healthy = Session::new("unrelated-healthy-root", "healthy-model");
+            healthy.add_message(Message::user("Healthy history"));
+            first.save_session(&healthy).await.unwrap();
+            first.flush_search_index().await;
+            let directory = first.sessions_root_dir().join(&recreated.id);
+            let evidence = home
+                .path()
+                .join(".root-revocations")
+                .join(format!("{}.json", recreated.id));
+            let before_evidence = fs::read(&evidence).await.unwrap();
+            let runtime_path = directory.join(RUNTIME_SIDECAR_FILE);
+            let before_runtime = fs::read(&runtime_path).await.unwrap();
+            let child_main = directory
+                .join("children")
+                .join(&child.id)
+                .join("session.json");
+            let before_child = fs::read(&child_main).await.unwrap();
+            let damaged_path = if corrupt_runtime {
+                runtime_path.clone()
+            } else {
+                directory.join("session.json")
+            };
+            fs::write(&damaged_path, b"{invalid").await.unwrap();
+            if rebuild {
+                fs::write(first.index_path(), b"{invalid").await.unwrap();
+            }
+
+            let restarted = store(home.path()).await;
+            assert!(restarted.get_index_entry(&recreated.id).await.is_none());
+            assert!(restarted.get_index_entry(&child.id).await.is_none());
+            let loaded = restarted.load_session(&healthy.id).await.unwrap().unwrap();
+            assert_eq!(loaded.model, healthy.model);
+            assert_eq!(loaded.messages.len(), 1);
+            assert!(restarted.load_root_authority(&recreated.id).await.is_err());
+            assert_eq!(fs::read(&evidence).await.unwrap(), before_evidence);
+            assert_eq!(fs::read(&damaged_path).await.unwrap(), b"{invalid");
+            assert_eq!(fs::read(&child_main).await.unwrap(), before_child);
+
+            // Main-only corruption retains the exact-runtime full-save repair
+            // contract. Missing/corrupt runtime authority cannot be restored by
+            // an ordinary writer; the fixture must explicitly repair that
+            // canonical evidence before any full save can proceed.
+            if corrupt_runtime {
+                reject(&restarted, &recreated).await;
+                fs::write(&runtime_path, &before_runtime).await.unwrap();
+            } else {
+                assert_eq!(fs::read(&runtime_path).await.unwrap(), before_runtime);
+            }
+            restarted.save_session(&recreated).await.unwrap();
+            let repaired = restarted
+                .load_root_authority(&recreated.id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(repaired.created_at, recreated.created_at);
+            assert_eq!(
+                restarted
+                    .load_session(&recreated.id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .messages
+                    .len(),
+                1
+            );
+            assert!(restarted.load_session(&healthy.id).await.unwrap().is_some());
+            assert_eq!(fs::read(&evidence).await.unwrap(), before_evidence);
+            reject(&restarted, &old).await;
+            restarted.flush_search_index().await;
+        }
+    }
+}

--- a/crates/infra/bamboo-storage/src/v2/supervisor.rs
+++ b/crates/infra/bamboo-storage/src/v2/supervisor.rs
@@ -1,17 +1,12 @@
 //! Trusted singleton identity. Canonical Session files are the only authority;
 //! the global index and unpublished staging directories never grant a role.
 
+use super::root_lifetime::RootPublicationFault;
 use super::*;
 use bamboo_domain::{
     SessionAuthorityConflict, SessionAuthorityIdentity, SupervisorBootstrapReceipt,
     DEFAULT_SUPERVISOR_SESSION_ID,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum SupervisorBootstrapFault {
-    BeforePublish,
-    BeforeIndex,
-}
 
 fn invalid(message: &str) -> io::Error {
     io::Error::new(
@@ -111,6 +106,9 @@ impl SessionStoreV2 {
         id: &str,
     ) -> io::Result<Option<Session>> {
         validate_session_id(id)?;
+        if self.root_directory_is_revoked(id).await? {
+            return Ok(None);
+        }
         if !real_directory(&self.sessions_dir).await? {
             return Err(invalid("sessions directory is missing"));
         }
@@ -167,8 +165,10 @@ impl SessionStoreV2 {
         &self,
         initial_model: &str,
     ) -> io::Result<SupervisorBootstrapReceipt> {
-        let _lifecycle = self.lock_session_lifecycle_shared().await?;
-        let _task = self.lock_runtime_task_sidecar_shared().await?;
+        let _lifecycle = self.lock_session_lifecycle_exclusive().await?;
+        let _task = self.lock_runtime_task_transaction_exclusive().await?;
+        self.recover_all_runtime_task_transactions_locked().await?;
+        self.recover_all_session_copy_transactions_locked().await?;
         let _session = self
             .acquire_session_maintenance_lock(DEFAULT_SUPERVISOR_SESSION_ID)
             .await?;
@@ -256,6 +256,8 @@ impl SessionStoreV2 {
         }
         let incarnation_id = Uuid::new_v4();
         let mut session = Session::new(DEFAULT_SUPERVISOR_SESSION_ID, initial_model.trim());
+        session.created_at = self.fresh_root_birth(DEFAULT_SUPERVISOR_SESSION_ID).await?;
+        session.updated_at = session.created_at;
         session.title = "Supervisor".to_string();
         session.title_generated = true;
         session.authority_identity = SessionAuthorityIdentity::Supervisor { incarnation_id };
@@ -263,6 +265,8 @@ impl SessionStoreV2 {
             .bamboo_home_dir
             .join(format!(".supervisor-bootstrap-{}", Uuid::new_v4()));
         let destination = self.sessions_dir.join(DEFAULT_SUPERVISOR_SESSION_ID);
+        self.remove_revoked_root_directory(DEFAULT_SUPERVISOR_SESSION_ID)
+            .await?;
         fs::create_dir(&staging).await?;
         let result = async {
             fs::create_dir(staging.join("children")).await?;
@@ -272,11 +276,11 @@ impl SessionStoreV2 {
             durable_atomic_write(&staging.join("session.json"), &bytes).await?;
             durable_atomic_write(&staging.join(RUNTIME_SIDECAR_FILE), &bytes).await?;
             sync_directory(&staging).await?;
-            self.maybe_fail_supervisor_bootstrap(SupervisorBootstrapFault::BeforePublish)?;
+            self.maybe_fail_root_publication(RootPublicationFault::BeforePublish)?;
             atomic_rename(&staging, &destination).await?;
             sync_parent_directory_entry(&staging).await?;
             sync_parent_directory_entry(&destination).await?;
-            self.maybe_fail_supervisor_bootstrap(SupervisorBootstrapFault::BeforeIndex)?;
+            self.maybe_fail_root_publication(RootPublicationFault::BeforeIndex)?;
             self.repair_index_from_authoritative_session(
                 &session,
                 Self::root_rel_path(DEFAULT_SUPERVISOR_SESSION_ID),
@@ -295,25 +299,6 @@ impl SessionStoreV2 {
             let _ = fs::remove_dir_all(&staging).await;
         }
         result
-    }
-
-    fn maybe_fail_supervisor_bootstrap(&self, fault: SupervisorBootstrapFault) -> io::Result<()> {
-        #[cfg(test)]
-        {
-            let mut pending = self
-                .supervisor_bootstrap_fault
-                .lock()
-                .expect("supervisor fault lock");
-            if pending.as_ref() == Some(&fault) {
-                *pending = None;
-                return Err(other_io_error(format!(
-                    "injected Supervisor bootstrap failure: {fault:?}"
-                )));
-            }
-        }
-        #[cfg(not(test))]
-        let _ = fault;
-        Ok(())
     }
 
     /// Called inside the final cross-process write lock. Merging callers must

--- a/crates/infra/bamboo-storage/src/v2/supervisor_tests.rs
+++ b/crates/infra/bamboo-storage/src/v2/supervisor_tests.rs
@@ -549,8 +549,8 @@ async fn legacy_sidecar_migration_cannot_recreate_missing_supervisor_authority()
 #[tokio::test]
 async fn bootstrap_failure_before_publish_leaves_no_final_identity_and_can_retry() {
     let (store, _home) = fixture().await;
-    *store.supervisor_bootstrap_fault.lock().unwrap() =
-        Some(supervisor::SupervisorBootstrapFault::BeforePublish);
+    *store.root_publication_fault.lock().unwrap() =
+        Some(root_lifetime::RootPublicationFault::BeforePublish);
     assert!(store
         .get_or_create_default_supervisor("model")
         .await
@@ -571,8 +571,8 @@ async fn bootstrap_failure_before_publish_leaves_no_final_identity_and_can_retry
 #[tokio::test]
 async fn bootstrap_failure_before_index_keeps_complete_identity_and_retry_repairs_index() {
     let (store, home) = fixture().await;
-    *store.supervisor_bootstrap_fault.lock().unwrap() =
-        Some(supervisor::SupervisorBootstrapFault::BeforeIndex);
+    *store.root_publication_fault.lock().unwrap() =
+        Some(root_lifetime::RootPublicationFault::BeforeIndex);
     assert!(store
         .get_or_create_default_supervisor("first-model")
         .await

--- a/docs/root-session-lifetimes.md
+++ b/docs/root-session-lifetimes.md
@@ -1,0 +1,91 @@
+# Root deletion and explicit recreation
+
+V2 storage retains canonical revocation evidence when a Root is deleted. An old
+full or runtime snapshot cannot recreate that Root through ordinary save, even
+when its directory and index entry are gone or another process has restarted.
+The existing Root context fence still checks birth, Project and metadata revision
+when a live directory exists.
+
+The lifetime cases have distinct boundaries:
+
+| Operation | Result |
+| --- | --- |
+| First full save of a never-deleted ID | Creates the Root as before. |
+| First runtime save with no persisted target | Falls back to full creation as before. |
+| Retry of an interrupted initial full save | May finish an empty creation layout or the exact existing runtime birth/context; it cannot advance a partial pair's context. |
+| Ordinary full/runtime save after deletion | Returns typed `SessionAuthorityConflict` before writing files, index, or search work. |
+| Trusted explicit same-ID recreation | Constructs a blank Ordinary Root with a host-generated birth newer than every revoked lifetime. |
+| Retry after complete recreation publication | Strictly validates the complete pair and returns the surviving Root, preserving its model and history. |
+
+Trusted hosts can recreate a deleted Ordinary ID through the Storage port exposed
+by the SDK:
+
+```rust,no_run
+use bamboo_sdk::Agent;
+
+async fn recreate(agent: &Agent, deleted_id: &str) -> std::io::Result<()> {
+    let root = agent.storage()
+        .recreate_root_session(deleted_id, "configured-model")
+        .await?;
+    println!("{} {}", root.id, root.created_at);
+    Ok(())
+}
+```
+
+The operation takes an ID and initial model, constructs the Session itself, and
+does not accept a snapshot or caller-selected birth marker. It is an in-process
+host port, with no model tool or new HTTP route. Normal HTTP creation uses fresh
+IDs and retains its existing idempotency contract. The reserved default Supervisor
+uses its separate trusted bootstrap port, which also assigns a fresh birth after
+deletion. Unsupported Storage implementations fail before mutation.
+
+Deletion acquires the existing exclusive lifecycle and Task locks, reads birth
+markers from canonical main/runtime files, then atomically writes and synchronizes
+`.root-revocations/<id>.json`. The record contains the ID, format version, and
+greatest revoked birth. It records only deletion evidence: active sessions and
+Supervisor management grants have no parallel registry. The cutoff never
+decreases. Recreation chooses the later of the current clock and one nanosecond
+after that cutoff; timestamp exhaustion is an error before publication.
+
+Revocation publication is the logical deletion point. Physical directory removal
+and derived index removal follow it, with removal errors propagated. A failure or
+crash after revocation can leave files or index rows behind, but strict authority,
+history, runtime, copy, migration and index-rebuild paths cannot restore the
+revoked Root's authority. Remaining children are hidden while that Root is
+revoked. Startup reconciles stale derived index rows from the same revocation
+evidence. Damage confined to one Root hides only that Root and its children from
+the derived index; reconciliation repeats after a required rebuild so compatibility
+recovery cannot restore those rows while healthy Roots remain available. A retry
+or trusted recreation can remove a remaining revoked directory.
+
+Recreation and Supervisor bootstrap publish a complete main/runtime pair through
+staged-directory rename under those same locks. A crash before publication leaves
+no new authority; unpublished staging directories are inert. A crash after pair
+publication but before index publication preserves the new lifetime, and retry
+repairs the index. Ordinary save callers still use the existing per-session and
+Task locks, so deletion cannot race the final writer check or a filesystem commit.
+
+Revocations live outside `sessions/` and survive the development `dev_reset`
+operation. Reset first records the canonical Roots it removes, including Roots
+missing from a stale local index. This prevents surviving processes from saving
+old snapshots after a history reset. Cleanup uses the same Root deletion boundary.
+Revocation evidence is not automatically pruned while old snapshots may exist.
+
+Existing corrupt, mismatched, unreadable, or non-regular revocation evidence fails
+closed. As with all canonical Session data, arbitrary removal or rollback of
+canonical files by the operating-system user is outside the storage trust
+boundary; no second index reconstructs deleted revocations. Deletions completed
+by older Bamboo versions before revocation evidence existed cannot be recovered
+retroactively. Unreadable canonical birth files must be repaired before a new
+deletion can safely establish their cutoff.
+
+The typed writer error also prevents the existing runtime persistence callbacks
+from publishing a rejected snapshot to caches or events, including callers that
+normally publish runtime state after an unrelated I/O error. A cached role, old
+snapshot, or recreated ID is not management authority; Supervisor controls must
+read the strict current Root and bind to its new birth/context.
+
+This boundary does not implement Supervisor relationships or control tools, and
+does not add generic Child or Task incarnations. In particular, it does not claim
+to distinguish an old child snapshot from a newly created child after the parent
+Root has been explicitly recreated; that requires its own lifecycle contract.

--- a/docs/supervisor-identity.md
+++ b/docs/supervisor-identity.md
@@ -26,6 +26,9 @@ The receipt contains only `session_id`, `incarnation_id` and `created`. Keep the
 incarnation with the ID: explicitly deleting and recreating the default Root
 produces a new incarnation. A receipt is an observation, not a transferable
 grant to inspect or control another Session.
+Root deletion also retains [canonical lifetime revocation evidence](root-session-lifetimes.md),
+so ordinary full/runtime snapshots cannot restore a deleted Root while its ID
+is absent. Trusted Supervisor bootstrap publishes a fresh birth after deletion.
 
 `Session.authority_identity` is a typed `Ordinary` or
 `Supervisor { incarnation_id }` value, separate from Root/Child kind and raw


### PR DESCRIPTION
## Summary

Deleting an Ordinary Root previously allowed an old full snapshot, or a cold runtime-save fallback, to recreate the deleted ID with its original birth, Project and metadata revision. V2 now durably records the greatest revoked Root birth at the deletion boundary and rejects those writes with SessionAuthorityConflict before publishing files, derived index updates, caches or events.

Trusted Storage::recreate_root_session constructs a blank Ordinary Root with a fresh host-generated birth; retry preserves the already published lifetime and its history. Supervisor rebootstrap uses the same boundary. Strict reads, recovery and index rebuild respect the canonical revocation record, including interrupted physical removal and development reset. Runtime existence checks use file metadata and do not read the conversation transcript.

This completes the deletion-lifetime prerequisite for #1071. Supervisor relationships/control tools and generic Child/Task incarnation semantics remain separate work. The persistence contract, crash windows, compatibility and canonical-data limitations are documented in docs/root-session-lifetimes.md.

Closes #1093

## Test Plan

- 248 bamboo-storage tests passed, including independent-store stale full/warm-runtime/cold-runtime writes, strict reads after logical deletion, index recovery, legitimate first creation, explicit recreation, and no cache/event publication after a deterministic merge/delete race.
- Publication fault coverage passed for Ordinary recreation and revoked Supervisor rebootstrap before directory publication and after publication/before index update; an actual index I/O failure preserves the complete pair for restart/retry.
- Independent public-port acceptance launched separate deletion, inspection, recreation and retry processes for each stale writer mode. All three return typed conflicts; none restores old authority after restart; new birth/model/history survive retries and stale post-recreation writes remain rejected.
- Child runtime tests use an 8 MiB invalid parent main file to verify metadata/control-only persistence while strict Root authority still refuses it. Nine damaged-parent cases reject writes and cache/event publication.
- Startup tests cover valid/corrupt index crossed with corrupt main/runtime, keep unrelated Roots available, exclude the unavailable family after rebuild, preserve canonical evidence, and retain the existing exact-runtime main-file repair rule.
- Final committed candidate `636fef3898e775e2bc5d023a617b5c8a02840d43`: `cargo test --locked` passed 8,602 unit/integration tests across 75 programs, plus 19 doc tests across 28 programs; zero failures. The existing 11 test and 120 doc-example ignores remain. The final Storage package contributes 248 passing tests.
- Formatting, diff checks and the exact all-features CI Clippy command passed. An independent reviewer verified all 11 committed blobs and repeated the four startup isolation cases with the final public probe binary; no unresolved findings remain.

No UI changes. Local browser acceptance of the complete Supervisor management workflow remains tracked by #1048 and its downstream children; this prerequisite does not claim that workflow is delivered.
