### PR TITLE
[bamboo] fix: isolate provider metadata updates from core drift

### DIFF
--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -4982,12 +4982,61 @@ impl AppState {
     where
         F: FnOnce(&mut Config) -> Result<(), AppError>,
     {
-        if provider_intents.is_empty() && provider_instance_intents.is_empty() {
+        self.update_config_with_provider_credentials_inner(
+            update,
+            provider_intents,
+            provider_instance_intents,
+            effects,
+            false,
+        )
+        .await
+    }
+
+    /// Compatibility provider metadata update pinned to the Providers revision
+    /// selected while holding `config_io_lock`. Modular runtimes commit only
+    /// Providers; legacy runtimes retain the generic compatibility behavior.
+    pub(crate) async fn update_provider_metadata<F>(
+        &self,
+        update: F,
+        effects: ConfigUpdateEffects,
+    ) -> Result<Config, AppError>
+    where
+        F: FnOnce(&mut Config) -> Result<(), AppError>,
+    {
+        self.update_config_with_provider_credentials_inner(
+            update,
+            BTreeSet::new(),
+            BTreeSet::new(),
+            effects,
+            true,
+        )
+        .await
+    }
+
+    async fn update_config_with_provider_credentials_inner<F>(
+        &self,
+        update: F,
+        provider_intents: BTreeSet<String>,
+        provider_instance_intents: BTreeSet<String>,
+        effects: ConfigUpdateEffects,
+        exact_provider_metadata: bool,
+    ) -> Result<Config, AppError>
+    where
+        F: FnOnce(&mut Config) -> Result<(), AppError>,
+    {
+        let exact_provider_metadata = exact_provider_metadata
+            && provider_intents.is_empty()
+            && provider_instance_intents.is_empty()
+            && self.config_facade.is_some();
+        if provider_intents.is_empty()
+            && provider_instance_intents.is_empty()
+            && !exact_provider_metadata
+        {
             return self.update_config(update, effects).await;
         }
         let io = self.config_io_lock.clone().lock_owned().await;
         let config_facade = self.config_facade.clone();
-        let (mut candidate, live_base, enforcement_newly_off) = {
+        let (mut candidate, live_base, enforcement_newly_off, provider_expected_revision) = {
             let cfg = self.config.read().await;
             reject_if_recovery_pending(&cfg)?;
             let was_off = cfg.plugin_trust.enforcement_is_off();
@@ -5035,7 +5084,16 @@ impl AppState {
                 })?;
             }
             let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
-            (candidate, live_base, newly_off)
+            let provider_expected_revision = exact_provider_metadata.then(|| {
+                config_facade
+                    .as_ref()
+                    .expect("exact provider metadata requires the modular facade")
+                    .registry()
+                    .providers
+                    .snapshot()
+                    .revision
+            });
+            (candidate, live_base, newly_off, provider_expected_revision)
         };
         let config = self.config.clone();
         let app_data_dir = self.app_data_dir.clone();
@@ -5052,14 +5110,24 @@ impl AppState {
                 let commit_facade = config_facade.clone();
                 let (candidate, commit) = tokio::task::spawn_blocking(move || {
                     let result = if let Some(facade) = commit_facade {
-                        let commit =
+                        let commit = if let Some(expected_revision) = provider_expected_revision {
+                            bamboo_config::persist_provider_credential_transaction_at_revision_with_adoption(
+                                &data_dir,
+                                &mut candidate,
+                                &provider_intents,
+                                &provider_instance_intents,
+                                expected_revision,
+                                facade.as_ref(),
+                            )?
+                        } else {
                             bamboo_config::persist_provider_instance_credential_transaction_with_adoption(
                                 &data_dir,
                                 &mut candidate,
                                 &provider_intents,
                                 &provider_instance_intents,
                                 facade.as_ref(),
-                            )?;
+                            )?
+                        };
                         Ok::<_, ConfigStoreError>((candidate, Some(commit)))
                     } else {
                         bamboo_config::persist_provider_instance_credential_transaction(
@@ -9421,6 +9489,106 @@ for line in sys.stdin:
                 "{file} must remain secret-free"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn provider_metadata_cancellation_after_commit_finishes_publication() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x6d; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        let state = Arc::new(state);
+        let instance_id = "metadata-cancellation".to_string();
+        let instance_id_for_update = instance_id.clone();
+        state
+            .update_config_with_provider_credentials(
+                move |config| {
+                    let instance = serde_json::from_value(serde_json::json!({
+                        "provider_type": "openai",
+                        "label": "Before cancellation",
+                        "api_key": "metadata-cancellation-secret"
+                    }))?;
+                    config
+                        .provider_instances
+                        .insert(instance_id_for_update.clone(), instance);
+                    config.default_provider_instance = Some(instance_id_for_update.clone());
+                    Ok(())
+                },
+                BTreeSet::new(),
+                BTreeSet::from([instance_id.clone()]),
+                ConfigUpdateEffects::default(),
+            )
+            .await
+            .unwrap();
+
+        let core_path = dir.path().join("core.json");
+        let core_before = std::fs::read(&core_path).unwrap();
+        state.config.write().await.server.bind = "0.0.0.0".to_string();
+        let mut feed = state.account_sink.subscribe();
+        let (reached_tx, reached_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        set_generic_before_event_test_hook(dir.path(), move || {
+            reached_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+
+        let operation = {
+            let state = state.clone();
+            let instance_id = instance_id.clone();
+            tokio::spawn(async move {
+                state
+                    .update_provider_metadata(
+                        move |config| {
+                            config
+                                .provider_instances
+                                .get_mut(&instance_id)
+                                .unwrap()
+                                .label = Some("Committed after cancellation".to_string());
+                            Ok(())
+                        },
+                        ConfigUpdateEffects::default(),
+                    )
+                    .await
+            })
+        };
+        tokio::task::spawn_blocking(move || reached_rx.recv().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .providers
+                .snapshot()
+                .revision,
+            2,
+            "the abort boundary must follow provider metadata adoption"
+        );
+        operation.abort();
+        assert!(operation.await.unwrap_err().is_cancelled());
+        release_tx.send(()).unwrap();
+        let converged = tokio::time::timeout(Duration::from_secs(5), state.config_io_lock.lock())
+            .await
+            .expect("detached provider metadata update must finish live publication");
+        drop(converged);
+
+        let live = state.config.read().await;
+        assert_eq!(
+            live.provider_instances[&instance_id].label.as_deref(),
+            Some("Committed after cancellation")
+        );
+        assert_eq!(live.server.bind, "0.0.0.0");
+        drop(live);
+        assert_eq!(std::fs::read(core_path).unwrap(), core_before);
+        assert!(matches!(
+            next_config_event(&mut feed, "providers").await,
+            AgentEvent::ConfigChanged {
+                section,
+                revision: 2
+            } if section == "providers"
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -569,53 +569,54 @@ pub async fn update_provider_instance(
             Value::String(value) => !config_manager::is_masked_api_key(value),
             _ => false,
         });
-    let provider_instance_intents = if has_api_key_intent {
-        std::collections::BTreeSet::from([instance_id.clone()])
-    } else {
-        std::collections::BTreeSet::new()
+    let update = move |config: &mut bamboo_config::Config| {
+        let existing = config
+            .provider_instances
+            .get(&instance_id)
+            .cloned()
+            .ok_or_else(|| {
+                AppError::BadRequest(format!("Provider instance '{}' not found", instance_id))
+            })?;
+
+        let updated = apply_instance_update(&existing, &payload_inner)?;
+        // This closure runs under config_io_lock, before either the metadata
+        // or credential transaction can commit. Keep the explicit default
+        // valid instead of failing its reload after publishing a disabled
+        // instance (#1097).
+        if !updated.enabled && config.default_provider_instance.as_deref() == Some(&instance_id) {
+            return Err(AppError::BadRequest(format!(
+                "Cannot disable default provider instance '{instance_id}'; set another enabled provider instance as default first"
+            )));
+        }
+        config
+            .provider_instances
+            .insert(instance_id.clone(), updated);
+        Ok(())
     };
 
-    let new_config = app_state
-        .update_config_with_provider_credentials(
-            move |config| {
-                let existing = config
-                    .provider_instances
-                    .get(&instance_id)
-                    .cloned()
-                    .ok_or_else(|| {
-                        AppError::BadRequest(format!(
-                            "Provider instance '{}' not found",
-                            instance_id
-                        ))
-                    })?;
-
-                let updated = apply_instance_update(&existing, &payload_inner)?;
-                // This closure runs under config_io_lock, before either the
-                // metadata or credential transaction can commit. Keep the
-                // explicit default valid instead of failing its reload after
-                // publishing a disabled instance (#1097).
-                if !updated.enabled
-                    && config.default_provider_instance.as_deref() == Some(&instance_id)
-                {
-                    return Err(AppError::BadRequest(format!(
-                        "Cannot disable default provider instance '{instance_id}'; set another enabled provider instance as default first"
-                    )));
-                }
-                config
-                    .provider_instances
-                    .insert(instance_id.clone(), updated);
-                // Ciphertext sync happens centrally in `update_config` via
-                // `Config::refresh_encrypted_secrets` (#515/#516).
-                Ok(())
-            },
-            std::collections::BTreeSet::new(),
-            provider_instance_intents,
-            ConfigUpdateEffects {
-                reload_provider: bamboo_config::patch::ReloadMode::Strict,
-                reconcile_mcp: bamboo_config::patch::ReloadMode::None,
-            },
-        )
-        .await?;
+    let new_config = if has_api_key_intent {
+        app_state
+            .update_config_with_provider_credentials(
+                update,
+                std::collections::BTreeSet::new(),
+                std::collections::BTreeSet::from([instance_id_for_response.clone()]),
+                ConfigUpdateEffects {
+                    reload_provider: bamboo_config::patch::ReloadMode::Strict,
+                    reconcile_mcp: bamboo_config::patch::ReloadMode::None,
+                },
+            )
+            .await?
+    } else {
+        app_state
+            .update_provider_metadata(
+                update,
+                ConfigUpdateEffects {
+                    reload_provider: bamboo_config::patch::ReloadMode::Strict,
+                    reconcile_mcp: bamboo_config::patch::ReloadMode::None,
+                },
+            )
+            .await?
+    };
 
     let updated = new_config
         .provider_instances
@@ -1466,5 +1467,400 @@ mod tests {
             Some("Renamed"),
             "the update itself should still apply"
         );
+    }
+
+    #[tokio::test]
+    async fn metadata_updates_ignore_live_core_drift_and_preserve_credentials_after_restart() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let mut state = AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state should initialize");
+        state.stop_config_watcher_for_test();
+        let app_state = web::Data::new(state);
+
+        create_provider_instance(
+            app_state.clone(),
+            web::Json(create_request("sk-provider-metadata-secret")),
+        )
+        .await
+        .expect("create should succeed");
+
+        let (instance_id, credential_ref) = {
+            let config = app_state.config.read().await;
+            let (instance_id, instance) = config
+                .provider_instances
+                .iter()
+                .next()
+                .expect("instance exists");
+            (
+                instance_id.clone(),
+                instance
+                    .credential_ref
+                    .clone()
+                    .expect("created credential reference"),
+            )
+        };
+        let facade = app_state
+            .config_facade
+            .as_ref()
+            .expect("modular config facade");
+        let provider_revision = facade.registry().providers.snapshot().revision;
+        let core_revision = facade.registry().core.snapshot().revision;
+        let core_path = temp_dir.path().join("core.json");
+        let core_before = std::fs::read(&core_path).expect("core section exists");
+
+        // Reproduce an environment-materialized Core value that is present in
+        // the process snapshot but does not belong to this Providers request.
+        app_state.config.write().await.server.bind = "0.0.0.0".to_string();
+        let event_baseline = app_state.account_sink.latest_seq();
+
+        update_provider_instance(
+            app_state.clone(),
+            web::Path::from(instance_id.clone()),
+            web::Json(UpdateInstanceRequest {
+                label: Some("Renamed after create".to_string()),
+                enabled: None,
+                config: None,
+            }),
+        )
+        .await
+        .expect("label-only update should ignore Core drift");
+        update_provider_instance(
+            app_state.clone(),
+            web::Path::from(instance_id.clone()),
+            web::Json(UpdateInstanceRequest {
+                label: None,
+                enabled: None,
+                config: Some(serde_json::json!({"model": "custom-model-after-create"})),
+            }),
+        )
+        .await
+        .expect("model-only update should ignore Core drift");
+
+        assert_eq!(
+            std::fs::read(&core_path).expect("core section remains readable"),
+            core_before,
+            "provider metadata updates must not rewrite Core"
+        );
+        assert_eq!(
+            facade.registry().core.snapshot().revision,
+            core_revision,
+            "provider metadata updates must not advance Core"
+        );
+        assert_eq!(
+            facade.registry().providers.snapshot().revision,
+            provider_revision + 2,
+            "each metadata update advances only Providers"
+        );
+        {
+            let config = app_state.config.read().await;
+            let instance = &config.provider_instances[&instance_id];
+            assert_eq!(instance.label.as_deref(), Some("Renamed after create"));
+            assert_eq!(instance.model.as_deref(), Some("custom-model-after-create"));
+            assert_eq!(instance.credential_ref.as_ref(), Some(&credential_ref));
+            assert_eq!(config.server.bind, "0.0.0.0");
+        }
+
+        let events = bamboo_engine::events::journal::read_since(
+            app_state.account_sink.events_dir(),
+            event_baseline,
+        )
+        .expect("config events should be journaled");
+        let provider_revisions = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                bamboo_agent_core::AgentEvent::ConfigChanged { section, revision }
+                | bamboo_agent_core::AgentEvent::ConfigRecovered { section, revision }
+                    if section == "providers" =>
+                {
+                    Some(*revision)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            provider_revisions,
+            vec![provider_revision + 1, provider_revision + 2]
+        );
+        assert!(events.iter().all(|event| {
+            !matches!(
+                &event.event,
+                bamboo_agent_core::AgentEvent::ConfigChanged { section, .. }
+                    | bamboo_agent_core::AgentEvent::ConfigRecovered { section, .. }
+                    | bamboo_agent_core::AgentEvent::ConfigInvalid { section, .. }
+                    if section == "core"
+            )
+        }));
+
+        drop(app_state);
+        let restarted = AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state should restart");
+        let config = restarted.config.read().await;
+        let instance = &config.provider_instances[&instance_id];
+        assert_eq!(instance.label.as_deref(), Some("Renamed after create"));
+        assert_eq!(instance.model.as_deref(), Some("custom-model-after-create"));
+        assert_eq!(instance.credential_ref.as_ref(), Some(&credential_ref));
+        drop(config);
+        assert_eq!(
+            restarted
+                .credential_store
+                .resolve(&credential_ref)
+                .expect("credential lookup")
+                .expect("credential remains configured")
+                .expose(),
+            "sk-provider-metadata-secret"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_metadata_updates_serialize_without_lost_fields() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let mut state = AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state should initialize");
+        state.stop_config_watcher_for_test();
+        let app_state = web::Data::new(state);
+        create_provider_instance(
+            app_state.clone(),
+            web::Json(create_request("sk-concurrent-provider-secret")),
+        )
+        .await
+        .expect("create should succeed");
+        let instance_id = app_state
+            .config
+            .read()
+            .await
+            .provider_instances
+            .keys()
+            .next()
+            .cloned()
+            .expect("instance exists");
+        let provider_revision = app_state
+            .config_facade
+            .as_ref()
+            .expect("modular config facade")
+            .registry()
+            .providers
+            .snapshot()
+            .revision;
+
+        let (label_result, model_result) = tokio::join!(
+            update_provider_instance(
+                app_state.clone(),
+                web::Path::from(instance_id.clone()),
+                web::Json(UpdateInstanceRequest {
+                    label: Some("Concurrent label".to_string()),
+                    enabled: None,
+                    config: None,
+                }),
+            ),
+            update_provider_instance(
+                app_state.clone(),
+                web::Path::from(instance_id.clone()),
+                web::Json(UpdateInstanceRequest {
+                    label: None,
+                    enabled: None,
+                    config: Some(serde_json::json!({"model": "concurrent-model"})),
+                }),
+            )
+        );
+        label_result.expect("concurrent label update");
+        model_result.expect("concurrent model update");
+
+        let config = app_state.config.read().await;
+        let instance = &config.provider_instances[&instance_id];
+        assert_eq!(instance.label.as_deref(), Some("Concurrent label"));
+        assert_eq!(instance.model.as_deref(), Some("concurrent-model"));
+        drop(config);
+        assert_eq!(
+            app_state
+                .config_facade
+                .as_ref()
+                .expect("modular config facade")
+                .registry()
+                .providers
+                .snapshot()
+                .revision,
+            provider_revision + 2
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_update_rejects_an_unobserved_external_provider_winner() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let mut state = AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state should initialize");
+        state.stop_config_watcher_for_test();
+        let app_state = web::Data::new(state);
+        create_provider_instance(
+            app_state.clone(),
+            web::Json(create_request("sk-provider-cas-secret")),
+        )
+        .await
+        .expect("create should succeed");
+        let instance_id = app_state
+            .config
+            .read()
+            .await
+            .provider_instances
+            .keys()
+            .next()
+            .cloned()
+            .expect("instance exists");
+        let provider_revision = app_state
+            .config_facade
+            .as_ref()
+            .expect("modular config facade")
+            .registry()
+            .providers
+            .snapshot()
+            .revision;
+
+        let external = bamboo_config::ConfigFacade::open(temp_dir.path())
+            .expect("external facade should open");
+        let mut external_candidate = external.effective_config();
+        external_candidate
+            .provider_instances
+            .get_mut(&instance_id)
+            .expect("external instance")
+            .label = Some("External winner".to_string());
+        let external_revision = bamboo_config::persist_provider_credential_transaction_at_revision(
+            temp_dir.path(),
+            &mut external_candidate,
+            &std::collections::BTreeSet::new(),
+            &std::collections::BTreeSet::new(),
+            provider_revision,
+        )
+        .expect("external provider update should win");
+        assert_eq!(external_revision, provider_revision + 1);
+        let providers_path = temp_dir.path().join("providers.json");
+        let external_bytes = std::fs::read(&providers_path).expect("external provider document");
+
+        let error = update_provider_instance(
+            app_state.clone(),
+            web::Path::from(instance_id.clone()),
+            web::Json(UpdateInstanceRequest {
+                label: Some("Stale local loser".to_string()),
+                enabled: None,
+                config: None,
+            }),
+        )
+        .await
+        .expect_err("stale provider metadata update must conflict");
+        assert!(matches!(
+            error,
+            AppError::ConfigConflict { expected, actual }
+                if expected == provider_revision && actual == external_revision
+        ));
+        assert_eq!(
+            std::fs::read(&providers_path).expect("provider document after conflict"),
+            external_bytes,
+            "the stale local writer must not overwrite the external winner"
+        );
+        assert_ne!(
+            app_state.config.read().await.provider_instances[&instance_id]
+                .label
+                .as_deref(),
+            Some("Stale local loser")
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_provider_key_replace_and_clear_keep_existing_transaction_semantics() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let mut state = AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state should initialize");
+        state.stop_config_watcher_for_test();
+        let app_state = web::Data::new(state);
+
+        create_provider_instance(
+            app_state.clone(),
+            web::Json(create_request("sk-original-provider-secret")),
+        )
+        .await
+        .expect("first create should succeed");
+        let first_id = app_state
+            .config
+            .read()
+            .await
+            .provider_instances
+            .keys()
+            .next()
+            .cloned()
+            .expect("first instance exists");
+        create_provider_instance(
+            app_state.clone(),
+            web::Json(create_request("sk-secondary-provider-secret")),
+        )
+        .await
+        .expect("second create should succeed");
+        let second_id = app_state
+            .config
+            .read()
+            .await
+            .provider_instances
+            .keys()
+            .find(|id| **id != first_id)
+            .cloned()
+            .expect("second instance exists");
+        set_default_provider_instance(
+            app_state.clone(),
+            web::Json(SetDefaultInstanceRequest {
+                default_provider_instance_id: second_id,
+            }),
+        )
+        .await
+        .expect("secondary instance should become default");
+
+        update_provider_instance(
+            app_state.clone(),
+            web::Path::from(first_id.clone()),
+            web::Json(UpdateInstanceRequest {
+                label: None,
+                enabled: None,
+                config: Some(serde_json::json!({"api_key": "sk-replaced-provider-secret"})),
+            }),
+        )
+        .await
+        .expect("explicit key replacement should succeed");
+        let credential_ref = app_state.config.read().await.provider_instances[&first_id]
+            .credential_ref
+            .clone()
+            .expect("replacement credential reference");
+        assert_eq!(
+            app_state
+                .credential_store
+                .resolve(&credential_ref)
+                .expect("replacement credential lookup")
+                .expect("replacement remains configured")
+                .expose(),
+            "sk-replaced-provider-secret"
+        );
+
+        update_provider_instance(
+            app_state.clone(),
+            web::Path::from(first_id.clone()),
+            web::Json(UpdateInstanceRequest {
+                label: None,
+                enabled: Some(false),
+                config: Some(serde_json::json!({"api_key": null})),
+            }),
+        )
+        .await
+        .expect("explicit key clear should succeed");
+        let config = app_state.config.read().await;
+        let cleared = &config.provider_instances[&first_id];
+        assert!(!cleared.enabled);
+        assert!(cleared.credential_ref.is_none());
+        assert!(cleared.api_key.is_empty());
+        drop(config);
+        assert!(app_state
+            .credential_store
+            .resolve(&credential_ref)
+            .expect("cleared credential lookup")
+            .is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Route provider-instance metadata-only PUT requests through the exact Providers transaction in modular runtimes.
- Capture the current Providers revision under the existing config I/O lock so local writes serialize and external winners return a conflict.
- Preserve live-only Core values, durable Core bytes/revision, credential references, explicit key replace/clear semantics, strict provider reload, and exact event publication.
- Add regressions for create then label/model save, restart credential retention, local concurrency, external CAS winners, explicit key changes, and cancellation after commit.

Closes #1126

## Test Plan

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- focused bamboo-server provider-instance tests (22 passed)
- focused post-commit metadata cancellation regression (1 passed)
- cargo test --all-features --lib --tests (all workspace suites passed)

## Screenshots

Not applicable; backend-only change.