### PR TITLE
ci: switch release producers to locked Lotus Next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Test frontend artifact verification policy
-        run: node --test scripts/lotus-next-artifact.test.cjs
+      - name: Test frontend artifact and release policies
+        run: node --test scripts/lotus-next-artifact.test.cjs scripts/release-frontend-policy.test.cjs
 
       - name: Stage frontend package
         shell: bash
@@ -250,8 +250,8 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Test frontend artifact verification policy
-        run: node --test scripts/lotus-next-artifact.test.cjs
+      - name: Test frontend artifact and release policies
+        run: node --test scripts/lotus-next-artifact.test.cjs scripts/release-frontend-policy.test.cjs
 
       - name: Stage frontend package
         shell: bash

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,17 +13,25 @@ name: Publish Docker image (GHCR)
 # larger-runner plan, drop the arm64 matrix entry or switch to a single QEMU
 # job with docker/setup-qemu-action.)
 #
-# The Bamboo repository default is its verified, crate-owned Lotus Next package.
-# The current Docker release producer still stages legacy @bigduu/lotus
-# explicitly until the bigduu/Zenith#187 release-ownership gate is complete.
+# The Bamboo repository and release producers default to the same verified,
+# crate-owned Lotus Next artifact. Legacy Lotus remains one explicit,
+# fixed-version rollback selection during the bounded migration window.
 
 on:
   workflow_dispatch:
     inputs:
+      frontend_package:
+        description: "Frontend package; legacy Lotus is the explicit fixed-version rollback path"
+        required: true
+        type: choice
+        default: "@bigduu/lotus-next"
+        options:
+          - "@bigduu/lotus-next"
+          - "@bigduu/lotus"
       lotus_version:
-        description: "@bigduu/lotus npm version to embed as the web frontend. 'latest' resolves the newest published version."
+        description: "Exact selected frontend npm version; from_lock uses the committed Lotus Next lock or fixed legacy rollback version"
         required: false
-        default: "latest"
+        default: "from_lock"
         type: string
   push:
     tags:
@@ -61,26 +69,39 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Stage frontend package from npm
-        # Preserve the current legacy release producer explicitly while the
-        # repository default moves to the locked Lotus Next artifact. Remove
-        # this override only through bigduu/Zenith#187. Tag pushes carry no
-        # inputs and stage 'latest'. LOTUS_SOURCE=package hard-fails when the
-        # requested package is missing instead of falling back.
+      - name: Resolve exact release frontend
+        id: frontend
         env:
-          LOTUS_VERSION: ${{ github.event.inputs.lotus_version || 'latest' }}
-          LOTUS_PACKAGE_NAME: "@bigduu/lotus"
+          # Tag pushes have no workflow inputs and therefore resolve the
+          # committed Lotus Next lock rather than a moving npm tag.
+          FRONTEND_PACKAGE: ${{ github.event.inputs.frontend_package || '@bigduu/lotus-next' }}
+          FRONTEND_VERSION: ${{ github.event.inputs.lotus_version || 'from_lock' }}
+        run: node scripts/release-frontend-policy.cjs
+
+      - name: Stage frontend package from npm
+        # The shared resolver selects the committed Lotus Next lock by default
+        # and permits only one fixed legacy rollback. LOTUS_SOURCE=package
+        # hard-fails when the exact package is missing instead of falling back.
+        env:
+          LOTUS_PACKAGE_NAME: ${{ steps.frontend.outputs.package_name }}
+          LOTUS_VERSION: ${{ steps.frontend.outputs.package_version }}
+          EXPECTED_FRONTEND_NAME: ${{ steps.frontend.outputs.frontend_name }}
         run: |
           set -euo pipefail
-          npm install --no-save --no-package-lock "@bigduu/lotus@${LOTUS_VERSION}"
+          npm install --no-save --no-package-lock --ignore-scripts "${LOTUS_PACKAGE_NAME}@${LOTUS_VERSION}"
           LOTUS_SOURCE=package node scripts/frontend-package.cjs stage
           FRONTEND_PACKAGE_DIR="crates/app/bamboo-server/frontend_package"
           test -f "${FRONTEND_PACKAGE_DIR}/lotus-frontend.zip"
           test -f "${FRONTEND_PACKAGE_DIR}/frontend-manifest.json"
+          EMBEDDED_NAME="$(node -p "require('./${FRONTEND_PACKAGE_DIR}/frontend-manifest.json').frontend_name")"
           EMBEDDED="$(node -p "require('./${FRONTEND_PACKAGE_DIR}/frontend-manifest.json').frontend_version")"
-          echo "Embedded lotus frontend version: ${EMBEDDED}"
-          if [ "${LOTUS_VERSION}" != "latest" ] && [ "${EMBEDDED}" != "${LOTUS_VERSION}" ]; then
-            echo "::error::Embedded lotus version ${EMBEDDED} does not match requested ${LOTUS_VERSION}"
+          echo "Embedded frontend: ${EMBEDDED_NAME}@${EMBEDDED}"
+          if [ "${EMBEDDED_NAME}" != "${EXPECTED_FRONTEND_NAME}" ]; then
+            echo "::error::Embedded frontend ${EMBEDDED_NAME} does not match expected ${EXPECTED_FRONTEND_NAME}"
+            exit 1
+          fi
+          if [ "${EMBEDDED}" != "${LOTUS_VERSION}" ]; then
+            echo "::error::Embedded frontend version ${EMBEDDED} does not match resolved ${LOTUS_VERSION}"
             exit 1
           fi
 

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -13,10 +13,18 @@ on:
         required: false
         default: false
         type: boolean
+      frontend_package:
+        description: "Frontend package; legacy Lotus is the explicit fixed-version rollback path"
+        required: true
+        type: choice
+        default: "@bigduu/lotus-next"
+        options:
+          - "@bigduu/lotus-next"
+          - "@bigduu/lotus"
       lotus_version:
-        description: "@bigduu/lotus npm version to embed as the web frontend (for example: 2026.3.11). 'latest' resolves the newest published version."
+        description: "Exact selected frontend npm version; from_lock uses the committed Lotus Next lock or fixed legacy rollback version"
         required: false
-        default: "latest"
+        default: "from_lock"
         type: string
 
 permissions:
@@ -36,27 +44,38 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Stage frontend package from npm
-        # Keep the current release-train producer on legacy Lotus until the
-        # independent release-ownership gate in bigduu/Zenith#187 migrates.
-        # The package name is explicit so the repository default can safely be
-        # Lotus Next; remove this override only through that gate.
-        # LOTUS_SOURCE=package hard-fails when the npm package is missing, so a
-        # fetch failure can never silently fall back to the stale zip.
+      - name: Resolve exact release frontend
+        id: frontend
         env:
-          LOTUS_VERSION: ${{ github.event.inputs.lotus_version || 'latest' }}
-          LOTUS_PACKAGE_NAME: "@bigduu/lotus"
+          FRONTEND_PACKAGE: ${{ github.event.inputs.frontend_package || '@bigduu/lotus-next' }}
+          FRONTEND_VERSION: ${{ github.event.inputs.lotus_version || 'from_lock' }}
+        run: node scripts/release-frontend-policy.cjs
+
+      - name: Stage frontend package from npm
+        # The shared resolver selects the committed Lotus Next lock by default
+        # and permits only one fixed legacy rollback. LOTUS_SOURCE=package
+        # hard-fails when the exact package is missing, so a fetch failure can
+        # never silently fall back to committed or adjacent bytes.
+        env:
+          LOTUS_PACKAGE_NAME: ${{ steps.frontend.outputs.package_name }}
+          LOTUS_VERSION: ${{ steps.frontend.outputs.package_version }}
+          EXPECTED_FRONTEND_NAME: ${{ steps.frontend.outputs.frontend_name }}
         run: |
           set -euo pipefail
-          npm install --no-save --no-package-lock "@bigduu/lotus@${LOTUS_VERSION}"
+          npm install --no-save --no-package-lock --ignore-scripts "${LOTUS_PACKAGE_NAME}@${LOTUS_VERSION}"
           LOTUS_SOURCE=package node scripts/frontend-package.cjs stage
           FRONTEND_PACKAGE_DIR="crates/app/bamboo-server/frontend_package"
           test -f "${FRONTEND_PACKAGE_DIR}/lotus-frontend.zip"
           test -f "${FRONTEND_PACKAGE_DIR}/frontend-manifest.json"
+          EMBEDDED_NAME="$(node -p "require('./${FRONTEND_PACKAGE_DIR}/frontend-manifest.json').frontend_name")"
           EMBEDDED="$(node -p "require('./${FRONTEND_PACKAGE_DIR}/frontend-manifest.json').frontend_version")"
-          echo "Embedded lotus frontend version: ${EMBEDDED}"
-          if [ "${LOTUS_VERSION}" != "latest" ] && [ "${EMBEDDED}" != "${LOTUS_VERSION}" ]; then
-            echo "::error::Embedded lotus version ${EMBEDDED} does not match requested ${LOTUS_VERSION}"
+          echo "Embedded frontend: ${EMBEDDED_NAME}@${EMBEDDED}"
+          if [ "${EMBEDDED_NAME}" != "${EXPECTED_FRONTEND_NAME}" ]; then
+            echo "::error::Embedded frontend ${EMBEDDED_NAME} does not match expected ${EXPECTED_FRONTEND_NAME}"
+            exit 1
+          fi
+          if [ "${EMBEDDED}" != "${LOTUS_VERSION}" ]; then
+            echo "::error::Embedded frontend version ${EMBEDDED} does not match resolved ${LOTUS_VERSION}"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,13 @@ LOTUS_SOURCE=package node scripts/frontend-package.cjs stage
 
 `LOTUS_SOURCE=local` and `stage:prebuilt` remain explicit developer paths for a
 clean, self-identifying Lotus Next build. The crate and Docker release workflows
-temporarily set
-`LOTUS_PACKAGE_NAME=@bigduu/lotus` themselves to preserve the independently
-gated legacy release producer. Remove that compatibility override only through
-the `bigduu/Zenith#187` release-ownership gate; the repository default never
-auto-selects it.
+use the same committed Lotus Next lock by default, including tag-triggered
+Docker builds; they never resolve a moving npm `latest` tag. Their
+`frontend_package` input is the single release-time rollback selector. Choosing
+legacy Lotus pins `@bigduu/lotus@2026.8.28`; an unsupported package, `latest`,
+or a version inconsistent with the selected fixed artifact fails before npm
+installation. Remove this transitional legacy choice only after the rollback
+window tracked by `bigduu/Zenith#187` is complete.
 
 Cargo never runs that staging command implicitly. This removes the previous
 ignored child-process status: explicit local and GitHub Actions callers receive
@@ -461,7 +463,7 @@ cargo build --release
 |---|---|
 | [**Bodhi**](https://github.com/bigduu/Bodhi-AI) | Tauri desktop shell: starts or reuses Bamboo, waits for health, manages the sidecar lifecycle, and displays the frontend served by Bamboo |
 | [**Lotus Next**](https://github.com/bigduu/lotus-next) | Canonical React + Vite UI and Bamboo's verified embedded default: HTTP requests, shared `/v2/stream` WebSocket by default, legacy SSE fallback |
-| [**Lotus**](https://github.com/bigduu/Lotus) | Legacy UI retained temporarily as an explicit rollback and release-producer path during the staged migration |
+| [**Lotus**](https://github.com/bigduu/Lotus) | Legacy UI retained temporarily only as an explicit fixed-artifact rollback during the staged migration |
 | [**Bamboo**](https://github.com/bigduu/Bamboo-agent) | Local-first Rust agent runtime and packaged Lotus Next host (this repo) |
 | [**bodhi-server**](https://github.com/bigduu/bodhi-server) | Optional hosted service for accounts, API keys, encrypted provider credentials, model routing, billing/quota, and provider proxy |
 | [**Pavilion**](https://github.com/bigduu/Pavilion) | Official website and documentation surface |

--- a/scripts/release-frontend-policy.cjs
+++ b/scripts/release-frontend-policy.cjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  LOTUS_NEXT_PACKAGE_NAME,
+  readArtifactLock,
+} = require("./lotus-next-artifact.cjs");
+
+const ROOT = path.resolve(__dirname, "..");
+const DEFAULT_LOCK_PATH = path.join(
+  ROOT,
+  "scripts",
+  "frontend-package-lock.json",
+);
+const LEGACY_LOTUS_PACKAGE_NAME = "@bigduu/lotus";
+const LEGACY_LOTUS_VERSION = "2026.8.28";
+const FROM_LOCK = "from_lock";
+
+function normalizeInput(value, fallback, label) {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
+  }
+  return value.trim() || fallback;
+}
+
+function resolveReleaseFrontend({
+  packageName,
+  requestedVersion,
+  lockPath = DEFAULT_LOCK_PATH,
+} = {}) {
+  const selectedPackage = normalizeInput(
+    packageName,
+    LOTUS_NEXT_PACKAGE_NAME,
+    "frontend package",
+  );
+  const selectedVersion = normalizeInput(
+    requestedVersion,
+    FROM_LOCK,
+    "frontend version",
+  );
+  const lock = readArtifactLock(lockPath);
+
+  let packageVersion;
+  let frontendName;
+  if (selectedPackage === LOTUS_NEXT_PACKAGE_NAME) {
+    packageVersion = lock.packageVersion;
+    frontendName = "lotus-next";
+  } else if (selectedPackage === LEGACY_LOTUS_PACKAGE_NAME) {
+    packageVersion = LEGACY_LOTUS_VERSION;
+    frontendName = "lotus";
+  } else {
+    throw new Error(
+      `Unsupported release frontend package ${JSON.stringify(selectedPackage)}; expected ${LOTUS_NEXT_PACKAGE_NAME} or ${LEGACY_LOTUS_PACKAGE_NAME}`,
+    );
+  }
+
+  if (selectedVersion !== FROM_LOCK && selectedVersion !== packageVersion) {
+    throw new Error(
+      `Requested frontend version ${JSON.stringify(selectedVersion)} does not match the allowed ${selectedPackage} version ${JSON.stringify(packageVersion)}`,
+    );
+  }
+
+  return Object.freeze({
+    packageName: selectedPackage,
+    packageVersion,
+    frontendName,
+  });
+}
+
+function assertGithubOutputValue(label, value) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (/[\r\n]/.test(value)) {
+    throw new Error(`${label} must not contain a line break`);
+  }
+}
+
+function formatGithubOutputs(resolution) {
+  const fields = [
+    ["package_name", resolution.packageName],
+    ["package_version", resolution.packageVersion],
+    ["frontend_name", resolution.frontendName],
+  ];
+  for (const [label, value] of fields) {
+    assertGithubOutputValue(label, value);
+  }
+  return `${fields.map(([label, value]) => `${label}=${value}`).join("\n")}\n`;
+}
+
+function main() {
+  const resolution = resolveReleaseFrontend({
+    packageName: process.env.FRONTEND_PACKAGE,
+    requestedVersion: process.env.FRONTEND_VERSION,
+  });
+  const output = formatGithubOutputs(resolution);
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, output, "utf8");
+  } else {
+    process.stdout.write(`${JSON.stringify(resolution)}\n`);
+  }
+  process.stderr.write(
+    `Resolved release frontend ${resolution.packageName}@${resolution.packageVersion} (${resolution.frontendName})\n`,
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  DEFAULT_LOCK_PATH,
+  FROM_LOCK,
+  LEGACY_LOTUS_PACKAGE_NAME,
+  LEGACY_LOTUS_VERSION,
+  formatGithubOutputs,
+  resolveReleaseFrontend,
+};

--- a/scripts/release-frontend-policy.test.cjs
+++ b/scripts/release-frontend-policy.test.cjs
@@ -1,0 +1,184 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const {
+  FROM_LOCK,
+  LEGACY_LOTUS_PACKAGE_NAME,
+  LEGACY_LOTUS_VERSION,
+  formatGithubOutputs,
+  resolveReleaseFrontend,
+} = require("./release-frontend-policy.cjs");
+
+const ROOT = path.resolve(__dirname, "..");
+const LOTUS_NEXT_PACKAGE_NAME = "@bigduu/lotus-next";
+const LOTUS_NEXT_VERSION = "2026.9.14";
+
+test("defaults releases and tag events to the exact locked Lotus Next artifact", () => {
+  assert.deepEqual(resolveReleaseFrontend(), {
+    packageName: LOTUS_NEXT_PACKAGE_NAME,
+    packageVersion: LOTUS_NEXT_VERSION,
+    frontendName: "lotus-next",
+  });
+  assert.deepEqual(
+    resolveReleaseFrontend({ packageName: "", requestedVersion: "" }),
+    resolveReleaseFrontend({
+      packageName: LOTUS_NEXT_PACKAGE_NAME,
+      requestedVersion: FROM_LOCK,
+    }),
+  );
+});
+
+test("accepts only the locked Lotus Next version", () => {
+  assert.equal(
+    resolveReleaseFrontend({
+      packageName: LOTUS_NEXT_PACKAGE_NAME,
+      requestedVersion: LOTUS_NEXT_VERSION,
+    }).packageVersion,
+    LOTUS_NEXT_VERSION,
+  );
+  for (const requestedVersion of ["latest", "2026.9.13", "2026.9.15"]) {
+    assert.throws(
+      () =>
+        resolveReleaseFrontend({
+          packageName: LOTUS_NEXT_PACKAGE_NAME,
+          requestedVersion,
+        }),
+      /does not match the allowed .* version/,
+    );
+  }
+});
+
+test("the explicit legacy rollback always resolves to one fixed version", () => {
+  for (const requestedVersion of [
+    undefined,
+    "",
+    FROM_LOCK,
+    LEGACY_LOTUS_VERSION,
+  ]) {
+    assert.deepEqual(
+      resolveReleaseFrontend({
+        packageName: LEGACY_LOTUS_PACKAGE_NAME,
+        requestedVersion,
+      }),
+      {
+        packageName: LEGACY_LOTUS_PACKAGE_NAME,
+        packageVersion: LEGACY_LOTUS_VERSION,
+        frontendName: "lotus",
+      },
+    );
+  }
+  assert.throws(
+    () =>
+      resolveReleaseFrontend({
+        packageName: LEGACY_LOTUS_PACKAGE_NAME,
+        requestedVersion: "latest",
+      }),
+    /does not match the allowed .* version/,
+  );
+});
+
+test("rejects unsupported package names before installation", () => {
+  assert.throws(
+    () =>
+      resolveReleaseFrontend({
+        packageName: "@bigduu/not-a-frontend",
+        requestedVersion: FROM_LOCK,
+      }),
+    /Unsupported release frontend package/,
+  );
+});
+
+test("GitHub outputs are single-line fixed fields", () => {
+  const resolution = resolveReleaseFrontend();
+  assert.equal(
+    formatGithubOutputs(resolution),
+    [
+      `package_name=${LOTUS_NEXT_PACKAGE_NAME}`,
+      `package_version=${LOTUS_NEXT_VERSION}`,
+      "frontend_name=lotus-next",
+      "",
+    ].join("\n"),
+  );
+  assert.throws(
+    () =>
+      formatGithubOutputs({
+        ...resolution,
+        packageVersion: `${LOTUS_NEXT_VERSION}\nunsafe=value`,
+      }),
+    /must not contain a line break/,
+  );
+});
+
+test("CLI appends the exact resolution to GITHUB_OUTPUT", (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "bamboo-release-frontend-policy-"),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const outputPath = path.join(directory, "github-output");
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, "release-frontend-policy.cjs")],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FRONTEND_PACKAGE: LOTUS_NEXT_PACKAGE_NAME,
+        FRONTEND_VERSION: LOTUS_NEXT_VERSION,
+        GITHUB_OUTPUT: outputPath,
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.equal(
+    fs.readFileSync(outputPath, "utf8"),
+    formatGithubOutputs(resolveReleaseFrontend()),
+  );
+});
+
+test("crate and Docker publishers share the fail-closed resolver contract", () => {
+  const workflowPaths = [
+    ".github/workflows/publish-crate.yml",
+    ".github/workflows/docker-publish.yml",
+  ];
+  for (const relativePath of workflowPaths) {
+    const source = fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+    assert.match(source, /frontend_package:\n/);
+    assert.match(source, /default: "@bigduu\/lotus-next"/);
+    assert.match(source, /- "@bigduu\/lotus-next"/);
+    assert.match(source, /- "@bigduu\/lotus"/);
+    assert.match(source, /default: "from_lock"/);
+    assert.match(source, /node scripts\/release-frontend-policy\.cjs/);
+    assert.match(
+      source,
+      /LOTUS_PACKAGE_NAME: \$\{\{ steps\.frontend\.outputs\.package_name \}\}/,
+    );
+    assert.match(
+      source,
+      /LOTUS_VERSION: \$\{\{ steps\.frontend\.outputs\.package_version \}\}/,
+    );
+    assert.match(
+      source,
+      /EXPECTED_FRONTEND_NAME: \$\{\{ steps\.frontend\.outputs\.frontend_name \}\}/,
+    );
+    assert.doesNotMatch(source, /LOTUS_PACKAGE_NAME: "@bigduu\/lotus"/);
+    assert.doesNotMatch(source, /@bigduu\/lotus@\$\{LOTUS_VERSION\}/);
+    assert.doesNotMatch(source, /lotus_version \|\| 'latest'/);
+  }
+
+  const ci = fs.readFileSync(
+    path.join(ROOT, ".github/workflows/ci.yml"),
+    "utf8",
+  );
+  assert.equal(
+    ci.match(/scripts\/release-frontend-policy\.test\.cjs/g)?.length,
+    2,
+  );
+});


### PR DESCRIPTION
## Summary

- make both crate and Docker release producers select the committed `@bigduu/lotus-next@2026.9.14` artifact lock by default, including tag-triggered Docker builds
- retain `@bigduu/lotus@2026.8.28` only as an explicit fixed rollback choice and reject `latest`, mismatched versions, and unsupported packages before installation
- share the resolver across both workflows, assert the staged frontend identity/version, and cover the contract in both CI lanes
- document the bounded rollback behavior; this PR does not publish anything or change the root release train

## Test Plan

- `node --test scripts/lotus-next-artifact.test.cjs scripts/release-frontend-policy.test.cjs` (12 passed)
- `actionlint -ignore SC2046 .github/workflows/ci.yml .github/workflows/publish-crate.yml .github/workflows/docker-publish.yml`
- `cargo fmt --all -- --check`
- `cargo test -p bamboo-server --test frontend_build_contract` (6 passed)
- `cargo clippy -p bamboo-server --all-targets` (passed; existing warnings remain outside this diff)
- installed and staged the real npm artifacts for both `@bigduu/lotus-next@2026.9.14` and rollback `@bigduu/lotus@2026.8.28` in a disposable worktree; verified their manifest identity/version and archive integrity

Closes #1133