### PR TITLE
feat: retain executing Supervisor identity through tool dispatch (#1111)

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/builder.rs
+++ b/crates/app/bamboo-sdk/src/agent/builder.rs
@@ -972,6 +972,7 @@ mod tests {
         tool_call_id: &'a str,
     ) -> ToolExecutionContext<'a> {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(session_id),
             root_session_id: None,
             tool_call_id,
@@ -1988,6 +1989,7 @@ mod tests {
             .execute_with_context(
                 &call_a,
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some("sdk-a-session"),
                     root_session_id: Some("sdk-a-root-session"),
                     tool_call_id: &call_a.id,
@@ -2027,6 +2029,7 @@ mod tests {
             .execute_with_context(
                 &call_b,
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some("sdk-b-session"),
                     root_session_id: Some("sdk-b-root-session"),
                     tool_call_id: &call_b.id,

--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -591,6 +591,7 @@ impl Agent {
 
         let exec_result = {
             let ctx = bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some(session.id.as_str()),
                 root_session_id: Some(if session.root_session_id.trim().is_empty() {
                     session.id.as_str()

--- a/crates/app/bamboo-server-tools/src/ledger/tests.rs
+++ b/crates/app/bamboo-server-tools/src/ledger/tests.rs
@@ -38,6 +38,7 @@ impl Storage for TestStorage {
 
 fn test_context(session_id: &str) -> ToolCtx {
     ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool-call-1",

--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -35,6 +35,7 @@ impl Storage for TestStorage {
 
 fn test_context(session_id: &str) -> ToolCtx {
     ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool-call-1",

--- a/crates/app/bamboo-server-tools/src/project_tools.rs
+++ b/crates/app/bamboo-server-tools/src/project_tools.rs
@@ -834,6 +834,7 @@ mod tests {
 
     fn context(session_id: &str, tool: &str) -> ToolCtx {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(session_id),
             root_session_id: None,
             tool_call_id: tool,

--- a/crates/app/bamboo-server-tools/src/skill_runtime/load_skill.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/load_skill.rs
@@ -364,7 +364,10 @@ impl LoadSkillTool {
                 false,
                 None,
                 Some(&provider_input),
-            );
+            )
+            // The repository Session above supplies configuration only. Keep
+            // the incoming lifetime, even if that ID was recreated meanwhile.
+            .with_executing_supervisor(ctx.executing_supervisor_for(&session.id));
             if !plan_allows_dynamic_provider(ctx.plan_read_only, &call.function.name) {
                 blocks.push(bamboo_skills::DynamicContextBlock {
                     provider_id: declaration.id,

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -595,6 +595,7 @@ Use the dynamic context."#,
     .with_test_context_tools(provider.clone());
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(8);
     let context = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "dynamic-load",
@@ -676,6 +677,7 @@ Use the dynamic context."#,
     .with_fail_closed_context_registry(provider.clone());
     let calls_before = provider.calls.load(Ordering::SeqCst);
     let production_context = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(production_session_id),
         root_session_id: None,
         tool_call_id: "production-authority-load",
@@ -749,6 +751,7 @@ Use the dynamic context."#,
     let typed_tool = LoadSkillTool::new(manager, runtime_config, repo.clone())
         .with_permission_checked_context_registry(context_tools, Some(permission_config.clone()));
     let typed_context = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(typed_session_id),
         root_session_id: None,
         tool_call_id: "typed-authority-load",
@@ -864,6 +867,7 @@ Plan must block this provider before dispatch."#,
         .with_test_context_tools(provider.clone());
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(8);
     let context = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "dynamic-approval-load",
@@ -903,6 +907,7 @@ Plan must block this provider before dispatch."#,
         .contains_key(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY));
 
     let plan_read_context = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "dynamic-plan-read-load",
@@ -934,6 +939,7 @@ Plan must block this provider before dispatch."#,
     assert!(event_rx.try_recv().is_err());
 
     let invalid_write_context = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "dynamic-invalid-write-load",
@@ -1140,6 +1146,7 @@ Use this demo skill."#,
         bamboo_engine::SessionRepository::new(sessions, storage, persistence),
     );
     let ctx = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool-call-1",
@@ -1200,6 +1207,7 @@ async fn load_skill_accepts_only_runtime_advertised_skill_ids() {
         .expect("publish automatic runtime selection");
     let tool = LoadSkillTool::new(skill_manager, config, repo.clone());
     let context = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool-call-runtime-allowlist",
@@ -1312,6 +1320,7 @@ async fn runtime_generation_marker_prevents_stale_metadata_from_repinning_live_c
         repo.clone(),
     );
     let context = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "runtime-pinned-load",
@@ -1432,6 +1441,7 @@ Use this demo skill."#,
         ),
     );
     let ctx = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool-call-2",
@@ -1514,6 +1524,7 @@ Use this demo skill."#,
     let read_tool = ReadSkillResourceTool::new(skill_manager, config, session_repo);
 
     let load_ctx = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool-call-load",
@@ -1527,6 +1538,7 @@ Use this demo skill."#,
         pre_parsed_args: None,
     };
     let read_ctx = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool-call-read",
@@ -1795,6 +1807,7 @@ async fn session_workspace_skill_catalog_selection_and_runtime_roots_are_isolate
         ),
     ] {
         let context = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(session_id),
             root_session_id: None,
             tool_call_id: "workspace-skill-call",

--- a/crates/app/bamboo-server-tools/tests/ask_agent_tool.rs
+++ b/crates/app/bamboo-server-tools/tests/ask_agent_tool.rs
@@ -18,6 +18,7 @@ async fn ask_agent_tool_queries_a_broker_agent() {
     // The in-server tool, as a root session would invoke it.
     let tool = AskAgentTool::new(endpoint, "tok");
     let ctx = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some("root-session"),
         root_session_id: None,
         tool_call_id: "tc1",
@@ -54,6 +55,7 @@ async fn ask_agent_tool_queries_a_broker_agent() {
 async fn ask_agent_tool_rejects_unknown_mode() {
     let tool = AskAgentTool::new("ws://127.0.0.1:1", "tok");
     let ctx = ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some("root-session"),
         root_session_id: None,
         tool_call_id: "tc2",
@@ -125,6 +127,7 @@ async fn concurrent_asks_to_one_worker_are_each_answered_correctly() {
             let sid = format!("root-{i}");
             let tc = format!("tc-{i}");
             let ctx = ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some(&sid),
                 root_session_id: None,
                 tool_call_id: &tc,

--- a/crates/app/bamboo-server-tools/tests/supervisor_dispatch.rs
+++ b/crates/app/bamboo-server-tools/tests/supervisor_dispatch.rs
@@ -1,0 +1,349 @@
+//! Real Core -> Root overlay -> owned load_skill -> concrete nested Tool path.
+
+use async_trait::async_trait;
+use bamboo_agent_core::tools::{
+    ExecutingSupervisorObservation, FunctionCall, Tool, ToolCall, ToolClass, ToolCtx, ToolError,
+    ToolExecutionContext, ToolExecutionSessionFlags, ToolExecutor, ToolOutcome, ToolResult,
+};
+use bamboo_domain::{Session, Storage, DEFAULT_SUPERVISOR_SESSION_ID};
+use bamboo_engine::session_app::supervisor::SupervisorSessionService;
+use bamboo_engine::{SessionCache, SessionRepository};
+use bamboo_server_tools::{LoadSkillTool, OverlayToolExecutor};
+use bamboo_skills::{SkillManager, SkillStoreConfig};
+use bamboo_storage::{LockedSessionStore, SessionStoreV2};
+use std::sync::{Arc, Mutex};
+use tokio::sync::{mpsc, RwLock, Semaphore};
+
+#[derive(Debug)]
+struct Seen {
+    observation: Option<ExecutingSupervisorObservation>,
+    allowed: bool,
+    bypass: bool,
+    auto: bool,
+    plan: bool,
+    args: serde_json::Value,
+}
+
+struct ReadProbe {
+    service: SupervisorSessionService,
+    seen: Arc<Mutex<Vec<Seen>>>,
+}
+
+#[async_trait]
+impl Tool for ReadProbe {
+    fn name(&self) -> &str {
+        "Read"
+    }
+    fn description(&self) -> &str {
+        "Observe nested context"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type":"object"})
+    }
+    fn classify(&self, _: &serde_json::Value) -> ToolClass {
+        ToolClass::READONLY_PARALLEL
+    }
+    async fn invoke(
+        &self,
+        args: serde_json::Value,
+        ctx: ToolCtx,
+    ) -> Result<ToolOutcome, ToolError> {
+        let allowed = match ctx.executing_supervisor {
+            Some(observation) => self
+                .service
+                .inspect_scope(&observation.supervisor_reference())
+                .await
+                .is_ok(),
+            None => false,
+        };
+        self.seen.lock().unwrap().push(Seen {
+            observation: ctx.executing_supervisor,
+            allowed,
+            bypass: ctx.bypass_permissions,
+            auto: ctx.auto_approve_permissions,
+            plan: ctx.plan_read_only,
+            args,
+        });
+        Ok(ToolOutcome::Completed(ToolResult {
+            success: true,
+            result: "provider observation recorded".into(),
+            display_preference: None,
+            images: vec![],
+        }))
+    }
+}
+
+struct PausedLoadSkill {
+    inner: LoadSkillTool,
+    entered: mpsc::UnboundedSender<Option<ExecutingSupervisorObservation>>,
+    resume: Arc<Semaphore>,
+}
+
+#[async_trait]
+impl Tool for PausedLoadSkill {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        self.inner.parameters_schema()
+    }
+    fn classify(&self, args: &serde_json::Value) -> ToolClass {
+        self.inner.classify(args)
+    }
+    async fn invoke(
+        &self,
+        args: serde_json::Value,
+        ctx: ToolCtx,
+    ) -> Result<ToolOutcome, ToolError> {
+        let retained = ctx.clone();
+        self.entered.send(retained.executing_supervisor).unwrap();
+        self.resume.acquire().await.unwrap().forget();
+        // The actual load_skill reads repository configuration only after the
+        // test replaces the Supervisor. The original owned context survives.
+        self.inner.invoke(args, retained).await
+    }
+}
+
+fn load_call(id: &str) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        tool_type: "function".into(),
+        function: FunctionCall {
+            name: "load_skill".into(),
+            arguments: serde_json::json!({"skill_id":"dispatch-probe"}).to_string(),
+        },
+    }
+}
+
+fn flags() -> ToolExecutionSessionFlags {
+    ToolExecutionSessionFlags {
+        bypass_permissions: true,
+        auto_approve_permissions: true,
+        plan_read_only: false,
+    }
+}
+
+fn configure(session: &mut Session, workspace: &std::path::Path) {
+    session.set_workspace_path_meta(workspace.to_string_lossy());
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.into(),
+        r#"["dispatch-probe"]"#.into(),
+    );
+}
+
+async fn core_dispatch(session: &mut Session, tools: &dyn ToolExecutor, id: &str) {
+    let (tx, _rx) = mpsc::channel(128);
+    bamboo_agent_core::tools::result_handler::execute_sub_actions(
+        &[load_call(id)],
+        &tx,
+        session,
+        tools,
+        flags(),
+        None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn supervisor_overlay_and_nested_load_skill_keep_original_identity_after_configuration_reload(
+) {
+    let home = tempfile::tempdir().unwrap();
+    let old_workspace = home.path().join("old-workspace");
+    let new_workspace = home.path().join("new-workspace");
+    for workspace in [&old_workspace, &new_workspace] {
+        std::fs::create_dir_all(workspace).unwrap();
+        std::fs::write(workspace.join("input.txt"), "workspace input").unwrap();
+    }
+    let skill_dir = home.path().join("skills/dispatch-probe");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        r#"---
+name: dispatch-probe
+description: Observe executing Supervisor transport
+metadata:
+  dynamic_context:
+    - id: observe
+      tool: Read
+      input:
+        path: input.txt
+      timeout_ms: 5000
+---
+Use the declared context.
+"#,
+    )
+    .unwrap();
+    let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: home.path().join("skills"),
+        ..Default::default()
+    }));
+    manager.initialize().await.unwrap();
+    let store: Arc<dyn Storage> =
+        Arc::new(SessionStoreV2::new(home.path().join("data")).await.unwrap());
+    let service = SupervisorSessionService::new(store.clone());
+    service.get_or_create_default("initial").await.unwrap();
+    let mut original_session = store
+        .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    configure(&mut original_session, &old_workspace);
+    store.save_session(&original_session).await.unwrap();
+    let original =
+        ExecutingSupervisorObservation::capture_from_executing_session(&original_session);
+    let repo = SessionRepository::new(
+        SessionCache::default(),
+        store.clone(),
+        Arc::new(LockedSessionStore::new(store.clone())),
+    );
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let permission_config = Arc::new(bamboo_tools::permission::PermissionConfig::new());
+    let base: Arc<dyn ToolExecutor> = Arc::new(
+        bamboo_tools::BuiltinToolExecutorBuilder::new()
+            .with_tool(ReadProbe {
+                service: service.clone(),
+                seen: seen.clone(),
+            })
+            .unwrap()
+            .with_permission_checker(Arc::new(
+                bamboo_tools::permission::ConfigPermissionChecker::new(permission_config.clone()),
+            ))
+            .build(),
+    );
+    let inner = LoadSkillTool::new(
+        manager,
+        Arc::new(RwLock::new(bamboo_llm::Config::default())),
+        repo.clone(),
+    )
+    .with_permission_checked_context_registry(base.clone(), Some(permission_config));
+    let (entered, mut entered_rx) = mpsc::unbounded_channel();
+    let resume = Arc::new(Semaphore::new(0));
+    let paused = Arc::new(PausedLoadSkill {
+        inner,
+        entered,
+        resume: resume.clone(),
+    });
+    let overlay = OverlayToolExecutor::new(base, paused.clone());
+    let execute = core_dispatch(&mut original_session, &overlay, "old-load");
+    let replace = async {
+        assert_eq!(entered_rx.recv().await.unwrap(), original);
+        assert!(store
+            .delete_session(DEFAULT_SUPERVISOR_SESSION_ID)
+            .await
+            .unwrap());
+        service.get_or_create_default("replacement").await.unwrap();
+        let mut fresh = store
+            .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+            .await
+            .unwrap()
+            .unwrap();
+        configure(&mut fresh, &new_workspace);
+        repo.save(&mut fresh).await.unwrap();
+        let replacement = ExecutingSupervisorObservation::capture_from_executing_session(&fresh);
+        assert_ne!(replacement, original);
+        resume.add_permits(1);
+        fresh
+    };
+    let (_, mut fresh) = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        tokio::join!(execute, replace)
+    })
+    .await
+    .expect("actual overlay and nested reload finish");
+    {
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "actual nested Tool::invoke must be reached");
+        assert_eq!(seen[0].observation, original);
+        assert!(
+            !seen[0].allowed,
+            "canonical service rejects the deleted lifetime"
+        );
+        assert!(
+            seen[0].args.to_string().contains("new-workspace"),
+            "configuration was actually reloaded from the replacement Session"
+        );
+        assert!(!seen[0].bypass);
+        assert!(seen[0].auto && !seen[0].plan);
+    }
+    resume.add_permits(1);
+    core_dispatch(&mut fresh, &overlay, "fresh-load").await;
+    {
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 2);
+        assert_eq!(
+            seen[1].observation,
+            ExecutingSupervisorObservation::capture_from_executing_session(&fresh)
+        );
+        assert!(
+            seen[1].allowed,
+            "fresh real dispatch passes canonical revalidation"
+        );
+    }
+
+    let mut ordinary = Session::new("ordinary-nested", "model");
+    configure(&mut ordinary, &new_workspace);
+    repo.save(&mut ordinary).await.unwrap();
+    let (tx, _rx) = mpsc::channel(128);
+    // A generic same-ID context and a forged mismatched caller must remain
+    // empty even though load_skill can read the current Supervisor configuration.
+    for (id, observation) in [(fresh.id.as_str(), None), (ordinary.id.as_str(), original)] {
+        let call = load_call("synthetic-load");
+        let mut context = ToolExecutionContext::for_dispatch(
+            id,
+            id,
+            &call.id,
+            &tx,
+            &[],
+            flags(),
+            false,
+            None,
+            None,
+        );
+        context.executing_supervisor = observation;
+        resume.add_permits(1);
+        let result = overlay.execute_with_context(&call, context).await.unwrap();
+        assert!(
+            result.success,
+            "synthetic dispatch still loads its allowed workflow"
+        );
+    }
+    {
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 4);
+        for item in &seen[2..] {
+            assert_eq!(item.observation, None);
+            assert!(!item.allowed && !item.bypass && item.auto && !item.plan);
+        }
+    }
+
+    // Existing public dispatch classifies load_skill itself as mutating. Test
+    // its already-owned nested Plan context at Tool::invoke, as direct callers
+    // do, without changing that independent outer authorization policy.
+    let call = load_call("owned-plan-load");
+    let current = ExecutingSupervisorObservation::capture_from_executing_session(&fresh);
+    let mut context = ToolExecutionContext::for_dispatch(
+        &fresh.id,
+        &fresh.root_session_id,
+        &call.id,
+        &tx,
+        &[],
+        flags(),
+        false,
+        None,
+        None,
+    )
+    .with_executing_supervisor(current)
+    .to_tool_ctx();
+    context.plan_read_only = true;
+    resume.add_permits(1);
+    paused
+        .invoke(serde_json::json!({"skill_id":"dispatch-probe"}), context)
+        .await
+        .unwrap();
+    let seen = seen.lock().unwrap();
+    assert_eq!(seen.len(), 5);
+    assert_eq!(seen[4].observation, current);
+    assert!(seen[4].allowed && seen[4].auto && seen[4].plan && !seen[4].bypass);
+}

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -373,6 +373,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                             executor.execute_with_context(
                                     &tool_call,
                                 bamboo_agent_core::tools::ToolExecutionContext {
+                                    executing_supervisor: None,
                                     session_id: Some(session.id.as_str()),
                                     root_session_id: Some(
                                         if session.root_session_id.trim().is_empty() {

--- a/crates/app/bamboo-server/src/app_state/tests.rs
+++ b/crates/app/bamboo-server/src/app_state/tests.rs
@@ -103,6 +103,7 @@ async fn injected_tool_event_publishers_are_isolated_between_app_states() {
         .execute_with_context(
             &call_a,
             ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("state-a-session"),
                 root_session_id: Some("state-a-root-session"),
                 tool_call_id: &call_a.id,
@@ -130,6 +131,7 @@ async fn injected_tool_event_publishers_are_isolated_between_app_states() {
         .execute_with_context(
             &call_b,
             ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("state-b-session"),
                 root_session_id: Some("state-b-root-session"),
                 tool_call_id: &call_b.id,
@@ -377,6 +379,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
         .execute_with_context(
             &write_target,
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-merge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-target",
@@ -411,6 +414,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
         .execute_with_context(
             &write_source,
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-merge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-source",
@@ -444,6 +448,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
         .execute_with_context(
             &merge_call,
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-merge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-merge",
@@ -498,6 +503,7 @@ async fn memory_tool_write_merges_near_identical_restatement_when_enabled() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-heuristic-merge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-heuristic-original",
@@ -532,6 +538,7 @@ async fn memory_tool_write_merges_near_identical_restatement_when_enabled() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-heuristic-merge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-heuristic-merge",
@@ -562,6 +569,7 @@ async fn memory_tool_write_merges_near_identical_restatement_when_enabled() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-heuristic-merge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-inspect-heuristic-merge",
@@ -609,6 +617,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-contradict"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-contradict-target",
@@ -641,6 +650,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-contradict"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-contradict-source",
@@ -674,6 +684,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-contradict"),
                 root_session_id: None,
                 tool_call_id: "tool-call-contradict",
@@ -728,6 +739,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-batch-purge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-stale",
@@ -759,6 +771,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-batch-purge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-mark-stale",
@@ -789,6 +802,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-batch-purge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-active",
@@ -822,6 +836,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-batch-purge"),
                 root_session_id: None,
                 tool_call_id: "tool-call-batch-purge",
@@ -861,6 +876,7 @@ async fn app_state_session_note_and_prompt_share_the_injected_jiandu_store() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-note-injected-store"),
                 root_session_id: None,
                 tool_call_id: "tool-call-session-note-injected-store",
@@ -916,6 +932,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-inspect"),
                 root_session_id: None,
                 tool_call_id: "tool-call-write-inspect",
@@ -943,6 +960,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-inspect"),
                 root_session_id: None,
                 tool_call_id: "tool-call-inspect",
@@ -980,6 +998,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 }),
             ),
             bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("session-inspect"),
                 root_session_id: None,
                 tool_call_id: "tool-call-rebuild",

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -796,6 +796,7 @@ impl ResumeExecutionPort for ConnectResumePort {
                             executor.execute_with_context(
                                 &tool_call,
                                 ToolExecutionContext {
+                                    executing_supervisor: None,
                                     session_id: Some(session.id.as_str()),
                                     root_session_id: Some(
                                         if session.root_session_id.trim().is_empty() {

--- a/crates/app/bamboo-server/src/handlers/tools/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/tools/mod.rs
@@ -172,6 +172,7 @@ pub async fn execute_tool(
         .execute_with_context(
             &call,
             ToolExecutionContext {
+                executing_supervisor: None,
                 session_id,
                 root_session_id: persisted_session.as_ref().map(|session| {
                     if session.root_session_id.trim().is_empty() {

--- a/crates/app/bamboo-server/src/schedule_app/scheduler_tool.rs
+++ b/crates/app/bamboo-server/src/schedule_app/scheduler_tool.rs
@@ -664,6 +664,7 @@ mod tests {
 
     fn context(session_id: &str) -> ToolCtx {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(session_id),
             root_session_id: None,
             tool_call_id: "scheduler-test",
@@ -803,6 +804,7 @@ mod tests {
             .execute_with_context(
                 &interactive_call,
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some(&interactive.id),
                     root_session_id: None,
                     tool_call_id: &interactive_call.id,

--- a/crates/app/bamboo-server/src/tool_event_recorder_example_tests.rs
+++ b/crates/app/bamboo-server/src/tool_event_recorder_example_tests.rs
@@ -38,6 +38,7 @@ async fn default_app_state_has_no_tool_event_background_work() {
         .execute_with_context(
             &call,
             ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("no-sink-session"),
                 root_session_id: Some("no-sink-root"),
                 tool_call_id: &call.id,

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -47,6 +47,7 @@ async fn invoke_completed(
 
 fn subagent_test_ctx(session_id: &str, tool_call_id: &str) -> ToolCtx {
     ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id,
@@ -834,6 +835,7 @@ async fn parent_wait_slots_drain_after_concurrent_registrations() {
 
 fn ctx_for<'a>(session_id: &'a str, tool_call_id: &'static str) -> ToolExecutionContext<'a> {
     ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id,
@@ -1103,6 +1105,7 @@ async fn create_publishes_started_before_fast_completion_and_caches_latest() {
             "workspace": harness.workspace_path.to_string_lossy()
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_1",
@@ -1214,6 +1217,7 @@ async fn create_uses_async_subagent_model_resolver() {
             "auto_run": false
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_async_resolver",
@@ -1364,6 +1368,7 @@ async fn resident_create_reuses_same_child_session() {
     let harness = build_test_harness().await;
     let workspace = tempfile::tempdir().expect("workspace");
     let ctx = |tcid: &'static str| ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(harness.parent_session_id.as_str()),
         root_session_id: None,
         tool_call_id: tcid,
@@ -1815,6 +1820,7 @@ async fn resident_reuse_rejects_cross_project_workspace_before_mutating_resident
         .expect("save parent");
     let ctx = |tool_call_id: &'static str| {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id,
@@ -1955,6 +1961,7 @@ async fn resident_reuse_rejects_stale_project_after_root_reassignment_without_mu
     harness.storage.save_session(&parent).await.unwrap();
     let context = |tool_call_id: &'static str| {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id,
@@ -2072,6 +2079,7 @@ async fn same_project_resident_reuse_persists_and_publishes_changed_workspace() 
     harness.storage.save_session(&parent).await.unwrap();
     let context = |tool_call_id: &'static str| {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id,
@@ -2179,6 +2187,7 @@ async fn resident_reuse_publication_uses_the_validating_instance_workspace_root(
     let workspace_b = tempfile::tempdir().expect("foreign workspace B");
     let context = |tool_call_id: &'static str| {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id,
@@ -2278,6 +2287,7 @@ async fn backward_compat_legacy_subagent_call_without_action_defaults_to_create(
             "workspace": harness.workspace_path.to_string_lossy()
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_legacy",
@@ -2383,6 +2393,7 @@ async fn send_message_appends_follow_up_without_replacing_history() {
             "auto_run": false
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_send_message",
@@ -2533,6 +2544,7 @@ async fn send_message_queues_on_running_child_without_interrupt() {
             "message": raw_message
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_running",
@@ -2633,6 +2645,7 @@ async fn send_message_can_interrupt_running_child() {
             "interrupt_running": true
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_interrupt_running",
@@ -2700,6 +2713,7 @@ async fn send_message_can_queue_child_immediately() {
             "message": "retry with a narrower scope"
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_queue",
@@ -2765,6 +2779,7 @@ async fn send_message_same_tool_call_retries_activation_without_duplicate_delive
     });
     let context = || {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_activation_retry",
@@ -2895,6 +2910,7 @@ async fn enqueue_child_run_starts_the_notification_relay_for_the_child() {
             "workspace": harness.workspace_path.to_string_lossy()
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_relay",
@@ -2975,6 +2991,7 @@ async fn cancel_stops_running_child() {
             "child_session_id": harness.child_session_id
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_cancel",
@@ -3008,6 +3025,7 @@ async fn list_returns_children() {
         &harness.tool,
         json!({"action": "list"}),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_list",
@@ -3057,6 +3075,7 @@ async fn get_returns_runner_diagnostics() {
             "child_session_id": harness.child_session_id
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_get_diagnostics",
@@ -3100,6 +3119,7 @@ async fn create_returns_duration_hint() {
             "workspace": harness.workspace_path.to_string_lossy()
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_create_hint",
@@ -3155,6 +3175,7 @@ async fn create_persists_explicit_reasoning_effort_to_child_session() {
             "reasoning_effort": "high"
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_create_with_effort",
@@ -3213,6 +3234,7 @@ async fn create_without_reasoning_effort_leaves_child_at_provider_default() {
             "auto_run": false
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_create_default_effort",
@@ -3276,6 +3298,7 @@ async fn update_can_change_reasoning_effort_on_existing_child() {
             "reasoning_effort": "max"
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_update_effort",
@@ -3317,6 +3340,7 @@ async fn delete_removes_child() {
             "child_session_id": harness.child_session_id
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_delete",
@@ -3360,6 +3384,7 @@ async fn create_requires_workspace() {
             "subagent_type": "general-purpose"
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_no_workspace",
@@ -3425,6 +3450,7 @@ async fn assigned_child_without_parent_workspace_uses_project_path() {
             "auto_run": false
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_project_default_workspace",
@@ -3500,6 +3526,7 @@ async fn assigned_child_without_parent_workspace_uses_project_path() {
             "auto_run": false
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_moved_project_default_workspace",
@@ -3545,6 +3572,7 @@ async fn create_sets_child_workspace() {
             "auto_run": false
         }),
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(harness.parent_session_id.as_str()),
             root_session_id: None,
             tool_call_id: "tool_call_workspace",

--- a/crates/core/bamboo-agent-core/src/tools/context.rs
+++ b/crates/core/bamboo-agent-core/src/tools/context.rs
@@ -13,7 +13,55 @@ use serde_json::Value;
 
 use crate::tools::{BashCompletionSink, ToolSchema};
 use crate::{AgentEvent, Session};
-use bamboo_domain::PermissionMode;
+use bamboo_domain::{
+    PermissionMode, SessionAuthorityIdentity, SessionKind, SupervisorReference,
+    DEFAULT_SUPERVISOR_SESSION_ID,
+};
+use uuid::Uuid;
+
+/// The lifetime observed when a real Supervisor Session admits a tool call.
+///
+/// This is not a grant: consumers must still check the reference against the
+/// canonical Supervisor service. It is intentionally separate from permission
+/// flags and is never deserialized from model arguments or permission lookups.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExecutingSupervisorObservation {
+    incarnation_id: Uuid,
+}
+
+impl ExecutingSupervisorObservation {
+    /// Capture only from the Session actually executing the call, before its
+    /// context is queued or transferred. Never call this on a replacement
+    /// Session loaded to resolve configuration or replay an old operation.
+    pub fn capture_from_executing_session(session: &Session) -> Option<Self> {
+        let SessionAuthorityIdentity::Supervisor { incarnation_id } = &session.authority_identity
+        else {
+            return None;
+        };
+        (session.id == DEFAULT_SUPERVISOR_SESSION_ID
+            && session.kind == SessionKind::Root
+            && session.root_session_id == session.id
+            && session.parent_session_id.is_none()
+            && session.spawn_depth == 0
+            && !incarnation_id.is_nil())
+        .then_some(Self {
+            incarnation_id: *incarnation_id,
+        })
+    }
+
+    /// Original identity for the canonical service to revalidate. Possession
+    /// of this observation does not attest that this lifetime still exists.
+    pub fn supervisor_reference(self) -> SupervisorReference {
+        SupervisorReference {
+            session_id: DEFAULT_SUPERVISOR_SESSION_ID.to_string(),
+            incarnation_id: self.incarnation_id,
+        }
+    }
+
+    pub(super) fn for_caller(self, session_id: Option<&str>) -> Option<Self> {
+        (session_id == Some(DEFAULT_SUPERVISOR_SESSION_ID)).then_some(self)
+    }
+}
 
 /// Per-session flags that flow into every tool call's [`ToolExecutionContext`].
 ///
@@ -77,7 +125,8 @@ impl ToolExecutionSessionFlags {
 
 /// Context passed to tools during execution.
 ///
-/// All fields are optional and should be treated as best-effort hints.
+/// Optional context does not grant authority. A captured Supervisor observation
+/// remains tied to its original caller and requires canonical revalidation.
 ///
 /// ⚠️ Real tool dispatch must build this via [`ToolExecutionContext::for_dispatch`]
 /// (both agent loops do), NOT a struct literal — that routes every per-session
@@ -88,6 +137,8 @@ impl ToolExecutionSessionFlags {
 pub struct ToolExecutionContext<'a> {
     /// Bamboo session id that is executing the tool.
     pub session_id: Option<&'a str>,
+    /// Original executing lifetime, absent for synthetic/permission-only paths.
+    pub executing_supervisor: Option<ExecutingSupervisorObservation>,
     /// Authoritative root-session identity for the executing session tree.
     /// Real dispatch snapshots it from `Session.root_session_id`; synthetic or
     /// opaque direct contexts leave it absent rather than inventing authority.
@@ -146,6 +197,7 @@ impl std::fmt::Debug for ToolExecutionContext<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ToolExecutionContext")
             .field("session_id", &self.session_id)
+            .field("executing_supervisor", &self.executing_supervisor)
             .field("root_session_id", &self.root_session_id)
             .field("tool_call_id", &self.tool_call_id)
             .field("event_tx", &self.event_tx)
@@ -164,6 +216,7 @@ impl<'a> ToolExecutionContext<'a> {
     pub fn none(tool_call_id: &'a str) -> Self {
         Self {
             session_id: None,
+            executing_supervisor: None,
             root_session_id: None,
             tool_call_id,
             event_tx: None,
@@ -177,8 +230,10 @@ impl<'a> ToolExecutionContext<'a> {
         }
     }
 
-    /// Build a context for a real tool dispatch, applying every per-session flag
-    /// from [`ToolExecutionSessionFlags`]. This is the SINGLE place that maps
+    /// Build a context applying every permission flag from
+    /// [`ToolExecutionSessionFlags`], without minting executing authority.
+    /// Real dispatch separately captures its executing Session observation and
+    /// retains it through [`Self::with_executing_supervisor`]. This maps
     /// session flags onto the context, and the only constructor the agent loops
     /// use — keep both loops (`per_call.rs`, `result_handler.rs`) on it so a new
     /// per-session field reaches all dispatch paths without per-site edits.
@@ -211,6 +266,7 @@ impl<'a> ToolExecutionContext<'a> {
     ) -> Self {
         Self {
             session_id: Some(session_id),
+            executing_supervisor: None,
             root_session_id: Some(if root_session_id.trim().is_empty() {
                 session_id
             } else {
@@ -226,6 +282,17 @@ impl<'a> ToolExecutionContext<'a> {
             bash_completion_sink,
             pre_parsed_args,
         }
+    }
+
+    /// Retain an already captured observation only for its original caller.
+    /// A child or absent caller cannot inherit Supervisor identity.
+    pub fn with_executing_supervisor(
+        mut self,
+        observation: Option<ExecutingSupervisorObservation>,
+    ) -> Self {
+        self.executing_supervisor =
+            observation.and_then(|observation| observation.for_caller(self.session_id));
+        self
     }
 
     /// Clone the sender (when present) for use in spawned tasks.
@@ -255,6 +322,9 @@ impl<'a> ToolExecutionContext<'a> {
     pub fn to_tool_ctx(&self) -> crate::tools::ToolCtx {
         crate::tools::ToolCtx {
             session_id: self.session_id.map(Arc::from),
+            executing_supervisor: self
+                .executing_supervisor
+                .and_then(|observation| observation.for_caller(self.session_id)),
             tool_call_id: Arc::from(self.tool_call_id),
             event_tx: self.event_tx.cloned(),
             available_tool_schemas: self
@@ -294,6 +364,112 @@ impl<'a> ToolExecutionContext<'a> {
             content: content.into(),
         })
         .await;
+    }
+}
+
+#[cfg(test)]
+mod supervisor_observation_tests {
+    use super::*;
+
+    fn supervisor() -> Session {
+        let mut session = Session::new(DEFAULT_SUPERVISOR_SESSION_ID, "model");
+        session.authority_identity = SessionAuthorityIdentity::Supervisor {
+            incarnation_id: Uuid::new_v4(),
+        };
+        session
+    }
+
+    #[test]
+    fn supervisor_observation_requires_typed_canonical_root_lineage() {
+        let valid = supervisor();
+        let observed = ExecutingSupervisorObservation::capture_from_executing_session(&valid)
+            .expect("canonical executing Supervisor");
+        assert_eq!(observed.supervisor_reference().session_id, valid.id);
+        for mutation in [
+            |s: &mut Session| s.authority_identity = SessionAuthorityIdentity::Ordinary,
+            |s: &mut Session| s.id = "other".into(),
+            |s: &mut Session| s.root_session_id = "other".into(),
+            |s: &mut Session| s.parent_session_id = Some("parent".into()),
+            |s: &mut Session| s.spawn_depth = 1,
+            |s: &mut Session| s.kind = SessionKind::Child,
+            |s: &mut Session| {
+                s.authority_identity = SessionAuthorityIdentity::Supervisor {
+                    incarnation_id: Uuid::nil(),
+                }
+            },
+        ] {
+            let mut malformed = valid.clone();
+            mutation(&mut malformed);
+            assert_eq!(
+                ExecutingSupervisorObservation::capture_from_executing_session(&malformed),
+                None,
+                "malformed Session: {malformed:?}"
+            );
+        }
+        let mut ordinary = Session::new(DEFAULT_SUPERVISOR_SESSION_ID, "model");
+        ordinary.metadata.insert(
+            "authority_identity".into(),
+            serde_json::to_string(&valid.authority_identity).unwrap(),
+        );
+        ordinary.metadata.insert("supervisor".into(), "true".into());
+        assert_eq!(
+            ExecutingSupervisorObservation::capture_from_executing_session(&ordinary),
+            None,
+            "reserved ID and forged metadata cannot supply a typed identity"
+        );
+    }
+
+    #[test]
+    fn supervisor_observation_is_not_minted_by_flags_arguments_or_generic_contexts() {
+        let session = supervisor();
+        let (tx, _rx) = mpsc::channel(1);
+        let forged_args = serde_json::json!({
+            "executing_supervisor": session.authority_identity,
+            "session_id": DEFAULT_SUPERVISOR_SESSION_ID,
+        });
+        let ctx = ToolExecutionContext::for_dispatch(
+            &session.id,
+            &session.root_session_id,
+            "call",
+            &tx,
+            &[],
+            ToolExecutionSessionFlags {
+                bypass_permissions: true,
+                auto_approve_permissions: true,
+                plan_read_only: true,
+            },
+            false,
+            None,
+            Some(&forged_args),
+        );
+        assert_eq!(ctx.executing_supervisor, None);
+        assert_eq!(ctx.to_tool_ctx().executing_supervisor, None);
+        assert_eq!(
+            ToolExecutionContext::none("none").executing_supervisor,
+            None
+        );
+        assert_eq!(
+            crate::tools::ToolCtx::none("owned").executing_supervisor,
+            None
+        );
+
+        let observation = ExecutingSupervisorObservation::capture_from_executing_session(&session);
+        let captured = ctx.with_executing_supervisor(observation);
+        let owned = captured.to_tool_ctx().clone();
+        assert_eq!(owned.executing_supervisor_for(&session.id), observation);
+        assert_eq!(owned.executing_supervisor_for("child"), None);
+        assert_eq!(
+            ToolExecutionContext::none("missing")
+                .with_executing_supervisor(observation)
+                .executing_supervisor,
+            None
+        );
+        // Even a struct-update caller mismatch is filtered at the owned seam.
+        let mismatched = ToolExecutionContext {
+            session_id: Some("child"),
+            ..captured
+        };
+        assert_eq!(mismatched.to_tool_ctx().executing_supervisor, None);
     }
 }
 
@@ -481,6 +657,7 @@ mod tests {
         .await
         .unwrap();
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("session_1"),
             root_session_id: None,
             tool_call_id: "call_1",
@@ -514,6 +691,7 @@ mod tests {
     async fn emit_converts_token_to_tool_token() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("session_1"),
             root_session_id: None,
             tool_call_id: "call_123",
@@ -549,6 +727,7 @@ mod tests {
     async fn emit_passes_through_non_token_events() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("session_1"),
             root_session_id: None,
             tool_call_id: "call_456",
@@ -595,6 +774,7 @@ mod tests {
     async fn emit_tool_token_convenience_method() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: None,
             root_session_id: None,
             tool_call_id: "call_abc",
@@ -652,6 +832,7 @@ mod tests {
     async fn cloned_sender_returns_clone_when_sender_present() {
         let (tx, _rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: None,
             root_session_id: None,
             tool_call_id: "call_clone",
@@ -682,6 +863,7 @@ mod tests {
     async fn emit_handles_multiple_sequential_calls() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("session_multi"),
             root_session_id: None,
             tool_call_id: "call_multi",
@@ -717,6 +899,7 @@ mod tests {
     fn context_is_clone_and_copy() {
         let (tx, _rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("session_copy"),
             root_session_id: None,
             tool_call_id: "call_copy",
@@ -751,6 +934,7 @@ mod tests {
     async fn emit_with_empty_tool_call_id() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: None,
             root_session_id: None,
             tool_call_id: "",
@@ -782,6 +966,7 @@ mod tests {
     async fn emit_with_unicode_content() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("会话"),
             root_session_id: None,
             tool_call_id: "调用_123",
@@ -817,6 +1002,7 @@ mod tests {
     async fn emit_with_special_characters_in_tool_call_id() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: None,
             root_session_id: None,
             tool_call_id: "call-with_special.chars:123",
@@ -848,6 +1034,7 @@ mod tests {
     async fn emit_tool_token_with_string_content() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: None,
             root_session_id: None,
             tool_call_id: "call_string",
@@ -877,6 +1064,7 @@ mod tests {
     async fn emit_tool_token_with_str_content() {
         let (tx, mut rx) = mpsc::channel(10);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: None,
             root_session_id: None,
             tool_call_id: "call_str",

--- a/crates/core/bamboo-agent-core/src/tools/mod.rs
+++ b/crates/core/bamboo-agent-core/src/tools/mod.rs
@@ -111,7 +111,9 @@ pub use agentic::{
     AgenticToolExecutor, AgenticToolResult, Interaction, InteractionRole, ToolGoal,
 };
 pub use bash_completion::{BashCompletionInfo, BashCompletionSink};
-pub use context::{ToolExecutionContext, ToolExecutionSessionFlags};
+pub use context::{
+    ExecutingSupervisorObservation, ToolExecutionContext, ToolExecutionSessionFlags,
+};
 pub use executor::{execute_tool_call, execute_tool_call_with_context, ToolError, ToolExecutor};
 pub use registry::{
     global_registry, normalize_tool_name, RegistryError, SharedTool, Tool, ToolRegistry,

--- a/crates/core/bamboo-agent-core/src/tools/result_handler.rs
+++ b/crates/core/bamboo-agent-core/src/tools/result_handler.rs
@@ -6,8 +6,9 @@ use tokio::sync::mpsc;
 use crate::composition::CompositionExecutor;
 use crate::tools::executor::execute_tool_call_with_context;
 use crate::tools::{
-    convert_from_standard_result, plan_mode_allows_tool, AgenticToolResult, ToolCall, ToolError,
-    ToolExecutionContext, ToolExecutionSessionFlags, ToolExecutor, ToolResult,
+    convert_from_standard_result, plan_mode_allows_tool, AgenticToolResult,
+    ExecutingSupervisorObservation, ToolCall, ToolError, ToolExecutionContext,
+    ToolExecutionSessionFlags, ToolExecutor, ToolResult,
 };
 use crate::{AgentEvent, Message, PendingQuestionSource, Session};
 
@@ -432,6 +433,10 @@ async fn execute_sub_actions_with_persistence(
     composition_executor: Option<Arc<CompositionExecutor>>,
     clarification_persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
 ) -> ToolHandlingOutcome {
+    // One executing lifetime owns the complete queue, including NeedMoreActions
+    // appended after an awaited tool. Configuration reloads cannot rebind it.
+    let executing_supervisor =
+        ExecutingSupervisorObservation::capture_from_executing_session(session);
     let mut pending: VecDeque<ToolCall> = actions.iter().cloned().collect();
     let mut processed = 0usize;
     let available_tools = tools.list_tools();
@@ -509,7 +514,8 @@ async fn execute_sub_actions_with_persistence(
             // re-parse leniently exactly as before — behavior preserved
             // (issue #106).
             None,
-        );
+        )
+        .with_executing_supervisor(executing_supervisor);
 
         match execute_tool_call_with_context(&action, tools, composition_executor.clone(), tool_ctx)
             .await

--- a/crates/core/bamboo-agent-core/src/tools/tool_runtime.rs
+++ b/crates/core/bamboo-agent-core/src/tools/tool_runtime.rs
@@ -175,6 +175,8 @@ pub struct RunningHandle {
 pub struct ToolCtx {
     /// Bamboo session id executing the tool.
     pub session_id: Option<Arc<str>>,
+    /// Lifetime captured by real dispatch; never refreshed from configuration.
+    pub executing_supervisor: Option<super::ExecutingSupervisorObservation>,
     /// The model's tool call id.
     pub tool_call_id: Arc<str>,
     /// Streaming progress channel (owned clone of the former `&mpsc::Sender`).
@@ -204,6 +206,7 @@ impl ToolCtx {
     pub fn none(tool_call_id: impl Into<Arc<str>>) -> Self {
         Self {
             session_id: None,
+            executing_supervisor: None,
             tool_call_id: tool_call_id.into(),
             event_tx: None,
             available_tool_schemas: Arc::from(Vec::new()),
@@ -224,6 +227,19 @@ impl ToolCtx {
     /// The session id as `&str`, if present.
     pub fn session_id(&self) -> Option<&str> {
         self.session_id.as_deref()
+    }
+
+    /// Preserve the original observation for same-caller nested dispatch only.
+    /// The caller ID is an identity check, not a source of new authority.
+    pub fn executing_supervisor_for(
+        &self,
+        session_id: &str,
+    ) -> Option<super::ExecutingSupervisorObservation> {
+        if self.session_id() != Some(session_id) {
+            return None;
+        }
+        self.executing_supervisor
+            .and_then(|observation| observation.for_caller(Some(session_id)))
     }
 
     /// Clone the event sender for a spawned task (peer of the former

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -7,7 +7,9 @@ use tokio::sync::mpsc;
 
 use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::task_context::TaskLoopContext;
-use bamboo_agent_core::tools::{ToolCall, ToolExecutor, ToolSchema};
+use bamboo_agent_core::tools::{
+    ExecutingSupervisorObservation, ToolCall, ToolExecutor, ToolSchema,
+};
 use bamboo_agent_core::{AgentError, AgentEvent, Session};
 use bamboo_domain::{
     AgentHookPoint, AgentRuntimeState, CapabilityLoadingMode, ClassifiedToolSchema,
@@ -56,6 +58,8 @@ mod loop_state;
 mod output_compressor;
 mod per_call;
 mod policy;
+#[cfg(test)]
+mod supervisor_dispatch_tests;
 mod task;
 pub(crate) mod tool_error_collector;
 
@@ -155,6 +159,8 @@ async fn execute_and_apply_single_tool_call(
             config.permission_mode.unwrap_or_default(),
         );
     let root_session_id = session.root_session_id.clone();
+    let executing_supervisor =
+        ExecutingSupervisorObservation::capture_from_executing_session(session);
     // Plan mode gate: block mutating tools (except pause/clarification tools)
     if session_flags.plan_read_only {
         let tool_name = tool_call.function.name.trim();
@@ -243,6 +249,7 @@ async fn execute_and_apply_single_tool_call(
                         metrics_collector,
                         session_id,
                         root_session_id: &root_session_id,
+                        executing_supervisor,
                         round_id,
                         round,
                         tools,
@@ -642,6 +649,8 @@ pub(crate) async fn execute_round_tool_calls(
             );
             let root_session_id = session.root_session_id.clone();
             let root_session_id = root_session_id.as_str();
+            let executing_supervisor =
+                ExecutingSupervisorObservation::capture_from_executing_session(session);
             let outcomes = tokio::time::timeout(
                 batch_timeout,
                 join_all(batch.iter().map(|tool_call| {
@@ -657,6 +666,7 @@ pub(crate) async fn execute_round_tool_calls(
                                     metrics_collector,
                                     session_id,
                                     root_session_id,
+                                    executing_supervisor,
                                     round_id,
                                     round,
                                     tools,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -5,8 +5,8 @@ use tokio::sync::mpsc;
 use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::{
-    parse_tool_args_best_effort, ToolCall, ToolExecutionContext, ToolExecutionSessionFlags,
-    ToolExecutor, ToolOutcome, ToolResult, ToolSchema,
+    parse_tool_args_best_effort, ExecutingSupervisorObservation, ToolCall, ToolExecutionContext,
+    ToolExecutionSessionFlags, ToolExecutor, ToolOutcome, ToolResult, ToolSchema,
 };
 use bamboo_agent_core::{AgentError, AgentEvent, Session};
 use bamboo_domain::{
@@ -42,6 +42,8 @@ pub(super) struct ToolExecutionOnlyContext<'a> {
     /// Root-session identity snapshotted from the executing Session before any
     /// parallel dispatch borrow begins.
     pub root_session_id: &'a str,
+    /// Original executing lifetime captured before this call is handed off.
+    pub executing_supervisor: Option<ExecutingSupervisorObservation>,
     pub round_id: &'a str,
     pub round: usize,
     pub tools: &'a Arc<dyn ToolExecutor>,
@@ -344,7 +346,8 @@ async fn execute_tool_call_only_with_execution_name(
         // `args` came from `parse_tool_args_best_effort`, the same parser the
         // executor would call, so reuse is byte-for-byte equivalent.
         Some(&args),
-    );
+    )
+    .with_executing_supervisor(ctx.executing_supervisor);
 
     // Outcome-aware dispatch. Extract a NeedsHuman pending question (handled in
     // apply before the success path) and collapse the rest to a ToolResult so the
@@ -1114,6 +1117,7 @@ mod hook_tests {
         execute_model_requested_tool_call_only(
             effective_callable_set,
             ToolExecutionOnlyContext {
+                executing_supervisor: None,
                 tool_call,
                 event_tx,
                 metrics_collector: None,
@@ -1199,6 +1203,7 @@ mod hook_tests {
         let unloaded = execute_model_requested_tool_call_only(
             &effective_callable_set,
             ToolExecutionOnlyContext {
+                executing_supervisor: None,
                 tool_call: &unloaded_call,
                 event_tx: &event_tx,
                 metrics_collector: None,
@@ -1467,6 +1472,7 @@ mod hook_tests {
         let mut runtime_state = AgentRuntimeState::new(&session.id);
 
         let outcome = execute_tool_call_only(ToolExecutionOnlyContext {
+            executing_supervisor: None,
             tool_call: &tool_call,
             event_tx: &event_tx,
             metrics_collector: None,
@@ -1526,6 +1532,7 @@ mod hook_tests {
         let mut runtime_state = AgentRuntimeState::new(&session.id);
 
         let outcome = execute_tool_call_only(ToolExecutionOnlyContext {
+            executing_supervisor: None,
             tool_call: &tool_call,
             event_tx: &event_tx,
             metrics_collector: None,
@@ -1604,6 +1611,7 @@ mod hook_tests {
         let mut runtime_state = AgentRuntimeState::new(&session.id);
 
         let outcome = execute_tool_call_only(ToolExecutionOnlyContext {
+            executing_supervisor: None,
             tool_call: &tool_call,
             event_tx: &event_tx,
             metrics_collector: None,
@@ -1658,6 +1666,7 @@ mod hook_tests {
         let outcome = bamboo_tools::with_approval_proxy(
             Some(reviewer_proxy),
             execute_tool_call_only(ToolExecutionOnlyContext {
+                executing_supervisor: None,
                 tool_call: &tool_call,
                 event_tx: &event_tx,
                 metrics_collector: None,
@@ -1789,6 +1798,7 @@ mod hook_tests {
             let mut session = Session::new(session_id, "model");
             let session_flags = ToolExecutionSessionFlags::from_session(&session);
             let outcome = execute_tool_call_only(ToolExecutionOnlyContext {
+                executing_supervisor: None,
                 tool_call: &tool_call,
                 event_tx: &event_tx,
                 metrics_collector: None,
@@ -1847,6 +1857,7 @@ mod hook_tests {
         let mut runtime_state = AgentRuntimeState::new(&session.id);
 
         let outcome = execute_tool_call_only(ToolExecutionOnlyContext {
+            executing_supervisor: None,
             tool_call: &tool_call,
             event_tx: &event_tx,
             metrics_collector: None,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/supervisor_dispatch_tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/supervisor_dispatch_tests.rs
@@ -1,0 +1,316 @@
+//! Acceptance coverage through the real native/core dispatch and owned Tool seam.
+
+use super::*;
+use bamboo_agent_core::storage::Storage;
+use bamboo_agent_core::tools::{
+    AgenticToolResult, FunctionCall, Tool, ToolClass, ToolCtx, ToolError,
+    ToolExecutionSessionFlags, ToolOutcome, ToolResult,
+};
+use bamboo_domain::{SessionAuthorityIdentity, SessionKind, DEFAULT_SUPERVISOR_SESSION_ID};
+use bamboo_storage::SessionStoreV2;
+use std::sync::Mutex;
+use tokio::sync::Semaphore;
+
+use crate::session_app::supervisor::SupervisorSessionService;
+
+type Observed = (Option<ExecutingSupervisorObservation>, bool);
+
+struct NoopProvider;
+#[async_trait::async_trait]
+impl LLMProvider for NoopProvider {
+    async fn chat_stream(
+        &self,
+        _: &[bamboo_agent_core::Message],
+        _: &[ToolSchema],
+        _: Option<u32>,
+        _: &str,
+    ) -> bamboo_llm::provider::Result<bamboo_llm::LLMStream> {
+        Ok(Box::pin(futures::stream::empty()))
+    }
+}
+
+struct Probe {
+    service: SupervisorSessionService,
+    entered: mpsc::UnboundedSender<Option<ExecutingSupervisorObservation>>,
+    resume: Arc<Semaphore>,
+    observed: Arc<Mutex<Vec<Observed>>>,
+}
+
+#[async_trait::async_trait]
+impl Tool for Probe {
+    fn name(&self) -> &str {
+        "Read"
+    }
+    fn description(&self) -> &str {
+        "Observe the executing lifetime"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type":"object"})
+    }
+    fn classify(&self, _: &serde_json::Value) -> ToolClass {
+        ToolClass::READONLY_PARALLEL
+    }
+
+    async fn invoke(
+        &self,
+        args: serde_json::Value,
+        ctx: ToolCtx,
+    ) -> Result<ToolOutcome, ToolError> {
+        // This owned clone outlives the borrowed dispatch context and the wait.
+        let retained = ctx.clone();
+        self.entered.send(retained.executing_supervisor).unwrap();
+        if args["pause"] == true {
+            self.resume.acquire().await.unwrap().forget();
+        }
+        let allowed = if let Some(observation) = retained.executing_supervisor {
+            self.service
+                .inspect_scope(&observation.supervisor_reference())
+                .await
+                .is_ok()
+        } else {
+            false
+        };
+        self.observed
+            .lock()
+            .unwrap()
+            .push((retained.executing_supervisor, allowed));
+        let result = if args["queue"] == true {
+            serde_json::to_string(&AgenticToolResult::NeedMoreActions {
+                actions: vec![call("queued", false, false)],
+                reason: "Continue the original dispatch".into(),
+            })
+            .unwrap()
+        } else {
+            serde_json::json!({"allowed":allowed}).to_string()
+        };
+        Ok(ToolOutcome::Completed(ToolResult {
+            success: true,
+            result,
+            display_preference: None,
+            images: vec![],
+        }))
+    }
+}
+
+fn call(id: &str, pause: bool, queue: bool) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        tool_type: "function".into(),
+        function: FunctionCall {
+            name: "Read".into(),
+            arguments: serde_json::json!({"pause":pause,"queue":queue}).to_string(),
+        },
+    }
+}
+
+async fn native_dispatch(
+    storage: Option<Arc<dyn Storage>>,
+    tools: Arc<dyn ToolExecutor>,
+    session: &mut Session,
+    calls: &[ToolCall],
+) {
+    let config = AgentLoopConfig {
+        storage,
+        ..Default::default()
+    };
+    let (event_tx, _event_rx) = mpsc::channel(128);
+    let llm: Arc<dyn LLMProvider> = Arc::new(NoopProvider);
+    let session_id = session.id.clone();
+    let frame = crate::runtime::runner::round_frame::RoundFrame {
+        session_id: &session_id,
+        round_id: "supervisor-dispatch",
+        turn: 0,
+        debug_enabled: false,
+        event_tx: &event_tx,
+        metrics_collector: None,
+        config: &config,
+        llm: &llm,
+        tools: &tools,
+    };
+    let schemas = tools.list_tools();
+    let effective = legacy_effective_callable_set(&schemas);
+    let mut runtime = AgentRuntimeState::new("supervisor-dispatch");
+    let mut task_context = None;
+    execute_round_tool_calls(RoundToolExecution {
+        tool_calls: calls,
+        frame: &frame,
+        session,
+        runtime_state: &mut runtime,
+        task_context: &mut task_context,
+        compression_model_name: None,
+        compression_model_provider: None,
+        tool_schemas: &schemas,
+        effective_callable_set: &effective,
+    })
+    .await
+    .expect("native dispatch");
+}
+
+async fn recreate(store: &Arc<dyn Storage>, service: &SupervisorSessionService) -> Session {
+    assert!(store
+        .delete_session(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap());
+    service.get_or_create_default("replacement").await.unwrap();
+    let mut session = store
+        .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    session.agent_runtime_state = Some(AgentRuntimeState::new("replacement-run"));
+    store.save_session(&session).await.unwrap();
+    session
+}
+
+async fn dispatch_race(native: bool, count: usize) {
+    let home = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Storage> = Arc::new(
+        SessionStoreV2::new(home.path().to_path_buf())
+            .await
+            .unwrap(),
+    );
+    let service = SupervisorSessionService::new(store.clone());
+    service.get_or_create_default("initial").await.unwrap();
+    let mut session = store
+        .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    session.agent_runtime_state = Some(AgentRuntimeState::new("initial-run"));
+    store.save_session(&session).await.unwrap();
+    let original =
+        ExecutingSupervisorObservation::capture_from_executing_session(&session).unwrap();
+    let (entered, mut entered_rx) = mpsc::unbounded_channel();
+    let resume = Arc::new(Semaphore::new(0));
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let tools: Arc<dyn ToolExecutor> = Arc::new(
+        bamboo_tools::BuiltinToolExecutorBuilder::new()
+            .with_tool(Probe {
+                service: service.clone(),
+                entered,
+                resume: resume.clone(),
+                observed: observed.clone(),
+            })
+            .unwrap()
+            .build(),
+    );
+    let calls = (0..count)
+        .map(|n| call(&format!("call-{n}"), true, !native))
+        .collect::<Vec<_>>();
+    let execute = async {
+        if native {
+            native_dispatch(Some(store.clone()), tools.clone(), &mut session, &calls).await;
+        } else {
+            let (tx, _rx) = mpsc::channel(128);
+            bamboo_agent_core::tools::result_handler::execute_sub_actions(
+                &calls,
+                &tx,
+                &mut session,
+                tools.as_ref(),
+                ToolExecutionSessionFlags::default(),
+                None,
+            )
+            .await;
+        }
+    };
+    let replace = async {
+        for _ in 0..count {
+            assert_eq!(entered_rx.recv().await.unwrap(), Some(original));
+        }
+        // In the two-call case neither call can complete before both entered:
+        // this exercises the actual native parallel batch, not serial replay.
+        let fresh = recreate(&store, &service).await;
+        assert_ne!(
+            ExecutingSupervisorObservation::capture_from_executing_session(&fresh),
+            Some(original)
+        );
+        resume.add_permits(count);
+        fresh
+    };
+    let (_, mut fresh) = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        tokio::join!(execute, replace)
+    })
+    .await
+    .expect("dispatch and replacement complete without deadlock");
+    let expected_calls = if native { count } else { count * 2 };
+    assert_eq!(
+        *observed.lock().unwrap(),
+        vec![(Some(original), false); expected_calls],
+        "retained and queued contexts must keep the old lifetime and fail strict validation"
+    );
+
+    let fresh_observation = ExecutingSupervisorObservation::capture_from_executing_session(&fresh);
+    native_dispatch(
+        Some(store),
+        tools,
+        &mut fresh,
+        &[call("fresh", false, false)],
+    )
+    .await;
+    assert_eq!(
+        observed.lock().unwrap().last(),
+        Some(&(fresh_observation, true))
+    );
+}
+
+#[tokio::test]
+async fn supervisor_native_sequential_owned_call_keeps_deleted_lifetime() {
+    dispatch_race(true, 1).await;
+}
+
+#[tokio::test]
+async fn supervisor_native_parallel_owned_calls_keep_one_deleted_lifetime() {
+    dispatch_race(true, 2).await;
+}
+
+#[tokio::test]
+async fn supervisor_core_sub_actions_and_need_more_actions_keep_deleted_lifetime() {
+    dispatch_race(false, 1).await;
+}
+
+#[tokio::test]
+async fn supervisor_native_ordinary_reserved_id_and_child_cannot_acquire_identity() {
+    let home = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Storage> = Arc::new(
+        SessionStoreV2::new(home.path().to_path_buf())
+            .await
+            .unwrap(),
+    );
+    let service = SupervisorSessionService::new(store.clone());
+    service.get_or_create_default("initial").await.unwrap();
+    let supervisor = store
+        .load_root_authority(DEFAULT_SUPERVISOR_SESSION_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    let (entered, _entered_rx) = mpsc::unbounded_channel();
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let tools: Arc<dyn ToolExecutor> = Arc::new(
+        bamboo_tools::BuiltinToolExecutorBuilder::new()
+            .with_tool(Probe {
+                service,
+                entered,
+                resume: Arc::new(Semaphore::new(0)),
+                observed: observed.clone(),
+            })
+            .unwrap()
+            .build(),
+    );
+    let mut child = supervisor.clone();
+    child.id = "child".into();
+    child.kind = SessionKind::Child;
+    child.parent_session_id = Some(supervisor.id.clone());
+    child.spawn_depth = 1;
+    let mut ordinary = supervisor;
+    ordinary.authority_identity = SessionAuthorityIdentity::Ordinary;
+    for mut session in [Session::new("ordinary", "model"), ordinary, child] {
+        native_dispatch(
+            None,
+            tools.clone(),
+            &mut session,
+            &[call("negative", false, false)],
+        )
+        .await;
+    }
+    assert_eq!(*observed.lock().unwrap(), vec![(None, false); 3]);
+}

--- a/crates/engine/bamboo-engine/src/workflow_run/executor.rs
+++ b/crates/engine/bamboo-engine/src/workflow_run/executor.rs
@@ -1567,6 +1567,7 @@ impl RunContext {
                     None => ToolExecutionSessionFlags::default(),
                 };
                 let context = ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some(&session_id),
                     // WorkflowRunSnapshot does not persist root-session identity.
                     // Fail closed for tool events instead of treating a child

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -1042,6 +1042,7 @@ mod tests {
         root_session_id: Option<&'a str>,
     ) -> ToolExecutionContext<'a> {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id,
             root_session_id,
             tool_call_id: &call.id,
@@ -1241,6 +1242,7 @@ mod tests {
         let (event_tx, _event_rx) = mpsc::channel(4);
         let call = make_tool_call("Write", args);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some(session_id),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -1732,6 +1734,7 @@ mod tests {
 
         let call = make_tool_call("Bash", json!({"command": command}));
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-bypass"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -1777,6 +1780,7 @@ mod tests {
             json!({"file_path": path_str, "content": "allowed by hook"}),
         );
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-hook-allow"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -1828,6 +1832,7 @@ mod tests {
         });
         let call = make_tool_call("Bash", json!({"command": command}));
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-hook-hard-dangerous"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -1877,6 +1882,7 @@ mod tests {
             json!({"file_path": path_str, "content": "must not be written"}),
         );
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-hook-explicit-deny"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -1928,6 +1934,7 @@ mod tests {
 
         let denied_call = make_tool_call("Bash", json!({"command": denied_command}));
         let denied_ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-forced"),
             root_session_id: None,
             tool_call_id: &denied_call.id,
@@ -1963,6 +1970,7 @@ mod tests {
             });
         let approved_call = make_tool_call("Bash", json!({"command": approved_command}));
         let approved_ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-forced"),
             root_session_id: None,
             tool_call_id: &approved_call.id,
@@ -2009,6 +2017,7 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::channel(8);
         let call = make_tool_call("Bash", json!({"command": command}));
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-auto"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -2054,6 +2063,7 @@ mod tests {
         let command = format!("printf blocked > {}", path.display());
         let call = make_tool_call("Bash", json!({"command": command}));
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("guardian-auto"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -2094,6 +2104,7 @@ mod tests {
             json!({"file_path": path_str, "content": "blocked"}),
         );
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-explicit-deny"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -2131,6 +2142,7 @@ mod tests {
             .build();
         let call = make_tool_call("Bash", json!({"command": "rm child-to-preserve"}));
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-explicit-delete-deny"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -2161,6 +2173,7 @@ mod tests {
             json!({"file_path": path, "content": "must not run"}),
         );
         let write_ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("plan-auto"),
             root_session_id: None,
             tool_call_id: &write.id,
@@ -2183,6 +2196,7 @@ mod tests {
         tokio::fs::write(&path, "readable").await.unwrap();
         let read = make_tool_call("Read", json!({"file_path": path}));
         let read_ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("plan-auto"),
             root_session_id: None,
             tool_call_id: &read.id,
@@ -2208,6 +2222,7 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::channel(4);
         let call = make_tool_call("request_permissions", json!({}));
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("auto-no-prompt"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -2250,6 +2265,7 @@ mod tests {
             json!({"file_path": "/etc/gated.conf", "content": "x"}),
         );
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-interactive"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -2327,6 +2343,7 @@ mod tests {
             .execute_with_context(
                 &call,
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some("proactive-session"),
                     root_session_id: None,
                     tool_call_id: &call.id,
@@ -2367,6 +2384,7 @@ mod tests {
             .execute_with_context(
                 &call,
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some("proactive-session"),
                     root_session_id: None,
                     tool_call_id: &call.id,
@@ -2399,6 +2417,7 @@ mod tests {
             .execute_with_context(
                 &call,
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some("proactive-session"),
                     root_session_id: None,
                     tool_call_id: &call.id,
@@ -2560,6 +2579,7 @@ mod tests {
 
         let call = make_tool_call("Write", json!({"file_path": path_str, "content": "ok"}));
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-worker"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -2601,6 +2621,7 @@ mod tests {
 
         let call = make_tool_call("Write", json!({"file_path": path_str, "content": "nope"}));
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-worker"),
             root_session_id: None,
             tool_call_id: &call.id,
@@ -2676,6 +2697,7 @@ mod tests {
             .execute_with_context(
                 &call,
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some("s1"),
                     root_session_id: None,
                     tool_call_id: &call.id,
@@ -3082,6 +3104,7 @@ mod tests {
         pre_parsed: Option<&'a serde_json::Value>,
     ) -> ToolExecutionContext<'a> {
         ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("s-106"),
             root_session_id: None,
             tool_call_id: call_id,

--- a/crates/engine/bamboo-tools/src/tools/bash.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash.rs
@@ -734,6 +734,7 @@ mod tests {
                     "command": mixed_output_command()
                 }),
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some("session_1"),
                     root_session_id: None,
                     tool_call_id: "call_1",
@@ -1164,6 +1165,7 @@ mod tests {
                     "workdir": "nested"
                 }),
                 ToolExecutionContext {
+                    executing_supervisor: None,
                     session_id: Some(&session_id),
                     root_session_id: None,
                     tool_call_id: "call_1",
@@ -1312,6 +1314,7 @@ mod tests {
         let tool = BashTool::new();
         let (tx, _rx) = mpsc::channel(32);
         let ctx = ToolExecutionContext {
+            executing_supervisor: None,
             session_id: Some("session_auto_fast"),
             root_session_id: None,
             tool_call_id: "call_auto_fast",

--- a/crates/engine/bamboo-tools/src/tools/edit.rs
+++ b/crates/engine/bamboo-tools/src/tools/edit.rs
@@ -715,6 +715,7 @@ mod tests {
 
     fn ctx(session_id: &str) -> ToolCtx {
         ToolCtx {
+            executing_supervisor: None,
             session_id: Some(std::sync::Arc::from(session_id)),
             tool_call_id: std::sync::Arc::from("call_1"),
             event_tx: None,
@@ -891,6 +892,7 @@ mod tests {
                     "new_string": "rust"
                 }),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session_1")),
                     tool_call_id: std::sync::Arc::from(call_id),
                     event_tx: None,
@@ -910,6 +912,7 @@ mod tests {
             .invoke(
                 json!({"file_path": file.path()}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session_1")),
                     tool_call_id: std::sync::Arc::from(call_id),
                     event_tx: None,
@@ -933,6 +936,7 @@ mod tests {
                     "new_string": "rust"
                 }),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session_1")),
                     tool_call_id: std::sync::Arc::from(call_id),
                     event_tx: None,
@@ -1519,6 +1523,7 @@ mod tests {
             .invoke(
                 json!({ "file_path": file.path() }),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session_edit_diag")),
                     tool_call_id: std::sync::Arc::from("call_1"),
                     event_tx: None,
@@ -1543,6 +1548,7 @@ mod tests {
                     "new_string": "{"
                 }),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session_edit_diag")),
                     tool_call_id: std::sync::Arc::from("call_2"),
                     event_tx: None,

--- a/crates/engine/bamboo-tools/src/tools/js_repl.rs
+++ b/crates/engine/bamboo-tools/src/tools/js_repl.rs
@@ -296,6 +296,7 @@ mod tests {
 
         let tool = JsReplTool::new();
         let ctx = ToolCtx {
+            executing_supervisor: None,
             session_id: Some(std::sync::Arc::from(session.as_str())),
             tool_call_id: std::sync::Arc::from("call_1"),
             event_tx: None,

--- a/crates/engine/bamboo-tools/src/tools/memory_note.rs
+++ b/crates/engine/bamboo-tools/src/tools/memory_note.rs
@@ -168,6 +168,7 @@ mod tests {
             .invoke(
                 json!({"action": "unknown"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session-1")),
                     tool_call_id: std::sync::Arc::from("tool_call_unknown"),
                     event_tx: None,
@@ -190,6 +191,7 @@ mod tests {
             .invoke(
                 json!({"action": "replace"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session-1")),
                     tool_call_id: std::sync::Arc::from("tool_call_replace"),
                     event_tx: None,
@@ -218,6 +220,7 @@ mod tests {
             .invoke(
                 json!({"action": "append", "topic": "backend", "content": "API finalized"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session-1")),
                     tool_call_id: std::sync::Arc::from("tool_call_append"),
                     event_tx: None,
@@ -243,6 +246,7 @@ mod tests {
             .invoke(
                 json!({"action": "read", "topic": "backend"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session-1")),
                     tool_call_id: std::sync::Arc::from("tool_call_read"),
                     event_tx: None,
@@ -270,6 +274,7 @@ mod tests {
             .invoke(
                 json!({"action": "list_topics"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session-1")),
                     tool_call_id: std::sync::Arc::from("tool_call_list"),
                     event_tx: None,
@@ -295,6 +300,7 @@ mod tests {
             .invoke(
                 json!({"action": "clear", "topic": "backend"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session-1")),
                     tool_call_id: std::sync::Arc::from("tool_call_clear"),
                     event_tx: None,
@@ -326,6 +332,7 @@ mod tests {
         tool.invoke(
             json!({"action": "replace", "topic": "default", "content": long_content}),
             ToolCtx {
+                executing_supervisor: None,
                 session_id: Some(std::sync::Arc::from("session-2")),
                 tool_call_id: std::sync::Arc::from("tool_call_replace_long"),
                 event_tx: None,
@@ -345,6 +352,7 @@ mod tests {
             .invoke(
                 json!({"action": "read", "topic": "default"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session-2")),
                     tool_call_id: std::sync::Arc::from("tool_call_read_long"),
                     event_tx: None,
@@ -369,6 +377,7 @@ mod tests {
         tool.invoke(
             json!({"action": "replace", "topic": "limit", "content": "x".repeat(crate::tools::session_memory::MAX_SESSION_NOTE_CHARS - 1)}),
             ToolCtx {
+                executing_supervisor: None,
                 session_id: Some(std::sync::Arc::from("session-3")),
                 tool_call_id: std::sync::Arc::from("tool_call_replace_limit"),
                 event_tx: None,
@@ -388,6 +397,7 @@ mod tests {
             .invoke(
                 json!({"action": "append", "topic": "limit", "content": "y"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session-3")),
                     tool_call_id: std::sync::Arc::from("tool_call_append_limit"),
                     event_tx: None,

--- a/crates/engine/bamboo-tools/src/tools/read.rs
+++ b/crates/engine/bamboo-tools/src/tools/read.rs
@@ -296,6 +296,7 @@ mod tests {
             .unwrap();
         let file_path = file.path().to_string_lossy().to_string();
         let make_ctx = || ToolCtx {
+            executing_supervisor: None,
             session_id: Some(std::sync::Arc::from("session_binary_read")),
             tool_call_id: std::sync::Arc::from("call_1"),
             event_tx: None,

--- a/crates/engine/bamboo-tools/src/tools/slash_command_tool.rs
+++ b/crates/engine/bamboo-tools/src/tools/slash_command_tool.rs
@@ -137,6 +137,7 @@ mod tests {
             .invoke(
                 json!({ "command": "/hello world" }),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from(session.as_str())),
                     tool_call_id: std::sync::Arc::from("call_1"),
                     event_tx: None,

--- a/crates/engine/bamboo-tools/src/tools/workspace.rs
+++ b/crates/engine/bamboo-tools/src/tools/workspace.rs
@@ -197,6 +197,7 @@ mod tests {
             .invoke(
                 json!({}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from(session.as_str())),
                     tool_call_id: std::sync::Arc::from("call_1"),
                     event_tx: None,
@@ -233,6 +234,7 @@ mod tests {
             .invoke(
                 json!({"path": workspace.to_string_lossy()}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from(session.as_str())),
                     tool_call_id: std::sync::Arc::from("call_1"),
                     event_tx: None,
@@ -257,6 +259,7 @@ mod tests {
             .invoke(
                 json!({}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from(session.as_str())),
                     tool_call_id: std::sync::Arc::from("call_2"),
                     event_tx: None,
@@ -289,6 +292,7 @@ mod tests {
             .invoke(
                 json!({"path": "/tmp/bamboo-no-such-workspace-xyz-99999"}),
                 ToolCtx {
+                    executing_supervisor: None,
                     session_id: Some(std::sync::Arc::from("session_1")),
                     tool_call_id: std::sync::Arc::from("call_1"),
                     event_tx: None,

--- a/crates/engine/bamboo-tools/src/tools/write.rs
+++ b/crates/engine/bamboo-tools/src/tools/write.rs
@@ -172,6 +172,7 @@ mod tests {
 
     fn ctx(session_id: &str) -> ToolCtx {
         ToolCtx {
+            executing_supervisor: None,
             session_id: Some(std::sync::Arc::from(session_id)),
             tool_call_id: std::sync::Arc::from("call_1"),
             event_tx: None,

--- a/crates/engine/bamboo-tools/tests/workspace_root_provider.rs
+++ b/crates/engine/bamboo-tools/tests/workspace_root_provider.rs
@@ -25,6 +25,7 @@ use serde_json::json;
 
 fn ctx_for(session: &str) -> ToolCtx {
     ToolCtx {
+        executing_supervisor: None,
         session_id: Some(std::sync::Arc::from(session)),
         tool_call_id: std::sync::Arc::from("call_1"),
         event_tx: None,

--- a/examples/tool-event-recorder/tests/tool_event_lifecycle.rs
+++ b/examples/tool-event-recorder/tests/tool_event_lifecycle.rs
@@ -155,6 +155,7 @@ async fn execute_write(state: &AppState, call_id: &str, path: &Path, content: &s
         .execute_with_context(
             &call,
             ToolExecutionContext {
+                executing_supervisor: None,
                 session_id: Some("recorder-session"),
                 root_session_id: Some("recorder-root-session"),
                 tool_call_id: &call.id,

--- a/tests/deploy_agent_tool_e2e.rs
+++ b/tests/deploy_agent_tool_e2e.rs
@@ -19,6 +19,7 @@ const TOKEN: &str = "deploy-e2e";
 
 fn ctx() -> ToolExecutionContext<'static> {
     ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some("root"),
         root_session_id: None,
         tool_call_id: "tc",

--- a/tests/schedule_tasks_tool.rs
+++ b/tests/schedule_tasks_tool.rs
@@ -92,6 +92,7 @@ impl ToolExecutor for NoopTools {
 
 fn ctx_for_session<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
     ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool_call",

--- a/tests/session_inspector_tool.rs
+++ b/tests/session_inspector_tool.rs
@@ -14,6 +14,7 @@ mod common;
 
 fn ctx_for_session<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
     ToolExecutionContext {
+        executing_supervisor: None,
         session_id: Some(session_id),
         root_session_id: None,
         tool_call_id: "tool_call",


### PR DESCRIPTION
## Summary

A Supervisor tool call can remain queued or await nested work while the original Root is deleted and recreated with the same ID. Capture the executing Supervisor incarnation at real dispatch and retain it through native sequential/parallel calls, core sub-action queues, borrowed-to-owned Tool::invoke conversion and same-caller nested skill dispatch. Canonical Supervisor service checks still determine whether that original lifetime is currently valid.

Only the actual executing typed Supervisor Root can supply the observation. Generic constructors, permission-only lookups, direct HTTP, WorkflowRun, composition and approval replay retain empty authority defaults. Nested configuration reloads preserve the original observation and existing permission posture; they cannot adopt a replacement Supervisor identity.

Closes #1111. Parent tracker: #1071. Durable approval transport remains a separate child after #1112/#1113. Model session_control, authorized directory, cross-Root exports and later control operations remain outside this PR.

## Test Plan

- New core observation tests: valid typed Root, malformed/Ordinary/Child/metadata/argument cases, generic defaults and mismatched caller stripping.
- Real native Tool::invoke: sequential and two parallel calls paused across deletion/recreation; both retain the old observation and fail canonical admission. A fresh current call succeeds.
- Real core sub-actions and queued NeedMoreActions retain the original observation.
- Real Core → overlay → owned load_skill → nested concrete Tool::invoke reads replacement configuration while retaining old identity. Empty/mismatched callers stay empty. Existing outer Plan rejection is preserved; inherited Plan/Auto and cleared Bypass are separately checked within LoadSkillTool::invoke.
- Recorder package fixture: exact `cargo test --locked -p bamboo-tool-event-recorder-example -- --test-threads=1` passes on the formal candidate in a neutral checkout (2 unit + 2 integration tests). The original `.codex` checkout run remains a recorded failure. Independent controls reproduced the same failure on the exact base, while both exact base and candidate passed in the neutral path; the unchanged sensitive-path policy and checkout-derived fixture root explain it. Pre-existing fixture portability is tracked separately in #1114.
- `cargo fmt --all -- --check`: PASS.
- Exact workspace CI Clippy command (`--all-features`, warnings denied, repository CI's explicit allowances): PASS.
- `cargo test --locked -- --test-threads=4`: PASS on the exact formal candidate in the neutral checkout; 8,639 passed, 0 failed, 131 existing ignored tests across 105 harnesses. Default frontend behavior, no source changes during validation.
- Independent complete-diff and exact-commit review: PASS on `c2539bf2c810e2af8de358fcbc6dd0131ddbb5e2`, tree `93de381150caad132ade7ecd648ffd13d71c5c91`. All 38 committed file contents and modes match the reviewed patch; seven production files carry semantic changes, while 29 constructor files add only explicit empty defaults.
- HTTP, WorkflowRun and SDK/server/Connect approval replay contexts retain empty defaults by source inspection; no separate endpoint negative runtime probes are claimed.

## Scope

The production changes are the context carrier and seven dispatch/bridge files. Additional constructor fixtures explicitly initialize the new field to None. No persistent authority store, Project grant, tool catalog, permission policy or model-control action is introduced.
