### PR TITLE
feat: preserve Supervisor identity through approved replay (#1119)

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/approval_replay.rs
+++ b/crates/app/bamboo-sdk/src/agent/approval_replay.rs
@@ -6,8 +6,9 @@ use bamboo_agent_core::{PendingQuestion, PendingQuestionSource};
 use bamboo_domain::resolve_tool_reference_name;
 use bamboo_engine::session_app::approval_replay::{
     apply_permission_replay_result, find_permission_replay_target, refresh_approval_replay_posture,
-    repark_permission_replay, restore_permission_replay_authorization, ApprovalReplayDecision,
-    PermissionReplayTarget,
+    repark_permission_replay, restore_permission_replay_authorization,
+    validate_pending_permission_replay_authority, validate_permission_replay_authority,
+    ApprovalReplayDecision, PermissionReplayTarget,
 };
 use bamboo_engine::session_app::respond::{
     PERMISSION_REEXECUTE_GENERATION_METADATA_KEY, PERMISSION_REEXECUTE_METADATA_KEY,
@@ -37,6 +38,16 @@ fn latest_result<'a>(session: &'a Session, id: &str) -> Option<&'a Message> {
 /// must never fall through the legacy path because generation extraction failed.
 fn typed_request(message: &Message) -> Result<Option<PermissionRequest>, AgentError> {
     let payload = serde_json::from_str::<serde_json::Value>(&message.content).ok();
+    let authority_key =
+        bamboo_agent_core::tools::ExecutingSupervisorObservation::PERMISSION_REPLAY_METADATA_KEY;
+    if payload
+        .as_ref()
+        .is_some_and(|value| value.get(authority_key).is_some())
+    {
+        return Err(invalid(
+            "Supervisor authority cannot originate in the result payload",
+        ));
+    }
     let metadata_request = message
         .metadata
         .as_ref()
@@ -58,13 +69,11 @@ fn typed_request(message: &Message) -> Result<Option<PermissionRequest>, AgentEr
         return Err(invalid("typed result does not have the Tool role"));
     }
     if request.is_none()
-        && (message
-            .metadata
+        && (message.metadata.as_ref().is_some_and(|value| {
+            value.get("permission_decision_receipt").is_some() || value.get(authority_key).is_some()
+        }) || payload
             .as_ref()
-            .is_some_and(|value| value.get("permission_decision_receipt").is_some())
-            || payload
-                .as_ref()
-                .is_some_and(|value| value.get("permission_decision_receipt").is_some()))
+            .is_some_and(|value| value.get("permission_decision_receipt").is_some()))
     {
         return Err(invalid("receipt is missing its typed request"));
     }
@@ -130,7 +139,8 @@ impl Agent {
                     let target =
                         find_permission_replay_target(session, &pending.tool_call_id, None)
                             .ok_or_else(|| invalid("pending operation is missing its tool call"))?;
-                    validate_request(session, &target, &request, executor.as_ref())?;
+                    let owner = validate_request(session, &target, &request, executor.as_ref())?;
+                    validate_pending_permission_replay_authority(session, &target, &owner)?;
                     let payload = serde_json::from_str::<serde_json::Value>(&message.content).ok();
                     if call_id.is_some()
                         || generation.is_some()
@@ -204,6 +214,12 @@ impl Agent {
 
         let tool_call = target.tool_call();
         let tool_name = &tool_call.function.name;
+        let replay_owner = execution_name.clone().unwrap_or_else(|| {
+            resolve_tool_reference_name(tool_name, |name| executor.owns_exact_tool(name))
+                .unwrap_or_else(|| tool_name.clone())
+        });
+        let executing_supervisor =
+            validate_permission_replay_authority(session, &target, &replay_owner)?;
         let decision = refresh_approval_replay_posture(
             self.storage().as_ref(),
             session,
@@ -217,7 +233,7 @@ impl Agent {
                 .as_ref()
                 .and_then(|checker| checker.permission_config())
                 .ok_or_else(|| invalid("typed authorization requires a PermissionConfig"))?;
-            restore_permission_replay_authorization(&config, session, &target)?;
+            restore_permission_replay_authorization(&config, session, &target, &replay_owner)?;
         }
         let flags = match decision {
             ApprovalReplayDecision::Execute(flags) => flags,
@@ -241,7 +257,7 @@ impl Agent {
             .await;
         let completed = async {
             let ctx = bamboo_agent_core::tools::ToolExecutionContext {
-                executing_supervisor: None,
+                executing_supervisor,
                 session_id: Some(session.id.as_str()),
                 root_session_id: Some(if session.root_session_id.trim().is_empty() {
                     session.id.as_str()
@@ -286,7 +302,7 @@ impl Agent {
                     )
                 }
             };
-            let reparked = repark_permission_replay(session, &target, &result)?;
+            let reparked = repark_permission_replay(session, &target, &result, &replay_owner)?;
             if reparked.is_none()
                 && !apply_permission_replay_result(
                     session,

--- a/crates/app/bamboo-sdk/src/agent/approval_replay_tests.rs
+++ b/crates/app/bamboo-sdk/src/agent/approval_replay_tests.rs
@@ -24,6 +24,9 @@ const CALL: &str = "reused-call";
 const CURRENT: &str = "generation-a";
 const SECOND: &str = "generation-b";
 
+#[path = "approval_supervisor_tests.rs"]
+mod supervisor;
+
 #[derive(Debug)]
 struct Invocation {
     name: String,

--- a/crates/app/bamboo-sdk/src/agent/approval_supervisor_process_tests.rs
+++ b/crates/app/bamboo-sdk/src/agent/approval_supervisor_process_tests.rs
@@ -1,0 +1,291 @@
+//! Four genuine process lifetimes share only completed durable writes.
+
+use super::*;
+use std::path::Path;
+
+const CHILD_TEST: &str =
+    "agent::approval_replay_tests::supervisor::process::supervisor_approval_process_child";
+const PROCESS_HOME: &str = "BAMBOO_SUPERVISOR_APPROVAL_TEST_HOME";
+const PROCESS_STAGE: &str = "BAMBOO_SUPERVISOR_APPROVAL_TEST_STAGE";
+
+struct StageProcess(std::process::Child);
+impl Drop for StageProcess {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+async fn fixture_at(home: &Path) -> Fixture {
+    let directory = tempfile::tempdir_in(home).unwrap();
+    let store = Arc::new(SessionStoreV2::new(home.to_path_buf()).await.unwrap());
+    let persistence = Arc::new(LockedSessionStore::new(store.clone()));
+    let repo = SessionRepository::new(SessionCache::default(), store.clone(), persistence.clone());
+    Fixture {
+        directory,
+        store,
+        persistence,
+        repo,
+        probe: Arc::new(Probe::default()),
+    }
+}
+
+fn canonical_config(home: &Path) -> Arc<PermissionConfig> {
+    let section = bamboo_tools::permission::PermissionSection::open(home).unwrap();
+    let snapshot = section.snapshot();
+    let config = Arc::new(PermissionConfig::new());
+    config.publish_persistent_policy(snapshot.revision, snapshot.data.as_ref());
+    assert_eq!(config.mode(), PermissionMode::Default);
+    config
+}
+
+async fn run_stage(home: &Path, stage: u32) {
+    let fixture = fixture_at(home).await;
+    if stage == 1 {
+        bamboo_tools::permission::storage::PermissionStorage::new(home)
+            .save(alias_config().as_ref())
+            .await
+            .unwrap();
+        setup_supervisor(&fixture).await;
+    }
+    let config = canonical_config(home);
+    let id = bamboo_domain::DEFAULT_SUPERVISOR_SESSION_ID;
+    let session = fixture.reload(id).await;
+    let original = bamboo_domain::SupervisorReference {
+        session_id: id.into(),
+        incarnation_id: match session.authority_identity {
+            bamboo_domain::SessionAuthorityIdentity::Supervisor { incarnation_id } => {
+                incarnation_id
+            }
+            _ => panic!("real bootstrap must retain its authority"),
+        },
+    };
+    if stage != 1 {
+        let request = serde_json::from_value::<PermissionRequest>(
+            session.messages[result_index(&session)]
+                .metadata
+                .as_ref()
+                .unwrap()["permission_request"]
+                .clone(),
+        )
+        .unwrap();
+        assert!(!config.consume_once_for_generation(
+            id,
+            CALL,
+            &request.request_generation,
+            request.permission_type,
+            &request.resource
+        ));
+        assert!(config
+            .decision_receipt(id, CALL, &request.request_generation)
+            .is_none());
+    }
+    let agent = protected_agent_with(&fixture, config, &["Bash"], true, None);
+    match stage {
+        1 => {
+            *fixture.probe.next_call.lock().unwrap() = Some(alias_call());
+            let output = events(agent.run_stream(session, "attach the permitted Root")).await;
+            assert!(output
+                .iter()
+                .any(|event| matches!(event, AgentEvent::NeedClarification { .. })));
+        }
+        2 => {
+            let request = current_request(&session);
+            assert_eq!(request.permission_type, PermissionType::ExecuteCommand);
+            fixture.approve(&request).await;
+            assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), 0);
+        }
+        3 => {
+            assert!(session.pending_question.is_none());
+            let output = events(agent.resume_stream(session)).await;
+            assert!(output
+                .iter()
+                .any(|event| matches!(event, AgentEvent::NeedClarification { .. })));
+            assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), 0);
+        }
+        4 => {
+            let request = current_request(&session);
+            assert_eq!(request.permission_type, PermissionType::WriteFile);
+            let waiting = events(agent.resume_stream(session)).await;
+            assert!(matches!(
+                waiting.as_slice(),
+                [AgentEvent::NeedClarification { .. }]
+            ));
+            assert_eq!(fixture.probe.provider_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+            let answered = fixture.approve(&request).await;
+            let output = events(agent.resume_stream(answered)).await;
+            assert!(!output.iter().any(|event| matches!(
+                event,
+                AgentEvent::NeedClarification { .. } | AgentEvent::Error { .. }
+            )));
+            assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 1);
+            assert!(
+                SupervisorSessionService::new(fixture.store.clone())
+                    .inspect_link(&original, TARGET)
+                    .await
+                    .unwrap()
+                    .authorized
+            );
+            let completed = fixture.reload(id).await;
+            assert!(completed.pending_question.is_none());
+            assert!(!completed
+                .metadata
+                .contains_key(PERMISSION_REEXECUTE_METADATA_KEY));
+            let again = events(agent.resume_stream(completed)).await;
+            assert!(!again
+                .iter()
+                .any(|event| matches!(event, AgentEvent::ToolLifecycle { .. })));
+            assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 1);
+        }
+        _ => panic!("unexpected child stage"),
+    }
+    // Read back the completed save before terminating P1-P3 without destructors.
+    let durable = fixture.reload(id).await;
+    let scope = SupervisorSessionService::new(fixture.store.clone())
+        .inspect_scope(&original)
+        .await
+        .unwrap();
+    assert_eq!(scope.state_revision, if stage == 4 { 2 } else { 1 });
+    assert_eq!(durable.pending_question.is_some(), stage == 1 || stage == 3);
+    assert_eq!(
+        fixture.probe.actions.load(Ordering::SeqCst),
+        usize::from(stage == 4)
+    );
+    let evidence = json!({
+        "stage":stage, "pid":std::process::id(), "reference":original,
+        "authority":authority(&durable), "result_id":durable.messages[result_index(&durable)].id,
+        "pending":durable.pending_question.is_some(), "revision":scope.state_revision,
+        "actions":fixture.probe.actions.load(Ordering::SeqCst),
+    });
+    std::fs::write(
+        home.join(format!("stage-{stage}.json")),
+        serde_json::to_vec_pretty(&evidence).unwrap(),
+    )
+    .unwrap();
+    println!("SUPERVISOR_APPROVAL_STAGE {evidence}");
+    std::io::Write::flush(&mut std::io::stdout()).unwrap();
+    if stage < 4 {
+        std::process::exit((40 + stage) as i32);
+    }
+}
+
+#[test]
+fn supervisor_approval_process_child() {
+    let Some(home) = std::env::var_os(PROCESS_HOME) else {
+        return;
+    };
+    let stage: u32 = std::env::var(PROCESS_STAGE).unwrap().parse().unwrap();
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(run_stage(Path::new(&home), stage));
+}
+
+#[tokio::test]
+async fn supervisor_approval_survives_four_processes_and_a_durable_repark() {
+    let home = tempfile::tempdir().unwrap();
+    let mut evidence = Vec::<Value>::new();
+    let mut pids = std::collections::BTreeSet::new();
+    let mut target_before = None;
+    for stage in 1..=4 {
+        let log_path = home.path().join(format!("stage-{stage}.log"));
+        let log = std::fs::File::create(&log_path).unwrap();
+        let mut child = StageProcess(
+            std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", CHILD_TEST, "--nocapture"])
+                .env(PROCESS_HOME, home.path())
+                .env(PROCESS_STAGE, stage.to_string())
+                .stdout(log.try_clone().unwrap())
+                .stderr(log)
+                .spawn()
+                .unwrap(),
+        );
+        let pid = child.0.id();
+        assert_ne!(pid, std::process::id());
+        assert!(
+            pids.insert(pid),
+            "each stage must execute in a distinct process"
+        );
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        let status = loop {
+            if let Some(status) = child.0.try_wait().unwrap() {
+                break status;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                child.0.kill().unwrap();
+                child.0.wait().unwrap();
+                panic!(
+                    "process stage {stage} timed out: {}",
+                    std::fs::read_to_string(&log_path).unwrap()
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        };
+        let output = std::fs::read_to_string(&log_path).unwrap();
+        assert_eq!(
+            status.code(),
+            Some(if stage < 4 { 40 + stage } else { 0 }),
+            "stage {stage}: {output}"
+        );
+        let proof: Value = serde_json::from_slice(
+            &std::fs::read(home.path().join(format!("stage-{stage}.json"))).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(proof["pid"], pid);
+        assert_eq!(proof["stage"], stage);
+        println!("verified process stage {stage}: {proof}");
+        let store = Arc::new(
+            SessionStoreV2::new(home.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+        let reference: bamboo_domain::SupervisorReference =
+            serde_json::from_value(proof["reference"].clone()).unwrap();
+        let durable = store
+            .load_session(&reference.session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(*authority(&durable), proof["authority"]);
+        assert_eq!(durable.pending_question.is_some(), stage == 1 || stage == 3);
+        let target =
+            serde_json::to_value(store.load_session(TARGET).await.unwrap().unwrap()).unwrap();
+        if let Some(before) = &target_before {
+            assert_eq!(&target, before);
+        } else {
+            target_before = Some(target);
+        }
+        let service = SupervisorSessionService::new(store);
+        assert_eq!(
+            service
+                .inspect_scope(&reference)
+                .await
+                .unwrap()
+                .state_revision,
+            if stage == 4 { 2 } else { 1 }
+        );
+        if stage == 4 {
+            assert!(
+                service
+                    .inspect_link(&reference, TARGET)
+                    .await
+                    .unwrap()
+                    .authorized
+            );
+        }
+        evidence.push(proof);
+    }
+    assert_eq!(evidence[0]["authority"], evidence[1]["authority"]);
+    assert_eq!(evidence[2]["authority"], evidence[3]["authority"]);
+    assert_ne!(
+        evidence[0]["authority"]["request_generation"],
+        evidence[2]["authority"]["request_generation"]
+    );
+    let mut a = evidence[0]["authority"].clone();
+    let mut b = evidence[2]["authority"].clone();
+    a.as_object_mut().unwrap().remove("request_generation");
+    b.as_object_mut().unwrap().remove("request_generation");
+    assert_eq!(a, b, "repark changes only the permission generation");
+}

--- a/crates/app/bamboo-sdk/src/agent/approval_supervisor_tests.rs
+++ b/crates/app/bamboo-sdk/src/agent/approval_supervisor_tests.rs
@@ -1,0 +1,679 @@
+//! Protected approval transport exercises native parking and actual service writes.
+
+use super::*;
+use bamboo_agent_core::tools::ExecutingSupervisorObservation;
+use bamboo_engine::session_app::supervisor::SupervisorSessionService;
+
+const TARGET: &str = "transport-target";
+const AUTHORITY: &str = ExecutingSupervisorObservation::PERMISSION_REPLAY_METADATA_KEY;
+type WriteBarrier = (
+    tokio::sync::mpsc::UnboundedSender<ExecutingSupervisorObservation>,
+    Arc<tokio::sync::Semaphore>,
+);
+
+#[path = "approval_supervisor_process_tests.rs"]
+mod process;
+
+struct ProtectedTool {
+    name: String,
+    service: SupervisorSessionService,
+    probe: Arc<Probe>,
+    config: Arc<PermissionConfig>,
+    second_context: bool,
+    barrier: Option<WriteBarrier>,
+}
+
+#[async_trait]
+impl Tool for ProtectedTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn description(&self) -> &str {
+        "Exercise strict Supervisor management after the real permission gate"
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({"type":"object","properties":{"command":{"type":"string"}},"required":["command"]})
+    }
+    async fn invoke(&self, args: Value, ctx: ToolCtx) -> Result<ToolOutcome, ToolError> {
+        assert!(!ctx.bypass_permissions && !ctx.auto_approve_permissions && !ctx.plan_read_only);
+        let mut gates = Vec::new();
+        if self.name == "execute_command" {
+            gates.push((PermissionType::ExecuteCommand, "current-command"));
+        }
+        if self.second_context {
+            gates.push((PermissionType::WriteFile, "second-resource"));
+        }
+        for (permission_type, resource) in gates {
+            match self
+                .config
+                .evaluate(bamboo_tools::permission::PermissionEvaluation {
+                    request_id: ctx.tool_call_id.to_string(),
+                    session_id: ctx.session_id.as_ref().unwrap().to_string(),
+                    workspace_path: None,
+                    tool_name: self.name.clone(),
+                    tool_args: args.clone(),
+                    permission_type,
+                    resource: resource.into(),
+                    operation_summary: "protected link operation".into(),
+                    risk_level: RiskLevel::High,
+                    bypass_requested: ctx.bypass_permissions,
+                    auto_approve_requested: ctx.auto_approve_permissions,
+                    platform_hard_deny: None,
+                    consume_once: true,
+                    supported_decisions: PermissionRequest::forced_decisions(),
+                }) {
+                bamboo_tools::permission::PermissionOutcome::Ask(request) => {
+                    self.config.register_pending_request(request.clone());
+                    let mut result = waiting_result(&request);
+                    result.success = true;
+                    return Ok(ToolOutcome::Completed(result));
+                }
+                bamboo_tools::permission::PermissionOutcome::Allow { .. } => {}
+                bamboo_tools::permission::PermissionOutcome::Deny { reason, .. } => {
+                    return Err(ToolError::Execution(reason.message))
+                }
+            }
+        }
+        self.probe.calls.lock().unwrap().push(Invocation {
+            name: self.name.clone(),
+            arguments: args,
+            generation: current_permission_replay_generation(
+                ctx.session_id.as_deref().unwrap(),
+                &ctx.tool_call_id,
+            ),
+            flags: ToolExecutionSessionFlags::default(),
+            supervisor_absent: ctx.executing_supervisor.is_none(),
+        });
+        let original = ctx
+            .executing_supervisor_for(ctx.session_id.as_deref().unwrap())
+            .ok_or_else(|| {
+                ToolError::Execution("original Supervisor observation missing".into())
+            })?;
+        if let Some((entered, release)) = &self.barrier {
+            entered.send(original).unwrap();
+            release.acquire().await.unwrap().forget();
+        }
+        self.service
+            .attach(&original.supervisor_reference(), 1, TARGET)
+            .await
+            .map_err(|error| ToolError::Execution(error.to_string()))?;
+        self.probe.actions.fetch_add(1, Ordering::SeqCst);
+        Ok(ToolOutcome::Completed(ToolResult::text(
+            true,
+            "strict write saved",
+        )))
+    }
+}
+
+fn protected_agent(fixture: &Fixture) -> Agent {
+    protected_agent_with(fixture, alias_config(), &["Bash"], false, None)
+}
+
+fn protected_agent_with(
+    fixture: &Fixture,
+    config: Arc<PermissionConfig>,
+    names: &[&str],
+    second_context: bool,
+    barrier: Option<WriteBarrier>,
+) -> Agent {
+    let registry = bamboo_tools::ToolRegistry::new();
+    for name in names {
+        registry
+            .register(ProtectedTool {
+                name: (*name).into(),
+                service: SupervisorSessionService::new(fixture.store.clone()),
+                probe: fixture.probe.clone(),
+                config: config.clone(),
+                second_context,
+                barrier: barrier.clone(),
+            })
+            .unwrap();
+    }
+    let executor = bamboo_tools::executor::BuiltinToolExecutor::with_registry_and_permissions(
+        registry,
+        Arc::new(ConfigPermissionChecker::new(config.clone())),
+    );
+    fixture.agent_with_executor(Some(config), Arc::new(executor), None)
+}
+
+async fn protected_pending() -> (Fixture, Session, bamboo_domain::SupervisorReference) {
+    protected_pending_with(&["Bash"]).await
+}
+
+async fn setup_supervisor(fixture: &Fixture) -> bamboo_domain::SupervisorReference {
+    let service = SupervisorSessionService::new(fixture.store.clone());
+    let bootstrap = service.get_or_create_default("test-model").await.unwrap();
+    let original = (&bootstrap).into();
+    // Scope is host configuration. The dispatched test tool can only attach an
+    // existing independent Root within this pre-authorized Project.
+    let mut target = Session::new(TARGET, "target-model");
+    target.set_project_id_meta("transport-project");
+    target.add_message(Message::user("independent history"));
+    fixture.store.save_session(&target).await.unwrap();
+    service
+        .configure_project_scope(&original, 0, ["transport-project".parse().unwrap()].into())
+        .await
+        .unwrap();
+    original
+}
+
+async fn protected_pending_with(
+    names: &[&str],
+) -> (Fixture, Session, bamboo_domain::SupervisorReference) {
+    let fixture = Fixture::new().await;
+    let original = setup_supervisor(&fixture).await;
+    let session = fixture.reload(&original.session_id).await;
+    *fixture.probe.next_call.lock().unwrap() = Some(alias_call());
+    let initial = events(
+        protected_agent_with(&fixture, alias_config(), names, false, None)
+            .run_stream(session, "attach the permitted Root"),
+    )
+    .await;
+    assert!(initial
+        .iter()
+        .any(|event| matches!(event, AgentEvent::NeedClarification { .. })));
+    let mut pending = fixture.reload(&original.session_id).await;
+    let record = authority(&pending).clone();
+    assert_eq!(
+        record["incarnation_id"],
+        original.incarnation_id.to_string()
+    );
+    assert_eq!(
+        record["result_message_id"],
+        pending.messages[result_index(&pending)].id
+    );
+    fixture.repo.save(&mut pending).await.unwrap();
+    assert_eq!(
+        *authority(&fixture.reload(&original.session_id).await),
+        record,
+        "lifecycle and subsequent save must retain the original host record"
+    );
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+    (fixture, pending, original)
+}
+
+fn result_index(session: &Session) -> usize {
+    session
+        .messages
+        .iter()
+        .rposition(|message| message.tool_call_id.as_deref() == Some(CALL))
+        .unwrap()
+}
+
+fn authority(session: &Session) -> &Value {
+    &session.messages[result_index(session)]
+        .metadata
+        .as_ref()
+        .unwrap()[AUTHORITY]
+}
+
+#[tokio::test]
+async fn supervisor_native_approved_replay_uses_original_identity() {
+    let (mut fixture, pending, original) = Box::pin(protected_pending()).await;
+    fixture.approve(&current_request(&pending)).await;
+    fixture.reopen_store().await;
+    let approved = fixture.reload(&original.session_id).await;
+    let completed = events(protected_agent(&fixture).resume_stream(approved)).await;
+    let scope = SupervisorSessionService::new(fixture.store.clone())
+        .inspect_scope(&original)
+        .await
+        .unwrap();
+    let final_session = fixture.reload(&original.session_id).await;
+    assert_eq!(
+        scope.state_revision, 2,
+        "approved native operation must perform the strict durable write; events={completed:?}; result={:?}",
+        final_session.messages.iter().rev().find(|message| message.tool_call_id.as_deref() == Some(CALL))
+    );
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 1);
+    assert!(
+        SupervisorSessionService::new(fixture.store.clone())
+            .inspect_link(&original, TARGET)
+            .await
+            .unwrap()
+            .authorized
+    );
+    let completed_again = events(protected_agent(&fixture).resume_stream(final_session)).await;
+    assert!(!completed_again
+        .iter()
+        .any(|event| matches!(event, AgentEvent::ToolLifecycle { .. })));
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn supervisor_replay_rejects_corrupted_native_bindings_before_protected_writes() {
+    for case in [
+        "record_message",
+        "record_session",
+        "record_call",
+        "record_owner",
+        "record_generation",
+        "unknown_version",
+        "malformed",
+        "absent",
+        "arguments",
+        "name",
+        "request_owner",
+        "receipt_generation",
+        "legacy_with_record",
+        "moved_occurrence",
+        "duplicate_call",
+        "ordinary",
+        "child",
+        "plan_invalid",
+    ] {
+        let (fixture, pending, original) = Box::pin(protected_pending()).await;
+        let target_before = serde_json::to_value(fixture.reload(TARGET).await).unwrap();
+        let mut approved = fixture.approve(&current_request(&pending)).await;
+        let index = result_index(&approved);
+        let call_index = approved.messages[..index]
+            .iter()
+            .rposition(|message| message.tool_calls.is_some())
+            .unwrap();
+        match case {
+            "record_message" => {
+                approved.messages[index].metadata.as_mut().unwrap()[AUTHORITY]
+                    ["result_message_id"] = json!("moved")
+            }
+            "record_session" => {
+                approved.messages[index].metadata.as_mut().unwrap()[AUTHORITY]["session_id"] =
+                    json!("other-session")
+            }
+            "record_call" => {
+                approved.messages[index].metadata.as_mut().unwrap()[AUTHORITY]["tool_call"]["id"] =
+                    json!("another-call")
+            }
+            "record_owner" => {
+                approved.messages[index].metadata.as_mut().unwrap()[AUTHORITY]["execution_name"] =
+                    json!("execute_command")
+            }
+            "record_generation" => {
+                approved.messages[index].metadata.as_mut().unwrap()[AUTHORITY]
+                    ["request_generation"] = json!("another-generation")
+            }
+            "unknown_version" => {
+                approved.messages[index].metadata.as_mut().unwrap()[AUTHORITY]["version"] =
+                    json!(99)
+            }
+            "malformed" => {
+                approved.messages[index].metadata.as_mut().unwrap()[AUTHORITY] = Value::Null
+            }
+            "absent" => {
+                approved.messages[index]
+                    .metadata
+                    .as_mut()
+                    .unwrap()
+                    .as_object_mut()
+                    .unwrap()
+                    .remove(AUTHORITY);
+            }
+            "arguments" => approved.messages[call_index].tool_calls.as_mut().unwrap()[0]
+                .function
+                .arguments
+                .push(' '),
+            "name" => {
+                approved.messages[call_index].tool_calls.as_mut().unwrap()[0]
+                    .function
+                    .name = "Write".into()
+            }
+            "request_owner" => {
+                approved.messages[index].metadata.as_mut().unwrap()["permission_request"]
+                    ["tool_name"] = json!("Write")
+            }
+            "receipt_generation" => {
+                approved.messages[index].metadata.as_mut().unwrap()["permission_decision_receipt"]
+                    ["decision"]["request_generation"] = json!("another-generation")
+            }
+            "legacy_with_record" => {
+                let metadata = approved.messages[index]
+                    .metadata
+                    .as_mut()
+                    .unwrap()
+                    .as_object_mut()
+                    .unwrap();
+                metadata.remove("permission_request");
+                metadata.remove("permission_decision_receipt");
+                approved
+                    .metadata
+                    .remove(PERMISSION_REEXECUTE_GENERATION_METADATA_KEY);
+            }
+            "moved_occurrence" => {
+                let next_call = approved.messages[call_index].clone();
+                let mut moved = approved.messages[index].clone();
+                moved.id = "another-real-result-id".into();
+                approved.add_message(next_call);
+                approved.add_message(moved);
+            }
+            "duplicate_call" => {
+                let calls = approved.messages[call_index].tool_calls.as_mut().unwrap();
+                calls.push(calls[0].clone());
+            }
+            "ordinary" => {
+                approved.authority_identity = bamboo_domain::SessionAuthorityIdentity::Ordinary
+            }
+            "child" => approved.kind = bamboo_domain::SessionKind::Child,
+            "plan_invalid" => {
+                approved.messages[index].metadata.as_mut().unwrap()[AUTHORITY]["version"] =
+                    json!(99);
+                let mut disk = fixture.reload(&original.session_id).await;
+                disk.agent_runtime_state.as_mut().unwrap().plan_mode = Some(serde_json::from_value(json!({
+                    "entered_at":"2026-09-09T00:00:00Z", "pre_permission_mode":"default", "status":"exploring"
+                })).unwrap());
+                fixture.store.save_session(&disk).await.unwrap();
+            }
+            _ => unreachable!(),
+        }
+        let completed = events(protected_agent(&fixture).resume_stream(approved)).await;
+        assert_eq!(
+            fixture.probe.actions.load(Ordering::SeqCst),
+            0,
+            "case={case}; events={completed:?}"
+        );
+        assert_eq!(
+            SupervisorSessionService::new(fixture.store.clone())
+                .inspect_scope(&original)
+                .await
+                .unwrap()
+                .state_revision,
+            1,
+            "case={case}"
+        );
+        assert_eq!(
+            serde_json::to_value(fixture.reload(TARGET).await).unwrap(),
+            target_before,
+            "case={case}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn supervisor_typed_response_rejects_payload_authority_without_erasing_evidence() {
+    let (fixture, mut pending, original) = Box::pin(protected_pending()).await;
+    let index = result_index(&pending);
+    let request = current_request(&pending);
+    let host_record = pending.messages[index]
+        .metadata
+        .as_mut()
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
+        .remove(AUTHORITY)
+        .unwrap();
+    let mut payload: Value = serde_json::from_str(&pending.messages[index].content).unwrap();
+    payload[AUTHORITY] = host_record;
+    pending.messages[index].content = payload.to_string();
+    fixture.repo.save(&mut pending).await.unwrap();
+    let before = serde_json::to_value(fixture.reload(&original.session_id).await).unwrap();
+    let guard = acquire_pending_response_guard(&original.session_id).await;
+    let result = submit_pending_permission_response_checked_guarded(
+        &fixture.repo,
+        RespondInput {
+            session_id: original.session_id.clone(),
+            user_response: "Approve".into(),
+            model: None,
+            model_ref: None,
+            provider: None,
+            reasoning_effort: None,
+        },
+        Some(CALL.into()),
+        PermissionDecisionReceipt {
+            session_id: original.session_id.clone(),
+            decision: PermissionDecision {
+                request_id: CALL.into(),
+                request_generation: request.request_generation,
+                decision: PermissionDecisionKind::AllowOnce,
+                matcher_id: None,
+                expected_policy_revision: Some(request.policy_revision),
+                confirm_global: false,
+            },
+            decided_at: std::time::SystemTime::now().into(),
+        },
+        &guard,
+    )
+    .await;
+    assert!(result.is_err());
+    assert_eq!(
+        serde_json::to_value(fixture.reload(&original.session_id).await).unwrap(),
+        before
+    );
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn supervisor_shared_validation_rejects_an_old_same_id_occurrence_without_grants() {
+    use bamboo_engine::session_app::approval_replay::{
+        find_permission_replay_target, restore_permission_replay_authorization,
+        validate_permission_replay_authority,
+    };
+    let (fixture, pending, _) = Box::pin(protected_pending()).await;
+    let request = current_request(&pending);
+    let mut session = fixture.approve(&request).await;
+    let old =
+        find_permission_replay_target(&session, CALL, Some(&request.request_generation)).unwrap();
+    session.add_message(Message::assistant(
+        "new operation",
+        Some(vec![alias_call()]),
+    ));
+    let mut newer = Message::tool_result(CALL, "new waiting occurrence");
+    newer.metadata = Some(json!({"permission_request":{"request_generation":"new-generation"}}));
+    session.add_message(newer);
+    assert!(validate_permission_replay_authority(&session, &old, "Bash").is_err());
+    let config = alias_config();
+    assert!(restore_permission_replay_authorization(&config, &session, &old, "Bash").is_err());
+    assert!(!config.consume_once_for_generation(
+        &session.id,
+        CALL,
+        &request.request_generation,
+        PermissionType::ExecuteCommand,
+        &request.resource
+    ));
+}
+
+#[tokio::test]
+async fn supervisor_exact_custom_owner_and_builtin_alias_remain_distinct() {
+    let (fixture, pending, original) = Box::pin(protected_pending()).await;
+    let approved = fixture.approve(&current_request(&pending)).await;
+    events(
+        protected_agent_with(
+            &fixture,
+            alias_config(),
+            &["Bash", "execute_command"],
+            false,
+            None,
+        )
+        .resume_stream(approved),
+    )
+    .await;
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        SupervisorSessionService::new(fixture.store.clone())
+            .inspect_scope(&original)
+            .await
+            .unwrap()
+            .state_revision,
+        1
+    );
+
+    let (fixture, pending, original) =
+        Box::pin(protected_pending_with(&["Bash", "execute_command"])).await;
+    assert_eq!(current_request(&pending).tool_name, "execute_command");
+    let approved = fixture.approve(&current_request(&pending)).await;
+    events(
+        protected_agent_with(
+            &fixture,
+            alias_config(),
+            &["Bash", "execute_command"],
+            false,
+            None,
+        )
+        .resume_stream(approved),
+    )
+    .await;
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 1);
+    assert!(
+        SupervisorSessionService::new(fixture.store.clone())
+            .inspect_link(&original, TARGET)
+            .await
+            .unwrap()
+            .authorized
+    );
+}
+
+#[tokio::test]
+async fn supervisor_sdk_text_answer_cannot_mint_a_typed_receipt() {
+    let (fixture, pending, original) = Box::pin(protected_pending()).await;
+    let agent = protected_agent(&fixture);
+    let answered = agent.answer(&pending.id, "Approve").await.unwrap().session;
+    assert!(answered.messages[result_index(&answered)]
+        .metadata
+        .as_ref()
+        .unwrap()
+        .get("permission_decision_receipt")
+        .is_none());
+    events(agent.resume_stream(answered)).await;
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        SupervisorSessionService::new(fixture.store.clone())
+            .inspect_scope(&original)
+            .await
+            .unwrap()
+            .state_revision,
+        1
+    );
+}
+
+#[tokio::test]
+async fn supervisor_recreated_after_restoration_is_rejected_at_the_final_writer() {
+    let (fixture, pending, original) = Box::pin(protected_pending()).await;
+    let target_before = serde_json::to_value(fixture.reload(TARGET).await).unwrap();
+    let approved = fixture.approve(&current_request(&pending)).await;
+    let (entered_tx, mut entered_rx) = tokio::sync::mpsc::unbounded_channel();
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let stream = protected_agent_with(
+        &fixture,
+        alias_config(),
+        &["Bash"],
+        false,
+        Some((entered_tx, release.clone())),
+    )
+    .resume_stream(approved);
+    let retained = tokio::time::timeout(std::time::Duration::from_secs(10), entered_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(retained.supervisor_reference(), original);
+    assert!(fixture
+        .store
+        .delete_session(&original.session_id)
+        .await
+        .unwrap());
+    let service = SupervisorSessionService::new(fixture.store.clone());
+    let replacement = service.get_or_create_default("replacement").await.unwrap();
+    assert_ne!(replacement.incarnation_id, original.incarnation_id);
+    release.add_permits(1);
+    let completed = events(stream).await;
+    assert_eq!(
+        fixture.probe.actions.load(Ordering::SeqCst),
+        0,
+        "events={completed:?}"
+    );
+    assert_eq!(
+        service
+            .inspect_scope(&(&replacement).into())
+            .await
+            .unwrap()
+            .state_revision,
+        0
+    );
+    assert_eq!(
+        serde_json::to_value(fixture.reload(TARGET).await).unwrap(),
+        target_before
+    );
+}
+
+#[tokio::test]
+async fn supervisor_waiting_validates_identity_without_requiring_an_answer() {
+    let (fixture, pending, _) = Box::pin(protected_pending()).await;
+    let initial_calls = fixture.probe.provider_calls.load(Ordering::SeqCst);
+    let waiting = events(protected_agent(&fixture).resume_stream(pending.clone())).await;
+    assert!(matches!(
+        waiting.as_slice(),
+        [AgentEvent::NeedClarification { .. }]
+    ));
+    for remove_request in [false, true] {
+        let mut broken = pending.clone();
+        let index = result_index(&broken);
+        let metadata = broken.messages[index].metadata.as_mut().unwrap();
+        if remove_request {
+            metadata
+                .as_object_mut()
+                .unwrap()
+                .remove("permission_request");
+            let mut payload: Value = serde_json::from_str(&broken.messages[index].content).unwrap();
+            payload
+                .as_object_mut()
+                .unwrap()
+                .remove("permission_request");
+            broken.messages[index].content = payload.to_string();
+        } else {
+            metadata[AUTHORITY]["version"] = json!(99);
+        }
+        let failed = events(protected_agent(&fixture).resume_stream(broken)).await;
+        assert!(failed
+            .iter()
+            .any(|event| matches!(event, AgentEvent::Error { .. })));
+        assert!(!failed
+            .iter()
+            .any(|event| matches!(event, AgentEvent::NeedClarification { .. })));
+    }
+    assert_eq!(
+        fixture.probe.provider_calls.load(Ordering::SeqCst),
+        initial_calls
+    );
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn ordinary_child_and_synthetic_callers_do_not_acquire_supervisor_authority() {
+    for child in [false, true] {
+        let fixture = Fixture::new().await;
+        let original = setup_supervisor(&fixture).await;
+        let supervisor = fixture.reload(&original.session_id).await;
+        let session = if child {
+            Session::new_child_of("ordinary-child", &supervisor, "test-model", "child")
+        } else {
+            Session::new("ordinary-root", "test-model")
+        };
+        let id = session.id.clone();
+        *fixture.probe.next_call.lock().unwrap() = Some(alias_call());
+        events(protected_agent(&fixture).run_stream(session, "attempt attach")).await;
+        let pending = fixture.reload(&id).await;
+        assert!(pending.messages[result_index(&pending)]
+            .metadata
+            .as_ref()
+            .is_none_or(|metadata| metadata.get(AUTHORITY).is_none()));
+        let approved = fixture.approve(&current_request(&pending)).await;
+        events(protected_agent(&fixture).resume_stream(approved)).await;
+        let mut synthetic = ToolCtx::none("synthetic-call");
+        synthetic.session_id = Some(original.session_id.as_str().into());
+        let result = ProtectedTool {
+            name: "Bash".into(),
+            service: SupervisorSessionService::new(fixture.store.clone()),
+            probe: fixture.probe.clone(),
+            config: alias_config(),
+            second_context: false,
+            barrier: None,
+        }
+        .invoke(json!({"command":"current-command"}), synthetic)
+        .await;
+        assert!(result.is_err());
+        assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            SupervisorSessionService::new(fixture.store.clone())
+                .inspect_scope(&original)
+                .await
+                .unwrap()
+                .state_revision,
+            1
+        );
+    }
+}

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -16,8 +16,8 @@ use bamboo_engine::model_config_helper::{
 };
 use bamboo_engine::session_app::approval_replay::{
     apply_permission_replay_result, find_permission_replay_target, refresh_approval_replay_posture,
-    repark_permission_replay, restore_permission_replay_authorization, ApprovalReplayDecision,
-    PermissionReplayTarget,
+    repark_permission_replay, restore_permission_replay_authorization,
+    validate_permission_replay_authority, ApprovalReplayDecision, PermissionReplayTarget,
 };
 use bamboo_engine::session_app::execute::consume_pending_clarification_resume;
 use bamboo_engine::session_app::provider_model::{persist_model_ref, session_effective_model_ref};
@@ -38,6 +38,10 @@ use crate::handlers::agent::execute::{spawn_agent_execution, spawn_event_forward
 /// `bamboo_engine::session_app::resume::ResumeExecutionPort` directly on
 /// `actix_web::web::Data<AppState>`.
 pub struct AppStateResumeRef(pub actix_web::web::Data<AppState>);
+
+#[cfg(test)]
+#[path = "supervisor_approval_tests.rs"]
+pub(crate) mod supervisor_tests;
 
 #[async_trait]
 impl ResumeExecutionPort for AppStateResumeRef {
@@ -290,6 +294,22 @@ impl ResumeExecutionPort for AppStateResumeRef {
                 }
                 let tool_call = replay_target.tool_call().clone();
                 let tool_name = tool_call.function.name.clone();
+                let executor = state.tools_for(crate::tools::ToolSurface::Root);
+                let replay_owner = bamboo_domain::resolve_tool_reference_name(&tool_name, |name| {
+                    executor.owns_exact_tool(name)
+                })
+                .unwrap_or_else(|| tool_name.clone());
+                let executing_supervisor = match validate_permission_replay_authority(
+                    &session,
+                    &replay_target,
+                    &replay_owner,
+                ) {
+                    Ok(observation) => observation,
+                    Err(error) => {
+                        tracing::error!(%session_id, %error, "Supervisor approval replay binding failed closed");
+                        return;
+                    }
+                };
                 let configured_mode = state
                     .permission_checker
                     .permission_config()
@@ -343,6 +363,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                             permission_config.as_ref(),
                             &session,
                             &replay_target,
+                            &replay_owner,
                         ) {
                             tracing::error!(
                                 %session_id,
@@ -352,7 +373,6 @@ impl ResumeExecutionPort for AppStateResumeRef {
                             );
                             return;
                         }
-                        let executor = state.tools_for(crate::tools::ToolSurface::Root);
                         let is_mutating = bamboo_tools::orchestrator::classify_tool(&tool_name)
                             == bamboo_tools::orchestrator::ToolMutability::Mutating;
 
@@ -370,10 +390,11 @@ impl ResumeExecutionPort for AppStateResumeRef {
                             session.id.as_str(),
                             reexecute_tool_call_id.as_str(),
                             reexecute_request_generation.as_deref(),
-                            executor.execute_with_context(
+                            executor.execute_exact_with_context_outcome(
                                     &tool_call,
+                                    &replay_owner,
                                 bamboo_agent_core::tools::ToolExecutionContext {
-                                    executing_supervisor: None,
+                                    executing_supervisor,
                                     session_id: Some(session.id.as_str()),
                                     root_session_id: Some(
                                         if session.root_session_id.trim().is_empty() {
@@ -394,7 +415,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                                 },
                             ),
                         )
-                        .await;
+                        .await.map(bamboo_agent_core::tools::ToolOutcome::into_tool_result);
 
                         match exec_result {
                             Ok(tool_result) => {
@@ -402,6 +423,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                                     &mut session,
                                     &replay_target,
                                     &tool_result,
+                                    &replay_owner,
                                 ) {
                                     Ok(Some(reparked)) => {
                                         let _ = mpsc_tx

--- a/crates/app/bamboo-server/src/app_state/supervisor_approval_tests.rs
+++ b/crates/app/bamboo-server/src/app_state/supervisor_approval_tests.rs
@@ -1,0 +1,542 @@
+//! Real Server/Connect dispatch and HTTP decision coverage for host authority.
+
+use super::*;
+use actix_web::{test, web, App};
+use bamboo_agent_core::tools::{
+    ExecutingSupervisorObservation, FunctionCall, Tool, ToolCall, ToolCtx, ToolError, ToolOutcome,
+    ToolResult, ToolSchema,
+};
+use bamboo_agent_core::{Message, Session};
+use bamboo_engine::session_app::supervisor::SupervisorSessionService;
+use bamboo_llm::{Config, LLMProvider, ProviderModelRouter, ProviderRegistry};
+use bamboo_tools::permission::{PermissionDecision, PermissionDecisionKind, PermissionRequest};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+pub(crate) const CALL: &str = "transport-call";
+const TARGET: &str = "transport-target";
+const AUTHORITY: &str = ExecutingSupervisorObservation::PERMISSION_REPLAY_METADATA_KEY;
+
+#[derive(Default)]
+struct Probe {
+    next_call: AtomicBool,
+    actions: AtomicUsize,
+    provider_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl LLMProvider for Probe {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<bamboo_llm::LLMStream, bamboo_llm::LLMError> {
+        self.provider_calls.fetch_add(1, Ordering::SeqCst);
+        let output = if self.next_call.swap(false, Ordering::SeqCst) {
+            bamboo_llm::LLMChunk::ToolCalls(vec![ToolCall {
+                id: CALL.into(),
+                tool_type: "function".into(),
+                function: FunctionCall {
+                    name: "execute_command".into(),
+                    arguments: json!({"command":"current-command"}).to_string(),
+                },
+            }])
+        } else {
+            bamboo_llm::LLMChunk::Token("done".into())
+        };
+        Ok(Box::pin(futures::stream::iter([
+            Ok(output),
+            Ok(bamboo_llm::LLMChunk::Done),
+        ])))
+    }
+}
+
+struct ProtectedTool {
+    service: SupervisorSessionService,
+    probe: Arc<Probe>,
+}
+
+#[async_trait]
+impl Tool for ProtectedTool {
+    fn name(&self) -> &str {
+        "Bash"
+    }
+    fn description(&self) -> &str {
+        "Exercise a strict Supervisor write after approval"
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({"type":"object","properties":{"command":{"type":"string"}},"required":["command"]})
+    }
+    async fn invoke(&self, _args: Value, ctx: ToolCtx) -> Result<ToolOutcome, ToolError> {
+        assert!(!ctx.bypass_permissions && !ctx.auto_approve_permissions && !ctx.plan_read_only);
+        let original = ctx
+            .executing_supervisor_for(ctx.session_id.as_deref().unwrap())
+            .ok_or_else(|| {
+                ToolError::Execution("original Supervisor observation missing".into())
+            })?;
+        self.service
+            .attach(&original.supervisor_reference(), 1, TARGET)
+            .await
+            .map_err(|error| ToolError::Execution(error.to_string()))?;
+        self.probe.actions.fetch_add(1, Ordering::SeqCst);
+        Ok(ToolOutcome::Completed(ToolResult::text(
+            true,
+            "strict write saved",
+        )))
+    }
+}
+
+pub(crate) struct Fixture {
+    directory: tempfile::TempDir,
+    pub(crate) state: web::Data<AppState>,
+    pub(crate) original: bamboo_domain::SupervisorReference,
+    probe: Arc<Probe>,
+}
+
+impl Fixture {
+    async fn open(path: &std::path::Path, probe: Arc<Probe>) -> web::Data<AppState> {
+        let mut config = Config::from_data_dir(Some(path.to_path_buf()));
+        config.provider = "test-provider".into();
+        let mut state = AppState::new_with_provider(path.to_path_buf(), config, probe.clone())
+            .await
+            .unwrap();
+        state.provider_registry = Arc::new(ProviderRegistry::new(
+            HashMap::from([(
+                "test-provider".into(),
+                probe.clone() as Arc<dyn LLMProvider>,
+            )]),
+            "test-provider".into(),
+        ));
+        state.provider_router = Arc::new(ProviderModelRouter::new(state.provider_registry.clone()));
+        state
+            .permission_checker
+            .permission_config()
+            .unwrap()
+            .set_ask_rules(["Bash(current-command)".into()]);
+        let registry = bamboo_tools::ToolRegistry::new();
+        registry
+            .register(ProtectedTool {
+                service: SupervisorSessionService::new(state.session_store.clone()),
+                probe,
+            })
+            .unwrap();
+        let executor = Arc::new(
+            bamboo_tools::executor::BuiltinToolExecutor::with_registry_and_permissions(
+                registry,
+                state.permission_checker.clone(),
+            ),
+        );
+        state.tool_factory =
+            crate::tools::ToolSurfaceFactory::new(executor.clone(), executor.clone(), executor);
+        web::Data::new(state)
+    }
+
+    pub(crate) async fn pending() -> Self {
+        let directory = tempfile::tempdir().unwrap();
+        let probe = Arc::new(Probe::default());
+        let state = Self::open(directory.path(), probe.clone()).await;
+        let service = SupervisorSessionService::new(state.session_store.clone());
+        let original = (&service.get_or_create_default("test-model").await.unwrap()).into();
+        let mut target = Session::new(TARGET, "target-model");
+        target.set_project_id_meta("transport-project");
+        target.add_message(Message::user("independent target history"));
+        state.storage.save_session(&target).await.unwrap();
+        service
+            .configure_project_scope(&original, 0, ["transport-project".parse().unwrap()].into())
+            .await
+            .unwrap();
+        let mut fixture = Self {
+            directory: directory,
+            state,
+            original,
+            probe,
+        };
+        fixture.park().await;
+        // Fresh stores, cache and permission configuration cannot inherit an
+        // in-memory pending request, decision receipt or AllowOnce grant.
+        fixture.state.shutdown().await;
+        fixture.state = Self::open(fixture.directory.path(), fixture.probe.clone()).await;
+        fixture
+    }
+
+    pub(crate) async fn prepare_workspace_catalog(&self) {
+        async fn bytes_if_present(path: &std::path::Path) -> Option<Vec<u8>> {
+            match tokio::fs::read(path).await {
+                Ok(bytes) => Some(bytes),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => panic!("failed to read {}: {error}", path.display()),
+            }
+        }
+        let session = self.reload().await;
+        assert!(session.pending_question.is_some());
+        assert_eq!(self.probe.actions.load(Ordering::SeqCst), 0);
+        assert_eq!(self.probe.provider_calls.load(Ordering::SeqCst), 1);
+        let workspace = session.workspace_path_meta().unwrap();
+        let session_dir = self.directory.path().join("sessions").join(&session.id);
+        let paths = [
+            session_dir.join("session.json"),
+            session_dir.join("runtime.json"),
+            self.directory.path().join("permissions.json"),
+        ];
+        let mut before = Vec::new();
+        for path in &paths {
+            before.push(bytes_if_present(path).await);
+        }
+        assert!(before[0].is_some() && before[1].is_some());
+        // Native catalog watcher registration can be slow under concurrent
+        // test load. Prepare this fresh instance before timing approval replay.
+        self.state
+            .skill_manager
+            .store_for_workspace(Some(std::path::Path::new(&workspace)))
+            .await
+            .unwrap();
+        for (path, bytes) in paths.iter().zip(before) {
+            assert_eq!(
+                bytes_if_present(path).await,
+                bytes,
+                "catalog preparation changed {}",
+                path.display()
+            );
+        }
+        assert_eq!(self.probe.actions.load(Ordering::SeqCst), 0);
+        assert_eq!(self.probe.provider_calls.load(Ordering::SeqCst), 1);
+    }
+
+    async fn park(&self) {
+        self.probe.next_call.store(true, Ordering::SeqCst);
+        let mut session = self.reload().await;
+        let workspace = self.directory.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        session.set_workspace_path_meta(workspace.to_string_lossy());
+        let (tx, mut rx) = tokio::sync::mpsc::channel(100);
+        let drain = tokio::spawn(async move {
+            let mut parked = false;
+            while let Some(event) = rx.recv().await {
+                parked |= matches!(event, AgentEvent::NeedClarification { .. });
+            }
+            parked
+        });
+        self.state
+            .agent
+            .execute_direct(
+                &mut session,
+                bamboo_engine::ExecuteRequestBuilder::new(
+                    "attach the permitted Root",
+                    tx,
+                    tokio_util::sync::CancellationToken::new(),
+                )
+                .tools(self.state.tools_for(crate::tools::ToolSurface::Root))
+                .provider_override(self.probe.clone())
+                .model("test-model")
+                .build(),
+            )
+            .await
+            .unwrap();
+        assert!(drain.await.unwrap());
+        let pending = self.reload().await;
+        assert!(pending.pending_question.is_some());
+        let result = pending
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.tool_call_id.as_deref() == Some(CALL))
+            .unwrap();
+        let authority = &result.metadata.as_ref().unwrap()[AUTHORITY];
+        assert_eq!(
+            authority["incarnation_id"],
+            self.original.incarnation_id.to_string()
+        );
+        assert_eq!(authority["result_message_id"], result.id);
+        assert_eq!(self.probe.actions.load(Ordering::SeqCst), 0);
+    }
+
+    pub(crate) async fn reload(&self) -> Session {
+        self.state
+            .storage
+            .load_session(&self.original.session_id)
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    pub(crate) async fn decision(&self) -> PermissionDecision {
+        let session = self.reload().await;
+        let result = session
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.tool_call_id.as_deref() == Some(CALL))
+            .unwrap();
+        let request: PermissionRequest =
+            serde_json::from_value(result.metadata.as_ref().unwrap()["permission_request"].clone())
+                .unwrap();
+        PermissionDecision {
+            request_id: CALL.into(),
+            request_generation: request.request_generation,
+            decision: PermissionDecisionKind::AllowOnce,
+            matcher_id: None,
+            expected_policy_revision: Some(request.policy_revision),
+            confirm_global: false,
+        }
+    }
+
+    pub(crate) async fn corrupt(&self) {
+        let mut session = self.reload().await;
+        let result = session
+            .messages
+            .iter_mut()
+            .rev()
+            .find(|m| m.tool_call_id.as_deref() == Some(CALL))
+            .unwrap();
+        result.metadata.as_mut().unwrap()[AUTHORITY]["version"] = json!(99);
+        self.state.session_repo.save(&mut session).await.unwrap();
+    }
+
+    pub(crate) async fn formal_approve(&self) {
+        let decision = self.decision().await;
+        let guard = bamboo_engine::session_app::respond::acquire_pending_response_guard(
+            &self.original.session_id,
+        )
+        .await;
+        bamboo_engine::session_app::respond::submit_pending_permission_response_checked_guarded(
+            &self.state.session_repo,
+            bamboo_engine::session_app::types::RespondInput {
+                session_id: self.original.session_id.clone(),
+                user_response: "Approve".into(),
+                model: None,
+                model_ref: None,
+                provider: None,
+                reasoning_effort: None,
+            },
+            Some(CALL.into()),
+            bamboo_tools::permission::PermissionDecisionReceipt {
+                session_id: self.original.session_id.clone(),
+                decision,
+                decided_at: std::time::SystemTime::now().into(),
+            },
+            &guard,
+        )
+        .await
+        .unwrap();
+    }
+
+    pub(crate) async fn settled(&self, writes: usize, replay_retained: bool) {
+        tokio::time::timeout(std::time::Duration::from_secs(15), async {
+            loop {
+                let active = self
+                    .state
+                    .agent_runners
+                    .read()
+                    .await
+                    .get(&self.original.session_id)
+                    .is_some_and(|runner| {
+                        matches!(
+                            runner.status,
+                            crate::app_state::AgentStatus::Pending
+                                | crate::app_state::AgentStatus::Running
+                        )
+                    });
+                if !active
+                    && self
+                        .state
+                        .session_activation_router
+                        .current_run_id(&self.original.session_id)
+                        .await
+                        .is_none()
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("adapter must finish or retire its reserved execution");
+        self.state.shutdown().await;
+        assert_eq!(self.probe.actions.load(Ordering::SeqCst), writes);
+        let scope = SupervisorSessionService::new(self.state.session_store.clone())
+            .inspect_scope(&self.original)
+            .await
+            .unwrap();
+        assert_eq!(scope.state_revision, 1 + writes as u64);
+        let session = self.reload().await;
+        if writes == 1 {
+            assert_eq!(session.last_run_status().as_deref(), Some("completed"));
+            let last = session.messages.last().unwrap();
+            assert!(matches!(last.role, bamboo_agent_core::Role::Assistant));
+            assert_eq!(last.content, "done");
+        }
+        assert_eq!(
+            session
+                .metadata
+                .contains_key(PERMISSION_REEXECUTE_METADATA_KEY),
+            replay_retained
+        );
+        assert!(session.pending_question.is_none());
+        let target = self
+            .state
+            .storage
+            .load_session(TARGET)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(target.messages.len(), 1);
+        assert_eq!(target.messages[0].content, "independent target history");
+    }
+}
+
+#[actix_web::test]
+async fn server_native_typed_supervisor_approval_survives_policy_refresh_and_rejects_corruption() {
+    for corrupt in [false, true] {
+        let fixture = Box::pin(Fixture::pending()).await;
+        if corrupt {
+            fixture.corrupt().await;
+        }
+        let mut decision = fixture.decision().await;
+        let app = test::init_service(App::new().app_data(fixture.state.clone()).route(
+            "/sessions/{session_id}/permission-decisions",
+            web::post().to(crate::handlers::agent::respond::submit_permission_decision),
+        ))
+        .await;
+        let uri = format!(
+            "/sessions/{}/permission-decisions",
+            fixture.original.session_id
+        );
+        let mut policy = fixture
+            .state
+            .permission_section
+            .snapshot()
+            .data
+            .as_ref()
+            .clone();
+        policy.ask_rules = vec!["Bash(current-command)".into()];
+        fixture.state.permission_section.commit(0, policy).unwrap();
+        let policy = fixture.state.permission_section.snapshot();
+        let permissions = fixture
+            .state
+            .permission_checker
+            .permission_config()
+            .unwrap();
+        permissions.publish_persistent_policy(policy.revision, policy.data.as_ref());
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&uri)
+                .set_json(&decision)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), actix_web::http::StatusCode::CONFLICT);
+        let refreshed = permissions
+            .pending_request(&fixture.original.session_id, CALL)
+            .unwrap();
+        assert_eq!(refreshed.policy_revision, 1);
+        assert_eq!(refreshed.request_generation, decision.request_generation);
+        assert_eq!(fixture.decision().await.expected_policy_revision, Some(0));
+        decision.expected_policy_revision = Some(refreshed.policy_revision);
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&uri)
+                .set_json(&decision)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), actix_web::http::StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["success"], true);
+        assert_eq!(body["replayed"], false);
+        assert_eq!(body["auto_resume_status"], "started");
+        assert_eq!(body["resume"]["auto_resume_status"], "started");
+        assert_eq!(
+            body["receipt"]["decision"]["request_generation"],
+            decision.request_generation
+        );
+        let completed = fixture.reload().await;
+        let result = completed
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.tool_call_id.as_deref() == Some(CALL))
+            .unwrap();
+        assert_eq!(
+            result.metadata.as_ref().unwrap()["permission_decision_receipt"]["decision"]
+                ["request_generation"],
+            decision.request_generation
+        );
+        assert_eq!(
+            result.metadata.as_ref().unwrap()["permission_request"]["policy_revision"],
+            0
+        );
+        assert_eq!(
+            result.metadata.as_ref().unwrap()["permission_decision_receipt"]["decision"]
+                ["expected_policy_revision"],
+            1
+        );
+        fixture.settled(usize::from(!corrupt), corrupt).await;
+    }
+}
+
+#[actix_web::test]
+async fn server_old_decision_cannot_answer_a_recreated_supervisor() {
+    let mut fixture = Box::pin(Fixture::pending()).await;
+    let old_decision = fixture.decision().await;
+    let old = fixture.original.clone();
+    assert!(fixture
+        .state
+        .storage
+        .delete_session(&old.session_id)
+        .await
+        .unwrap());
+    let service = SupervisorSessionService::new(fixture.state.session_store.clone());
+    fixture.original = (&service.get_or_create_default("replacement").await.unwrap()).into();
+    assert_ne!(fixture.original.incarnation_id, old.incarnation_id);
+    service
+        .configure_project_scope(
+            &fixture.original,
+            0,
+            ["transport-project".parse().unwrap()].into(),
+        )
+        .await
+        .unwrap();
+    Box::pin(fixture.park()).await;
+    let replacement_pending = fixture.reload().await;
+    assert_ne!(
+        fixture.decision().await.request_generation,
+        old_decision.request_generation
+    );
+    let app = test::init_service(App::new().app_data(fixture.state.clone()).route(
+        "/sessions/{session_id}/permission-decisions",
+        web::post().to(crate::handlers::agent::respond::submit_permission_decision),
+    ))
+    .await;
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!(
+                "/sessions/{}/permission-decisions",
+                old.session_id
+            ))
+            .set_json(&old_decision)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), actix_web::http::StatusCode::CONFLICT);
+    assert_eq!(
+        serde_json::to_value(fixture.reload().await).unwrap(),
+        serde_json::to_value(replacement_pending).unwrap()
+    );
+    assert_eq!(fixture.probe.actions.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        service
+            .inspect_scope(&fixture.original)
+            .await
+            .unwrap()
+            .state_revision,
+        1
+    );
+    fixture.state.shutdown().await;
+}

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -32,8 +32,8 @@ use bamboo_engine::runtime::execution::agent_spawn::{
 };
 use bamboo_engine::session_app::approval_replay::{
     apply_permission_replay_result, find_permission_replay_target, refresh_approval_replay_posture,
-    repark_permission_replay, restore_permission_replay_authorization, ApprovalReplayDecision,
-    PermissionReplayTarget,
+    repark_permission_replay, restore_permission_replay_authorization,
+    validate_permission_replay_authority, ApprovalReplayDecision, PermissionReplayTarget,
 };
 use bamboo_engine::session_app::execute::consume_pending_clarification_resume;
 use bamboo_engine::session_app::resolution::resolve_resume_config_snapshot;
@@ -717,6 +717,22 @@ impl ResumeExecutionPort for ConnectResumePort {
                 }
                 let tool_call = replay_target.tool_call().clone();
                 let tool_name = tool_call.function.name.clone();
+                let executor = ctx.tools.clone();
+                let replay_owner = bamboo_domain::resolve_tool_reference_name(&tool_name, |name| {
+                    executor.owns_exact_tool(name)
+                })
+                .unwrap_or_else(|| tool_name.clone());
+                let executing_supervisor = match validate_permission_replay_authority(
+                    &session,
+                    &replay_target,
+                    &replay_owner,
+                ) {
+                    Ok(observation) => observation,
+                    Err(error) => {
+                        tracing::error!(%session_id, %error, "Supervisor approval replay binding failed closed");
+                        return;
+                    }
+                };
                 let configured_mode = ctx
                     .permission_checker
                     .permission_config()
@@ -768,6 +784,7 @@ impl ResumeExecutionPort for ConnectResumePort {
                             permission_config.as_ref(),
                             &session,
                             &replay_target,
+                            &replay_owner,
                         ) {
                             tracing::error!(
                                 %session_id,
@@ -777,7 +794,6 @@ impl ResumeExecutionPort for ConnectResumePort {
                             );
                             return;
                         }
-                        let executor = ctx.tools.clone();
                         let is_mutating = bamboo_tools::orchestrator::classify_tool(&tool_name)
                             == bamboo_tools::orchestrator::ToolMutability::Mutating;
                         let mut emitter = bamboo_tools::ToolEmitter::new(
@@ -793,10 +809,11 @@ impl ResumeExecutionPort for ConnectResumePort {
                             session.id.as_str(),
                             reexecute_tool_call_id.as_str(),
                             reexecute_request_generation.as_deref(),
-                            executor.execute_with_context(
+                            executor.execute_exact_with_context_outcome(
                                 &tool_call,
+                                &replay_owner,
                                 ToolExecutionContext {
-                                    executing_supervisor: None,
+                                    executing_supervisor,
                                     session_id: Some(session.id.as_str()),
                                     root_session_id: Some(
                                         if session.root_session_id.trim().is_empty() {
@@ -817,7 +834,7 @@ impl ResumeExecutionPort for ConnectResumePort {
                                 },
                             ),
                         )
-                        .await;
+                        .await.map(bamboo_agent_core::tools::ToolOutcome::into_tool_result);
 
                         match exec_result {
                             Ok(tool_result) => {
@@ -825,6 +842,7 @@ impl ResumeExecutionPort for ConnectResumePort {
                                     &mut session,
                                     &replay_target,
                                     &tool_result,
+                                    &replay_owner,
                                 ) {
                                     Ok(Some(reparked)) => {
                                         let _ = mpsc_tx
@@ -993,6 +1011,82 @@ mod tests {
     use bamboo_agent_core::Message;
 
     use super::*;
+
+    fn supervisor_context(state: &crate::app_state::AppState) -> ConnectContext {
+        ConnectContext {
+            agent: state.agent.clone(),
+            tools: state.tools_for(crate::tools::ToolSurface::Root),
+            session_repo: state.session_repo.clone(),
+            agent_runners: state.agent_runners.clone(),
+            session_event_senders: state.session_event_senders.clone(),
+            account_feed_inbox: None,
+            app_data_dir: Some(state.app_data_dir.clone()),
+            config: state.config.clone(),
+            provider_registry: state.provider_registry.clone(),
+            project_store: state.project_store.clone(),
+            workspace_resolver: state.workspace_resolver.clone(),
+            project_ids_by_platform: Arc::new(Default::default()),
+            permission_checker: state.permission_checker.clone(),
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_supervisor_typed_replay_restores_identity_and_rejects_corruption() {
+        use crate::app_state::resume_adapter::supervisor_tests::Fixture;
+        for corrupt in [false, true] {
+            let fixture = Box::pin(Fixture::pending()).await;
+            fixture.prepare_workspace_catalog().await;
+            fixture.formal_approve().await;
+            if corrupt {
+                fixture.corrupt().await;
+            }
+            let ctx = supervisor_context(&fixture.state);
+            let session = fixture.reload().await;
+            let config = resolve_resume_config_snapshot(
+                &*ctx.config.read().await,
+                &ctx.provider_registry,
+                &session,
+                None,
+            );
+            let outcome = bamboo_engine::session_app::resume::resume_session_execution(
+                &ConnectResumePort { ctx },
+                &session.id,
+                config,
+            )
+            .await;
+            assert!(matches!(
+                outcome,
+                bamboo_engine::session_app::types::ResumeOutcome::Started { .. }
+            ));
+            fixture.settled(usize::from(!corrupt), corrupt).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_supervisor_text_answer_cannot_replace_a_typed_receipt() {
+        use crate::app_state::resume_adapter::supervisor_tests::{Fixture, CALL};
+        let fixture = Box::pin(Fixture::pending()).await;
+        let responder = EngineResponder::new(supervisor_context(&fixture.state));
+        let outcome = responder
+            .respond_and_resume(&fixture.original.session_id, Some(CALL), "Approve".into())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RespondAndResumeOutcome::Resumed(_)));
+        fixture.settled(0, true).await;
+        let session = fixture.reload().await;
+        let result = session
+            .messages
+            .iter()
+            .rev()
+            .find(|message| message.tool_call_id.as_deref() == Some(CALL))
+            .unwrap();
+        assert!(result
+            .metadata
+            .as_ref()
+            .unwrap()
+            .get("permission_decision_receipt")
+            .is_none());
+    }
 
     fn append_permission_round(
         session: &mut Session,

--- a/crates/core/bamboo-agent-core/src/tools/context.rs
+++ b/crates/core/bamboo-agent-core/src/tools/context.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc;
 
 use serde_json::Value;
 
-use crate::tools::{BashCompletionSink, ToolSchema};
+use crate::tools::{BashCompletionSink, ToolCall, ToolSchema};
 use crate::{AgentEvent, Session};
 use bamboo_domain::{
     PermissionMode, SessionAuthorityIdentity, SessionKind, SupervisorReference,
@@ -29,7 +29,25 @@ pub struct ExecutingSupervisorObservation {
     incarnation_id: Uuid,
 }
 
+/// Host metadata only; never copied from a tool's result payload.
+const SUPERVISOR_PERMISSION_REPLAY_METADATA_KEY: &str = "permission.executing_supervisor.v1";
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SupervisorPermissionReplayRecord {
+    version: u8,
+    incarnation_id: Uuid,
+    session_id: String,
+    result_message_id: String,
+    request_generation: String,
+    tool_call: ToolCall,
+    execution_name: String,
+}
+
 impl ExecutingSupervisorObservation {
+    pub const PERMISSION_REPLAY_METADATA_KEY: &'static str =
+        SUPERVISOR_PERMISSION_REPLAY_METADATA_KEY;
+
     /// Capture only from the Session actually executing the call, before its
     /// context is queued or transferred. Never call this on a replacement
     /// Session loaded to resolve configuration or replay an old operation.
@@ -56,6 +74,122 @@ impl ExecutingSupervisorObservation {
             session_id: DEFAULT_SUPERVISOR_SESSION_ID.to_string(),
             incarnation_id: self.incarnation_id,
         }
+    }
+
+    /// Encode this already captured observation at the host's waiting-message
+    /// writer. The original operation and actual new result ID are immutable
+    /// bindings, not values to recover from model-visible result JSON.
+    pub fn permission_replay_record(
+        self,
+        session_id: &str,
+        result_message_id: &str,
+        tool_call: &ToolCall,
+        execution_name: &str,
+        request_generation: &str,
+    ) -> Value {
+        serde_json::to_value(SupervisorPermissionReplayRecord {
+            version: 1,
+            incarnation_id: self.incarnation_id,
+            session_id: session_id.to_string(),
+            result_message_id: result_message_id.to_string(),
+            request_generation: request_generation.to_string(),
+            tool_call: tool_call.clone(),
+            execution_name: execution_name.to_string(),
+        })
+        .expect("Supervisor permission binding serializes")
+    }
+
+    /// Narrow host restoration from an exact durable result occurrence. The
+    /// caller must additionally validate the typed request/receipt contract
+    /// before granting permissions or handing this observation to a tool.
+    /// This never captures an identity from the reloaded Session.
+    pub fn restore_permission_replay_record(
+        session: &Session,
+        result_index: usize,
+        tool_call: &ToolCall,
+        execution_name: &str,
+        request_generation: Option<&str>,
+    ) -> Result<Option<Self>, &'static str> {
+        let message = session
+            .messages
+            .get(result_index)
+            .ok_or("result occurrence missing")?;
+        if serde_json::from_str::<Value>(&message.content)
+            .ok()
+            .is_some_and(|payload| {
+                payload
+                    .get(SUPERVISOR_PERMISSION_REPLAY_METADATA_KEY)
+                    .is_some()
+            })
+        {
+            return Err("Supervisor authority is not accepted from a result payload");
+        }
+        let Some(value) = message
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(SUPERVISOR_PERMISSION_REPLAY_METADATA_KEY))
+        else {
+            return Ok(None);
+        };
+        let record: SupervisorPermissionReplayRecord = serde_json::from_value(value.clone())
+            .map_err(|_| "Supervisor permission binding is malformed")?;
+        let latest_result = session
+            .messages
+            .iter()
+            .rposition(|message| message.tool_call_id.as_deref() == Some(tool_call.id.as_str()));
+        let newer_call = session.messages[result_index + 1..].iter().any(|message| {
+            message
+                .tool_calls
+                .as_ref()
+                .is_some_and(|calls| calls.iter().any(|call| call.id == tool_call.id))
+        });
+        let preceding_call = session.messages[..result_index]
+            .iter()
+            .rev()
+            .find(|message| {
+                message
+                    .tool_calls
+                    .as_ref()
+                    .is_some_and(|calls| calls.iter().any(|call| call.id == tool_call.id))
+            });
+        let exact_call = preceding_call.is_some_and(|message| {
+            message.role == bamboo_domain::Role::Assistant
+                && message.tool_calls.as_ref().is_some_and(|calls| {
+                    let matching: Vec<_> = calls
+                        .iter()
+                        .filter(|call| call.id == tool_call.id)
+                        .collect();
+                    matching.len() == 1 && matching[0] == tool_call
+                })
+        });
+        if record.version != 1
+            || record.incarnation_id.is_nil()
+            || session.id != DEFAULT_SUPERVISOR_SESSION_ID
+            || session.kind != SessionKind::Root
+            || session.root_session_id != session.id
+            || session.parent_session_id.is_some()
+            || session.spawn_depth != 0
+            || session.authority_identity
+                != (SessionAuthorityIdentity::Supervisor {
+                    incarnation_id: record.incarnation_id,
+                })
+            || message.role != bamboo_domain::Role::Tool
+            || latest_result != Some(result_index)
+            || newer_call
+            || !exact_call
+            || record.session_id != session.id
+            || record.result_message_id != message.id
+            || record.tool_call != *tool_call
+            || record.execution_name != execution_name
+            || execution_name.trim().is_empty()
+            || record.request_generation.trim().is_empty()
+            || Some(record.request_generation.as_str()) != request_generation
+        {
+            return Err("Supervisor permission binding does not match the current operation");
+        }
+        Ok(Some(Self {
+            incarnation_id: record.incarnation_id,
+        }))
     }
 
     pub(super) fn for_caller(self, session_id: Option<&str>) -> Option<Self> {

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -173,6 +173,7 @@ async fn execute_and_apply_single_tool_call(
                 tool_name
             );
             let outcome = per_call::ToolExecutionOutcome {
+                permission_replay_origin: None,
                 needs_human: None,
                 post_tool_hook_eligible: false,
                 result: Err(format!("Plan mode: {} operation blocked", tool_name)),
@@ -232,6 +233,7 @@ async fn execute_and_apply_single_tool_call(
                     policy_error
                 );
                 per_call::ToolExecutionOutcome {
+                    permission_replay_origin: None,
                     needs_human: None,
                     post_tool_hook_eligible: false,
                     result: Err(policy_error),
@@ -275,6 +277,7 @@ async fn execute_and_apply_single_tool_call(
                 message
             );
             per_call::ToolExecutionOutcome {
+                permission_replay_origin: None,
                 needs_human: None,
                 post_tool_hook_eligible: false,
                 result: Err(message),
@@ -681,6 +684,7 @@ pub(crate) async fn execute_round_tool_calls(
                         .await
                         .unwrap_or_else(|_| {
                             Ok(per_call::ToolExecutionOutcome {
+                                permission_replay_origin: None,
                                 needs_human: None,
                                 post_tool_hook_eligible: true,
                                 result: Err(format!(
@@ -705,6 +709,7 @@ pub(crate) async fn execute_round_tool_calls(
                     .iter()
                     .map(|_batch_call| {
                         Ok(per_call::ToolExecutionOutcome {
+                            permission_replay_origin: None,
                             needs_human: None,
                             post_tool_hook_eligible: true,
                             result: Err(format!(

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
@@ -240,6 +240,7 @@ fn plan_content_summary(result_payload: &str) -> Option<String> {
 /// `maybe_handle_user_question_tool` sniff path until they too migrate.
 pub(super) async fn suspend_for_pending_question(
     tool_call: &ToolCall,
+    permission_replay_origin: Option<&crate::session_app::approval_replay::PermissionReplayOrigin>,
     pq: bamboo_agent_core::PendingQuestion,
     result: ToolResult,
     session: &mut Session,
@@ -269,7 +270,13 @@ pub(super) async fn suspend_for_pending_question(
     // The tool's own result IS the paired tool_result (carries the rich display
     // payload: conclusion / plan / permission data), kept identical to the
     // pre-Phase-B transcript.
-    append_waiting_tool_result_message(session, tool_call, &result.result, session_id);
+    append_waiting_tool_result_message(
+        session,
+        tool_call,
+        &result.result,
+        session_id,
+        permission_replay_origin,
+    );
 
     send_event_with_metrics(
         event_tx,
@@ -310,6 +317,8 @@ pub(super) async fn suspend_for_pending_question(
 }
 
 pub(super) struct UserQuestionToolContext<'a> {
+    pub(super) permission_replay_origin:
+        Option<&'a crate::session_app::approval_replay::PermissionReplayOrigin>,
     pub(super) tool_call: &'a ToolCall,
     pub(super) result: &'a ToolResult,
     pub(super) session: &'a mut Session,
@@ -322,6 +331,7 @@ pub(super) struct UserQuestionToolContext<'a> {
 
 pub(super) async fn maybe_handle_user_question_tool(context: UserQuestionToolContext<'_>) -> bool {
     let UserQuestionToolContext {
+        permission_replay_origin,
         tool_call,
         result,
         session,
@@ -361,7 +371,13 @@ pub(super) async fn maybe_handle_user_question_tool(context: UserQuestionToolCon
         None
     };
 
-    append_waiting_tool_result_message(session, tool_call, &result.result, session_id);
+    append_waiting_tool_result_message(
+        session,
+        tool_call,
+        &result.result,
+        session_id,
+        permission_replay_origin,
+    );
 
     send_event_with_metrics(
         event_tx,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/session_effects.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/session_effects.rs
@@ -11,11 +11,15 @@ pub(super) fn append_waiting_tool_result_message(
     tool_call: &ToolCall,
     tool_result_payload: &str,
     session_id: &str,
+    permission_replay_origin: Option<&crate::session_app::approval_replay::PermissionReplayOrigin>,
 ) {
-    let tool_result_msg = bamboo_agent_core::Message::tool_result(
+    let mut tool_result_msg = bamboo_agent_core::Message::tool_result(
         tool_call.id.clone(),
         tool_result_payload.to_string(),
     );
+    if let Some(origin) = permission_replay_origin {
+        origin.bind_waiting_message(&mut tool_result_msg);
+    }
     tracing::debug!(
         "[{}] Adding tool result message for {}, tool_call_id: {}, message_id: {}",
         session_id,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/tests.rs
@@ -47,6 +47,7 @@ async fn maybe_handle_user_question_tool_sets_pending_question_and_emits_events(
     let mut session = Session::new("session-1", "model");
 
     let handled = maybe_handle_user_question_tool(UserQuestionToolContext {
+        permission_replay_origin: None,
         tool_call: &tool_call,
         result: &result,
         session: &mut session,
@@ -148,6 +149,7 @@ async fn legacy_pending_question_persistence_failure_never_publishes_clarificati
 
     assert!(
         maybe_handle_user_question_tool(UserQuestionToolContext {
+            permission_replay_origin: None,
             tool_call: &tool_call,
             result: &result,
             session: &mut session,
@@ -198,6 +200,7 @@ async fn maybe_handle_user_question_tool_handles_request_permissions() {
     let mut session = Session::new("session-perm", "model");
 
     let handled = maybe_handle_user_question_tool(UserQuestionToolContext {
+        permission_replay_origin: None,
         tool_call: &tool_call,
         result: &result,
         session: &mut session,
@@ -343,6 +346,7 @@ async fn maybe_handle_user_question_tool_persists_exit_plan_file_and_emits_updat
     });
 
     let handled = maybe_handle_user_question_tool(UserQuestionToolContext {
+        permission_replay_origin: None,
         tool_call: &tool_call,
         result: &result,
         session: &mut session,
@@ -454,6 +458,7 @@ async fn maybe_handle_user_question_tool_ignores_unrelated_tool_calls() {
     let mut session = Session::new("session-1", "model");
 
     let handled = maybe_handle_user_question_tool(UserQuestionToolContext {
+        permission_replay_origin: None,
         tool_call: &tool_call,
         result: &result,
         session: &mut session,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths.rs
@@ -16,6 +16,8 @@ mod success_path;
 mod workspace;
 
 pub(super) struct SuccessPathContext<'a> {
+    pub permission_replay_origin:
+        Option<&'a crate::session_app::approval_replay::PermissionReplayOrigin>,
     pub tool_call: &'a ToolCall,
     pub result: &'a ToolResult,
     pub event_tx: &'a mpsc::Sender<AgentEvent>,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
@@ -101,6 +101,7 @@ pub(super) async fn handle_successful_tool_result(mut ctx: SuccessPathContext<'_
 
     if clarification::maybe_handle_user_question_tool(clarification::UserQuestionToolContext {
         tool_call: ctx.tool_call,
+        permission_replay_origin: ctx.permission_replay_origin,
         result: ctx.result,
         session: ctx.session,
         event_tx: ctx.event_tx,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -18,6 +18,7 @@ use bamboo_metrics::MetricsCollector;
 use super::execution_paths;
 use super::loop_state::RoundExecutionState;
 use super::policy;
+use crate::session_app::approval_replay::PermissionReplayOrigin;
 
 fn preview_for_log(value: &str, max_chars: usize) -> String {
     let mut iter = value.chars();
@@ -89,6 +90,7 @@ pub(super) struct ToolExecutionApplyContext<'a> {
 }
 
 pub(super) struct ToolExecutionOutcome {
+    pub permission_replay_origin: Option<PermissionReplayOrigin>,
     pub result: Result<ToolResult, String>,
     /// Set when the tool returned [`ToolOutcome::NeedsHuman`] — the structured
     /// pending question the loop suspends on (its display `result` is carried in
@@ -130,6 +132,7 @@ pub(super) async fn execute_model_requested_tool_call_only(
             ctx.tool_call.function.name,
         );
         return Ok(ToolExecutionOutcome {
+            permission_replay_origin: None,
             result: Err(message),
             needs_human: None,
             post_tool_hook_eligible: false,
@@ -162,6 +165,7 @@ async fn execute_tool_call_only_with_execution_name(
             policy_error
         );
         return Ok(ToolExecutionOutcome {
+            permission_replay_origin: None,
             needs_human: None,
             post_tool_hook_eligible: false,
             result: Err(policy_error),
@@ -267,6 +271,7 @@ async fn execute_tool_call_only_with_execution_name(
                 let end_event = emitter.error(reason.clone()).clone();
                 let _ = ctx.event_tx.send(end_event.into_agent_event()).await;
                 return Ok(ToolExecutionOutcome {
+                    permission_replay_origin: None,
                     result: Err(format!("Tool execution denied by hook: {reason}")),
                     needs_human: None,
                     post_tool_hook_eligible: false,
@@ -401,6 +406,9 @@ async fn execute_tool_call_only_with_execution_name(
     );
 
     Ok(ToolExecutionOutcome {
+        permission_replay_origin: ctx.executing_supervisor.map(|observation| {
+            PermissionReplayOrigin::new(observation, ctx.session_id, ctx.tool_call, execution_name)
+        }),
         result: result.map_err(|error| error.to_string()),
         needs_human,
         post_tool_hook_eligible,
@@ -481,6 +489,7 @@ async fn hook_ask_outcome(
             })
             .await;
         return (!approved).then(|| ToolExecutionOutcome {
+            permission_replay_origin: None,
             result: Err("Tool execution denied by parent agent review".to_string()),
             needs_human: None,
             post_tool_hook_eligible: false,
@@ -489,6 +498,7 @@ async fn hook_ask_outcome(
     }
 
     Some(ToolExecutionOutcome {
+        permission_replay_origin: None,
         result: Err(
             "Hook requested approval, but no parent-agent reviewer is available; denied"
                 .to_string(),
@@ -623,6 +633,7 @@ pub(super) async fn apply_tool_execution_outcome(
         .await;
         super::clarification::suspend_for_pending_question(
             ctx.tool_call,
+            outcome.permission_replay_origin.as_ref(),
             pending_question,
             display_result,
             ctx.session,
@@ -641,6 +652,7 @@ pub(super) async fn apply_tool_execution_outcome(
                 let r = execution_paths::handle_successful_tool_result(
                     execution_paths::SuccessPathContext {
                         tool_call: ctx.tool_call,
+                        permission_replay_origin: outcome.permission_replay_origin.as_ref(),
                         result: &result,
                         event_tx: ctx.event_tx,
                         metrics_collector: ctx.metrics_collector,
@@ -695,7 +707,15 @@ pub(super) async fn apply_tool_execution_outcome(
         .rev()
         .find(|m| m.tool_call_id.as_deref() == Some(&tool_call_id_for_meta))
     {
-        msg.metadata = Some(metadata_value);
+        let metadata = msg.metadata.get_or_insert_with(|| serde_json::json!({}));
+        if let Some(object) = metadata.as_object_mut() {
+            object.extend(
+                metadata_value
+                    .as_object()
+                    .expect("lifecycle metadata object")
+                    .clone(),
+            );
+        }
     }
 
     if let Some(hook_outcome) = deferred_hook_control {
@@ -1375,6 +1395,7 @@ mod hook_tests {
         let tool_call = probe_call("canonical-tool");
         let (event_tx, mut event_rx) = mpsc::channel(16);
         let outcome = ToolExecutionOutcome {
+            permission_replay_origin: None,
             result: Ok(ToolResult::text(false, "decision pending")),
             needs_human: Some(bamboo_agent_core::PendingQuestion {
                 tool_call_id: "stale-call".to_string(),
@@ -1703,6 +1724,7 @@ mod hook_tests {
         let tool_call = probe_call("probe");
         let mut session = Session::new("post-feedback", "model");
         let outcome = ToolExecutionOutcome {
+            permission_replay_origin: None,
             result: Ok(ToolResult::text(true, "raw output")),
             needs_human: None,
             post_tool_hook_eligible: true,
@@ -1746,6 +1768,7 @@ mod hook_tests {
         let tool_call = probe_call("probe");
         let mut session = Session::new("post-error-feedback", "model");
         let outcome = ToolExecutionOutcome {
+            permission_replay_origin: None,
             result: Err("executor exploded".to_string()),
             needs_human: None,
             post_tool_hook_eligible: true,

--- a/crates/engine/bamboo-engine/src/session_app/approval_replay.rs
+++ b/crates/engine/bamboo-engine/src/session_app/approval_replay.rs
@@ -7,7 +7,8 @@
 
 use bamboo_agent_core::storage::Storage;
 use bamboo_agent_core::tools::{
-    plan_mode_allows_tool, ToolCall, ToolExecutionSessionFlags, ToolResult,
+    plan_mode_allows_tool, ExecutingSupervisorObservation, ToolCall, ToolExecutionSessionFlags,
+    ToolResult,
 };
 use bamboo_agent_core::{AgentError, PendingQuestionSource, Session};
 use bamboo_domain::{permission_request_generation, AgentRuntimeState, PermissionMode};
@@ -18,6 +19,68 @@ use bamboo_tools::permission::{
 use serde::{Deserialize, Serialize};
 
 const PERMISSION_REPLAY_APPROVALS_METADATA_KEY: &str = "permission.replay_approvals.v1";
+
+/// Original host dispatch, retained through result application without reading
+/// a possibly replaced Session or trusting the tool's display payload.
+pub(crate) struct PermissionReplayOrigin {
+    observation: ExecutingSupervisorObservation,
+    session_id: String,
+    tool_call: ToolCall,
+    execution_name: String,
+}
+
+impl PermissionReplayOrigin {
+    pub(crate) fn new(
+        observation: ExecutingSupervisorObservation,
+        session_id: &str,
+        tool_call: &ToolCall,
+        execution_name: &str,
+    ) -> Self {
+        Self {
+            observation,
+            session_id: session_id.into(),
+            tool_call: tool_call.clone(),
+            execution_name: execution_name.into(),
+        }
+    }
+
+    pub(crate) fn bind_waiting_message(&self, message: &mut bamboo_agent_core::Message) {
+        let Ok(payload) = serde_json::from_str::<serde_json::Value>(&message.content) else {
+            return;
+        };
+        if payload.get("status").and_then(serde_json::Value::as_str)
+            != Some("awaiting_permission_approval")
+        {
+            return;
+        }
+        let Some(request) = payload
+            .get("permission_request")
+            .cloned()
+            .and_then(|value| serde_json::from_value::<PermissionRequest>(value).ok())
+        else {
+            return;
+        };
+        if request.session_id != self.session_id
+            || request.request_id != self.tool_call.id
+            || request.tool_name != self.execution_name
+            || request.request_generation.trim().is_empty()
+            || message.tool_call_id.as_deref() != Some(self.tool_call.id.as_str())
+        {
+            return;
+        }
+        let record = self.observation.permission_replay_record(
+            &self.session_id,
+            &message.id,
+            &self.tool_call,
+            &self.execution_name,
+            &request.request_generation,
+        );
+        message.metadata = Some(serde_json::json!({
+            "permission_request": request,
+            ExecutingSupervisorObservation::PERMISSION_REPLAY_METADATA_KEY: record,
+        }));
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct PermissionReplayApproval {
@@ -175,6 +238,8 @@ fn validate_replay_approval(
 ) -> Result<(), AgentError> {
     let request = &approval.request;
     let decision = &approval.decision;
+    // expected_policy_revision was checked as an ingress CAS. A refresh can
+    // retain this request generation while the durable request has its old revision.
     if request.session_id != session.id
         || request.request_id != tool_call_id
         || request.request_generation.trim().is_empty()
@@ -211,36 +276,92 @@ fn selected_replay_matcher(
         })
 }
 
-/// Rebuild the exact runtime capabilities needed by a typed approved replay.
-///
-/// The current receipt and any earlier contexts approved for the same concrete
-/// invocation live on the generation-bound result message. This lets a daemon
-/// restart recover an AllowOnce/AllowSession without broadening it, and lets a
-/// tool with multiple permission contexts restart its checks while retaining
-/// only the contexts the operator already approved.
-pub fn restore_permission_replay_authorization(
-    config: &PermissionConfig,
+/// Pure admission, including present-invalid authority on legacy and Plan
+/// paths. Run this before changing replay markers or installing any grants.
+pub fn validate_permission_replay_authority(
     session: &Session,
     target: &PermissionReplayTarget,
-) -> Result<(), AgentError> {
-    let Some(replay_generation) = target.request_generation() else {
-        return Ok(());
-    };
-    let workspace = session
-        .workspace
-        .as_deref()
-        .map(str::trim)
-        .filter(|workspace| !workspace.is_empty())
-        .map(ToOwned::to_owned);
-    config.set_session_workspace(session.id.clone(), workspace);
+    execution_name: &str,
+) -> Result<Option<ExecutingSupervisorObservation>, AgentError> {
+    let observation = ExecutingSupervisorObservation::restore_permission_replay_record(
+        session,
+        target.result_message_index,
+        &target.tool_call,
+        execution_name,
+        target.request_generation(),
+    )
+    .map_err(|error| AgentError::Tool(error.into()))?;
+    if observation.is_some() {
+        let approvals = validated_replay_approvals(session, target)?;
+        if approvals.is_empty()
+            || approvals
+                .iter()
+                .any(|approval| approval.request.tool_name != execution_name)
+        {
+            return Err(AgentError::Tool(
+                "Supervisor approval owner does not match dispatch".into(),
+            ));
+        }
+    }
+    Ok(observation)
+}
 
+/// An unanswered native approval can be displayed again without a receipt,
+/// but its host identity must already match the waiting operation. This pure
+/// check never returns an executable observation or installs a permission.
+pub fn validate_pending_permission_replay_authority(
+    session: &Session,
+    target: &PermissionReplayTarget,
+    execution_name: &str,
+) -> Result<(), AgentError> {
+    let observation = ExecutingSupervisorObservation::restore_permission_replay_record(
+        session,
+        target.result_message_index,
+        &target.tool_call,
+        execution_name,
+        target.request_generation(),
+    )
+    .map_err(|error| AgentError::Tool(error.into()))?;
+    if observation.is_some() {
+        let metadata = session.messages[target.result_message_index]
+            .metadata
+            .as_ref()
+            .expect("validated host metadata");
+        let request = metadata
+            .get("permission_request")
+            .cloned()
+            .and_then(|value| serde_json::from_value::<PermissionRequest>(value).ok())
+            .ok_or_else(|| {
+                AgentError::Tool(
+                    "Supervisor waiting approval is missing its durable request".into(),
+                )
+            })?;
+        if request.session_id != session.id
+            || request.request_id != target.tool_call.id
+            || request.tool_name != execution_name
+            || target.request_generation() != Some(request.request_generation.as_str())
+            || metadata.get("permission_decision_receipt").is_some()
+        {
+            return Err(AgentError::Tool(
+                "Supervisor waiting approval does not match its request".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validated_replay_approvals(
+    session: &Session,
+    target: &PermissionReplayTarget,
+) -> Result<Vec<PermissionReplayApproval>, AgentError> {
+    let Some(replay_generation) = target.request_generation() else {
+        return Ok(Vec::new());
+    };
     let message = session
         .messages
         .get(target.result_message_index)
         .filter(|message| message.id == target.result_message_id)
-        .ok_or_else(|| {
-            AgentError::Tool("permission replay result occurrence changed".to_string())
-        })?;
+        .ok_or_else(|| AgentError::Tool("permission replay result occurrence changed".into()))?;
     let mut approvals = message
         .metadata
         .as_ref()
@@ -257,7 +378,7 @@ pub fn restore_permission_replay_authorization(
     let (request, receipt) = message_permission_contract(session, target)?;
     if receipt.session_id != session.id || request.request_generation != replay_generation {
         return Err(AgentError::Tool(
-            "permission replay receipt does not match the active generation".to_string(),
+            "permission replay receipt does not match the active generation".into(),
         ));
     }
     approvals.push(PermissionReplayApproval {
@@ -266,52 +387,89 @@ pub fn restore_permission_replay_authorization(
     });
     if approvals.len() > 64 {
         return Err(AgentError::Tool(
-            "permission replay approval ledger exceeded its safety bound".to_string(),
+            "permission replay approval ledger exceeded its safety bound".into(),
         ));
     }
-
     for approval in &approvals {
-        validate_replay_approval(session, target.tool_call.id.as_str(), approval)?;
+        validate_replay_approval(session, &target.tool_call.id, approval)?;
+        match approval.decision.decision {
+            PermissionDecisionKind::AllowOnce => {}
+            PermissionDecisionKind::AllowSession | PermissionDecisionKind::AllowGlobal => {
+                selected_replay_matcher(approval)?;
+            }
+            PermissionDecisionKind::AllowWorkspace => {
+                let workspace = session
+                    .workspace
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|workspace| !workspace.is_empty());
+                if workspace != approval.request.workspace_path.as_deref() {
+                    return Err(AgentError::Tool(
+                        "workspace permission replay does not match the durable session workspace"
+                            .into(),
+                    ));
+                }
+                selected_replay_matcher(approval)?;
+            }
+            PermissionDecisionKind::DenyOnce | PermissionDecisionKind::DenySession => {
+                return Err(AgentError::Tool(
+                    "denied permission unexpectedly carried an execution replay marker".into(),
+                ));
+            }
+        }
+    }
+    Ok(approvals)
+}
+
+/// Rebuild the exact runtime capabilities needed by a typed approved replay.
+///
+/// The current receipt and any earlier contexts approved for the same concrete
+/// invocation live on the generation-bound result message. This lets a daemon
+/// restart recover an AllowOnce/AllowSession without broadening it, and lets a
+/// tool with multiple permission contexts restart its checks while retaining
+/// only the contexts the operator already approved.
+pub fn restore_permission_replay_authorization(
+    config: &PermissionConfig,
+    session: &Session,
+    target: &PermissionReplayTarget,
+    execution_name: &str,
+) -> Result<(), AgentError> {
+    validate_permission_replay_authority(session, target, execution_name)?;
+    let approvals = validated_replay_approvals(session, target)?;
+    let Some(replay_generation) = target.request_generation() else {
+        return Ok(());
+    };
+    config.set_session_workspace(
+        session.id.clone(),
+        session
+            .workspace
+            .as_deref()
+            .map(str::trim)
+            .filter(|workspace| !workspace.is_empty())
+            .map(ToOwned::to_owned),
+    );
+    // Every record and matcher was validated before the first installation.
+    for approval in &approvals {
         match approval.decision.decision {
             PermissionDecisionKind::AllowOnce => config
                 .grant_once_for_generation(
-                    session.id.as_str(),
-                    target.tool_call.id.as_str(),
+                    &session.id,
+                    &target.tool_call.id,
                     replay_generation,
                     approval.request.permission_type,
                     approval.request.resource.clone(),
                 )
                 .map_err(AgentError::Tool)?,
-            PermissionDecisionKind::AllowSession => {
-                config
-                    .grant_typed_scoped_session_permission(
-                        session.id.as_str(),
-                        approval.request.permission_type,
-                        selected_replay_matcher(approval)?,
-                    )
-                    .map_err(AgentError::Tool)?;
-            }
-            PermissionDecisionKind::AllowWorkspace => {
-                let authoritative = session
-                    .workspace
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|workspace| !workspace.is_empty());
-                if authoritative != approval.request.workspace_path.as_deref() {
-                    return Err(AgentError::Tool(
-                        "workspace permission replay does not match the durable session workspace"
-                            .to_string(),
-                    ));
-                }
-                selected_replay_matcher(approval)?;
-            }
-            PermissionDecisionKind::AllowGlobal => {
-                selected_replay_matcher(approval)?;
-            }
+            PermissionDecisionKind::AllowSession => config
+                .grant_typed_scoped_session_permission(
+                    &session.id,
+                    approval.request.permission_type,
+                    selected_replay_matcher(approval)?,
+                )
+                .map_err(AgentError::Tool)?,
+            PermissionDecisionKind::AllowWorkspace | PermissionDecisionKind::AllowGlobal => {}
             PermissionDecisionKind::DenyOnce | PermissionDecisionKind::DenySession => {
-                return Err(AgentError::Tool(
-                    "denied permission unexpectedly carried an execution replay marker".to_string(),
-                ));
+                unreachable!("validated above")
             }
         }
     }
@@ -326,6 +484,7 @@ pub fn repark_permission_replay(
     session: &mut Session,
     target: &PermissionReplayTarget,
     result: &ToolResult,
+    execution_name: &str,
 ) -> Result<Option<ReparkedPermissionApproval>, AgentError> {
     let payload = match serde_json::from_str::<serde_json::Value>(&result.result) {
         Ok(payload)
@@ -337,6 +496,18 @@ pub fn repark_permission_replay(
         }
         _ => return Ok(None),
     };
+    // Validate the old durable identity/receipt without installing grants again.
+    let original_observation =
+        validate_permission_replay_authority(session, target, execution_name)?;
+    let prior_approvals = validated_replay_approvals(session, target)?;
+    if payload
+        .get(ExecutingSupervisorObservation::PERMISSION_REPLAY_METADATA_KEY)
+        .is_some()
+    {
+        return Err(AgentError::Tool(
+            "Supervisor authority cannot originate in a replay result payload".into(),
+        ));
+    }
     let new_request = payload
         .get("permission_request")
         .cloned()
@@ -347,7 +518,11 @@ pub fn repark_permission_replay(
     if new_request.session_id != session.id
         || new_request.request_id != target.tool_call.id
         || new_request.request_generation.trim().is_empty()
+        || new_request.tool_name != execution_name
         || target.request_generation() == Some(new_request.request_generation.as_str())
+        || prior_approvals
+            .iter()
+            .any(|approval| approval.request.request_generation == new_request.request_generation)
     {
         return Err(AgentError::Tool(
             "replayed permission gate returned an invalid next-generation identity".to_string(),
@@ -425,6 +600,18 @@ pub fn repark_permission_replay(
         PERMISSION_REPLAY_APPROVALS_METADATA_KEY.to_string(),
         serde_json::to_value(approvals).expect("permission replay approvals serialize"),
     );
+    if let Some(original) = original_observation {
+        object.insert(
+            ExecutingSupervisorObservation::PERMISSION_REPLAY_METADATA_KEY.to_string(),
+            original.permission_replay_record(
+                &session.id,
+                &target.result_message_id,
+                &target.tool_call,
+                execution_name,
+                &new_request.request_generation,
+            ),
+        );
+    }
     object.insert(
         "permission_request".to_string(),
         serde_json::to_value(&new_request).expect("permission request serializes"),
@@ -821,30 +1008,59 @@ mod tests {
     }
 
     #[test]
-    fn restart_restores_exact_allow_once_and_session_authorizations() {
-        let allow_once = approved_replay_session(
-            "generation-1",
-            "context-one",
-            PermissionDecisionKind::AllowOnce,
-        );
-        let target =
-            find_permission_replay_target(&allow_once, "call-1", Some("generation-1")).unwrap();
-        let restarted = PermissionConfig::new();
-        restore_permission_replay_authorization(&restarted, &allow_once, &target).unwrap();
-        assert!(restarted.consume_once_for_generation(
-            "replay",
-            "call-1",
-            "generation-1",
-            PermissionType::ExecuteCommand,
-            "context-one"
-        ));
-        assert!(!restarted.consume_once_for_generation(
-            "replay",
-            "call-1",
-            "generation-1",
-            PermissionType::ExecuteCommand,
-            "different-context"
-        ));
+    fn restart_restores_refreshed_typed_allow_once_and_session_authorizations() {
+        for expected_policy_revision in [None, Some(0), Some(1)] {
+            let mut allow_once = approved_replay_session(
+                "generation-1",
+                "context-one",
+                PermissionDecisionKind::AllowOnce,
+            );
+            // A same-generation refresh leaves the original durable request at 0.
+            allow_once
+                .messages
+                .last_mut()
+                .unwrap()
+                .metadata
+                .as_mut()
+                .unwrap()["permission_decision_receipt"]["decision"]["expected_policy_revision"] =
+                serde_json::json!(expected_policy_revision);
+            let target =
+                find_permission_replay_target(&allow_once, "call-1", Some("generation-1")).unwrap();
+            assert!(
+                validate_permission_replay_authority(&allow_once, &target, "multi_context")
+                    .unwrap()
+                    .is_none()
+            );
+            let restarted = PermissionConfig::new();
+            restore_permission_replay_authorization(
+                &restarted,
+                &allow_once,
+                &target,
+                "multi_context",
+            )
+            .unwrap();
+            assert!(!restarted.consume_once_for_generation(
+                "replay",
+                "call-1",
+                "generation-1",
+                PermissionType::ExecuteCommand,
+                "different-context"
+            ));
+            assert!(restarted.consume_once_for_generation(
+                "replay",
+                "call-1",
+                "generation-1",
+                PermissionType::ExecuteCommand,
+                "context-one"
+            ));
+            assert!(!restarted.consume_once_for_generation(
+                "replay",
+                "call-1",
+                "generation-1",
+                PermissionType::ExecuteCommand,
+                "context-one"
+            ));
+        }
 
         let allow_session = approved_replay_session(
             "generation-session",
@@ -855,7 +1071,13 @@ mod tests {
             find_permission_replay_target(&allow_session, "call-1", Some("generation-session"))
                 .unwrap();
         let restarted = PermissionConfig::new();
-        restore_permission_replay_authorization(&restarted, &allow_session, &target).unwrap();
+        restore_permission_replay_authorization(
+            &restarted,
+            &allow_session,
+            &target,
+            "multi_context",
+        )
+        .unwrap();
         assert!(restarted.is_scoped_session_granted(
             "replay",
             PermissionType::ExecuteCommand,
@@ -874,7 +1096,8 @@ mod tests {
             find_permission_replay_target(&session, "call-1", Some("generation-workspace"))
                 .unwrap();
         let restarted = PermissionConfig::new();
-        restore_permission_replay_authorization(&restarted, &session, &target).unwrap();
+        restore_permission_replay_authorization(&restarted, &session, &target, "multi_context")
+            .unwrap();
         assert_eq!(
             restarted.session_workspace("replay").as_deref(),
             Some("/workspace/a")
@@ -888,7 +1111,8 @@ mod tests {
         assert!(restore_permission_replay_authorization(
             &PermissionConfig::new(),
             &mismatched,
-            &target
+            &target,
+            "multi_context"
         )
         .is_err());
     }
@@ -925,9 +1149,10 @@ mod tests {
             images: Vec::new(),
         };
 
-        let reparked = repark_permission_replay(&mut session, &target, &next_result)
-            .unwrap()
-            .expect("second context must park");
+        let reparked =
+            repark_permission_replay(&mut session, &target, &next_result, "multi_context")
+                .unwrap()
+                .expect("second context must park");
         assert_eq!(reparked.question, "Approve context two?");
         assert_eq!(
             session
@@ -969,7 +1194,8 @@ mod tests {
         let target =
             find_permission_replay_target(&session, "call-1", Some("generation-2")).unwrap();
         let restarted = PermissionConfig::new();
-        restore_permission_replay_authorization(&restarted, &session, &target).unwrap();
+        restore_permission_replay_authorization(&restarted, &session, &target, "multi_context")
+            .unwrap();
         for resource in ["context-one", "context-two"] {
             assert!(restarted.consume_once_for_generation(
                 "replay",

--- a/crates/engine/bamboo-engine/src/session_app/respond.rs
+++ b/crates/engine/bamboo-engine/src/session_app/respond.rs
@@ -415,6 +415,19 @@ fn apply_pending_response(
         .take()
         .ok_or(RespondError::NoPendingQuestion)?;
 
+    if session
+        .messages
+        .iter()
+        .rev()
+        .find(|message| message.tool_call_id.as_deref() == Some(pending.tool_call_id.as_str()))
+        .is_some_and(result_payload_has_supervisor_authority)
+    {
+        session.pending_question = Some(pending);
+        return Err(RespondError::InvalidResponse(
+            "Supervisor authority cannot originate in a tool result payload".into(),
+        ));
+    }
+
     if let Some(expected) = expected_tool_call_id {
         if pending.tool_call_id != expected {
             let actual = pending.tool_call_id.clone();
@@ -720,6 +733,11 @@ pub fn update_or_append_tool_result_message(
 ) -> bool {
     for message in session.messages.iter_mut().rev() {
         if message.tool_call_id.as_deref() == Some(tool_call_id) {
+            // Retain invalid input for fail-closed inspection; replacing the
+            // payload must not disguise forged authority as absent legacy data.
+            if result_payload_has_supervisor_authority(message) {
+                return false;
+            }
             // Preserve the server-issued typed permission contract outside the
             // model-visible content before replacing the synthetic waiting
             // payload with the selected answer. This lets an exact durable
@@ -746,6 +764,12 @@ pub fn update_or_append_tool_result_message(
         true,
     ));
     false
+}
+
+fn result_payload_has_supervisor_authority(message: &Message) -> bool {
+    serde_json::from_str::<serde_json::Value>(&message.content).ok().is_some_and(|payload| {
+        payload.get(bamboo_agent_core::tools::ExecutingSupervisorObservation::PERMISSION_REPLAY_METADATA_KEY).is_some()
+    })
 }
 
 fn insert_message_metadata(message: &mut Message, key: &str, value: serde_json::Value) {
@@ -1815,7 +1839,7 @@ mod receipt_persistence_tests {
             serde_json::json!({"command":"current-command"}).to_string()
         );
         let config = PermissionConfig::new();
-        restore_permission_replay_authorization(&config, &restarted, &target).unwrap();
+        restore_permission_replay_authorization(&config, &restarted, &target, "Bash").unwrap();
         // Try mismatches before consuming the valid grant, so these assertions
         // cannot pass merely because the one-shot grant was already exhausted.
         for (session_id, call_id, generation, resource) in [


### PR DESCRIPTION
## Summary

A Supervisor tool call that pauses for permission loses its original execution identity when resumed from durable state. Approval can succeed while the protected management operation is rejected. Preserve the host-captured identity and actual selected tool owner in the existing approval record, bound to the original Session lifetime, result Message.id, permission generation and complete ToolCall.

Server, Connect and SDK replay validate that binding before restoring permissions or changing replay state, then dispatch with the original observation. A second permission gate retains the original lifetime and operation while advancing the generation. The strict Supervisor service still checks the canonical lifetime at its final writer. Tool-result JSON cannot supply authority, and malformed, moved, stale or mismatched records cannot authorize protected dispatch. A legitimate permission-policy refresh may update the decision's CAS token while preserving the original request generation.

Closes #1119. This is the bounded approval-identity prerequisite of #1071; the complete Supervisor feature remains open.

## Test Plan

Candidate: `0da4423a027ec1c42028c478e6f61035378b9ee9`; tree: `2c8157a640d3338e150853abcaae06d057bcbe3d`; base: `4ac6947a40f14a4e0fd7bd63266527072dfa68cf`.

**Final local full verification failed as recorded below. Complete remote Server coverage and all exact-commit checks now pass; the local macOS failures remain open in their separate issues.**

- The unchanged base regression reaches native SDK parking, formal typed AllowOnce and reopened storage, then fails because protected replay has no original Supervisor identity. The candidate passes the same regression.
- The four-process parent fixture passes in the final full run: native park A, formal AllowOnce A, public replay into durable park B, then proof B is unanswered followed by formal AllowOnce B and a strict management write. Four distinct PIDs are required; stages 1–3 perform zero management writes and stage 4 performs one. Original lifetime, ToolCall and result Message.id remain fixed while generation advances. Replay after saved normal completion does not redispatch. The child helper's early-return pass is not counted as separate process evidence.
- The focused matrix covers eighteen corruption/caller combinations, custom-owner precedence, builtin aliases, ordinary/Child/synthetic contexts, Plan/legacy behavior, policy CAS refresh, wrong-resource/duplicate grant consumption, text-answer rejection and deletion/recreation between identity restoration and the strict final write. The final complete Engine and SDK suites pass: 1,493 and 82 tests respectively.
- The final actual Server binary passes native parking → fresh AppState → formal typed HTTP policy refresh/retry → strict write, Connect typed replay and forged text approval rejection. These three cases pass both in the final focused run and in the final full run before the separate Server abort. Valid/corrupt authority branches are exercised; valid replay must persist `completed` plus final Assistant `done`, and invalid authority must keep zero protected writes. The original 15-second deadline and both runner/router retirement assertions remain.
- Connect test setup prepares the fresh instance's workspace catalog from the durable session path before formal approval. It verifies unchanged raw session/runtime/permission bytes and zero protected writes or extra provider calls during preparation. It inherits no prior permission grants, authority or catalog. Temporary diagnosis instrumentation was removed. This is fixture preparation, not a production watcher change or performance guarantee.
- Final `cargo fmt --all -- --check` and the repository's exact CI Clippy command pass. Independent complete source/acceptance review reports no unresolved diff-introduced blocker and verifies all 17 committed/working/archived files, actual test artifacts and logs. Subsequent independent failure and closeout reviews retain the full-run FAIL and incomplete Server coverage; source review alone does not authorize merge.

## Completed remote verification

[CI run 34290228756](https://github.com/bigduu/Bamboo-agent/actions/runs/34290228756) completed successfully. GitHub checked out merge ref `6449240602fe55371bc29183466cfa71c86efec8`, whose parents are the current base and candidate and whose complete tree exactly equals the reviewed candidate tree above.

| Actual CI command | Completed result | Complete Server library result |
| --- | --- | --- |
| `cargo test --all-features --lib --tests` | 8,650 passed / 0 failed / 11 ignored, across 77 harnesses | 1,996 passed / 0 failed / 1 ignored |
| `cargo test --tests` | 8,648 passed / 0 failed / 11 ignored, across 76 harnesses | 1,995 passed / 0 failed / 1 ignored |

The counts exclude the nested Config child self-test from duplicate counting. Both actual configurations pass the four-process parent, native SDK restoration, Server typed policy refresh/corruption and recreated-Supervisor rejection, Connect typed/text cases, both typed-chat barrier cases and the Skills watcher case. These are Linux CI results and do not relabel the local macOS failures.

The separate all-features E2E command passes 208 tests. The real SSH/SFTP transport step and example builds pass. All 20 source checks have completed: 18 successes, plus the two expected dev-promotion skips. Final format, exact CI Clippy and complete independent source review remain bound to the same candidate. No source edits were made after its final local validation.

Final Test job log SHA-256: `97d4f0c8088b200761da9432e82adb580272a40c75b4650e199da48899e8aee6`; E2E job log SHA-256: `c769484c27f3f36acf054611b2ebbb0529a414ffd32b6c26f82e374569c55d6a`. Complete raw logs, exact checkout/tree binding, step results and per-harness/critical-case summaries are retained with the local evidence.

## Final local full result and retained failures

`cargo test --locked --no-fail-fast -- --test-threads=4` completed with **exit 101**. Default workspace, normal assertions/stack/frontend mode, no custom RUSTFLAGS and no skipped failures. Across complete unit/integration harnesses: 6,652 passed / 1 failed / 10 ignored; doctests across 28 crates: 19 passed / 120 ignored. The aborted Server harness separately logged 364 passes / one ignored entry, with **no complete summary**. Those entries do not establish complete Server coverage.

- **New adjacent failure #1121:** `cancelled_typed_chat_finishes_the_committed_pin_handoff` timed out at its 10-second POST-save barrier (`chat/handler/tests.rs:2027`) and aborted the Server process. The identical saved binary passes this single case with original settings (1/0, 14.91 test seconds). Five inspected historical logs have passes, with no same-case old failure found. Two reviews verify 178 related source/dependency objects unchanged through the candidate and three ancestors, and the request before the barrier does not invoke the changed identity paths. The actual stalled phase and indirect suite-load effects remain unknown. This is not claimed as a proven baseline failure or as fixed. #1121 records the bounded separate investigation; complete remote Server tests remain mandatory.
- **Existing Skills failure #1117:** `store::tests::os_watcher_hot_discovers_workspace_legacy_workflow` leaves Skills at 182 passed / 1 failed. The final raw diagnostic matches the saved pristine `d7ce9775` baseline after replacing only the unique temporary-root path. All 216 retained dependency fingerprint records and six complete source objects were verified. Candidate and baseline executable bytes differ and are not represented as identical. This classification applies only to Skills.
- Earlier V2 full verification aborted at the pre-commit barrier tracked in #1120, for which exact ancestor failure evidence exists. A supplemental V2 run failed in the newly added Connect settlement case; that acceptance-path failure prompted the bounded preparation correction above. Both historical runs remain failed. The corrected Connect case passes under the final full workload, but this does not erase the separate Server abort.

Final full raw log SHA-256: `640d79a534e5f9bafa56f05034c6cbe4cee957e10f0b8579c36011b41f4d1ac0`. Original logs, crash reports, same-binary rerun, complete source bindings and independent reviews are preserved locally.

## Scope and evidence limits

Seventeen changed files, twelve existing production paths, +2198/-111. Three native transport/process fixtures account for most additions. The four-hour scope review limited the final correction to two test areas. The existing permission metadata and replay ledger remain the sole protocol; no new store, model management tool, frontend, host settings API, queue or production watcher change.

Protected probes use real SDK/runner/permission/storage paths and call the strict Supervisor service using only ToolCtx identity. They do not establish model-issued management or physical shell execution. Process replacement occurs after completed durable saves; it does not establish full daemon/CUA startup, power-loss recovery, external-side-effect rollback or physical exactly-once execution. Visible typed approval and actual model-issued management remain acceptance work in subsequent slices.

Host/disk persistence retains its trusted-host boundary. Model and ordinary HTTP inputs do not gain arbitrary Message.metadata or Supervisor-record write access.
