### PR TITLE
fix: bind SDK approval replay to current occurrences (#1113)

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/approval_replay.rs
+++ b/crates/app/bamboo-sdk/src/agent/approval_replay.rs
@@ -1,0 +1,360 @@
+//! SDK entry-point adapter for durable, occurrence-bound permission replay.
+
+use super::{Agent, AgentError, AgentEvent, Message, Session};
+use bamboo_agent_core::tools::{ToolExecutor, ToolOutcome};
+use bamboo_agent_core::{PendingQuestion, PendingQuestionSource};
+use bamboo_domain::resolve_tool_reference_name;
+use bamboo_engine::session_app::approval_replay::{
+    apply_permission_replay_result, find_permission_replay_target, refresh_approval_replay_posture,
+    repark_permission_replay, restore_permission_replay_authorization, ApprovalReplayDecision,
+    PermissionReplayTarget,
+};
+use bamboo_engine::session_app::respond::{
+    PERMISSION_REEXECUTE_GENERATION_METADATA_KEY, PERMISSION_REEXECUTE_METADATA_KEY,
+};
+use bamboo_tools::permission::{with_permission_replay_generation, PermissionRequest};
+use tokio::sync::mpsc;
+
+#[derive(Debug)]
+pub(super) enum ReplayDisposition {
+    Continue,
+    AwaitingApproval(PendingQuestion),
+}
+
+fn invalid(message: &str) -> AgentError {
+    AgentError::Tool(format!("permission replay {message}"))
+}
+
+fn latest_result<'a>(session: &'a Session, id: &str) -> Option<&'a Message> {
+    session
+        .messages
+        .iter()
+        .rev()
+        .find(|message| message.tool_call_id.as_deref() == Some(id))
+}
+
+/// Field presence decides whether a result is typed. A malformed/blank request
+/// must never fall through the legacy path because generation extraction failed.
+fn typed_request(message: &Message) -> Result<Option<PermissionRequest>, AgentError> {
+    let payload = serde_json::from_str::<serde_json::Value>(&message.content).ok();
+    let metadata_request = message
+        .metadata
+        .as_ref()
+        .and_then(|value| value.get("permission_request"));
+    let payload_request = payload
+        .as_ref()
+        .and_then(|value| value.get("permission_request"));
+    let decode = |value: &serde_json::Value| {
+        serde_json::from_value::<PermissionRequest>(value.clone())
+            .map_err(|_| invalid("request is malformed"))
+    };
+    let durable = metadata_request.map(decode).transpose()?;
+    let waiting = payload_request.map(decode).transpose()?;
+    if matches!((&durable, &waiting), (Some(a), Some(b)) if a != b) {
+        return Err(invalid("request payload and metadata disagree"));
+    }
+    let request = durable.or(waiting);
+    if request.is_some() && !matches!(message.role, super::Role::Tool) {
+        return Err(invalid("typed result does not have the Tool role"));
+    }
+    if request.is_none()
+        && (message
+            .metadata
+            .as_ref()
+            .is_some_and(|value| value.get("permission_decision_receipt").is_some())
+            || payload
+                .as_ref()
+                .is_some_and(|value| value.get("permission_decision_receipt").is_some()))
+    {
+        return Err(invalid("receipt is missing its typed request"));
+    }
+    Ok(request)
+}
+
+fn validate_request(
+    session: &Session,
+    target: &PermissionReplayTarget,
+    request: &PermissionRequest,
+    executor: &dyn ToolExecutor,
+) -> Result<String, AgentError> {
+    // Requests name the selected execution identity, while history and pending
+    // questions retain the caller's spelling. Exact custom registrations must
+    // win before builtin aliases, just as they do in the live executor.
+    let execution_name = resolve_tool_reference_name(&target.tool_call().function.name, |name| {
+        executor.owns_exact_tool(name)
+    })
+    .ok_or_else(|| invalid("current tool is unavailable"))?;
+    if request.session_id != session.id
+        || request.request_id != target.tool_call().id
+        || request.tool_name != execution_name
+        || request.request_generation.trim().is_empty()
+        || target.request_generation() != Some(request.request_generation.as_str())
+    {
+        return Err(invalid("request does not match the current operation"));
+    }
+    Ok(execution_name)
+}
+
+fn clear_markers(session: &mut Session) {
+    session.metadata.remove(PERMISSION_REEXECUTE_METADATA_KEY);
+    session
+        .metadata
+        .remove(PERMISSION_REEXECUTE_GENERATION_METADATA_KEY);
+}
+
+impl Agent {
+    /// Resolve only the newest same-ID occurrence. An unanswered typed request
+    /// remains waiting across new SDK calls/restarts; plain User text is not an
+    /// authorization response. Successful terminal events follow durable save.
+    pub(super) async fn reexecute_approved_tool_if_pending(
+        &self,
+        session: &mut Session,
+        event_tx: &mpsc::Sender<AgentEvent>,
+    ) -> Result<ReplayDisposition, AgentError> {
+        let call_id = session
+            .metadata
+            .get(PERMISSION_REEXECUTE_METADATA_KEY)
+            .cloned();
+        let generation = session
+            .metadata
+            .get(PERMISSION_REEXECUTE_GENERATION_METADATA_KEY)
+            .cloned();
+        if call_id.is_none() && generation.is_some() {
+            return Err(invalid("generation marker has no tool-call marker"));
+        }
+        let executor = self.inner.default_tools();
+
+        if let Some(pending) = session.pending_question.as_ref() {
+            if let Some(message) = latest_result(session, &pending.tool_call_id) {
+                if let Some(request) = typed_request(message)? {
+                    let target =
+                        find_permission_replay_target(session, &pending.tool_call_id, None)
+                            .ok_or_else(|| invalid("pending operation is missing its tool call"))?;
+                    validate_request(session, &target, &request, executor.as_ref())?;
+                    let payload = serde_json::from_str::<serde_json::Value>(&message.content).ok();
+                    if call_id.is_some()
+                        || generation.is_some()
+                        || pending.source != PendingQuestionSource::PauseTool
+                        || pending.tool_name != target.tool_call().function.name
+                        || message.metadata.as_ref().is_some_and(|metadata| {
+                            metadata.get("permission_decision_receipt").is_some()
+                        })
+                        || payload
+                            .as_ref()
+                            .is_some_and(|value| value.get("permission_decision_receipt").is_some())
+                        || payload
+                            .as_ref()
+                            .and_then(|value| value.get("status"))
+                            .and_then(serde_json::Value::as_str)
+                            != Some("awaiting_permission_approval")
+                        || session
+                            .metadata
+                            .get("runtime.suspend_reason")
+                            .map(String::as_str)
+                            != Some("awaiting_clarification")
+                    {
+                        return Err(invalid("pending approval state is contradictory"));
+                    }
+                    return Ok(ReplayDisposition::AwaitingApproval(pending.clone()));
+                }
+            }
+        }
+
+        let Some(call_id) = call_id else {
+            return Ok(ReplayDisposition::Continue);
+        };
+        if call_id.trim().is_empty()
+            || generation
+                .as_ref()
+                .is_some_and(|value| value.trim().is_empty())
+        {
+            return Err(invalid("marker is empty"));
+        }
+        let request = latest_result(session, &call_id)
+            .map(typed_request)
+            .transpose()?
+            .flatten();
+        let Some(target) = find_permission_replay_target(session, &call_id, None) else {
+            if generation.is_some() || request.is_some() {
+                return Err(invalid("typed target is missing"));
+            }
+            // Preserve the old SDK's call-ID-only ghost-marker compatibility.
+            clear_markers(session);
+            return Ok(ReplayDisposition::Continue);
+        };
+        if generation.as_deref() != target.request_generation() {
+            return Err(invalid("generation does not match the newest operation"));
+        }
+        let execution_name = if let Some(request) = request.as_ref() {
+            let name = validate_request(session, &target, request, executor.as_ref())?;
+            if generation.as_deref() != Some(request.request_generation.as_str())
+                || session.pending_question.is_some()
+            {
+                return Err(invalid(
+                    "typed operation has not been answered for this generation",
+                ));
+            }
+            Some(name)
+        } else {
+            if generation.is_some() || target.request_generation().is_some() {
+                return Err(invalid("generation is missing its typed request"));
+            }
+            None
+        };
+
+        let tool_call = target.tool_call();
+        let tool_name = &tool_call.function.name;
+        let decision = refresh_approval_replay_posture(
+            self.storage().as_ref(),
+            session,
+            self.permission_mode,
+            execution_name.as_deref().unwrap_or(tool_name),
+        )
+        .await?;
+        if request.is_some() {
+            let config = self
+                .permission_checker
+                .as_ref()
+                .and_then(|checker| checker.permission_config())
+                .ok_or_else(|| invalid("typed authorization requires a PermissionConfig"))?;
+            restore_permission_replay_authorization(&config, session, &target)?;
+        }
+        let flags = match decision {
+            ApprovalReplayDecision::Execute(flags) => flags,
+            ApprovalReplayDecision::BlockedByPlan(_) => {
+                if !apply_permission_replay_result(session, &target, format!(
+                    "Plan mode blocked approved mutating tool '{tool_name}'; the stale approval was not executed"), false) {
+                    return Err(invalid("result occurrence changed"));
+                }
+                clear_markers(session);
+                self.save_permission_replay(session).await?;
+                return Ok(ReplayDisposition::Continue);
+            }
+        };
+
+        let is_mutating = bamboo_tools::orchestrator::classify_tool(tool_name)
+            == bamboo_tools::orchestrator::ToolMutability::Mutating;
+        let mut emitter = bamboo_tools::ToolEmitter::new(&call_id, tool_name, is_mutating);
+        emitter.set_auto_approved(true);
+        let _ = event_tx
+            .send(emitter.begin().clone().into_agent_event())
+            .await;
+        let completed = async {
+            let ctx = bamboo_agent_core::tools::ToolExecutionContext {
+                executing_supervisor: None,
+                session_id: Some(session.id.as_str()),
+                root_session_id: Some(if session.root_session_id.trim().is_empty() {
+                    session.id.as_str()
+                } else {
+                    session.root_session_id.as_str()
+                }),
+                tool_call_id: &call_id,
+                event_tx: Some(event_tx),
+                available_tool_schemas: None,
+                bypass_permissions: flags.bypass_permissions,
+                auto_approve_permissions: flags.auto_approve_permissions,
+                plan_read_only: flags.plan_read_only,
+                can_async_resume: false,
+                bash_completion_sink: None,
+                pre_parsed_args: None,
+            };
+            let dispatch = async {
+                match execution_name.as_deref() {
+                    Some(name) => executor
+                        .execute_exact_with_context_outcome(tool_call, name, ctx)
+                        .await
+                        .map(ToolOutcome::into_tool_result),
+                    None => executor.execute_with_context(tool_call, ctx).await,
+                }
+            };
+            let (result, execution_error) = match with_permission_replay_generation(
+                &session.id,
+                &call_id,
+                generation.as_deref(),
+                dispatch,
+            )
+            .await
+            {
+                Ok(result) => (result, None),
+                Err(error) => {
+                    // A real tool failure after valid admission remains input
+                    // for normal model recovery, once that failed result saves.
+                    let message = format!("Tool re-execution after approval failed: {error}");
+                    (
+                        bamboo_agent_core::tools::ToolResult::text(false, message.clone()),
+                        Some(message),
+                    )
+                }
+            };
+            let reparked = repark_permission_replay(session, &target, &result)?;
+            if reparked.is_none()
+                && !apply_permission_replay_result(
+                    session,
+                    &target,
+                    result.result.clone(),
+                    result.success,
+                )
+            {
+                return Err(invalid("result occurrence changed"));
+            }
+            clear_markers(session);
+            self.save_permission_replay(session).await?;
+            Ok((result, reparked, execution_error))
+        }
+        .await;
+        let (result, reparked, execution_error) = match completed {
+            Ok(completed) => completed,
+            Err(error) => {
+                let _ = event_tx
+                    .send(emitter.error(error.to_string()).clone().into_agent_event())
+                    .await;
+                return Err(error);
+            }
+        };
+        if let Some(message) = execution_error {
+            let _ = event_tx
+                .send(emitter.error(message).clone().into_agent_event())
+                .await;
+            return Ok(ReplayDisposition::Continue);
+        }
+        let _ = event_tx
+            .send(
+                emitter
+                    .finish(Some(
+                        if reparked.is_some() {
+                            "Awaiting additional permission approval"
+                        } else {
+                            "Re-executed after approval"
+                        }
+                        .into(),
+                    ))
+                    .clone()
+                    .into_agent_event(),
+            )
+            .await;
+        let _ = event_tx
+            .send(AgentEvent::ToolComplete {
+                tool_call_id: call_id.clone(),
+                result,
+            })
+            .await;
+        if let Some(reparked) = reparked {
+            return Ok(ReplayDisposition::AwaitingApproval(PendingQuestion {
+                question: reparked.question,
+                options: reparked.options,
+                tool_call_id: call_id,
+                tool_name: tool_name.clone(),
+                allow_custom: reparked.allow_custom,
+                source: PendingQuestionSource::PauseTool,
+            }));
+        }
+        Ok(ReplayDisposition::Continue)
+    }
+
+    async fn save_permission_replay(&self, session: &mut Session) -> Result<(), AgentError> {
+        self.persistence()
+            .save_runtime_session(session)
+            .await
+            .map_err(|error| invalid(&format!("persistence failed: {error}")))
+    }
+}

--- a/crates/app/bamboo-sdk/src/agent/approval_replay_tests.rs
+++ b/crates/app/bamboo-sdk/src/agent/approval_replay_tests.rs
@@ -1,0 +1,1302 @@
+use super::*;
+use bamboo_agent_core::storage::Storage;
+use bamboo_agent_core::tools::{
+    FunctionCall, Tool, ToolCall, ToolCtx, ToolError, ToolExecutionContext,
+    ToolExecutionSessionFlags, ToolExecutor, ToolOutcome, ToolResult, ToolSchema,
+};
+use bamboo_domain::{AgentRuntimeState, PendingQuestionSource, RuntimeSessionPersistence};
+use bamboo_engine::session_app::respond::{
+    acquire_pending_response_guard, submit_pending_permission_response_checked_guarded,
+    PERMISSION_REEXECUTE_GENERATION_METADATA_KEY,
+};
+use bamboo_engine::{SessionCache, SessionRepository};
+use bamboo_storage::{LockedSessionStore, SessionStoreV2};
+use bamboo_tools::permission::{
+    current_permission_replay_generation, ConfigPermissionChecker, PermissionConfig,
+    PermissionDecision, PermissionDecisionKind, PermissionDecisionReceipt, PermissionReasonCode,
+    PermissionRequest, RiskLevel,
+};
+use serde_json::{json, Value};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+const CALL: &str = "reused-call";
+const CURRENT: &str = "generation-a";
+const SECOND: &str = "generation-b";
+
+#[derive(Debug)]
+struct Invocation {
+    name: String,
+    arguments: Value,
+    generation: Option<String>,
+    flags: ToolExecutionSessionFlags,
+    supervisor_absent: bool,
+}
+
+#[derive(Default)]
+struct Probe {
+    calls: Mutex<Vec<Invocation>>,
+    actions: AtomicUsize,
+    provider_calls: AtomicUsize,
+    fail_execution: AtomicBool,
+    next_call: Mutex<Option<ToolCall>>,
+}
+
+#[async_trait]
+impl LLMProvider for Probe {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<bamboo_llm::LLMStream, bamboo_llm::LLMError> {
+        self.provider_calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(call) = self.next_call.lock().unwrap().take() {
+            return Ok(Box::pin(futures::stream::iter([
+                Ok(bamboo_llm::LLMChunk::ToolCalls(vec![call])),
+                Ok(bamboo_llm::LLMChunk::Done),
+            ])));
+        }
+        Ok(Box::pin(futures::stream::iter([
+            Ok(bamboo_llm::LLMChunk::Token("done".into())),
+            Ok(bamboo_llm::LLMChunk::Done),
+        ])))
+    }
+}
+
+struct RecordingExecutor {
+    probe: Arc<Probe>,
+    config: Arc<PermissionConfig>,
+    typed: bool,
+    second_context: bool,
+    action_log: std::path::PathBuf,
+}
+
+#[async_trait]
+impl ToolExecutor for RecordingExecutor {
+    async fn execute(&self, _call: &ToolCall) -> Result<ToolResult, ToolError> {
+        panic!("replay must supply its execution context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        call: &ToolCall,
+        ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolResult, ToolError> {
+        let session_id = ctx.session_id.expect("session identity");
+        let generation = current_permission_replay_generation(session_id, &call.id);
+        self.probe.calls.lock().unwrap().push(Invocation {
+            name: call.function.name.clone(),
+            arguments: serde_json::from_str(&call.function.arguments).unwrap(),
+            generation: generation.clone(),
+            flags: ToolExecutionSessionFlags {
+                bypass_permissions: ctx.bypass_permissions,
+                auto_approve_permissions: ctx.auto_approve_permissions,
+                plan_read_only: ctx.plan_read_only,
+            },
+            supervisor_absent: ctx.executing_supervisor.is_none(),
+        });
+        if self.typed {
+            let generation =
+                generation.ok_or_else(|| ToolError::Execution("missing generation".into()))?;
+            for (other_session, other_generation, other_resource) in [
+                ("another-session", generation.as_str(), "current-command"),
+                (session_id, "another-generation", "current-command"),
+                (session_id, generation.as_str(), "another-command"),
+            ] {
+                assert!(!self.config.consume_once_for_generation(
+                    other_session,
+                    CALL,
+                    other_generation,
+                    PermissionType::ExecuteCommand,
+                    other_resource,
+                ));
+            }
+            if !self.config.consume_once_for_generation(
+                session_id,
+                CALL,
+                &generation,
+                PermissionType::ExecuteCommand,
+                "current-command",
+            ) {
+                return Err(ToolError::Execution("missing exact A authorization".into()));
+            }
+            if self.second_context
+                && !self.config.consume_once_for_generation(
+                    session_id,
+                    CALL,
+                    &generation,
+                    PermissionType::WriteFile,
+                    "second-resource",
+                )
+            {
+                return Ok(waiting_result(&request(
+                    session_id,
+                    SECOND,
+                    "second-resource",
+                    PermissionType::WriteFile,
+                )));
+            }
+        }
+        if self.probe.fail_execution.load(Ordering::SeqCst) {
+            return Err(ToolError::Execution("intentional execution failure".into()));
+        }
+        let mut log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.action_log)
+            .map_err(|error| ToolError::Execution(error.to_string()))?;
+        std::io::Write::write_all(&mut log, b"physical action\n")
+            .map_err(|error| ToolError::Execution(error.to_string()))?;
+        self.probe.actions.fetch_add(1, Ordering::SeqCst);
+        Ok(ToolResult::text(
+            true,
+            format!("REAL OUTPUT {}", call.function.arguments),
+        ))
+    }
+
+    fn list_tools(&self) -> Vec<ToolSchema> {
+        vec![serde_json::from_value(json!({
+            "type": "function", "function": { "name": "Bash", "description": "record execution",
+            "parameters": { "type": "object", "properties": { "command": { "type": "string" } } } }
+        }))
+        .unwrap()]
+    }
+}
+
+struct Fixture {
+    directory: tempfile::TempDir,
+    store: Arc<SessionStoreV2>,
+    persistence: Arc<LockedSessionStore>,
+    repo: SessionRepository,
+    probe: Arc<Probe>,
+}
+
+struct RegisteredProbeTool {
+    name: String,
+    probe: Arc<Probe>,
+    config: Arc<PermissionConfig>,
+}
+
+#[async_trait]
+impl Tool for RegisteredProbeTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn description(&self) -> &str {
+        "record the selected exact tool"
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": { "command": { "type": "string" } }, "required": ["command"] })
+    }
+    async fn invoke(&self, args: Value, ctx: ToolCtx) -> Result<ToolOutcome, ToolError> {
+        let session_id = ctx.session_id.as_deref().unwrap();
+        // Bash is gated by the real BuiltinToolExecutor. The exact custom
+        // registration requests its own permission through the same public
+        // evaluator, so the engine creates both pending structures itself.
+        if self.name == "execute_command" {
+            match self
+                .config
+                .evaluate(bamboo_tools::permission::PermissionEvaluation {
+                    request_id: ctx.tool_call_id.to_string(),
+                    session_id: session_id.into(),
+                    workspace_path: None,
+                    tool_name: self.name.clone(),
+                    tool_args: args.clone(),
+                    permission_type: PermissionType::ExecuteCommand,
+                    resource: args["command"].as_str().unwrap().into(),
+                    operation_summary: "custom operation".into(),
+                    risk_level: RiskLevel::High,
+                    bypass_requested: ctx.bypass_permissions,
+                    auto_approve_requested: ctx.auto_approve_permissions,
+                    platform_hard_deny: None,
+                    consume_once: true,
+                    supported_decisions: PermissionRequest::forced_decisions(),
+                }) {
+                bamboo_tools::permission::PermissionOutcome::Ask(request) => {
+                    self.config.register_pending_request(request.clone());
+                    let mut result = waiting_result(&request);
+                    // The normal runner's legacy prompt adapter accepts only
+                    // successful gate synths, matching BuiltinToolExecutor.
+                    result.success = true;
+                    return Ok(ToolOutcome::Completed(result));
+                }
+                bamboo_tools::permission::PermissionOutcome::Allow { .. } => {}
+                bamboo_tools::permission::PermissionOutcome::Deny { reason, .. } => {
+                    return Err(ToolError::Execution(reason.message));
+                }
+            }
+        }
+        self.probe.calls.lock().unwrap().push(Invocation {
+            name: self.name.clone(),
+            arguments: args.clone(),
+            generation: current_permission_replay_generation(session_id, &ctx.tool_call_id),
+            flags: ToolExecutionSessionFlags {
+                bypass_permissions: ctx.bypass_permissions,
+                auto_approve_permissions: ctx.auto_approve_permissions,
+                plan_read_only: ctx.plan_read_only,
+            },
+            supervisor_absent: ctx.executing_supervisor.is_none(),
+        });
+        self.probe.actions.fetch_add(1, Ordering::SeqCst);
+        Ok(ToolOutcome::Completed(ToolResult::text(
+            true,
+            format!("REAL OUTPUT {args}"),
+        )))
+    }
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let directory = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            SessionStoreV2::new(directory.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+        let storage: Arc<dyn Storage> = store.clone();
+        let persistence = Arc::new(LockedSessionStore::new(storage.clone()));
+        let repo = SessionRepository::new(SessionCache::default(), storage, persistence.clone());
+        Self {
+            directory,
+            store,
+            persistence,
+            repo,
+            probe: Arc::new(Probe::default()),
+        }
+    }
+
+    fn agent(
+        &self,
+        config: Option<Arc<PermissionConfig>>,
+        typed: bool,
+        second_context: bool,
+        persistence: Option<Arc<dyn RuntimeSessionPersistence>>,
+    ) -> Agent {
+        let executor = Arc::new(RecordingExecutor {
+            probe: self.probe.clone(),
+            config: config.clone().unwrap_or_default(),
+            typed,
+            second_context,
+            action_log: self.directory.path().join("actions.log"),
+        });
+        self.agent_with_executor(config, executor, persistence)
+    }
+
+    fn agent_with_executor(
+        &self,
+        config: Option<Arc<PermissionConfig>>,
+        executor: Arc<dyn ToolExecutor>,
+        persistence: Option<Arc<dyn RuntimeSessionPersistence>>,
+    ) -> Agent {
+        let metrics = bamboo_metrics::MetricsCollector::spawn(
+            Arc::new(bamboo_metrics::SqliteMetricsStorage::new(
+                self.directory.path().join("metrics.db"),
+            )),
+            7,
+        );
+        let runtime = RuntimeAgent::builder()
+            .storage(self.store.clone())
+            .persistence(persistence.unwrap_or_else(|| self.persistence.clone()))
+            .attachment_reader(self.store.clone())
+            .skill_manager(Arc::new(bamboo_skills::SkillManager::new()))
+            .metrics_collector(metrics)
+            .config(Arc::new(tokio::sync::RwLock::new(
+                bamboo_llm::Config::default(),
+            )))
+            .provider(self.probe.clone())
+            .default_tools(executor)
+            .build()
+            .unwrap();
+        Agent::from_runtime_with_config(
+            runtime,
+            Some("configured System".into()),
+            Some("test-model".into()),
+            None,
+            None,
+            None,
+            config.map(|config| {
+                Arc::new(ConfigPermissionChecker::new(config)) as Arc<dyn PermissionChecker>
+            }),
+            PermissionMode::Default,
+        )
+    }
+
+    fn registered_agent(&self, config: Arc<PermissionConfig>, names: &[&str]) -> Agent {
+        let registry = bamboo_tools::ToolRegistry::new();
+        for name in names {
+            registry
+                .register(RegisteredProbeTool {
+                    name: (*name).into(),
+                    probe: self.probe.clone(),
+                    config: config.clone(),
+                })
+                .unwrap();
+        }
+        let executor = bamboo_tools::executor::BuiltinToolExecutor::with_registry_and_permissions(
+            registry,
+            Arc::new(ConfigPermissionChecker::new(config.clone())),
+        );
+        self.agent_with_executor(Some(config), Arc::new(executor), None)
+    }
+
+    async fn reload(&self, id: &str) -> Session {
+        let durable = self.store.load_session(id).await.unwrap().unwrap();
+        serde_json::from_slice(&serde_json::to_vec(&durable).unwrap()).unwrap()
+    }
+
+    async fn reopen_store(&mut self) {
+        let store = Arc::new(
+            SessionStoreV2::new(self.directory.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+        let storage: Arc<dyn Storage> = store.clone();
+        let persistence = Arc::new(LockedSessionStore::new(storage.clone()));
+        self.repo = SessionRepository::new(SessionCache::default(), storage, persistence.clone());
+        self.persistence = persistence;
+        self.store = store;
+    }
+
+    async fn approve(&self, request: &PermissionRequest) -> Session {
+        let guard = acquire_pending_response_guard(&request.session_id).await;
+        submit_pending_permission_response_checked_guarded(
+            &self.repo,
+            RespondInput {
+                session_id: request.session_id.clone(),
+                user_response: "Approve".into(),
+                model: None,
+                model_ref: None,
+                provider: None,
+                reasoning_effort: None,
+            },
+            Some(CALL.into()),
+            PermissionDecisionReceipt {
+                session_id: request.session_id.clone(),
+                decision: PermissionDecision {
+                    request_id: CALL.into(),
+                    request_generation: request.request_generation.clone(),
+                    decision: PermissionDecisionKind::AllowOnce,
+                    matcher_id: None,
+                    expected_policy_revision: Some(request.policy_revision),
+                    confirm_global: false,
+                },
+                decided_at: std::time::SystemTime::now().into(),
+            },
+            &guard,
+        )
+        .await
+        .unwrap()
+        .0
+    }
+}
+
+fn request(
+    id: &str,
+    generation: &str,
+    resource: &str,
+    permission_type: PermissionType,
+) -> PermissionRequest {
+    PermissionRequest {
+        request_id: CALL.into(),
+        request_generation: generation.into(),
+        session_id: id.into(),
+        workspace_path: None,
+        tool_name: "Bash".into(),
+        permission_type,
+        resource: resource.into(),
+        operation_summary: format!("operate on {resource}"),
+        risk_level: RiskLevel::High,
+        reason_code: PermissionReasonCode::RiskThreshold,
+        effective_mode: PermissionMode::Default,
+        bypass_requested: false,
+        auto_approve_requested: false,
+        policy_revision: 4,
+        matched_rule: None,
+        allowed_decisions: vec![
+            PermissionDecisionKind::AllowOnce,
+            PermissionDecisionKind::DenyOnce,
+        ],
+        suggested_matchers: vec![],
+    }
+}
+
+fn waiting_result(request: &PermissionRequest) -> ToolResult {
+    ToolResult { success: false, result: json!({
+        "status": "awaiting_permission_approval", "question": "Permission required", "options": ["Approve", "Deny"],
+        "allow_custom": false, "permission_type": request.permission_type, "resource": request.resource,
+        "permission_request": request,
+    }).to_string(), display_preference: Some("request_permissions".into()), images: vec![] }
+}
+
+fn parked(id: &str, typed: bool) -> (Session, PermissionRequest) {
+    let mut session = Session::new(id, "test-model");
+    session.agent_runtime_state = Some(AgentRuntimeState::new(id));
+    session.add_message(Message::system("caller System"));
+    session.add_message(Message::user("perform the operation"));
+    let current = request(
+        id,
+        CURRENT,
+        "current-command",
+        PermissionType::ExecuteCommand,
+    );
+    for (name, request) in [
+        (
+            "old",
+            request(
+                id,
+                "generation-old",
+                "old-command",
+                PermissionType::ExecuteCommand,
+            ),
+        ),
+        ("current", current.clone()),
+    ] {
+        session.add_message(Message::assistant(
+            "",
+            Some(vec![ToolCall {
+                id: CALL.into(),
+                tool_type: "function".into(),
+                function: FunctionCall {
+                    name: "Bash".into(),
+                    arguments: json!({"command": request.resource}).to_string(),
+                },
+            }]),
+        ));
+        let mut payload: Value = serde_json::from_str(&waiting_result(&request).result).unwrap();
+        if !typed {
+            payload
+                .as_object_mut()
+                .unwrap()
+                .remove("permission_request");
+        }
+        let mut result = Message::tool_result_with_status(CALL, payload.to_string(), false);
+        result.id = format!("result-{name}");
+        session.add_message(result);
+    }
+    session.set_pending_question_with_source(
+        CALL.into(),
+        "Bash".into(),
+        "Permission required".into(),
+        vec!["Approve".into(), "Deny".into()],
+        false,
+        PendingQuestionSource::PauseTool,
+    );
+    session.metadata.insert(
+        "runtime.suspend_reason".into(),
+        "awaiting_clarification".into(),
+    );
+    (session, current)
+}
+
+fn result_message(session: &Session, id: &str) -> Value {
+    serde_json::to_value(
+        session
+            .messages
+            .iter()
+            .find(|message| message.id == id)
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn legacy_public_answer_run_replays_only_the_latest_occurrence() {
+    let fixture = Fixture::new().await;
+    let (mut session, _) = parked("legacy-duplicate", false);
+    let old = result_message(&session, "result-old");
+    fixture.repo.save(&mut session).await.unwrap();
+    let agent = fixture.agent(None, false, false, None);
+    let mut session = agent.answer(&session.id, "Approve").await.unwrap().session;
+    agent.run(&mut session, "continue").await.unwrap();
+    let calls = fixture.probe.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].arguments, json!({"command": "current-command"}));
+    assert!(calls[0].generation.is_none());
+    assert_eq!(result_message(&session, "result-old"), old);
+    assert!(result_message(&session, "result-current")["content"]
+        .as_str()
+        .unwrap()
+        .starts_with("REAL OUTPUT"));
+    assert!(fixture.probe.provider_calls.load(Ordering::SeqCst) > 0);
+}
+
+#[tokio::test]
+async fn typed_public_resume_restores_exact_once_after_storage_and_serde_reload() {
+    let fixture = Fixture::new().await;
+    let (mut session, request) = parked("typed-restart", true);
+    let old = result_message(&session, "result-old");
+    fixture.repo.save(&mut session).await.unwrap();
+    fixture.approve(&request).await;
+    let mut session = fixture.reload(&session.id).await;
+    let config = Arc::new(PermissionConfig::new());
+    let agent = fixture.agent(Some(config.clone()), true, false, None);
+    agent.resume(&mut session).await.unwrap();
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 1);
+    let calls = fixture.probe.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].arguments, json!({"command": "current-command"}));
+    assert_eq!(calls[0].generation.as_deref(), Some(CURRENT));
+    assert!(calls[0].supervisor_absent);
+    assert_eq!(calls[0].flags, ToolExecutionSessionFlags::default());
+    assert!(!config.consume_once_for_generation(
+        &session.id,
+        CALL,
+        CURRENT,
+        PermissionType::ExecuteCommand,
+        "current-command"
+    ));
+    assert_eq!(result_message(&session, "result-old"), old);
+    assert!(fixture.probe.provider_calls.load(Ordering::SeqCst) > 0);
+}
+
+async fn events(mut receiver: mpsc::Receiver<AgentEvent>) -> Vec<AgentEvent> {
+    tokio::time::timeout(std::time::Duration::from_secs(10), async move {
+        let mut events = Vec::new();
+        while let Some(event) = receiver.recv().await {
+            events.push(event);
+        }
+        events
+    })
+    .await
+    .expect("SDK stream must terminate")
+}
+
+fn replay_state(session: &Session) -> Value {
+    json!({
+        "pending": session.pending_question,
+        "call": session.metadata.get(PERMISSION_REEXECUTE_METADATA_KEY),
+        "generation": session.metadata.get(PERMISSION_REEXECUTE_GENERATION_METADATA_KEY),
+        "suspend_reason": session.metadata.get("runtime.suspend_reason"),
+        "current": result_message(session, "result-current"),
+        "old": result_message(session, "result-old"),
+    })
+}
+
+fn alias_call() -> ToolCall {
+    ToolCall {
+        id: CALL.into(),
+        tool_type: "function".into(),
+        function: FunctionCall {
+            name: "execute_command".into(),
+            arguments: json!({"command": "current-command"}).to_string(),
+        },
+    }
+}
+
+fn current_request(session: &Session) -> PermissionRequest {
+    let result = session
+        .messages
+        .iter()
+        .rev()
+        .find(|message| message.tool_call_id.as_deref() == Some(CALL))
+        .unwrap();
+    let payload: Value = serde_json::from_str(&result.content).unwrap();
+    serde_json::from_value(payload["permission_request"].clone()).unwrap()
+}
+
+fn alias_config() -> Arc<PermissionConfig> {
+    let config = Arc::new(PermissionConfig::new());
+    config.set_ask_rules(["Bash(current-command)".into(), "execute_command".into()]);
+    config
+}
+
+async fn alias_pending_fixture() -> (Fixture, Session, PermissionRequest) {
+    let fixture = Fixture::new().await;
+    let agent = fixture.registered_agent(alias_config(), &["Bash"]);
+    *fixture.probe.next_call.lock().unwrap() = Some(alias_call());
+    let initial_events =
+        events(agent.run_stream(Session::new("alias-pending", "test-model"), "operate")).await;
+    assert!(initial_events
+        .iter()
+        .any(|event| matches!(event, AgentEvent::NeedClarification { .. })));
+    let pending = agent.load_session("alias-pending").await.unwrap().unwrap();
+    assert_eq!(
+        pending.pending_question.as_ref().unwrap().tool_name,
+        "execute_command"
+    );
+    assert_eq!(
+        pending.pending_question.as_ref().unwrap().source,
+        PendingQuestionSource::PauseTool
+    );
+    let request = current_request(&pending);
+    assert_eq!(request.tool_name, "Bash");
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+    (fixture, pending, request)
+}
+
+#[tokio::test]
+async fn typed_alias_pending_retains_the_real_original_question_identity() {
+    let (fixture, pending, _) = Box::pin(alias_pending_fixture()).await;
+    let agent = fixture.registered_agent(alias_config(), &["Bash"]);
+    let calls_before = fixture.probe.provider_calls.load(Ordering::SeqCst);
+    let waiting = events(agent.resume_stream(pending)).await;
+    assert_eq!(waiting.len(), 1);
+    assert!(
+        matches!(&waiting[0], AgentEvent::NeedClarification { tool_name: Some(name), .. } if name == "execute_command")
+    );
+    assert_eq!(
+        fixture.probe.provider_calls.load(Ordering::SeqCst),
+        calls_before
+    );
+    assert!(fixture.probe.calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn typed_alias_approved_replay_reaches_the_registered_bash_owner() {
+    let (mut fixture, _, request) = Box::pin(alias_pending_fixture()).await;
+    fixture.approve(&request).await;
+    fixture.reopen_store().await;
+    let agent = fixture.registered_agent(alias_config(), &["Bash"]);
+    let session = agent
+        .load_session(&request.session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let calls_before = fixture.probe.provider_calls.load(Ordering::SeqCst);
+    let completed = events(agent.resume_stream(session)).await;
+    assert!(!completed.iter().any(|event| matches!(
+        event,
+        AgentEvent::Error { .. } | AgentEvent::NeedClarification { .. }
+    )));
+    let calls = fixture.probe.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "Bash");
+    assert_eq!(calls[0].arguments, json!({"command": "current-command"}));
+    assert_eq!(
+        calls[0].generation.as_deref(),
+        Some(request.request_generation.as_str())
+    );
+    assert!(calls[0].supervisor_absent);
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 1);
+    assert!(fixture.probe.provider_calls.load(Ordering::SeqCst) > calls_before);
+}
+
+#[tokio::test]
+async fn typed_alias_exact_custom_owner_cannot_borrow_bash_approval() {
+    let (fixture, mut pending, request) = Box::pin(alias_pending_fixture()).await;
+    let shadow = fixture.registered_agent(alias_config(), &["Bash", "execute_command"]);
+    let before = fixture.probe.provider_calls.load(Ordering::SeqCst);
+    assert!(Box::pin(shadow.resume(&mut pending)).await.is_err());
+    let mut approved = fixture.approve(&request).await;
+    assert!(Box::pin(shadow.resume(&mut approved)).await.is_err());
+    assert!(fixture.probe.calls.lock().unwrap().is_empty());
+    assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), before);
+
+    // A fresh operation actually resolved to the exact custom registration
+    // receives that custom tool's own typed request and can resume normally.
+    *fixture.probe.next_call.lock().unwrap() = Some(alias_call());
+    let initial =
+        events(shadow.run_stream(Session::new("custom-control", "test-model"), "operate")).await;
+    let pending = shadow
+        .load_session("custom-control")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        pending.pending_question.is_some(),
+        "custom tool must request its own permission: {initial:?}; calls={:?}",
+        fixture.probe.calls.lock().unwrap()
+    );
+    assert_eq!(
+        pending.pending_question.as_ref().unwrap().tool_name,
+        "execute_command"
+    );
+    let request = current_request(&pending);
+    assert_eq!(request.tool_name, "execute_command");
+    let approved = fixture.approve(&request).await;
+    let completed = events(shadow.resume_stream(approved)).await;
+    assert!(!completed.iter().any(|event| matches!(
+        event,
+        AgentEvent::Error { .. } | AgentEvent::NeedClarification { .. }
+    )));
+    let calls = fixture.probe.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "execute_command");
+    assert_eq!(
+        calls[0].generation.as_deref(),
+        Some(request.request_generation.as_str())
+    );
+}
+
+#[tokio::test]
+async fn second_context_stays_waiting_across_unanswered_public_entries_and_restart() {
+    let mut fixture = Fixture::new().await;
+    let (mut session, request_a) = parked("multiple-contexts", true);
+    let old = result_message(&session, "result-old");
+    fixture.repo.save(&mut session).await.unwrap();
+    let session = fixture.approve(&request_a).await;
+    let agent = fixture.agent(Some(Arc::new(PermissionConfig::new())), true, true, None);
+    let first_events = events(agent.resume_stream(session)).await;
+    drop(agent);
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+    assert!(!fixture.directory.path().join("actions.log").exists());
+    assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), 0);
+    assert!(first_events.iter().any(|event| matches!(event, AgentEvent::NeedClarification { tool_call_id: Some(id), .. } if id == CALL)));
+    assert!(!first_events.iter().any(|event| matches!(
+        event,
+        AgentEvent::Error { .. } | AgentEvent::Complete { .. }
+    )));
+    let pending = fixture.reload(&request_a.session_id).await;
+    let saved = replay_state(&pending);
+    assert!(pending.pending_question.is_some());
+    assert!(saved["call"].is_null() && saved["generation"].is_null());
+    let result = result_message(&pending, "result-current");
+    assert_eq!(
+        result["metadata"]["permission_request"]["request_generation"],
+        SECOND
+    );
+    assert_eq!(
+        result["metadata"]["permission.replay_approvals.v1"][0]["request"]["request_generation"],
+        CURRENT
+    );
+    assert!(result["metadata"]
+        .get("permission_decision_receipt")
+        .is_none());
+    assert_eq!(result_message(&pending, "result-old"), old);
+
+    // Box each test phase to bound the orchestration frame. Calls within each
+    // phase remain direct and consecutive, with no spawn or scheduler yield.
+    Box::pin(assert_wait_releases_direct_ownership(&fixture, &pending)).await;
+    Box::pin(assert_contradictory_wait_is_rejected(&fixture, &pending)).await;
+    Box::pin(assert_unanswered_public_entries_stay_waiting(
+        &fixture, &pending,
+    ))
+    .await;
+    Box::pin(approve_second_context_and_resume(&mut fixture, &pending)).await;
+}
+
+async fn assert_wait_releases_direct_ownership(fixture: &Fixture, pending: &Session) {
+    let saved = replay_state(pending);
+    std::fs::write(fixture.directory.path().join("config.json"), r#"{
+        "provider": "anthropic", "providers": { "anthropic": { "api_key": "test-key", "model": "test-model" } }
+    }"#).unwrap();
+    let delivery_builder = AgentBuilder::new()
+        .model("test-model")
+        .provider(fixture.probe.clone())
+        .session_delivery(SessionActivationRouter::new());
+    let delivery = Box::pin(
+        delivery_builder.with_defaults_for_data_dir(fixture.directory.path().to_path_buf()),
+    )
+    .await
+    .unwrap()
+    .build()
+    .unwrap();
+    let mut repeated = delivery.load_session(&pending.id).await.unwrap().unwrap();
+    assert_eq!(replay_state(&repeated), saved);
+    Box::pin(delivery.resume(&mut repeated)).await.unwrap();
+    // No yield or retry: a handled wait must release its logical execution
+    // ownership before returning to the caller.
+    Box::pin(delivery.run_session(&mut repeated)).await.unwrap();
+    assert_eq!(replay_state(&repeated), saved);
+    let mut orphaned = repeated.clone();
+    orphaned.metadata.insert(
+        PERMISSION_REEXECUTE_GENERATION_METADATA_KEY.into(),
+        CURRENT.into(),
+    );
+    assert!(Box::pin(delivery.resume(&mut orphaned)).await.is_err());
+    Box::pin(delivery.resume(&mut repeated)).await.unwrap();
+    assert_eq!(replay_state(&repeated), saved);
+}
+
+async fn assert_contradictory_wait_is_rejected(fixture: &Fixture, pending: &Session) {
+    for case in [
+        "old-markers",
+        "conflicting-request",
+        "malformed-payload-request",
+        "unexpected-receipt",
+    ] {
+        let mut contradictory = pending.clone();
+        let message = contradictory
+            .messages
+            .iter_mut()
+            .find(|message| message.id == "result-current")
+            .unwrap();
+        let mut payload: Value = serde_json::from_str(&message.content).unwrap();
+        match case {
+            "old-markers" => {
+                contradictory
+                    .metadata
+                    .insert(PERMISSION_REEXECUTE_METADATA_KEY.into(), CALL.into());
+                contradictory.metadata.insert(
+                    PERMISSION_REEXECUTE_GENERATION_METADATA_KEY.into(),
+                    CURRENT.into(),
+                );
+            }
+            "conflicting-request" => {
+                payload["permission_request"]["resource"] = json!("different-resource")
+            }
+            "malformed-payload-request" => payload["permission_request"] = Value::Null,
+            "unexpected-receipt" => payload["permission_decision_receipt"] = Value::Null,
+            _ => unreachable!(),
+        }
+        message.content = payload.to_string();
+        let before = replay_state(&contradictory);
+        let fresh = fixture.agent(Some(Arc::new(PermissionConfig::new())), true, true, None);
+        assert!(
+            Box::pin(fresh.resume(&mut contradictory)).await.is_err(),
+            "must reject {case}"
+        );
+        assert_eq!(replay_state(&contradictory), before);
+        assert_eq!(fixture.probe.calls.lock().unwrap().len(), 1);
+        assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), 0);
+    }
+}
+
+async fn assert_unanswered_public_entries_stay_waiting(fixture: &Fixture, pending: &Session) {
+    let saved = replay_state(pending);
+    for entry in ["resume", "run_session", "continue", "Approve", "stream"] {
+        let mut reloaded = fixture.reload(&pending.id).await;
+        let messages_before = serde_json::to_value(&reloaded.messages).unwrap();
+        let fresh = fixture.agent(Some(Arc::new(PermissionConfig::new())), true, true, None);
+        match entry {
+            "resume" => Box::pin(fresh.resume(&mut reloaded)).await.unwrap(),
+            "run_session" => Box::pin(fresh.run_session(&mut reloaded)).await.unwrap(),
+            "stream" => {
+                let waiting_events = events(fresh.run_stream(reloaded.clone(), "Approve")).await;
+                assert_eq!(waiting_events.iter().filter(|event| matches!(event, AgentEvent::NeedClarification {
+                    tool_call_id: Some(id), question, ..
+                } if id == CALL && question == &pending.pending_question.as_ref().unwrap().question)).count(), 1);
+                assert!(!waiting_events.iter().any(|event| matches!(
+                    event,
+                    AgentEvent::ToolComplete { .. }
+                        | AgentEvent::Error { .. }
+                        | AgentEvent::ToolLifecycle { .. }
+                        | AgentEvent::Complete { .. }
+                )));
+            }
+            input => Box::pin(fresh.run(&mut reloaded, input)).await.unwrap(),
+        }
+        assert_eq!(replay_state(&reloaded), saved, "unanswered {entry}");
+        if matches!(entry, "continue" | "Approve") {
+            let last = reloaded.messages.pop().unwrap();
+            assert!(matches!(last.role, Role::User));
+            assert_eq!(last.content, entry);
+        }
+        assert_eq!(
+            serde_json::to_value(&reloaded.messages).unwrap(),
+            messages_before
+        );
+        assert_eq!(fixture.probe.calls.lock().unwrap().len(), 1);
+        assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+        assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(replay_state(&fixture.reload(&pending.id).await), saved);
+    }
+}
+
+async fn approve_second_context_and_resume(fixture: &mut Fixture, pending: &Session) {
+    let result = result_message(pending, "result-current");
+    let request_b: PermissionRequest =
+        serde_json::from_value(result["metadata"]["permission_request"].clone()).unwrap();
+    let approved = fixture.approve(&request_b).await;
+    let old_store = fixture.store.clone();
+    let old_persistence = fixture.persistence.clone();
+    fixture.reopen_store().await;
+    assert!(!Arc::ptr_eq(&old_store, &fixture.store));
+    assert!(!Arc::ptr_eq(&old_persistence, &fixture.persistence));
+    drop((old_store, old_persistence));
+    let final_config = Arc::new(PermissionConfig::new());
+    let fresh = fixture.agent(Some(final_config.clone()), true, true, None);
+    let loaded = fresh.load_session(&pending.id).await.unwrap().unwrap();
+    let mut session: Session =
+        serde_json::from_slice(&serde_json::to_vec(&loaded).unwrap()).unwrap();
+    assert_eq!(replay_state(&session), replay_state(&approved));
+    Box::pin(fresh.resume(&mut session)).await.unwrap();
+    let calls = fixture.probe.calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].generation.as_deref(), Some(CURRENT));
+    assert_eq!(calls[1].generation.as_deref(), Some(SECOND));
+    assert!(calls
+        .iter()
+        .all(|call| call.supervisor_absent
+            && call.arguments == json!({"command": "current-command"})));
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        std::fs::read_to_string(fixture.directory.path().join("actions.log")).unwrap(),
+        "physical action\n"
+    );
+    assert!(fixture.probe.provider_calls.load(Ordering::SeqCst) > 0);
+    assert_eq!(
+        result_message(&session, "result-old"),
+        result_message(pending, "result-old")
+    );
+    for (kind, resource) in [
+        (PermissionType::ExecuteCommand, "current-command"),
+        (PermissionType::WriteFile, "second-resource"),
+    ] {
+        assert!(!final_config.consume_once_for_generation(
+            &session.id,
+            CALL,
+            SECOND,
+            kind,
+            resource
+        ));
+    }
+}
+
+#[tokio::test]
+async fn invalid_typed_replay_is_rejected_before_executor_or_provider() {
+    for case in [
+        "orphan",
+        "empty-marker",
+        "unknown",
+        "old-still-present",
+        "missing-marker",
+        "missing-receipt",
+        "wrong-session",
+        "wrong-decision-generation",
+        "missing-config",
+        "malformed-request",
+        "blank-request-generation",
+        "receipt-without-request",
+        "wrong-tool",
+        "denied-receipt",
+        "non-tool-result",
+    ] {
+        let fixture = Fixture::new().await;
+        let (mut session, request) = parked(&format!("invalid-{case}"), true);
+        fixture.repo.save(&mut session).await.unwrap();
+        let mut session = fixture.approve(&request).await;
+        let result = session
+            .messages
+            .iter_mut()
+            .find(|message| message.id == "result-current")
+            .unwrap();
+        let metadata = result.metadata.as_mut().unwrap();
+        match case {
+            "orphan" => {
+                session.metadata.remove(PERMISSION_REEXECUTE_METADATA_KEY);
+            }
+            "empty-marker" | "unknown" | "old-still-present" => {
+                session.metadata.insert(
+                    PERMISSION_REEXECUTE_GENERATION_METADATA_KEY.into(),
+                    match case {
+                        "empty-marker" => "",
+                        "unknown" => "unknown",
+                        _ => "generation-old",
+                    }
+                    .into(),
+                );
+            }
+            "missing-marker" => {
+                session
+                    .metadata
+                    .remove(PERMISSION_REEXECUTE_GENERATION_METADATA_KEY);
+            }
+            "missing-receipt" => {
+                metadata
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("permission_decision_receipt");
+            }
+            "wrong-session" => {
+                metadata["permission_decision_receipt"]["session_id"] = json!("another-session")
+            }
+            "wrong-decision-generation" => {
+                metadata["permission_decision_receipt"]["decision"]["request_generation"] =
+                    json!("another-generation")
+            }
+            "malformed-request" => metadata["permission_request"] = Value::Null,
+            "blank-request-generation" => {
+                metadata["permission_request"]["request_generation"] = json!(" ")
+            }
+            "receipt-without-request" => {
+                metadata
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("permission_request");
+            }
+            "wrong-tool" => metadata["permission_request"]["tool_name"] = json!("Write"),
+            "denied-receipt" => {
+                metadata["permission_decision_receipt"]["decision"]["decision"] =
+                    json!(PermissionDecisionKind::DenyOnce)
+            }
+            "non-tool-result" => result.role = Role::User,
+            "missing-config" => {}
+            _ => unreachable!(),
+        }
+        fixture.repo.save(&mut session).await.unwrap();
+        let before = replay_state(&session);
+        let config = (case != "missing-config").then(|| Arc::new(PermissionConfig::new()));
+        let agent = fixture.agent(config, true, false, None);
+        assert!(
+            agent.resume(&mut session).await.is_err(),
+            "must reject {case}"
+        );
+        assert_eq!(replay_state(&session), before, "preserve rejected {case}");
+        assert_eq!(
+            fixture.probe.calls.lock().unwrap().len(),
+            0,
+            "executor {case}"
+        );
+        assert_eq!(
+            fixture.probe.provider_calls.load(Ordering::SeqCst),
+            0,
+            "provider {case}"
+        );
+        assert!(!fixture.directory.path().join("actions.log").exists());
+    }
+}
+
+#[tokio::test]
+async fn typed_text_answer_cannot_downgrade_to_legacy_replay() {
+    let fixture = Fixture::new().await;
+    let (mut session, _) = parked("typed-text-answer", true);
+    fixture.repo.save(&mut session).await.unwrap();
+    let agent = fixture.agent(Some(Arc::new(PermissionConfig::new())), true, false, None);
+    let answered = agent.answer(&session.id, "Approve").await.unwrap();
+    assert!(answered.session.pending_question.is_none());
+    assert!(!answered.permission_grants.is_empty());
+    assert!(answered
+        .session
+        .metadata
+        .get(PERMISSION_REEXECUTE_GENERATION_METADATA_KEY)
+        .is_none());
+    let result = result_message(&answered.session, "result-current");
+    assert!(result["metadata"]["permission_request"].is_object());
+    assert!(result["metadata"]
+        .get("permission_decision_receipt")
+        .is_none());
+    let before = replay_state(&answered.session);
+    let rejected = events(agent.resume_stream(answered.session)).await;
+    assert_eq!(
+        rejected
+            .iter()
+            .filter(|event| matches!(event, AgentEvent::Error { .. }))
+            .count(),
+        1
+    );
+    assert!(!rejected.iter().any(|event| matches!(
+        event,
+        AgentEvent::ToolLifecycle { .. }
+            | AgentEvent::ToolComplete { .. }
+            | AgentEvent::NeedClarification { .. }
+            | AgentEvent::Complete { .. }
+    )));
+    assert_eq!(fixture.probe.calls.lock().unwrap().len(), 0);
+    assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(replay_state(&fixture.reload(&session.id).await), before);
+}
+
+#[tokio::test]
+async fn admitted_tool_errors_are_saved_before_normal_model_recovery() {
+    for typed in [false, true] {
+        let fixture = Fixture::new().await;
+        let (mut session, request) = parked("execution-error", typed);
+        fixture.repo.save(&mut session).await.unwrap();
+        let agent = fixture.agent(Some(Arc::new(PermissionConfig::new())), typed, false, None);
+        let session = if typed {
+            fixture.approve(&request).await
+        } else {
+            agent.answer(&session.id, "Approve").await.unwrap().session
+        };
+        let old = result_message(&session, "result-old");
+        fixture.probe.fail_execution.store(true, Ordering::SeqCst);
+        let completed = events(agent.resume_stream(session)).await;
+        assert_eq!(completed.iter().filter(|event| matches!(event, AgentEvent::ToolLifecycle { phase, .. } if phase == "error")).count(), 1);
+        assert!(!completed.iter().any(|event| matches!(
+            event,
+            AgentEvent::Error { .. } | AgentEvent::ToolComplete { .. }
+        )));
+        assert_eq!(fixture.probe.calls.lock().unwrap().len(), 1);
+        assert!(fixture.probe.provider_calls.load(Ordering::SeqCst) > 0);
+        assert!(!fixture.directory.path().join("actions.log").exists());
+        let saved = fixture.reload(&request.session_id).await;
+        let result = result_message(&saved, "result-current");
+        assert_eq!(result["tool_success"], false);
+        assert!(result["content"]
+            .as_str()
+            .unwrap()
+            .contains("intentional execution failure"));
+        assert_eq!(result_message(&saved, "result-old"), old);
+        assert!(!saved
+            .metadata
+            .contains_key(PERMISSION_REEXECUTE_METADATA_KEY));
+        assert!(!saved
+            .metadata
+            .contains_key(PERMISSION_REEXECUTE_GENERATION_METADATA_KEY));
+    }
+}
+
+#[tokio::test]
+async fn legacy_pending_question_does_not_inherit_an_old_typed_wait() {
+    let fixture = Fixture::new().await;
+    let (mut session, _) = parked("ordinary-pending", false);
+    let old = session
+        .messages
+        .iter_mut()
+        .find(|message| message.id == "result-old")
+        .unwrap();
+    old.metadata = Some(
+        json!({"permission_request": request(&session.id, "old-typed", "old-command", PermissionType::ExecuteCommand)}),
+    );
+    session.pending_question.as_mut().unwrap().source = PendingQuestionSource::AgenticClarification;
+    fixture.repo.save(&mut session).await.unwrap();
+    let agent = fixture.agent(None, false, false, None);
+    Box::pin(agent.run_session(&mut session)).await.unwrap();
+    assert!(fixture.probe.provider_calls.load(Ordering::SeqCst) > 0);
+    assert!(fixture.probe.calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn latest_plan_blocks_current_occurrence_before_public_provider_continuation() {
+    let fixture = Fixture::new().await;
+    let (mut session, request) = parked("typed-plan", true);
+    fixture.repo.save(&mut session).await.unwrap();
+    let mut stale = fixture.approve(&request).await;
+    let old = result_message(&stale, "result-old");
+    stale
+        .agent_runtime_state
+        .as_mut()
+        .unwrap()
+        .set_permission_mode(bamboo_domain::SessionPermissionMode::Auto);
+    let mut latest = fixture.reload(&stale.id).await;
+    latest.agent_runtime_state.as_mut().unwrap().plan_mode = Some(serde_json::from_value(json!({
+        "entered_at": "2026-07-31T00:00:00Z", "pre_permission_mode": "default", "status": "exploring",
+    })).unwrap());
+    fixture.repo.save(&mut latest).await.unwrap();
+    let agent = fixture.agent(Some(Arc::new(PermissionConfig::new())), true, false, None);
+    let completed = events(agent.resume_stream(stale)).await;
+    assert!(!completed.iter().any(|event| matches!(
+        event,
+        AgentEvent::ToolLifecycle { .. }
+            | AgentEvent::ToolComplete { .. }
+            | AgentEvent::Error { .. }
+    )));
+    assert_eq!(fixture.probe.calls.lock().unwrap().len(), 0);
+    assert!(fixture.probe.provider_calls.load(Ordering::SeqCst) > 0);
+    let saved = fixture.reload(&session.id).await;
+    assert!(!saved
+        .metadata
+        .contains_key(PERMISSION_REEXECUTE_METADATA_KEY));
+    assert!(!saved
+        .metadata
+        .contains_key(PERMISSION_REEXECUTE_GENERATION_METADATA_KEY));
+    assert_eq!(result_message(&saved, "result-old"), old);
+    let result = result_message(&saved, "result-current");
+    assert_eq!(result["tool_success"], false);
+    assert!(result["content"]
+        .as_str()
+        .unwrap()
+        .contains("Plan mode blocked"));
+}
+
+struct FailReplaySave {
+    inner: Arc<LockedSessionStore>,
+    attempts: AtomicUsize,
+}
+
+#[async_trait]
+impl RuntimeSessionPersistence for FailReplaySave {
+    async fn save_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
+        let result = result_message(session, "result-current");
+        let content = result["content"].as_str().unwrap();
+        if content.starts_with("REAL OUTPUT")
+            || content.starts_with("Plan mode blocked")
+            || result["metadata"]["permission_request"]["request_generation"] == SECOND
+        {
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            return Err(std::io::Error::other("injected replay persistence failure"));
+        }
+        self.inner.save_runtime_session(session).await
+    }
+
+    async fn load_runtime_session(&self, id: &str) -> std::io::Result<Option<Session>> {
+        self.inner.load_runtime_session(id).await
+    }
+}
+
+#[tokio::test]
+async fn output_repark_and_plan_save_failures_stop_provider_and_success_events() {
+    for (scenario, stream) in [
+        ("output", false),
+        ("output", true),
+        ("repark", true),
+        ("plan", false),
+        ("plan", true),
+    ] {
+        let second_context = scenario == "repark";
+        let plan = scenario == "plan";
+        let fixture = Fixture::new().await;
+        let (mut session, request) = parked("save-failure", true);
+        fixture.repo.save(&mut session).await.unwrap();
+        let mut session = fixture.approve(&request).await;
+        if plan {
+            session
+                .agent_runtime_state
+                .as_mut()
+                .unwrap()
+                .set_permission_mode(bamboo_domain::SessionPermissionMode::Auto);
+            let mut latest = fixture.reload(&request.session_id).await;
+            latest.agent_runtime_state.as_mut().unwrap().plan_mode = Some(
+                serde_json::from_value(json!({
+                    "entered_at": "2026-07-31T00:00:00Z",
+                    "pre_permission_mode": "default", "status": "exploring",
+                }))
+                .unwrap(),
+            );
+            fixture.repo.save(&mut latest).await.unwrap();
+        }
+        let durable_before = fixture.reload(&request.session_id).await;
+        let before = replay_state(&durable_before);
+        let runtime_before = serde_json::to_value(&durable_before.agent_runtime_state).unwrap();
+        let persistence = Arc::new(FailReplaySave {
+            inner: fixture.persistence.clone(),
+            attempts: AtomicUsize::new(0),
+        });
+        let agent = fixture.agent(
+            Some(Arc::new(PermissionConfig::new())),
+            true,
+            second_context,
+            Some(persistence.clone()),
+        );
+        if stream {
+            let failed = events(agent.resume_stream(session)).await;
+            assert_eq!(
+                failed
+                    .iter()
+                    .filter(|event| matches!(event, AgentEvent::Error { .. }))
+                    .count(),
+                1
+            );
+            assert!(failed.iter().any(|event| matches!(event, AgentEvent::Error { message } if message.contains("injected replay persistence failure"))));
+            assert_eq!(failed.iter().filter(
+                |event| matches!(event, AgentEvent::ToolLifecycle { phase, .. } if phase == "error")
+            ).count(), usize::from(!plan));
+            if plan {
+                assert!(!failed
+                    .iter()
+                    .any(|event| matches!(event, AgentEvent::ToolLifecycle { .. })));
+            }
+            assert!(!failed.iter().any(|event| matches!(
+                event,
+                AgentEvent::ToolComplete { .. }
+                    | AgentEvent::NeedClarification { .. }
+                    | AgentEvent::Complete { .. }
+            )));
+            assert!(!failed.iter().any(|event| matches!(event, AgentEvent::ToolLifecycle { phase, .. } if phase == "finished")));
+        } else {
+            let error = agent.resume(&mut session).await.unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("injected replay persistence failure"));
+        }
+        assert_eq!(persistence.attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            fixture.probe.calls.lock().unwrap().len(),
+            usize::from(!plan)
+        );
+        assert_eq!(
+            fixture.probe.actions.load(Ordering::SeqCst),
+            usize::from(!second_context && !plan)
+        );
+        assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), 0);
+        let durable_after = fixture.reload(&request.session_id).await;
+        assert_eq!(replay_state(&durable_after), before);
+        assert_eq!(
+            serde_json::to_value(&durable_after.agent_runtime_state).unwrap(),
+            runtime_before
+        );
+    }
+}

--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -40,10 +40,14 @@
 //! The SDK never reimplements the agent loop. `run` / `run_stream` funnel into
 //! `bamboo_engine::Agent::execute` (the single canonical execution path).
 
+mod approval_replay;
 mod builder;
 mod error;
 mod execute_request;
 mod tools;
+
+#[cfg(test)]
+mod approval_replay_tests;
 
 use std::sync::Arc;
 
@@ -52,9 +56,7 @@ pub use builder::AgentBuilder;
 pub use execute_request::ExecuteRequestBuilder;
 use tokio::sync::mpsc;
 
-use bamboo_engine::session_app::approval_replay::{
-    refresh_approval_replay_posture, ApprovalReplayDecision,
-};
+use approval_replay::ReplayDisposition;
 use bamboo_engine::session_app::errors::{SessionLoadError, SessionSaveError};
 use bamboo_engine::session_app::repository::SessionAccess;
 use bamboo_engine::session_app::respond::{
@@ -456,12 +458,39 @@ impl Agent {
         // the re-execution marker `submit_pending_response` set — the gated tool
         // never actually ran (the permission gate intercepted it before
         // execution), so re-run it now for real and write the genuine output back
-        // before the loop resumes. No-op when the marker is absent (the common,
-        // non-permission path), so this is safe to run unconditionally on every
-        // entry into the loop, not just `resume`. See
+        // before the loop resumes. An unanswered typed request also keeps this
+        // entry waiting after its replay markers have been cleared. Check every
+        // ergonomic entry into the loop, not just `resume`. See
         // `reexecute_approved_tool_if_pending` for the full rationale.
-        self.reexecute_approved_tool_if_pending(session, &event_tx)
-            .await?;
+        match self
+            .reexecute_approved_tool_if_pending(session, &event_tx)
+            .await
+        {
+            Ok(ReplayDisposition::Continue) => {}
+            Ok(ReplayDisposition::AwaitingApproval(pending)) => {
+                direct_lease.abandon().await;
+                let _ = event_tx
+                    .send(AgentEvent::NeedClarification {
+                        question: pending.question,
+                        options: (!pending.options.is_empty()).then_some(pending.options),
+                        tool_call_id: Some(pending.tool_call_id),
+                        tool_name: Some(pending.tool_name),
+                        allow_custom: pending.allow_custom,
+                        source: Some(pending.source),
+                    })
+                    .await;
+                return Ok(());
+            }
+            Err(error) => {
+                direct_lease.abandon().await;
+                let _ = event_tx
+                    .send(AgentEvent::Error {
+                        message: error.to_string(),
+                    })
+                    .await;
+                return Err(error);
+            }
+        }
 
         // Apply the instruction as the session's leading System message, set
         // the configured model, and refresh the typed prompt snapshot via the
@@ -496,165 +525,6 @@ impl Agent {
         self.inner
             .execute_direct_registered(session, builder.build(), direct_lease)
             .await
-    }
-
-    /// Port of `bamboo-server`'s `resume_adapter.rs` re-execution logic: after
-    /// [`answer`](Self::answer) approves a permission prompt,
-    /// `submit_pending_response` stamps `session.metadata` with
-    /// [`PERMISSION_REEXECUTE_METADATA_KEY`] (the approved tool call's id) — the
-    /// gated tool was intercepted BEFORE it ran, so its recorded result is only
-    /// the synthetic "Selected response: Approve" placeholder. This re-runs the
-    /// original tool call for real, against the SAME executor the loop itself
-    /// uses ([`bamboo_engine::Agent::default_tools`]), and overwrites the
-    /// placeholder tool-result message with the genuine output — so the resumed
-    /// loop sees what the operation actually did instead of inferring it.
-    ///
-    /// Emits the same `ToolStart`/`ToolComplete` (or `ToolError`) lifecycle
-    /// events onto `event_tx` that a normal dispatch would, so a streaming
-    /// consumer sees the re-run tool card update exactly like the HTTP surface
-    /// does. Best-effort persists the updated session via
-    /// [`persistence`](Self::persistence) so the real output survives even if the
-    /// process stops before the loop's own next save — logged, not propagated,
-    /// since the loop's subsequent save will also capture it.
-    ///
-    /// No-op (returns immediately) when the marker is absent, so it is safe to
-    /// call unconditionally at the top of every execution, not just resumes.
-    async fn reexecute_approved_tool_if_pending(
-        &self,
-        session: &mut Session,
-        event_tx: &mpsc::Sender<AgentEvent>,
-    ) -> Result<(), AgentError> {
-        let Some(tool_call_id) = session
-            .metadata
-            .get(PERMISSION_REEXECUTE_METADATA_KEY)
-            .cloned()
-        else {
-            return Ok(());
-        };
-
-        let Some(tool_call) = find_pending_tool_call(session, &tool_call_id) else {
-            session.metadata.remove(PERMISSION_REEXECUTE_METADATA_KEY);
-            tracing::warn!(
-                session_id = %session.id,
-                tool_call_id = %tool_call_id,
-                "Permission re-exec marker set but tool call not found in history"
-            );
-            return Ok(());
-        };
-
-        let tool_name = tool_call.function.name.clone();
-        let decision = refresh_approval_replay_posture(
-            self.storage().as_ref(),
-            session,
-            self.permission_mode,
-            &tool_name,
-        )
-        .await?;
-
-        let flags = match decision {
-            ApprovalReplayDecision::Execute(flags) => flags,
-            ApprovalReplayDecision::BlockedByPlan(_) => {
-                session.metadata.remove(PERMISSION_REEXECUTE_METADATA_KEY);
-                apply_tool_result(
-                    session,
-                    &tool_call_id,
-                    format!(
-                        "Plan mode blocked approved mutating tool '{tool_name}'; the stale approval was not executed"
-                    ),
-                    false,
-                );
-                if let Err(error) = self.persistence().save_runtime_session(session).await {
-                    tracing::warn!(
-                        session_id = %session.id,
-                        %error,
-                        "Failed to persist Plan-blocked approval replay (loop's own save will retry)"
-                    );
-                }
-                return Ok(());
-            }
-        };
-        session.metadata.remove(PERMISSION_REEXECUTE_METADATA_KEY);
-
-        let executor = self.inner.default_tools();
-        let is_mutating = bamboo_tools::orchestrator::classify_tool(&tool_name)
-            == bamboo_tools::orchestrator::ToolMutability::Mutating;
-
-        // Frame the re-run with the same lifecycle events the normal loop emits
-        // (via ToolEmitter) so a streaming consumer's tool card updates
-        // (running -> finished) and ToolComplete carries the REAL output — raw
-        // `execute_with_context` only streams tool tokens, not lifecycle.
-        let mut emitter = bamboo_tools::ToolEmitter::new(&tool_call.id, &tool_name, is_mutating);
-        emitter.set_auto_approved(true);
-        let _ = event_tx
-            .send(emitter.begin().clone().into_agent_event())
-            .await;
-
-        let exec_result = {
-            let ctx = bamboo_agent_core::tools::ToolExecutionContext {
-                executing_supervisor: None,
-                session_id: Some(session.id.as_str()),
-                root_session_id: Some(if session.root_session_id.trim().is_empty() {
-                    session.id.as_str()
-                } else {
-                    session.root_session_id.as_str()
-                }),
-                tool_call_id: tool_call_id.as_str(),
-                event_tx: Some(event_tx),
-                available_tool_schemas: None,
-                bypass_permissions: flags.bypass_permissions,
-                auto_approve_permissions: flags.auto_approve_permissions,
-                plan_read_only: flags.plan_read_only,
-                can_async_resume: false,
-                bash_completion_sink: None,
-                pre_parsed_args: None,
-            };
-            executor.execute_with_context(&tool_call, ctx).await
-        };
-
-        let (content, success) = match exec_result {
-            Ok(tool_result) => {
-                let _ = event_tx
-                    .send(
-                        emitter
-                            .finish(Some("Re-executed after approval".to_string()))
-                            .clone()
-                            .into_agent_event(),
-                    )
-                    .await;
-                let _ = event_tx
-                    .send(AgentEvent::ToolComplete {
-                        tool_call_id: tool_call.id.clone(),
-                        result: tool_result.clone(),
-                    })
-                    .await;
-                (tool_result.result, tool_result.success)
-            }
-            Err(error) => {
-                let message = format!("Tool re-execution after approval failed: {error}");
-                let _ = event_tx
-                    .send(emitter.error(message.clone()).clone().into_agent_event())
-                    .await;
-                (message, false)
-            }
-        };
-
-        tracing::info!(
-            session_id = %session.id,
-            tool_name = %tool_name,
-            tool_call_id = %tool_call_id,
-            success,
-            "Re-executed approved tool after permission grant"
-        );
-        apply_tool_result(session, &tool_call_id, content, success);
-
-        if let Err(error) = self.persistence().save_runtime_session(session).await {
-            tracing::warn!(
-                session_id = %session.id,
-                %error,
-                "Failed to persist session after tool re-execution (loop's own save will retry)"
-            );
-        }
-        Ok(())
     }
 
     /// Access the shared storage backend.
@@ -734,6 +604,12 @@ impl Agent {
     /// and overwrites the synthetic "Selected response: Approve" placeholder
     /// with the operation's genuine output before the loop continues — see
     /// `reexecute_approved_tool_if_pending`.
+    ///
+    /// This text-only method does not issue typed permission receipts. A typed
+    /// permission decision must be submitted through a typed response adapter
+    /// before resuming. Although a valid text option can consume the pending
+    /// question here, subsequent replay rejects its missing generation/receipt;
+    /// it does not restore the consumed question or infer approval from text.
     ///
     /// NOTE: `ChildApprovalRequested` (an out-of-process sub-agent worker's
     /// gated tool, proxied over the actor protocol) is a SEPARATE mechanism
@@ -1000,32 +876,6 @@ impl SessionAccess for Agent {
 
     async fn save_and_cache(&self, session: &mut Session) -> Result<(), SessionSaveError> {
         SessionAccess::save_session(self, session).await
-    }
-}
-
-/// Find the original tool call (with its arguments) by id in the session
-/// history. Mirrors `bamboo-server`'s `resume_adapter::find_pending_tool_call`.
-fn find_pending_tool_call(
-    session: &Session,
-    tool_call_id: &str,
-) -> Option<bamboo_agent_core::tools::ToolCall> {
-    session.messages.iter().find_map(|message| {
-        message
-            .tool_calls
-            .as_ref()
-            .and_then(|calls| calls.iter().find(|call| call.id == tool_call_id).cloned())
-    })
-}
-
-/// Overwrite the tool-result message for `tool_call_id` with the real tool
-/// output. Mirrors `bamboo-server`'s `resume_adapter::apply_tool_result`.
-fn apply_tool_result(session: &mut Session, tool_call_id: &str, content: String, success: bool) {
-    for message in &mut session.messages {
-        if message.tool_call_id.as_deref() == Some(tool_call_id) {
-            message.content = content;
-            message.tool_success = Some(success);
-            return;
-        }
     }
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/agent.rs
+++ b/crates/engine/bamboo-engine/src/runtime/agent.rs
@@ -37,6 +37,16 @@ pub struct DirectExecutionLease {
     registration: Option<crate::session_activation::SessionRunRegistration>,
 }
 
+impl DirectExecutionLease {
+    /// Release ownership before returning a handled pre-execution stop to an
+    /// SDK caller, so its next resume does not race the asynchronous Drop path.
+    pub async fn abandon(mut self) {
+        if let Some(registration) = self.registration.take() {
+            registration.abandon().await;
+        }
+    }
+}
+
 impl Agent {
     /// Wrap an existing [`AgentRuntime`] in an `Agent`.
     pub fn from_runtime(runtime: Arc<AgentRuntime>) -> Self {


### PR DESCRIPTION
## Summary

SDK approval replay could select an older call/result when a provider reused a tool-call ID, lose the typed permission context after reload, or continue into the model after another permission gate. Bind replay to the newest concrete result and its generation, restore the existing typed receipt/approval ledger, and save the real result or renewed pending request before continuing or publishing success.

Repeated unanswered `run`, `run_session`, `resume` and stream calls remain waiting, including after reopening storage. Normal User text does not authorize the pending request. Release the existing direct execution lease before returning a handled wait or replay error so the same Agent can immediately re-enter.

Typed tool identity follows the existing catalog resolver and exact dispatch interface: legal builtin aliases work, while an exact custom registration cannot borrow a builtin approval. Preserve original call spelling/arguments, legacy dispatch, current Plan restrictions and normal model recovery after a successfully saved executor failure.

Closes #1113. This is a prerequisite of #1071.

## Scope

Four files: the SDK replay adapter and facade, a ten-line wrapper around the existing engine lease-abandon operation, and focused behavioral tests. Production net +220 lines; no new approval store, queue or lifecycle protocol.

The raw `Agent.execute` entry point retains its existing boundary. `answer()` remains text-only: answering a typed request through it does not mint a typed receipt, and replay rejects that state. Supervisor authority transport, model management tools and the user-facing Supervisor flow remain separate work under #1071.

## Test Plan

Exact candidate: `c69ee771da6df63b65b2ea6b309abb3f770e3df8`, based on `d7ce9775833fe4b0a79bec018d2e584b61328667`; complete tree `99e540fc67d9e3f24b38548a2834796a254e01b9`.

| Verification | Result |
| --- | --- |
| Original d7 production with the final identical 12-test file | 1 passed / 11 failed, successfully compiled |
| Earlier strict-name candidate with real alias/custom-control tests | 1 passed / 2 failed; custom control passed |
| Final focused SDK matrix, default test settings | 12 passed |
| Final focused matrix, supplementary test profile with debug assertions disabled | 12 passed |
| Independent review of the exact committed source and test evidence | PASS; both earlier findings fixed and re-reviewed |
| All SDK unit tests in the final complete backend run | 71 passed / 0 failed |
| Final formatting | PASS |
| Final exact CI Clippy | PASS |
| Both complete local `cargo test --locked -- --test-threads=4` attempts | FAIL (exit 101): the same unchanged Skills workspace watcher; see #1117 |
| Original full-run test executable, both watcher cases rerun | 2 passed / 0 failed |
| Pristine d7 baseline with the same default-workspace compilation and unfiltered 183-case Skills harness | 182 passed / 1 failed: exact same workspace watcher diagnostic |
| Final remote complete backend suites: `cargo test --all-features --lib --tests` and `cargo test --tests` | PASS; the watcher and previously failing H1 test both pass in both feature selections |
| Real SSH/SFTP integration, example build and all live CI checks | PASS: 18 successful checks; 2 expected dev promotion skips |

The matrix exercises repeated call/result IDs and different arguments, real typed AllowOnce response persistence, serialization and storage reopening, second-context repark, repeated unanswered public entry points, invalid generations/receipts/configuration, text-only answer rejection, Plan changes, output/repark/Plan save failures and event ordering. Alias cases use the normal SDK runner and real Builtin permission gate; the exact custom tool control explicitly requests its own permission through PermissionConfig::evaluate.

The defaults-backed activation test loads the same durable home through a new Agent and performs consecutive wait/wait and error/retry calls. Final B approval recovery recreates StoreV2, persistence, repository/cache and Agent/config, then reloads and checks the saved state. These are fresh-object tests within one process, not an independent OS-process restart. Controlled tool probes are used; the supplementary assertion profile is not an optimized release binary or a replacement for remote CI.

Save failures stop the current SDK call before provider continuation or success publication. A physical tool action or in-memory change may already have occurred; no action rollback or physical exactly-once guarantee is claimed.

## Complete-run failures and final validation assessment

Both complete local commands stopped at `bamboo-skills` with the same workspace hot-discovery timeout. SDK 71/71, engine 1493/1493 and server 1992/1992 non-ignored tests had passed. A pristine d7 baseline was then compiled using the same default workspace selection; the Skills test-unit fingerprint and all 216 dependency feature/profile signatures match. Its single unfiltered 183-test run reproduced the exact failure: Ready, received 5, rejected 3, coalesced 3, reloads 0 and no processed event. The plugin watcher passed in this matched baseline run. Earlier focused retests and a package-scoped baseline are retained separately.

This is a reproduced pre-existing local failure, tracked in #1117. Both local complete runs remain FAIL; no assertion, timeout, test selection, stack setting, watcher source or dependency was changed to obtain a green result. The final backend validation uses the successful complete remote suites together with passing local affected suites and independent review. This does not establish a green full local macOS run or a root cause for the watcher.

The first remote Test attempt failed at an unchanged H1 graceful-stop fixture, already tracked in #878. Only failed jobs were requested for rerun. The final [Test job](https://github.com/bigduu/Bamboo-agent/actions/runs/34248044199/job/102146266885) passed both complete backend test commands, real SSH/SFTP transport and example compilation. GitHub checked out temporary merge `5881bc3f0cf010dbb940c8e276186df6a665388c` (c69 into d7); its complete tree is verified equal to the candidate `99e540fc67d9e3f24b38548a2834796a254e01b9`. This temporary ref is not a delivered squash commit.

Final readiness still requires the current exact head/base, acceptance, independent review, review-thread and protection checks. Supervisor authority transport and the complete model/UI flow remain outstanding under #1071.
